### PR TITLE
Backported fix for simulation of exotica 

### DIFF
--- a/SimG4Core/CustomPhysics/python/CustomPhysics_cfi.py
+++ b/SimG4Core/CustomPhysics/python/CustomPhysics_cfi.py
@@ -16,7 +16,9 @@ customPhysicsSetup = cms.PSet(
     gamma = cms.double(0.1),
     reggeModel = cms.bool(False),
     hadronLifeTime = cms.double(-1.),
-    mixing = cms.double(1.)
+    mixing = cms.double(1.),
 
+    # dark photon
+    dark_factor = cms.double(1.0)
 )
 

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -33,7 +33,7 @@ CustomPhysicsList::CustomPhysicsList(std::string name, const edm::ParameterSet &
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
   particleDefFilePath = fp.fullPath();
   edm::LogInfo("CustomPhysics")<<"Path for custom particle definition file: "
-			       <<particleDefFilePath;
+			       <<particleDefFilePath<< "\n" << "      dark_factor= " << dfactor;
   myHelper = 0;  
 }
 


### PR DESCRIPTION
Bugfix #17283 is backported. The fix does not affect any run for normal primary particles.