### PR TITLE
Switching BoostedDoubleSV tagger to v4 training for AK8 jets

### DIFF
--- a/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
@@ -4,7 +4,7 @@ from RecoBTag.SecondaryVertex.trackSelection_cff import *
 
 candidateBoostedDoubleSecondaryVertexAK8Computer = cms.ESProducer("CandidateBoostedDoubleSecondaryVertexESProducer",
     useCondDB = cms.bool(False),
-    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_v3.weights.xml.gz'),
+    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_v4.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(False)
 )


### PR DESCRIPTION
New BoostedDoubleSV tagger training for AK8 jets presented in https://indico.cern.ch/event/596134/contributions/2413751/attachments/1391765/2120352/double-b-v4.pdf

Request to add new training to externals is here https://github.com/cms-sw/cmsdist/issues/2788

@cvernier