### PR TITLE
CTPPS: miniAOD (minimal back-port of #17162)

### DIFF
--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Authors:
+*   Jan Kašpar (jan.kaspar@gmail.com)
+*
+****************************************************************************/
+
+#ifndef DataFormats_CTPPSReco_CTPPSLocalTrackLite
+#define DataFormats_CTPPSReco_CTPPSLocalTrackLite
+
+/**
+ *\brief Local (=single RP) track with essential information only.
+ **/
+struct CTPPSLocalTrackLite
+{
+  public:
+    CTPPSLocalTrackLite(uint32_t pid=0, float px=0., float pxu=-1., float py=0., float pyu=-1., float pt=0., float ptu=-1.)
+      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), time(pt), time_unc(ptu)
+    {
+    }
+
+    uint32_t getRPId() const
+    {
+      return rpId;
+    }
+
+    float getX() const
+    {
+      return x;
+    }
+
+    float getXUnc() const
+    {
+      return x_unc;
+    }
+
+    float getY() const
+    {
+      return y;
+    }
+
+    float getYUnc() const
+    {
+      return y_unc;
+    }
+
+    float getTime() const
+    {
+      return time;
+    }
+
+    float getTimeUnc() const
+    {
+      return time_unc;
+    }
+
+  protected:
+    /// RP id
+    uint32_t rpId;
+
+    /// horizontal hit position and uncertainty, mm
+    float x, x_unc;
+
+    /// vertical hit position and uncertainty, mm
+    float y, y_unc;
+
+    /// time information and uncertainty
+    float time, time_unc;
+};
+
+#endif

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -12,44 +12,55 @@
 /**
  *\brief Local (=single RP) track with essential information only.
  **/
-struct CTPPSLocalTrackLite
+class CTPPSLocalTrackLite
 {
   public:
-    CTPPSLocalTrackLite(uint32_t pid=0, float px=0., float pxu=-1., float py=0., float pyu=-1., float pt=0., float ptu=-1.)
+    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), time(0.), time_unc(-1.)
+    {
+    }
+
+    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float pt=0., float ptu=-1.)
       : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), time(pt), time_unc(ptu)
     {
     }
 
+    /// returns the RP id
     uint32_t getRPId() const
     {
       return rpId;
     }
 
+    /// returns the horizontal track position
     float getX() const
     {
       return x;
     }
 
+    /// returns the horizontal track position uncertainty
     float getXUnc() const
     {
       return x_unc;
     }
 
+    /// returns the vertical track position
     float getY() const
     {
       return y;
     }
 
+    /// returns the vertical track position uncertainty
     float getYUnc() const
     {
       return y_unc;
     }
 
+    /// returns the track time
     float getTime() const
     {
       return time;
     }
 
+    /// returns the track time uncertainty
     float getTimeUnc() const
     {
       return time_unc;

--- a/DataFormats/CTPPSReco/src/classes.h
+++ b/DataFormats/CTPPSReco/src/classes.h
@@ -7,6 +7,8 @@
 #include "DataFormats/CTPPSReco/interface/TotemRPUVPattern.h"
 #include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"
 
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+
 #include <vector>
 
 namespace DataFormats_CTPPSReco {
@@ -35,5 +37,13 @@ namespace DataFormats_CTPPSReco {
     edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack>> w_dsv_ft;
     edm::DetSetVector<TotemRPLocalTrack::FittedRecHit> dsv_ft_frh;
     edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack::FittedRecHit>> w_dsv_ft_frh;
+   
+    std::vector<edm::DetSet<TotemRPLocalTrack::FittedRecHit> > v_ds_ft_frh;
+    std::vector<TotemRPLocalTrack::FittedRecHit> v_ft_frh;
+
+    CTPPSLocalTrackLite cltl;
+    std::vector<CTPPSLocalTrackLite> v_cltl;
+    edm::Wrapper<CTPPSLocalTrackLite> w_cltl;
+    edm::Wrapper<std::vector<CTPPSLocalTrackLite>> w_v_cltl;
   };
 }

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -34,8 +34,8 @@
   <class name="std::vector<edm::DetSet<TotemRPLocalTrack::FittedRecHit> >"/>
   <class name="std::vector<TotemRPLocalTrack::FittedRecHit>"/>
 
-  <class name="CTPPSLocalTrackLite"  ClassVersion="2">
-    <version ClassVersion="2" checksum="3838813906"/>
+  <class name="CTPPSLocalTrackLite" ClassVersion="3">
+    <version ClassVersion="3" checksum="3838813906"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -31,4 +31,13 @@
   <class name="edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack>>"/>
   <class name="edm::DetSetVector<TotemRPLocalTrack::FittedRecHit>"/>
   <class name="edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack::FittedRecHit>>"/>
+  <class name="std::vector<edm::DetSet<TotemRPLocalTrack::FittedRecHit> >"/>
+  <class name="std::vector<TotemRPLocalTrack::FittedRecHit>"/>
+
+  <class name="CTPPSLocalTrackLite"  ClassVersion="2">
+    <version ClassVersion="2" checksum="3838813906"/>
+  </class>
+  <class name="std::vector<CTPPSLocalTrackLite>"/>
+  <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>
+  <class name="edm::Wrapper<std::vector<CTPPSLocalTrackLite>>"/>
 </lcgdict>

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -66,6 +66,8 @@ MicroEventContent = cms.PSet(
         'keep recoBeamHaloSummary_BeamHaloSummary_*_*',
         # Lumi
         'keep LumiScalerss_scalersRawToDigi_*_*',
+        # CTPPS
+        'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
     )
 )
 MicroEventContentMC = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -295,6 +295,8 @@ def miniAOD_customizeCommon(process):
     process.slimmedMETsPuppi.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyPuppi")
     del process.slimmedMETsPuppi.caloMET
 
+    process.load("RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi")
+
 
 
 def miniAOD_customizeMC(process):

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -295,8 +295,6 @@ def miniAOD_customizeCommon(process):
     process.slimmedMETsPuppi.tXYUncForT01Smear = cms.InputTag("patPFMetT0pcT1SmearTxyPuppi")
     del process.slimmedMETsPuppi.caloMET
 
-    process.load("RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi")
-
 
 
 def miniAOD_customizeMC(process):
@@ -336,6 +334,8 @@ def miniAOD_customizeOutput(out):
 def miniAOD_customizeData(process):
     from PhysicsTools.PatAlgos.tools.coreTools import runOnData
     runOnData( process, outputModules = [] )
+
+    process.load("RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi")
 
 def miniAOD_customizeAllData(process):
     miniAOD_customizeCommon(process)

--- a/RecoCTPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
+++ b/RecoCTPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
@@ -9,7 +9,10 @@ RecoCTPPSFEVT = cms.PSet(
     'keep TotemRPClusteredmDetSetVector_totemRPClusterProducer_*_*',
     'keep TotemRPRecHitedmDetSetVector_totemRPRecHitProducer_*_*',
     'keep TotemRPUVPatternedmDetSetVector_totemRPUVPatternFinder_*_*',
-    'keep TotemRPLocalTrackedmDetSetVector_totemRPLocalTrackFitter_*_*'
+    'keep TotemRPLocalTrackedmDetSetVector_totemRPLocalTrackFitter_*_*',
+
+    # CTPPS common
+    'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
   )
 )
 
@@ -23,7 +26,10 @@ RecoCTPPSRECO = cms.PSet(
     'keep TotemRPClusteredmDetSetVector_totemRPClusterProducer_*_*',
     'keep TotemRPRecHitedmDetSetVector_totemRPRecHitProducer_*_*',
     'keep TotemRPUVPatternedmDetSetVector_totemRPUVPatternFinder_*_*',
-    'keep TotemRPLocalTrackedmDetSetVector_totemRPLocalTrackFitter_*_*'
+    'keep TotemRPLocalTrackedmDetSetVector_totemRPLocalTrackFitter_*_*',
+
+    # CTPPS common
+    'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
   )
 )
 
@@ -37,6 +43,9 @@ RecoCTPPSAOD = cms.PSet(
     'keep TotemRPClusteredmDetSetVector_totemRPClusterProducer_*_*',
     'keep TotemRPRecHitedmDetSetVector_totemRPRecHitProducer_*_*',
     'keep TotemRPUVPatternedmDetSetVector_totemRPUVPatternFinder_*_*',
-    'keep TotemRPLocalTrackedmDetSetVector_totemRPLocalTrackFitter_*_*'
+    'keep TotemRPLocalTrackedmDetSetVector_totemRPLocalTrackFitter_*_*',
+
+    # CTPPS common
+    'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
   )
 )

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -1,0 +1,81 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Authors:
+*   Jan Kašpar (jan.kaspar@gmail.com)
+*
+****************************************************************************/
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+
+//----------------------------------------------------------------------------------------------------
+
+/**
+ * \brief Distills the essential track data from all RPs.
+ **/
+class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<>
+{
+  public:
+    explicit CTPPSLocalTrackLiteProducer(const edm::ParameterSet& conf);
+  
+    virtual ~CTPPSLocalTrackLiteProducer() {}
+  
+    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  
+  private:
+    edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> siStripTrackToken;
+};
+
+//----------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------
+
+using namespace std;
+using namespace edm;
+
+//----------------------------------------------------------------------------------------------------
+
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(edm::ParameterSet const& conf)
+{
+  siStripTrackToken = consumes<DetSetVector<TotemRPLocalTrack>>(conf.getParameter<edm::InputTag>("tagSiStripTrack"));
+
+  produces<vector<CTPPSLocalTrackLite>>();
+}
+
+//----------------------------------------------------------------------------------------------------
+ 
+void CTPPSLocalTrackLiteProducer::produce(edm::Event& e, const edm::EventSetup& es)
+{
+  // get input from Si strips
+  edm::Handle< DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
+  e.getByToken(siStripTrackToken, inputSiStripTracks);
+
+  // prepare output
+  vector<CTPPSLocalTrackLite> output;
+  
+  // process tracks from Si strips
+  for (const auto rpv : *inputSiStripTracks)
+  {
+    const uint32_t rpId = rpv.detId();
+
+    for (const auto t : rpv)
+    {
+      if (t.isValid())
+        output.push_back(CTPPSLocalTrackLite(rpId, t.getX0(), t.getX0Sigma(), t.getY0(), t.getY0Sigma()));
+    }
+  }
+
+  // save output to event
+  e.put(make_unique<vector<CTPPSLocalTrackLite>>(output));
+}
+
+//----------------------------------------------------------------------------------------------------
+
+DEFINE_FWK_MODULE(CTPPSLocalTrackLiteProducer);

--- a/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
+++ b/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+ctppsLocalTrackLiteProducer = cms.EDProducer("CTPPSLocalTrackLiteProducer",
+    tagSiStripTrack = cms.InputTag("totemRPLocalTrackFitter")
+)

--- a/RecoCTPPS/TotemRPLocal/python/totemRPLocalReconstruction_cff.py
+++ b/RecoCTPPS/TotemRPLocal/python/totemRPLocalReconstruction_cff.py
@@ -15,9 +15,14 @@ from RecoCTPPS.TotemRPLocal.totemRPUVPatternFinder_cfi import *
 # local track fitting
 from RecoCTPPS.TotemRPLocal.totemRPLocalTrackFitter_cfi import *
 
+# lite local-track collection from all RPs
+from RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi import *
+
 totemRPLocalReconstruction = cms.Sequence(
     totemRPClusterProducer *
     totemRPRecHitProducer *
     totemRPUVPatternFinder *
-    totemRPLocalTrackFitter
+    totemRPLocalTrackFitter *
+
+    ctppsLocalTrackLiteProducer
 )


### PR DESCRIPTION
This is a minimal back-port of #17162 intended for the upcoming re-miniAOD campaign. Minimal in the sense that the DetId-related changes in #17162 are not back-ported.

`runTheMatrix.py -l limited` yields
```
	10 10 9 7 5 1 1 1 tests passed, 0 0 0 0 0 0 0 0 failed
```

Regarding the potential problem in #17162, I've run
```
runTheMatrix.py -l 136.731 -j 16 -t 8
```
5 times, on 3 different Lxplus nodes. There was one crash with a signature different from what is discussed for #17162, therefore non conclusive.