### PR TITLE
Fix pickling of SortedKeysDict

### DIFF
--- a/FWCore/ParameterSet/python/DictTypes.py
+++ b/FWCore/ParameterSet/python/DictTypes.py
@@ -21,12 +21,13 @@ class SortedKeysDict(dict):
     def __repr__(self):
         meat = ', '.join([ '%s: %s' % (repr(key), repr(val)) for key,val in self.iteritems() ])
         return '{' + meat + '}'
-
     def __iter__(self):
         for key in self.list:
             yield key
     def __setitem__(self, key, value):
         dict.__setitem__(self, key, value)
+        if not hasattr(self,'list'):
+          self.list = list()
         if not key in self.list:
             self.list.append(key)
     def __delitem__(self, key):


### PR DESCRIPTION
When trying out mpi4py's serialization of cms.Process using pickling
trying to read-back a SortedKeysDict failed. The unpickling process
is not guaranteed to call __init__ which meant self.list was not
being initialized.