### PR TITLE
Resolve -Werror=format-truncation= issues

### DIFF
--- a/TBDataFormats/HcalTBObjects/src/HcalTBEventPosition.cc
+++ b/TBDataFormats/HcalTBObjects/src/HcalTBEventPosition.cc
@@ -75,15 +75,8 @@ using namespace std;
   }
 
   ostream& operator<<(ostream& s, const HcalTBEventPosition& htbep) {
-    char str[180];
-
-    snprintf (str,180, "HF Table (X,Y,V) = (%f,%f,%f)\n",
-	     htbep.hfTableX(),htbep.hfTableY(),htbep.hfTableV());
-    s << str;
-
-    snprintf (str, 180, "HB/HE Table (eta,phi) = (%f,%f)\n",
-	     htbep.hbheTableEta(),htbep.hbheTablePhi());
-    s << str;
+    s << "HF Table (X,Y,V) = (" << htbep.hfTableX() << "," << htbep.hfTableY() << "," << htbep.hfTableV() << ")" << std::endl;
+    s << "HB/HE Table (eta,phi) = (" << htbep.hbheTableEta() << "," << htbep.hbheTablePhi() << ")" << std::endl;
 
     vector<double> xvec, yvec;
     vector<double>::const_iterator j;


### PR DESCRIPTION
By default `%f` precision is 6 digits after comma. Same applies to
`std::to_string()` and `operator<<` on `std::basic_ostream`.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>