### PR TITLE
Replace deprecated throw with noexcept

### DIFF
--- a/RecoParticleFlow/PFClusterTools/interface/Calibrator.h
+++ b/RecoParticleFlow/PFClusterTools/interface/Calibrator.h
@@ -32,8 +32,7 @@ public:
 	 * Returns the calibration coefficient for each detector element, using data
 	 * from all particle depositions stored within.
 	 */
-	std::map<DetectorElementPtr, double> getCalibrationCoefficients() throw(
-			PFToolsException&) {
+	std::map<DetectorElementPtr, double> getCalibrationCoefficients() noexcept(false) {
 		return getCalibrationCoefficientsCore();
 	}
 	
@@ -56,7 +55,7 @@ public:
 
 protected:
 	virtual std::map<DetectorElementPtr, double>
-			getCalibrationCoefficientsCore() throw(PFToolsException&);
+			getCalibrationCoefficientsCore() noexcept(false);
 
 	std::vector<DetectorElementPtr> myDetectorElements;
 	std::vector<ParticleDepositPtr> myParticleDeposits;

--- a/RecoParticleFlow/PFClusterTools/interface/DetectorElement.h
+++ b/RecoParticleFlow/PFClusterTools/interface/DetectorElement.h
@@ -62,7 +62,7 @@ public:
 	/*
 	 * Set the calibration of this detector element. Must be > 0.
 	 */
-	void setCalib(double calib) throw(PFToolsException&) {
+	void setCalib(double calib) noexcept(false) {
 		setCalibCore(calib);
 	}
 
@@ -72,7 +72,7 @@ public:
 private:
 	virtual double getCalibCore() const;
 	virtual double getCalibCore(double eta, double phi) const;
-	virtual void setCalibCore(double calib) throw(PFToolsException&);
+	virtual void setCalibCore(double calib) noexcept(false);
 	
 	DetectorElement(const DetectorElement& de);
 	DetectorElementType myType;

--- a/RecoParticleFlow/PFClusterTools/interface/LinearCalibrator.h
+++ b/RecoParticleFlow/PFClusterTools/interface/LinearCalibrator.h
@@ -38,7 +38,7 @@ public:
 protected:
 	
 	virtual std::map<DetectorElementPtr, double>
-			getCalibrationCoefficientsCore() throw(PFToolsException&);
+			getCalibrationCoefficientsCore() noexcept(false);
 
 
 	LinearCalibrator(const LinearCalibrator& lc);

--- a/RecoParticleFlow/PFClusterTools/interface/PFToolsException.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFToolsException.h
@@ -15,9 +15,9 @@ class PFToolsException : public std::exception {
 public:
 	PFToolsException(const std::string& aErrorDescription="");
 	
-	virtual ~PFToolsException() throw();
+	virtual ~PFToolsException() noexcept;
 	
-	virtual const char* what() const throw();
+	virtual const char* what() const noexcept;
 	
 protected:
 	std::string myDescription;

--- a/RecoParticleFlow/PFClusterTools/interface/SpaceManager.h
+++ b/RecoParticleFlow/PFClusterTools/interface/SpaceManager.h
@@ -45,7 +45,7 @@ public:
 	void createCalibrators(const Calibrator& toClone, const unsigned nEta,
 			const double etaMin, const double etaMax, const unsigned nPhi,
 			const double phiMin, const double phiMax, const unsigned nEnergy,
-			const double energyMin, const double energyMax) throw(PFToolsException&);
+			const double energyMin, const double energyMax) noexcept(false);
 	
 	void createCalibrators(const Calibrator& toClone);
 

--- a/RecoParticleFlow/PFClusterTools/src/Calibrator.cc
+++ b/RecoParticleFlow/PFClusterTools/src/Calibrator.cc
@@ -18,8 +18,7 @@ void Calibrator::addParticleDeposit(ParticleDepositPtr pd) {
 	myParticleDeposits.push_back(pd);
 }
 
-std::map<DetectorElementPtr, double> Calibrator::getCalibrationCoefficientsCore() throw(
-		PFToolsException&) {
+std::map<DetectorElementPtr, double> Calibrator::getCalibrationCoefficientsCore() noexcept(false) {
 
 	std::cout << __PRETTY_FUNCTION__
 			<< ": Not implemented in default Calibrator class!\n";

--- a/RecoParticleFlow/PFClusterTools/src/DetectorElement.cc
+++ b/RecoParticleFlow/PFClusterTools/src/DetectorElement.cc
@@ -8,7 +8,7 @@ DetectorElement::DetectorElement(DetectorElementType type, double calib) :
 
 }
 
-void DetectorElement::setCalibCore(double calib) throw(PFToolsException&){
+void DetectorElement::setCalibCore(double calib) noexcept(false) {
 	//I'll tolerate very small negative numbers (artefacts of the minimisation algo
 	//but otherwise this shouldn't be allowed.
 //	if(calib > -0.01) {

--- a/RecoParticleFlow/PFClusterTools/src/LinearCalibrator.cc
+++ b/RecoParticleFlow/PFClusterTools/src/LinearCalibrator.cc
@@ -59,7 +59,7 @@ LinearCalibrator* LinearCalibrator::create() const {
 }
 
 std::map<DetectorElementPtr, double> LinearCalibrator::getCalibrationCoefficientsCore()
-		throw(PFToolsException&) {
+		noexcept(false) {
 //	std::cout << __PRETTY_FUNCTION__
 //			<< ": determining linear calibration coefficients...\n";
 	if (!hasParticles()) {

--- a/RecoParticleFlow/PFClusterTools/src/PFToolsException.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFToolsException.cc
@@ -8,10 +8,10 @@ PFToolsException::PFToolsException(const std::string& aErrorDescription)
 	myDescription = aErrorDescription;
 }
 
-PFToolsException::~PFToolsException() throw() 
+PFToolsException::~PFToolsException() noexcept
 {
 }
 
-const char* PFToolsException::what() const throw(){
+const char* PFToolsException::what() const noexcept {
 	return myDescription.c_str();
 }

--- a/RecoParticleFlow/PFClusterTools/src/SpaceManager.cc
+++ b/RecoParticleFlow/PFClusterTools/src/SpaceManager.cc
@@ -169,7 +169,7 @@ void SpaceManager::createCalibrators(const Calibrator& toClone,
 		const unsigned nEta, const double etaMin, const double etaMax,
 		const unsigned nPhi, const double phiMin, const double phiMax,
 		const unsigned nEnergy, const double energyMin, const double energyMax)
-		throw(PFToolsException&) {
+		noexcept(false) {
 	clear();
 
 	if (nEta == 0|| nPhi ==0|| nEnergy == 0) {


### PR DESCRIPTION
`throw` dynamic exception specifier was deprecated in C++11 and removed in
C++17. Replace it with `noexcept`and `noexcept(false)`.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>