### PR TITLE
Access to X and Y Offsets

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
@@ -186,6 +186,13 @@ public:
     return m_COLS_PER_ROC; 	 
   }
 
+  float xoffset() const {
+    return m_xoffset;
+  }
+  float yoffset() const {
+    return m_yoffset;
+  }
+  
 private:
 
   float m_pitchx;


### PR DESCRIPTION
* Allow access to x and y offsets calculated in a constructor
* Needed for an event display to minimize amount of data stored in a reco geometry file