### PR TITLE
Remove TString where possible and use specific conversion functions

### DIFF
--- a/DQMOffline/Trigger/src/GeneralHLTOffline.cc
+++ b/DQMOffline/Trigger/src/GeneralHLTOffline.cc
@@ -450,14 +450,14 @@ void GeneralHLTOffline::setupHltMatrix(DQMStore::IBooker & iBooker, const std::s
   std::string PD_Folder;
   std::string Path_Folder;
 
-  PD_Folder = TString("HLT/GeneralHLTOffline/"+label);
+  PD_Folder = "HLT/GeneralHLTOffline/" + label;
 
   iBooker.setCurrentFolder(PD_Folder.c_str());
 
   // make it the top level directory, that is on the same dir level as
   // paths
   std::string folderz;
-  folderz = TString("HLT/GeneralHLTOffline/"+label);
+  folderz = "HLT/GeneralHLTOffline/" + label;
   iBooker.setCurrentFolder(folderz.c_str());
 
   std::string dnamez = "cppath_" + label + "_" + hlt_menu_;

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -14,6 +14,7 @@
 #include "DataFormats/Candidate/interface/CandMatchMap.h"
 
 #include <iostream>
+#include <string>
 
 //////////////////////////////////////////////////////////////////////////////
 //////// Namespaces and Typedefs /////////////////////////////////////////////
@@ -65,7 +66,7 @@ HLTMuonMatchAndPlot::HLTMuonMatchAndPlot(const ParameterSet & pset,
   //  size_t nModules = moduleLabels_.size();
   TObjArray * levelArray = levelRegexp.MatchS(moduleLabel_);
   if (levelArray->GetEntriesFast() > 0) {
-    triggerLevel_ = ((TObjString *)levelArray->At(0))->GetString();
+    triggerLevel_ = static_cast<std::string>(((TObjString *)levelArray->At(0))->GetString());
   }
   delete levelArray;
 


### PR DESCRIPTION
This is because we are in C++17 and TString support both conversions, std::string and std::string_view and so does C++ Standard Library (e.g., std::string ctors and operators) thus compiler doesn't know what to do.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>
