### PR TITLE
CA tuning (pixelTracks and iter0) for tracking @HLT

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -312,6 +312,19 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 
     return process
 
+# modify the HLT configuration to run the Phase I tracking in the particle flow sequence
+def customizeHLTForPFTrackingPhaseI2017tuningIter0(process):
+    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.pt1    = cms.double( 0.8 ) # lowpt
+    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.pt2    = cms.double( 2   ) # highpt
+    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.value1 = cms.double( 150 ) # chi2lowpt
+    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.value2 = cms.double(  50 ) # chi2highpt
+    process.hltPixelTracks.OrderedHitsFactoryPSet.CAThetaCut  = cms.double( 0.002 )
+    process.hltPixelTracks.OrderedHitsFactoryPSet.CAPhiCut    = cms.double( 0.2   )
+    process.hltPixelTracks.OrderedHitsFactoryPSet.CAHardPtCut = cms.double( 0     )
+    
+    return process
+
 # attach `customizeHLTForPFTrackingPhaseI2017` to the `phase1Pixel` era
 def modifyHLTForPFTrackingPhaseI2017(process):
     phase1Pixel.toModify(process, customizeHLTForPFTrackingPhaseI2017)
+    phase1Pixel.toModify(process, customizeHLTForPFTrackingPhaseI2017tuningIter0)

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -314,13 +314,13 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 
 # modify the HLT configuration to run the Phase I tracking in the particle flow sequence
 def customizeHLTForPFTrackingPhaseI2017tuningIter0(process):
-    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.pt1    = cms.double( 0.8 ) # lowpt
-    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.pt2    = cms.double( 2   ) # highpt
-    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.value1 = cms.double( 150 ) # chi2lowpt
-    process.hltPixelTracks.OrderedHitsFactoryPSet.maxChi2.value2 = cms.double(  50 ) # chi2highpt
-    process.hltPixelTracks.OrderedHitsFactoryPSet.CAThetaCut  = cms.double( 0.002 )
-    process.hltPixelTracks.OrderedHitsFactoryPSet.CAPhiCut    = cms.double( 0.2   )
-    process.hltPixelTracks.OrderedHitsFactoryPSet.CAHardPtCut = cms.double( 0     )
+    process.hltPixelTracksHitQuadruplets.maxChi2.pt1    = cms.double( 0.8 ) # lowpt
+    process.hltPixelTracksHitQuadruplets.maxChi2.pt2    = cms.double( 2   ) # highpt
+    process.hltPixelTracksHitQuadruplets.maxChi2.value1 = cms.double( 150 ) # chi2lowpt
+    process.hltPixelTracksHitQuadruplets.maxChi2.value2 = cms.double(  50 ) # chi2highpt
+    process.hltPixelTracksHitQuadruplets.CAThetaCut  = cms.double( 0.002 )
+    process.hltPixelTracksHitQuadruplets.CAPhiCut    = cms.double( 0.2   )
+    process.hltPixelTracksHitQuadruplets.CAHardPtCut = cms.double( 0     )
     
     return process
 


### PR DESCRIPTION
tuning of CA for pixelTracks and iter0 step in the tracking @ HLT

w/ this update we are expecting an improvement on performance (both efficiency and fake)
and on timing as well

pixelTracks:
efficiency vs pt
![efficpt_hltpixel](https://cloud.githubusercontent.com/assets/4946419/22542265/46f6eb5c-e92b-11e6-93ff-4978dc0e9840.png)
efficiency vs eta
![effic_hltpixel](https://cloud.githubusercontent.com/assets/4946419/22542316/8ee39e06-e92b-11e6-83c4-f1bf0ae28080.png)

fake vs pt
![fakeratept_hltpixel](https://cloud.githubusercontent.com/assets/4946419/22542361/b74fa218-e92b-11e6-83d1-ef56bbe2305f.png)

fake vs eta
![fakerate_hltpixel](https://cloud.githubusercontent.com/assets/4946419/22542381/c9dd9cfa-e92b-11e6-8ba7-f65c870d5e28.png)

iter0 HighPurity
efficiency vs pt
![efficpt_hltiter0pflowtrackselectionhighpurity](https://cloud.githubusercontent.com/assets/4946419/22542303/78f6cdac-e92b-11e6-8b9f-092476b03b93.png)

efficiency vs eta
![effic_hltiter0pflowtrackselectionhighpurity](https://cloud.githubusercontent.com/assets/4946419/22542306/7e5c9358-e92b-11e6-8998-cc033645411b.png)

fake vs pt
![fakeratept_hltiter0pflowtrackselectionhighpurity](https://cloud.githubusercontent.com/assets/4946419/22542334/9ff8196a-e92b-11e6-8587-75103e049f94.png)

fake vs eta
![fakerate_hltiter0pflowtrackselectionhighpurity](https://cloud.githubusercontent.com/assets/4946419/22542371/bd8943be-e92b-11e6-9d07-3062b095cf04.png)


iter2 merged
efficiency vs pt
![efficpt_hltiter2merged](https://cloud.githubusercontent.com/assets/4946419/22542292/6e697272-e92b-11e6-9f4b-78e44a547dbc.png)

efficiency vs eta
![effic_hltiter2merged](https://cloud.githubusercontent.com/assets/4946419/22542314/874801b4-e92b-11e6-8e8b-92d04c35001c.png)

fake vs pt
![fakeratept_hltiter2merged](https://cloud.githubusercontent.com/assets/4946419/22542351/acec7512-e92b-11e6-9458-650ca2298d94.png)

fake vs eta
![fakerate_hltiter2merged](https://cloud.githubusercontent.com/assets/4946419/22542376/c3612fa4-e92b-11e6-95c2-631718ab827d.png)
