### PR TITLE
Increase buffer for string format

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/ParticleListDrawer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/ParticleListDrawer.cc
@@ -93,10 +93,10 @@ void ParticleListDrawer::analyze(const edm::Event& iEvent, const edm::EventSetup
     out << endl
 	<< "[ParticleListDrawer] analysing particle collection " << src_.label() << endl;
 
-    snprintf(buf, 256, " idx  |    ID -       Name |Stat|  Mo1  Mo2  Da1  Da2 |nMo nDa|    pt       eta     phi   |     px         py         pz        m     |");
+    snprintf(buf, sizeof(buf), " idx  |    ID -       Name |Stat|  Mo1  Mo2  Da1  Da2 |nMo nDa|    pt       eta     phi   |     px         py         pz        m     |");
     out << buf;
     if (printVertex_) {
-      snprintf(buf, 256, "        vx       vy        vz     |");
+      snprintf(buf, sizeof(buf), "        vx       vy        vz     |");
       out << buf;
     }
     out << endl;
@@ -145,8 +145,8 @@ void ParticleListDrawer::analyze(const edm::Event& iEvent, const edm::EventSetup
       found = find(cands.begin(), cands.end(), p->daughter(nDa-1));
       if(found != cands.end()) iDa2 = found - cands.begin() ;
 
-      char buf[256];
-      snprintf(buf, 256,
+      char buf[2400];
+      snprintf(buf, sizeof(buf),
 	     " %4d | %5d - %10s | %2d | %4d %4d %4d %4d | %2d %2d | %7.3f %10.3f %6.3f | %10.3f %10.3f %10.3f %8.3f |",
              idx,
              p->pdgId(),
@@ -164,7 +164,7 @@ void ParticleListDrawer::analyze(const edm::Event& iEvent, const edm::EventSetup
       out << buf;
 
       if (printVertex_) {
-        snprintf(buf, 256, " %10.3f %10.3f %10.3f |",
+        snprintf(buf, sizeof(buf), " %10.3f %10.3f %10.3f |",
                  p->vertex().x(),
                  p->vertex().y(),
                  p->vertex().z());


### PR DESCRIPTION
The 'buf' is too small, GCC calculated that output lenght could be up to
2341 and 948 bytes in a few places. Let's increase the buffer to make
sure we never truncate the output.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>