### PR TITLE
Update 2017 default datasets

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1699,8 +1699,8 @@ steps['DBLMINIAODMCUP15NODQM'] = merge([{'--conditions':'auto:run2_mc',
 from  Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
 
 defaultDataSets={}
-defaultDataSets['2017']='CMSSW_8_1_0_pre16-81X_upgrade2017_realistic_v22-v'
-defaultDataSets['2017Design']='CMSSW_8_1_0_pre16-81X_upgrade2017_design_IdealBS_v6-v'
+defaultDataSets['2017']='CMSSW_8_1_0-81X_upgrade2017_realistic_v26-v'
+defaultDataSets['2017Design']='CMSSW_9_0_0_pre1-90X_upgrade2017_design_IdealBS_v0-v'
 defaultDataSets['2023D7']=''
 defaultDataSets['2023D10']=''
 defaultDataSets['2023D7Timing']=''


### PR DESCRIPTION
This PR proposes to update the 2017 default GEN-SIM datasets to the latest ones. Running
```
runTheMatrix -i all -l 10020.0,10024.0
```
fails on DAS query e.g. in CMSSW_9_0_X_2017-01-22-2300
```
das_client --limit 0 --query 'file dataset=/RelValTenMuE_0_200/CMSSW_8_1_0_pre16-81X_upgrade2017_realistic_v22-v1/GEN-SIM site=T2_CH_CERN'
```

Checking the sites of this dataset gives
```
$ das_client --limit 0 --query 'site dataset=/RelValTenMuE_0_200/CMSSW_8_1_0_pre16-81X_upgrade2017_realistic_v22-v1/GEN-SIM'
T1_US_FNAL_Disk
T1_US_FNAL_MSS
T1_US_FNAL_Buffer
```
while for the most recent ones
```
$ das_client --limit 0 --query 'site dataset=/RelValTTbar_13/CMSSW_8_1_0-81X_upgrade2017_realistic_v26-v1/GEN-SIM'
T1_US_FNAL_Disk
T1_US_FNAL_Buffer
T2_CH_CERN
T1_US_FNAL_MSS
$ das_client --limit 0 --query 'site dataset=/RelValTTbar_13/CMSSW_9_0_0_pre1-90X_upgrade2017_design_IdealBS_v0-v1/GEN-SIM'
T1_US_FNAL_Buffer
T1_US_FNAL_Disk
T2_CH_CERN
T1_US_FNAL_MSS
```
T2_CH_CERN is listed.

Tested in CMSSW_9_0_X_2017-01-22-2300, the 2017 workflows run again with `-i all`.