### PR TITLE
Removing 'cout' comments  from code used in prod (phase2 Track Trigger) 

### DIFF
--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.h
@@ -99,12 +99,6 @@ void TTClusterBuilder< T >::beginRun( const edm::Run& run, const edm::EventSetup
   /// Get the clustering algorithm 
   iSetup.get< TTClusterAlgorithmRecord >().get( theClusterFindingAlgoHandle );
 
-  /// Print some information when loaded
-  std::cout << std::endl;
-  std::cout << "TTClusterBuilder< " << templateNameFinder< T >() << " > loaded modules:"
-            << "\n\tTTClusterAlgorithm:\t" << theClusterFindingAlgoHandle->AlgorithmName()
-            << std::endl;
-  std::cout << std::endl;
 }
 
 /// End run

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
@@ -94,11 +94,6 @@ void TTStubBuilder< T >::beginRun( const edm::Run& run, const edm::EventSetup& i
 {
   /// Get the stub finding algorithm
   iSetup.get< TTStubAlgorithmRecord >().get( theStubFindingAlgoHandle );
-  /// Print some information when loaded
-  std::cout << std::endl;
-  std::cout << "TTStubBuilder< " << templateNameFinder< T >() << " > loaded modules:"
-            << "\n\tTTStubAlgorithm:\t" << theStubFindingAlgoHandle->AlgorithmName()
-            << std::endl;
 }
 
 /// End run


### PR DESCRIPTION
Title said it all,  I realized that some comments were coming from cout in step2 phase2 logs 