### PR TITLE
Avoid sequence expansion in customizeHLTTrackingForPhaseI2017

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -25,6 +25,15 @@ def modifyHLTPhaseIPixelGeom(process):
 
 # modify the HLT configuration to run the Phase I tracking in the particle flow sequence
 def customizeHLTForPFTrackingPhaseI2017(process):
+    # Bit of a hack to replace a module/sequence with another without
+    # expanding the sequences containing it, but works
+    #
+    # In principle setattr(process) can be used to replace a
+    # module/sequence too, but it expands the sequences making life
+    # more complex
+    modifier = cms.Modifier()
+    modifier._setChosen()
+
 
     process.hltPixelLayerTriplets.layerList = cms.vstring(
         'BPix1+BPix2+BPix3',
@@ -115,7 +124,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 
     process.hltPixelTracks.SeedingHitSets = "hltPixelTracksHitQuadruplets"
 
-    process.HLTDoRecoPixelTracksSequence = cms.Sequence(
+    process.HLTDoRecoPixelTracksSequence = cms.Sequence( # this sequence doesn't exist, but why to add it?
         process.hltPixelLayerQuadruplets +
         process.hltPixelTracksTrackingRegions +
         process.hltPixelTracksHitDoublets +
@@ -129,7 +138,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
     process.hltIter0PFlowTrackCutClassifier.mva.min3DLayers  = cms.vint32( 0, 3, 4 )
     process.hltIter0PFlowTrackCutClassifier.mva.minPixelHits = cms.vint32( 0, 3, 4 )
 
-    process.hltIter1PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
+    modifier.toReplaceWith(process.hltIter1PixelLayerTriplets, cms.EDProducer( "SeedingLayersEDProducer",
         layerList = cms.vstring( 
             'BPix1+BPix2+BPix3', 
             'BPix1+BPix2+FPix1_pos', 
@@ -161,7 +170,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
             hitErrorRPhi = cms.double( 0.0027 )
         ),
         TIB = cms.PSet( )
-    )
+    ))
     
     process.HLTIter1PSetTrajectoryFilterIT = cms.PSet( 
         ComponentType = cms.string('CkfBaseTrajectoryFilter'),
@@ -226,7 +235,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         useSameTrajFilter = cms.bool(False) # new ! other iteration should have it set to True
     )
 
-    process.HLTIterativeTrackingIteration1 = cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerTriplets + process.hltIter1PFlowPixelTrackingRegions + process.hltIter1PFlowPixelClusterCheck + process.hltIter1PFlowPixelHitDoublets + process.hltIter1PFlowPixelHitTriplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity )
+    modifier.toReplaceWith(process.HLTIterativeTrackingIteration1, cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerTriplets + process.hltIter1PFlowPixelTrackingRegions + process.hltIter1PFlowPixelClusterCheck + process.hltIter1PFlowPixelHitDoublets + process.hltIter1PFlowPixelHitTriplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity ))
 
     process.hltIter2PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
         layerList = cms.vstring( 
@@ -286,10 +295,10 @@ def customizeHLTForPFTrackingPhaseI2017(process):
             if key not in skipSet:
                 setattr(new, key, getattr(old, key))
     from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cfi import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
-    process.hltIter2PFlowPixelSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(seedingHitSets="hltIter2PFlowPixelHitTriplets")
+    modifier.toReplaceWith(process.hltIter2PFlowPixelSeeds, _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(seedingHitSets="hltIter2PFlowPixelHitTriplets"))
     _copy(process.HLTSeedFromConsecutiveHitsTripletOnlyCreator, process.hltIter2PFlowPixelSeeds, skip=["ComponentName"])
 
-    process.HLTIterativeTrackingIteration2 = cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelTrackingRegions + process.hltIter2PFlowPixelClusterCheck + process.hltIter2PFlowPixelHitDoublets + process.hltIter2PFlowPixelHitTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity )
+    modifier.toReplaceWith(process.HLTIterativeTrackingIteration2, cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelTrackingRegions + process.hltIter2PFlowPixelClusterCheck + process.hltIter2PFlowPixelHitDoublets + process.hltIter2PFlowPixelHitTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity ))
 
     # Need to operate on Paths as well...
     for seqs in [process.sequences_(), process.paths_()]:


### PR DESCRIPTION
The automatic expansion of sequences in `customizeHLTTrackingForPhaseI2017.py` after #17170 can, in some cases, lead to necessary modules missing in the sequences. While the full menu apparently works (since the 2017 workflows have run successfully after the integration of #17170), a recipe provided by @silviodonato fails
```
hltGetConfiguration /dev/CMSSW_9_0_0/HLT --path HLTFirstPath,HLT_PFHT125_v5,HLTEndPath \
  --globaltag  auto:phase1_2017_realistic \
  --input /store/relval/CMSSW_9_0_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW/PU25ns_90X_upgrade2017_realistic_v0_HLT2017Trk-v1/10000/0480A4C5-F7C2-E611-9FE0-0CC47A4D767A.root  \
  --no-output  > hlt1.py 

# in hlt1.py replace
# process = cms.Process( "HLTX")
# with
# from Configuration.StandardSequences.Eras import eras 
# process = cms.Process( "HLTX", eras.phase1Pixel) 
```

This PR fixes the problem by avoiding the expansion of sequences caused by `setattr(process, ...)` by using a a `cms.Modifier` to replace modules/sequences "in place".

Tested in 9_0_0_pre3 (and CMSSW_9_0_X_2017-01-25-1100+#17170), the recipe above works again (as well as limited matrix, add addOnTests).

@silviodonato @Martin-Grunewald @mtosi @JanFSchulte 