### PR TITLE
Replace forward decl for PFTrackTransformer with full header incl

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
@@ -11,6 +11,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 
 #include <memory>
 #include <vector>
@@ -24,8 +25,6 @@
 */
 class Trajectory;
 
-
-class PFTrackTransformer;
 class PFTrackProducer : public edm::stream::EDProducer<> {
 public:
   


### PR DESCRIPTION
Looks like now `std::unique_ptr` uses `sizeof(_Tp)` thus we need to know
full class layout.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>