### PR TITLE
Configurable Pixel Cluster Shape in LowPtSeedComparitor

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -109,7 +109,8 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         CAHardPtCut = cms.double(0),
         SeedComparitorPSet = cms.PSet( 
             ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
-            clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
+            clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" ),
+            clusterShapeHitFilter = cms.string('ClusterShapeHitFilter')
         )
     )
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -408,6 +408,14 @@ def customiseFor17098(process):
        producer.copyTrajectories = cms.untracked.bool(False)
     return process
 
+# Configurable Pixel Cluster Shape in LowPtSeedComparitor
+def customiseFor17393(process):
+    for producer in producers_by_type(process,"PixelTripletHLTEDProducer"):
+         if hasattr(producer,'SeedComparitorPSet'):
+             if (producer.SeedComparitorPSet.ComponentName.value() == 'LowPtClusterShapeSeedComparitor'):
+                  producer.SeedComparitorPSet.clusterShapeHitFilter = cms.string('ClusterShapeHitFilter')
+    return process
+
 #
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -436,6 +444,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
         process = customiseFor17094(process)
         process = customiseFor17170(process)
         process = customiseFor17098(process)
+        process = customiseFor17393(process)
         pass
 
 #   stage-2 changes only if needed

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
@@ -32,6 +32,7 @@ class LowPtClusterShapeSeedComparitor : public SeedComparitor
    edm::ESHandle<TrackerTopology> theTTopo;
    edm::EDGetTokenT<SiPixelClusterShapeCache> thePixelClusterShapeCacheToken;
    edm::Handle<SiPixelClusterShapeCache> thePixelClusterShapeCache;
+   std::string theShapeFilterLabel_;
 };
 
 #endif

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/LowPtClusterShapeSeedComparitor_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/LowPtClusterShapeSeedComparitor_cfi.py
@@ -3,4 +3,5 @@ import FWCore.ParameterSet.Config as cms
 LowPtClusterShapeSeedComparitor = cms.PSet(
     ComponentName = cms.string('LowPtClusterShapeSeedComparitor'),
     clusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache'),
+    clusterShapeHitFilter = cms.string('ClusterShapeHitFilter')
 )

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
@@ -106,12 +106,13 @@ namespace {
 
 /*****************************************************************************/
 LowPtClusterShapeSeedComparitor::LowPtClusterShapeSeedComparitor(const edm::ParameterSet& ps, edm::ConsumesCollector& iC):
-  thePixelClusterShapeCacheToken(iC.consumes<SiPixelClusterShapeCache>(ps.getParameter<edm::InputTag>("clusterShapeCacheSrc")))
+  thePixelClusterShapeCacheToken(iC.consumes<SiPixelClusterShapeCache>(ps.getParameter<edm::InputTag>("clusterShapeCacheSrc"))),
+  theShapeFilterLabel_(ps.getParameter<std::string>("clusterShapeHitFilter"))
 {}
 
 /*****************************************************************************/
 void LowPtClusterShapeSeedComparitor::init(const edm::Event& e, const edm::EventSetup& es) {
-  es.get<CkfComponentsRecord>().get("ClusterShapeHitFilter", theShapeFilter);
+  es.get<CkfComponentsRecord>().get(theShapeFilterLabel_, theShapeFilter);
   es.get<TrackerTopologyRcd>().get(theTTopo);
 
   e.getByToken(thePixelClusterShapeCacheToken, thePixelClusterShapeCache);


### PR DESCRIPTION
After a private chat with @makortel, we decided to set the pixel cluster shape filter in the 'LowPtClusterShapeSeedComparitor' configurable. The 'LowPtClusterShapeSeedComparitor' is used for all pixel use cases and the cluster shape filtering name was set hard-coded to 'ClusterShapeHitFilter'.
This change increases the flexibility of the code and the relationship between the two is also showing up in edmConfigDump, while it was not clear before.
No changes are expected in any phases.