### PR TITLE
Bugfix EcalSimProducer for APD simulation

### DIFF
--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -246,6 +246,7 @@ EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::stream
    if( m_apdSeparateDigi )
    {
      m_APDCoder.reset( new EcalCoder( false            , 
+                                      m_PreMix1        ,
                                       m_EBCorrNoise[0].get() ,
                                       m_EECorrNoise[0].get() ,
                                       m_EBCorrNoise[1].get() ,


### PR DESCRIPTION
I found a bug in a part of the code that's not used in the standard sequences (needed only if one wants to simulate ECAL barrel "spike" noise).