### PR TITLE
Add LumiScalers collection to SiStripCalMinBias output

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
@@ -12,6 +12,8 @@ OutALCARECOSiStripCalMinBias_noDrop = cms.PSet(
         'keep DetIdedmEDCollection_siStripDigis_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep LumiScalerss_scalersRawToDigi_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_TriggerResults_*_*')
 )
 


### PR DESCRIPTION
   Greetings, 
with this PR we aim to add to the `SiStripCalMinBias` ALCARECO output products the `LumiScalers` and `DcsStatus` collections. This is done in view of streamlining several analyses in the context of the SiStrip DPG, (for example assessment of the hit efficiency as a function of instantaneous luminosity or PU, prepared in this PR https://github.com/cms-sw/cmssw/pull/16540).
Change of data volume should be negligible, testing wf. 1000.0 in `CMSSW_9_0_X_2017-02-05-2300` via:

```
runTheMatrix.py -l 1000.0 --command='-n 100'  
edmFileUtil SiStripCalMinBias.root
```
yields:

```
SiStripCalMinBias.root (1 runs, 1 lumis, 29 events, 4185563 bytes)
```

in the baseline release and

```
SiStripCalMinBias.root (1 runs, 1 lumis, 29 events, 4189455 bytes)
```

in the proposed branch, with an effective increase of ~135b/evt.

attn: @dimattia @jlagram @boudoul 
