### PR TITLE
protect print-out in FSimTrack

### DIFF
--- a/FastSimulation/Event/src/FSimTrack.cc
+++ b/FastSimulation/Event/src/FSimTrack.cc
@@ -127,7 +127,7 @@ std::ostream& operator <<(std::ostream& o , const FSimTrack& t) {
     << std::setw(6) << std::setprecision(1) << vertex1.x() << " " 
     << std::setw(6) << std::setprecision(1) << vertex1.y() << " " 
     << std::setw(6) << std::setprecision(1) << vertex1.z() << " "
-    << std::setw(4) << t.mother().id() << " ";
+    << std::setw(4) << (t.noMother() ? -1 :t.mother().id()) << " ";
   
   if ( !t.noEndVertex() ) {
     XYZTLorentzVector vertex2 = t.endVertex().position();


### PR DESCRIPTION
This is a fix for a very rare bug in the FSimTrack printout. One should first check that a  FSimTrack has a mother trying to print its index and it wasn't done.  
To my knowledge, a FSimTrack without a mother should not exist in the FastSim. That's why the problem was never noticed before. 
I saw the problem because I tried to build a FSimEvent from Geant4 SimTracks and SimVertices. 