### PR TITLE
geometry updates: Tracker and Gem affecting 2017 and 2018 scenarios

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,17 +38,17 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v4',
+    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '90X_upgrade2017_realistic_v4',
+    'phase1_2017_realistic': '90X_upgrade2017_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v4',
+    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v2',
+    'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic': '90X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic': '90X_upgrade2018_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_cosmics':   '90X_upgrade2018cosmics_realistic_peak_v2',
+    'phase1_2018_cosmics':   '90X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunII simulation

   * **PhaseI 2017 design scenario** : [90X_upgrade2017_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_design_IdealBS_v4) as [90X_upgrade2017_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_design_IdealBS_v5) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_design_IdealBS_v4/90X_upgrade2017_design_IdealBS_v5):
      * GEM slice test added: reco and sim geometry
      * pixel overlap fixes and connectors fixes, and correspondingly updated RECO geometry
      * summary of geometry related PR's involved in this talk by @ianna https://indico.cern.ch/event/592612/contributions/2447142/
      * HE sim nor reco geometries touched, all left as already merged for 90x in PR 17198

   * **PhaseI 2017 realistic scenario** : [90X_upgrade2017_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v5) as [90X_upgrade2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_realistic_v5/90X_upgrade2017_realistic_v4):
      * GEM slice test added: reco and sim geometry
      * pixel overlap fixes and connectors fixes, and correspondingly updated RECO geometry
      * summary of geometry related PR's involved in this talk by @ianna https://indico.cern.ch/event/592612/contributions/2447142/
      * HE sim nor reco geometries touched, all left as already merged for 90x in PR 17198

   * **PhaseI 2017 cosmics scenario** : [90X_upgrade2017cosmics_realistic_peak_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v5) as [90X_upgrade2017cosmics_realistic_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v5/90X_upgrade2017cosmics_realistic_peak_v4):
      * GEM slice test added: reco and sim geometry
      * pixel overlap fixes and connectors fixes, and correspondingly updated RECO geometry
      * summary of geometry related PR's involved in this talk by @ianna https://indico.cern.ch/event/592612/contributions/2447142/
      * HE sim nor reco geometries touched, all left as already merged for 90x in PR 17198
      
   * **PhaseI 2018 design scenario** : [90X_upgrade2018_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_design_IdealBS_v3) as [90X_upgrade2018_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018_design_IdealBS_v3/90X_upgrade2018_design_IdealBS_v2):
      * the same logical changes as for 2017 (above) are done here for 2018, however on top of HCAL where HE is phaseI
      * GEM slice test added: reco and sim geometry
      * pixel overlap fixes and connectors fixes, and correspondingly updated RECO geometry
      * summary of geometry related PR's involved in this talk by @ianna https://indico.cern.ch/event/592612/contributions/2447142/

   * **PhaseI 2018 realistic scenario** : [90X_upgrade2018_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_realistic_v3) as [90X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018_realistic_v3/90X_upgrade2018_realistic_v2):
      * the same logical changes as for 2017 (above) are done here for 2018, however on top of HCAL where HE is phaseI
      * GEM slice test added: reco and sim geometry
      * pixel overlap fixes and connectors fixes, and correspondingly updated RECO geometry
      * summary of geometry related PR's involved in this talk by @ianna https://indico.cern.ch/event/592612/contributions/2447142/

   * **PhaseI 2018 cosmics scenario** : [90X_upgrade2018cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018cosmics_realistic_peak_v3) as [90X_upgrade2018cosmics_realistic_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018cosmics_realistic_peak_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018cosmics_realistic_peak_v3/90X_upgrade2018cosmics_realistic_peak_v2):
      * the same logical changes as for 2017 (above) are done here for 2018, however on top of HCAL where HE is phaseI
      * GEM slice test added: reco and sim geometry
      * pixel overlap fixes and connectors fixes, and correspondingly updated RECO geometry
      * summary of geometry related PR's involved in this talk by @ianna https://indico.cern.ch/event/592612/contributions/2447142/