### PR TITLE
Add missing initializations needed by python CmsRun

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -4,6 +4,7 @@ PSet script.   See notes in EventProcessor.cpp for details about it.
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/interface/EventProcessor.h"
+#include "FWCore/Framework/interface/defaultCmsRunServices.h"
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
@@ -332,22 +333,10 @@ int main(int argc, char* argv[]) {
       }
 
       context = "Initializing default service configurations";
-      std::vector<std::string> defaultServices;
-      defaultServices.reserve(8);
-      defaultServices.push_back("MessageLogger");
-      defaultServices.push_back("InitRootHandlers");
-#ifdef linux
-      defaultServices.push_back("EnableFloatingPointExceptions");
-#endif
-      defaultServices.push_back("UnixSignalService");
-      defaultServices.push_back("AdaptorConfig");
-      defaultServices.push_back("SiteLocalConfigService");
-      defaultServices.push_back("StatisticsSenderService");
-      defaultServices.push_back("CondorStatusService");
 
       // Default parameters will be used for the default services
       // if they are not overridden from the configuration files.
-      processDesc->addServices(defaultServices);
+      processDesc->addServices(edm::defaultCmsRunServices());
 
       context = "Setting MessageLogger defaults";
       // Decide what mode of hardcoded MessageLogger defaults to use

--- a/FWCore/Framework/interface/defaultCmsRunServices.h
+++ b/FWCore/Framework/interface/defaultCmsRunServices.h
@@ -1,0 +1,34 @@
+#ifndef FWCore_Framework_defaultCmsRunServices_h
+#define FWCore_Framework_defaultCmsRunServices_h
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class  :     defaultCmsRunServices
+// 
+/**\class defaultCmsRunServices defaultCmsRunServices.h FWCore/Framework/interface/defaultCmsRunServices.h
+
+ Description: Returns the names of the standard cmsRun default services
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Mon Jan 30 13:40:06 CDT 2017
+//
+
+// user include files
+
+// system include files
+
+#include <vector>
+#include <string>
+
+// forward declarations
+
+namespace edm {
+   std::vector<std::string> defaultCmsRunServices();
+}
+
+#endif

--- a/FWCore/Framework/src/defaultCmsRunServices.cc
+++ b/FWCore/Framework/src/defaultCmsRunServices.cc
@@ -1,0 +1,34 @@
+// -*- ++ -*-
+//
+// Package:     FWCore/Framework
+// Function:    defaultCmsRunServices
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  root
+//         Created:  Tue, 06 Sep 2016 16:04:28 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/defaultCmsRunServices.h"
+
+namespace edm {
+   std::vector<std::string> defaultCmsRunServices() {
+      std::vector<std::string> returnValue = {"MessageLogger",
+                                              "InitRootHandlers",
+#ifdef linux
+                                              "EnableFloatingPointExceptions",
+#endif
+                                              "UnixSignalService",
+                                              "AdaptorConfig",
+                                              "SiteLocalConfigService",
+                                              "StatisticsSenderService",
+                                              "CondorStatusService"};
+
+      return returnValue;
+   }
+   
+}

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -196,7 +196,6 @@ namespace edm {
   }
   
   void setMaxLoggedErrorsSummaryIndicies(unsigned int iMax) {
-    assert(0==errorSummaryMaps.size());
     errorSummaryMaps.resize(iMax);
   }
 

--- a/FWCore/PythonFramework/src/PythonEventProcessor.cc
+++ b/FWCore/PythonFramework/src/PythonEventProcessor.cc
@@ -17,6 +17,14 @@
 #include "FWCore/PythonFramework/interface/PythonEventProcessor.h"
 #include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
 
+#include "FWCore/Framework/interface/defaultCmsRunServices.h"
+#include "FWCore/ParameterSet/interface/ProcessDesc.h"
+
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+
+#include "FWCore/MessageLogger/interface/JobReport.h"
+
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 
@@ -28,6 +36,15 @@ namespace {
          });
       return 0;
    }
+  
+  std::shared_ptr<edm::ProcessDesc> addDefaultServicesToProcessDesc(std::shared_ptr<edm::ProcessDesc> iDesc) {
+    iDesc->addServices(edm::defaultCmsRunServices());
+    return iDesc;
+  }
+
+  edm::ServiceToken createJobReport() {
+    return edm::ServiceRegistry::createContaining(std::make_shared<edm::serviceregistry::ServiceWrapper<edm::JobReport>>(std::make_unique<edm::JobReport>(nullptr)));
+  }
 }
 
 //
@@ -43,7 +60,7 @@ namespace {
 //
 PythonEventProcessor::PythonEventProcessor(PythonProcessDesc const& iDesc)
 : forcePluginSetupFirst_(setupPluginSystem())
-  ,processor_(iDesc.processDesc(),edm::ServiceToken(),edm::serviceregistry::kOverlapIsError)
+  ,processor_(addDefaultServicesToProcessDesc(iDesc.processDesc()),createJobReport(),edm::serviceregistry::kOverlapIsError)
 {
 }
 


### PR DESCRIPTION
Some Services were not initialized in python CmsRun which caused more advanced configurations to fail.