### PR TITLE
Changed Merger template EDProducer into global module

### DIFF
--- a/CommonTools/UtilAlgos/interface/Merger.h
+++ b/CommonTools/UtilAlgos/interface/Merger.h
@@ -17,7 +17,7 @@
  * $Id: Merger.h,v 1.2 2010/02/20 20:55:21 wmtan Exp $
  *
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/transform.h"
@@ -28,7 +28,7 @@
 template<typename InputCollection,
 	 typename OutputCollection = InputCollection,
 	 typename P = typename edm::clonehelper::CloneTrait<InputCollection>::type>
-class Merger : public edm::EDProducer {
+class Merger : public edm::global::EDProducer<> {
 public:
   /// constructor from parameter set
   explicit Merger( const edm::ParameterSet& );
@@ -37,7 +37,7 @@ public:
 
 private:
   /// process an event
-  virtual void produce( edm::Event&, const edm::EventSetup&) override;
+  virtual void produce( edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   /// vector of strings
   typedef std::vector<edm::EDGetTokenT<InputCollection> > vtoken;
   /// labels of the collections to be merged
@@ -55,7 +55,7 @@ Merger<InputCollection, OutputCollection, P>::~Merger() {
 }
 
 template<typename InputCollection, typename OutputCollection, typename P>
-void Merger<InputCollection, OutputCollection, P>::produce( edm::Event& evt, const edm::EventSetup&) {
+void Merger<InputCollection, OutputCollection, P>::produce( edm::StreamID, edm::Event& evt, const edm::EventSetup&) const {
   std::unique_ptr<OutputCollection> coll( new OutputCollection );
   for( typename vtoken::const_iterator s = srcToken_.begin(); s != srcToken_.end(); ++ s ) {
     edm::Handle<InputCollection> h;


### PR DESCRIPTION
Measurements of upgrade scenarios found modules based on this
template were stalling under high numbers of threads.