### PR TITLE
Madgraph 2.4.2 cards

### DIFF
--- a/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms 
 externalLHEProducer = cms.EDProducer('ExternalLHEProducer', 
-                                     scriptName = cms.FileInPath("GeneratorInterface/LHEInterface/data/run_generic_tarball.sh"), 
-                                     outputFile = cms.string("cmsgrid_final.lhe"), 
-                                     numberOfParameters = cms.uint32(2), 
-                                     args = cms.vstring('slc6_amd64_gcc472/13TeV/madgraph/V5_2.2.1/dyellell01234j_5f_LO_MLM/v1/',
-                                                        'dyellell01234j_5f_LO_MLM_tarball.tar.gz'),
+                                     scriptName = cms.FileInPath("GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh"), 
+                                     outputFile = cms.string("cmsgrid_final.lhe"),  
+                                     numberOfParameters = cms.uint32(1), 
+                                     args = cms.vstring(#'slc6_amd64_gcc472/13TeV/madgraph/V5_2.2.1/dyellell01234j_5f_LO_MLM/v1/',
+                                                        #'dyellell01234j_5f_LO_MLM_tarball.tar.gz'
+                                                        '/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/dyellell01234j_5f_LO_MLM/v1/dyellell01234j_5f_LO_MLM_tarball.tar.xz'),
                                      nEvents = cms.untracked.uint32(10)
                                      ) 

--- a/Configuration/Generator/python/DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # https://github.com/cms-sw/genproductions/tree/e30fc9c7d9226a2c96869c0ddbe5e65884afd013/bin/MadGraph5_aMCatNLO/cards/production/13TeV/dyellell012j_5f_NLO_FXFX
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.2.2/dyellell012j_5f_NLO_FXFX/v1/dyellell012j_5f_NLO_FXFX_tarball.tar.xz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/dyellell012j_5f_NLO_FXFX/v1/dyellell012j_5f_NLO_FXFX_tarball.tar.xz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.2.2/tt012j_5f_ckm_NLO_FXFX/v1/tt012j_5f_ckm_NLO_FXFX_tarball.tar.xz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/tt012j_5f_ckm_NLO_FXFX/v1/tt012j_5f_ckm_NLO_FXFX_tarball.tar.xz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),

--- a/Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.2.2/WJets_HT_LO_MLM/WJetsToLNu_HT-incl/V1/WJetsToLNu_HT-incl_tarball.tar.xz'),
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.4.2/lv_bwcutoff_WJetsToLNu_HT-incl/v1/lv_bwcutoff_WJetsToLNu_HT-incl_tarball.tar.xz'),
     nEvents = cms.untracked.uint32(5000),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),


### PR DESCRIPTION
I update the  _DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff, DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff, TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff_ and _WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff_ configuration file to use the new gridpack generated with Madggraph **2.4.2** . 