### PR TITLE
phaseI  geometry updates, alignment ideal pixel and realistic strip, ideal phaseI BS away from 000

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,18 +37,18 @@ autoCond = {
     'run2_hlt_relval'   :   '90X_dataRun2_HLT_relval_v0',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v0',
-    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v6',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
+    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '90X_upgrade2017_realistic_v6',
+    'phase1_2017_realistic': '90X_upgrade2017_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v6',
+    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v4',
+    'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic': '90X_upgrade2018_realistic_v4',
+    'phase1_2018_realistic': '90X_upgrade2018_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_cosmics':   '90X_upgrade2018cosmics_realistic_peak_v4',
+    'phase1_2018_cosmics':   '90X_upgrade2018cosmics_realistic_peak_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunII simulation

   * **PhaseI 2017 cosmics scenario** : [90X_upgrade2017cosmics_realistic_peak_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v7) as [90X_upgrade2017cosmics_realistic_peak_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v7/90X_upgrade2017cosmics_realistic_peak_v6):
      * geometry updates to fit large-size pixel reactivated, see Tracker Overlap Bugfixes #17383 and Replace Polycone in Pixel Fwd #17387 https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2803/1.html
      * alignment payload with ideal pixel and strip as in the current realistic phase-0 scenario (en par with phase0 as far as pixel are concerned)

   * **PhaseI 2017 design scenario** : [90X_upgrade2017_design_IdealBS_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_design_IdealBS_v7) as [90X_upgrade2017_design_IdealBS_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_design_IdealBS_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_design_IdealBS_v7/90X_upgrade2017_design_IdealBS_v6):
      * Ideal_Centered_SLHC_v3 is physics-wise the same as Ideal_Centered_SLHC_v2, except small 1E-5 displacement in Z to stay away from 000
      * geometry updates to fit large-size pixel reactivated, Tracker Overlap Bugfixes #17383 and Replace Polycone in Pixel Fwd #17387 , see : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2803/1.html

   * **PhaseI 2017 realistic scenario** : [90X_upgrade2017_realistic_v7](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v7) as [90X_upgrade2017_realistic_v6](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v6) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_realistic_v7/90X_upgrade2017_realistic_v6):
      * geometry updates to fit large-size pixel reactivated, see Tracker Overlap Bugfixes #17383 and Replace Polycone in Pixel Fwd #17387 https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2803/1.html
      * alignment payload with ideal pixel and strip as in the current realistic phase-0 scenario (en par with phase0 as far as pixel are concerned)

   * **PhaseI 2018 cosmics scenario** : [90X_upgrade2018cosmics_realistic_peak_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018cosmics_realistic_peak_v5) as [90X_upgrade2018cosmics_realistic_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018cosmics_realistic_peak_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018cosmics_realistic_peak_v5/90X_upgrade2018cosmics_realistic_peak_v4):
      * geometry updates to fit large-size pixel reactivated, see Tracker Overlap Bugfixes #17383 and Replace Polycone in Pixel Fwd #17387 https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2803/1.html
      * alignment payload with ideal pixel and strip as in the current realistic phase-0 scenario (en par with phase0 as far as pixel are concerned)

   * **PhaseI 2018 design scenario** : [90X_upgrade2018_design_IdealBS_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_design_IdealBS_v5) as [90X_upgrade2018_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_design_IdealBS_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018_design_IdealBS_v5/90X_upgrade2018_design_IdealBS_v4):
      * Ideal_Centered_SLHC_v3 is physics-wise the same as Ideal_Centered_SLHC_v2, except small 1E-5 displacement in Z to stay away from 000
      * geometry updates to fit large-size pixel reactivated, see Tracker Overlap Bugfixes #17383 and Replace Polycone in Pixel Fwd #17387 https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2803/1.html

   * **PhaseI 2018 realistic scenario** : [90X_upgrade2018_realistic_v5](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_realistic_v5) as [90X_upgrade2018_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_realistic_v4) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018_realistic_v5/90X_upgrade2018_realistic_v4):
      * geometry updates to fit large-size pixel reactivated, see Tracker Overlap Bugfixes #17383 and Replace Polycone in Pixel Fwd #17387 https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2803/1.html
      * alignment payload with ideal pixel and strip as in the current realistic phase-0 scenario (en par with phase0 as far as pixel are concerned)