### PR TITLE
DataFormats/CaloTowers : changes needed to compile on macOS sierra with system clang and libc++

### DIFF
--- a/DataFormats/CaloTowers/interface/CaloTower.h
+++ b/DataFormats/CaloTowers/interface/CaloTower.h
@@ -62,7 +62,7 @@ public:
    // setters
   void addConstituent( DetId id ) { constituents_.push_back( id ); }
   void addConstituents( const std::vector<DetId>& ids );
-  void setConstituents( std::vector<DetId>&& ids ) { constituents_=std::move(ids);}
+  void setConstituents( std::vector<DetId>& ids ) { constituents_=ids;}
 
   void setEcalTime(int t) { ecalTime_ = t; };
   void setHcalTime(int t) { hcalTime_ = t; };

--- a/DataFormats/CaloTowers/interface/CaloTower.h
+++ b/DataFormats/CaloTowers/interface/CaloTower.h
@@ -62,8 +62,11 @@ public:
    // setters
   void addConstituent( DetId id ) { constituents_.push_back( id ); }
   void addConstituents( const std::vector<DetId>& ids );
+#ifdef __ROOTCLING__
   void setConstituents( std::vector<DetId>& ids ) { constituents_=ids;}
-
+#else
+  void setConstituents( std::vector<DetId>&& ids ) { constituents_=std::move(ids);}
+#endif
   void setEcalTime(int t) { ecalTime_ = t; };
   void setHcalTime(int t) { hcalTime_ = t; };
   void setHcalSubdet(int lastHB, int lastHE, int lastHF, int lastHO) {

--- a/DataFormats/CaloTowers/interface/CaloTower.h
+++ b/DataFormats/CaloTowers/interface/CaloTower.h
@@ -63,7 +63,7 @@ public:
   void addConstituent( DetId id ) { constituents_.push_back( id ); }
   void addConstituents( const std::vector<DetId>& ids );
 #ifdef __ROOTCLING__
-  void setConstituents( std::vector<DetId>& ids ) { constituents_=ids;}
+  void setConstituents( const std::vector<DetId>& ids ) { constituents_=ids;}
 #else
   void setConstituents( std::vector<DetId>&& ids ) { constituents_=std::move(ids);}
 #endif


### PR DESCRIPTION
input_line_480:5:39: error: rvalue reference to type 'vector<...>' cannot bind to lvalue of type 'vector<...>'
    ((CaloTower*)obj)->setConstituents((vector<DetId>&)*(vector<DetId>*)args[0]);
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/gartung/spack/opt/spack/darwin-sierra-x86_64/clang-8.0.0-apple/fwlite-9.0.X-az5p3l77zcgnhp5tqilkw3riti3zbviu/CMSSW_9_0_X/src/DataFormats/CaloTowers/interface/CaloTower.h:65:46: note: passing argument to parameter 'ids' here
   void setConstituents( std::vector<DetId>&& ids ) { constituents_=std::move(ids);}
                                              ^
Error in <TClingCallFunc::make_wrapper>: Failed to compile

https://sft.its.cern.ch/jira/browse/ROOT-8075