### PR TITLE
RPCRecHit local x position correction

### DIFF
--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
@@ -12,6 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
 
 // First Step
 bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
@@ -24,18 +25,32 @@ bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
   const float fstrip = (roll.centreOfStrip(cluster.firstStrip())).x();
   const float lstrip = (roll.centreOfStrip(cluster.lastStrip())).x();
   const float centreOfCluster = (fstrip + lstrip)/2;
+  const double y = cluster.hasY() ? cluster.y() : 0;
+  Point = LocalPoint(centreOfCluster, y, 0);
 
-  Point = LocalPoint(centreOfCluster,cluster.y(),0);
   if ( !cluster.hasY() ) {
     error = LocalError(roll.localError((cluster.firstStrip()+cluster.lastStrip())/2.));
   }
   else {
     // Use the default one for local x error
-    const float ex2 = roll.localError((cluster.firstStrip()+cluster.lastStrip())/2.).xx();
+    float ex2 = roll.localError((cluster.firstStrip()+cluster.lastStrip())/2.).xx();
     // Maximum estimate of local y error, (distance to the boundary)/sqrt(3)
     // which gives consistent error to the default one at y=0
     const float stripLen = roll.specificTopology().stripLength();
     const float maxDy = stripLen/2 - std::abs(cluster.y());
+
+    // Apply x-position correction for the endcap
+    if ( roll.id().region() != 0 ) {
+      const auto& topo = dynamic_cast<const TrapezoidalStripTopology&>(roll.topology());
+      const double angle = topo.stripAngle((cluster.firstStrip()+cluster.lastStrip())/2.);
+      const double x = centreOfCluster + y*std::tan(angle);
+      Point = LocalPoint(x, y, 0);
+
+      // rescale x-error by the change of local pitch
+      const double scale = topo.localPitch(Point)/topo.pitch();
+      ex2 *= scale*scale;
+    }
+
     error = LocalError(ex2, 0, maxDy*maxDy/3.);
   }
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitStandardAlgo.cc
@@ -43,7 +43,7 @@ bool RPCRecHitStandardAlgo::compute(const RPCRoll& roll,
     if ( roll.id().region() != 0 ) {
       const auto& topo = dynamic_cast<const TrapezoidalStripTopology&>(roll.topology());
       const double angle = topo.stripAngle((cluster.firstStrip()+cluster.lastStrip())/2.);
-      const double x = centreOfCluster + y*std::tan(angle);
+      const double x = centreOfCluster - y*std::tan(angle);
       Point = LocalPoint(x, y, 0);
 
       // rescale x-error by the change of local pitch


### PR DESCRIPTION
The local x-position of RPCRecHit was computed as the center of the clustered strips at y=0.
Since the y-measurement is available for iRPC chambers, the x-position of the RPCRecHits have to be corrected to account trapezoidal shape of the endcap chambers.

Related PR: #17252