### PR TITLE
Fix a typo in quadruplet seeds

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -43,7 +43,7 @@ _layerListForPhase2 = ['BPix1+BPix2+BPix3+BPix4',
 # removed as redundant in current geometry (here for documentation)
 #                       'FPix1_pos+FPix2_pos+FPix3_pos+FPix4_pos', 'FPix1_neg+FPix2_neg+FPix3_neg+FPix4_neg',
                        'FPix2_pos+FPix3_pos+FPix4_pos+FPix5_pos', 'FPix2_neg+FPix3_neg+FPix4_neg+FPix5_neg',
-                       'FPix3_pos+FPix4_pos+FPix5_pos+FPix6_pos', 'FPix3_neg+FPix4_neg+FPix5_neg+FPix6_pos',
+                       'FPix3_pos+FPix4_pos+FPix5_pos+FPix6_pos', 'FPix3_neg+FPix4_neg+FPix5_neg+FPix6_neg',
                        'FPix4_pos+FPix5_pos+FPix6_pos+FPix7_pos', 'FPix4_neg+FPix5_neg+FPix6_neg+FPix7_neg',
 #  removed as redunant and covering effectively only eta>4   (here for documentation, to be optimized after TDR)
 #                       'FPix5_pos+FPix6_pos+FPix7_pos+FPix8_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix8_neg',


### PR DESCRIPTION
This only affects PhaseII.
Due to the current redundancy in seeding, I do not expect substantial changes (if any at all).