### PR TITLE
Remove check on TrackingParticle::numberOfHits()==0 from QuickTrackAssociatorByHits

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -296,8 +296,12 @@ template<typename T_TPCollection,typename iter> std::vector<std::pair<edm::Ref<T
 	{
 		const TrackingParticle* pTrackingParticle=getTrackingParticleAt( trackingParticles, i );
 
-		// Ignore TrackingParticles with no hits
-		if( pTrackingParticle->numberOfHits()==0 ) continue;
+		// Historically there was a requirement that pTrackingParticle->numberOfHits() > 0
+		// However, in TrackingTruthAccumulator, the numberOfHits is calculated from a subset
+		// of the SimHits of the SimTracks of a TrackingParticle (essentially limiting the
+		// processType and particleType to those of the "first" hit, and particleType to the pdgId of the SimTrack).
+		// But, here the association between tracks and TrackingParticles is done with *all* the hits of
+		// TrackingParticle, so we should not rely on the numberOfHits() calculated with a subset of SimHits.
 
 		double numberOfAssociatedHits=0;
 		// Loop over all of the sim track identifiers and see if any of them are part of this TrackingParticle. If they are, add
@@ -356,8 +360,12 @@ template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<
                                 if(trackingParticleKeys && trackingParticleKeys->find(trackingParticle.key()) == trackingParticleKeys->end())
                                   continue;
 
-				// Ignore TrackingParticles with no hits
-				if( trackingParticle->numberOfHits() == 0 ) continue;
+				// Historically there was a requirement that pTrackingParticle->numberOfHits() > 0
+				// However, in TrackingTruthAccumulator, the numberOfHits is calculated from a subset
+				// of the SimHits of the SimTracks of a TrackingParticle (essentially limiting the
+				// processType and particleType to those of the "first" hit, and particleType to the pdgId of the SimTrack).
+				// But, here the association between tracks and TrackingParticles is done with *all* the hits of
+				// TrackingParticle, so we should not rely on the numberOfHits() calculated with a subset of SimHits.
 
 				/* Alternative implementation to avoid the use of lmap... memory slightly improved but slightly slower...
 				 std::pair<edm::Ref<TrackingParticleCollection>,size_t> tpIntPair(trackingParticle, 1);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1422,7 +1422,6 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(const OmniClusterRef& cl
       auto tpIndex = tpKeyToIndex.find(trackingParticle.key());
       if( tpIndex == tpKeyToIndex.end())
         continue;
-      if( trackingParticle->numberOfHits() == 0 ) continue;
 
       //now get the corresponding sim hit
       std::pair<TrackingParticleRef, TrackPSimHitRef> simHitTPpairWithDummyTP(trackingParticle,TrackPSimHitRef());


### PR DESCRIPTION
Currently `QuickTrackAssociatorByHits` ignores TrackingParticles with `numberOHits()==0` from track-TrackingParticle association. While this seems like a nice performance optimization, it does cause some track-TrackingParticle pairs to not be associated because of how the `numberOfHits()` is calculated in `TrackingTruthAccumulator`:

1. only SimHits with the same `particleType` as the `SimTrack`'s `pdgId` and the same `particleType` and `processType` as the "first hit" are counted
2. the definition of "first hit" is not robust (or very counter-intuitive if that is the intention; I'll give more details  in another PR ~~fixing that issue~~ improving the situation, the PR is #17382).

Because of 1, I propose to include also TrackingParticles with `numberOfHits()==0` in the track-TrackingParticle association, because the association is (effectively) done with **all** SimHits of a TrackingParticle (via the Pixel/StripDigiSimLinks).

"Accidentally", this PR also fixes the problem caused of 2.

Here are MTV plots in CMSSW_9_0_X_2017-01-23-1100 for ttbar+35PU for phase0, phase1, and phase1 with CA seeding, and CMSSW_9_0_0_pre2 for phase2 (D4) ttbar+PU200
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_9_0_X_phase2debug/
and here for phase2 (D4) ttbar noPU in CMSSW_9_0_X_2017-01-23-1100 (thanks to @ebrondol)
http://ebrondol.web.cern.ch/ebrondol/Phase2Tracking/fixFakes/20170125_TTbar/

The effect on efficiency in phase0, phase1, phase2 PU200 is tiny; phase2 noPU shows few percent increase in |eta| 2-3. The effect on fake rate in phase0, phase1, phase2 PU200 is a 1-2 % overall decrease (can be more in specific phase space regions); phase2 noPU shows ~40 % overall decrease.

Tested in CMSSW_9_0_X_2017-01-23-1100 and CMSSW_9_0_0_pre2, expecting changes like above in the track-TrackingParticle association (no change expected e.g. on RECO itself).

@VinInn @rovere @ebrondol @slava77 