### PR TITLE
add base configuration for arbitrary pileup functions

### DIFF
--- a/SimGeneral/MixingModule/python/mix_probFunction_25ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_probFunction_25ns_PoissonOOTPU_cfi.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup with an arbitrary function
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("EmbeddedRootSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          # The following lines define a flat distribution from 0-9 interactions
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9),
+          # sum of probValues should be 1.0!
+          probValue = cms.vdouble(
+                       0.1,
+                       0.1,
+                       0.1,
+                       0.1,
+                       0.1,
+                       0.1,
+                       0.1,
+                       0.1,
+                       0.1,
+                       0.1
+                    ),
+
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+	sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+


### PR DESCRIPTION
Simplify specification of new pileup distributions by providing all basic Run 2 beam parameters for pileup.  New pileup distributions can be specified by only giving the function itself.