### PR TITLE
Fix calculation of TrackingParticle::numberOfHits()

### DIFF
--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -655,8 +655,8 @@ namespace // Unnamed namespace for things only used in this file
 		// through the hits "in order" (ok, most important is
 		// to get the first hit right because processType and
 		// particleType are taken from it)
-		for( std::multimap<unsigned int,size_t>::const_iterator iHitIndex=trackIdToHitIndex_.lower_bound( simTrack.trackId() );
-				iHitIndex!=trackIdToHitIndex_.upper_bound( simTrack.trackId() );
+		for( auto iHitIndex=trackIdToHitIndex_.lower_bound( simTrack.trackId() ), end=trackIdToHitIndex_.upper_bound( simTrack.trackId() );
+				iHitIndex!=end;
 				++iHitIndex )
 		{
 			const auto& pSimHit=simHits_[ iHitIndex->second ];

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -661,6 +661,10 @@ namespace // Unnamed namespace for things only used in this file
 		{
 			const auto& pSimHit=simHits_[ iHitIndex->second ];
 
+                        // Skip hits with particle type different from SimTrack pdgId
+                        if(pSimHit->particleType() != pdgId)
+                          continue;
+
 			// Initial condition for consistent simhit selection
 			if( init )
 			{
@@ -678,7 +682,7 @@ namespace // Unnamed namespace for things only used in this file
 			if( allowDifferentProcessTypeForDifferentDetectors_ && newDetector.det()!=oldDetector.det() ) processType=pSimHit->processType();
 
 			// Check for delta and interaction products discards
-			if( processType==pSimHit->processType() && particleType==pSimHit->particleType() && pdgId==pSimHit->particleType() )
+			if( processType==pSimHit->processType() && particleType==pSimHit->particleType() )
 			{
 				++numberOfHits;
 				oldLayer=newLayer;

--- a/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
@@ -71,6 +71,13 @@ TrackingParticleNumberOfLayers::calculate(const edm::Handle<TrackingParticleColl
       if(range.first == range.second) continue;
 
       auto iHitPtr = range.first;
+      for(; iHitPtr != range.second; ++iHitPtr) {
+        // prevent simhits with particleType != pdgId from being the "first hit"
+        if(iHitPtr->second->particleType() == pdgId)
+          break;
+      }
+      if(iHitPtr == range.second) // no simhits with particleType == pdgId
+        continue;
       int processType = iHitPtr->second->processType();
       int particleType = iHitPtr->second->particleType();
 

--- a/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
@@ -4,9 +4,19 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 namespace {
   bool trackIdHitPairLess(const std::pair<unsigned int, const PSimHit*>& a, const std::pair<unsigned int, const PSimHit*>& b) {
+    return a.first < b.first;
+  }
+
+  bool trackIdHitPairLessSort(const std::pair<unsigned int, const PSimHit*>& a, const std::pair<unsigned int, const PSimHit*>& b) {
+    if(a.first == b.first) {
+      const auto atof = edm::isFinite(a.second->timeOfFlight()) ? a.second->timeOfFlight() : std::numeric_limits<decltype(a.second->timeOfFlight())>::max();
+      const auto btof = edm::isFinite(b.second->timeOfFlight()) ? b.second->timeOfFlight() : std::numeric_limits<decltype(b.second->timeOfFlight())>::max();
+      return atof < btof;
+    }
     return a.first < b.first;
   }
 }
@@ -23,7 +33,7 @@ TrackingParticleNumberOfLayers::TrackingParticleNumberOfLayers(const edm::Event&
       trackIdToHitPtr_.emplace_back(simHit.trackId(), &simHit);
     }
   }
-  std::stable_sort(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), trackIdHitPairLess);
+  std::stable_sort(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), trackIdHitPairLessSort);
 }
 
 std::tuple<std::unique_ptr<edm::ValueMap<unsigned int>>,


### PR DESCRIPTION
The `TrackingParticle::numberOfHits()` (and the two other "number of hits") is calculated in a loop over the SimHits of a SimTrack, where only SimHits with the same `particleType` as the SimTrack's `pdgId` and the same `particleType` and `processType` as the "first hit" (or that's how the intention looks like). The purpose seems to be to ignore hits from e.g. delta rays or decays where the same SimTrack is reused.

I agree with the intention, but the definition of "first hit" is flawed. When iterating over the `multimap` from SimTrack id to an index in a `vector<const PSimHit*>` in
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_0_pre2/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc#L637-L674
the SimHits of a SimTracks are iterated in the order they get inserted in the `multimap` in
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_0_pre2/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc#L563-L566
The order of SimHits originates from
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_0_pre2/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc#L515-L530
and
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_0_pre2/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc#L306-L314
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_0_pre2/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py#L11-L27
i.e. first muon detectors, then pixel, and last (strip) tracker. If the "first hit" (according to the current logic) has `particleType` different from the SimTrack's `pdgId`, the resulting `numberOfHits` is zero. In phase0/1 this can happen if a non-muon particle decays to a muon resulting hit(s) in muon detectors. In phase2 the problem is exacerbated because also outer tracker SimHits are stored in the "pixel hit" collections, and for some reason for some SimTracks the OT SimHits have smaller index than pixel SimHits (typically leading to `numberOfHits()` being 0).

The proposed fix is to sort the SimHits by their `timeOfFlight()` before being inserted to the `multimap`, and ignore SimHits having `particleType` different from TrackingParticle `pdgId` from the "first hit" `particleType`+`processType` deduction (they are anyway ignored from the `numberOfHits` calculation already now).

But even this is not perfect, as there are cases where e.g. all SimHits have `particleType` different from TrackingParticle `pdgId`. So some further thought is still needed, but I think this PR is nevertheless an improvement. Similar fix is applied to `TrackingParticleNumberOfHits` as well.

Given that prior #17338 the TrackingParticles with `numberOfHits()==0` were ignored in `QuickTrackAssociatorByHits`, this bug caused some legitimate track-TrackingParticle pairs to not be associated. Already alone this PR would give almost the same changes in track true/fake classification as #17338 (there are cases where all SimHits of a TrackingParticle have a different `particleType` from the TrackingParticle `pdgId`, so #17338 was anyway needed). On top of #17338, the plots showing the number of hits or layers are expected to show small changes.

Tested in CMSSW_9_0_X_2017-01-22-2300 (on top of #17338), expected changes in validation plots are described above. No changes are expected in reco quantities.

@rovere @VinInn @ebrondol @slava77 

