### PR TITLE
Fix of GenFilterInfo in CMSSW_8_0_X

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenFilterInfo.cc
@@ -86,7 +86,7 @@ double GenFilterInfo::filterEfficiency(int idwtup) const {
     eff = numEventsTotal() > 0 ? (double) numEventsPassed() / (double) numEventsTotal(): -1;
     break;
   default:
-    eff = sumWeights() > 1e-6? sumPassWeights()/sumWeights(): -1;
+    eff = sumWeights() > 0? sumPassWeights()/sumWeights(): -1;
     break;
   }
   return eff;
@@ -99,14 +99,14 @@ double GenFilterInfo::filterEfficiencyError(int idwtup) const {
   switch(idwtup) {
   case 3: case -3:
     {
-      double effp  = numTotalPositiveEvents() > 1e-6? 
+      double effp  = numTotalPositiveEvents() > 0? 
 	(double)numPassPositiveEvents()/(double)numTotalPositiveEvents():0;
-      double effp_err2 = numTotalPositiveEvents() > 1e-6?
+      double effp_err2 = numTotalPositiveEvents() > 0?
 	(1-effp)*effp/(double)numTotalPositiveEvents(): 0;
 
-      double effn  = numTotalNegativeEvents() > 1e-6? 
+      double effn  = numTotalNegativeEvents() > 0? 
 	(double)numPassNegativeEvents()/(double)numTotalNegativeEvents():0;
-      double effn_err2 = numTotalNegativeEvents() > 1e-6? 
+      double effn_err2 = numTotalNegativeEvents() > 0? 
 	(1-effn)*effn/(double)numTotalNegativeEvents(): 0;
 
       efferr = numEventsTotal() > 0 ? sqrt ( 
@@ -122,7 +122,7 @@ double GenFilterInfo::filterEfficiencyError(int idwtup) const {
       double numerator =
 	sumPassWeights2() * sumFailWeights()* sumFailWeights() +
 	sumFailWeights2() * sumPassWeights()* sumPassWeights();
-      efferr = denominator>1e-6? 
+      efferr = denominator>0? 
 	sqrt(numerator/denominator):-1;
       break;
     }


### PR DESCRIPTION
replace all the 1e-6 with zeros so that when the cross sections or weights are small, the output filter or jet matching efficiency are correctly computed.