### PR TITLE
Convert RAWSIM to LZMA.

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -170,12 +170,23 @@ AODEventContent = cms.PSet(
 #
 #
 # RAWSIM Data Tier definition
+# ===========================
 #
+# Here, we sacrifice memory and CPU time to decrease the on-disk size as
+# much as possible.  Given the current per-event GEN-SIM and DIGI-RECO times,
+# the extra CPU time for LZMA compression works out to be ~1%.  The GEN-SIM
+# use case of reading a minbias event for `classic pileup` has a similar CPU
+# impact.
+# The memory increase appears to be closer to 50MB - but that should be
+# acceptable as the introduction of multithreaded processing has bought us some
+# breathing room.
 #
 RAWSIMEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+    eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
+    compressionAlgorithm=cms.untracked.string("LZMA"),
+    compressionLevel=cms.untracked.int32(9),
 )
 #
 #


### PR DESCRIPTION
LZMA (plus more significant memory budget for writing) provides approximately a 20% reduction in per-event disk sizes at a cost of CPU time that measures O(1%) for GEN-SIM (writing) and DIGI-RECO (reading).

@davidlange6, @sextonkennedy - this is the compression change that we discussed approximately 3 weeks ago.  I just never got around to putting in a PR.