### PR TITLE
The new gcc ABI for C++11 uses different namespace

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -42,8 +42,9 @@ namespace edm {
     static boost::regex const reWrapper("edm::Wrapper<(.*)>");
     static boost::regex const reString("std::basic_string<char>");
     static boost::regex const reString2("std::string");
-    static boost::regex const reStringCXX11("std::__cxx11::basic_string<char>");
-    static boost::regex const reString2CXX11("std::__cxx11::basic_string<char,std::char_traits<char> >");
+    static boost::regex const reString3("std::basic_string<char,std::char_traits<char> >");
+    //The c++11 abi for gcc internally uses a different namespace for standard classes
+    static boost::regex const reCXX11("std::__cxx11::");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
     static boost::regex const reULongLong("ULong64_t");
     static boost::regex const reLongLong("Long64_t");
@@ -77,10 +78,10 @@ namespace edm {
        using boost::regex;
        std::string name = regex_replace(iIn, reWrapper, "$1");
        name = regex_replace(name,reAIKR,"");
+      name = regex_replace(name,reCXX11,"std::");
        name = regex_replace(name,reString,"String");
        name = regex_replace(name,reString2,"String");
-       name = regex_replace(name,reStringCXX11,"String");
-       name = regex_replace(name,reString2CXX11,"String");
+       name = regex_replace(name,reString3,"String");
        name = regex_replace(name,reSorted,"sSorted<$1>");
        name = regex_replace(name,reULongLong,"ull");
        name = regex_replace(name,reLongLong,"ll");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -44,7 +44,11 @@ void testfriendlyName::test()
   classToFriendly.insert( Values("std::string","String"));
   classToFriendly.insert( Values("std::__cxx11::basic_string<char>","String"));
   classToFriendly.insert( Values("std::__cxx11::basic_string<char,std::char_traits<char> >","String"));
+  classToFriendly.insert( Values("std::list<int>","intstdlist"));
+  classToFriendly.insert( Values("std::__cxx11::list<int>","intstdlist"));
   classToFriendly.insert( Values("std::vector<std::shared_ptr<bar::Foo>>","barFooSharedPtrs"));
+  classToFriendly.insert( Values("std::vector<std::basic_string<char>>","Strings"));
+  classToFriendly.insert( Values("std::__cxx11::vector<std::__cxx11::basic_string<char>>","Strings"));
   classToFriendly.insert( Values("std::unique_ptr<Foo>","FooUniquePtr"));
   classToFriendly.insert( Values("std::unique_ptr<bar::Foo>","barFooUniquePtr"));
   classToFriendly.insert( Values("std::vector<std::unique_ptr<bar::Foo>>","barFooUniquePtrs"));


### PR DESCRIPTION
The gcc ABI for C++11 internally uses the namespace std::__cxx11
for the standard library containers. The friendly class name
generator now knows about that naming in order to keep the
branch names the same as before the ABI change.