### PR TITLE
SimDataFormats/PileupSummaryInfo : Changes needed to compile with macOS clang and libc++

### DIFF
--- a/SimDataFormats/PileupSummaryInfo/BuildFile.xml
+++ b/SimDataFormats/PileupSummaryInfo/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
 <use   name="hepmc"/>
+<use   name="rooteg"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/PileupSummaryInfo/BuildFile.xml
+++ b/SimDataFormats/PileupSummaryInfo/BuildFile.xml
@@ -1,8 +1,8 @@
 <use   name="DataFormats/Math"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="hepmc"/>
-<use   name="rooteg"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
Root libeg needed to provide \_hepevt\_ symbol.