### PR TITLE
Add HcalHPD type

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -564,30 +564,37 @@ HcalSiPMParameter HcalDbHardcode::makeHardcodeSiPMParameter (HcalGenericDetId fI
   HcalSiPMType theType = HcalNoSiPM;
   double thePe2fC = getParameters(fId).photoelectronsToAnalog();
   double theDC = getParameters(fId).darkCurrent(0);
-  if (fId.genericSubdet() == HcalGenericDetId::HcalGenBarrel && useHBUpgrade_) {
-    HcalDetId hid(fId);
-    int nLayersInDepth = getLayersInDepth(hid.ietaAbs(),hid.depth(),topo);
-    if(nLayersInDepth > 4) {
-      theType = HcalHBHamamatsu2;
-      theDC = getParameters(fId).darkCurrent(1);
+  if (fId.genericSubdet() == HcalGenericDetId::HcalGenBarrel) {
+    if(useHBUpgrade_) {
+      HcalDetId hid(fId);
+      int nLayersInDepth = getLayersInDepth(hid.ietaAbs(),hid.depth(),topo);
+      if(nLayersInDepth > 4) {
+        theType = HcalHBHamamatsu2;
+        theDC = getParameters(fId).darkCurrent(1);
+      }
+      else {
+        theType = HcalHBHamamatsu1;
+        theDC = getParameters(fId).darkCurrent(0);
+      }
     }
-    else {
-      theType = HcalHBHamamatsu1;
-      theDC = getParameters(fId).darkCurrent(0);
+    else theType = HcalHPD;
+  } else if (fId.genericSubdet() == HcalGenericDetId::HcalGenEndcap) {
+    if(useHEUpgrade_) {
+      HcalDetId hid(fId);
+      int nLayersInDepth = getLayersInDepth(hid.ietaAbs(),hid.depth(),topo);
+      if(nLayersInDepth > 4) {
+        theType = HcalHEHamamatsu2;
+        theDC = getParameters(fId).darkCurrent(1);
+      }
+      else {
+        theType = HcalHEHamamatsu1;
+        theDC = getParameters(fId).darkCurrent(0);
+      }
     }
-  } else if (fId.genericSubdet() == HcalGenericDetId::HcalGenEndcap && useHEUpgrade_) {
-    HcalDetId hid(fId);
-    int nLayersInDepth = getLayersInDepth(hid.ietaAbs(),hid.depth(),topo);
-    if(nLayersInDepth > 4) {
-      theType = HcalHEHamamatsu2;
-      theDC = getParameters(fId).darkCurrent(1);
-    }
-    else {
-      theType = HcalHEHamamatsu1;
-      theDC = getParameters(fId).darkCurrent(0);
-    }
-  } else if (fId.genericSubdet() == HcalGenericDetId::HcalGenOuter && useHOUpgrade_) {
-    theType = HcalHOHamamatsu;
+    else theType = HcalHPD;
+  } else if (fId.genericSubdet() == HcalGenericDetId::HcalGenOuter) {
+    if(useHOUpgrade_) theType = HcalHOHamamatsu;
+    else theType = HcalHPD;
   }
   
   return HcalSiPMParameter(fId.rawId(), theType, thePe2fC, theDC, 0, 0);
@@ -597,7 +604,7 @@ void HcalDbHardcode::makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& s
   // SiPMCharacteristics are constants for each type of SiPM:
   // Type, # of pixels, 3 parameters for non-linearity, cross talk parameter, ..
   // Obtained from data sheet and measurements
-  // types (in order): HcalHOZecotek=1, HcalHOHamamatsu, HcalHEHamamatsu1, HcalHEHamamatsu2, HcalHBHamamatsu1
+  // types (in order): HcalHOZecotek=1, HcalHOHamamatsu, HcalHEHamamatsu1, HcalHEHamamatsu2, HcalHBHamamatsu1, HcalHBHamamatsu2, HcalHPD
   for(unsigned ip = 0; ip < theSiPMCharacteristics_.size(); ++ip){
     auto& ps = theSiPMCharacteristics_[ip];
     sipm.loadObject(ip+1,

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -35,7 +35,7 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         qieSlope      = cms.vdouble(0.912,0.917,0.922,0.923),
         mcShape       = cms.int32(125),
         recoShape     = cms.int32(105),
-        photoelectronsToAnalog = cms.double(0.0),
+        photoelectronsToAnalog = cms.double(0.3305),
         darkCurrent   = cms.vdouble(0.0),
     ),
     he = cms.PSet(
@@ -48,7 +48,7 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         qieSlope      = cms.vdouble(0.912,0.916,0.920,0.922),
         mcShape       = cms.int32(125),
         recoShape     = cms.int32(105),
-        photoelectronsToAnalog = cms.double(0.0),
+        photoelectronsToAnalog = cms.double(0.3305),
         darkCurrent   = cms.vdouble(0.0),
     ),
     hf = cms.PSet(
@@ -116,7 +116,7 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         photoelectronsToAnalog = cms.double(0.0),
         darkCurrent   = cms.vdouble(0.0),
     ),
-    # types (in order): HcalHOZecotek, HcalHOHamamatsu, HcalHEHamamatsu1, HcalHEHamamatsu2, HcalHBHamamatsu1, HcalHBHamamatsu2
+    # types (in order): HcalHOZecotek, HcalHOHamamatsu, HcalHEHamamatsu1, HcalHEHamamatsu2, HcalHBHamamatsu1, HcalHBHamamatsu2, HcalHPD
     SiPMCharacteristics = cms.VPSet(
         cms.PSet( pixels = cms.int32(36000), crosstalk = cms.double(0.0), nonlin1 = cms.double(1.0), nonlin2 = cms.double(0.0), nonlin3 = cms.double(0.0) ),
         cms.PSet( pixels = cms.int32(2500), crosstalk = cms.double(0.0), nonlin1 = cms.double(1.0), nonlin2 = cms.double(0.0), nonlin3 = cms.double(0.0) ),
@@ -124,6 +124,7 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
         cms.PSet( pixels = cms.int32(38018), crosstalk = cms.double(0.196), nonlin1 = cms.double(1.00546), nonlin2 = cms.double(6.40239E-6), nonlin3 = cms.double(1.27011E-10) ),
         cms.PSet( pixels = cms.int32(27370), crosstalk = cms.double(0.17), nonlin1 = cms.double(1.00985), nonlin2 = cms.double(7.84089E-6), nonlin3 = cms.double(2.86282E-10) ),
         cms.PSet( pixels = cms.int32(38018), crosstalk = cms.double(0.196), nonlin1 = cms.double(1.00546), nonlin2 = cms.double(6.40239E-6), nonlin3 = cms.double(1.27011E-10) ),
+        cms.PSet( pixels = cms.int32(0), crosstalk = cms.double(0.0), nonlin1 = cms.double(1.0), nonlin2 = cms.double(0.0), nonlin3 = cms.double(0.0) ),
     ),
 )
 

--- a/CalibFormats/HcalObjects/interface/HcalSiPMType.h
+++ b/CalibFormats/HcalObjects/interface/HcalSiPMType.h
@@ -3,6 +3,6 @@
 
 enum HcalSiPMType {HcalNoSiPM=0, HcalHOZecotek=1, HcalHOHamamatsu=2, 
 		   HcalHEHamamatsu1=3, HcalHEHamamatsu2=4, HcalHBHamamatsu1=5,
-		   HcalHBHamamatsu2=6};
+		   HcalHBHamamatsu2=6, HcalHPD=7};
 
 #endif


### PR DESCRIPTION
Based on discussions in #17311, this PR adds an "HcalHPD" type to the `HcalSiPMType` enum. This is done in order to access per-channel `photoelectronsToAnalog` values for HPDs from the database, repurposing the `SiPMParameters` object. The hardcode conditions are updated appropriately. All other values for SiPM-related quantities will be set to dummy values, since they will not be used for HPDs.

I tested the effect of this PR locally by changing the `photoelectronsToAnalog` value in `Hcal_Conditions_forGlobalTag_cff` and observing changes in digi, rechit, etc. distributions. No changes in central workflows are expected.

Updates to the database conditions for HCAL will follow separately. Removal of the `photoelectronsToAnalog` Python parameter in `hcalSimParameters_cfi` may also follow separately.

attn: @abdoulline, @mariadalfonso 