### PR TITLE
Fix for exotica simulation

### DIFF
--- a/SimG4Core/CustomPhysics/python/CustomPhysics_cfi.py
+++ b/SimG4Core/CustomPhysics/python/CustomPhysics_cfi.py
@@ -17,6 +17,8 @@ customPhysicsSetup = cms.PSet(
     gamma = cms.double(0.1),
     reggeModel = cms.bool(False),
     hadronLifeTime = cms.double(-1.),
-    mixing = cms.double(1.)
+    mixing = cms.double(1.),
 
+    # dark photon
+    dark_factor = cms.double(1.0)
 )

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -26,7 +26,7 @@ CustomPhysicsList::CustomPhysicsList(std::string name, const edm::ParameterSet &
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
-    dfactor = p.getParameter<double>("dark_factor");
+  dfactor = p.getParameter<double>("dark_factor");
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
   fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
 

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -33,7 +33,7 @@ CustomPhysicsList::CustomPhysicsList(std::string name, const edm::ParameterSet &
   particleDefFilePath = fp.fullPath();
   edm::LogInfo("SimG4CoreCustomPhysics") 
     << "CustomPhysicsList: Path for custom particle definition file: \n"
-    <<particleDefFilePath;
+    <<particleDefFilePath << "\n" << "      dark_factor= " << dfactor;
 }
 
 CustomPhysicsList::~CustomPhysicsList() {


### PR DESCRIPTION
The default value of a factor for EM coupling of a dark photon was not defined. No effect for the default production. Likely should be backported to 7_1_X.