### PR TITLE
Silent warning due to missing templates in PhaseII

### DIFF
--- a/DQM/TrackingMonitor/python/trackingRecoMaterialAnalyzer_cfi.py
+++ b/DQM/TrackingMonitor/python/trackingRecoMaterialAnalyzer_cfi.py
@@ -18,6 +18,9 @@ materialDumperAnalyzer = cms.EDAnalyzer("TrackingRecoMaterialAnalyser",
                                         PropagatorOpposite = cms.string("RungeKuttaTrackerPropagatorOpposite")
 )
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(materialDumperAnalyzer, TrackerRecHitBuilder='WithTrackAngle')
+
 materialDumper = cms.Sequence(materialDumperAnalyzer)
 materialDumper_step = cms.Path(materialDumper)
 


### PR DESCRIPTION
The materialDumpAnalyser uses internally a refitter to
extract the angle of incidence of the track with respect to
the sensor surface. The refitter uses 'angleAndTemplate',
that in PhaseII is missing. This PR drops the template
part.