### PR TITLE
Converted from legacy to global module

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/CandOneToManyDeltaRMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/CandOneToManyDeltaRMatcher.cc
@@ -8,7 +8,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -16,12 +16,12 @@
 #include<vector>
 #include<iostream>
 
-class CandOneToManyDeltaRMatcher : public edm::EDProducer {
+class CandOneToManyDeltaRMatcher : public edm::global::EDProducer<> {
  public:
   CandOneToManyDeltaRMatcher( const edm::ParameterSet & );
   ~CandOneToManyDeltaRMatcher();
  private:
-  void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce( edm::StreamID, edm::Event&, const edm::EventSetup& ) const override;
 
   edm::EDGetTokenT<reco::CandidateCollection> sourceToken_;
   edm::EDGetTokenT<reco::CandidateCollection> matchedToken_;
@@ -73,7 +73,7 @@ CandOneToManyDeltaRMatcher::CandOneToManyDeltaRMatcher( const ParameterSet & cfg
 CandOneToManyDeltaRMatcher::~CandOneToManyDeltaRMatcher() {
 }
 
-void CandOneToManyDeltaRMatcher::produce( Event& evt, const EventSetup& es ) {
+void CandOneToManyDeltaRMatcher::produce( edm::StreamID, Event& evt, const EventSetup& es ) const {
 
   Handle<CandidateCollection> source;
   Handle<CandidateCollection> matched;

--- a/PhysicsTools/JetMCAlgos/plugins/GenJetBCEnergyRatio.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenJetBCEnergyRatio.cc
@@ -7,7 +7,7 @@
 //=======================================================================
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -48,7 +48,7 @@ using namespace ROOT::Math::VectorUtil;
 using namespace JetMCTagUtils;
 using namespace CandMCTagUtils;
 
-class GenJetBCEnergyRatio : public edm::EDProducer
+class GenJetBCEnergyRatio : public edm::global::EDProducer<>
 {
   public:
     GenJetBCEnergyRatio( const edm::ParameterSet & );
@@ -57,8 +57,7 @@ class GenJetBCEnergyRatio : public edm::EDProducer
     typedef reco::JetFloatAssociation::Container JetBCEnergyRatioCollection;
 
   private:
-    virtual void produce(edm::Event&, const edm::EventSetup& ) override;
-    Handle< View <Jet> > genjets;
+    virtual void produce(StreamID, edm::Event&, const edm::EventSetup& ) const override;
     edm::EDGetTokenT< View <Jet> > m_genjetsSrcToken;
 
 };
@@ -80,8 +79,9 @@ GenJetBCEnergyRatio::~GenJetBCEnergyRatio()
 
 // ------------ method called to produce the data  ------------
 
-void GenJetBCEnergyRatio::produce( Event& iEvent, const EventSetup& iEs )
+void GenJetBCEnergyRatio::produce( StreamID, Event& iEvent, const EventSetup& iEs )const
 {
+  Handle< View <Jet> > genjets;
   iEvent.getByToken(m_genjetsSrcToken, genjets);
 
   typedef edm::RefToBase<reco::Jet> JetRef;

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourIdentifier.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourIdentifier.cc
@@ -36,7 +36,7 @@
 //=======================================================================
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -83,7 +83,7 @@ namespace reco { namespace modules {
 //--------------------------------------------------------------------------
 //
 //--------------------------------------------------------------------------
-class JetFlavourIdentifier : public edm::EDProducer
+class JetFlavourIdentifier : public edm::global::EDProducer<>
 {
   public:
   enum DEFINITION_T { PHYSICS=0, ALGO, NEAREST_STATUS2, NEAREST_STATUS3, HEAVIEST,
@@ -94,19 +94,17 @@ class JetFlavourIdentifier : public edm::EDProducer
     ~JetFlavourIdentifier();
 
   private:
-    virtual void produce(edm::Event&, const edm::EventSetup& ) override;
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup& ) const override;
 
-    JetFlavour::Leptons findLeptons(const GenParticleRef &);
-    std::vector<const reco::Candidate*> findCandidates(const reco::Candidate*, int);
-    void fillLeptons(const std::vector<const reco::Candidate*> &, JetFlavour::Leptons &, int, int);
+    JetFlavour::Leptons findLeptons(const GenParticleRef &) const;
+    std::vector<const reco::Candidate*> findCandidates(const reco::Candidate*, int, math::XYZTLorentzVector const&  thePartonLV) const;
+    void fillLeptons(const std::vector<const reco::Candidate*> &, JetFlavour::Leptons &, int, int, math::XYZTLorentzVector const&  thePartonLV) const;
     static int heaviestFlavour(int);
 
-    Handle<JetMatchedPartonsCollection> theTagByRef;
     EDGetTokenT<JetMatchedPartonsCollection> sourceByReferToken_;
     bool physDefinition;
     bool leptonInfo_;
     DEFINITION_T definition;
-    math::XYZTLorentzVector thePartonLV;
 
 };
 } }
@@ -139,9 +137,10 @@ JetFlavourIdentifier::~JetFlavourIdentifier()
 
 // ------------ method called to produce the data  ------------
 
-void JetFlavourIdentifier::produce( Event& iEvent, const EventSetup& iEs )
+void JetFlavourIdentifier::produce( StreamID, Event& iEvent, const EventSetup& iEs ) const
 {
   // Get the JetMatchedPartons
+  Handle<JetMatchedPartonsCollection> theTagByRef;
   iEvent.getByToken (sourceByReferToken_, theTagByRef);
 
   // Create a JetFlavourMatchingCollection
@@ -282,11 +281,11 @@ void JetFlavourIdentifier::produce( Event& iEvent, const EventSetup& iEs )
 
 }
 
-JetFlavour::Leptons JetFlavourIdentifier::findLeptons(const GenParticleRef &parton)
+JetFlavour::Leptons JetFlavourIdentifier::findLeptons(const GenParticleRef &parton) const
 {
   JetFlavour::Leptons theLeptons;
 
-  thePartonLV = parton->p4();
+  auto const& thePartonLV = parton->p4();
 
   ///first daughter of the parton should be an MC particle (pdgId==92,93)
   const reco::Candidate *mcstring = parton->daughter(0);
@@ -294,17 +293,17 @@ JetFlavour::Leptons JetFlavourIdentifier::findLeptons(const GenParticleRef &part
 //  std::cout << "parton DeltaR: " << DeltaR(thePartonLV, parton->p4()) << std::endl;
 
   ///lookup particles with parton flavour and weak decay
-  std::vector<const reco::Candidate*> candidates = findCandidates(mcstring, partonFlavour);
+  std::vector<const reco::Candidate*> candidates = findCandidates(mcstring, partonFlavour, parton->p4());
 //  std::cout << "Candidates are:" << std::endl;
 //  for(unsigned int j = 0; j < candidates.size(); j++) std::cout << "   --> " << candidates[j]->pdgId() << std::endl;
 
   ///count leptons of candidates
-  fillLeptons(candidates, theLeptons, 1, partonFlavour);
+  fillLeptons(candidates, theLeptons, 1, partonFlavour, thePartonLV);
 
   return theLeptons;
 }
 
-std::vector<const reco::Candidate*> JetFlavourIdentifier::findCandidates(const reco::Candidate *cand, int partonFlavour)
+std::vector<const reco::Candidate*> JetFlavourIdentifier::findCandidates(const reco::Candidate *cand, int partonFlavour, math::XYZTLorentzVector const& thePartonLV) const
 {
   std::vector<const reco::Candidate*> cands;
   if(!cand) return cands;
@@ -323,7 +322,7 @@ std::vector<const reco::Candidate*> JetFlavourIdentifier::findCandidates(const r
       if (flavour == partonFlavour ||
           (flavour >= 10 && partonFlavour >= 10)) {
 //        std::cout << "<------- " << std::endl;
-        std::vector<const reco::Candidate*> newcands = findCandidates(cand->daughter(i), partonFlavour);
+        std::vector<const reco::Candidate*> newcands = findCandidates(cand->daughter(i), partonFlavour, thePartonLV);
 //        std::cout << " ------->" << std::endl;
         std::copy(newcands.begin(), newcands.end(), std::back_inserter(cands));
       }
@@ -340,7 +339,7 @@ std::vector<const reco::Candidate*> JetFlavourIdentifier::findCandidates(const r
   return cands;
 }
 
-void JetFlavourIdentifier::fillLeptons(const std::vector<const reco::Candidate*> &cands, JetFlavour::Leptons &leptons, int rank, int flavour)
+void JetFlavourIdentifier::fillLeptons(const std::vector<const reco::Candidate*> &cands, JetFlavour::Leptons &leptons, int rank, int flavour, math::XYZTLorentzVector const& thePartonLV) const
 {
   for(unsigned int j = 0; j < cands.size(); j++) {
     for(unsigned int i = 0; i < cands[j]->numberOfDaughters(); i++) {
@@ -360,9 +359,9 @@ void JetFlavourIdentifier::fillLeptons(const std::vector<const reco::Candidate*>
         int heaviest = heaviestFlavour(pdgId);
         int heaviest_ = heaviest < 10 ? heaviest : 0;
         if (!heaviest || (flavour < 4 ? (heaviest_ < 4) : (heaviest >= 4))) {
-          std::vector<const reco::Candidate*> newcands = findCandidates(cands[j]->daughter(i), heaviest);
+          std::vector<const reco::Candidate*> newcands = findCandidates(cands[j]->daughter(i), heaviest, thePartonLV);
           if (pdgId <= 110) newcands.push_back(cands[j]->daughter(i));
-          fillLeptons(newcands, leptons, rank * 10, std::max(heaviest_, flavour));
+          fillLeptons(newcands, leptons, rank * 10, std::max(heaviest_, flavour), thePartonLV);
         }
       }
     }

--- a/PhysicsTools/JetMCAlgos/plugins/JetPartonMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetPartonMatcher.cc
@@ -52,7 +52,7 @@
 //=======================================================================
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -91,23 +91,25 @@ using namespace reco;
 using namespace edm;
 using namespace ROOT::Math::VectorUtil;
 
-class JetPartonMatcher : public edm::EDProducer
+class JetPartonMatcher : public edm::global::EDProducer<>
 {
   public:
     JetPartonMatcher( const edm::ParameterSet & );
     ~JetPartonMatcher();
 
   private:
-    virtual void produce(edm::Event&, const edm::EventSetup& ) override;
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup& ) const override;
 
-    int fillAlgoritDefinition( const Jet& );
-    int fillPhysicsDefinition( const Jet& );
-    int theHeaviest;
-    int theNearest2;
-    int theNearest3;
-    int theHardest;
+    struct WorkingVariables {
+      Handle <GenParticleRefVector> particles;
+      int theHeaviest = 0;
+      int theNearest2 =0;
+      int theNearest3 = 0;
+      int theHardest = 0;
+    };
 
-    Handle <GenParticleRefVector> particles;
+    int fillAlgoritDefinition( const Jet&, WorkingVariables& ) const;
+    int fillPhysicsDefinition( const Jet&, WorkingVariables& ) const;
 
     edm::EDGetTokenT<edm::View <reco::Jet> > m_jetsSrcToken;
     edm::EDGetTokenT<GenParticleRefVector> m_ParticleSrcToken;
@@ -120,11 +122,7 @@ class JetPartonMatcher : public edm::EDProducer
 
 //=========================================================================
 
-JetPartonMatcher::JetPartonMatcher( const edm::ParameterSet& iConfig ) :
-  theHeaviest(0),
-  theNearest2(0),
-  theNearest3(0),
-  theHardest(0)
+JetPartonMatcher::JetPartonMatcher( const edm::ParameterSet& iConfig ) 
 {
     produces<JetMatchedPartonsCollection>();
     m_jetsSrcToken           = consumes<edm::View <reco::Jet> >(iConfig.getParameter<edm::InputTag>("jets"));
@@ -147,16 +145,17 @@ JetPartonMatcher::~JetPartonMatcher()
 
 // ------------ method called to produce the data  ------------
 
-void JetPartonMatcher::produce( Event& iEvent, const EventSetup& iEs )
+void JetPartonMatcher::produce(edm::StreamID, Event& iEvent, const EventSetup& iEs ) const
 {
+  WorkingVariables wv;
   edm::Handle <edm::View <reco::Jet> > jets_h;
   iEvent.getByToken(m_jetsSrcToken,     jets_h    );
-  iEvent.getByToken(m_ParticleSrcToken, particles );
+  iEvent.getByToken(m_ParticleSrcToken, wv.particles );
 
-  edm::LogVerbatim("JetPartonMatcher") << "=== Partons size:" << particles->size();
+  edm::LogVerbatim("JetPartonMatcher") << "=== Partons size:" << wv.particles->size();
 
-  for( size_t m = 0; m != particles->size(); ++ m ) {
-    const GenParticle & aParton = *(particles->at(m).get());
+  for( size_t m = 0; m != wv.particles->size(); ++ m ) {
+    const GenParticle & aParton = *(wv.particles->at(m).get());
     edm::LogVerbatim("JetPartonMatcher") <<  aParton.status() << " " <<
                                              aParton.pdgId()  << " " <<
                                              aParton.pt()     << " " <<
@@ -168,8 +167,8 @@ void JetPartonMatcher::produce( Event& iEvent, const EventSetup& iEs )
 
   for (size_t j = 0; j < jets_h->size(); j++) {
 
-    const int theMappedPartonAlg = fillAlgoritDefinition( (*jets_h)[j] );
-    const int theMappedPartonPhy = fillPhysicsDefinition( (*jets_h)[j] );
+    const int theMappedPartonAlg = fillAlgoritDefinition( (*jets_h)[j], wv );
+    const int theMappedPartonPhy = fillPhysicsDefinition( (*jets_h)[j], wv );
 
     GenParticleRef pHV;
     GenParticleRef pN2;
@@ -177,11 +176,11 @@ void JetPartonMatcher::produce( Event& iEvent, const EventSetup& iEs )
     GenParticleRef pPH;
     GenParticleRef pAL;
 
-    if(theHeaviest>=0)        pHV = particles->at( theHeaviest        );
-    if(theNearest2>=0)        pN2 = particles->at( theNearest2        );
-    if(theNearest3>=0)        pN3 = particles->at( theNearest3        );
-    if(theMappedPartonPhy>=0) pPH = particles->at( theMappedPartonPhy );
-    if(theMappedPartonAlg>=0) pAL = particles->at( theMappedPartonAlg );
+    if(wv.theHeaviest>=0)        pHV = wv.particles->at( wv.theHeaviest        );
+    if(wv.theNearest2>=0)        pN2 = wv.particles->at( wv.theNearest2        );
+    if(wv.theNearest3>=0)        pN3 = wv.particles->at( wv.theNearest3        );
+    if(theMappedPartonPhy>=0) pPH = wv.particles->at( theMappedPartonPhy );
+    if(theMappedPartonAlg>=0) pAL = wv.particles->at( theMappedPartonAlg );
 
     (*jetMatchedPartons)[jets_h->refAt(j)]=MatchedPartons(pHV,pN2,pN3,pPH,pAL);
   }
@@ -213,7 +212,7 @@ void JetPartonMatcher::produce( Event& iEvent, const EventSetup& iEs )
 //
 // ToDo: if more than one b(c) in the cone --> the selected parton is not always the one with highest pT
 //
-int JetPartonMatcher::fillAlgoritDefinition( const Jet& theJet ) {
+int JetPartonMatcher::fillAlgoritDefinition( const Jet& theJet, WorkingVariables& wv ) const {
 
   int tempParticle = -1;
   int tempPartonHighestPt = -1;
@@ -241,8 +240,8 @@ int JetPartonMatcher::fillAlgoritDefinition( const Jet& theJet ) {
   //    then it will first look for top quarks, then W bosons, then gluons.
   // 2) If no priority items are found, do the default "standard"
   //    matching.
-  for( size_t m = 0; m != particles->size() && !foundPriority; ++ m ) {
-    const Candidate & aParton = *(particles->at(m).get());
+  for( size_t m = 0; m != wv.particles->size() && !foundPriority; ++ m ) {
+    const Candidate & aParton = *(wv.particles->at(m).get());
 
     // "Priority" behavoir:
     // Associate to the first particle found in the priority list, regardless
@@ -290,13 +289,13 @@ int JetPartonMatcher::fillAlgoritDefinition( const Jet& theJet ) {
   }
 
   if ( foundPriority ) {
-    theHeaviest = tempParticle; // The priority-matched particle
-    theHardest  = -1;  //  set the rest to -1
-    theNearest2 = -1;  // "                  "
+    wv.theHeaviest = tempParticle; // The priority-matched particle
+    wv.theHardest  = -1;  //  set the rest to -1
+    wv.theNearest2 = -1;  // "                  "
   } else {
-    theHeaviest = tempParticle;
-    theHardest  = tempPartonHighestPt;
-    theNearest2 = tempNearest;
+    wv.theHeaviest = tempParticle;
+    wv.theHardest  = tempPartonHighestPt;
+    wv.theNearest2 = tempNearest;
     if ( tempParticle == -1 ) tempParticle = tempPartonHighestPt;
   }
   return tempParticle;
@@ -324,7 +323,7 @@ int JetPartonMatcher::fillAlgoritDefinition( const Jet& theJet ) {
 // associatedInitialParticle can be -1 --> no initialParticle in the cone or rejected association
 // True Flavour of the jet --> flavour of the associatedInitialParticle
 //
-int JetPartonMatcher::fillPhysicsDefinition( const Jet& theJet ) {
+int JetPartonMatcher::fillPhysicsDefinition( const Jet& theJet, WorkingVariables& wv ) const {
 
   float TheBiggerConeSize = 0.7; // In HepMC it's 0.3 --> it's a mistake: value has to be 0.7
   int tempParticle = -1;
@@ -355,9 +354,9 @@ int JetPartonMatcher::fillPhysicsDefinition( const Jet& theJet ) {
   //    then it will first look for top quarks, then W bosons, then gluons.
   // 2) If no priority items are found, do the default "standard"
   //    matching.
-  for( size_t m = 0; m != particles->size() && !foundPriority; ++ m ) {
+  for( size_t m = 0; m != wv.particles->size() && !foundPriority; ++ m ) {
 
-    const Candidate & aParticle = *(particles->at(m).get());
+    const Candidate & aParticle = *(wv.particles->at(m).get());
 
     // "Priority" behavoir:
     // Associate to the first particle found in the priority list, regardless
@@ -419,16 +418,16 @@ int JetPartonMatcher::fillPhysicsDefinition( const Jet& theJet ) {
 
   // Here's the default behavior for assignment if there is no priority.
   if ( !foundPriority ) {
-    theNearest3 = tempNearest;
+    wv.theNearest3 = tempNearest;
 
     if(nInTheCone != 1) return -1; // rejected --> only one initialParton requested
     if(theContaminations.size() == 0 ) return tempParticle; //no contamination
-    int initialPartonFlavour = abs( (particles->at(tempParticle).get()) ->pdgId() );
+    int initialPartonFlavour = abs( (wv.particles->at(tempParticle).get()) ->pdgId() );
 
     vector<const Candidate *>::const_iterator itCont = theContaminations.begin();
     for( ; itCont != theContaminations.end(); itCont++ ) {
       int contaminatingFlavour = abs( (*itCont)->pdgId() );
-      if( (*itCont)->numberOfMothers()>0 && (*itCont)->mother(0) == particles->at(tempParticle).get() ) continue; // mother is the initialParton --> OK
+      if( (*itCont)->numberOfMothers()>0 && (*itCont)->mother(0) == wv.particles->at(tempParticle).get() ) continue; // mother is the initialParton --> OK
       if( initialPartonFlavour == 4 ) {
 	if( contaminatingFlavour == 4 ) continue; // keep association --> the initialParton is a c --> the contaminated parton is a c
 	tempParticle = -1; // all the other cases reject!
@@ -438,10 +437,10 @@ int JetPartonMatcher::fillPhysicsDefinition( const Jet& theJet ) {
   }
   // If there is priority, then just set the heaviest to priority, the rest are -1.
   else {
-    theHeaviest = tempParticle; // Set the heaviest to tempParticle
-    theNearest2 = -1; //  Set the rest to -1
-    theNearest3 = -1; // "                  "
-    theHardest = -1;  // "                  "
+    wv.theHeaviest = tempParticle; // Set the heaviest to tempParticle
+    wv.theNearest2 = -1; //  Set the rest to -1
+    wv.theNearest3 = -1; // "                  "
+    wv.theHardest = -1;  // "                  "
   }
 
   return tempParticle;

--- a/PhysicsTools/JetMCAlgos/plugins/PartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/PartonSelector.cc
@@ -7,7 +7,7 @@
 //=======================================================================
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -33,7 +33,7 @@ using namespace std;
 using namespace reco;
 using namespace edm;
 
-class PartonSelector : public edm::EDProducer
+class PartonSelector : public edm::global::EDProducer<>
 {
   public:
     PartonSelector( const edm::ParameterSet & );
@@ -41,7 +41,7 @@ class PartonSelector : public edm::EDProducer
 
   private:
 
-    virtual void produce(edm::Event&, const edm::EventSetup& ) override;
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup& ) const override;
     bool withLeptons;  // Optionally specify leptons
     bool withTop;      // Optionally include top quarks in the list
     bool acceptNoDaughters;      // Parton with zero daugthers are not considered by default, make it configurable
@@ -80,7 +80,7 @@ PartonSelector::~PartonSelector()
 
 // ------------ method called to produce the data  ------------
 
-void PartonSelector::produce( Event& iEvent, const EventSetup& iEs )
+void PartonSelector::produce( StreamID, Event& iEvent, const EventSetup& iEs ) const
 {
 
   //edm::Handle <reco::CandidateView> particles;


### PR DESCRIPTION
Multi-threaded performance testing showed several of the modules
from PhysicsTools/JetMCAlgos were causing stalls. They, along with
a couple of other ones, were converted to global modules.