### PR TITLE
Improve performance of Cellular Automaton for regional tracking at HLT

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
@@ -86,21 +86,21 @@ void CAHitNtupletEDProducerT<T_Generator>::produce(edm::Event& iEvent, const edm
   generator_.initEvent(iEvent, iSetup);
 
   LogDebug("CAHitNtupletEDProducer") << "Creating ntuplets for " << regionDoublets.regionSize() << " regions, and " << regionDoublets.layerPairsSize() << " layer pairs";
-
-  typename T_Generator::ResultType ntuplets;
-  ntuplets.reserve(localRA_.upper());
-
+  std::vector<typename T_Generator::ResultType> ntuplets;
+  ntuplets.resize(regionDoublets.regionSize());
+  for(auto ntuplet : ntuplets)  ntuplet.reserve(localRA_.upper()); 
+ 
+  generator_.hitNtuplets(regionDoublets, ntuplets, iSetup, seedingLayerHits);
+  int index = 0;
   for(const auto& regionLayerPairs: regionDoublets) {
     const TrackingRegion& region = regionLayerPairs.region();
     auto seedingHitSetsFiller = seedingHitSets->beginRegion(&region);
 
-    LogTrace("CAHitNtupletEDProducer") << " starting region";
 
-    generator_.hitNtuplets(regionLayerPairs, ntuplets, iSetup, seedingLayerHits);
-    LogTrace("CAHitNtupletEDProducer") << "  created " << ntuplets.size() << " ntuplets";
-    fillNtuplets(seedingHitSetsFiller, ntuplets);
+    fillNtuplets(seedingHitSetsFiller, ntuplets[index]);
 
-    ntuplets.clear();
+    ntuplets[index].clear();
+    index++;
   }
   localRA_.update(seedingHitSets->size());
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
@@ -88,8 +88,8 @@ void CAHitNtupletEDProducerT<T_Generator>::produce(edm::Event& iEvent, const edm
   LogDebug("CAHitNtupletEDProducer") << "Creating ntuplets for " << regionDoublets.regionSize() << " regions, and " << regionDoublets.layerPairsSize() << " layer pairs";
   std::vector<typename T_Generator::ResultType> ntuplets;
   ntuplets.resize(regionDoublets.regionSize());
-  for(auto ntuplet : ntuplets)  ntuplet.reserve(localRA_.upper()); 
- 
+  for(auto& ntuplet : ntuplets)  ntuplet.reserve(localRA_.upper()); 
+   
   generator_.hitNtuplets(regionDoublets, ntuplets, iSetup, seedingLayerHits);
   int index = 0;
   for(const auto& regionLayerPairs: regionDoublets) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletEDProducerT.cc
@@ -96,9 +96,7 @@ void CAHitNtupletEDProducerT<T_Generator>::produce(edm::Event& iEvent, const edm
     const TrackingRegion& region = regionLayerPairs.region();
     auto seedingHitSetsFiller = seedingHitSets->beginRegion(&region);
 
-
     fillNtuplets(seedingHitSetsFiller, ntuplets[index]);
-
     ntuplets[index].clear();
     index++;
   }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -13,7 +13,6 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 
 
@@ -53,6 +52,7 @@ caThetaCut(cfg.getParameter<double>("CAThetaCut")),
 caPhiCut(cfg.getParameter<double>("CAPhiCut")),
 caHardPtCut(cfg.getParameter<double>("CAHardPtCut")),
 caOnlyOneLastHitPerLayerFilter(cfg.getParameter<bool>("CAOnlyOneLastHitPerLayerFilter"))
+
 {
   if(needSeedingLayerSetsHits)
     theSeedingLayerToken = iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"));
@@ -82,6 +82,7 @@ void CAHitQuadrupletGenerator::fillDescriptions(edm::ParameterSetDescription& de
   desc.add<double>("CAPhiCut", 10);
   desc.add<double>("CAHardPtCut", 0);
   desc.add<bool>("CAOnlyOneLastHitPerLayerFilter",false);
+
   edm::ParameterSetDescription descMaxChi2;
   descMaxChi2.add<double>("pt1", 0.2);
   descMaxChi2.add<double>("pt2", 1.5);
@@ -99,11 +100,8 @@ void CAHitQuadrupletGenerator::fillDescriptions(edm::ParameterSetDescription& de
 void CAHitQuadrupletGenerator::initEvent(const edm::Event& ev, const edm::EventSetup& es) {
   if (theComparitor) theComparitor->init(ev, es);
 }
-
 namespace {
-  template <typename T_HitDoublets, typename T_GeneratorOrPairsFunction>
-  void fillGraph(const SeedingLayerSetsHits& layers, CAGraph& g, T_HitDoublets& hitDoublets,
-                 T_GeneratorOrPairsFunction generatorOrPairsFunction) {
+  void createGraphStructure(const SeedingLayerSetsHits& layers, CAGraph& g) {
 	for (unsigned int i = 0; i < layers.size(); i++)
 	{
 		for (unsigned int j = 0; j < 4; ++j)
@@ -131,7 +129,45 @@ namespace {
 				}
 
 			}
+		}
+	}
+  }
+}
+namespace {
+  void clearGraphStructure(const SeedingLayerSetsHits& layers, CAGraph& g) {
+	g.theLayerPairs.clear();
+	for (unsigned int i = 0; i < g.theLayers.size(); i++ ){
+		g.theLayers[i].theInnerLayers.clear();
+		g.theLayers[i].theInnerLayerPairs.clear();
+		g.theLayers[i].theOuterLayers.clear();
+		g.theLayers[i].theOuterLayerPairs.clear();
+
+	}
+
+  }
+}
+namespace {
+  template <typename T_HitDoublets, typename T_GeneratorOrPairsFunction>
+  void fillGraph(const SeedingLayerSetsHits& layers, CAGraph& g, T_HitDoublets& hitDoublets,
+                 T_GeneratorOrPairsFunction generatorOrPairsFunction) {
+	for (unsigned int i = 0; i < layers.size(); i++)
+	{
+		for (unsigned int j = 0; j < 4; ++j)
+		{
+			auto vertexIndex = 0;
+			auto foundVertex = std::find(g.theLayers.begin(), g.theLayers.end(),
+					layers[i][j].name());
+			if (foundVertex == g.theLayers.end())
+			{
+				vertexIndex = g.theLayers.size() - 1;
+			}
 			else
+			{
+				vertexIndex = foundVertex - g.theLayers.begin();
+			}
+	
+			
+			if (j > 0)
 			{
 
 				auto innerVertex = std::find(g.theLayers.begin(),
@@ -178,11 +214,12 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
 	CAGraph g;
 
-
 	std::vector<HitDoublets> hitDoublets;
 
 
 	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
+	
+	createGraphStructure(layers, g);
         fillGraph(layers, g, hitDoublets,
                   [&](const SeedingLayerSetsHits::SeedingLayer& inner,
                       const SeedingLayerSetsHits::SeedingLayer& outer,
@@ -202,12 +239,13 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
         hitQuadruplets(region, result, hitDoubletsPtr, g, es);
         theLayerCache.clear();
 }
-
-void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets::RegionLayerSets& regionLayerPairs,
-                                              OrderedHitSeeds& result,
+void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDoublets,
+                                              std::vector<OrderedHitSeeds, std::allocator<OrderedHitSeeds> >& result,
                                               const edm::EventSetup& es,
                                               const SeedingLayerSetsHits& layers) {
   CAGraph g;
+
+
 
   std::vector<const HitDoublets *> hitDoublets;
 
@@ -216,32 +254,38 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets::Region
                            SeedingLayerSetsHits::LayerIndex outer) {
     return pair.innerLayerIndex() == inner && pair.outerLayerIndex() == outer;
   };
-  fillGraph(layers, g, hitDoublets,
-            [&](const SeedingLayerSetsHits::SeedingLayer& inner,
-                const SeedingLayerSetsHits::SeedingLayer& outer,
-                std::vector<const HitDoublets *>& hitDoublets) {
-      using namespace std::placeholders;
-      auto found = std::find_if(regionLayerPairs.begin(), regionLayerPairs.end(),
-                                std::bind(layerPairEqual, _1, inner.index(), outer.index()));
-      if(found != regionLayerPairs.end()) {
-        hitDoublets.emplace_back(&(found->doublets()));
-        return true;
-      }
-      return false;
-    });
 
-  hitQuadruplets(regionLayerPairs.region(), result, hitDoublets, g, es);
-}
+ int index =0;
+ for(const auto& regionLayerPairs: regionDoublets) {
 
-void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
-                                              OrderedHitSeeds & result,
-                                              std::vector<const HitDoublets *>& hitDoublets, const CAGraph& g,
-                                              const edm::EventSetup& es) {
-	//Retrieve tracker topology from geometry
+	 const TrackingRegion& region = regionLayerPairs.region();
+	 hitDoublets.clear();
+
+	  if (index == 0){   
+	  	createGraphStructure(layers, g);
+	  }
+	  else{  
+		clearGraphStructure(layers, g);
+	  }
+
+	  fillGraph(layers, g, hitDoublets,
+	            [&](const SeedingLayerSetsHits::SeedingLayer& inner,
+	                const SeedingLayerSetsHits::SeedingLayer& outer,
+	                std::vector<const HitDoublets *>& hitDoublets) {
+	      using namespace std::placeholders;
+	      auto found = std::find_if(regionLayerPairs.begin(), regionLayerPairs.end(),
+	                                std::bind(layerPairEqual, _1, inner.index(), outer.index()));
+	      if(found != regionLayerPairs.end()) {
+	        hitDoublets.emplace_back(&(found->doublets()));
+	        return true;
+	      }
+	      return false;
+	    });
 	edm::ESHandle<TrackerTopology> tTopoHand;
 	es.get<TrackerTopologyRcd>().get(tTopoHand);
 	const TrackerTopology *tTopo=tTopoHand.product();	
-	
+
+
 	const int numberOfHitsInNtuplet = 4;
 	std::vector<CACell::CAntuplet> foundQuadruplets;
 
@@ -257,29 +301,183 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
-  // re-used thoughout, need to be vectors because of RZLine interface
+ 	// re-used thoughout, need to be vectors because of RZLine interface
+	std::array<float, 4> bc_r;
+	std::array<float, 4> bc_z;
+  	std::array<float, 4> bc_errZ2;
+  	std::array<GlobalPoint, 4> gps;
+  	std::array<GlobalError, 4> ges;
+  	std::array<bool, 4> barrels;
+ 	unsigned int fourthLayerId = 0;
+  	unsigned int previousfourthLayerId = 0;
+  	int subDetId = 0; 
+  	int previousSubDetId = 0;
+ 	unsigned int sideId = 0; 
+  	unsigned int previousSideId = 0;
+ 	std::array<unsigned int, 2> previousCellIds ={{0,0}};
+  	bool isTheSameTriplet = false;
+	bool isTheSameFourthLayer = false;
+	bool hasAlreadyPushedACandidate = false;
+	float selectedChi2 = std::numeric_limits<float>::max();
+
+ 	unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
+
+  	// Loop over quadruplets
+  	for (unsigned int quadId = 0; quadId < numberOfFoundQuadruplets; ++quadId)
+  	{
+
+    	auto isBarrel = [](const unsigned id) -> bool
+    	{
+      	return id == PixelSubdetector::PixelBarrel;
+    	};
+    	for(unsigned int i = 0; i< 3; ++i)
+    	{
+        	auto const& ahit = foundQuadruplets[quadId][i]->getInnerHit();
+        	gps[i] = ahit->globalPosition();
+        	ges[i] = ahit->globalPositionError();
+        	barrels[i] = isBarrel(ahit->geographicalId().subdetId());
+    	}
+
+    	auto const& ahit = foundQuadruplets[quadId][2]->getOuterHit();
+    	gps[3] = ahit->globalPosition();
+    	ges[3] = ahit->globalPositionError();
+    	barrels[3] = isBarrel(ahit->geographicalId().subdetId());
+    	if(caOnlyOneLastHitPerLayerFilter)
+   	{
+    		fourthLayerId = tTopo->layer(ahit->geographicalId());
+            	sideId = tTopo->side(ahit->geographicalId());
+            	subDetId = ahit->geographicalId().subdetId();
+    		isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
+   		isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
+
+    		previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
+    		previousfourthLayerId = fourthLayerId;
+
+
+    		if(!(isTheSameTriplet && isTheSameFourthLayer ))
+    		{
+    			selectedChi2 = std::numeric_limits<float>::max();
+    			hasAlreadyPushedACandidate = false;
+    		}
+
+    	}
+    	// TODO:
+    	// - 'line' is not used for anything
+    	// - if we decide to always do the circle fit for 4 hits, we don't
+    	//   need ThirdHitPredictionFromCircle for the curvature; then we
+    	//   could remove extraHitRPhitolerance configuration parameter
+    	PixelRecoLineRZ line(gps[0], gps[2]);
+    	ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2], extraHitRPhitolerance);
+    	const float curvature = predictionRPhi.curvature(ThirdHitPredictionFromCircle::Vector2D(gps[1].x(), gps[1].y()));
+    	const float abscurv = std::abs(curvature);
+    	const float thisMaxChi2 = maxChi2Eval.value(abscurv);
+    	if (theComparitor)
+    	{
+      		SeedingHitSet tmpTriplet(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+
+
+      		if (!theComparitor->compatible(tmpTriplet) )
+      		{
+       	 		continue;
+      		}
+    	}
+
+    	float chi2 = std::numeric_limits<float>::quiet_NaN();
+    	// TODO: Do we have any use case to not use bending correction?
+    	if (useBendingCorrection)
+   	{
+      	// Following PixelFitterByConformalMappingAndLine
+      	const float simpleCot = ( gps.back().z() - gps.front().z() ) / (gps.back().perp() - gps.front().perp() );
+     	const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
+      	for (int i=0; i < 4; ++i)
+      	{
+        	const GlobalPoint & point = gps[i];
+        	const GlobalError & error = ges[i];
+        	bc_r[i] = sqrt( sqr(point.x() - region.origin().x()) + sqr(point.y() - region.origin().y()) );
+        	bc_r[i] += pixelrecoutilities::LongitudinalBendingCorrection(pt, es)(bc_r[i]);
+        	bc_z[i] = point.z() - region.origin().z();
+        	bc_errZ2[i] =  (barrels[i]) ? error.czz() : error.rerr(point)*sqr(simpleCot);
+      	}
+      	RZLine rzLine(bc_r, bc_z, bc_errZ2, RZLine::ErrZ2_tag());
+      	chi2 = rzLine.chi2();
+    	} 
+	else
+    	{
+      	RZLine rzLine(gps, ges, barrels);
+      	chi2 = rzLine.chi2();
+    	}
+    	if (edm::isNotFinite(chi2) || chi2 > thisMaxChi2)
+    	{
+      	continue;
+              
+    	}
+    	// TODO: Do we have any use case to not use circle fit? Maybe
+    	// HLT where low-pT inefficiency is not a problem?
+    	if (fitFastCircle)
+    	{
+      	FastCircleFit c(gps, ges);
+      	chi2 += c.chi2();
+      	if (edm::isNotFinite(chi2))
+        	continue;
+      	if (fitFastCircleChi2Cut && chi2 > thisMaxChi2)
+        	continue;
+    	}
+    	if(caOnlyOneLastHitPerLayerFilter)
+    	{
+    		if (chi2 < selectedChi2)
+   		{
+    			selectedChi2 = chi2;
+
+    			if(hasAlreadyPushedACandidate)
+    			{
+    				result[index].pop_back();
+
+    			}
+	    		result[index].emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+	    		hasAlreadyPushedACandidate = true;
+
+    		}
+   	}
+    	else
+    	{
+	       	result[index].emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+    	}
+        }
+	index++;
+     }
+	for (unsigned int i = 0; i < result.size(); i++ ){
+	}
+
+}
+
+void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
+                                              OrderedHitSeeds & result,
+                                              std::vector<const HitDoublets *>& hitDoublets, const CAGraph& g,
+                                              const edm::EventSetup& es) {
+	const int numberOfHitsInNtuplet = 4;
+	std::vector<CACell::CAntuplet> foundQuadruplets;
+	CellularAutomaton ca(g);
+
+	ca.createAndConnectCells(hitDoublets, region, caThetaCut,
+			caPhiCut, caHardPtCut);
+
+	ca.evolve(numberOfHitsInNtuplet);
+
+	ca.findNtuplets(foundQuadruplets, numberOfHitsInNtuplet);
+
+
+	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
+
   std::array<float, 4> bc_r;
   std::array<float, 4> bc_z;
   std::array<float, 4> bc_errZ2;
   std::array<GlobalPoint, 4> gps;
   std::array<GlobalError, 4> ges;
   std::array<bool, 4> barrels;
-  unsigned int fourthLayerId = 0;
-  unsigned int previousfourthLayerId = 0;
-  int subDetId = 0; 
-  int previousSubDetId = 0;
-  unsigned int sideId = 0; 
-  unsigned int previousSideId = 0; 
-  std::array<unsigned int, 2> previousCellIds ={{0,0}};
-  bool isTheSameTriplet = false;
-  bool isTheSameFourthLayer = false;
-  bool hasAlreadyPushedACandidate = false;
-  float selectedChi2 = std::numeric_limits<float>::max();
-
 
   unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
 
-  // Loop over quadruplets
+
   for (unsigned int quadId = 0; quadId < numberOfFoundQuadruplets; ++quadId)
   {
 
@@ -300,32 +498,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
     ges[3] = ahit->globalPositionError();
     barrels[3] = isBarrel(ahit->geographicalId().subdetId());
 
-    if(caOnlyOneLastHitPerLayerFilter)
-    {
-            fourthLayerId = tTopo->layer(ahit->geographicalId());
-            sideId = tTopo->side(ahit->geographicalId());
-            subDetId = ahit->geographicalId().subdetId();
-	    isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
-            isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
 
-	    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
-	    previousfourthLayerId = fourthLayerId;
-
-
-	    if(!(isTheSameTriplet && isTheSameFourthLayer ))
-	    {
-		selectedChi2 = std::numeric_limits<float>::max();
-		hasAlreadyPushedACandidate = false;
-	    }
-
-    }
-
-
-    // TODO:
-    // - 'line' is not used for anything
-    // - if we decide to always do the circle fit for 4 hits, we don't
-    //   need ThirdHitPredictionFromCircle for the curvature; then we
-    //   could remove extraHitRPhitolerance configuration parameter
     PixelRecoLineRZ line(gps[0], gps[2]);
     ThirdHitPredictionFromCircle predictionRPhi(gps[0], gps[2], extraHitRPhitolerance);
     const float curvature = predictionRPhi.curvature(ThirdHitPredictionFromCircle::Vector2D(gps[1].x(), gps[1].y()));
@@ -344,10 +517,10 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
     }
 
     float chi2 = std::numeric_limits<float>::quiet_NaN();
-    // TODO: Do we have any use case to not use bending correction?
+
     if (useBendingCorrection)
     {
-      // Following PixelFitterByConformalMappingAndLine
+
       const float simpleCot = ( gps.back().z() - gps.front().z() ) / (gps.back().perp() - gps.front().perp() );
       const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
       for (int i=0; i < 4; ++i)
@@ -361,8 +534,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
       }
       RZLine rzLine(bc_r, bc_z, bc_errZ2, RZLine::ErrZ2_tag());
       chi2 = rzLine.chi2();
-    } 
-    else
+    } else
     {
       RZLine rzLine(gps, ges, barrels);
       chi2 = rzLine.chi2();
@@ -372,8 +544,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
       continue;
               
     }
-    // TODO: Do we have any use case to not use circle fit? Maybe
-    // HLT where low-pT inefficiency is not a problem?
+
     if (fitFastCircle)
     {
       FastCircleFit c(gps, ges);
@@ -384,31 +555,6 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
         continue;
     }
 
-    if(caOnlyOneLastHitPerLayerFilter)
-    {
-	    if (chi2 < selectedChi2)
-	    {
-		selectedChi2 = chi2;
-
-		if(hasAlreadyPushedACandidate)
-		{
-			result.pop_back();
-
-		}
-		result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),
-				foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
-		hasAlreadyPushedACandidate = true;
-
-	    }
-    }
-    else
-    {
-
-       result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
-    }
-     
+    result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
   }
-
 }
-
-

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -375,56 +375,50 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
     		// TODO: Do we have any use case to not use bending correction?
     		if (useBendingCorrection)
    		{
-      		// Following PixelFitterByConformalMappingAndLine
-      		const float simpleCot = ( gps.back().z() - gps.front().z() ) / (gps.back().perp() - gps.front().perp() );
-     		const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
-      		for (int i=0; i < 4; ++i)
-      		{
-        		const GlobalPoint & point = gps[i];
-        		const GlobalError & error = ges[i];
-        		bc_r[i] = sqrt( sqr(point.x() - region.origin().x()) + sqr(point.y() - region.origin().y()) );
-        		bc_r[i] += pixelrecoutilities::LongitudinalBendingCorrection(pt, es)(bc_r[i]);
-        		bc_z[i] = point.z() - region.origin().z();
-        		bc_errZ2[i] =  (barrels[i]) ? error.czz() : error.rerr(point)*sqr(simpleCot);
-      		}
-      		RZLine rzLine(bc_r, bc_z, bc_errZ2, RZLine::ErrZ2_tag());
-      		chi2 = rzLine.chi2();
+      			// Following PixelFitterByConformalMappingAndLine
+      			const float simpleCot = ( gps.back().z() - gps.front().z() ) / (gps.back().perp() - gps.front().perp() );
+     			const float pt = 1.f / PixelRecoUtilities::inversePt(abscurv, es);
+      			for (int i=0; i < 4; ++i)
+      			{
+        			const GlobalPoint & point = gps[i];
+        			const GlobalError & error = ges[i];
+        			bc_r[i] = sqrt( sqr(point.x() - region.origin().x()) + sqr(point.y() - region.origin().y()) );
+        			bc_r[i] += pixelrecoutilities::LongitudinalBendingCorrection(pt, es)(bc_r[i]);
+        			bc_z[i] = point.z() - region.origin().z();
+        			bc_errZ2[i] =  (barrels[i]) ? error.czz() : error.rerr(point)*sqr(simpleCot);
+      			}
+      			RZLine rzLine(bc_r, bc_z, bc_errZ2, RZLine::ErrZ2_tag());
+      			chi2 = rzLine.chi2();
     		}
 		else
     		{
-      		RZLine rzLine(gps, ges, barrels);
-      		chi2 = rzLine.chi2();
+      			RZLine rzLine(gps, ges, barrels);
+      			chi2 = rzLine.chi2();
     		}
     		if (edm::isNotFinite(chi2) || chi2 > thisMaxChi2)
     		{
-      		continue;
-              
+      			continue;
     		}
     		// TODO: Do we have any use case to not use circle fit? Maybe
     		// HLT where low-pT inefficiency is not a problem?
     		if (fitFastCircle)
     		{
-      		FastCircleFit c(gps, ges);
-      		chi2 += c.chi2();
-      		if (edm::isNotFinite(chi2))
-        		continue;
-      		if (fitFastCircleChi2Cut && chi2 > thisMaxChi2)
-        		continue;
+      			FastCircleFit c(gps, ges);
+      			chi2 += c.chi2();
+      			if (edm::isNotFinite(chi2)) continue;
+      			if (fitFastCircleChi2Cut && chi2 > thisMaxChi2) continue;
     		}
     		if(caOnlyOneLastHitPerLayerFilter)
     		{
     			if (chi2 < selectedChi2)
    			{
     				selectedChi2 = chi2;
-
     				if(hasAlreadyPushedACandidate)
     				{
     					result[index].pop_back();
-
     				}
 	    			result[index].emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
 	    			hasAlreadyPushedACandidate = true;
-
     			}
    		}
     		else

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -99,7 +99,6 @@ void CAHitQuadrupletGenerator::fillDescriptions(edm::ParameterSetDescription& de
 void CAHitQuadrupletGenerator::initEvent(const edm::Event& ev, const edm::EventSetup& es) {
   if (theComparitor) theComparitor->init(ev, es);
 }
-
 namespace {
   void createGraphStructure(const SeedingLayerSetsHits& layers, CAGraph& g) {
 	for (unsigned int i = 0; i < layers.size(); i++)
@@ -210,11 +209,11 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
 	CAGraph g;
 
-
 	std::vector<HitDoublets> hitDoublets;
 
 
-	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);	
+	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
+	
 	createGraphStructure(layers, g);
         fillGraph(layers, g, hitDoublets,
                   [&](const SeedingLayerSetsHits::SeedingLayer& inner,
@@ -296,7 +295,7 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
- 	// re-used thoughout, need to be vectors because of RZLine interface
+ 	// re-used thoughout
 	std::array<float, 4> bc_r;
 	std::array<float, 4> bc_z;
   	std::array<float, 4> bc_errZ2;
@@ -305,8 +304,12 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
   	std::array<bool, 4> barrels;
 	bool hasAlreadyPushedACandidate = false;
 	float selectedChi2 = std::numeric_limits<float>::max();
+  	unsigned int previousfourthLayerId = 0;
+	std::array<unsigned int, 2> previousCellIds ={{0,0}};
+	unsigned int previousSideId = 0;
+	int previousSubDetId = 0;
 
- 	unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
+	unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
 
   	// Loop over quadruplets
   	for (unsigned int quadId = 0; quadId < numberOfFoundQuadruplets; ++quadId)
@@ -314,7 +317,7 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
 
     		auto isBarrel = [](const unsigned id) -> bool
     		{
-      		return id == PixelSubdetector::PixelBarrel;
+      			return id == PixelSubdetector::PixelBarrel;
     		};
     		for(unsigned int i = 0; i< 3; ++i)
     		{
@@ -330,21 +333,11 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
     		barrels[3] = isBarrel(ahit->geographicalId().subdetId());
     		if(caOnlyOneLastHitPerLayerFilter)
    		{
-	 		unsigned int fourthLayerId = 0;
-  			unsigned int previousfourthLayerId = 0;
- 	 		int subDetId = 0; 
- 	 		int previousSubDetId = 0;
-	 		unsigned int sideId = 0; 
- 	 		unsigned int previousSideId = 0;
-	 		std::array<unsigned int, 2> previousCellIds ={{0,0}};
-	  		bool isTheSameTriplet = false;
-			bool isTheSameFourthLayer = false;
-
-    			fourthLayerId = tTopo->layer(ahit->geographicalId());
-            		sideId = tTopo->side(ahit->geographicalId());
-            		subDetId = ahit->geographicalId().subdetId();
-    			isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
-   			isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
+ 	     		const auto fourthLayerId = tTopo->layer(ahit->geographicalId());
+            		const auto sideId = tTopo->side(ahit->geographicalId());
+            		const auto subDetId = ahit->geographicalId().subdetId();
+    			const auto isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
+   			const auto isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
 
     			previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
     			previousfourthLayerId = fourthLayerId;
@@ -468,7 +461,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
-  // re-used thoughout, need to be vectors because of RZLine interface
+  // re-used thoughout
   std::array<float, 4> bc_r;
   std::array<float, 4> bc_z;
   std::array<float, 4> bc_errZ2;
@@ -477,7 +470,10 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
   std::array<bool, 4> barrels;
   bool hasAlreadyPushedACandidate = false;
   float selectedChi2 = std::numeric_limits<float>::max();
-
+  unsigned int previousfourthLayerId = 0;
+  std::array<unsigned int, 2> previousCellIds ={{0,0}};
+  unsigned int previousSideId = 0;
+  int previousSubDetId = 0;
 
   unsigned int numberOfFoundQuadruplets = foundQuadruplets.size();
 
@@ -504,21 +500,11 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
     if(caOnlyOneLastHitPerLayerFilter)
     {
-	    unsigned int fourthLayerId = 0;
-	    unsigned int previousfourthLayerId = 0;
-	    int subDetId = 0; 
-	    int previousSubDetId = 0;
-	    unsigned int sideId = 0; 
-	    unsigned int previousSideId = 0; 
-	    std::array<unsigned int, 2> previousCellIds ={{0,0}};
-	    bool isTheSameTriplet = false;
-	    bool isTheSameFourthLayer = false;
-
-            fourthLayerId = tTopo->layer(ahit->geographicalId());
-            sideId = tTopo->side(ahit->geographicalId());
-            subDetId = ahit->geographicalId().subdetId();
-	    isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
-            isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
+	    const auto fourthLayerId = tTopo->layer(ahit->geographicalId());
+            const auto sideId = tTopo->side(ahit->geographicalId());
+            const auto subDetId = ahit->geographicalId().subdetId();
+    	    const auto isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
+            const auto isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
 
 	    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
 	    previousfourthLayerId = fourthLayerId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -99,6 +99,7 @@ void CAHitQuadrupletGenerator::fillDescriptions(edm::ParameterSetDescription& de
 void CAHitQuadrupletGenerator::initEvent(const edm::Event& ev, const edm::EventSetup& es) {
   if (theComparitor) theComparitor->init(ev, es);
 }
+
 namespace {
   void createGraphStructure(const SeedingLayerSetsHits& layers, CAGraph& g) {
 	for (unsigned int i = 0; i < layers.size(); i++)
@@ -209,11 +210,11 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
 	CAGraph g;
 
+
 	std::vector<HitDoublets> hitDoublets;
 
 
-	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);
-	
+	HitPairGeneratorFromLayerPair thePairGenerator(0, 1, &theLayerCache);	
 	createGraphStructure(layers, g);
         fillGraph(layers, g, hitDoublets,
                   [&](const SeedingLayerSetsHits::SeedingLayer& inner,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -54,8 +54,8 @@ public:
             const edm::Event & ev, const edm::EventSetup& es);
 
     // new-style
-    void hitNtuplets(const IntermediateHitDoublets::RegionLayerSets& regionLayerPairs,
-                     OrderedHitSeeds& result,
+    void hitNtuplets(const IntermediateHitDoublets& regionDoublets,
+                     std::vector<OrderedHitSeeds, std::allocator<OrderedHitSeeds> >& result,
                      const edm::EventSetup& es,
                      const SeedingLayerSetsHits& layers);
 
@@ -147,5 +147,6 @@ private:
     const float caPhiCut = 0.1f;
     const float caHardPtCut = 0.f;
     const bool caOnlyOneLastHitPerLayerFilter = false;
+
 };
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -55,7 +55,7 @@ public:
 
     // new-style
     void hitNtuplets(const IntermediateHitDoublets& regionDoublets,
-                     std::vector<OrderedHitSeeds, std::allocator<OrderedHitSeeds> >& result,
+                     std::vector<OrderedHitSeeds>& result,
                      const edm::EventSetup& es,
                      const SeedingLayerSetsHits& layers);
 
@@ -147,6 +147,5 @@ private:
     const float caPhiCut = 0.1f;
     const float caHardPtCut = 0.f;
     const bool caOnlyOneLastHitPerLayerFilter = false;
-
 };
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -126,22 +126,17 @@ namespace {
   }
 }
 // Pseudocode: clear out the graph for the next iteration in the loop over all regions
-
 namespace {
   void clearGraphStructure(const SeedingLayerSetsHits& layers, CAGraph& g) {
 	g.theLayerPairs.clear();
-	for (unsigned int i = 0; i < layers.size(); i++)
-	{
-		for (unsigned int j = 0; j < 3; ++j)
-		{
-			auto foundVertex = std::find(g.theLayers.begin(), g.theLayers.end(),
-					layers[i][j].name());
-			if (foundVertex->isOuterHitOfCell.size() > 0)
-			{
-				foundVertex->isOuterHitOfCell.clear();
-			}
-		}
+	for (unsigned int i = 0; i < g.theLayers.size(); i++ ){
+		g.theLayers[i].theInnerLayers.clear();
+		g.theLayers[i].theInnerLayerPairs.clear();
+		g.theLayers[i].theOuterLayers.clear();
+		g.theLayers[i].theOuterLayerPairs.clear();
+
 	}
+
   }
 }
 // Pseudocode: fill graph for this iteration in the loop over all the regions

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -91,7 +91,6 @@ void CAHitTripletGenerator::initEvent(const edm::Event& ev, const edm::EventSetu
   if (theComparitor) theComparitor->init(ev, es);
 }
 
-// Pseudocode: Function to set up the graph structure based on the available layers. Done in the first iteration of the loop over the regions
 namespace {
   void createGraphStructure(const SeedingLayerSetsHits& layers, CAGraph& g) {
 	for (unsigned int i = 0; i < layers.size(); i++)
@@ -125,7 +124,6 @@ namespace {
 	}
   }
 }
-// Pseudocode: clear out the graph for the next iteration in the loop over all regions
 namespace {
   void clearGraphStructure(const SeedingLayerSetsHits& layers, CAGraph& g) {
 	g.theLayerPairs.clear();
@@ -139,7 +137,6 @@ namespace {
 
   }
 }
-// Pseudocode: fill graph for this iteration in the loop over all the regions
 namespace {
   template <typename T_HitDoublets, typename T_GeneratorOrPairsFunction>
   void fillGraph(const SeedingLayerSetsHits& layers, CAGraph& g, T_HitDoublets& hitDoublets,
@@ -240,20 +237,18 @@ void CAHitTripletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDou
     return pair.innerLayerIndex() == inner && pair.outerLayerIndex() == outer;
   };
 
- // Pseudocode: start loop over the regions
  int index =0;
  for(const auto& regionLayerPairs: regionDoublets) {
 
 	 const TrackingRegion& region = regionLayerPairs.region();
-	 hitDoublets.clear(); //Psuedocode: make sure the doublets are empty in the beginning
+	 hitDoublets.clear(); 
 
-	  if (index == 0){   //Psuedocode: in first iteration, create the graph strucutre
+	  if (index == 0){   
 	  	createGraphStructure(layers, g);
 	  }
-	  else{  // Psuedocode:in following iterations, clean out the graph, but do not recreate the structure 
+	  else{   
   		clearGraphStructure(layers, g);
 	  }
-	  // Psuedocode:now fill the graph for this region
 	  fillGraph(layers, g, hitDoublets,
 	            [&](const SeedingLayerSetsHits::SeedingLayer& inner,
 	                const SeedingLayerSetsHits::SeedingLayer& outer,
@@ -267,9 +262,7 @@ void CAHitTripletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDou
 	      }
 	      return false;
 	    });
-	// Psuedocode: removed CAHitTrippletGenerator::hitQuadruplets function to have everything in one loop over the regions
-	const int numberOfHitsInNtuplet = 3;// should probably be made dynamic?
-	/// Psuedocode:from here on out, no further changes to the code necessary
+	const int numberOfHitsInNtuplet = 3;
 	std::vector<CACell::CAntuplet> foundTriplets;
 
 	CellularAutomaton ca(g);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -102,7 +102,8 @@ namespace {
 					layers[i][j].name());
 			if (foundVertex == g.theLayers.end())
 			{
-				g.theLayers.emplace_back(layers[i][j].name(), layers[i][j].hits().size());
+				g.theLayers.emplace_back(layers[i][j].name(),
+					        layers[i][j].hits().size());
 				vertexIndex = g.theLayers.size() - 1;
 			}
 			else

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -273,7 +273,6 @@ void CAHitTripletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDou
 	ca.findTriplets(hitDoublets, foundTriplets, region, caThetaCut, caPhiCut,
                         caHardPtCut);
 
-	//ca.findNtuplets(foundTriplets, numberOfHitsInNtuplet);
 
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
@@ -19,6 +19,7 @@
 
 #include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
 
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitSeeds.h"
 class TrackingRegion;
 class SeedingLayerSetsHits;
 
@@ -33,8 +34,9 @@ public:
     typedef LayerHitMapCache LayerCacheType;
 
     static constexpr unsigned int minLayers = 3;
-    typedef OrderedHitTriplets ResultType;
+    //typedef OrderedHitTriplets ResultType;
 
+    typedef OrderedHitSeeds ResultType;
 public:
 
     CAHitTripletGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC, bool needSeedingLayerSetsHits=true): CAHitTripletGenerator(cfg, iC, needSeedingLayerSetsHits) {}
@@ -52,10 +54,15 @@ public:
             const edm::Event & ev, const edm::EventSetup& es);
 
     // new-style
-    void hitNtuplets(const IntermediateHitDoublets::RegionLayerSets& regionLayerPairs,
-                     OrderedHitTriplets& result,
+    //void hitNtuplets(const IntermediateHitDoublets::RegionLayerSets& regionLayerPairs,
+    //                 OrderedHitTriplets& result,
+     //                const edm::EventSetup& es,
+      //               const SeedingLayerSetsHits& layers);
+    void hitNtuplets(const IntermediateHitDoublets& regionDoublets,
+                     std::vector<OrderedHitSeeds, std::allocator<OrderedHitSeeds> >& result,
                      const edm::EventSetup& es,
                      const SeedingLayerSetsHits& layers);
+
 
 private:
     // actual work

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
@@ -34,8 +34,6 @@ public:
     typedef LayerHitMapCache LayerCacheType;
 
     static constexpr unsigned int minLayers = 3;
-    //typedef OrderedHitTriplets ResultType;
-
     typedef OrderedHitSeeds ResultType;
 public:
 
@@ -53,16 +51,10 @@ public:
     virtual void hitTriplets(const TrackingRegion& reg, OrderedHitTriplets & triplets,
             const edm::Event & ev, const edm::EventSetup& es);
 
-    // new-style
-    //void hitNtuplets(const IntermediateHitDoublets::RegionLayerSets& regionLayerPairs,
-    //                 OrderedHitTriplets& result,
-     //                const edm::EventSetup& es,
-      //               const SeedingLayerSetsHits& layers);
     void hitNtuplets(const IntermediateHitDoublets& regionDoublets,
-                     std::vector<OrderedHitSeeds, std::allocator<OrderedHitSeeds> >& result,
+                     std::vector<OrderedHitSeeds>& result,
                      const edm::EventSetup& es,
                      const SeedingLayerSetsHits& layers);
-
 
 private:
     // actual work


### PR DESCRIPTION
So far, for each tracking region at the HLT, a new CA Graph structure is created. This update intends to improve performance by re-using the data structure and re-filling it for each of the regions. For this, some code is rearranged, but the algorithm itself is not changed at all. 

Some details and performance tests can be found here: https://cernbox.cern.ch/index.php/s/UWvE7a7itx6VGBs

The executive summary is:
- Checked physics results both offline and online -> 100% identical 
- Checked timing of modules: Modules using regional tracking speed up between 3 and 40%. The gain strongly depends on the size of the regions, for many small regions the reduction in overhead naturally matters more than for few large ones. 
