### PR TITLE
[90X] Fully geometry-independent TkAl-PCL

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterSelector.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterSelector.cc
@@ -336,7 +336,7 @@ unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInp
     numAli += this->add(theTracker->subStructures(substructName), paramSel);
   }
   ////////////////////////////////////
-  // Old hardcoded (i.e. deprecated) tracker section (NOTE: no check on theTracker != 0)
+  // Old hardcoded, but geometry-independent tracker section (NOTE: no check on theTracker != 0)
   ////////////////////////////////////
   else if (name == "AllDets")       numAli += this->addAllDets(paramSel);
   else if (name == "AllRods")       numAli += this->addAllRods(paramSel);
@@ -375,6 +375,7 @@ unsigned int AlignmentParameterSelector::addSelection(const std::string &nameInp
   else if (name == "PXECDets") numAli += this->add(theTracker->pixelEndcapGeomDets(), paramSel);
   else if (name == "PXECPetals") numAli += this->add(theTracker->pixelEndcapPetals(), paramSel);
   else if (name == "PXECLayers") numAli += this->add(theTracker->pixelEndcapLayers(), paramSel);
+  else if (name == "PXECHalfCylinders") numAli += this->add(theTracker->pixelEndcapHalfCylinders(), paramSel);
   else if (name == "PXEndCaps") numAli += this->add(theTracker->pixelEndCaps(), paramSel);
   //
   // Pixel Barrel+endcap

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
@@ -80,13 +80,8 @@ from Alignment.CommonAlignmentProducer.TrackerAlignmentProducerForPCL_cff import
 SiPixelAliMilleAlignmentProducer = copy.deepcopy(AlignmentProducer)
 SiPixelAliMilleAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
     alignParams = cms.vstring(
-        'TrackerTPBHalfBarrel,111111',
-        'TrackerTPEHalfCylinder,111111',
-
-        'TrackerTIBHalfBarrel,000000',
-        'TrackerTOBHalfBarrel,000000',
-        'TrackerTIDEndcap,000000',
-        'TrackerTECEndcap,000000'
+        "PixelHalfBarrels,111111",
+        "PXECHalfCylinders,111111",
         )
     )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
@@ -78,13 +78,8 @@ from Alignment.CommonAlignmentProducer.TrackerAlignmentProducerForPCL_cff import
 SiPixelAliMilleAlignmentProducer = copy.deepcopy(AlignmentProducer)
 SiPixelAliMilleAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
     alignParams = cms.vstring(
-        'TrackerTPBHalfBarrel,111111',
-        'TrackerTPEHalfCylinder,111111',
-
-        'TrackerTIBHalfBarrel,000000',
-        'TrackerTOBHalfBarrel,000000',
-        'TrackerTIDEndcap,000000',
-        'TrackerTECEndcap,000000'
+        "PixelHalfBarrels,111111",
+        "PXECHalfCylinders,111111",
         )
     )
 

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester0T_cff.py
@@ -15,13 +15,8 @@ SiPixelAliPedeAlignmentProducer = copy.deepcopy(AlignmentProducer)
 
 SiPixelAliPedeAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
     alignParams = cms.vstring(
-        'TrackerTPBHalfBarrel,111111',
-        'TrackerTPEHalfCylinder,111111',
-
-        'TrackerTIBHalfBarrel,000000',
-        'TrackerTOBHalfBarrel,000000',
-        'TrackerTIDEndcap,000000',
-        'TrackerTECEndcap,000000'
+        "PixelHalfBarrels,111111",
+        "PXECHalfCylinders,111111",
         )
     )
 

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -18,13 +18,8 @@ from Alignment.MillePedeAlignmentAlgorithm.MillePedeDQMModule_cff import *
 
 SiPixelAliPedeAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
     alignParams = cms.vstring(
-        'TrackerTPBHalfBarrel,111111',
-        'TrackerTPEHalfCylinder,111111',
-
-        'TrackerTIBHalfBarrel,000000',
-        'TrackerTOBHalfBarrel,000000',
-        'TrackerTIDEndcap,000000',
-        'TrackerTECEndcap,000000'
+        "PixelHalfBarrels,111111",
+        "PXECHalfCylinders,111111",
         )
     )
 

--- a/Alignment/TrackerAlignment/interface/AlignableTracker.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTracker.h
@@ -56,6 +56,10 @@ public:
   Alignables& TIDs() {
     return this->subStructures(alignableObjectId_.typeToName(align::TIDEndcap));
   }
+  /// Return pixel endcap half cylinders
+  Alignables& pixelEndcapHalfCylinders() {
+    return this->subStructures(alignableObjectId_.typeToName(align::TPEHalfCylinder));
+  }
 
   /// Return inner and outer barrel GeomDets together 
   Alignables barrelGeomDets() { return this->merge(this->innerBarrelGeomDets(),


### PR DESCRIPTION
Finalize work on geometry-independent TkAl-PCL.
The code changes allow a transparent transition from phase-0 to phase-1 geometry w/o requiring the PCL configuration to be changed.
Independent of the used tracker geometry, this configuration will now select automatically the correct alignables.