### PR TITLE
Resolve missing-braces error

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -212,9 +212,9 @@ struct Rot3 {
     axis{ix,iy,iz}{}
 
   constexpr Rot3( T xx, T xy, T xz, T yx, T yy, T yz, T zx, T zy, T zz) :
-    axis{ (Vec){xx,xy,xz,0},
-      (Vec){yx,yy,yz,0},
-	(Vec){zx,zy,zz,0}
+    axis{ {(Vec){xx,xy,xz,0}},
+          {(Vec){yx,yy,yz,0}},
+          {(Vec){zx,zy,zz,0}}
   }{}
   
   constexpr Rot3 transpose() const {


### PR DESCRIPTION
    ExtVec.h:218:3: error: missing braces around initializer for
    'Rot3<float>::Vec {aka __vector(4) float}' [-Werror=missing-braces]
    ExtVec.h:218:3: error: missing braces around initializer for
    'Rot3<double>::Vec {aka __vector(4) double}' [-Werror=missing-braces]

Alternative working solution seems to be:
```
diff --git a/DataFormats/Math/interface/ExtVec.h b/DataFormats/Math/interface/ExtVec.h
index b3be2d6..329d6da 100644
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -212,9 +212,9 @@ struct Rot3 {
     axis{ix,iy,iz}{}

   constexpr Rot3( T xx, T xy, T xz, T yx, T yy, T yz, T zx, T zy, T zz) :
-    axis{ {(Vec){xx,xy,xz,0}},
-          {(Vec){yx,yy,yz,0}},
-          {(Vec){zx,zy,zz,0}}
+    axis{ {xx,xy,xz,0},
+          {yx,yy,yz,0},
+          {zx,zy,zz,0}
   }{}
```

Clang 4.0 RC1 and GCC 5 are happy with the current version (have not looked at GCC 6). GCC 7, Clang 4.0 RC1 and GCC 5 are happy with this PR or alternative solution. I lack the the brain capacity today to dive into gazillions of ways one can initialise something in C++<magic number>. I found that similar issues were resolved in e.g. WebKit project.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>