### PR TITLE
Extending tracking ntuples for phase2

### DIFF
--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -2409,9 +2409,9 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
         if(clusterRef.isPixel()){
           hitType.push_back( static_cast<int>(HitType::Pixel));
         } else if(clusterRef.isPhase2()){
-          hitType.push_back( static_cast<int>(HitType::Strip));
-        } else {
           hitType.push_back( static_cast<int>(HitType::Phase2OT));
+        } else {
+          hitType.push_back( static_cast<int>(HitType::Strip));
         }
       } else  {
         LogTrace("TrackingNtuple") << " - invalid hit";

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -223,7 +223,6 @@ namespace {
 
     double adcSum = 0;
     StripDigiSimLink found;
-
     int first  = cluster.firstStrip();
     for(size_t i=0; i<cluster.amplitudes().size(); ++i) {
       adcSum += cluster.amplitudes()[i];
@@ -251,24 +250,26 @@ namespace {
   std::map<unsigned int, double> chargeFraction(const Phase2TrackerCluster1D& cluster, const DetId& detId,
                                                 const edm::DetSetVector<PixelDigiSimLink>& digiSimLink) {
     std::map<unsigned int, double> simTrackIdToAdc;
-
+    LogDebug("TrackingNtuple") << "chargeFraction for phase2 clusters..";
     auto idetset = digiSimLink.find(detId);
     if(idetset == digiSimLink.end())
       return simTrackIdToAdc;
 
     double adcSum = 0;
     PixelDigiSimLink found;
+    LogDebug("TrackingNtuple") << "size of the cluster: " << cluster.size();
 
     for (unsigned int istr(0); istr < cluster.size(); ++istr) {
       //In the OT, there is no measurement of the charge, so no ADC value.
       //Only in the SSA chip (so in PSs) you have one "threshold" flag that tells you if the charge of at least one strip in the cluster exceeded 1.2 MIPs.
-
-      //const SiPixelCluster::Pixel& pixel = cluster.pixel(iPix);
-      //adcSum += pixel.adc;
       uint32_t channel = Phase2TrackerDigi::pixelToChannel(cluster.firstRow() + istr, cluster.column());
       forEachMatchedSimLink(*idetset, channel, [&](const PixelDigiSimLink& simLink){
-          //double& adc = simTrackIdToAdc[simLink.SimTrackId()];
-          //adc += pixel.adc*simLink.fraction();
+          LogDebug("TrackingNtuple") << "forEachMatchedSimLink";
+          if(cluster.threshold()){ 
+              double& adc = simTrackIdToAdc[simLink.SimTrackId()];
+              adc += simLink.fraction(); 
+              LogDebug("TrackingNtuple") << "adc: " << adc;
+          }
         });
     }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -58,6 +58,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
@@ -222,6 +223,7 @@ namespace {
 
     double adcSum = 0;
     StripDigiSimLink found;
+
     int first  = cluster.firstStrip();
     for(size_t i=0; i<cluster.amplitudes().size(); ++i) {
       adcSum += cluster.amplitudes()[i];
@@ -237,6 +239,46 @@ namespace {
     }
     return simTrackIdToAdc;
   }
+
+
+  //FIXME::Erica not clear because I need both
+  std::map<unsigned int, double> chargeFraction(const Phase2TrackerCluster1D& cluster, const DetId& detId,
+                                                const edm::DetSetVector<StripDigiSimLink>& digiSimLink) {
+    std::map<unsigned int, double> simTrackIdToAdc;
+    return simTrackIdToAdc;
+  }
+
+  std::map<unsigned int, double> chargeFraction(const Phase2TrackerCluster1D& cluster, const DetId& detId,
+                                                const edm::DetSetVector<PixelDigiSimLink>& digiSimLink) {
+    std::map<unsigned int, double> simTrackIdToAdc;
+
+    auto idetset = digiSimLink.find(detId);
+    if(idetset == digiSimLink.end())
+      return simTrackIdToAdc;
+
+    double adcSum = 0;
+    PixelDigiSimLink found;
+    for (unsigned int istr(0); istr < cluster.size(); ++istr) {
+      //FIXME::where is the adc info for Phase2TrackerCluster1D?
+      //const SiPixelCluster::Pixel& pixel = cluster.pixel(iPix);
+      //adcSum += pixel.adc;
+      uint32_t channel = Phase2TrackerDigi::pixelToChannel(cluster.firstRow() + istr, cluster.column());
+      forEachMatchedSimLink(*idetset, channel, [&](const PixelDigiSimLink& simLink){
+          //double& adc = simTrackIdToAdc[simLink.SimTrackId()];
+          //adc += pixel.adc*simLink.fraction();
+        });
+    }
+
+    for(auto& pair: simTrackIdToAdc) {
+      if(adcSum == 0.)
+        pair.second = 0.;
+      else
+        pair.second /= adcSum;
+    }
+
+    return simTrackIdToAdc;
+  }
+
 }
 
 //
@@ -331,6 +373,17 @@ private:
                             std::vector<std::pair<int, int> >& monoStereoClusterList
                             );
 
+  void fillPhase2OTHits(const edm::Event& iEvent,
+                        const ClusterTPAssociation& clusterToTPMap,
+                        const TrackingParticleRefKeyToIndex& tpKeyToIndex,
+                        const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                        const edm::DetSetVector<PixelDigiSimLink>& digiSimLink,
+                        const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                        const TrackerTopology& tTopo,
+                        const SimHitRefKeyToIndex& simHitRefKeyToIndex,
+                        std::set<edm::ProductID>& hitProductIds
+                        );
+
   void fillSeeds(const edm::Event& iEvent,
                  const TrackingParticleRefVector& tpCollection,
                  const TrackingParticleRefKeyToIndex& tpKeyToIndex,
@@ -395,7 +448,8 @@ private:
                           const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                           const edm::DetSetVector<SimLink>& digiSimLinks,
                           const SimHitRefKeyToIndex& simHitRefKeyToIndex,
-                          HitType hitType
+                          HitType hitType,
+                          bool isPhase2 = false
                           );
 
   // ----------member data ---------------------------
@@ -408,11 +462,13 @@ private:
   edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> trackAssociatorToken_;
   edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelSimLinkToken_;
   edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripSimLinkToken_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinksToken_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
   edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitToken_;
   edm::EDGetTokenT<SiStripRecHit2DCollection> stripRphiRecHitToken_;
   edm::EDGetTokenT<SiStripRecHit2DCollection> stripStereoRecHitToken_;
   edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> stripMatchedRecHitToken_;
+  edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> phase2OTRecHitToken_;
   edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
   edm::EDGetTokenT<TrackingVertexCollection> trackingVertexToken_;
   edm::EDGetTokenT<edm::ValueMap<unsigned int> > tpNLayersToken_;
@@ -581,6 +637,30 @@ private:
   std::vector<float> glu_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi ;
   ////////////////////
+  // phase2 Outer Tracker hits
+  // (first) index runs through hits
+  std::vector<short> ph2_isBarrel ;
+  std::vector<unsigned short> ph2_det    ;
+  std::vector<unsigned short> ph2_lay    ;
+  std::vector<unsigned int> ph2_detId    ;
+  std::vector<std::vector<int> > ph2_trkIdx;    // second index runs through tracks containing this hit
+  std::vector<std::vector<int> > ph2_seeIdx;    // second index runs through seeds containing this hit
+  std::vector<std::vector<int> > ph2_simHitIdx; // second index runs through SimHits inducing this hit
+  std::vector<std::vector<float> > ph2_chargeFraction; // second index runs through SimHits inducing this hit
+  std::vector<unsigned short> ph2_simType;
+  std::vector<float> ph2_x    ;
+  std::vector<float> ph2_y    ;
+  std::vector<float> ph2_z    ;
+  std::vector<float> ph2_xx   ;
+  std::vector<float> ph2_xy   ;
+  std::vector<float> ph2_yy   ;
+  std::vector<float> ph2_yz   ;
+  std::vector<float> ph2_zz   ;
+  std::vector<float> ph2_zx   ;
+  std::vector<float> ph2_radL ;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
+  std::vector<float> ph2_bbxi ;
+
+  ////////////////////
   // invalid (missing/inactive/etc) hits
   // (first) index runs through hits
   std::vector<short> inv_isBarrel;
@@ -688,11 +768,13 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   trackAssociatorToken_(consumes<reco::TrackToTrackingParticleAssociator>(iConfig.getUntrackedParameter<edm::InputTag>("trackAssociator"))),
   pixelSimLinkToken_(consumes<edm::DetSetVector<PixelDigiSimLink> >(iConfig.getUntrackedParameter<edm::InputTag>("pixelDigiSimLink"))),
   stripSimLinkToken_(consumes<edm::DetSetVector<StripDigiSimLink> >(iConfig.getUntrackedParameter<edm::InputTag>("stripDigiSimLink"))),
+  siphase2OTSimLinksToken_(consumes<edm::DetSetVector<PixelDigiSimLink> >(iConfig.getUntrackedParameter<edm::InputTag>("phase2OTSimLink"))),
   beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getUntrackedParameter<edm::InputTag>("beamSpot"))),
   pixelRecHitToken_(consumes<SiPixelRecHitCollection>(iConfig.getUntrackedParameter<edm::InputTag>("pixelRecHits"))),
   stripRphiRecHitToken_(consumes<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stripRphiRecHits"))),
   stripStereoRecHitToken_(consumes<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stripStereoRecHits"))),
   stripMatchedRecHitToken_(consumes<SiStripMatchedRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stripMatchedRecHits"))),
+  phase2OTRecHitToken_(consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getUntrackedParameter<edm::InputTag>("phase2OTRecHits"))),
   vertexToken_(consumes<reco::VertexCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vertices"))),
   trackingVertexToken_(consumes<TrackingVertexCollection>(iConfig.getUntrackedParameter<edm::InputTag>("trackingVertices"))),
   tpNLayersToken_(consumes<edm::ValueMap<unsigned int> >(iConfig.getUntrackedParameter<edm::InputTag>("trackingParticleNlayers"))),
@@ -875,6 +957,30 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("glu_zx"        , &glu_zx       );
     t->Branch("glu_radL"      , &glu_radL     );
     t->Branch("glu_bbxi"      , &glu_bbxi     );
+    //phase2 OT
+    t->Branch("ph2_isBarrel"  , &ph2_isBarrel );
+    t->Branch("ph2_det"       , &ph2_det      );
+    t->Branch("ph2_lay"       , &ph2_lay      );
+    t->Branch("ph2_detId"     , &ph2_detId    );
+    t->Branch("ph2_trkIdx"    , &ph2_trkIdx   );
+    if(includeSeeds_) {
+      t->Branch("ph2_seeIdx"    , &ph2_seeIdx   );
+    }
+    t->Branch("ph2_simHitIdx" , &ph2_simHitIdx);
+    t->Branch("ph2_chargeFraction", &ph2_chargeFraction);
+    t->Branch("ph2_simType", &ph2_simType);
+    t->Branch("ph2_x"     , &ph2_x    );
+    t->Branch("ph2_y"     , &ph2_y    );
+    t->Branch("ph2_z"     , &ph2_z    );
+    t->Branch("ph2_xx"    , &ph2_xx   );
+    t->Branch("ph2_xy"    , &ph2_xy   );
+    t->Branch("ph2_yy"    , &ph2_yy   );
+    t->Branch("ph2_yz"    , &ph2_yz   );
+    t->Branch("ph2_zz"    , &ph2_zz   );
+    t->Branch("ph2_zx"    , &ph2_zx   );
+    t->Branch("ph2_radL"  , &ph2_radL );
+    t->Branch("ph2_bbxi"  , &ph2_bbxi );
+    t->Branch("ph2_bbxi"  , &ph2_bbxi );
     //invalid hits
     t->Branch("inv_isBarrel"  , &inv_isBarrel );
     t->Branch("inv_det"       , &inv_det      );
@@ -1123,6 +1229,27 @@ void TrackingNtuple::clearVariables() {
   glu_zx       .clear();
   glu_radL     .clear();
   glu_bbxi     .clear();
+  //phase2 OT
+  ph2_isBarrel .clear();
+  ph2_det      .clear();
+  ph2_lay      .clear();
+  ph2_detId    .clear();
+  ph2_trkIdx   .clear();
+  ph2_seeIdx   .clear();
+  ph2_simHitIdx.clear();
+  ph2_chargeFraction.clear();
+  ph2_simType.clear();
+  ph2_x    .clear();
+  ph2_y    .clear();
+  ph2_z    .clear();
+  ph2_xx   .clear();
+  ph2_xy   .clear();
+  ph2_yy   .clear();
+  ph2_yz   .clear();
+  ph2_zz   .clear();
+  ph2_zx   .clear();
+  ph2_radL .clear();
+  ph2_bbxi .clear();
   //invalid hits
   inv_isBarrel .clear();
   inv_det      .clear();
@@ -1309,14 +1436,18 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   const auto& pixelDigiSimLinks = *pixelDigiSimLinksHandle;
 
   edm::Handle<edm::DetSetVector<StripDigiSimLink> > stripDigiSimLinksHandle;
-  iEvent.getByToken(stripSimLinkToken_, stripDigiSimLinksHandle);
-  const auto& stripDigiSimLinks = *stripDigiSimLinksHandle;
+  bool foundStripSimLinks = iEvent.getByToken(stripSimLinkToken_, stripDigiSimLinksHandle);
+
+  // Phase2 OT DigiSimLink
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinksHandle;
+  bool foundPhase2OTSimLinks = iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinksHandle);
 
   //beamspot
   Handle<reco::BeamSpot> recoBeamSpotHandle;
   iEvent.getByToken(beamSpotToken_, recoBeamSpotHandle);
   BeamSpot const & bs = *recoBeamSpotHandle;
   fillBeamSpot(bs);
+
 
   //prapare list to link matched hits to collection
   vector<pair<int,int> > monoStereoClusterList;
@@ -1328,10 +1459,20 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     fillPixelHits(iEvent, clusterToTPMap, tpKeyToIndex, *simHitsTPAssoc, pixelDigiSimLinks, *theTTRHBuilder, tTopo, simHitRefKeyToIndex, hitProductIds);
 
     //strip hits
-    fillStripRphiStereoHits(iEvent, clusterToTPMap, tpKeyToIndex, *simHitsTPAssoc, stripDigiSimLinks, *theTTRHBuilder, tTopo, simHitRefKeyToIndex, hitProductIds);
+    if(foundStripSimLinks){
+      LogDebug("TrackingNtuple") << "foundStripSimLink" ;
+      const auto& stripDigiSimLinks = *stripDigiSimLinksHandle;
+      fillStripRphiStereoHits(iEvent, clusterToTPMap, tpKeyToIndex, *simHitsTPAssoc, stripDigiSimLinks, *theTTRHBuilder, tTopo, simHitRefKeyToIndex, hitProductIds);
 
-    //matched hits
-    fillStripMatchedHits(iEvent, *theTTRHBuilder, tTopo, monoStereoClusterList);
+      //matched hits
+      fillStripMatchedHits(iEvent, *theTTRHBuilder, tTopo, monoStereoClusterList);
+    }
+
+    if(foundPhase2OTSimLinks){
+      LogDebug("TrackingNtuple") << "foundPhase2OTSimLinks" ;
+      const auto& phase2OTSimLinks = *siphase2OTSimLinksHandle;
+      fillPhase2OTHits(iEvent, clusterToTPMap, tpKeyToIndex, *simHitsTPAssoc, phase2OTSimLinks, *theTTRHBuilder, tTopo, simHitRefKeyToIndex, hitProductIds);
+    }
   }
 
   //seeds
@@ -1397,11 +1538,14 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(const OmniClusterRef& cl
                                                         const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                                                         const edm::DetSetVector<SimLink>& digiSimLinks,
                                                         const SimHitRefKeyToIndex& simHitRefKeyToIndex,
-                                                        HitType hitType
+                                                        HitType hitType,
+                                                        bool isPhase2
                                                         ) {
   SimHitData ret;
 
-  auto simTrackIdToChargeFraction = chargeFraction(GetCluster<SimLink>::call(cluster), hitId, digiSimLinks);
+  std::map<unsigned int, double> simTrackIdToChargeFraction;
+  if(!isPhase2) simTrackIdToChargeFraction = chargeFraction(GetCluster<SimLink>::call(cluster), hitId, digiSimLinks);
+  else simTrackIdToChargeFraction = chargeFraction(cluster.phase2OTCluster(), hitId, digiSimLinks);
 
   ret.type = HitSimType::Noise;
   auto range = clusterToTPMap.equal_range( cluster );
@@ -1787,6 +1931,73 @@ void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
   }
 }
 
+void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
+                                   const ClusterTPAssociation& clusterToTPMap,
+                                   const TrackingParticleRefKeyToIndex& tpKeyToIndex,
+                                   const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
+                                   const edm::DetSetVector<PixelDigiSimLink>& digiSimLink,
+                                   const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                   const TrackerTopology& tTopo,
+                                   const SimHitRefKeyToIndex& simHitRefKeyToIndex,
+                                   std::set<edm::ProductID>& hitProductIds
+                                   ) {
+  edm::Handle<Phase2TrackerRecHit1DCollectionNew> phase2OTHits;
+  iEvent.getByToken(phase2OTRecHitToken_, phase2OTHits);
+  for (auto it = phase2OTHits->begin(); it!=phase2OTHits->end(); it++ ) {
+    const DetId hitId = it->detId();
+    for (auto hit = it->begin(); hit!=it->end(); hit++ ) {
+      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&*hit);
+
+      hitProductIds.insert(hit->cluster().id());
+
+      const int key = hit->cluster().key();
+      const int lay = tTopo.layer(hitId);
+      SimHitData simHitData = matchCluster(hit->firstClusterRef(), hitId, key, ttrh,
+                                           clusterToTPMap, tpKeyToIndex, simHitsTPAssoc, digiSimLink, simHitRefKeyToIndex, HitType::Strip, true);
+
+      ph2_isBarrel .push_back( hitId.subdetId()==1 );
+      ph2_det      .push_back( hitId.subdetId() );
+      ph2_lay      .push_back( lay );
+      ph2_detId    .push_back( hitId.rawId() );
+      ph2_trkIdx   .emplace_back(); // filled in fillTracks
+      ph2_seeIdx   .emplace_back(); // filled in fillSeeds
+      ph2_simHitIdx.push_back( simHitData.matchingSimHit );
+      ph2_simType.push_back( static_cast<int>(simHitData.type) );
+      ph2_x    .push_back( ttrh->globalPosition().x() );
+      ph2_y    .push_back( ttrh->globalPosition().y() );
+      ph2_z    .push_back( ttrh->globalPosition().z() );
+      ph2_xx   .push_back( ttrh->globalPositionError().cxx() );
+      ph2_xy   .push_back( ttrh->globalPositionError().cyx() );
+      ph2_yy   .push_back( ttrh->globalPositionError().cyy() );
+      ph2_yz   .push_back( ttrh->globalPositionError().czy() );
+      ph2_zz   .push_back( ttrh->globalPositionError().czz() );
+      ph2_zx   .push_back( ttrh->globalPositionError().czx() );
+      ph2_chargeFraction.push_back( simHitData.chargeFraction );
+      ph2_radL .push_back( ttrh->surface()->mediumProperties().radLen() );
+      ph2_bbxi .push_back( ttrh->surface()->mediumProperties().xi() );
+
+      LogTrace("TrackingNtuple") << "phase2 OT cluster=" << key
+                                 << " subdId=" << hitId.subdetId()
+                                 << " lay=" << lay
+                                 << " rawId=" << hitId.rawId()
+                                 << " pos =" << ttrh->globalPosition()
+                                 << " nMatchingSimHit=" << simHitData.matchingSimHit.size();
+
+      if(!simHitData.matchingSimHit.empty()) {
+        const auto simHitIdx = simHitData.matchingSimHit[0];
+        LogTrace("TrackingNtuple") << " firstMatchingSimHit=" << simHitIdx
+                                   << " simHitPos=" << GlobalPoint(simhit_x[simHitIdx], simhit_y[simHitIdx], simhit_z[simHitIdx])
+                                   << " energyLoss=" << simhit_eloss[simHitIdx]
+                                   << " particleType=" << simhit_particle[simHitIdx]
+                                   << " processType=" << simhit_process[simHitIdx]
+                                   << " bunchCrossing=" << simHitData.bunchCrossing[0]
+                                   << " event=" << simHitData.event[0];
+      }
+    }
+  }
+}
+
+
 void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
                                const TrackingParticleRefVector& tpCollection,
                                const TrackingParticleRefKeyToIndex& tpKeyToIndex,
@@ -1833,6 +2044,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
                                << " ProductID " << id;
 
     for(const auto& seedTrackRef: seedTrackRefs) {
+
       const auto& seedTrack = *seedTrackRef;
       const auto& seedRef = seedTrack.seedRef();
       const auto& seed = *seedRef;
@@ -1912,7 +2124,8 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
           }
           hitIdx.push_back( clusterKey );
           hitType.push_back( static_cast<int>(HitType::Pixel) );
-	} else {
+	} else if (subid == (int) StripSubdetector::TOB || subid == (int) StripSubdetector::TID ||
+	           subid == (int) StripSubdetector::TIB || subid == (int) StripSubdetector::TEC) {
 	  if (trackerHitRTTI::isMatched(*recHit)) {
 	    const SiStripMatchedRecHit2D * matchedHit = dynamic_cast<const SiStripMatchedRecHit2D *>(&*recHit);
             if(includeAllHits_) {
@@ -1930,16 +2143,30 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
 	  } else {
 	    const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
             const auto& clusterRef = bhit->firstClusterRef();
-            const auto clusterKey = clusterRef.cluster_strip().key();
+            unsigned int clusterKey;
+            if(clusterRef.isPhase2()){
+              clusterKey = clusterRef.cluster_phase2OT().key();
+            } else {
+              clusterKey = clusterRef.cluster_strip().key();
+            }
+
             if(includeAllHits_) {
               checkProductID(hitProductIds, clusterRef.id(), "seed");
-              str_seeIdx[clusterKey].push_back(seedIndex);
+              if(clusterRef.isPhase2()){
+                ph2_seeIdx[clusterKey].push_back(seedIndex);
+              } else {
+                str_seeIdx[clusterKey].push_back(seedIndex);
+              }
             }
+
             hitIdx.push_back( clusterKey );
             hitType.push_back( static_cast<int>(HitType::Strip) );
 	  }
-	}
+	} else {
+          LogTrace("TrackingNtuple") << " not pixel and not Strip detector";
+        }
       }
+      LogTrace("TrackingNtuple") << " after running on hits";
       see_hitIdx  .push_back( hitIdx  );
       see_hitType .push_back( hitType );
       see_nPixel  .push_back( std::count(hitType.begin(), hitType.end(), static_cast<int>(HitType::Pixel)) );
@@ -2138,15 +2365,29 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
         //ugly... but works
         const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*hit);
         const auto& clusterRef = bhit->firstClusterRef();
-        const auto clusterKey = clusterRef.isPixel() ? clusterRef.cluster_pixel().key() :  clusterRef.cluster_strip().key();
+        unsigned int clusterKey;
+        if(clusterRef.isPixel()){
+          clusterKey = clusterRef.cluster_pixel().key();
+        } else if(clusterRef.isPhase2()){
+          clusterKey = clusterRef.cluster_phase2OT().key();
+        } else {
+          clusterKey = clusterRef.cluster_strip().key();
+        }
 
         LogTrace("TrackingNtuple") << " id: " << hitId.rawId() << " - globalPos =" << hit->globalPosition()
                                    << " cluster=" << clusterKey
+                                   << " clusterRef ID=" << clusterRef.id()
                                    << " eta,phi: " << hit->globalPosition().eta() << "," << hit->globalPosition().phi();
         if(includeAllHits_) {
           checkProductID(hitProductIds, clusterRef.id(), "track");
-          if(isPixel) pix_trkIdx[clusterKey].push_back(iTrack);
-          else        str_trkIdx[clusterKey].push_back(iTrack);
+          if(clusterRef.isPixel()){
+            pix_trkIdx[clusterKey].push_back(iTrack);
+          } else if(clusterRef.isPhase2()){
+            ph2_trkIdx[clusterKey].push_back(iTrack);
+          } else {
+            str_trkIdx[clusterKey].push_back(iTrack);
+          }
+
         }
 
         hitIdx.push_back(clusterKey);
@@ -2388,11 +2629,13 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<edm::InputTag>("trackAssociator", edm::InputTag("quickTrackAssociatorByHits"));
   desc.addUntracked<edm::InputTag>("pixelDigiSimLink", edm::InputTag("simSiPixelDigis"));
   desc.addUntracked<edm::InputTag>("stripDigiSimLink", edm::InputTag("simSiStripDigis"));
+  desc.addUntracked<edm::InputTag>("phase2OTSimLink", edm::InputTag(""));
   desc.addUntracked<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
   desc.addUntracked<edm::InputTag>("pixelRecHits", edm::InputTag("siPixelRecHits"));
   desc.addUntracked<edm::InputTag>("stripRphiRecHits", edm::InputTag("siStripMatchedRecHits", "rphiRecHit"));
   desc.addUntracked<edm::InputTag>("stripStereoRecHits", edm::InputTag("siStripMatchedRecHits", "stereoRecHit"));
   desc.addUntracked<edm::InputTag>("stripMatchedRecHits", edm::InputTag("siStripMatchedRecHits", "matchedRecHit"));
+  desc.addUntracked<edm::InputTag>("phase2OTRecHits", edm::InputTag("siPhase2RecHits"));
   desc.addUntracked<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.addUntracked<edm::InputTag>("trackingVertices", edm::InputTag("mix", "MergedTrackTruth"));
   desc.addUntracked<edm::InputTag>("trackingParticleNlayers", edm::InputTag("trackingParticleNumberOfLayersProducer", "trackerLayers"));

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -464,6 +464,7 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelSimLinkToken_;
   edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripSimLinkToken_;
   edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinksToken_;
+  bool includeStripHits_, includePhase2OTHits_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
   edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitToken_;
   edm::EDGetTokenT<SiStripRecHit2DCollection> stripRphiRecHitToken_;
@@ -771,6 +772,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   pixelSimLinkToken_(consumes<edm::DetSetVector<PixelDigiSimLink> >(iConfig.getUntrackedParameter<edm::InputTag>("pixelDigiSimLink"))),
   stripSimLinkToken_(consumes<edm::DetSetVector<StripDigiSimLink> >(iConfig.getUntrackedParameter<edm::InputTag>("stripDigiSimLink"))),
   siphase2OTSimLinksToken_(consumes<edm::DetSetVector<PixelDigiSimLink> >(iConfig.getUntrackedParameter<edm::InputTag>("phase2OTSimLink"))),
+  includeStripHits_(iConfig.getUntrackedParameter<edm::InputTag>("stripDigiSimLink").label() != ""),
+  includePhase2OTHits_(iConfig.getUntrackedParameter<edm::InputTag>("phase2OTSimLink").label() != ""),
   beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getUntrackedParameter<edm::InputTag>("beamSpot"))),
   pixelRecHitToken_(consumes<SiPixelRecHitCollection>(iConfig.getUntrackedParameter<edm::InputTag>("pixelRecHits"))),
   stripRphiRecHitToken_(consumes<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stripRphiRecHits"))),
@@ -915,74 +918,80 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("pix_bbxi"  , &pix_bbxi );
     t->Branch("pix_bbxi"  , &pix_bbxi );
     //strips
-    t->Branch("str_isBarrel"  , &str_isBarrel );
-    t->Branch("str_isStereo"  , &str_isStereo );
-    t->Branch("str_det"       , &str_det      );
-    t->Branch("str_lay"       , &str_lay      );
-    t->Branch("str_detId"     , &str_detId    );
-    t->Branch("str_trkIdx"    , &str_trkIdx   );
-    if(includeSeeds_) {
-      t->Branch("str_seeIdx"    , &str_seeIdx   );
+    if(includeStripHits_){
+      LogDebug("TrackingNtuple") << "including strips";
+      t->Branch("str_isBarrel"  , &str_isBarrel );
+      t->Branch("str_isStereo"  , &str_isStereo );
+      t->Branch("str_det"       , &str_det      );
+      t->Branch("str_lay"       , &str_lay      );
+      t->Branch("str_detId"     , &str_detId    );
+      t->Branch("str_trkIdx"    , &str_trkIdx   );
+      if(includeSeeds_) {
+        t->Branch("str_seeIdx"    , &str_seeIdx   );
+      }
+      t->Branch("str_simHitIdx" , &str_simHitIdx);
+      t->Branch("str_chargeFraction", &str_chargeFraction);
+      t->Branch("str_simType", &str_simType);
+      t->Branch("str_x"     , &str_x    );
+      t->Branch("str_y"     , &str_y    );
+      t->Branch("str_z"     , &str_z    );
+      t->Branch("str_xx"    , &str_xx   );
+      t->Branch("str_xy"    , &str_xy   );
+      t->Branch("str_yy"    , &str_yy   );
+      t->Branch("str_yz"    , &str_yz   );
+      t->Branch("str_zz"    , &str_zz   );
+      t->Branch("str_zx"    , &str_zx   );
+      t->Branch("str_radL"  , &str_radL );
+      t->Branch("str_bbxi"  , &str_bbxi );
+      //matched hits
+      t->Branch("glu_isBarrel"  , &glu_isBarrel );
+      t->Branch("glu_det"       , &glu_det      );
+      t->Branch("glu_lay"       , &glu_lay      );
+      t->Branch("glu_detId"     , &glu_detId    );
+      t->Branch("glu_monoIdx"   , &glu_monoIdx  );
+      t->Branch("glu_stereoIdx" , &glu_stereoIdx);
+      if(includeSeeds_) {
+        t->Branch("glu_seeIdx"    , &glu_seeIdx   );
+      }
+      t->Branch("glu_x"         , &glu_x        );
+      t->Branch("glu_y"         , &glu_y        );
+      t->Branch("glu_z"         , &glu_z        );
+      t->Branch("glu_xx"        , &glu_xx       );
+      t->Branch("glu_xy"        , &glu_xy       );
+      t->Branch("glu_yy"        , &glu_yy       );
+      t->Branch("glu_yz"        , &glu_yz       );
+      t->Branch("glu_zz"        , &glu_zz       );
+      t->Branch("glu_zx"        , &glu_zx       );
+      t->Branch("glu_radL"      , &glu_radL     );
+      t->Branch("glu_bbxi"      , &glu_bbxi     );
     }
-    t->Branch("str_simHitIdx" , &str_simHitIdx);
-    t->Branch("str_chargeFraction", &str_chargeFraction);
-    t->Branch("str_simType", &str_simType);
-    t->Branch("str_x"     , &str_x    );
-    t->Branch("str_y"     , &str_y    );
-    t->Branch("str_z"     , &str_z    );
-    t->Branch("str_xx"    , &str_xx   );
-    t->Branch("str_xy"    , &str_xy   );
-    t->Branch("str_yy"    , &str_yy   );
-    t->Branch("str_yz"    , &str_yz   );
-    t->Branch("str_zz"    , &str_zz   );
-    t->Branch("str_zx"    , &str_zx   );
-    t->Branch("str_radL"  , &str_radL );
-    t->Branch("str_bbxi"  , &str_bbxi );
-    //matched hits
-    t->Branch("glu_isBarrel"  , &glu_isBarrel );
-    t->Branch("glu_det"       , &glu_det      );
-    t->Branch("glu_lay"       , &glu_lay      );
-    t->Branch("glu_detId"     , &glu_detId    );
-    t->Branch("glu_monoIdx"   , &glu_monoIdx  );
-    t->Branch("glu_stereoIdx" , &glu_stereoIdx);
-    if(includeSeeds_) {
-      t->Branch("glu_seeIdx"    , &glu_seeIdx   );
-    }
-    t->Branch("glu_x"         , &glu_x        );
-    t->Branch("glu_y"         , &glu_y        );
-    t->Branch("glu_z"         , &glu_z        );
-    t->Branch("glu_xx"        , &glu_xx       );
-    t->Branch("glu_xy"        , &glu_xy       );
-    t->Branch("glu_yy"        , &glu_yy       );
-    t->Branch("glu_yz"        , &glu_yz       );
-    t->Branch("glu_zz"        , &glu_zz       );
-    t->Branch("glu_zx"        , &glu_zx       );
-    t->Branch("glu_radL"      , &glu_radL     );
-    t->Branch("glu_bbxi"      , &glu_bbxi     );
     //phase2 OT
-    t->Branch("ph2_isBarrel"  , &ph2_isBarrel );
-    t->Branch("ph2_det"       , &ph2_det      );
-    t->Branch("ph2_lay"       , &ph2_lay      );
-    t->Branch("ph2_detId"     , &ph2_detId    );
-    t->Branch("ph2_trkIdx"    , &ph2_trkIdx   );
-    if(includeSeeds_) {
-      t->Branch("ph2_seeIdx"    , &ph2_seeIdx   );
+    if(includePhase2OTHits_){
+      LogDebug("TrackingNtuple") << "including phase2 ot";
+      t->Branch("ph2_isBarrel"  , &ph2_isBarrel );
+      t->Branch("ph2_det"       , &ph2_det      );
+      t->Branch("ph2_lay"       , &ph2_lay      );
+      t->Branch("ph2_detId"     , &ph2_detId    );
+      t->Branch("ph2_trkIdx"    , &ph2_trkIdx   );
+      if(includeSeeds_) {
+        t->Branch("ph2_seeIdx"    , &ph2_seeIdx   );
+      }
+      t->Branch("ph2_simHitIdx" , &ph2_simHitIdx);
+      t->Branch("ph2_chargeFraction", &ph2_chargeFraction);
+      t->Branch("ph2_simType", &ph2_simType);
+      t->Branch("ph2_x"     , &ph2_x    );
+      t->Branch("ph2_y"     , &ph2_y    );
+      t->Branch("ph2_z"     , &ph2_z    );
+      t->Branch("ph2_xx"    , &ph2_xx   );
+      t->Branch("ph2_xy"    , &ph2_xy   );
+      t->Branch("ph2_yy"    , &ph2_yy   );
+      t->Branch("ph2_yz"    , &ph2_yz   );
+      t->Branch("ph2_zz"    , &ph2_zz   );
+      t->Branch("ph2_zx"    , &ph2_zx   );
+      t->Branch("ph2_radL"  , &ph2_radL );
+      t->Branch("ph2_bbxi"  , &ph2_bbxi );
+      t->Branch("ph2_bbxi"  , &ph2_bbxi );
     }
-    t->Branch("ph2_simHitIdx" , &ph2_simHitIdx);
-    t->Branch("ph2_chargeFraction", &ph2_chargeFraction);
-    t->Branch("ph2_simType", &ph2_simType);
-    t->Branch("ph2_x"     , &ph2_x    );
-    t->Branch("ph2_y"     , &ph2_y    );
-    t->Branch("ph2_z"     , &ph2_z    );
-    t->Branch("ph2_xx"    , &ph2_xx   );
-    t->Branch("ph2_xy"    , &ph2_xy   );
-    t->Branch("ph2_yy"    , &ph2_yy   );
-    t->Branch("ph2_yz"    , &ph2_yz   );
-    t->Branch("ph2_zz"    , &ph2_zz   );
-    t->Branch("ph2_zx"    , &ph2_zx   );
-    t->Branch("ph2_radL"  , &ph2_radL );
-    t->Branch("ph2_bbxi"  , &ph2_bbxi );
-    t->Branch("ph2_bbxi"  , &ph2_bbxi );
     //invalid hits
     t->Branch("inv_isBarrel"  , &inv_isBarrel );
     t->Branch("inv_det"       , &inv_det      );
@@ -1440,11 +1449,11 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   const auto& pixelDigiSimLinks = *pixelDigiSimLinksHandle;
 
   edm::Handle<edm::DetSetVector<StripDigiSimLink> > stripDigiSimLinksHandle;
-  bool foundStripSimLinks = iEvent.getByToken(stripSimLinkToken_, stripDigiSimLinksHandle);
+  iEvent.getByToken(stripSimLinkToken_, stripDigiSimLinksHandle);
 
   // Phase2 OT DigiSimLink
   edm::Handle<edm::DetSetVector<PixelDigiSimLink> > siphase2OTSimLinksHandle;
-  bool foundPhase2OTSimLinks = iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinksHandle);
+  iEvent.getByToken(siphase2OTSimLinksToken_, siphase2OTSimLinksHandle);
 
   //beamspot
   Handle<reco::BeamSpot> recoBeamSpotHandle;
@@ -1463,7 +1472,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     fillPixelHits(iEvent, clusterToTPMap, tpKeyToIndex, *simHitsTPAssoc, pixelDigiSimLinks, *theTTRHBuilder, tTopo, simHitRefKeyToIndex, hitProductIds);
 
     //strip hits
-    if(foundStripSimLinks){
+    if(includeStripHits_){
       LogDebug("TrackingNtuple") << "foundStripSimLink" ;
       const auto& stripDigiSimLinks = *stripDigiSimLinksHandle;
       fillStripRphiStereoHits(iEvent, clusterToTPMap, tpKeyToIndex, *simHitsTPAssoc, stripDigiSimLinks, *theTTRHBuilder, tTopo, simHitRefKeyToIndex, hitProductIds);
@@ -1472,7 +1481,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       fillStripMatchedHits(iEvent, *theTTRHBuilder, tTopo, monoStereoClusterList);
     }
 
-    if(foundPhase2OTSimLinks){
+    if(includePhase2OTHits_){
       LogDebug("TrackingNtuple") << "foundPhase2OTSimLinks" ;
       const auto& phase2OTSimLinks = *siphase2OTSimLinksHandle;
       fillPhase2OTHits(iEvent, clusterToTPMap, tpKeyToIndex, *simHitsTPAssoc, phase2OTSimLinks, *theTTRHBuilder, tTopo, simHitRefKeyToIndex, hitProductIds);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -258,8 +258,11 @@ namespace {
 
     double adcSum = 0;
     PixelDigiSimLink found;
+
     for (unsigned int istr(0); istr < cluster.size(); ++istr) {
-      //FIXME::where is the adc info for Phase2TrackerCluster1D?
+      //In the OT, there is no measurement of the charge, so no ADC value.
+      //Only in the SSA chip (so in PSs) you have one "threshold" flag that tells you if the charge of at least one strip in the cluster exceeded 1.2 MIPs.
+
       //const SiPixelCluster::Pixel& pixel = cluster.pixel(iPix);
       //adcSum += pixel.adc;
       uint32_t channel = Phase2TrackerDigi::pixelToChannel(cluster.firstRow() + istr, cluster.column());
@@ -449,8 +452,7 @@ private:
                           const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                           const edm::DetSetVector<SimLink>& digiSimLinks,
                           const SimHitRefKeyToIndex& simHitRefKeyToIndex,
-                          HitType hitType,
-                          bool isPhase2 = false
+                          HitType hitType
                           );
 
   // ----------member data ---------------------------
@@ -1551,8 +1553,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(const OmniClusterRef& cl
                                                         const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                                                         const edm::DetSetVector<SimLink>& digiSimLinks,
                                                         const SimHitRefKeyToIndex& simHitRefKeyToIndex,
-                                                        HitType hitType,
-                                                        bool isPhase2
+                                                        HitType hitType
                                                         ) {
   SimHitData ret;
 
@@ -1966,7 +1967,7 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
       const int key = hit->cluster().key();
       const int lay = tTopo.layer(hitId);
       SimHitData simHitData = matchCluster(hit->firstClusterRef(), hitId, key, ttrh,
-                                           clusterToTPMap, tpKeyToIndex, simHitsTPAssoc, digiSimLink, simHitRefKeyToIndex, HitType::Phase2OT, true);
+                                           clusterToTPMap, tpKeyToIndex, simHitsTPAssoc, digiSimLink, simHitRefKeyToIndex, HitType::Phase2OT);
 
       ph2_isBarrel .push_back( hitId.subdetId()==1 );
       ph2_det      .push_back( hitId.subdetId() );

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -921,7 +921,6 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("pix_bbxi"  , &pix_bbxi );
     //strips
     if(includeStripHits_){
-      LogDebug("TrackingNtuple") << "including strips";
       t->Branch("str_isBarrel"  , &str_isBarrel );
       t->Branch("str_isStereo"  , &str_isStereo );
       t->Branch("str_det"       , &str_det      );
@@ -969,7 +968,6 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     }
     //phase2 OT
     if(includePhase2OTHits_){
-      LogDebug("TrackingNtuple") << "including phase2 ot";
       t->Branch("ph2_isBarrel"  , &ph2_isBarrel );
       t->Branch("ph2_det"       , &ph2_det      );
       t->Branch("ph2_lay"       , &ph2_lay      );
@@ -2184,7 +2182,6 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
           LogTrace("TrackingNtuple") << " not pixel and not Strip detector";
         }
       }
-      LogTrace("TrackingNtuple") << " after running on hits";
       see_hitIdx   .push_back( hitIdx  );
       see_hitType  .push_back( hitType );
       see_nPixel   .push_back( std::count(hitType.begin(), hitType.end(), static_cast<int>(HitType::Pixel)) );

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -243,43 +243,15 @@ namespace {
   std::map<unsigned int, double> chargeFraction(const Phase2TrackerCluster1D& cluster, const DetId& detId,
                                                 const edm::DetSetVector<StripDigiSimLink>& digiSimLink) {
     std::map<unsigned int, double> simTrackIdToAdc;
-    auto ex = cms::Exception("LogicError") << "Not possible to use StripDigiSimLink with Phase2TrackerCluster1D! ";
+    throw cms::Exception("LogicError") << "Not possible to use StripDigiSimLink with Phase2TrackerCluster1D! ";
     return simTrackIdToAdc;
   }
 
+  //In the OT, there is no measurement of the charge, so no ADC value.
+  //Only in the SSA chip (so in PSs) you have one "threshold" flag that tells you if the charge of at least one strip in the cluster exceeded 1.2 MIPs.
   std::map<unsigned int, double> chargeFraction(const Phase2TrackerCluster1D& cluster, const DetId& detId,
                                                 const edm::DetSetVector<PixelDigiSimLink>& digiSimLink) {
     std::map<unsigned int, double> simTrackIdToAdc;
-    LogDebug("TrackingNtuple") << "chargeFraction for phase2 clusters..";
-    auto idetset = digiSimLink.find(detId);
-    if(idetset == digiSimLink.end())
-      return simTrackIdToAdc;
-
-    double adcSum = 0;
-    PixelDigiSimLink found;
-    LogDebug("TrackingNtuple") << "size of the cluster: " << cluster.size();
-
-    for (unsigned int istr(0); istr < cluster.size(); ++istr) {
-      //In the OT, there is no measurement of the charge, so no ADC value.
-      //Only in the SSA chip (so in PSs) you have one "threshold" flag that tells you if the charge of at least one strip in the cluster exceeded 1.2 MIPs.
-      uint32_t channel = Phase2TrackerDigi::pixelToChannel(cluster.firstRow() + istr, cluster.column());
-      forEachMatchedSimLink(*idetset, channel, [&](const PixelDigiSimLink& simLink){
-          LogDebug("TrackingNtuple") << "forEachMatchedSimLink";
-          if(cluster.threshold()){ 
-              double& adc = simTrackIdToAdc[simLink.SimTrackId()];
-              adc += simLink.fraction(); 
-              LogDebug("TrackingNtuple") << "adc: " << adc;
-          }
-        });
-    }
-
-    for(auto& pair: simTrackIdToAdc) {
-      if(adcSum == 0.)
-        pair.second = 0.;
-      else
-        pair.second /= adcSum;
-    }
-
     return simTrackIdToAdc;
   }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -623,7 +623,7 @@ private:
   std::vector<std::vector<int> > ph2_trkIdx;    // second index runs through tracks containing this hit
   std::vector<std::vector<int> > ph2_seeIdx;    // second index runs through seeds containing this hit
   std::vector<std::vector<int> > ph2_simHitIdx; // second index runs through SimHits inducing this hit
-  std::vector<std::vector<float> > ph2_chargeFraction; // second index runs through SimHits inducing this hit
+  //std::vector<std::vector<float> > ph2_chargeFraction; // Not supported at the moment for Phase2
   std::vector<unsigned short> ph2_simType;
   std::vector<float> ph2_x    ;
   std::vector<float> ph2_y    ;
@@ -950,7 +950,6 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
         t->Branch("ph2_seeIdx"    , &ph2_seeIdx   );
       }
       t->Branch("ph2_simHitIdx" , &ph2_simHitIdx);
-      t->Branch("ph2_chargeFraction", &ph2_chargeFraction);
       t->Branch("ph2_simType", &ph2_simType);
       t->Branch("ph2_x"     , &ph2_x    );
       t->Branch("ph2_y"     , &ph2_y    );
@@ -1222,7 +1221,6 @@ void TrackingNtuple::clearVariables() {
   ph2_trkIdx   .clear();
   ph2_seeIdx   .clear();
   ph2_simHitIdx.clear();
-  ph2_chargeFraction.clear();
   ph2_simType.clear();
   ph2_x    .clear();
   ph2_y    .clear();
@@ -1957,7 +1955,6 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
       ph2_yz   .push_back( ttrh->globalPositionError().czy() );
       ph2_zz   .push_back( ttrh->globalPositionError().czz() );
       ph2_zx   .push_back( ttrh->globalPositionError().czx() );
-      ph2_chargeFraction.push_back( simHitData.chargeFraction );
       ph2_radL .push_back( ttrh->surface()->mediumProperties().radLen() );
       ph2_bbxi .push_back( ttrh->surface()->mediumProperties().xi() );
 

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -36,6 +36,16 @@ def customiseTrackingNtuple(process):
     if hasattr(process, "prevalidation_step"):
         modifier.toReplaceWith(process.prevalidation_step, cms.Path())
 
+    # remove the validation_stepN and prevalidatin_stepN of phase2 validation...    
+    for p in [process.paths_(), process.endpaths_()]:    
+        for pathName, path in p.iteritems():    
+            if "prevalidation_step" in pathName:    
+                if len(pathName.replace("prevalidation_step", "")) > 0:    
+                    modifier.toReplaceWith(path, cms.Path())    
+            elif "validation_step" in pathName:    
+                if len(pathName.replace("validation_step", "")) > 0:    
+                    modifier.toReplaceWith(path, cms.EndPath())
+
     # Remove all output modules
     for outputModule in process.outputModules_().itervalues():
         for path in process.paths_().itervalues():

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+def _label(tag):
+    t = cms.InputTag(tag)
+    return t.getModuleLabel()+t.getProductInstanceLabel()
+
 def customiseTrackingNtuple(process):
     process.load("Validation.RecoTrack.trackingNtuple_cff")
     process.TFileService = cms.Service("TFileService",
@@ -23,7 +27,7 @@ def customiseTrackingNtuple(process):
         ntuplePath.insert(0, cms.SequencePlaceholder("mix"))
 
         process.load("Validation.RecoTrack.crossingFramePSimHitToPSimHits_cfi")
-        instanceLabels = [tag.getModuleLabel()+tag.getProductInstanceLabel() for tag in process.simHitTPAssocProducer.simHitSrc]
+        instanceLabels = [_label(tag) for tag in process.simHitTPAssocProducer.simHitSrc]
         process.crossingFramePSimHitToPSimHits.src = ["mix:"+l for l in instanceLabels]
         process.simHitTPAssocProducer.simHitSrc = ["crossingFramePSimHitToPSimHits:"+l for l in instanceLabels]
         process.trackingNtupleSequence.insert(0, process.crossingFramePSimHitToPSimHits)

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -6,6 +6,7 @@ from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
 from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import *
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 from Validation.RecoTrack.trackingNtuple_cfi import *
@@ -55,18 +56,23 @@ def _filterForNtuple(lst):
 _seedProducers = _filterForNtuple(_TrackValidation_cff._seedProducers)
 _seedProducers_trackingPhase1 = _filterForNtuple(_TrackValidation_cff._seedProducers_trackingPhase1)
 _seedProducers_trackingPhase1QuadProp = _filterForNtuple(_TrackValidation_cff._seedProducers_trackingPhase1QuadProp)
+_seedProducers_trackingPhase2PU140  = _filterForNtuple(_TrackValidation_cff._seedProducers_trackingPhase2PU140)
 
 (_seedSelectors, trackingNtupleSeedSelectors) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers, globals())
 (_seedSelectors_trackingPhase1, _trackingNtupleSeedSelectors_trackingPhase1) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers_trackingPhase1, globals())
 (_seedSelectors_trackingPhase1QuadProp, _trackingNtupleSeedSelectors_trackingPhase1QuadProp) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers_trackingPhase1QuadProp, globals())
+(_seedSelectors_trackingPhase2PU140, _trackingNtupleSeedSelectors_trackingPhase2PU140) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers_trackingPhase2PU140, globals())
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase1.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelectors_trackingPhase1)
 trackingPhase1QuadProp.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelectors_trackingPhase1QuadProp)
+trackingPhase2PU140.toReplaceWith(trackingNtupleSeedSelectors, _trackingNtupleSeedSelectors_trackingPhase2PU140)
 
 trackingNtuple.seedTracks = _seedSelectors
 trackingPhase1.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase1)
 trackingPhase1QuadProp.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase1)
+trackingPhase2PU140.toModify(trackingNtuple, seedTracks = _seedSelectors_trackingPhase2PU140)
 
 trackingNtupleSequence = cms.Sequence()
 # reproduce hits because they're not stored in RECO
@@ -75,6 +81,11 @@ if _includeHits:
         siPixelRecHits +
         siStripMatchedRecHits
     )
+    _phase2_trackingNtupleSequence = trackingNtupleSequence.copy()
+    _phase2_trackingNtupleSequence.remove(siStripMatchedRecHits)
+    _phase2_trackingNtupleSequence += (siPhase2RecHits)
+    trackingPhase2PU140.toReplaceWith(trackingNtupleSequence, _phase2_trackingNtupleSequence)
+
 if _includeSeeds:
     trackingNtupleSequence += trackingNtupleSeedSelectors
 
@@ -87,4 +98,10 @@ trackingNtupleSequence += (
     trackingParticleNumberOfLayersProducer +
     # ntuplizer
     trackingNtuple
+)
+
+trackingPhase2PU140.toModify(trackingNtuple, # FIXME
+  pixelDigiSimLink = cms.untracked.InputTag('simSiPixelDigis', "Pixel"),
+  stripDigiSimLink = cms.untracked.InputTag(''),
+  phase2OTSimLink = cms.untracked.InputTag('simSiPixelDigis', "Tracker")
 )


### PR DESCRIPTION
Main changes:
- Introducing a new HitType (Phase2OT)
- Adapting the code to get phase2 OT clusters
- Removing chargeFraction for phase2 because not supported

This PR has been tested in CMSSW_9_0_X_2017-02-06-1100 for Phase2 workflow - it should be compatible with Phase1. @makortel can you maybe confirm?