### PR TITLE
add 10 electrons gun gen fragment

### DIFF
--- a/Configuration/Generator/python/TenE_E_0_200_pythia8_cfi.py
+++ b/Configuration/Generator/python/TenE_E_0_200_pythia8_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 # Modified from Configuration/Generator/python/TenMuE_0_200_pythia8_cfi.py
- = cms.EDFilter("Pythia8EGun",
+generator = cms.EDFilter("Pythia8EGun",
     PGunParameters = cms.PSet(
         MaxE = cms.double(200.0),
         MinE = cms.double(0.0),

--- a/Configuration/Generator/python/TenE_E_0_200_pythia8_cfi.py
+++ b/Configuration/Generator/python/TenE_E_0_200_pythia8_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+# Modified from Configuration/Generator/python/TenMuE_0_200_pythia8_cfi.py
+ = cms.EDFilter("Pythia8EGun",
+    PGunParameters = cms.PSet(
+        MaxE = cms.double(200.0),
+        MinE = cms.double(0.0),
+        ParticleID = cms.vint32(-11,-11,-11,-11,-11),
+        AddAntiParticle = cms.bool(True),
+        MaxEta = cms.double(3.),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-3.),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+
+    ),
+    Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+
+    psethack = cms.string('Ten e w/ energy 0 to 200'),
+    firstRun = cms.untracked.uint32(1),
+    PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+
+)


### PR DESCRIPTION
as requested by EGM for both offline and HLT reconstruction/ID/etc validation
this is the gen fragment for generating events w/ 10 electrons w/
- energy [0;200] GeV
- |eta| < 3.
this gen fragment is a copy-n-paste of the [TenMu gun](https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_X/Configuration/Generator/python/TenMuE_0_200_pythia8_cfi.py)

I simply changed -13 into -11
and increased the eta acceptance

this will be used for standard relval samples for release validation
and it will help the development and tuning of the EGM reco/ID/etc

@paramatti @fcouderc @gpasztor 