### PR TITLE
Fix config for Phase2 EB trig prim digis

### DIFF
--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -38,3 +38,7 @@ phase2_timing.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outpu
 
 phase2_timing.toModify(SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EETimeDigi_*') )
 phase2_timing.toModify(SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EBTimeDigi_*') )
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )
+phase2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simEcalUnsuppressedDigis_*_*') )

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 # This object modifies the event content for different scenarios
-from Configuration.StandardSequences.Eras import eras
 
 SimCalorimetryFEVTDEBUG = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_simEcalDigis_*_*', 
         'keep *_simEcalPreshowerDigis_*_*', 
         'keep *_simEcalTriggerPrimitiveDigis_*_*', 
-        'keep *_simEcalEBTriggerPrimitiveDigis_*_*', 
+        'keep *_simEcalEBTriggerPrimitiveDigis_*_*',
         'keep *_simHcalDigis_*_*', 
         'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
         'drop ZDCDataFramesSorted_mix_simHcalUnsuppressedDigis*_*',
@@ -29,5 +28,13 @@ SimCalorimetryAOD = cms.PSet(
 #
 # Add extra event content if running in Run 2
 #
-eras.run2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
-eras.run2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+run2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
+run2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
+
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+phase2_timing.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EETimeDigi_*') )
+phase2_timing.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EBTimeDigi_*') )
+
+phase2_timing.toModify(SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EETimeDigi_*') )
+phase2_timing.toModify(SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_mix_EBTimeDigi_*') )

--- a/SimCalorimetry/Configuration/python/ecalDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/ecalDigiSequence_cff.py
@@ -11,8 +11,9 @@ from SimCalorimetry.EcalZeroSuppressionProducers.ecalPreshowerDigis_cfi import *
 # simEcalUnsuppressedDigis is now done inside mixing module
 ecalDigiSequence = cms.Sequence(simEcalTriggerPrimitiveDigis*simEcalDigis*simEcalPreshowerDigis)
 
-from SimCalorimetry.EcalEBTrigPrimProducers.ecalEBTriggerPrimitiveDigis_cff import simEcalEBTriggerPrimitiveDigis as _simEcalEBTriggerPrimitiveDigis
-_phase2_ecalDigiSequence = cms.Sequence(_simEcalEBTriggerPrimitiveDigis*ecalDigiSequence)
+from SimCalorimetry.EcalEBTrigPrimProducers.ecalEBTriggerPrimitiveDigis_cff import *
+_phase2_ecalDigiSequence = ecalDigiSequence.copy()
+_phase2_ecalDigiSequence.insert(0,simEcalEBTriggerPrimitiveDigis)
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toReplaceWith(ecalDigiSequence,_phase2_ecalDigiSequence)

--- a/SimCalorimetry/Configuration/python/ecalDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/ecalDigiSequence_cff.py
@@ -3,15 +3,18 @@ import FWCore.ParameterSet.Config as cms
 # unsuppressed digis simulation - fast preshower
 from SimCalorimetry.EcalSimProducers.ecaldigi_cfi import *
 # ECAL Trigger Primitives (needed by SRP)
-from SimCalorimetry.EcalEBTrigPrimProducers.ecalEBTriggerPrimitiveDigis_cff import *
 from SimCalorimetry.EcalTrigPrimProducers.ecalTriggerPrimitiveDigis_cff import *
 # Selective Readout Processor producer
 from SimCalorimetry.EcalSelectiveReadoutProducers.ecalDigis_cfi import *
 # Preshower Zero suppression producer
 from SimCalorimetry.EcalZeroSuppressionProducers.ecalPreshowerDigis_cfi import *
 # simEcalUnsuppressedDigis is now done inside mixing module
-ecalDigiSequence = cms.Sequence(simEcalEBTriggerPrimitiveDigis*simEcalTriggerPrimitiveDigis*simEcalDigis*simEcalPreshowerDigis)
+ecalDigiSequence = cms.Sequence(simEcalTriggerPrimitiveDigis*simEcalDigis*simEcalPreshowerDigis)
 
+from SimCalorimetry.EcalEBTrigPrimProducers.ecalEBTriggerPrimitiveDigis_cff import simEcalEBTriggerPrimitiveDigis as _simEcalEBTriggerPrimitiveDigis
+_phase2_ecalDigiSequence = cms.Sequence(_simEcalEBTriggerPrimitiveDigis*ecalDigiSequence)
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(ecalDigiSequence,_phase2_ecalDigiSequence)
 
 

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalEBTrigPrimTestAlgo.cc
@@ -208,7 +208,6 @@ void EcalEBTrigPrimTestAlgo::run(const edm::EventSetup & setup,
     const EcalTrigTowerDetId &thisTower=hitTowers_[itow].second;
     if (debug_) std::cout << " Data for TOWER num " << itow << " index " << index << " TowerId " << thisTower <<  " size " << towerMapEB_[itow].size() << std::endl;    
     // loop over all strips assigned to this trigger tower
-    int nstr=0;
     int nxstals=0;
     for(unsigned int iStrip = 0; iStrip < towerMapEB_[itow].size();++iStrip)
       {

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalFenixLinearizer.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalFenixLinearizer.cc
@@ -34,7 +34,6 @@ void EcalFenixLinearizer::setParameters(uint32_t raw, const EcalTPGPedestals * e
   }
   else std::cout <<" could not find EcalTPGLinearizationConstMap entry for "<<raw << std::endl;
 
-  const EcalTPGPedestalsMap & pedMap = ecaltpPed->getMap() ;
   EcalTPGPedestalsMapIterator itped=ecaltpPed->find(raw);
   if (itped!=ecaltpPed->end())   peds_=&(*itped);
   else std::cout <<" could not find EcalTPGPedestalsMap entry for "<<raw << std::endl;

--- a/SimCalorimetry/EcalEBTrigPrimProducers/python/ecalEBTriggerPrimitiveDigis_cff.py
+++ b/SimCalorimetry/EcalEBTrigPrimProducers/python/ecalEBTriggerPrimitiveDigis_cff.py
@@ -10,5 +10,5 @@ from SimCalorimetry.EcalEBTrigPrimProducers.ecalEBTriggerPrimitiveDigis_cfi impo
 
 
 #Common
-from Configuration.StandardSequences.Eras import eras
-eras.phase2_hgcal.toModify( simEcalEBTriggerPrimitiveDigis, BarrelOnly = cms.bool(True) )
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hgcal.toModify( simEcalEBTriggerPrimitiveDigis, BarrelOnly = cms.bool(True) )


### PR DESCRIPTION
This should resolve regressions introduced in #16598.

attn: @nancymarinelli, @smuzaffar, @rekovic 

@nancymarinelli, the `BarrelOnly` parameter can probably be removed from your new modules (since they are EB-only anyway), but that's not urgent.