### PR TITLE
Fix the sumET correction in MET particle shifter class

### DIFF
--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
@@ -26,14 +26,14 @@ void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt
 	originalParticle != originalParticles->end(); ++originalParticle ) {
     metCorrection->mex   += originalParticle->px();
     metCorrection->mey   += originalParticle->py();
-    metCorrection->sumet += originalParticle->et();
+    metCorrection->sumet -= originalParticle->et();
   }
 
   for ( CandidateView::const_iterator shiftedParticle = shiftedParticles->begin();
 	shiftedParticle != shiftedParticles->end(); ++shiftedParticle ) {
     metCorrection->mex   -= shiftedParticle->px();
     metCorrection->mey   -= shiftedParticle->py();
-    metCorrection->sumet -= shiftedParticle->et();
+    metCorrection->sumet += shiftedParticle->et();
   }
 
   evt.put(std::move(metCorrection));


### PR DESCRIPTION
Fix the sumET correction when computing shifted METs (i.e. uncertainty variations or the EGamma correction For Moriond 2017).

Changes expected : 
- sumET of MET variations

Package touched :
PhyscisTools/PatUtils