### PR TITLE
more workflows that can not use recycled gensim at this point

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1701,8 +1701,8 @@ from  Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
 defaultDataSets={}
 #defaultDataSets['2017']='CMSSW_8_1_0_pre16-81X_upgrade2017_realistic_v22-v'
 #defaultDataSets['2017Design']='CMSSW_8_1_0_pre16-81X_upgrade2017_design_IdealBS_v6-v'
-defaultDataSets['2018']='CMSSW_8_1_0_pre16-81X_upgrade2017_realistic_v22-v'
-defaultDataSets['2018Design']='CMSSW_8_1_0_pre16-81X_upgrade2017_design_IdealBS_v6-v'
+#defaultDataSets['2018']='CMSSW_8_1_0_pre16-81X_upgrade2017_realistic_v22-v'
+#defaultDataSets['2018Design']='CMSSW_8_1_0_pre16-81X_upgrade2017_design_IdealBS_v6-v'
 defaultDataSets['2023D7']=''
 defaultDataSets['2023D10']=''
 defaultDataSets['2023D7Timing']=''

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -10,9 +10,9 @@ upgradeKeys[2017] = [
     '2017Design',
 #    '2017DesignPU',
     '2018',
-    '2018PU',
+#    '2018PU',
     '2018Design',
-    '2018DesignPU',
+#    '2018DesignPU',
 ]
 
 upgradeKeys[2023] = [


### PR DESCRIPTION
the 2018 ones have the same problem as the 2017 ones I fixed this morning