### PR TITLE
Reactivate big pixels for the Phase 1 pixel topology

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml
@@ -2,7 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
  <ConstantsSection  label="trackerParameters.xml" eval="true">
   <Vector name="vPars" type="numeric" nEntries="6">
-    80, 52, 0, 0, 2, 8
+    80, 52, 1, 2, 2, 8
   </Vector>
   <Vector name="Subdetector1" type="numeric" nEntries="6">
     20, 12, 2, 0xF, 0xFF, 0x3FF

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -91,7 +91,7 @@ TrackerGeomBuilderFromGeometricDet::build( const GeometricDet* gd, const PTracke
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelPhase1Barrel) 
       buildPixel(dets[i],tracker,GeomDetEnumerators::SubDetector::P1PXB,
-		 true,
+		 false,
 		 BIG_PIX_PER_ROC_X,
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelEndCap)
@@ -101,7 +101,7 @@ TrackerGeomBuilderFromGeometricDet::build( const GeometricDet* gd, const PTracke
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelPhase1EndCap)
       buildPixel(dets[i],tracker,GeomDetEnumerators::SubDetector::P1PXEC,
-		 true,
+		 false,
 		 BIG_PIX_PER_ROC_X,
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelPhase2EndCap)


### PR DESCRIPTION
These changes enable big pixels along the edges of the pixel readout chips.
They were disabled in the Phase 1 TDR, but the actual sensor design is the same as that of the Phase 0 detector so the relevant parameters were reverted in this PR.
