### PR TITLE
Fix or suppress warnings related to Phase0 HE in 2017

### DIFF
--- a/Validation/GlobalHits/BuildFile.xml
+++ b/Validation/GlobalHits/BuildFile.xml
@@ -4,6 +4,8 @@
 <use   name="FWCore/Utilities"/>
 <use   name="SimDataFormats/ValidationFormats"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="SimDataFormats/CaloTest"/>
+<use   name="DataFormats/HcalDetId"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/Common"/>
 <use   name="Geometry/CommonDetUnit"/>
@@ -13,6 +15,7 @@
 <use   name="Geometry/DTGeometry"/>
 <use   name="Geometry/RPCGeometry"/>
 <use   name="Geometry/CaloTopology"/>
+<use   name="Geometry/HcalCommonData"/>
 <use   name="Geometry/Records"/>
 <use   name="DQMServices/Core"/>
 <use   name="root"/>

--- a/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
@@ -48,6 +48,7 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 
 // data in edm::event
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -105,6 +106,7 @@ class GlobalHitsAnalyzer : public DQMEDAnalyzer
   std::string label;
   bool getAllProvenances;
   bool printProvenanceInfo;
+  bool testNumber;
 
   bool validHepMCevt;
   bool validG4VtxContainer;
@@ -179,6 +181,7 @@ class GlobalHitsAnalyzer : public DQMEDAnalyzer
   MonitorElement *meCaloHcalEta;  
   edm::InputTag HCalSrc_;
   edm::EDGetTokenT<edm::PCaloHitContainer>  HCalSrc_Token_;
+  const HcalDDDRecConstants *hcons;
 
   // Tracker info
   // Pixel info

--- a/Validation/GlobalHits/python/globalhits_analyze_cfi.py
+++ b/Validation/GlobalHits/python/globalhits_analyze_cfi.py
@@ -37,6 +37,7 @@ globalhitsanalyze = cms.EDAnalyzer("GlobalHitsAnalyzer",
     # 3 provides output of the store step + 2
     Frequency = cms.untracked.int32(50),
     ECalEBSrc = cms.InputTag("g4SimHits","EcalHitsEB"),
+    testNumber = cms.untracked.bool(False),
 
     validHepMCevt = cms.untracked.bool(True),
     validG4VtxContainer = cms.untracked.bool(True),
@@ -63,3 +64,7 @@ globalhitsanalyze = cms.EDAnalyzer("GlobalHitsAnalyzer",
 )
 
 
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+run2_HCAL_2017.toModify(globalhitsanalyze,
+    testNumber    = cms.untracked.bool(True)
+)

--- a/Validation/HcalDigis/BuildFile.xml
+++ b/Validation/HcalDigis/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="Geometry/HcalTowerAlgo"/>
 <use   name="Geometry/CaloGeometry"/>
+<use   name="Geometry/Records"/>
 <use   name="CalibFormats/HcalObjects"/>
 <use   name="DQMServices/Core"/>
 <use   name="SimDataFormats/CaloTest"/>

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -18,6 +18,7 @@
 
 #include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include <Validation/HcalDigis/interface/HcalDigisValidation.h>
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
@@ -604,7 +605,10 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
                   int z, lay;
                   HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
                   int sign = (z==0) ? (-1):(1);
-                  ieta     *= sign;
+                  HcalDDDRecConstants::HcalID hcid = hcons->getHCID(sub, ieta, iphi, lay, depth);
+                  ieta = sign*hcid.eta;
+                  iphi = hcid.phi;
+                  depth = hcid.depth;
                 } else {
                   HcalDetId id = HcalDetId(id_);
                   sub       = id.subdet(); 
@@ -820,7 +824,10 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
                   int z, lay;
                   HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
                   int sign = (z==0) ? (-1):(1);
-                  ieta     *= sign;
+                  HcalDDDRecConstants::HcalID hcid = hcons->getHCID(sub, ieta, iphi, lay, depth);
+                  ieta = sign*hcid.eta;
+                  iphi = hcid.phi;
+                  depth = hcid.depth;
                 } else {
                   HcalDetId id = HcalDetId(id_);
                   sub       = id.subdet(); 
@@ -935,7 +942,10 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
                   int z, lay;
                   HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
                   int sign = (z==0) ? (-1):(1);
-                  ieta     *= sign;
+                  HcalDDDRecConstants::HcalID hcid = hcons->getHCID(sub, ieta, iphi, lay, depth);
+                  ieta = sign*hcid.eta;
+                  iphi = hcid.phi;
+                  depth = hcid.depth;
                 } else {
                   HcalDetId id = HcalDetId(id_);
                   sub          = id.subdet();
@@ -1153,7 +1163,10 @@ template<class dataFrameType> void HcalDigisValidation::reco(const edm::Event& i
                   int z, lay;
                   HcalTestNumbering::unpackHcalIndex(id_, sub, z, depth, ieta, iphi, lay);
                   int sign = (z==0) ? (-1):(1);
-                  ieta     *= sign;
+                  HcalDDDRecConstants::HcalID hcid = hcons->getHCID(sub, ieta, iphi, lay, depth);
+                  ieta = sign*hcid.eta;
+                  iphi = hcid.phi;
+                  depth = hcid.depth;
                 } else {
                   HcalDetId id = HcalDetId(id_);
                   sub       = id.subdet();


### PR DESCRIPTION
Followup to #17198.

Validation warnings related to improper handling of TestNumbering for HCAL SimHits have been fixed.
@bsunanda, @hatakeyamak, @kencall at some point we should tweak [HcalHitRelabeller](https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_X/SimCalorimetry/HcalSimProducers/src/HcalHitRelabeller.cc) to be useful as a general helper class for TestNumbering SimHit processing. There's no reason for the Validation code to use `HcalTestNumbering` or `HcalDDDRecConstants` classes unless the actual layer information is needed.

I couldn't figure out the source of the DQM printout (which was using `std::cout`), so I just commented it out. @deguio @vkhristenko please investigate when you have time. There must be an inconsistency with the constants or something.