### PR TITLE
Remove char buffer and sprintf with std::string/std::to_string

### DIFF
--- a/Validation/Geometry/src/MaterialBudgetCastorHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetCastorHistos.cc
@@ -12,6 +12,8 @@
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
+#include <string>
+
 MaterialBudgetCastorHistos::MaterialBudgetCastorHistos(const edm::ParameterSet &p){
 
   binEta      = p.getUntrackedParameter<int>("NBinEta", 100);
@@ -183,7 +185,7 @@ void MaterialBudgetCastorHistos::book() {
 				 << "in phi from " << -maxPhi << " to " 
 				 << maxPhi;
   
-  char  name[10], title[80], tag1[10], tag2[15];
+  std::string tag1, tag2;
   // total X0
   for (int i=0; i<maxSet; i++) {
     double minEta=etaLow;
@@ -193,57 +195,46 @@ void MaterialBudgetCastorHistos::book() {
       minEta = -etaHigh;
       maxEta = -etaLow;
       ireg  -= 10;
-      sprintf (tag2, " (-ve Eta Side)");
+      tag2 = " (-ve Eta Side)";
     } else {
-      sprintf (tag2, " (+ve Eta Side)");
+      tag2 = " (+ve Eta Side)";
     }
     if ((i%2) == 0) {
       ireg  /= 2;
-      sprintf (tag1, " == Start");
+      tag1 = " == Start";
     } else {
       ireg   = (ireg-1)/2;
-      sprintf (tag1, " == End");
+      tag1 = " == End";
     }
-    sprintf(name, "%d", i+100);
-    sprintf(title, "MB(X0) prof Eta in region %d%s%s", ireg, tag1, tag2);
-    me100[i] =  tfile->make<TProfile>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+200);
-    sprintf(title, "MB(L0) prof Eta in region %d%s%s", ireg, tag1, tag2);
-    me200[i] = tfile->make<TProfile>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+300);
-    sprintf(title, "MB(Step) prof Eta in region %d%s%s", ireg, tag1, tag2);
-    me300[i] = tfile->make<TProfile>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+400);
-    sprintf(title, "Eta in region %d%s%s", ireg, tag1, tag2);
-    me400[i] = tfile->make<TH1F>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+500);
-    sprintf(title, "MB(X0) prof Ph in region %d%s%s", ireg, tag1, tag2);
-    me500[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+600);
-    sprintf(title, "MB(L0) prof Ph in region %d%s%s", ireg, tag1, tag2);
-    me600[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+700);
-    sprintf(title, "MB(Step) prof Ph in region %d%s%s", ireg, tag1, tag2);
-    me700[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+800);
-    sprintf(title, "Phi in region %d%s%s", ireg, tag1, tag2);
-    me800[i] = tfile->make<TH1F>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+900);
-    sprintf(title, "MB(X0) prof Eta Phi in region %d%s%s", ireg, tag1, tag2);
-    me900[i] = tfile->make<TProfile2D>(name, title, binEta/2, minEta, maxEta,
-				       binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+1000);
-    sprintf(title, "MB(L0) prof Eta Phi in region %d%s%s", ireg, tag1, tag2);
-    me1000[i]= tfile->make<TProfile2D>(name, title, binEta/2, minEta, maxEta,
-				       binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+1100);
-    sprintf(title, "MB(Step) prof Eta Phi in region %d%s%s", ireg, tag1, tag2);
-    me1100[i]= tfile->make<TProfile2D>(name, title, binEta/2, minEta, maxEta,
-				       binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+1200);
-    sprintf(title, "Eta vs Phi in region %d%s%s", ireg, tag1, tag2);
-    me1200[i]= tfile->make<TH2F>(name, title, binEta/2, minEta, maxEta, 
-				 binPhi/2, -maxPhi, maxPhi);
+    std::string title = std::to_string(ireg) + tag1 + tag2;
+    me100[i] = tfile->make<TProfile>(std::to_string(i + 100).c_str(),
+                  ("MB(X0) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me200[i] = tfile->make<TProfile>(std::to_string(i + 200).c_str(),
+                  ("MB(L0) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me300[i] = tfile->make<TProfile>(std::to_string(i + 300).c_str(),
+                  ("MB(Step) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me400[i] = tfile->make<TH1F>(std::to_string(i + 400).c_str(),
+                  ("Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me500[i] = tfile->make<TProfile>(std::to_string(i + 500).c_str(),
+                  ("MB(X0) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me600[i] = tfile->make<TProfile>(std::to_string(i + 600).c_str(),
+                  ("MB(L0) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me700[i] = tfile->make<TProfile>(std::to_string(i + 700).c_str(),
+                  ("MB(Step) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me800[i] = tfile->make<TH1F>(std::to_string(i + 800).c_str(),
+                  ("Phi in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me900[i] = tfile->make<TProfile2D>(std::to_string(i + 900).c_str(),
+                  ("MB(X0) prof Eta Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
+    me1000[i]= tfile->make<TProfile2D>(std::to_string(i + 1000).c_str(),
+                  ("MB(L0) prof Eta Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
+    me1100[i]= tfile->make<TProfile2D>(std::to_string(i + 1100).c_str(),
+                  ("MB(Step) prof Eta Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
+    me1200[i]= tfile->make<TH2F>(std::to_string(i + 1200).c_str(),
+                  ("Eta vs Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
   }
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Booking user "

--- a/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
@@ -12,6 +12,8 @@
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
+#include <string>
+
 MaterialBudgetHcalHistos::MaterialBudgetHcalHistos(const edm::ParameterSet &p){
 
   binEta      = p.getUntrackedParameter<int>("NBinEta", 260);
@@ -274,61 +276,48 @@ void MaterialBudgetHcalHistos::book() {
 				 << "in phi from " << -maxPhi << " to " 
 				 << maxPhi;
   
-  char  name[10], title[40];
+  std::string iter;
   // total X0
   for (int i=0; i<maxSet; i++) {
-    sprintf(name, "%d", i+100);
-    sprintf(title, "MB(X0) prof Eta in region %d", i);
-    me100[i] =  tfile->make<TProfile>(name, title, binEta, -maxEta, maxEta);
-    sprintf(name, "%d", i+200);
-    sprintf(title, "MB(L0) prof Eta in region %d", i);
-    me200[i] = tfile->make<TProfile>(name, title, binEta, -maxEta, maxEta);
-    sprintf(name, "%d", i+300);
-    sprintf(title, "MB(Step) prof Eta in region %d", i);
-    me300[i] = tfile->make<TProfile>(name, title, binEta, -maxEta, maxEta);
-    sprintf(name, "%d", i+400);
-    sprintf(title, "Eta in region %d", i);
-    me400[i] = tfile->make<TH1F>(name, title, binEta, -maxEta, maxEta);
-    sprintf(name, "%d", i+500);
-    sprintf(title, "MB(X0) prof Ph in region %d", i);
-    me500[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+600);
-    sprintf(title, "MB(L0) prof Ph in region %d", i);
-    me600[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+700);
-    sprintf(title, "MB(Step) prof Ph in region %d", i);
-    me700[i] = tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+800);
-    sprintf(title, "Phi in region %d", i);
-    me800[i] = tfile->make<TH1F>(name, title, binPhi, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+900);
-    sprintf(title, "MB(X0) prof Eta Phi in region %d", i);
-    me900[i] = tfile->make<TProfile2D>(name, title, binEta/2, -maxEta, maxEta,
-				       binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+1000);
-    sprintf(title, "MB(L0) prof Eta Phi in region %d", i);
-    me1000[i]= tfile->make<TProfile2D>(name, title, binEta/2, -maxEta, maxEta,
-				       binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+1100);
-    sprintf(title, "MB(Step) prof Eta Phi in region %d", i);
-    me1100[i]= tfile->make<TProfile2D>(name, title, binEta/2, -maxEta, maxEta,
-				       binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+1200);
-    sprintf(title, "Eta vs Phi in region %d", i);
-    me1200[i]= tfile->make<TH2F>(name, title, binEta/2, -maxEta, maxEta, 
-				 binPhi/2, -maxPhi, maxPhi);
+    iter = std::to_string(i);
+    me100[i] = tfile->make<TProfile>(std::to_string(i + 100).c_str(),
+                  ("MB(X0) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me200[i] = tfile->make<TProfile>(std::to_string(i + 200).c_str(),
+                  ("MB(L0) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me300[i] = tfile->make<TProfile>(std::to_string(i + 300).c_str(),
+                  ("MB(Step) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me400[i] = tfile->make<TH1F>(std::to_string(i + 400).c_str(),
+                  ("Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me500[i] = tfile->make<TProfile>(std::to_string(i + 500).c_str(),
+                  ("MB(X0) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me600[i] = tfile->make<TProfile>(std::to_string(i + 600).c_str(),
+                  ("MB(L0) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me700[i] = tfile->make<TProfile>(std::to_string(i + 700).c_str(),
+                  ("MB(Step) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me800[i] = tfile->make<TH1F>(std::to_string(i + 800).c_str(),
+                  ("Phi in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me900[i] = tfile->make<TProfile2D>(std::to_string(i + 900).c_str(),
+                  ("MB(X0) prof Eta Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
+    me1000[i]= tfile->make<TProfile2D>(std::to_string(i + 1000).c_str(),
+                  ("MB(L0) prof Eta Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
+    me1100[i]= tfile->make<TProfile2D>(std::to_string(i + 1100).c_str(),
+                  ("MB(Step) prof Eta Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
+    me1200[i]= tfile->make<TH2F>(std::to_string(i + 1200).c_str(),
+                  ("Eta vs Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
   }
   for (int i=0; i<maxSet2; i++) {
-    sprintf(name, "%d", i+1300);
-    sprintf(title, "Events with layers Hit (0 all, 1 HB, ..) for %d", i);
-    me1300[i]= tfile->make<TH1F>(name, title, binEta, -maxEta, maxEta);
-    sprintf(name, "%d", i+1400);
-    sprintf(title, "Eta vs Phi for layers hit in %d", i);
-    me1400[i]= tfile->make<TH2F>(name, title, binEta/2, -maxEta, maxEta, 
-				 binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+1500);
-    sprintf(title, "Number of layers crossed (0 all, 1 HB, ..) for %d", i);
-    me1500[i]= tfile->make<TProfile>(name, title, binEta, -maxEta, maxEta);
+    iter = std::to_string(i);
+    me1300[i]= tfile->make<TH1F>(std::to_string(i + 1300).c_str(),
+                  ("Events with layers Hit (0 all, 1 HB, ..) for " + iter).c_str(), binEta, -maxEta, maxEta);
+    me1400[i]= tfile->make<TH2F>(std::to_string(i + 1400).c_str(),
+                  ("Eta vs Phi for layers hit in " + iter).c_str(), binEta/2, -maxEta, maxEta,
+                  binPhi/2, -maxPhi, maxPhi);
+    me1500[i]= tfile->make<TProfile>(std::to_string(i + 1500).c_str(),
+                  ("Number of layers crossed (0 all, 1 HB, ..) for " + iter).c_str(), binEta, -maxEta, maxEta);
   }
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Booking user "


### PR DESCRIPTION
Originally I expected ROOT classes to support std::string, but they
actually take const char * instead thus I had to use .c_str(), which is
not the nicest code. Hopefully ROOT classess makes a copy and not just
saves the pointer internally as std::string will be temporaries.

We should make sure we don't have dangling pointers somewhere here.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>