### PR TITLE
Cleanup throw specifier and boost stuff

### DIFF
--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
@@ -6,7 +6,6 @@
 #include <stdexcept>
 #include <cstring>
 #include <cstdlib>
-#include <boost/tuple/tuple.hpp>
 #include <boost/format.hpp>
 
 #include "FWCore/Framework/interface/Event.h"

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -3,7 +3,7 @@
 #include <string>
 #include <cassert>
 #include <exception>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -68,16 +68,16 @@ const G4AffineTransform& GetTransform(const G4TouchableHistory* touchable, int d
 //   - how may steps up in the hierarchy it is (0 is the starting volume)
 // if no sensitive detector is found, return a NULL pointer and 0
 
-boost::tuple<const G4VPhysicalVolume*, int> GetSensitiveVolume( const G4VTouchable* touchable )
+std::tuple<const G4VPhysicalVolume*, int> GetSensitiveVolume( const G4VTouchable* touchable )
 {
   int depth = touchable->GetHistoryDepth();
   for (int level = 0; level < depth; ++level) {      // 0 is self
     const G4VPhysicalVolume* volume = touchable->GetVolume(level);
     if (volume->GetLogicalVolume()->GetSensitiveDetector() != 0) {
-      return boost::make_tuple(volume, level);
+      return std::make_tuple(volume, level);
     }
   }
-  return boost::tuple<const G4VPhysicalVolume*, int>(0, 0);
+  return std::tuple<const G4VPhysicalVolume*, int>(0, 0);
 }
 
 //-------------------------------------------------------------------------
@@ -189,7 +189,7 @@ void TrackingMaterialProducer::update(const G4Step* step)
   int level = 0;
   const G4VPhysicalVolume* sensitive = 0;
   GlobalPoint position;
-  boost::tuples::tie(sensitive, level) = GetSensitiveVolume(touchable);
+  std::tie(sensitive, level) = GetSensitiveVolume(touchable);
   if (sensitive) {
     const G4VSolid &          solid     = *touchable->GetSolid( level );
     const G4AffineTransform & transform = GetTransform( touchable, level );

--- a/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
@@ -132,7 +132,7 @@ protected:
   std::vector<position> splitSegment( Range x, Range y ) const;
 
   /// check the weights passed as an std::vector have the correct size
-  void check_weight(const std::vector<double> & weight) throw (std::invalid_argument)
+  void check_weight(const std::vector<double> & weight) noexcept(false)
   {
     // run time check for vector size
     if (weight.size() != m_size)

--- a/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <iostream>
 #include <stdexcept>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <TH2F.h>
 #include <TH2I.h>
@@ -25,10 +25,10 @@ protected:
   size_t m_yBins;
   size_t m_size;
 
-  std::vector< boost::shared_ptr<Histogram> > m_histograms;
-  boost::shared_ptr<Histogram> m_normalization;
-  boost::shared_ptr<ColorMap>  m_colormap;
-  boost::shared_ptr<Histogram> m_dummy;
+  std::vector< std::shared_ptr<Histogram> > m_histograms;
+  std::shared_ptr<Histogram> m_normalization;
+  std::shared_ptr<ColorMap>  m_colormap;
+  std::shared_ptr<Histogram> m_dummy;
 
 public:
   /// default CTOR 


### PR DESCRIPTION
Basically `throw` dynamic exception specifier was deprecated in C++11 and removed in C++17. Also some things like `boost::shared_ptr` and `boost::tuples::tie` + `boost::tuple` are now available under C++ standard library thus we should avoid external dependency -- _boost_. There is now alternative for `boost::format`, but that could still be rewritten.