### PR TITLE
DQM plots for the Phase 2 Track Trigger

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -836,12 +836,11 @@ if fastSim.isChosen():
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
-  phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + [
-  'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
-  'keep *_TTClustersFromPhase2TrackerDigis_*_*',
-  'keep *_TTStubsFromPhase2TrackerDigis_*_*'
-   ])
-
+    phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + [
+        'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
+        'keep *_TTClustersFromPhase2TrackerDigis_*_*',
+        'keep *_TTStubsFromPhase2TrackerDigis_*_*'
+    ])
 
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import RecoLocalFastTimeFEVT, RecoLocalFastTimeRECO, RecoLocalFastTimeAOD
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
@@ -853,4 +852,3 @@ _addOutputCommands(FEVTDEBUGHLTEventContent,RecoLocalFastTimeFEVT)
 _addOutputCommands(FEVTEventContent,RecoLocalFastTimeFEVT)
 _addOutputCommands(RECOSIMEventContent,RecoLocalFastTimeRECO)
 _addOutputCommands(AODSIMEventContent,RecoLocalFastTimeAOD)
-

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1810,16 +1810,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     if cust!=None : upgradeStepDict['DigiFull'][k]['--customise']=cust
     if era is not None: upgradeStepDict['DigiFull'][k]['--era']=era
     
-    upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),
-                                      '--conditions':gt,
-                                      '--datatier':'GEN-SIM-DIGI-RAW',
-                                      '-n':'10',
-                                      '--eventcontent':'FEVTDEBUGHLT',
-                                      '--geometry' : geom
-                                      }
-    if cust!=None : upgradeStepDict['DigiFullTrigger'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['DigiFullTrigger'][k]['--era']=era
-    
     if k2 in PUDataSets:
         upgradeStepDict['DigiFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['DigiFull'][k]])
 
@@ -1834,8 +1824,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     if cust!=None : upgradeStepDict['DigiFullTrigger'][k]['--customise']=cust
     if era is not None: upgradeStepDict['DigiFullTrigger'][k]['--era']=era
- 
- 
+
+
     if k2 in PUDataSets:
         upgradeStepDict['DigiFullTriggerPU'][k]=merge([PUDataSets[k2],upgradeStepDict['DigiFullTrigger'][k]])
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1809,7 +1809,17 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     if cust!=None : upgradeStepDict['DigiFull'][k]['--customise']=cust
     if era is not None: upgradeStepDict['DigiFull'][k]['--era']=era
- 
+    
+    upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),
+                                      '--conditions':gt,
+                                      '--datatier':'GEN-SIM-DIGI-RAW',
+                                      '-n':'10',
+                                      '--eventcontent':'FEVTDEBUGHLT',
+                                      '--geometry' : geom
+                                      }
+    if cust!=None : upgradeStepDict['DigiFullTrigger'][k]['--customise']=cust
+    if era is not None: upgradeStepDict['DigiFullTrigger'][k]['--era']=era
+    
     if k2 in PUDataSets:
         upgradeStepDict['DigiFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['DigiFull'][k]])
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1809,7 +1809,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     if cust!=None : upgradeStepDict['DigiFull'][k]['--customise']=cust
     if era is not None: upgradeStepDict['DigiFull'][k]['--era']=era
-    
+ 
     if k2 in PUDataSets:
         upgradeStepDict['DigiFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['DigiFull'][k]])
 
@@ -1824,8 +1824,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     if cust!=None : upgradeStepDict['DigiFullTrigger'][k]['--customise']=cust
     if era is not None: upgradeStepDict['DigiFullTrigger'][k]['--era']=era
-
-
+ 
+ 
     if k2 in PUDataSets:
         upgradeStepDict['DigiFullTriggerPU'][k]=merge([PUDataSets[k2],upgradeStepDict['DigiFullTrigger'][k]])
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -81,8 +81,7 @@ upgradeSteps=[
     'HARVESTFull_trackingOnlyPU',
     'HARVESTFullGlobal',
     'HARVESTFullGlobalPU',
-    'ALCAFull',
-    'DigiFullTrigger'
+    'ALCAFull'
 ]
 
 upgradeProperties = {}

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -81,7 +81,8 @@ upgradeSteps=[
     'HARVESTFull_trackingOnlyPU',
     'HARVESTFullGlobal',
     'HARVESTFullGlobalPU',
-    'ALCAFull'
+    'ALCAFull',
+    'DigiFullTrigger'
 ]
 
 upgradeProperties = {}

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-### put L1 track trigger configs here
-
 from L1Trigger.TrackTrigger.TrackTrigger_cff import *
+##from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 
-
+#L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
 L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs)

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTCluster.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTCluster.h
@@ -12,8 +12,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DQM/SiStripCommon/interface/TkHistoMap.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTCluster.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTCluster.h
@@ -1,0 +1,61 @@
+#ifndef Phase2OuterTracker_OuterTrackerMonitorTTCluster_h
+#define Phase2OuterTracker_OuterTrackerMonitorTTCluster_h
+
+#include <vector>
+#include <memory>
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+class DQMStore;
+
+class OuterTrackerMonitorTTCluster : public edm::EDAnalyzer {
+
+public:
+  explicit OuterTrackerMonitorTTCluster(const edm::ParameterSet&);
+  ~OuterTrackerMonitorTTCluster();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob() ;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+ 
+  // TTCluster stacks
+  MonitorElement* Cluster_IMem_Barrel = 0;
+  MonitorElement* Cluster_IMem_Endcap_Disc = 0;
+  MonitorElement* Cluster_IMem_Endcap_Ring = 0;
+  MonitorElement* Cluster_IMem_Endcap_Ring_Fw[5] = {0, 0, 0, 0, 0};
+  MonitorElement* Cluster_IMem_Endcap_Ring_Bw[5] = {0, 0, 0, 0, 0};
+  MonitorElement* Cluster_OMem_Barrel = 0;
+  MonitorElement* Cluster_OMem_Endcap_Disc = 0;
+  MonitorElement* Cluster_OMem_Endcap_Ring = 0;
+  MonitorElement* Cluster_OMem_Endcap_Ring_Fw[5] = {0, 0, 0, 0, 0};
+  MonitorElement* Cluster_OMem_Endcap_Ring_Bw[5] = {0, 0, 0, 0, 0};
+  MonitorElement* Cluster_W = 0;
+  MonitorElement* Cluster_Eta = 0;
+  
+  MonitorElement* Cluster_Barrel_XY = 0;
+  MonitorElement* Cluster_Barrel_XY_Zoom = 0;
+  MonitorElement* Cluster_Endcap_Fw_XY = 0;
+  MonitorElement* Cluster_Endcap_Bw_XY = 0;
+  MonitorElement* Cluster_RZ = 0;
+  MonitorElement* Cluster_Endcap_Fw_RZ_Zoom = 0;
+  MonitorElement* Cluster_Endcap_Bw_RZ_Zoom = 0;
+
+ private:
+  DQMStore* dqmStore_;
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > >  tagTTClustersToken_;
+
+  std::string topFolderName_;
+};
+#endif

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTClusterClient.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTClusterClient.h
@@ -12,8 +12,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DQM/SiStripCommon/interface/TkHistoMap.h"
 
 class DQMStore;
 

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTClusterClient.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTClusterClient.h
@@ -1,0 +1,31 @@
+#ifndef Phase2OuterTracker_OuterTrackerMonitorTTClusterClient_h
+#define Phase2OuterTracker_OuterTrackerMonitorTTClusterClient_h
+
+
+#include <vector>
+#include <memory>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
+
+class DQMStore;
+
+class OuterTrackerMonitorTTClusterClient : public edm::EDAnalyzer {
+
+public:
+  explicit OuterTrackerMonitorTTClusterClient(const edm::ParameterSet&);
+  ~OuterTrackerMonitorTTClusterClient();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  //virtual void beginJob() ;
+  virtual void endJob() ;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  
+};
+#endif

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStub.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStub.h
@@ -1,0 +1,75 @@
+#ifndef Phase2OuterTracker_OuterTrackerMonitorTTStub_h
+#define Phase2OuterTracker_OuterTrackerMonitorTTStub_h
+
+#include <vector>
+#include <memory>
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+class DQMStore;
+
+class OuterTrackerMonitorTTStub : public edm::EDAnalyzer {
+
+public:
+  explicit OuterTrackerMonitorTTStub(const edm::ParameterSet&);
+  ~OuterTrackerMonitorTTStub();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob() ;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+ 
+  // TTStub stacks
+  // * Global position of the stubs * //
+  MonitorElement* Stub_Barrel_XY = 0;  //TTStub barrel y vs x
+  MonitorElement* Stub_Barrel_XY_Zoom = 0;  //TTStub barrel y vs x zoom
+  MonitorElement* Stub_Endcap_Fw_XY = 0; //TTStub Forward Endcap y vs. x
+  MonitorElement* Stub_Endcap_Bw_XY = 0; //TTStub Backward Endcap y vs. x
+  MonitorElement* Stub_RZ = 0; // TTStub #rho vs. z
+  MonitorElement* Stub_Endcap_Fw_RZ_Zoom = 0; // TTStub Forward Endcap #rho vs. z
+  MonitorElement* Stub_Endcap_Bw_RZ_Zoom = 0; // TTStub Backward Endcap #rho vs. z
+  
+  // * Number of stubs * //
+  MonitorElement* Stub_Barrel = 0; //TTStub per layer
+  MonitorElement* Stub_Endcap_Disc = 0; // TTStubs per disc
+  MonitorElement* Stub_Endcap_Disc_Fw = 0; //TTStub per disc	
+  MonitorElement* Stub_Endcap_Disc_Bw = 0; //TTStub per disc
+  MonitorElement* Stub_Endcap_Ring = 0; // TTStubs per ring
+  MonitorElement* Stub_Endcap_Ring_Fw[5] = {0, 0, 0, 0, 0}; // TTStubs per EC ring
+  MonitorElement* Stub_Endcap_Ring_Bw[5] = {0, 0, 0, 0, 0}; //TTStub per EC ring
+  
+  // * Stub Eta distribution * //
+  MonitorElement* Stub_Eta = 0; //TTstub eta distribution
+  
+  // * STUB Displacement - offset * //
+  MonitorElement* Stub_Barrel_W = 0; //TTstub Pos-Corr Displacement (layer)
+  MonitorElement* Stub_Barrel_O = 0; // TTStub Offset (layer)
+  MonitorElement* Stub_Endcap_Disc_W = 0; // TTstub Pos-Corr Displacement (disc)
+  MonitorElement* Stub_Endcap_Disc_O = 0; // TTStub Offset (disc)
+  MonitorElement* Stub_Endcap_Ring_W = 0; // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement* Stub_Endcap_Ring_O = 0; // TTStub Offset (EC ring)
+  MonitorElement* Stub_Endcap_Ring_W_Fw[5] = {0, 0, 0, 0, 0}; // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement* Stub_Endcap_Ring_O_Fw[5] = {0, 0, 0, 0, 0}; // TTStub Offset (EC ring)
+  MonitorElement* Stub_Endcap_Ring_W_Bw[5] = {0, 0, 0, 0, 0}; // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement* Stub_Endcap_Ring_O_Bw[5] = {0, 0, 0, 0, 0}; // TTStub Offset (EC ring)
+
+ private:
+  DQMStore* dqmStore_;
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > > >  tagTTStubsToken_;
+
+  std::string topFolderName_;
+};
+#endif
+
+

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStub.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStub.h
@@ -12,8 +12,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DQM/SiStripCommon/interface/TkHistoMap.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStubClient.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStubClient.h
@@ -1,0 +1,31 @@
+#ifndef Phase2OuterTracker_OuterTrackerMonitorTTStubClient_h
+#define Phase2OuterTracker_OuterTrackerMonitorTTStubClient_h
+
+
+#include <vector>
+#include <memory>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
+
+class DQMStore;
+
+class OuterTrackerMonitorTTStubClient : public edm::EDAnalyzer {
+
+public:
+  explicit OuterTrackerMonitorTTStubClient(const edm::ParameterSet&);
+  ~OuterTrackerMonitorTTStubClient();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  //virtual void beginJob() ;
+  virtual void endJob() ;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  
+};
+#endif

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStubClient.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStubClient.h
@@ -12,8 +12,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DQM/SiStripCommon/interface/TkHistoMap.h"
 
 class DQMStore;
 

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrack.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrack.h
@@ -1,0 +1,67 @@
+#ifndef Phase2OuterTracker_OuterTrackerMonitorTTTrack_h
+#define Phase2OuterTracker_OuterTrackerMonitorTTTrack_h
+
+#include <vector>
+#include <memory>
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+class DQMStore;
+
+class OuterTrackerMonitorTTTrack : public edm::EDAnalyzer {
+
+public:
+  explicit OuterTrackerMonitorTTTrack(const edm::ParameterSet&);
+  ~OuterTrackerMonitorTTTrack();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob() ;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+ 
+  
+  MonitorElement* Track_N = 0;
+  MonitorElement* Track_NStubs = 0;
+  
+  /// Low-quality TTTracks (made from less than X TTStubs)
+  MonitorElement* Track_LQ_N = 0;
+  MonitorElement* Track_LQ_Pt = 0;
+  MonitorElement* Track_LQ_Eta = 0;
+  MonitorElement* Track_LQ_Phi = 0;
+  MonitorElement* Track_LQ_VtxZ0 = 0;
+  MonitorElement* Track_LQ_Chi2 = 0;
+  MonitorElement* Track_LQ_Chi2Red = 0;
+  MonitorElement* Track_LQ_Chi2_NStubs = 0;
+  MonitorElement* Track_LQ_Chi2Red_NStubs = 0;
+  
+  /// High-quality TTTracks (made from at least X TTStubs)
+  MonitorElement* Track_HQ_N = 0;
+  MonitorElement* Track_HQ_Pt = 0;
+  MonitorElement* Track_HQ_Eta = 0;
+  MonitorElement* Track_HQ_Phi = 0;
+  MonitorElement* Track_HQ_VtxZ0 = 0;
+  MonitorElement* Track_HQ_Chi2 = 0;
+  MonitorElement* Track_HQ_Chi2Red = 0;
+  MonitorElement* Track_HQ_Chi2_NStubs = 0;
+  MonitorElement* Track_HQ_Chi2Red_NStubs = 0;
+
+
+ private:
+  DQMStore* dqmStore_;
+  edm::ParameterSet conf_;
+  //edm::EDGetTokenT<edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > > >  tagTTTracksToken_;
+
+  std::string topFolderName_;
+  unsigned int HQDelim_;
+};
+#endif

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrack.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrack.h
@@ -12,8 +12,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DQM/SiStripCommon/interface/TkHistoMap.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrackClient.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrackClient.h
@@ -1,0 +1,31 @@
+#ifndef Phase2OuterTracker_OuterTrackerMonitorTTTrackClient_h
+#define Phase2OuterTracker_OuterTrackerMonitorTTTrackClient_h
+
+
+#include <vector>
+#include <memory>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
+
+class DQMStore;
+
+class OuterTrackerMonitorTTTrackClient : public edm::EDAnalyzer {
+
+public:
+  explicit OuterTrackerMonitorTTTrackClient(const edm::ParameterSet&);
+  ~OuterTrackerMonitorTTTrackClient();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  //virtual void beginJob() ;
+  virtual void endJob() ;
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  
+};
+#endif

--- a/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrackClient.h
+++ b/DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrackClient.h
@@ -12,8 +12,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DQM/SiStripCommon/interface/TkHistoMap.h"
 
 class DQMStore;
 

--- a/DQM/Phase2OuterTracker/plugins/BuildFile.xml
+++ b/DQM/Phase2OuterTracker/plugins/BuildFile.xml
@@ -1,0 +1,17 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ParameterSet"/>
+<use name="DQMServices/Core"/>
+<use name="CommonTools/TriggerUtils"/>
+<use name="DataFormats/L1TrackTrigger"/>
+<use name="DataFormats/L1Trigger"/>
+<use name="CalibTracker/Records"/>
+<use name="CondFormats/L1TObjects"/>
+<use name="DPGAnalysis/SiStripTools"/>
+<use name="DQM/SiStripCommon"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="SimDataFormats/TrackingAnalysis"/>
+<use name="SimDataFormats/TrackingHit"/>
+<use name="SimTracker/TrackerHitAssociation"/>
+<flags EDM_PLUGIN="1"/>

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
@@ -1,0 +1,389 @@
+// -*- C++ -*-
+//
+// Package:    Phase2OuterTracker
+// Class:      Phase2OuterTracker
+//
+/**\class Phase2OuterTracker OuterTrackerMonitorTTCluster.cc DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+ 
+ Description: [one line class summary]
+ 
+ Implementation:
+ [Notes on implementation]
+ */
+//
+// Original Author:  Isabelle Helena J De Bruyn
+//         Created:  Mon, 10 Feb 2014 13:57:08 GMT
+//
+
+// system include files
+#include <memory>
+#include <vector>
+#include <numeric>
+#include <iostream>
+#include <fstream>
+#include <math.h>
+#include "TMath.h"
+#include "TNamed.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
+#include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTCluster.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
+
+//
+// constructors and destructor
+//
+OuterTrackerMonitorTTCluster::OuterTrackerMonitorTTCluster(const edm::ParameterSet& iConfig)
+: dqmStore_(edm::Service<DQMStore>().operator->()), conf_(iConfig)
+{
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+  tagTTClustersToken_ = consumes<edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > (conf_.getParameter<edm::InputTag>("TTClusters") );
+}
+
+OuterTrackerMonitorTTCluster::~OuterTrackerMonitorTTCluster()
+{
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void OuterTrackerMonitorTTCluster::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  /// Track Trigger Clusters
+  edm::Handle< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > Phase2TrackerDigiTTClusterHandle;
+  iEvent.getByToken( tagTTClustersToken_, Phase2TrackerDigiTTClusterHandle );
+  
+  /// Geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  const TrackerTopology* tTopo;
+  iSetup.get< TrackerTopologyRcd >().get(tTopoHandle);
+  tTopo = tTopoHandle.product();
+  
+  edm::ESHandle< TrackerGeometry > tGeometryHandle;
+  const TrackerGeometry* theTrackerGeometry;
+  iSetup.get< TrackerDigiGeometryRecord >().get( tGeometryHandle );
+  theTrackerGeometry = tGeometryHandle.product();
+  
+  
+  /// Loop over the input Clusters
+  typename edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >::const_iterator inputIter;
+  typename edmNew::DetSet< TTCluster< Ref_Phase2TrackerDigi_ > >::const_iterator contentIter;
+  for ( inputIter = Phase2TrackerDigiTTClusterHandle->begin();
+        inputIter != Phase2TrackerDigiTTClusterHandle->end();
+        ++inputIter )
+  {
+    for(contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter)
+    { 
+      //Make reference cluster
+      edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > tempCluRef = edmNew::makeRefTo( Phase2TrackerDigiTTClusterHandle, contentIter );
+      
+      DetId detIdClu = theTrackerGeometry->idToDet( tempCluRef->getDetId() )->geographicalId();
+      unsigned int memberClu = tempCluRef->getStackMember();
+      unsigned int widClu = tempCluRef->findWidth();
+      
+      MeasurementPoint mp = tempCluRef->findAverageLocalCoordinates();
+      const GeomDet* theGeomDet = theTrackerGeometry->idToDet(detIdClu);
+      Global3DPoint posClu = theGeomDet->surface().toGlobal( theGeomDet->topology().localPosition(mp) );
+      
+      double eta = posClu.eta();
+      
+      Cluster_W->Fill(widClu, memberClu);
+      Cluster_Eta->Fill(eta);
+      Cluster_RZ->Fill( posClu.z(), posClu.perp() );
+      
+      if ( detIdClu.subdetId() == static_cast<int>(StripSubdetector::TOB) )  // Phase 2 Outer Tracker Barrel
+      {
+        
+        if ( memberClu == 0 ) Cluster_IMem_Barrel->Fill(tTopo->layer(detIdClu));
+        else Cluster_OMem_Barrel->Fill(tTopo->layer(detIdClu));
+        
+        Cluster_Barrel_XY->Fill( posClu.x(), posClu.y() );
+        Cluster_Barrel_XY_Zoom->Fill( posClu.x(), posClu.y() );
+        
+      }	// end if isBarrel
+      else if ( detIdClu.subdetId() == static_cast<int>(StripSubdetector::TID) )  // Phase 2 Outer Tracker Endcap
+      {
+        
+        if ( memberClu == 0 )
+        {
+          Cluster_IMem_Endcap_Disc->Fill(tTopo->layer(detIdClu)); // returns wheel
+          Cluster_IMem_Endcap_Ring->Fill(tTopo->tidRing(detIdClu));
+        }
+        else
+        {
+          Cluster_OMem_Endcap_Disc->Fill(tTopo->layer(detIdClu)); // returns wheel
+          Cluster_OMem_Endcap_Ring->Fill(tTopo->tidRing(detIdClu));
+        }
+        
+        if ( posClu.z() > 0 )
+        {
+          Cluster_Endcap_Fw_XY->Fill( posClu.x(), posClu.y() );
+          Cluster_Endcap_Fw_RZ_Zoom->Fill( posClu.z(), posClu.perp() );
+          if (memberClu == 0) Cluster_IMem_Endcap_Ring_Fw[tTopo->layer(detIdClu)-1]->Fill(tTopo->tidRing(detIdClu));
+          else Cluster_OMem_Endcap_Ring_Fw[tTopo->layer(detIdClu)-1]->Fill(tTopo->tidRing(detIdClu));
+        }
+        else
+        {
+          Cluster_Endcap_Bw_XY->Fill( posClu.x(), posClu.y() );
+          Cluster_Endcap_Bw_RZ_Zoom->Fill( posClu.z(), posClu.perp() );
+          if (memberClu == 0) Cluster_IMem_Endcap_Ring_Bw[tTopo->layer(detIdClu)-1]->Fill(tTopo->tidRing(detIdClu));
+          else Cluster_OMem_Endcap_Ring_Bw[tTopo->layer(detIdClu)-1]->Fill(tTopo->tidRing(detIdClu));
+        }
+        
+      } // end if isEndcap
+    } // end loop contentIter
+  } // end loop inputIter
+} // end of method
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+OuterTrackerMonitorTTCluster::beginRun(const edm::Run& run, const edm::EventSetup& es)
+{
+  SiStripFolderOrganizer folder_organizer;
+  folder_organizer.setSiStripFolderName(topFolderName_);
+  folder_organizer.setSiStripFolder();	
+  std::string HistoName;
+  
+  dqmStore_->setCurrentFolder(topFolderName_+"/Clusters/NClusters");
+  
+  // NClusters
+  edm::ParameterSet psTTCluster_Barrel =  conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Barrel");
+  HistoName = "NClusters_IMem_Barrel";
+  Cluster_IMem_Barrel = dqmStore_->book1D(HistoName, HistoName,
+      psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Barrel.getParameter<double>("xmin"),
+      psTTCluster_Barrel.getParameter<double>("xmax"));
+  Cluster_IMem_Barrel->setAxisTitle("Barrel Layer", 1);
+  Cluster_IMem_Barrel->setAxisTitle("# L1 Clusters", 2);
+  
+  HistoName = "NClusters_OMem_Barrel";
+  Cluster_OMem_Barrel = dqmStore_->book1D(HistoName, HistoName,
+      psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Barrel.getParameter<double>("xmin"),
+      psTTCluster_Barrel.getParameter<double>("xmax"));
+  Cluster_OMem_Barrel->setAxisTitle("Barrel Layer", 1);
+  Cluster_OMem_Barrel->setAxisTitle("# L1 Clusters", 2);
+  
+  edm::ParameterSet psTTCluster_ECDisc =  conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECDiscs");
+  HistoName = "NClusters_IMem_Endcap_Disc";
+  Cluster_IMem_Endcap_Disc = dqmStore_->book1D(HistoName, HistoName,
+      psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_ECDisc.getParameter<double>("xmin"),
+      psTTCluster_ECDisc.getParameter<double>("xmax"));
+  Cluster_IMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
+  Cluster_IMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
+  
+  HistoName = "NClusters_OMem_Endcap_Disc";
+  Cluster_OMem_Endcap_Disc = dqmStore_->book1D(HistoName, HistoName,
+      psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_ECDisc.getParameter<double>("xmin"),
+      psTTCluster_ECDisc.getParameter<double>("xmax"));
+  Cluster_OMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
+  Cluster_OMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
+  
+  edm::ParameterSet psTTCluster_ECRing =  conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECRings");  
+  HistoName = "NClusters_IMem_Endcap_Ring";
+  Cluster_IMem_Endcap_Ring = dqmStore_->book1D(HistoName, HistoName,
+      psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_ECRing.getParameter<double>("xmin"),
+      psTTCluster_ECRing.getParameter<double>("xmax"));
+  Cluster_IMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
+  Cluster_IMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
+  
+  HistoName = "NClusters_OMem_Endcap_Ring";
+  Cluster_OMem_Endcap_Ring = dqmStore_->book1D(HistoName, HistoName,
+      psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_ECRing.getParameter<double>("xmin"),
+      psTTCluster_ECRing.getParameter<double>("xmax"));
+  Cluster_OMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
+  Cluster_OMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "NClusters_IMem_Disc+%d", i+1);  
+    Cluster_IMem_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(histo, histo, 
+        psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
+        psTTCluster_ECRing.getParameter<double>("xmin"), 
+        psTTCluster_ECRing.getParameter<double>("xmax")); 
+    Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring",1); 
+    Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ",2);
+  }
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "NClusters_IMem_Disc-%d", i+1);  
+    Cluster_IMem_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(histo, histo, 
+        psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
+        psTTCluster_ECRing.getParameter<double>("xmin"), 
+        psTTCluster_ECRing.getParameter<double>("xmax")); 
+    Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring",1); 
+    Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ",2);
+  }
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "NClusters_OMem_Disc+%d", i+1);  
+    Cluster_OMem_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(histo, histo, 
+        psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
+        psTTCluster_ECRing.getParameter<double>("xmin"), 
+        psTTCluster_ECRing.getParameter<double>("xmax")); 
+    Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring",1); 
+    Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ",2);
+  }
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "NClusters_OMem_Disc-%d", i+1);  
+    Cluster_OMem_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(histo, histo, 
+        psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
+        psTTCluster_ECRing.getParameter<double>("xmin"), 
+        psTTCluster_ECRing.getParameter<double>("xmax")); 
+    Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring",1); 
+    Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ",2);
+  }
+  
+  
+  dqmStore_->setCurrentFolder(topFolderName_+"/Clusters");
+        
+  //Cluster Width
+  edm::ParameterSet psTTClusterWidth =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Width");
+  HistoName = "Cluster_W";
+  Cluster_W = dqmStore_->book2D(HistoName, HistoName,
+      psTTClusterWidth.getParameter<int32_t>("Nbinsx"),
+      psTTClusterWidth.getParameter<double>("xmin"),
+      psTTClusterWidth.getParameter<double>("xmax"),
+      psTTClusterWidth.getParameter<int32_t>("Nbinsy"),
+      psTTClusterWidth.getParameter<double>("ymin"),
+      psTTClusterWidth.getParameter<double>("ymax"));
+  Cluster_W->setAxisTitle("L1 Cluster Width", 1);
+  Cluster_W->setAxisTitle("Stack Member", 2);
+  
+  //Cluster eta distribution
+  edm::ParameterSet psTTClusterEta = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Eta");
+  HistoName = "Cluster_Eta";
+  Cluster_Eta = dqmStore_->book1D(HistoName, HistoName, 
+      psTTClusterEta.getParameter<int32_t>("Nbinsx"),
+      psTTClusterEta.getParameter<double>("xmin"),
+      psTTClusterEta.getParameter<double>("xmax"));
+  Cluster_Eta->setAxisTitle("#eta", 1);
+  Cluster_Eta->setAxisTitle("# L1 Clusters", 2);
+  
+  dqmStore_->setCurrentFolder(topFolderName_+"/Clusters/Position");
+  
+  //Position plots
+  edm::ParameterSet psTTCluster_Barrel_XY =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  HistoName = "Cluster_Barrel_XY";
+  Cluster_Barrel_XY = dqmStore_->book2D(HistoName, HistoName,
+      psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Barrel_XY.getParameter<double>("xmin"),
+      psTTCluster_Barrel_XY.getParameter<double>("xmax"),
+      psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsy"),
+      psTTCluster_Barrel_XY.getParameter<double>("ymin"),
+      psTTCluster_Barrel_XY.getParameter<double>("ymax"));
+  Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position x [cm]", 1);
+  Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position y [cm]", 2);
+  
+  edm::ParameterSet psTTCluster_Barrel_XY_Zoom =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Barrel_XY_Zoom");
+  HistoName = "Cluster_Barrel_XY_Zoom";
+  Cluster_Barrel_XY_Zoom = dqmStore_->book2D(HistoName, HistoName,
+      psTTCluster_Barrel_XY_Zoom.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Barrel_XY_Zoom.getParameter<double>("xmin"),
+      psTTCluster_Barrel_XY_Zoom.getParameter<double>("xmax"),
+      psTTCluster_Barrel_XY_Zoom.getParameter<int32_t>("Nbinsy"),
+      psTTCluster_Barrel_XY_Zoom.getParameter<double>("ymin"),
+      psTTCluster_Barrel_XY_Zoom.getParameter<double>("ymax"));
+  Cluster_Barrel_XY_Zoom->setAxisTitle("L1 Cluster Barrel position x [cm]", 1);
+  Cluster_Barrel_XY_Zoom->setAxisTitle("L1 Cluster Barrel position y [cm]", 2);
+  
+  edm::ParameterSet psTTCluster_Endcap_Fw_XY =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  HistoName = "Cluster_Endcap_Fw_XY";
+  Cluster_Endcap_Fw_XY = dqmStore_->book2D(HistoName, HistoName,
+      psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Endcap_Fw_XY.getParameter<double>("xmin"),
+      psTTCluster_Endcap_Fw_XY.getParameter<double>("xmax"),
+      psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
+      psTTCluster_Endcap_Fw_XY.getParameter<double>("ymin"),
+      psTTCluster_Endcap_Fw_XY.getParameter<double>("ymax"));
+  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position x [cm]", 1);
+  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position y [cm]", 2);
+  
+  edm::ParameterSet psTTCluster_Endcap_Bw_XY =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  HistoName = "Cluster_Endcap_Bw_XY";
+  Cluster_Endcap_Bw_XY = dqmStore_->book2D(HistoName, HistoName,
+      psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Endcap_Bw_XY.getParameter<double>("xmin"),
+      psTTCluster_Endcap_Bw_XY.getParameter<double>("xmax"),
+      psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
+      psTTCluster_Endcap_Bw_XY.getParameter<double>("ymin"),
+      psTTCluster_Endcap_Bw_XY.getParameter<double>("ymax"));
+  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position x [cm]", 1);
+  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position y [cm]", 2);
+  
+  //TTCluster #rho vs. z
+  edm::ParameterSet psTTCluster_RZ =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_RZ");
+  HistoName = "Cluster_RZ";
+  Cluster_RZ = dqmStore_->book2D(HistoName, HistoName,
+      psTTCluster_RZ.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_RZ.getParameter<double>("xmin"),
+      psTTCluster_RZ.getParameter<double>("xmax"),
+      psTTCluster_RZ.getParameter<int32_t>("Nbinsy"),
+      psTTCluster_RZ.getParameter<double>("ymin"),
+      psTTCluster_RZ.getParameter<double>("ymax"));
+  Cluster_RZ->setAxisTitle("L1 Cluster position z [cm]", 1);
+  Cluster_RZ->setAxisTitle("L1 Cluster position #rho [cm]", 2);
+  
+  //TTCluster Forward Endcap #rho vs. z
+  edm::ParameterSet psTTCluster_Endcap_Fw_RZ_Zoom =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Endcap_Fw_RZ_Zoom");
+  HistoName = "Cluster_Endcap_Fw_RZ_Zoom";
+  Cluster_Endcap_Fw_RZ_Zoom = dqmStore_->book2D(HistoName, HistoName,
+      psTTCluster_Endcap_Fw_RZ_Zoom.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Endcap_Fw_RZ_Zoom.getParameter<double>("xmin"),
+      psTTCluster_Endcap_Fw_RZ_Zoom.getParameter<double>("xmax"),
+      psTTCluster_Endcap_Fw_RZ_Zoom.getParameter<int32_t>("Nbinsy"),
+      psTTCluster_Endcap_Fw_RZ_Zoom.getParameter<double>("ymin"),
+      psTTCluster_Endcap_Fw_RZ_Zoom.getParameter<double>("ymax"));
+  Cluster_Endcap_Fw_RZ_Zoom->setAxisTitle("L1 Cluster Forward Endcap position z [cm]", 1);
+  Cluster_Endcap_Fw_RZ_Zoom->setAxisTitle("L1 Cluster Forward Endcap position #rho [cm]", 2);
+  
+  //TTCluster Backward Endcap #rho vs. z
+  edm::ParameterSet psTTCluster_Endcap_Bw_RZ_Zoom =  conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Endcap_Bw_RZ_Zoom");
+  HistoName = "Cluster_Endcap_Bw_RZ_Zoom";
+  Cluster_Endcap_Bw_RZ_Zoom = dqmStore_->book2D(HistoName, HistoName,
+      psTTCluster_Endcap_Bw_RZ_Zoom.getParameter<int32_t>("Nbinsx"),
+      psTTCluster_Endcap_Bw_RZ_Zoom.getParameter<double>("xmin"),
+      psTTCluster_Endcap_Bw_RZ_Zoom.getParameter<double>("xmax"),
+      psTTCluster_Endcap_Bw_RZ_Zoom.getParameter<int32_t>("Nbinsy"),
+      psTTCluster_Endcap_Bw_RZ_Zoom.getParameter<double>("ymin"),
+      psTTCluster_Endcap_Bw_RZ_Zoom.getParameter<double>("ymax"));
+  Cluster_Endcap_Bw_RZ_Zoom->setAxisTitle("L1 Cluster Backward Endcap position z [cm]", 1);
+  Cluster_Endcap_Bw_RZ_Zoom->setAxisTitle("L1 Cluster Backward Endcap position #rho [cm]", 2);
+                                  
+}//end of method
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+OuterTrackerMonitorTTCluster::endJob(void) 
+{
+	
+}
+
+DEFINE_FWK_MODULE(OuterTrackerMonitorTTCluster);

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
@@ -25,7 +25,6 @@
 // user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTCluster.h"
 #include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
@@ -149,9 +148,6 @@ void OuterTrackerMonitorTTCluster::analyze(const edm::Event& iEvent, const edm::
 void
 OuterTrackerMonitorTTCluster::beginRun(const edm::Run& run, const edm::EventSetup& es)
 {
-  SiStripFolderOrganizer folder_organizer;
-  folder_organizer.setSiStripFolderName(topFolderName_);
-  folder_organizer.setSiStripFolder();	
   std::string HistoName;
   
   dqmStore_->setCurrentFolder(topFolderName_+"/Clusters/NClusters");
@@ -208,10 +204,10 @@ OuterTrackerMonitorTTCluster::beginRun(const edm::Run& run, const edm::EventSetu
   Cluster_OMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
   Cluster_OMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "NClusters_IMem_Disc+%d", i+1);  
-    Cluster_IMem_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(histo, histo, 
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "NClusters_IMem_Disc+"+std::to_string(i+1);
+    Cluster_IMem_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(HistoName, HistoName,
         psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
         psTTCluster_ECRing.getParameter<double>("xmin"), 
         psTTCluster_ECRing.getParameter<double>("xmax")); 
@@ -219,10 +215,10 @@ OuterTrackerMonitorTTCluster::beginRun(const edm::Run& run, const edm::EventSetu
     Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ",2);
   }
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "NClusters_IMem_Disc-%d", i+1);  
-    Cluster_IMem_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(histo, histo, 
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "NClusters_IMem_Disc-"+std::to_string(i+1);
+    Cluster_IMem_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(HistoName, HistoName,
         psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
         psTTCluster_ECRing.getParameter<double>("xmin"), 
         psTTCluster_ECRing.getParameter<double>("xmax")); 
@@ -230,10 +226,10 @@ OuterTrackerMonitorTTCluster::beginRun(const edm::Run& run, const edm::EventSetu
     Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ",2);
   }
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "NClusters_OMem_Disc+%d", i+1);  
-    Cluster_OMem_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(histo, histo, 
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "NClusters_OMem_Disc+"+std::to_string(i+1);
+    Cluster_OMem_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(HistoName, HistoName,
         psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
         psTTCluster_ECRing.getParameter<double>("xmin"), 
         psTTCluster_ECRing.getParameter<double>("xmax")); 
@@ -241,10 +237,10 @@ OuterTrackerMonitorTTCluster::beginRun(const edm::Run& run, const edm::EventSetu
     Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ",2);
   }
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "NClusters_OMem_Disc-%d", i+1);  
-    Cluster_OMem_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(histo, histo, 
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "NClusters_OMem_Disc-"+std::to_string(i+1);
+    Cluster_OMem_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(HistoName, HistoName,
         psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"), 
         psTTCluster_ECRing.getParameter<double>("xmin"), 
         psTTCluster_ECRing.getParameter<double>("xmax")); 
@@ -271,7 +267,7 @@ OuterTrackerMonitorTTCluster::beginRun(const edm::Run& run, const edm::EventSetu
   //Cluster eta distribution
   edm::ParameterSet psTTClusterEta = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Eta");
   HistoName = "Cluster_Eta";
-  Cluster_Eta = dqmStore_->book1D(HistoName, HistoName, 
+  Cluster_Eta = dqmStore_->book1D(HistoName, HistoName,
       psTTClusterEta.getParameter<int32_t>("Nbinsx"),
       psTTClusterEta.getParameter<double>("xmin"),
       psTTClusterEta.getParameter<double>("xmax"));

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
@@ -21,22 +21,13 @@
 #include <numeric>
 #include <iostream>
 #include <fstream>
-#include <math.h>
-#include "TMath.h"
-#include "TNamed.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
+
+// user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTCluster.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
-
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTClusterClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTClusterClient.cc
@@ -1,0 +1,84 @@
+// -*- C++ -*-
+//
+// Package:    Phase2OuterTracker
+// Class:      Phase2OuterTracker
+// 
+/**\class Phase2OuterTracker OuterTrackerMonitorTTClusterClient.cc DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTClusterClient.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Isabelle Helena J De Bruyn
+//         Created:  Mon, 10 Feb 2014 13:57:08 GMT
+// 
+
+// system include files
+#include <memory>
+#include <vector>
+#include <numeric>
+#include <fstream>
+#include <math.h>
+#include "TNamed.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
+#include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTClusterClient.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+
+#include "TMath.h"
+#include <iostream>
+
+//
+// constructors and destructor
+//
+OuterTrackerMonitorTTClusterClient::OuterTrackerMonitorTTClusterClient(const edm::ParameterSet& iConfig)
+{
+ 
+}
+
+
+OuterTrackerMonitorTTClusterClient::~OuterTrackerMonitorTTClusterClient()
+{
+ 
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+OuterTrackerMonitorTTClusterClient::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+OuterTrackerMonitorTTClusterClient::beginRun(const edm::Run& run, const edm::EventSetup& es)
+{
+
+
+}//end of method
+
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+OuterTrackerMonitorTTClusterClient::endJob(void) 
+{
+
+}
+
+DEFINE_FWK_MODULE(OuterTrackerMonitorTTClusterClient);

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTClusterClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTClusterClient.cc
@@ -19,23 +19,17 @@
 #include <memory>
 #include <vector>
 #include <numeric>
+#include <iostream>
 #include <fstream>
-#include <math.h>
-#include "TNamed.h"
+
+// user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTClusterClient.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 
-#include "TMath.h"
-#include <iostream>
 
 //
 // constructors and destructor

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTClusterClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTClusterClient.cc
@@ -26,7 +26,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTClusterClient.h"
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -28,7 +28,6 @@
 // user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStub.h"
 #include "DataFormats/L1TrackTrigger/interface/TTStub.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
@@ -163,10 +162,6 @@ OuterTrackerMonitorTTStub::analyze(const edm::Event& iEvent, const edm::EventSet
 void 
 OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
 {
-   //Make subdivision in the rootfile
-  SiStripFolderOrganizer folder_organizer;
-  folder_organizer.setSiStripFolderName(topFolderName_);
-  folder_organizer.setSiStripFolder();
   std::string HistoName;    
 
   dqmStore_->setCurrentFolder(topFolderName_+"/Stubs/Position");
@@ -270,7 +265,7 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   //TTStub eta 
   edm::ParameterSet psTTStub_Eta =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Eta");
   HistoName = "Stub_Eta"; 
-  Stub_Eta = dqmStore_ ->book1D(HistoName,HistoName, 
+  Stub_Eta = dqmStore_ ->book1D(HistoName,HistoName,
       psTTStub_Eta.getParameter<int32_t>("Nbinsx"), 
       psTTStub_Eta.getParameter<double>("xmin"), 
       psTTStub_Eta.getParameter<double>("xmax"));
@@ -282,7 +277,7 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   //TTStub barrel stack
   edm::ParameterSet psTTStub_Barrel =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Layers");
   HistoName = "NStubs_Barrel"; 
-  Stub_Barrel = dqmStore_ ->book1D(HistoName,HistoName, 
+  Stub_Barrel = dqmStore_ ->book1D(HistoName,HistoName,
       psTTStub_Barrel.getParameter<int32_t>("Nbinsx"), 
       psTTStub_Barrel.getParameter<double>("xmin"), 
       psTTStub_Barrel.getParameter<double>("xmax"));
@@ -292,7 +287,7 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   //TTStub Endcap stack
   edm::ParameterSet psTTStub_ECDisc =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Discs");
   HistoName = "NStubs_Endcap_Disc"; 
-  Stub_Endcap_Disc = dqmStore_ ->book1D(HistoName,HistoName, 
+  Stub_Endcap_Disc = dqmStore_ ->book1D(HistoName,HistoName,
       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"), 
       psTTStub_ECDisc.getParameter<double>("xmin"), 
       psTTStub_ECDisc.getParameter<double>("xmax"));
@@ -301,7 +296,7 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   
   //TTStub Endcap stack
   HistoName = "NStubs_Endcap_Disc_Fw"; 
-  Stub_Endcap_Disc_Fw = dqmStore_ ->book1D(HistoName,HistoName, 
+  Stub_Endcap_Disc_Fw = dqmStore_ ->book1D(HistoName,HistoName,
       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"), 
       psTTStub_ECDisc.getParameter<double>("xmin"), 
       psTTStub_ECDisc.getParameter<double>("xmax"));
@@ -310,7 +305,7 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   
   //TTStub Endcap stack
   HistoName = "NStubs_Endcap_Disc_Bw"; 
-  Stub_Endcap_Disc_Bw = dqmStore_ ->book1D(HistoName,HistoName, 
+  Stub_Endcap_Disc_Bw = dqmStore_ ->book1D(HistoName,HistoName,
       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"), 
       psTTStub_ECDisc.getParameter<double>("xmin"), 
       psTTStub_ECDisc.getParameter<double>("xmax"));
@@ -320,18 +315,18 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   edm::ParameterSet psTTStub_ECRing =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Rings");
   
   HistoName = "NStubs_Endcap_Ring"; 
-  Stub_Endcap_Ring = dqmStore_ ->book1D(HistoName,HistoName, 
+  Stub_Endcap_Ring = dqmStore_ ->book1D(HistoName,HistoName,
       psTTStub_ECRing.getParameter<int32_t>("Nbinsx"), 
       psTTStub_ECRing.getParameter<double>("xmin"), 
       psTTStub_ECRing.getParameter<double>("xmax"));
   Stub_Endcap_Ring->setAxisTitle("Endcap Ring",1); 
   Stub_Endcap_Ring->setAxisTitle("# L1 Stubs ",2);
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "NStubs_Disc+%d", i+1);  
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "NStubs_Disc+"+std::to_string(i+1);
     //TTStub Endcap stack
-    Stub_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(histo, histo, 
+    Stub_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(HistoName, HistoName,
         psTTStub_ECRing.getParameter<int32_t>("Nbinsx"), 
         psTTStub_ECRing.getParameter<double>("xmin"), 
         psTTStub_ECRing.getParameter<double>("xmax")); 
@@ -339,11 +334,11 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
     Stub_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Stubs ",2);
   }
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "NStubs_Disc-%d", i+1);  
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "NStubs_Disc-"+std::to_string(i+1);
     //TTStub Endcap stack
-    Stub_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(histo, histo, 
+    Stub_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(HistoName, HistoName,
         psTTStub_ECRing.getParameter<int32_t>("Nbinsx"), 
         psTTStub_ECRing.getParameter<double>("xmin"), 
         psTTStub_ECRing.getParameter<double>("xmax")); 
@@ -391,10 +386,10 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   Stub_Endcap_Ring_W->setAxisTitle("Endcap Ring",1); 
   Stub_Endcap_Ring_W->setAxisTitle("Trigger Offset",2);
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "Stub_Width_Disc+%d", i+1);
-    Stub_Endcap_Ring_W_Fw[i] = dqmStore_->book2D(histo, histo,
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "Stub_Width_Disc+"+std::to_string(i+1);
+    Stub_Endcap_Ring_W_Fw[i] = dqmStore_->book2D(HistoName, HistoName,
         psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
         psTTStub_ECRing_2D.getParameter<double>("xmin"),
         psTTStub_ECRing_2D.getParameter<double>("xmax"),
@@ -405,10 +400,10 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
     Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Displacement - Offset",2);
   }
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "Stub_Width_Disc-%d", i+1);
-    Stub_Endcap_Ring_W_Bw[i] = dqmStore_->book2D(histo, histo,
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "Stub_Width_Disc-"+std::to_string(i+1);
+    Stub_Endcap_Ring_W_Bw[i] = dqmStore_->book2D(HistoName, HistoName,
         psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
         psTTStub_ECRing_2D.getParameter<double>("xmin"),
         psTTStub_ECRing_2D.getParameter<double>("xmax"),
@@ -454,10 +449,10 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
   Stub_Endcap_Ring_O->setAxisTitle("Endcap Ring",1); 
   Stub_Endcap_Ring_O->setAxisTitle("Trigger Offset",2);
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "Stub_Offset_Disc+%d", i+1);
-    Stub_Endcap_Ring_O_Fw[i] = dqmStore_->book2D(histo, histo,
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "Stub_Offset_Disc+"+std::to_string(i+1);
+    Stub_Endcap_Ring_O_Fw[i] = dqmStore_->book2D(HistoName, HistoName,
         psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
         psTTStub_ECRing_2D.getParameter<double>("xmin"),
         psTTStub_ECRing_2D.getParameter<double>("xmax"),
@@ -468,10 +463,10 @@ OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
     Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Trigger Offset",2);
   }
   
-  for(int i=0;i<5;i++){
-    Char_t histo[200];
-    sprintf(histo, "Stub_Offset_Disc-%d", i+1);
-    Stub_Endcap_Ring_O_Bw[i] = dqmStore_->book2D(histo, histo,
+  for (int i = 0; i < 5; i++)
+  {
+    HistoName = "Stub_Offset_Disc-"+std::to_string(i+1);
+    Stub_Endcap_Ring_O_Bw[i] = dqmStore_->book2D(HistoName, HistoName,
         psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
         psTTStub_ECRing_2D.getParameter<double>("xmin"),
         psTTStub_ECRing_2D.getParameter<double>("xmax"),

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -24,24 +24,13 @@
 #include <numeric>
 #include <iostream>
 #include <fstream>
-#include <math.h>
-#include "TMath.h"
-#include "TNamed.h"
 
 // user include files
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStub.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "DataFormats/L1TrackTrigger/interface/TTStub.h"
-
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -1,0 +1,505 @@
+// -*- C++ -*-
+//
+// Package:    Phase2OuterTracker
+// Class:      Phase2OuterTracker
+// 
+/**\class Phase2OuterTracker OuterTrackerMonitorTTStub.cc DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Isis Marina Van Parijs
+//         Created:  Fri, 24 Oct 2014 12:31:31 GMT
+// $Id$
+//
+//
+
+
+// system include files
+#include <memory>
+#include <vector>
+#include <numeric>
+#include <iostream>
+#include <fstream>
+#include <math.h>
+#include "TMath.h"
+#include "TNamed.h"
+
+// user include files
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
+#include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStub.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
+
+//
+// constructors and destructor
+//
+OuterTrackerMonitorTTStub::OuterTrackerMonitorTTStub(const edm::ParameterSet& iConfig)
+: dqmStore_(edm::Service<DQMStore>().operator->()), conf_(iConfig)
+{
+   //now do what ever initialization is needed
+   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+   tagTTStubsToken_ = consumes<edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > > > (conf_.getParameter<edm::InputTag>("TTStubs") );
+}
+
+
+OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+OuterTrackerMonitorTTStub::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  /// Track Trigger Stubs
+  edm::Handle< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > > > Phase2TrackerDigiTTStubHandle;
+  iEvent.getByToken( tagTTStubsToken_, Phase2TrackerDigiTTStubHandle );
+  
+  /// Geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  const TrackerTopology* tTopo;
+  iSetup.get< TrackerTopologyRcd >().get(tTopoHandle);
+  tTopo = tTopoHandle.product();
+  
+  edm::ESHandle< TrackerGeometry > tGeometryHandle;
+  const TrackerGeometry* theTrackerGeometry;
+  iSetup.get< TrackerDigiGeometryRecord >().get( tGeometryHandle );
+  theTrackerGeometry = tGeometryHandle.product();
+  
+  
+  /// Loop over input Stubs
+  typename edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >::const_iterator inputIter;
+  typename edmNew::DetSet< TTStub< Ref_Phase2TrackerDigi_ > >::const_iterator contentIter;
+  for ( inputIter = Phase2TrackerDigiTTStubHandle->begin();
+        inputIter != Phase2TrackerDigiTTStubHandle->end();
+        ++inputIter )
+  {
+    for ( contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter )
+    {
+      /// Make reference stub
+      edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > tempStubRef = edmNew::makeRefTo( Phase2TrackerDigiTTStubHandle, contentIter );
+      
+      /// Get det ID (place of the stub)
+      //  tempStubRef->getDetId() gives the stackDetId, not rawId
+      DetId detIdStub = theTrackerGeometry->idToDet( (tempStubRef->getClusterRef(0))->getDetId() )->geographicalId();
+      
+      /// Get trigger displacement/offset
+      double displStub = tempStubRef->getTriggerDisplacement();
+      double offsetStub = tempStubRef->getTriggerOffset();
+      
+      /// Define position stub by position inner cluster
+      MeasurementPoint mp = (tempStubRef->getClusterRef(0))->findAverageLocalCoordinates();
+      const GeomDet* theGeomDet = theTrackerGeometry->idToDet(detIdStub);
+      Global3DPoint posStub = theGeomDet->surface().toGlobal( theGeomDet->topology().localPosition(mp) );
+      
+      double eta = posStub.eta();
+      
+      Stub_Eta->Fill(eta);
+      Stub_RZ->Fill( posStub.z(), posStub.perp() );
+
+      if ( detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB) )  // Phase 2 Outer Tracker Barrel
+      {
+        Stub_Barrel->Fill(tTopo->layer(detIdStub)); 
+
+        Stub_Barrel_XY->Fill( posStub.x(), posStub.y() );
+        Stub_Barrel_XY_Zoom->Fill( posStub.x(), posStub.y() );
+	     
+        Stub_Barrel_W->Fill(tTopo->layer(detIdStub), displStub - offsetStub);
+        Stub_Barrel_O->Fill(tTopo->layer(detIdStub), offsetStub);
+      }
+      else if ( detIdStub.subdetId() == static_cast<int>(StripSubdetector::TID) )  // Phase 2 Outer Tracker Endcap
+      {
+        int disc = tTopo->layer(detIdStub); // returns wheel
+        int ring = tTopo->tidRing(detIdStub);
+        Stub_Endcap_Disc->Fill(disc);
+        Stub_Endcap_Ring->Fill(ring);
+        Stub_Endcap_Disc_W->Fill(disc, displStub - offsetStub);
+        Stub_Endcap_Ring_W->Fill(ring, displStub - offsetStub);
+        Stub_Endcap_Disc_O->Fill(disc, offsetStub);
+        Stub_Endcap_Ring_O->Fill(ring, offsetStub);
+
+        if ( posStub.z() > 0 )
+        {
+          Stub_Endcap_Fw_XY->Fill( posStub.x(), posStub.y() );
+          Stub_Endcap_Fw_RZ_Zoom->Fill( posStub.z(), posStub.perp() );
+          Stub_Endcap_Disc_Fw->Fill(disc);
+          Stub_Endcap_Ring_Fw[disc-1]->Fill(ring);
+          Stub_Endcap_Ring_W_Fw[disc-1]->Fill(ring, displStub - offsetStub);
+          Stub_Endcap_Ring_O_Fw[disc-1]->Fill(ring, offsetStub);
+        }
+        else
+        {
+          Stub_Endcap_Bw_XY->Fill( posStub.x(), posStub.y() );
+          Stub_Endcap_Bw_RZ_Zoom->Fill( posStub.z(), posStub.perp() );
+          Stub_Endcap_Disc_Bw->Fill(disc);
+          Stub_Endcap_Ring_Bw[disc-1]->Fill(ring);
+          Stub_Endcap_Ring_W_Bw[disc-1]->Fill(ring, displStub - offsetStub);
+          Stub_Endcap_Ring_O_Bw[disc-1]->Fill(ring, offsetStub);
+        }
+      }
+    }
+  }
+} // end of method
+
+
+// ------------ method called when starting to processes a run  ------------
+void 
+OuterTrackerMonitorTTStub::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+   //Make subdivision in the rootfile
+  SiStripFolderOrganizer folder_organizer;
+  folder_organizer.setSiStripFolderName(topFolderName_);
+  folder_organizer.setSiStripFolder();
+  std::string HistoName;    
+
+  dqmStore_->setCurrentFolder(topFolderName_+"/Stubs/Position");
+  
+  
+  ////////////////////////////////////////
+  ///// GLOBAL POSITION OF THE STUB //////
+  ////////////////////////////////////////
+  
+  edm::ParameterSet psTTStub_Barrel_XY =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  HistoName = "Stub_Barrel_XY";
+  Stub_Barrel_XY = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Barrel_XY.getParameter<double>("xmin"),
+      psTTStub_Barrel_XY.getParameter<double>("xmax"),
+      psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Barrel_XY.getParameter<double>("ymin"),
+      psTTStub_Barrel_XY.getParameter<double>("ymax"));
+  Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position x [cm]", 1);
+  Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position y [cm]", 2);
+  
+  edm::ParameterSet psTTStub_Barrel_XY_Zoom =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_Barrel_XY_Zoom");
+  HistoName = "Stub_Barrel_XY_Zoom";
+  Stub_Barrel_XY_Zoom = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Barrel_XY_Zoom.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Barrel_XY_Zoom.getParameter<double>("xmin"),
+      psTTStub_Barrel_XY_Zoom.getParameter<double>("xmax"),
+      psTTStub_Barrel_XY_Zoom.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Barrel_XY_Zoom.getParameter<double>("ymin"),
+      psTTStub_Barrel_XY_Zoom.getParameter<double>("ymax"));
+  Stub_Barrel_XY_Zoom->setAxisTitle("L1 Stub Barrel position x [cm]", 1);
+  Stub_Barrel_XY_Zoom->setAxisTitle("L1 Stub Barrel position y [cm]", 2);
+  
+  
+  edm::ParameterSet psTTStub_Endcap_Fw_XY =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  HistoName = "Stub_Endcap_Fw_XY";
+  Stub_Endcap_Fw_XY = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Endcap_Fw_XY.getParameter<double>("xmin"),
+      psTTStub_Endcap_Fw_XY.getParameter<double>("xmax"),
+      psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Endcap_Fw_XY.getParameter<double>("ymin"),
+      psTTStub_Endcap_Fw_XY.getParameter<double>("ymax"));
+  Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
+  Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
+  
+  
+  edm::ParameterSet psTTStub_Endcap_Bw_XY =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  HistoName = "Stub_Endcap_Bw_XY";
+  Stub_Endcap_Bw_XY = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Endcap_Bw_XY.getParameter<double>("xmin"),
+      psTTStub_Endcap_Bw_XY.getParameter<double>("xmax"),
+      psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Endcap_Bw_XY.getParameter<double>("ymin"),
+      psTTStub_Endcap_Bw_XY.getParameter<double>("ymax"));
+  Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
+  Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
+  
+  //TTStub #rho vs. z
+  edm::ParameterSet psTTStub_RZ =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_RZ");
+  HistoName = "Stub_RZ";
+  Stub_RZ = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_RZ.getParameter<int32_t>("Nbinsx"),
+      psTTStub_RZ.getParameter<double>("xmin"),
+      psTTStub_RZ.getParameter<double>("xmax"),
+      psTTStub_RZ.getParameter<int32_t>("Nbinsy"),
+      psTTStub_RZ.getParameter<double>("ymin"),
+      psTTStub_RZ.getParameter<double>("ymax"));
+  Stub_RZ->setAxisTitle("L1 Stub position z [cm]", 1);
+  Stub_RZ->setAxisTitle("L1 Stub position #rho [cm]", 2);
+  
+  //TTStub Forward Endcap #rho vs. z
+  edm::ParameterSet psTTStub_Endcap_Fw_RZ_Zoom =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_Endcap_Fw_RZ_Zoom");
+  HistoName = "Stub_Endcap_Fw_RZ_Zoom";
+  Stub_Endcap_Fw_RZ_Zoom = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Endcap_Fw_RZ_Zoom.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Endcap_Fw_RZ_Zoom.getParameter<double>("xmin"),
+      psTTStub_Endcap_Fw_RZ_Zoom.getParameter<double>("xmax"),
+      psTTStub_Endcap_Fw_RZ_Zoom.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Endcap_Fw_RZ_Zoom.getParameter<double>("ymin"),
+      psTTStub_Endcap_Fw_RZ_Zoom.getParameter<double>("ymax"));
+  Stub_Endcap_Fw_RZ_Zoom->setAxisTitle("L1 Stub Endcap position z [cm]", 1);
+  Stub_Endcap_Fw_RZ_Zoom->setAxisTitle("L1 Stub Endcap position #rho [cm]", 2);
+  
+  //TTStub Backward Endcap #rho vs. z
+  edm::ParameterSet psTTStub_Endcap_Bw_RZ_Zoom =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_Endcap_Bw_RZ_Zoom");
+  HistoName = "Stub_Endcap_Bw_RZ_Zoom";
+  Stub_Endcap_Bw_RZ_Zoom = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Endcap_Bw_RZ_Zoom.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Endcap_Bw_RZ_Zoom.getParameter<double>("xmin"),
+      psTTStub_Endcap_Bw_RZ_Zoom.getParameter<double>("xmax"),
+      psTTStub_Endcap_Bw_RZ_Zoom.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Endcap_Bw_RZ_Zoom.getParameter<double>("ymin"),
+      psTTStub_Endcap_Bw_RZ_Zoom.getParameter<double>("ymax"));
+  Stub_Endcap_Bw_RZ_Zoom->setAxisTitle("L1 Stub Endcap position z [cm]", 1);
+  Stub_Endcap_Bw_RZ_Zoom->setAxisTitle("L1 Stub Endcap position #rho [cm]", 2);  
+
+  dqmStore_->setCurrentFolder(topFolderName_+"/Stubs");
+  
+  //TTStub eta 
+  edm::ParameterSet psTTStub_Eta =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Eta");
+  HistoName = "Stub_Eta"; 
+  Stub_Eta = dqmStore_ ->book1D(HistoName,HistoName, 
+      psTTStub_Eta.getParameter<int32_t>("Nbinsx"), 
+      psTTStub_Eta.getParameter<double>("xmin"), 
+      psTTStub_Eta.getParameter<double>("xmax"));
+  Stub_Eta->setAxisTitle("#eta",1); 
+  Stub_Eta->setAxisTitle("# L1 Stubs ",2);
+
+  dqmStore_->setCurrentFolder(topFolderName_+"/Stubs/NStubs");
+  
+  //TTStub barrel stack
+  edm::ParameterSet psTTStub_Barrel =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Layers");
+  HistoName = "NStubs_Barrel"; 
+  Stub_Barrel = dqmStore_ ->book1D(HistoName,HistoName, 
+      psTTStub_Barrel.getParameter<int32_t>("Nbinsx"), 
+      psTTStub_Barrel.getParameter<double>("xmin"), 
+      psTTStub_Barrel.getParameter<double>("xmax"));
+  Stub_Barrel->setAxisTitle("Barrel Layer",1); 
+  Stub_Barrel->setAxisTitle("# L1 Stubs ",2);
+  
+  //TTStub Endcap stack
+  edm::ParameterSet psTTStub_ECDisc =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Discs");
+  HistoName = "NStubs_Endcap_Disc"; 
+  Stub_Endcap_Disc = dqmStore_ ->book1D(HistoName,HistoName, 
+      psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"), 
+      psTTStub_ECDisc.getParameter<double>("xmin"), 
+      psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc->setAxisTitle("Endcap Disc",1); 
+  Stub_Endcap_Disc->setAxisTitle("# L1 Stubs ",2);
+  
+  //TTStub Endcap stack
+  HistoName = "NStubs_Endcap_Disc_Fw"; 
+  Stub_Endcap_Disc_Fw = dqmStore_ ->book1D(HistoName,HistoName, 
+      psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"), 
+      psTTStub_ECDisc.getParameter<double>("xmin"), 
+      psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc_Fw->setAxisTitle("Forward Endcap Disc",1); 
+  Stub_Endcap_Disc_Fw->setAxisTitle("# L1 Stubs ",2);
+  
+  //TTStub Endcap stack
+  HistoName = "NStubs_Endcap_Disc_Bw"; 
+  Stub_Endcap_Disc_Bw = dqmStore_ ->book1D(HistoName,HistoName, 
+      psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"), 
+      psTTStub_ECDisc.getParameter<double>("xmin"), 
+      psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc_Bw->setAxisTitle("Backward Endcap Disc",1); 
+  Stub_Endcap_Disc_Bw->setAxisTitle("# L1 Stubs ",2);
+  
+  edm::ParameterSet psTTStub_ECRing =  conf_.getParameter<edm::ParameterSet>("TH1TTStub_Rings");
+  
+  HistoName = "NStubs_Endcap_Ring"; 
+  Stub_Endcap_Ring = dqmStore_ ->book1D(HistoName,HistoName, 
+      psTTStub_ECRing.getParameter<int32_t>("Nbinsx"), 
+      psTTStub_ECRing.getParameter<double>("xmin"), 
+      psTTStub_ECRing.getParameter<double>("xmax"));
+  Stub_Endcap_Ring->setAxisTitle("Endcap Ring",1); 
+  Stub_Endcap_Ring->setAxisTitle("# L1 Stubs ",2);
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "NStubs_Disc+%d", i+1);  
+    //TTStub Endcap stack
+    Stub_Endcap_Ring_Fw[i] = dqmStore_ ->book1D(histo, histo, 
+        psTTStub_ECRing.getParameter<int32_t>("Nbinsx"), 
+        psTTStub_ECRing.getParameter<double>("xmin"), 
+        psTTStub_ECRing.getParameter<double>("xmax")); 
+    Stub_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring",1); 
+    Stub_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Stubs ",2);
+  }
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "NStubs_Disc-%d", i+1);  
+    //TTStub Endcap stack
+    Stub_Endcap_Ring_Bw[i] = dqmStore_ ->book1D(histo, histo, 
+        psTTStub_ECRing.getParameter<int32_t>("Nbinsx"), 
+        psTTStub_ECRing.getParameter<double>("xmin"), 
+        psTTStub_ECRing.getParameter<double>("xmax")); 
+    Stub_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring",1); 
+    Stub_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Stubs ",2);
+  }
+  
+  //TTStub displ/offset
+  edm::ParameterSet psTTStub_Barrel_2D =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Layer");
+  edm::ParameterSet psTTStub_ECDisc_2D =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Disc");
+  edm::ParameterSet psTTStub_ECRing_2D =  conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Ring");
+
+  dqmStore_->setCurrentFolder(topFolderName_+"/Stubs/Width");
+  
+  HistoName = "Stub_Width_Barrel";
+  Stub_Barrel_W = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Barrel_2D.getParameter<double>("xmin"),
+      psTTStub_Barrel_2D.getParameter<double>("xmax"),
+      psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Barrel_2D.getParameter<double>("ymin"),
+      psTTStub_Barrel_2D.getParameter<double>("ymax"));
+  Stub_Barrel_W->setAxisTitle("Barrel Layer",1); 
+  Stub_Barrel_W->setAxisTitle("Displacement - Offset",2);
+  
+  HistoName = "Stub_Width_Endcap_Disc";
+  Stub_Endcap_Disc_W = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
+      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
+      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
+      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
+      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
+      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Disc_W->setAxisTitle("Endcap Disc",1); 
+  Stub_Endcap_Disc_W->setAxisTitle("Displacement - Offset",2);
+  
+  HistoName = "Stub_Width_Endcap_Ring";
+  Stub_Endcap_Ring_W = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+      psTTStub_ECRing_2D.getParameter<double>("xmin"),
+      psTTStub_ECRing_2D.getParameter<double>("xmax"),
+      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+      psTTStub_ECRing_2D.getParameter<double>("ymin"),
+      psTTStub_ECRing_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Ring_W->setAxisTitle("Endcap Ring",1); 
+  Stub_Endcap_Ring_W->setAxisTitle("Trigger Offset",2);
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "Stub_Width_Disc+%d", i+1);
+    Stub_Endcap_Ring_W_Fw[i] = dqmStore_->book2D(histo, histo,
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+        psTTStub_ECRing_2D.getParameter<double>("xmin"),
+        psTTStub_ECRing_2D.getParameter<double>("xmax"),
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+        psTTStub_ECRing_2D.getParameter<double>("ymin"),
+        psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Endcap Ring",1); 
+    Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Displacement - Offset",2);
+  }
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "Stub_Width_Disc-%d", i+1);
+    Stub_Endcap_Ring_W_Bw[i] = dqmStore_->book2D(histo, histo,
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+        psTTStub_ECRing_2D.getParameter<double>("xmin"),
+        psTTStub_ECRing_2D.getParameter<double>("xmax"),
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+        psTTStub_ECRing_2D.getParameter<double>("ymin"),
+        psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Endcap Ring",1); 
+    Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Displacement - Offset",2);
+  }
+
+  dqmStore_->setCurrentFolder(topFolderName_+"/Stubs/Offset");
+  
+  HistoName = "Stub_Offset_Barrel";
+  Stub_Barrel_O = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
+      psTTStub_Barrel_2D.getParameter<double>("xmin"),
+      psTTStub_Barrel_2D.getParameter<double>("xmax"),
+      psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
+      psTTStub_Barrel_2D.getParameter<double>("ymin"),
+      psTTStub_Barrel_2D.getParameter<double>("ymax"));
+  Stub_Barrel_O->setAxisTitle("Barrel Layer",1); 
+  Stub_Barrel_O->setAxisTitle("Trigger Offset",2);
+  
+  HistoName = "Stub_Offset_Endcap_Disc";
+  Stub_Endcap_Disc_O = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
+      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
+      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
+      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
+      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
+      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Disc_O->setAxisTitle("Endcap Disc",1); 
+  Stub_Endcap_Disc_O->setAxisTitle("Trigger Offset",2);
+  
+  HistoName = "Stub_Offset_Endcap_Ring";
+  Stub_Endcap_Ring_O = dqmStore_->book2D(HistoName, HistoName,
+      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+      psTTStub_ECRing_2D.getParameter<double>("xmin"),
+      psTTStub_ECRing_2D.getParameter<double>("xmax"),
+      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+      psTTStub_ECRing_2D.getParameter<double>("ymin"),
+      psTTStub_ECRing_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Ring_O->setAxisTitle("Endcap Ring",1); 
+  Stub_Endcap_Ring_O->setAxisTitle("Trigger Offset",2);
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "Stub_Offset_Disc+%d", i+1);
+    Stub_Endcap_Ring_O_Fw[i] = dqmStore_->book2D(histo, histo,
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+        psTTStub_ECRing_2D.getParameter<double>("xmin"),
+        psTTStub_ECRing_2D.getParameter<double>("xmax"),
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+        psTTStub_ECRing_2D.getParameter<double>("ymin"),
+        psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Endcap Ring",1); 
+    Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Trigger Offset",2);
+  }
+  
+  for(int i=0;i<5;i++){
+    Char_t histo[200];
+    sprintf(histo, "Stub_Offset_Disc-%d", i+1);
+    Stub_Endcap_Ring_O_Bw[i] = dqmStore_->book2D(histo, histo,
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+        psTTStub_ECRing_2D.getParameter<double>("xmin"),
+        psTTStub_ECRing_2D.getParameter<double>("xmax"),
+        psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+        psTTStub_ECRing_2D.getParameter<double>("ymin"),
+        psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Endcap Ring",1); 
+    Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Trigger Offset",2);
+  }
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+OuterTrackerMonitorTTStub::endJob() 
+{
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(OuterTrackerMonitorTTStub);

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStubClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStubClient.cc
@@ -19,23 +19,17 @@
 #include <memory>
 #include <vector>
 #include <numeric>
+#include <iostream>
 #include <fstream>
-#include <math.h>
-#include "TNamed.h"
+
+// user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStubClient.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 
-#include "TMath.h"
-#include <iostream>
 
 //
 // constructors and destructor

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStubClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStubClient.cc
@@ -1,0 +1,84 @@
+// -*- C++ -*-
+//
+// Package:    Phase2OuterTracker
+// Class:      Phase2OuterTracker
+// 
+/**\class Phase2OuterTracker OuterTrackerMonitorTTStubClient.cc DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStubClient.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Isabelle Helena J De Bruyn
+//         Created:  Mon, 14 Nov 2014 12:07:38 GMT
+// 
+
+// system include files
+#include <memory>
+#include <vector>
+#include <numeric>
+#include <fstream>
+#include <math.h>
+#include "TNamed.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
+#include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStubClient.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+
+#include "TMath.h"
+#include <iostream>
+
+//
+// constructors and destructor
+//
+OuterTrackerMonitorTTStubClient::OuterTrackerMonitorTTStubClient(const edm::ParameterSet& iConfig)
+{
+ 
+}
+
+
+OuterTrackerMonitorTTStubClient::~OuterTrackerMonitorTTStubClient()
+{
+ 
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+OuterTrackerMonitorTTStubClient::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+OuterTrackerMonitorTTStubClient::beginRun(const edm::Run& run, const edm::EventSetup& es)
+{
+
+
+}//end of method
+
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+OuterTrackerMonitorTTStubClient::endJob(void) 
+{
+
+}
+
+DEFINE_FWK_MODULE(OuterTrackerMonitorTTStubClient);

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStubClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTStubClient.cc
@@ -26,7 +26,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTStubClient.h"
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -1,0 +1,365 @@
+// -*- C++ -*-
+//
+// Package:    Phase2OuterTracker
+// Class:      Phase2OuterTracker
+//
+/**\class Phase2OuterTracker OuterTrackerMonitorTTTrack.cc DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+ 
+ Description: [one line class summary]
+ 
+ Implementation:
+ [Notes on implementation]
+ */
+//
+// Original Author:  Isis Marina Van Parijs
+//         Created:  Mon, 16 Feb 2014 15:49:32 GMT
+//
+
+// system include files
+#include <memory>
+#include <vector>
+#include <numeric>
+#include <iostream>
+#include <fstream>
+#include <math.h>
+#include "TMath.h"
+#include "TNamed.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
+#include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrack.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+//#include "DataFormats/L1TrackTrigger/interface/TTTrack.h" // does not exist yet in 81X
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
+//
+// constructors and destructor
+//
+OuterTrackerMonitorTTTrack::OuterTrackerMonitorTTTrack(const edm::ParameterSet& iConfig)
+: dqmStore_(edm::Service<DQMStore>().operator->()), conf_(iConfig)
+{
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+  //tagTTTracksToken_ = consumes<edmNew::DetSetVector< TTTrack< Ref_Phase2TrackerDigi_ > > > (conf_.getParameter<edm::InputTag>("TTTracks") );
+  HQDelim_ = conf_.getParameter<int>("HQDelim");
+}
+
+OuterTrackerMonitorTTTrack::~OuterTrackerMonitorTTTrack()
+{
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void OuterTrackerMonitorTTTrack::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  /*
+  /// Track Trigger Tracks
+  edm::Handle< std::vector< TTTrack< Ref_Phase2TrackerDigi_ > > > Phase2TrackerDigiTTTrackHandle;
+  iEvent.getByToken( tagTTTracksToken_, Phase2TrackerDigiTTTrackHandle );
+  
+  unsigned int numHQTracks = 0;
+  unsigned int numLQTracks = 0;
+  unsigned int numTracks = 0; 
+  
+  /// Go on only if there are TTTracks from Phase2TrackerDigis
+  if ( Phase2TrackerDigiTTTrackHandle->size() > 0 )
+  {
+    /// Loop over TTTracks
+    unsigned int tkCnt = 0;
+    std::vector< TTTrack< Ref_Phase2TrackerDigi_ > >::const_iterator iterTTTrack;
+    for ( iterTTTrack = Phase2TrackerDigiTTTrackHandle->begin();iterTTTrack != Phase2TrackerDigiTTTrackHandle->end();++iterTTTrack )
+    {
+      /// Make the pointer
+      edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > tempTrackPtr( Phase2TrackerDigiTTTrackHandle, tkCnt++ );
+      numTracks++;
+      
+      unsigned int nStubs = tempTrackPtr->getStubRefs().size();
+      
+      double trackPt = tempTrackPtr->getMomentum().perp();
+      double trackPhi = tempTrackPtr->getMomentum().phi();
+      double trackEta = tempTrackPtr->getMomentum().eta();
+      double trackVtxZ0 = tempTrackPtr->getPOCA().z();
+      double trackChi2 = tempTrackPtr->getChi2();
+      double trackChi2R = tempTrackPtr->getChi2Red();
+      
+      Track_NStubs->Fill(nStubs);
+      
+      if ( nStubs >= HQDelim_ )
+      {
+        numHQTracks++;
+        
+        Track_HQ_Pt->Fill( trackPt );
+        Track_HQ_Eta->Fill( trackEta );
+        Track_HQ_Phi->Fill( trackPhi );
+        Track_HQ_VtxZ0->Fill( trackVtxZ0 );
+        Track_HQ_Chi2->Fill( trackChi2 );
+        Track_HQ_Chi2Red->Fill( trackChi2R );
+        
+        Track_HQ_Chi2_NStubs->Fill( nStubs, trackChi2 );
+        Track_HQ_Chi2Red_NStubs->Fill( nStubs, trackChi2R );
+      }
+      else
+      {
+        numLQTracks++;
+        
+        Track_LQ_Pt->Fill( trackPt );
+        Track_LQ_Eta->Fill( trackEta );
+        Track_LQ_Phi->Fill( trackPhi );
+        Track_LQ_VtxZ0->Fill( trackVtxZ0 );
+        Track_LQ_Chi2->Fill( trackChi2 );
+        Track_LQ_Chi2Red->Fill( trackChi2R );
+        
+        Track_LQ_Chi2_NStubs->Fill( nStubs, trackChi2 );
+        Track_LQ_Chi2Red_NStubs->Fill( nStubs, trackChi2R );
+      }
+    } // End of loop over TTTracks
+    
+  } // End TTTracks from pixeldigis 
+
+  Track_N->Fill(numTracks); 
+  Track_HQ_N->Fill( numHQTracks );
+  Track_LQ_N->Fill( numLQTracks );
+  */
+} // end of method
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+OuterTrackerMonitorTTTrack::beginRun(const edm::Run& run, const edm::EventSetup& es)
+{
+  SiStripFolderOrganizer folder_organizer;
+  folder_organizer.setSiStripFolderName(topFolderName_);
+  folder_organizer.setSiStripFolder();	
+	std::string HistoName;
+  
+  dqmStore_->setCurrentFolder(topFolderName_+"/Tracks/");
+  
+  //Nb of tracks
+  edm::ParameterSet psTrack_N =  conf_.getParameter<edm::ParameterSet>("TH1_NTracks");
+  HistoName = "Track_N";
+  Track_N = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_N.getParameter<int32_t>("Nbinsx"),
+      psTrack_N.getParameter<double>("xmin"),
+      psTrack_N.getParameter<double>("xmax"));
+  Track_N->setAxisTitle("# L1 Tracks", 1);
+  Track_N->setAxisTitle("# Events", 2);
+  
+  //Nb of stubs
+  edm::ParameterSet psTrack_NStubs =  conf_.getParameter<edm::ParameterSet>("TH1_NStubs");
+  HistoName = "Track_NStubs";
+  Track_NStubs = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+      psTrack_NStubs.getParameter<double>("xmin"),
+      psTrack_NStubs.getParameter<double>("xmax"));
+  Track_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
+  Track_NStubs->setAxisTitle("# L1 Tracks", 2);
+  
+  
+  /// Low-quality tracks
+  dqmStore_->setCurrentFolder(topFolderName_+"/Tracks/LQ");
+  
+  // Nb of L1Tracks
+  HistoName = "Track_LQ_N";
+  Track_LQ_N = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_N.getParameter<int32_t>("Nbinsx"),
+      psTrack_N.getParameter<double>("xmin"),
+      psTrack_N.getParameter<double>("xmax"));
+  Track_LQ_N->setAxisTitle("# L1 Tracks", 1);
+  Track_LQ_N->setAxisTitle("# Events", 2);
+  
+  //Pt of the tracks
+  edm::ParameterSet psTrack_Pt =  conf_.getParameter<edm::ParameterSet>("TH1_Track_Pt");
+  HistoName = "Track_LQ_Pt";
+  Track_LQ_Pt = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Pt.getParameter<int32_t>("Nbinsx"),
+      psTrack_Pt.getParameter<double>("xmin"),
+      psTrack_Pt.getParameter<double>("xmax"));
+  Track_LQ_Pt->setAxisTitle("p_{T} [GeV]", 1);
+  Track_LQ_Pt->setAxisTitle("# L1 Tracks", 2);
+  
+  //Phi
+  edm::ParameterSet psTrack_Phi =  conf_.getParameter<edm::ParameterSet>("TH1_Track_Phi");
+  HistoName = "Track_LQ_Phi";
+  Track_LQ_Phi = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Phi.getParameter<int32_t>("Nbinsx"),
+      psTrack_Phi.getParameter<double>("xmin"),
+      psTrack_Phi.getParameter<double>("xmax"));
+  Track_LQ_Phi->setAxisTitle("#phi", 1);
+  Track_LQ_Phi->setAxisTitle("# L1 Tracks", 2);
+  
+  //Eta
+  edm::ParameterSet psTrack_Eta =  conf_.getParameter<edm::ParameterSet>("TH1_Track_Eta");
+  HistoName = "Track_LQ_Eta";
+  Track_LQ_Eta = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Eta.getParameter<int32_t>("Nbinsx"),
+      psTrack_Eta.getParameter<double>("xmin"),
+      psTrack_Eta.getParameter<double>("xmax"));
+  Track_LQ_Eta->setAxisTitle("#eta", 1);
+  Track_LQ_Eta->setAxisTitle("# L1 Tracks", 2);
+  
+  //VtxZ0
+   edm::ParameterSet psTrack_VtxZ0 =  conf_.getParameter<edm::ParameterSet>("TH1_Track_VtxZ0");
+  HistoName = "Track_LQ_VtxZ0";
+  Track_LQ_VtxZ0 = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_VtxZ0.getParameter<int32_t>("Nbinsx"),
+      psTrack_VtxZ0.getParameter<double>("xmin"),
+      psTrack_VtxZ0.getParameter<double>("xmax"));
+  Track_LQ_VtxZ0->setAxisTitle("L1 Track vertex position z [cm]", 1);
+  Track_LQ_VtxZ0->setAxisTitle("# L1 Tracks", 2);
+  
+  //chi2
+   edm::ParameterSet psTrack_Chi2 =  conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
+  HistoName = "Track_LQ_Chi2";
+  Track_LQ_Chi2 = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2.getParameter<double>("xmin"),
+      psTrack_Chi2.getParameter<double>("xmax"));
+  Track_LQ_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
+  Track_LQ_Chi2->setAxisTitle("# L1 Tracks", 2);
+  
+  //chi2Red
+  edm::ParameterSet psTrack_Chi2Red =  conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
+  HistoName = "Track_LQ_Chi2Red";
+  Track_LQ_Chi2Red = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2Red.getParameter<double>("xmin"),
+      psTrack_Chi2Red.getParameter<double>("xmax"));
+  Track_LQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
+  Track_LQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
+  
+  edm::ParameterSet psTrack_Chi2_NStubs =  conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2_NStubs");
+  HistoName = "Track_LQ_Chi2_NStubs";
+  Track_LQ_Chi2_NStubs = dqmStore_->book2D(HistoName, HistoName,
+      psTrack_Chi2_NStubs.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2_NStubs.getParameter<double>("xmin"),
+      psTrack_Chi2_NStubs.getParameter<double>("xmax"),
+      psTrack_Chi2_NStubs.getParameter<int32_t>("Nbinsy"),
+      psTrack_Chi2_NStubs.getParameter<double>("ymin"),
+      psTrack_Chi2_NStubs.getParameter<double>("ymax"));
+  Track_LQ_Chi2_NStubs->setAxisTitle("# L1 Stubs", 1);
+  Track_LQ_Chi2_NStubs->setAxisTitle("L1 Track #chi^{2}", 2);
+  
+  edm::ParameterSet psTrack_Chi2Red_NStubs =  conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
+  HistoName = "Track_LQ_Chi2Red_NStubs";
+  Track_LQ_Chi2Red_NStubs = dqmStore_->book2D(HistoName, HistoName,
+      psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
+      psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
+  Track_LQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
+  Track_LQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+  
+  
+  /// High-quality tracks
+  dqmStore_->setCurrentFolder(topFolderName_+"/Tracks/HQ");
+  
+  // Nb of L1Tracks
+  HistoName = "Track_HQ_N";
+  Track_HQ_N = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_N.getParameter<int32_t>("Nbinsx"),
+      psTrack_N.getParameter<double>("xmin"),
+      psTrack_N.getParameter<double>("xmax"));
+  Track_HQ_N->setAxisTitle("# L1 Tracks", 1);
+  Track_HQ_N->setAxisTitle("# Events", 2);
+  
+  //Pt of the tracks
+  HistoName = "Track_HQ_Pt";
+  Track_HQ_Pt = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Pt.getParameter<int32_t>("Nbinsx"),
+      psTrack_Pt.getParameter<double>("xmin"),
+      psTrack_Pt.getParameter<double>("xmax"));
+  Track_HQ_Pt->setAxisTitle("p_{T} [GeV]", 1);
+  Track_HQ_Pt->setAxisTitle("# L1 Tracks", 2);
+  
+  //Phi
+  HistoName = "Track_HQ_Phi";
+  Track_HQ_Phi = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Phi.getParameter<int32_t>("Nbinsx"),
+      psTrack_Phi.getParameter<double>("xmin"),
+      psTrack_Phi.getParameter<double>("xmax"));
+  Track_HQ_Phi->setAxisTitle("#phi", 1);
+  Track_HQ_Phi->setAxisTitle("# L1 Tracks", 2);
+  
+  //Eta
+  HistoName = "Track_HQ_Eta";
+  Track_HQ_Eta = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Eta.getParameter<int32_t>("Nbinsx"),
+      psTrack_Eta.getParameter<double>("xmin"),
+      psTrack_Eta.getParameter<double>("xmax"));
+  Track_HQ_Eta->setAxisTitle("#eta", 1);
+  Track_HQ_Eta->setAxisTitle("# L1 Tracks", 2);
+  
+  //VtxZ0
+  HistoName = "Track_HQ_VtxZ0";
+  Track_HQ_VtxZ0 = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_VtxZ0.getParameter<int32_t>("Nbinsx"),
+      psTrack_VtxZ0.getParameter<double>("xmin"),
+      psTrack_VtxZ0.getParameter<double>("xmax"));
+  Track_HQ_VtxZ0->setAxisTitle("L1 Track vertex position z [cm]", 1);
+  Track_HQ_VtxZ0->setAxisTitle("# L1 Tracks", 2);
+  
+  //chi2
+  HistoName = "Track_HQ_Chi2";
+  Track_HQ_Chi2 = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2.getParameter<double>("xmin"),
+      psTrack_Chi2.getParameter<double>("xmax"));
+  Track_HQ_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
+  Track_HQ_Chi2->setAxisTitle("# L1 Tracks", 2);
+  
+  //chi2Red
+  HistoName = "Track_HQ_Chi2Red";
+  Track_HQ_Chi2Red = dqmStore_->book1D(HistoName, HistoName,
+      psTrack_Chi2Red.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2Red.getParameter<double>("xmin"),
+      psTrack_Chi2Red.getParameter<double>("xmax"));
+  Track_HQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
+  Track_HQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
+  
+  HistoName = "Track_HQ_Chi2_NStubs";
+  Track_HQ_Chi2_NStubs = dqmStore_->book2D(HistoName, HistoName,
+      psTrack_Chi2_NStubs.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2_NStubs.getParameter<double>("xmin"),
+      psTrack_Chi2_NStubs.getParameter<double>("xmax"),
+      psTrack_Chi2_NStubs.getParameter<int32_t>("Nbinsy"),
+      psTrack_Chi2_NStubs.getParameter<double>("ymin"),
+      psTrack_Chi2_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Chi2_NStubs->setAxisTitle("# L1 Stubs", 1);
+  Track_HQ_Chi2_NStubs->setAxisTitle("L1 Track #chi^{2}", 2);
+  
+  HistoName = "Track_HQ_Chi2Red_NStubs";
+  Track_HQ_Chi2Red_NStubs = dqmStore_->book2D(HistoName, HistoName,
+      psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsx"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("xmin"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("xmax"),
+      psTrack_Chi2Red_NStubs.getParameter<int32_t>("Nbinsy"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("ymin"),
+      psTrack_Chi2Red_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
+  Track_HQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+  
+}//end of method
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+OuterTrackerMonitorTTTrack::endJob(void) 
+{
+	
+}
+
+DEFINE_FWK_MODULE(OuterTrackerMonitorTTTrack);

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -21,25 +21,18 @@
 #include <numeric>
 #include <iostream>
 #include <fstream>
-#include <math.h>
-#include "TMath.h"
-#include "TNamed.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
+
+// user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrack.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 //#include "DataFormats/L1TrackTrigger/interface/TTTrack.h" // does not exist yet in 81X
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
 
 //
 // constructors and destructor
@@ -143,7 +136,7 @@ OuterTrackerMonitorTTTrack::beginRun(const edm::Run& run, const edm::EventSetup&
   SiStripFolderOrganizer folder_organizer;
   folder_organizer.setSiStripFolderName(topFolderName_);
   folder_organizer.setSiStripFolder();	
-	std::string HistoName;
+  std::string HistoName;
   
   dqmStore_->setCurrentFolder(topFolderName_+"/Tracks/");
   

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -25,7 +25,6 @@
 // user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrack.h"
 //#include "DataFormats/L1TrackTrigger/interface/TTTrack.h" // does not exist yet in 81X
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
@@ -133,9 +132,6 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event& iEvent, const edm::Ev
 void
 OuterTrackerMonitorTTTrack::beginRun(const edm::Run& run, const edm::EventSetup& es)
 {
-  SiStripFolderOrganizer folder_organizer;
-  folder_organizer.setSiStripFolderName(topFolderName_);
-  folder_organizer.setSiStripFolder();	
   std::string HistoName;
   
   dqmStore_->setCurrentFolder(topFolderName_+"/Tracks/");

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrackClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrackClient.cc
@@ -26,7 +26,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrackClient.h"
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrackClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrackClient.cc
@@ -19,23 +19,17 @@
 #include <memory>
 #include <vector>
 #include <numeric>
+#include <iostream>
 #include <fstream>
-#include <math.h>
-#include "TNamed.h"
+
+// user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
 #include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrackClient.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/Core/interface/MonitorElement.h"
-
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 
-#include "TMath.h"
-#include <iostream>
 
 //
 // constructors and destructor

--- a/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrackClient.cc
+++ b/DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrackClient.cc
@@ -1,0 +1,84 @@
+// -*- C++ -*-
+//
+// Package:    Phase2OuterTracker
+// Class:      Phase2OuterTracker
+// 
+/**\class Phase2OuterTracker OuterTrackerMonitorTTTrackClient.cc DQM/Phase2OuterTracker/plugins/OuterTrackerMonitorTTTrackClient.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Isabelle Helena J De Bruyn
+//         Created:  Mon, 10 Feb 2014 13:57:08 GMT
+// 
+
+// system include files
+#include <memory>
+#include <vector>
+#include <numeric>
+#include <fstream>
+#include <math.h>
+#include "TNamed.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DQM/SiStripCommon/interface/SiStripFolderOrganizer.h"
+#include "DQM/Phase2OuterTracker/interface/OuterTrackerMonitorTTTrackClient.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+
+#include "TMath.h"
+#include <iostream>
+
+//
+// constructors and destructor
+//
+OuterTrackerMonitorTTTrackClient::OuterTrackerMonitorTTTrackClient(const edm::ParameterSet& iConfig)
+{
+ 
+}
+
+
+OuterTrackerMonitorTTTrackClient::~OuterTrackerMonitorTTTrackClient()
+{
+ 
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+OuterTrackerMonitorTTTrackClient::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+OuterTrackerMonitorTTTrackClient::beginRun(const edm::Run& run, const edm::EventSetup& es)
+{
+
+
+}//end of method
+
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+OuterTrackerMonitorTTTrackClient::endJob(void) 
+{
+
+}
+
+DEFINE_FWK_MODULE(OuterTrackerMonitorTTTrackClient);

--- a/DQM/Phase2OuterTracker/python/OuterTrackerClientConfig_cff.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerClientConfig_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.Phase2OuterTracker.OuterTrackerMonitorTTClusterClient_cfi import *
+from DQM.Phase2OuterTracker.OuterTrackerMonitorTTStubClient_cfi import *
+#from DQM.Phase2OuterTracker.OuterTrackerMonitorTTTrackClient_cfi import *
+
+OuterTrackerClient = cms.Sequence(OuterTrackerMonitorTTClusterClient
+				  * OuterTrackerMonitorTTStubClient
+#				  * OuterTrackerMonitorTTTrackClient
+          )
+

--- a/DQM/Phase2OuterTracker/python/OuterTrackerClientConfig_cff.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerClientConfig_cff.py
@@ -5,7 +5,7 @@ from DQM.Phase2OuterTracker.OuterTrackerMonitorTTStubClient_cfi import *
 #from DQM.Phase2OuterTracker.OuterTrackerMonitorTTTrackClient_cfi import *
 
 OuterTrackerClient = cms.Sequence(OuterTrackerMonitorTTClusterClient
-				  * OuterTrackerMonitorTTStubClient
-#				  * OuterTrackerMonitorTTTrackClient
-          )
+                                 * OuterTrackerMonitorTTStubClient
+#                                 * OuterTrackerMonitorTTTrackClient
+                                 )
 

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTClusterClient_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTClusterClient_cfi.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+OuterTrackerMonitorTTClusterClient = cms.EDAnalyzer('OuterTrackerMonitorTTClusterClient')

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTCluster_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTCluster_cfi.py
@@ -1,0 +1,98 @@
+import FWCore.ParameterSet.Config as cms
+
+OuterTrackerMonitorTTCluster = cms.EDAnalyzer('OuterTrackerMonitorTTCluster',
+
+    TopFolderName = cms.string('Phase2OuterTracker'),
+    TTClusters    = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
+#    TTClusters    = cms.InputTag("TTStubsFromPhase2TrackerDigis", "ClusterAccepted"),
+
+# Number of clusters per layer
+    TH1TTCluster_Barrel = cms.PSet(
+        Nbinsx = cms.int32(6),
+        xmax = cms.double(6.5),                  
+        xmin = cms.double(0.5)
+        ),
+
+# Number of clusters per disc
+    TH1TTCluster_ECDiscs = cms.PSet(
+        Nbinsx = cms.int32(5),
+        xmax = cms.double(5.5),                 
+        xmin = cms.double(0.5)
+        ),
+
+# Number of clusters per EC ring
+    TH1TTCluster_ECRings = cms.PSet(
+        Nbinsx = cms.int32(16),
+        xmin = cms.double(0.5),
+        xmax = cms.double(16.5)
+        ),
+
+# Cluster eta distribution
+    TH1TTCluster_Eta = cms.PSet(
+        Nbinsx = cms.int32(45),
+        xmax = cms.double(3.0),
+        xmin = cms.double(-3.0)
+        ),
+
+# Cluster Width vs. I/O sensor
+    TH2TTCluster_Width = cms.PSet(
+        Nbinsx = cms.int32(7),
+        xmax = cms.double(6.5),                   
+        xmin = cms.double(-0.5),
+        Nbinsy = cms.int32(2),
+        ymax = cms.double(1.5),
+        ymin = cms.double(-0.5)
+        ),
+
+# TTCluster barrel y vs x
+# TTCluster forward/backward endcap y vs x
+    TH2TTCluster_Position = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(120),
+        xmin = cms.double(-120),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(120),
+        ymin = cms.double(-120)
+        ),
+
+#TTCluster barrel y vs x zoomed
+    TH2TTCluster_Barrel_XY_Zoom = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(60),
+        xmin = cms.double(30),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(15),
+        ymin = cms.double(-15)
+        ),
+
+#TTCluster #rho vs z
+    TH2TTCluster_RZ = cms.PSet(
+        Nbinsx = cms.int32(900),
+        xmax = cms.double(300),
+        xmin = cms.double(-300),
+        Nbinsy = cms.int32(900),
+        ymax = cms.double(120),
+        ymin = cms.double(0)
+        ),
+
+#TTCluster Forward Endcap #rho vs. z
+    TH2TTCluster_Endcap_Fw_RZ_Zoom = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(170),
+        xmin = cms.double(140),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(60),
+        ymin = cms.double(30)
+        ),
+
+#TTCluster Backward Endcap #rho vs. z
+    TH2TTCluster_Endcap_Bw_RZ_Zoom = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(-140),
+        xmin = cms.double(-170),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(100),
+        ymin = cms.double(70)
+        )
+
+)

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTStubClient_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTStubClient_cfi.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+OuterTrackerMonitorTTStubClient = cms.EDAnalyzer('OuterTrackerMonitorTTStubClient')

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
@@ -1,0 +1,118 @@
+import FWCore.ParameterSet.Config as cms
+
+OuterTrackerMonitorTTStub = cms.EDAnalyzer('OuterTrackerMonitorTTStub',
+    
+    TopFolderName = cms.string('Phase2OuterTracker'),
+    TTStubs       = cms.InputTag("TTStubsFromPhase2TrackerDigis", "StubAccepted"),
+
+
+# TTStub barrel y vs x
+# TTStub forward/backward endcap y vs x
+    TH2TTStub_Position = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(120),
+        xmin = cms.double(-120),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(120),
+        ymin = cms.double(-120)
+        ),
+
+#TTStub barrel y vs x zoomed
+    TH2TTStub_Barrel_XY_Zoom = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(60),
+        xmin = cms.double(30),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(15),
+        ymin = cms.double(-15)
+        ),
+
+#TTStub #rho vs z
+    TH2TTStub_RZ = cms.PSet(
+        Nbinsx = cms.int32(900),
+        xmax = cms.double(300),
+        xmin = cms.double(-300),
+        Nbinsy = cms.int32(900),
+        ymax = cms.double(120),
+        ymin = cms.double(0)
+        ),
+
+#TTStub Forward Endcap #rho vs. z
+    TH2TTStub_Endcap_Fw_RZ_Zoom = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(170),
+        xmin = cms.double(140),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(60),
+        ymin = cms.double(30)
+        ),
+
+#TTStub Backward Endcap #rho vs. z
+    TH2TTStub_Endcap_Bw_RZ_Zoom = cms.PSet(
+        Nbinsx = cms.int32(960),
+        xmax = cms.double(-140),
+        xmin = cms.double(-170),
+        Nbinsy = cms.int32(960),
+        ymax = cms.double(100),
+        ymin = cms.double(70)
+        ),
+
+#TTStub eta distribution
+    TH1TTStub_Eta = cms.PSet(
+        Nbinsx = cms.int32(45),
+        xmin = cms.double(-3),
+        xmax = cms.double(3)
+        ),
+
+#TTStub Barrel Layers
+    TH1TTStub_Layers = cms.PSet(
+        Nbinsx = cms.int32(6),
+        xmin = cms.double(0.5),
+        xmax = cms.double(6.5)
+        ),
+
+#TTStub EC Discs
+    TH1TTStub_Discs = cms.PSet(
+        Nbinsx = cms.int32(5),
+        xmin = cms.double(0.5),
+        xmax = cms.double(5.5)
+        ),
+
+#TTStub EC Rings
+    TH1TTStub_Rings = cms.PSet(
+        Nbinsx = cms.int32(16),
+        xmin = cms.double(0.5),
+        xmax = cms.double(16.5)
+        ),
+
+#TTStub displacement or offset per Layer
+    TH2TTStub_DisOf_Layer = cms.PSet(
+        Nbinsx = cms.int32(6),
+        xmax = cms.double(6.5),
+        xmin = cms.double(0.5),
+        Nbinsy = cms.int32(43),
+        ymax = cms.double(10.75),
+        ymin = cms.double(-10.75)
+        ),
+
+#TTStub displacement or offset per Disc
+    TH2TTStub_DisOf_Disc = cms.PSet(
+        Nbinsx = cms.int32(5),
+        xmax = cms.double(5.5),
+        xmin = cms.double(0.5),
+        Nbinsy = cms.int32(43),
+        ymax = cms.double(10.75),
+        ymin = cms.double(-10.75)
+        ),
+
+#TTStub displacement or offset per Ring
+    TH2TTStub_DisOf_Ring = cms.PSet(
+        Nbinsx = cms.int32(16),
+        xmax = cms.double(16.5),
+        xmin = cms.double(0.5),
+        Nbinsy = cms.int32(43),
+        ymax = cms.double(10.75),
+        ymin = cms.double(-10.75)
+        ),
+
+)

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrackClient_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrackClient_cfi.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+OuterTrackerMonitorTTTrackClient = cms.EDAnalyzer('OuterTrackerMonitorTTTrackClient')

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import math
 
 OuterTrackerMonitorTTTrack = cms.EDAnalyzer('OuterTrackerMonitorTTTrack',
 
@@ -31,8 +32,8 @@ OuterTrackerMonitorTTTrack = cms.EDAnalyzer('OuterTrackerMonitorTTTrack',
 #Phi of the track
     TH1_Track_Phi = cms.PSet(
         Nbinsx = cms.int32(45),
-        xmax = cms.double(3.1416),
-        xmin = cms.double(-3.1416)
+        xmax = cms.double(math.pi),
+        xmin = cms.double(-math.pi)
         ),
 
 #Eta of the track

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
@@ -1,0 +1,91 @@
+import FWCore.ParameterSet.Config as cms
+
+OuterTrackerMonitorTTTrack = cms.EDAnalyzer('OuterTrackerMonitorTTTrack',
+
+    TopFolderName  = cms.string('Phase2OuterTracker'),
+    TTTracks       = cms.InputTag("TTTracksFromPhase2TrackerDigis", "Level1TTTracks"),
+    HQDelim        = cms.int32(4),
+
+
+# Number of Stubs
+    TH1_NStubs = cms.PSet(
+        Nbinsx = cms.int32(11),
+        xmax = cms.double(10.5),
+        xmin = cms.double(-0.5)
+        ),
+
+# Number of TTTracks
+    TH1_NTracks = cms.PSet(
+        Nbinsx = cms.int32(100),
+        xmax = cms.double(99.5),
+        xmin = cms.double(-0.5)
+        ),
+
+#Pt of the track
+    TH1_Track_Pt = cms.PSet(
+        Nbinsx = cms.int32(50),
+        xmax = cms.double(100),
+        xmin = cms.double(0)
+        ),
+
+#Phi of the track
+    TH1_Track_Phi = cms.PSet(
+        Nbinsx = cms.int32(45),
+        xmax = cms.double(3.1416),
+        xmin = cms.double(-3.1416)
+        ),
+
+#Eta of the track
+    TH1_Track_Eta = cms.PSet(
+        Nbinsx = cms.int32(45),
+        xmax = cms.double(3.0),
+        xmin = cms.double(-3.0)
+        ),
+
+#VtxZ0 of the track
+    TH1_Track_VtxZ0 = cms.PSet(
+        Nbinsx = cms.int32(51),
+        xmax = cms.double(25),
+        xmin = cms.double(-25)
+        ),
+
+#Chi2 of the track
+    TH1_Track_Chi2 = cms.PSet(
+        Nbinsx = cms.int32(100),
+        xmax = cms.double(50),
+        xmin = cms.double(0)
+        ),
+
+#Chi2R of the track
+    TH1_Track_Chi2R = cms.PSet(
+        Nbinsx = cms.int32(100),
+        xmax = cms.double(10),
+        xmin = cms.double(0)
+        ),
+
+#Chi2 of the track vs Nb of stubs
+    TH2_Track_Chi2_NStubs = cms.PSet(
+        Nbinsx = cms.int32(11),
+        xmax = cms.double(10.5),
+        xmin = cms.double(-0.5),
+        Nbinsy = cms.int32(100),
+        ymax = cms.double(50),
+        ymin = cms.double(0)
+        ),
+
+#Chi2R of the track vs Nb of stubs
+    TH2_Track_Chi2R_NStubs = cms.PSet(
+        Nbinsx = cms.int32(11),
+        xmax = cms.double(10.5),
+        xmin = cms.double(-0.5),
+        Nbinsy = cms.int32(100),
+        ymax = cms.double(10),
+        ymin = cms.double(0)
+        ),
+
+
+
+)
+
+
+

--- a/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
@@ -83,9 +83,4 @@ OuterTrackerMonitorTTTrack = cms.EDAnalyzer('OuterTrackerMonitorTTTrack',
         ymin = cms.double(0)
         ),
 
-
-
 )
-
-
-

--- a/DQM/Phase2OuterTracker/python/OuterTrackerSourceConfig_cff.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerSourceConfig_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.Phase2OuterTracker.OuterTrackerMonitorTTCluster_cfi import *
+from DQM.Phase2OuterTracker.OuterTrackerMonitorTTStub_cfi import *
+#from DQM.Phase2OuterTracker.OuterTrackerMonitorTTTrack_cfi import *
+
+OuterTrackerSource = cms.Sequence(OuterTrackerMonitorTTCluster
+				  * OuterTrackerMonitorTTStub
+#				  * OuterTrackerMonitorTTTrack
+          )

--- a/DQM/Phase2OuterTracker/python/OuterTrackerSourceConfig_cff.py
+++ b/DQM/Phase2OuterTracker/python/OuterTrackerSourceConfig_cff.py
@@ -5,6 +5,6 @@ from DQM.Phase2OuterTracker.OuterTrackerMonitorTTStub_cfi import *
 #from DQM.Phase2OuterTracker.OuterTrackerMonitorTTTrack_cfi import *
 
 OuterTrackerSource = cms.Sequence(OuterTrackerMonitorTTCluster
-				  * OuterTrackerMonitorTTStub
-#				  * OuterTrackerMonitorTTTrack
-          )
+                                 * OuterTrackerMonitorTTStub
+#                                 * OuterTrackerMonitorTTTrack
+                                 )

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -43,6 +43,7 @@ from DQMOffline.RecoB.dqmCollector_cff import *
 from DQMOffline.JetMET.SusyPostProcessor_cff import *
 from DQMOffline.JetMET.dataCertificationJetMET_cff import *
 from DQM.TrackingMonitorClient.TrackingClientConfig_Tier0_cff import *
+from DQM.Phase2OuterTracker.OuterTrackerClientConfig_cff import *
 
 DQMOffline_SecondStep_PrePOG = cms.Sequence( TrackingOfflineDQMClient *
                                              muonQualityTests *
@@ -107,6 +108,14 @@ DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
 
 DQMHarvestTracking = cms.Sequence( TrackingOfflineDQMClient *
                                    dqmFastTimerServiceClient )
+
+DQMHarvestOuterTracker = cms.Sequence( dqmRefHistoRootFileGetter *
+                                 dqmDcsInfoClient *
+                                 OuterTrackerClient *
+                                 dqmFEDIntegrityClient *
+                                 DQMMessageLoggerClientSeq *
+                                 dqmFastTimerServiceClient
+                                 )
 
 DQMHarvestMuon = cms.Sequence( dtClients *
                                rpcTier0Client *

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -46,6 +46,7 @@ from DQM.Physics.DQMPhysics_cff import *
 from DQM.Physics.DQMTopMiniAOD_cff import *
 from Validation.RecoTau.DQMSequences_cfi import *
 from DQM.TrackingMonitorSource.TrackingSourceConfig_Tier0_cff import *
+from DQM.Phase2OuterTracker.OuterTrackerSourceConfig_cff import *
 # miniAOD DQM validation
 from Validation.RecoParticleFlow.miniAODDQM_cff import *
 from DQM.TrackingMonitor.tracksDQMMiniAOD_cff import * 
@@ -104,6 +105,15 @@ DQMOfflineTracking = cms.Sequence( TrackingDQMSourceTier0Common *
                                    pvMonitor *
                                    materialDumperAnalyzer
                                  )
+
+DQMOuterTracker = cms.Sequence( dqmDcsInfo *
+                                OuterTrackerSource *
+                                DQMMessageLogger *
+                                dqmPhysics *
+                                pvMonitor *
+                                produceDenoms
+                                )
+
 DQMOfflineCommon = cms.Sequence( dqmDcsInfo *
                                  DQMMessageLogger *
                                  SiStripDQMTier0Common *
@@ -132,6 +142,7 @@ DQMOfflineCommonSiStripZeroBias = cms.Sequence( dqmDcsInfo *
                                  produceDenoms *
                                  pfTauRunDQMValidation 
                                  )
+
 DQMOfflineMuon = cms.Sequence( dtSources *
                                rpcTier0Source *
                                cscSources *

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -7,6 +7,9 @@ autoDQM = { 'common' : ['DQMOfflineCommon',
             'trackingOnlyDQM' : ["DQMOfflineTracking",
                                  "PostDQMOffline",
                                  "DQMHarvestTracking"],
+            'outerTracker': ['DQMOuterTracker',
+                             'PostDQMOffline',
+                             'DQMHarvestOuterTracker'],
             'muon': ['DQMOfflineMuon',
                      'PostDQMOffline',
                      'DQMHarvestMuon+DQMCertMuon'],
@@ -38,7 +41,6 @@ autoDQM = { 'common' : ['DQMOfflineCommon',
             'allForPrompt':  ['@common+@muon+@hcal+@jetmet+@ecal',
                               'PostDQMOffline',
                               '@common+@muon+@hcal+@jetmet+@ecal'],
-
             'miniAODDQM': ['DQMOfflineMiniAOD',
                            'PostDQMOfflineMiniAOD',
                            'DQMHarvestMiniAOD'],
@@ -53,7 +55,7 @@ autoDQM = { 'common' : ['DQMOfflineCommon',
                           'dqmHarvesting']
             }
 
-_phase2_allowed = ['trackingOnlyDQM','muon','hcal','hcal2','egamma']
+_phase2_allowed = ['trackingOnlyDQM','outerTracker','muon','hcal','hcal2','egamma']
 autoDQM['phase2'] = ['','','']
 for i in [0,2]:
     autoDQM['phase2'][i] = '+'.join([autoDQM[m][i] for m in _phase2_allowed])

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
@@ -34,7 +34,6 @@ void TTClusterBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, co
       if(!tTopo->isLower(detid) ) continue; // loop on the stacks: choose the lower arbitrarily
       DetId lowerDetid = detid;
       DetId upperDetid = tTopo->partnerDetId(detid);
-      //DetId stackDetid = tTopo->stack(detid);
 
       /// Temp vectors containing the vectors of the                                                                                                        
       /// hits used to build each cluster                                                                                                                  

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
@@ -34,7 +34,7 @@ void TTClusterBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, co
       if(!tTopo->isLower(detid) ) continue; // loop on the stacks: choose the lower arbitrarily
       DetId lowerDetid = detid;
       DetId upperDetid = tTopo->partnerDetId(detid);
-      DetId stackDetid = tTopo->stack(detid);
+      //DetId stackDetid = tTopo->stack(detid);
 
       /// Temp vectors containing the vectors of the                                                                                                        
       /// hits used to build each cluster                                                                                                                  
@@ -57,7 +57,7 @@ void TTClusterBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, co
 	edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >::FastFiller lowerOutputFiller( *ttClusterDSVForOutput, lowerDetid ); 
       for ( unsigned int i = 0; i < lowerHits.size(); i++ )
 	{
-	  TTCluster< Ref_Phase2TrackerDigi_ > temp( lowerHits.at(i), stackDetid, 0, storeLocalCoord );
+	  TTCluster< Ref_Phase2TrackerDigi_ > temp( lowerHits.at(i), lowerDetid, 0, storeLocalCoord );
 	  lowerOutputFiller.push_back( temp );
 	}
       if ( lowerOutputFiller.empty() )
@@ -67,7 +67,7 @@ void TTClusterBuilder< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, co
        edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >::FastFiller upperOutputFiller( *ttClusterDSVForOutput, upperDetid );
      for ( unsigned int i = 0; i < upperHits.size(); i++ )
        {
-	 TTCluster< Ref_Phase2TrackerDigi_ > temp( upperHits.at(i), stackDetid, 1, storeLocalCoord );
+	 TTCluster< Ref_Phase2TrackerDigi_ > temp( upperHits.at(i), upperDetid, 1, storeLocalCoord );
 	 upperOutputFiller.push_back( temp );
        }
      if ( upperOutputFiller.empty() )


### PR DESCRIPTION
This PR includes new DQM plots for the phase 2 track trigger (e.g. position & occupancy plots, eta distributions of TTClusters and TTStubs). It is based on the code in L1Trigger/TrackTrigger/test/ and was previously included in the 62X_SLHC release. An overview of its use and purpose can be found in the linked presentation.
As the TTTracks are not yet available, the relevant code is commented.

This is a follow-up of PR #17314

https://indico.cern.ch/event/536863/contributions/2410741/attachments/1390920/2118789/161220_DQM_Phase2OuterTracker.pdf

@idebruyn @ivanpari 