### PR TITLE
2015LowPUMixProfile90X

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -108,6 +108,7 @@ addMixingScenario("2015_25ns_HiLum_PoissonOOTPU",{'file': 'SimGeneral.MixingModu
 addMixingScenario("2015_25ns_Startup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25ns_Startup_PoissonOOTPU_cfi'})
 addMixingScenario("2015_50ns_Startup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_50ns_Startup_PoissonOOTPU_cfi'})
 addMixingScenario("2015_25ns_FallMC_matchData_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25ns_FallMC_matchData_PoissonOOTPU_cfi'})
+addMixingScenario("2015_25nsLowPU_matchData_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25nsLowPU_matchData_PoissonOOTPU_cfi'})
 addMixingScenario("2016_25ns_SpringMC_PUScenarioV1_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2016_25ns_SpringMC_PUScenarioV1_PoissonOOTPU_cfi'})
 addMixingScenario("2016_25ns_Moriond17MC_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2016_25ns_Moriond17MC_PoissonOOTPU_cfi'})
 addMixingScenario("mix_2016_PoissonOOTPU_HighPUTrains_Fill5412",{'file': 'SimGeneral.MixingModule.mix_2016_PoissonOOTPU_HighPUTrains_Fill5412_cfi'})

--- a/SimGeneral/MixingModule/python/mix_2015_25nsLowPU_matchData_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_25nsLowPU_matchData_PoissonOOTPU_cfi.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12),
+          probValue = cms.vdouble(
+                   0.862811884308912,
+                   0.122649088500652,
+                   0.013156023430157,
+                   0.001271967352346,
+                   0.000100080253829,
+                   8.21711557752311E-06,
+                   1.47486689852979E-06,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07,
+                   2.10695271218541E-07),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+	sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+


### PR DESCRIPTION
As requested by @davidlange6, is present the the new PU mixing profile on 90X release to produce MC with PU compatible with the CMS+TOTEM run (low PU data) taken on 2015. 

Also is present some commands to use the new PU profile, the current example have "similar" commands that will be used to produce the samples on 766 release.

1) copy of the Pythia fragment
curl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-RunIISummer15GS-00070 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-RunIISummer15GS-00070-fragment.py [ -s Configuration/GenProduction/python/FSQ-RunIISummer15GS-00070-fragment.py ]

2) create the python configuration
cmsDriver.py Configuration/GenProduction/python/FSQ-RunIISummer15GS-00070-fragment.py --fileout file:FSQ-RunIISummer15GS-00070.root --mc --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions auto:run2_mc --beamspot Realistic100ns13TeVCollisionBetaStar90m --step GEN,SIM --magField 38T_PostLS1 --python_filename FSQ-RunIISummer15GS-00070_1_cfg.py --no_exec -n 30

3) run the GENSIM python configuration
cmsRun FSQ-RunIISummer15GS-00070_1_cfg.py

4) first step of the DigiReco step (when the PU mixing is defined)
cmsDriver.py step1 --filein file:FSQ-RunIISummer15GS-00070.root --fileout file:FSQ-RunIIFall15DR76-00050_step1.root --pileup_input "dbs:/MinBias_TuneCUETP8M1_13TeV-pythia8/RunIISummer15GS-MCRUN2_71_V1-v2/GEN-SIM" --mc --eventcontent RAWDEBUG --datatier GEN-SIM-RAWDEBUG --conditions auto:run2_mc --step DIGI:pdigi_valid,L1,DIGI2RAW,HLT --era Run2_2016 --python_filename FSQ-RunIIFall15DR76-00050_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 30 --pileup=2015_25nsLowPU_matchData_PoissonOOTPU

5) execute the previous step
cmsRun FSQ-RunIIFall15DR76-00050_1_cfg.py

6) second step of the DigiReco
cmsDriver.py step2 --filein file:FSQ-RunIIFall15DR76-00050_step1.root --fileout file:FSQ-RunIIFall15DR76-00050.root --mc --eventcontent RECODEBUG,DQM --runUnscheduled --datatier GEN-SIM-RECODEBUG,DQMIO --conditions auto:run2_mc --step RAW2DIGI,L1Reco,RECO,EI,DQM:DQMOfflinePOGMC --era Run2_2016 --python_filename FSQ-RunIIFall15DR76-00050_2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 30

7) execute the previous step
cmsRun FSQ-RunIIFall15DR76-00050_2_cfg.py

look the file FSQ-RunIIFall15DR76-00050.root and check the PU distribution.