### PR TITLE
Avoid freeing memory owned by TMVA::Reader

### DIFF
--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -36,9 +36,6 @@ class TMVAEvaluator {
     std::string mMethod;
     mutable std::mutex m_mutex;
     [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVA::Reader> mReader;
-    #if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    std::unique_ptr<TMVA::IMethod> mIMethod;
-    #endif
     std::shared_ptr<const GBRForest> mGBRForest;
 
     [[cms::thread_guard("m_mutex")]] mutable std::map<std::string,std::pair<size_t,float>> mVariables;

--- a/CommonTools/Utils/src/TMVAEvaluator.cc
+++ b/CommonTools/Utils/src/TMVAEvaluator.cc
@@ -35,11 +35,7 @@ void TMVAEvaluator::initialize(const std::string & options, const std::string & 
   }
 
   // load the TMVA weights
-  #if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  mIMethod = std::unique_ptr<TMVA::IMethod>( reco::details::loadTMVAWeights(mReader.get(), mMethod.c_str(), weightFile.c_str()) );
-  #else
   reco::details::loadTMVAWeights(mReader.get(), mMethod.c_str(), weightFile.c_str());
-  #endif
 
   if (useGBRForest)
   {
@@ -47,9 +43,6 @@ void TMVAEvaluator::initialize(const std::string & options, const std::string & 
 
     // now can free some memory
     mReader.reset(nullptr);
-    #if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    mIMethod.reset(nullptr);
-    #endif
 
     mUsingGBRForest = true;
     mUseAdaBoost = useAdaBoost;

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -38,7 +38,9 @@ fNMVABins(0)
 EGammaMvaEleEstimator::~EGammaMvaEleEstimator()
 {
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     if (fTMVAMethod[i]) delete fTMVAMethod[i];
+#endif
     if (fTMVAReader[i]) delete fTMVAReader[i];
   }
 }
@@ -65,7 +67,9 @@ void EGammaMvaEleEstimator::initialize( std::string methodName,
   //clean up first
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
     if (fTMVAReader[i]) delete fTMVAReader[i];
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     if (fTMVAMethod[i]) delete fTMVAMethod[i];
+#endif
   }
   fTMVAReader.clear();
   fTMVAMethod.clear();

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -38,9 +38,6 @@ fNMVABins(0)
 EGammaMvaEleEstimator::~EGammaMvaEleEstimator()
 {
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    if (fTMVAMethod[i]) delete fTMVAMethod[i];
-#endif
     if (fTMVAReader[i]) delete fTMVAReader[i];
   }
 }
@@ -67,9 +64,6 @@ void EGammaMvaEleEstimator::initialize( std::string methodName,
   //clean up first
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
     if (fTMVAReader[i]) delete fTMVAReader[i];
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    if (fTMVAMethod[i]) delete fTMVAMethod[i];
-#endif
   }
   fTMVAReader.clear();
   fTMVAMethod.clear();

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -22,7 +22,9 @@ fNMVABins(0)
 EGammaMvaEleEstimatorCSA14::~EGammaMvaEleEstimatorCSA14()
 {
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     if (fTMVAMethod[i]) delete fTMVAMethod[i];
+#endif
     if (fTMVAReader[i]) delete fTMVAReader[i];
   }
 }
@@ -49,7 +51,9 @@ void EGammaMvaEleEstimatorCSA14::initialize( std::string methodName,
   //clean up first
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
     if (fTMVAReader[i]) delete fTMVAReader[i];
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     if (fTMVAMethod[i]) delete fTMVAMethod[i];
+#endif
   }
   fTMVAReader.clear();
   fTMVAMethod.clear();

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -22,9 +22,6 @@ fNMVABins(0)
 EGammaMvaEleEstimatorCSA14::~EGammaMvaEleEstimatorCSA14()
 {
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    if (fTMVAMethod[i]) delete fTMVAMethod[i];
-#endif
     if (fTMVAReader[i]) delete fTMVAReader[i];
   }
 }
@@ -51,9 +48,6 @@ void EGammaMvaEleEstimatorCSA14::initialize( std::string methodName,
   //clean up first
   for (unsigned int i=0;i<fTMVAReader.size(); ++i) {
     if (fTMVAReader[i]) delete fTMVAReader[i];
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    if (fTMVAMethod[i]) delete fTMVAMethod[i];
-#endif
   }
   fTMVAReader.clear();
   fTMVAMethod.clear();

--- a/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
+++ b/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
@@ -56,8 +56,15 @@ class ProcTMVA : public VarProcessor {
 	virtual void eval(ValueIterator iter, unsigned int n) const override;
 
     private:
-  std::auto_ptr<TMVA::Reader>     reader;
-  std::auto_ptr<TMVA::MethodBase> method;
+  std::unique_ptr<TMVA::Reader>     reader;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
+  // Versions of ROOT older than 6.07 don't cleanup the classifier methods
+  // leading to memory leaks, so use unique_ptr for older versions
+  template <class T> using maybe_own = std::unique_ptr<T>;
+#else
+  template <class T> using maybe_own = T*;
+#endif
+  maybe_own<TMVA::MethodBase> method;
   std::string   methodName;
   unsigned int  nVars;
 
@@ -73,7 +80,7 @@ ProcTMVA::ProcTMVA(const char *name,
 	VarProcessor(name, calib, computer)
 {
 
-  reader = std::auto_ptr<TMVA::Reader>(new TMVA::Reader( "!Color:Silent" ));
+  reader = std::unique_ptr<TMVA::Reader>(new TMVA::Reader( "!Color:Silent" ));
   
   ext::imemstream is(
 		     reinterpret_cast<const char*>(&calib->store.front()),
@@ -105,9 +112,9 @@ ProcTMVA::ProcTMVA(const char *name,
     TMVA::Types::Instance().GetMethodType(methodName);
   // Check if xml format
   if (weight_text.find("<?xml") != std::string::npos) {
-   method = std::auto_ptr<TMVA::MethodBase>
-     ( dynamic_cast<TMVA::MethodBase*>
-       ( reader->BookMVA( methodType, weight_text.c_str() ) ) );
+     method = maybe_own<TMVA::MethodBase>
+       ( dynamic_cast<TMVA::MethodBase*>
+	 ( reader->BookMVA( methodType, weight_text.c_str() ) ) );
   } else {
     // Write to a temporary file
     TString weight_file_name(boost::filesystem::unique_path().c_str());
@@ -118,7 +125,7 @@ ProcTMVA::ProcTMVA(const char *name,
     edm::LogInfo("LegacyMVA") << "Building legacy TMVA plugin - "
       << "the weights are being stored in " << weight_file_name << std::endl;
     methodName_t.Append(methodName.c_str());
-    method = std::auto_ptr<TMVA::MethodBase>
+    method = maybe_own<TMVA::MethodBase>
       ( dynamic_cast<TMVA::MethodBase*>
         ( reader->BookMVA( methodName_t, weight_file_name ) ) );
     remove(weight_file_name.Data());
@@ -174,14 +181,14 @@ ProcTMVA::ProcTMVA(const char *name,
 			  TMVA::Types::Instance().GetMethodType(methodName);
 
  if (isXml){
-   method = std::auto_ptr<TMVA::MethodBase>
+   method = std::unique_ptr<TMVA::MethodBase>
      ( dynamic_cast<TMVA::MethodBase*>
        ( reader->BookMVA( methodType, weights.c_str() ) ) ); 
  }
  else{
    methodName_t.Clear();
    methodName_t.Append(methodName.c_str());
-   method = std::auto_ptr<TMVA::MethodBase>
+   method = std::unique_ptr<TMVA::MethodBase>
      ( dynamic_cast<TMVA::MethodBase*>
        ( reader->BookMVA( methodName_t, weight_file_name ) ) );
  }
@@ -206,7 +213,7 @@ void ProcTMVA::eval(ValueIterator iter, unsigned int n) const
   inputs.reserve(n);
 	for(unsigned int i = 0; i < n; i++)
     inputs.push_back(*iter++);
-  std::auto_ptr<TMVA::Event> evt(new TMVA::Event(inputs, 2));
+  std::unique_ptr<TMVA::Event> evt(new TMVA::Event(inputs, 2));
 
   double result = method->GetMvaValue(evt.get());
 

--- a/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
+++ b/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
@@ -57,14 +57,7 @@ class ProcTMVA : public VarProcessor {
 
     private:
   std::unique_ptr<TMVA::Reader>     reader;
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  // Versions of ROOT older than 6.07 don't cleanup the classifier methods
-  // leading to memory leaks, so use unique_ptr for older versions
-  template <class T> using maybe_own = std::unique_ptr<T>;
-#else
-  template <class T> using maybe_own = T*;
-#endif
-  maybe_own<TMVA::MethodBase> method;
+  TMVA::MethodBase* method;
   std::string   methodName;
   unsigned int  nVars;
 
@@ -112,9 +105,7 @@ ProcTMVA::ProcTMVA(const char *name,
     TMVA::Types::Instance().GetMethodType(methodName);
   // Check if xml format
   if (weight_text.find("<?xml") != std::string::npos) {
-     method = maybe_own<TMVA::MethodBase>
-       ( dynamic_cast<TMVA::MethodBase*>
-	 ( reader->BookMVA( methodType, weight_text.c_str() ) ) );
+     method = dynamic_cast<TMVA::MethodBase*>( reader->BookMVA( methodType, weight_text.c_str() ) );
   } else {
     // Write to a temporary file
     TString weight_file_name(boost::filesystem::unique_path().c_str());
@@ -125,9 +116,7 @@ ProcTMVA::ProcTMVA(const char *name,
     edm::LogInfo("LegacyMVA") << "Building legacy TMVA plugin - "
       << "the weights are being stored in " << weight_file_name << std::endl;
     methodName_t.Append(methodName.c_str());
-    method = maybe_own<TMVA::MethodBase>
-      ( dynamic_cast<TMVA::MethodBase*>
-        ( reader->BookMVA( methodName_t, weight_file_name ) ) );
+    method = dynamic_cast<TMVA::MethodBase*>( reader->BookMVA( methodName_t, weight_file_name ) );
     remove(weight_file_name.Data());
   }
 

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
@@ -184,7 +184,11 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
   //
   // Book the method and set up the weights file
   //
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
+#else
+  tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
+#endif
   
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>(tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
@@ -184,11 +184,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
   //
   // Book the method and set up the weights file
   //
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
-#else
   tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
-#endif
   
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>(tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
@@ -208,7 +208,11 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
+#else
+  tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
+#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15NonTrig.cc
@@ -208,11 +208,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
-#else
   tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
-#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
@@ -187,7 +187,11 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
+#else
+  tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
+#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Spring15Trig.cc
@@ -187,11 +187,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
-#else
   tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
-#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
@@ -44,7 +44,11 @@ ElectronMVAEstimator::ElectronMVAEstimator(std::string fileName):
   // Taken from Daniele (his mail from the 30/11)
   //  tmvaReader.BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
   // training of the 7/12 with Nvtx added
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA(ele_mva_name,fileName.c_str()) );
+#else
+  tmvaReader.BookMVA(ele_mva_name,fileName.c_str());
+#endif
   gbr.emplace_back(new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA(ele_mva_name) ) ) );
 }
 
@@ -80,7 +84,11 @@ ElectronMVAEstimator::ElectronMVAEstimator(const Configuration & cfg):cfg_(cfg){
     // Taken from Daniele (his mail from the 30/11)
     //  tmvaReader.BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
     // training of the 7/12 with Nvtx added
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA(ele_mva_name,wgtfile) );
+#else
+    tmvaReader.BookMVA(ele_mva_name,wgtfile);
+#endif
     gbr.emplace_back(new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA(ele_mva_name) ) ) );
   }
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
@@ -44,11 +44,7 @@ ElectronMVAEstimator::ElectronMVAEstimator(std::string fileName):
   // Taken from Daniele (his mail from the 30/11)
   //  tmvaReader.BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
   // training of the 7/12 with Nvtx added
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA(ele_mva_name,fileName.c_str()) );
-#else
   tmvaReader.BookMVA(ele_mva_name,fileName.c_str());
-#endif
   gbr.emplace_back(new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA(ele_mva_name) ) ) );
 }
 
@@ -84,11 +80,7 @@ ElectronMVAEstimator::ElectronMVAEstimator(const Configuration & cfg):cfg_(cfg){
     // Taken from Daniele (his mail from the 30/11)
     //  tmvaReader.BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
     // training of the 7/12 with Nvtx added
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA(ele_mva_name,wgtfile) );
-#else
     tmvaReader.BookMVA(ele_mva_name,wgtfile);
-#endif
     gbr.emplace_back(new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA(ele_mva_name) ) ) );
   }
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16GeneralPurpose.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16GeneralPurpose.cc
@@ -226,7 +226,11 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath() ) );
+#else
+  tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath());
+#endif
 
   return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(MethodName_) ) ) );
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16GeneralPurpose.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16GeneralPurpose.cc
@@ -226,11 +226,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath() ) );
-#else
   tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath());
-#endif
 
   return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(MethodName_) ) ) );
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16HZZ.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16HZZ.cc
@@ -249,7 +249,11 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath() ) );
+#else
+  tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath());
+#endif
 
   return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(MethodName_) ) ) );
 }

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16HZZ.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimatorRun2Spring16HZZ.cc
@@ -249,11 +249,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath() ) );
-#else
   tmpTMVAReader.BookMVA(MethodName_ , weightFile.fullPath());
-#endif
 
   return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(MethodName_) ) ) );
 }

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -61,7 +61,11 @@ SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cf
     
     // Taken from Daniele (his mail from the 30/11)    
     // training of the 7/12 with Nvtx added
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA("BDT",weightsfiles[i]) );
+#else
+    tmvaReader.BookMVA("BDT",weightsfiles[i]);
+#endif
     gbr[i].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA("BDT") ) ) );
   }
 }

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -61,11 +61,7 @@ SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cf
     
     // Taken from Daniele (his mail from the 30/11)    
     // training of the 7/12 with Nvtx added
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA("BDT",weightsfiles[i]) );
-#else
     tmvaReader.BookMVA("BDT",weightsfiles[i]);
-#endif
     gbr[i].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA("BDT") ) ) );
   }
 }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
@@ -175,7 +175,11 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
   //
   // Book the method and set up the weights file
   //
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
+#else
+  tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
+#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
@@ -175,11 +175,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
   //
   // Book the method and set up the weights file
   //
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
-#else
   tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
-#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 }

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
@@ -184,7 +184,11 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
   std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
+#else
+  tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
+#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
@@ -184,11 +184,7 @@ createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
   //
   // Book the method and set up the weights file
   //
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
-#else
   tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath());
-#endif
 
   return std::make_unique<const GBRForest>(dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) );
 

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -151,7 +151,11 @@ std::unique_ptr<const GBRForest> PileupJetIdAlgo::getMVA(const std::vector<std::
             if( tmvaNames_[*it].empty() ) tmvaNames_[*it] = *it;
             tmpTMVAReader.AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
         }
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
         std::unique_ptr<TMVA::IMethod> temp( reco::details::loadTMVAWeights(&tmpTMVAReader,  tmvaMethod_.c_str(), tmvaWeights.c_str() ) );
+#else
+        reco::details::loadTMVAWeights(&tmpTMVAReader,  tmvaMethod_.c_str(), tmvaWeights.c_str());
+#endif
         return( std::make_unique<const GBRForest> ( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(tmvaMethod_.c_str()) ) ) );
 }
 

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -151,11 +151,7 @@ std::unique_ptr<const GBRForest> PileupJetIdAlgo::getMVA(const std::vector<std::
             if( tmvaNames_[*it].empty() ) tmvaNames_[*it] = *it;
             tmpTMVAReader.AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
         }
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-        std::unique_ptr<TMVA::IMethod> temp( reco::details::loadTMVAWeights(&tmpTMVAReader,  tmvaMethod_.c_str(), tmvaWeights.c_str() ) );
-#else
         reco::details::loadTMVAWeights(&tmpTMVAReader,  tmvaMethod_.c_str(), tmvaWeights.c_str());
-#endif
         return( std::make_unique<const GBRForest> ( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(tmvaMethod_.c_str()) ) ) );
 }
 

--- a/RecoParticleFlow/PFProducer/src/PFEGammaHeavyObjectCache.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaHeavyObjectCache.cc
@@ -27,7 +27,11 @@ namespace pfEGHelpers {
       //   tmvaReaderEle_.AddVariable("HOverPin",&HOverPin);
       tmvaReaderEle_.AddVariable("lateBrem",&lateBrem);
       tmvaReaderEle_.AddVariable("firstBrem",&firstBrem);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
       std::unique_ptr<TMVA::IMethod> temp( tmvaReaderEle_.BookMVA("BDT", wfile.fullPath().c_str()) );
+#else
+      tmvaReaderEle_.BookMVA("BDT", wfile.fullPath().c_str());
+#endif
       gbrEle_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReaderEle_.FindMVA("BDT") ) ) );
     }
     {
@@ -42,7 +46,11 @@ namespace pfEGHelpers {
       tmvaReader_.AddVariable("track_pt", &track_pt);  
       tmvaReader_.AddVariable("STIP",&STIP);  
       tmvaReader_.AddVariable("nlost", &nlost);  
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
       std::unique_ptr<TMVA::IMethod> temp( tmvaReader_.BookMVA("BDT", wfile.fullPath().c_str()) );
+#else
+      tmvaReader_.BookMVA("BDT", wfile.fullPath().c_str());
+#endif
       gbrSingleLeg_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader_.FindMVA("BDT") ) ) );
     }
   }

--- a/RecoParticleFlow/PFProducer/src/PFEGammaHeavyObjectCache.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaHeavyObjectCache.cc
@@ -27,11 +27,7 @@ namespace pfEGHelpers {
       //   tmvaReaderEle_.AddVariable("HOverPin",&HOverPin);
       tmvaReaderEle_.AddVariable("lateBrem",&lateBrem);
       tmvaReaderEle_.AddVariable("firstBrem",&firstBrem);
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-      std::unique_ptr<TMVA::IMethod> temp( tmvaReaderEle_.BookMVA("BDT", wfile.fullPath().c_str()) );
-#else
       tmvaReaderEle_.BookMVA("BDT", wfile.fullPath().c_str());
-#endif
       gbrEle_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReaderEle_.FindMVA("BDT") ) ) );
     }
     {
@@ -46,11 +42,7 @@ namespace pfEGHelpers {
       tmvaReader_.AddVariable("track_pt", &track_pt);  
       tmvaReader_.AddVariable("STIP",&STIP);  
       tmvaReader_.AddVariable("nlost", &nlost);  
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-      std::unique_ptr<TMVA::IMethod> temp( tmvaReader_.BookMVA("BDT", wfile.fullPath().c_str()) );
-#else
       tmvaReader_.BookMVA("BDT", wfile.fullPath().c_str());
-#endif
       gbrSingleLeg_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader_.FindMVA("BDT") ) ) );
     }
   }

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -510,7 +510,11 @@ namespace goodseedhelpers {
         reader.AddVariable("pt", &pt);
         reader.AddVariable("eta", &eta);
         
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
         std::unique_ptr<TMVA::IMethod> temp( reader.BookMVA(method_, weights[j].fullPath().c_str()) );
+#else
+        reader.BookMVA(method_, weights[j].fullPath().c_str());
+#endif
         
         gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA(method_) ) ) );
       }    

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -510,11 +510,7 @@ namespace goodseedhelpers {
         reader.AddVariable("pt", &pt);
         reader.AddVariable("eta", &eta);
         
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-        std::unique_ptr<TMVA::IMethod> temp( reader.BookMVA(method_, weights[j].fullPath().c_str()) );
-#else
         reader.BookMVA(method_, weights[j].fullPath().c_str());
-#endif
         
         gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA(method_) ) ) );
       }    

--- a/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
@@ -45,7 +45,11 @@ namespace convbremhelpers {
     reader.AddVariable("kftrack_Epout",&Epout);
     reader.AddVariable("kftrack_detaBremKF",&detaBremKF);
     reader.AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
     std::unique_ptr<TMVA::IMethod> temp( reader.BookMVA("BDT", weights.c_str()) );
+#else
+    reader.BookMVA("BDT", weights.c_str());
+#endif
     return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA("BDT") ) ) );
   }  
 }

--- a/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
@@ -45,11 +45,7 @@ namespace convbremhelpers {
     reader.AddVariable("kftrack_Epout",&Epout);
     reader.AddVariable("kftrack_detaBremKF",&detaBremKF);
     reader.AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,7,0)
-    std::unique_ptr<TMVA::IMethod> temp( reader.BookMVA("BDT", weights.c_str()) );
-#else
     reader.BookMVA("BDT", weights.c_str());
-#endif
     return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA("BDT") ) ) );
   }  
 }


### PR DESCRIPTION
Older versions of TMVA::Reader didn't clean up classification methods, and so leaked memory.  Some CMS code cleaned up the memory itself to avoid leaking.  Starting with ROOT 6.07+, TMVA::Reader now cleans up after itself, so the CMS cleanups are resulting in double frees and potentially corrupted memory.  This (rather ugly) PR patches all the places I could easily find to not assume ownership of the objects.  More details are in issue #17256