### PR TITLE
make TestSiStripDCS unit test to return non-zero exit code if failled

### DIFF
--- a/CalibTracker/SiStripDCS/test/UnitTests/MasterTestSiStripDCS.cpp
+++ b/CalibTracker/SiStripDCS/test/UnitTests/MasterTestSiStripDCS.cpp
@@ -41,5 +41,6 @@ int main( int argc, char* argv[] )
   // Outputs the name of each test when it is executed.
   CppUnit::BriefTestProgressListener progress;
   runner.eventManager().addListener( &progress );
-  runner.run();
+  if (!runner.run()) { return 1; }
+  return 0;
 }

--- a/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
@@ -46,6 +46,8 @@ public:
     pset.addParameter("Tmin", vectorDate(2009, 12, 7,  12,  0, 0, 000));
     pset.addParameter("Tmax", vectorDate(2009, 12, 8, 9, 0, 0, 000));
     pset.addParameter("TSetMin", vectorDate(2007, 11, 26, 0, 0, 0, 0));
+    pset.addParameter<uint32_t>("DeltaTmin", 2);
+    pset.addParameter<uint32_t>("MaxIOVlength", 90);
     pset.addParameter("DetIdListFile", std::string("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"));
     pset.addParameter("ExcludedDetIdListFile", std::string(""));
     pset.addParameter("HighVoltageOnThreshold", 0.97);


### PR DESCRIPTION
Default values of missing parameters are added from
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_X/CalibTracker/SiStripDCS/test/dcs_o2o_template_cfg.py#L75
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_X/CalibTracker/SiStripDCS/test/dcs_o2o_template_cfg.py#L78
