### PR TITLE
Fix FriendlyName and TypeDemangler for the extra namespace qualifier added

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -45,6 +45,7 @@ namespace edm {
     static boost::regex const reStringCXX11("std::__cxx11::basic_string<char>");
     static boost::regex const reString2CXX11("std::__cxx11::basic_string<char,std::char_traits<char> >");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
+    static boost::regex const reclangabi("std::__1::");
     static boost::regex const reULongLong("ULong64_t");
     static boost::regex const reLongLong("Long64_t");
     static boost::regex const reUnsigned("unsigned ");
@@ -77,6 +78,7 @@ namespace edm {
        using boost::regex;
        std::string name = regex_replace(iIn, reWrapper, "$1");
        name = regex_replace(name,reAIKR,"");
+       name = regex_replace(name,reclangabi,"std::");
        name = regex_replace(name,reString,"String");
        name = regex_replace(name,reString2,"String");
        name = regex_replace(name,reStringCXX11,"String");

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -113,6 +113,10 @@ namespace edm {
     replaceString(demangledName, ", ", ",");
     // No space before opening square bracket
     replaceString(demangledName, " [", "[");
+    // clang libc++ uses __1:: namespace
+    replaceString(demangledName, "std::__1::", "std::");
+    // new gcc abi uses __cxx11:: namespace
+    replaceString(demangledName, "std::__cxx11::", "std::");
     // Strip default allocator
     std::string const allocator(",std::allocator<");
     removeParameter(demangledName, allocator);


### PR DESCRIPTION
for clang libc++ abi (std::__1::) and new gcc abi (std::__cxx11::)