### PR TITLE
Fix module summary information

### DIFF
--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -143,22 +143,22 @@ namespace edm {
     virtual Types moduleType() const =0;
 
     void clearCounters() {
-      timesRun_.store(0,std::memory_order_relaxed);
-      timesVisited_.store(0,std::memory_order_relaxed);
-      timesPassed_.store(0,std::memory_order_relaxed);
-      timesFailed_.store(0,std::memory_order_relaxed);
-      timesExcept_.store(0,std::memory_order_relaxed);
+      timesRun_.store(0,std::memory_order_release);
+      timesVisited_.store(0,std::memory_order_release);
+      timesPassed_.store(0,std::memory_order_release);
+      timesFailed_.store(0,std::memory_order_release);
+      timesExcept_.store(0,std::memory_order_release);
     }
 
     void addedToPath() {
       ++numberOfPathsOn_;
     }
     //NOTE: calling state() is done to force synchronization across threads
-    int timesRun() const { return timesRun_.load(std::memory_order_relaxed); }
-    int timesVisited() const { return timesVisited_.load(std::memory_order_relaxed); }
-    int timesPassed() const { return timesPassed_.load(std::memory_order_relaxed); }
-    int timesFailed() const { return timesFailed_.load(std::memory_order_relaxed); }
-    int timesExcept() const { return timesExcept_.load(std::memory_order_relaxed); }
+    int timesRun() const { return timesRun_.load(std::memory_order_acquire); }
+    int timesVisited() const { return timesVisited_.load(std::memory_order_acquire); }
+    int timesPassed() const { return timesPassed_.load(std::memory_order_acquire); }
+    int timesFailed() const { return timesFailed_.load(std::memory_order_acquire); }
+    int timesExcept() const { return timesExcept_.load(std::memory_order_acquire); }
     State state() const { return state_; }
 
     int timesPass() const { return timesPassed(); } // for backward compatibility only - to be removed soon

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -82,7 +82,6 @@ namespace edm {
     switch (state) {
       case Worker::Fail:
       {
-        ++timesFailed_;
         rc = false;
         break;
       }


### PR DESCRIPTION
The summary information about module running is not correct.
The per path accounting was double counting each failure. This
problem was obvious.
The per module accounting was sometimes not adding up to
match the per path information (it was always less). No clear
reason was found for this, although the use of memory_order_relaxed
may be the cause (so was changed).