### PR TITLE
Update JetID Functor to new recommendations

### DIFF
--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -105,8 +105,8 @@ jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
     #for PFJets: LOOSE,TIGHT
     JetIDQuality               = cms.string("LOOSE"),
     #options for Calo and JPT: PURE09,DQM09,CRAFT08
-    #for PFJets: FIRSTDATA or RUNIISTARTUP (suitable for RECO beyond 7_2_X)
-    JetIDVersion               = cms.string("RUNIISTARTUP"),
+    #for PFJets: FIRSTDATA or RUNIISTARTUP (suitable for RECO beyond 7_2_X) or WINTER16 (for 8_0_X onwards)
+    JetIDVersion               = cms.string("WINTER16"),
     JetType = cms.string('pf'),#pf, calo or jpt
     JetCorrections = cms.InputTag("dqmAk4PFL1FastL2L3ResidualCorrector"),
     jetsrc = cms.InputTag("ak4PFJets"),

--- a/DQMOffline/JetMET/src/JetAnalyzer.cc
+++ b/DQMOffline/JetMET/src/JetAnalyzer.cc
@@ -150,6 +150,8 @@ JetAnalyzer::JetAnalyzer(const edm::ParameterSet& pSet)
       pfjetidversion = PFJetIDSelectionFunctor::FIRSTDATA;
     }else if(JetIDVersion_== "RUNIISTARTUP"){
       pfjetidversion = PFJetIDSelectionFunctor::RUNIISTARTUP;
+    }else if(JetIDVersion_== "WINTER16"){
+      pfjetidversion = PFJetIDSelectionFunctor::WINTER16;
     }else{
       if (verbose_) std::cout<<"no valid PF JetID version given"<<std::endl;
     }

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -77,11 +77,11 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
 
   if(isPFMet_){
    pflowToken_ = consumes<std::vector<reco::PFCandidate> >(pSet.getParameter<edm::InputTag>("srcPFlow"));
-   pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::RUNIISTARTUP, PFJetIDSelectionFunctor::LOOSE);
+   pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::WINTER16, PFJetIDSelectionFunctor::LOOSE);
   }
   if(isMiniAODMet_){
     pflowPackedToken_ = consumes<std::vector<pat::PackedCandidate> >(pSet.getParameter<edm::InputTag>("srcPFlow"));
-    pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::RUNIISTARTUP, PFJetIDSelectionFunctor::LOOSE);
+    pfjetIDFunctorLoose=PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::WINTER16, PFJetIDSelectionFunctor::LOOSE);
   }
   MuonsToken_ = consumes<reco::MuonCollection>(pSet.getParameter<edm::InputTag>       ("muonsrc"));
 

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -25,7 +25,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
  public: // interface
 
-  enum Version_t { FIRSTDATA, RUNIISTARTUP, N_VERSIONS };
+  enum Version_t { FIRSTDATA, RUNIISTARTUP, WINTER16, N_VERSIONS };
   enum Quality_t { LOOSE, TIGHT, N_QUALITY};
 
   PFJetIDSelectionFunctor() {}
@@ -43,9 +43,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
    if ( versionStr == "FIRSTDATA" )
      version_ = FIRSTDATA;
-   else if( versionStr == "RUNIISTARTUP" ) 
+   else if( versionStr == "RUNIISTARTUP") 
      version_ = RUNIISTARTUP;  
-   else version_ = RUNIISTARTUP;//set RUNII STARTUP 50 ns points as default
+   // WINTER16 implements most recent (as of Feb 2017) JetID criteria
+   // See: https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016
+   else if( versionStr == "WINTER16") 
+     version_ = WINTER16;  
+   else version_ = WINTER16;//set WINTER16 as default
+   
 
    if      ( qualityStr == "LOOSE") quality_ = LOOSE;
    else if ( qualityStr == "TIGHT") quality_ = TIGHT;
@@ -57,11 +62,19 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     push_back("NEF" );
     push_back("NCH" );
     push_back("nConstituents");
-    if(version_ == RUNIISTARTUP){
+    if(version_ == RUNIISTARTUP ){
       push_back("NEF_FW");
       push_back("nNeutrals_FW");
     }
-
+    if(version_ == WINTER16 ){
+      push_back("NHF_EC");
+      push_back("NEF_EC");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW");
+    }
+ 
+ 
 
     // Set some default cuts for LOOSE, TIGHT
     if ( quality_ == LOOSE ) {
@@ -75,6 +88,15 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	set("NEF_FW",0.90);
 	set("nNeutrals_FW",10);
       }
+      if(version_ == WINTER16){
+	set("NHF_EC",0.98);
+	set("NEF_EC",0.01);
+	set("nNeutrals_EC",2);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+
+
     } else if ( quality_ == TIGHT ) {
       set("CHF", 0.0);
       set("NHF", 0.9);
@@ -86,6 +108,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	set("NEF_FW",0.90);
 	set("nNeutrals_FW",10);
       }
+      if(version_ == WINTER16){
+	set("NHF_EC",0.98);
+	set("NEF_EC",0.01);
+	set("nNeutrals_EC",2);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+
     }
 
 
@@ -100,6 +130,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       if ( params.exists("NEF_FW") ) set("NEF_FW", params.getParameter<double> ("NEF_FW") );
       if ( params.exists("nNeutrals_FW") ) set("nNeutrals_FW", params.getParameter<int> ("nNeutrals_FW") );
     }
+    if(version_ == WINTER16){
+      if ( params.exists("NHF_EC") ) set("NHF_EC", params.getParameter<int> ("NHF_EC") );
+      if ( params.exists("NEF_EC") ) set("NEF_EC", params.getParameter<int> ("NEF_EC") );
+      if ( params.exists("nNeutrals_EC") ) set("nNeutrals_EC", params.getParameter<int> ("nNeutrals_EC") );
+      if ( params.exists("NEF_FW") ) set("NEF_FW", params.getParameter<double> ("NEF_FW") );
+      if ( params.exists("nNeutrals_FW") ) set("nNeutrals_FW", params.getParameter<int> ("nNeutrals_FW") );
+    }
+
 
     if ( params.exists("cutsToIgnore") )
       setIgnoredCuts( params.getParameter<std::vector<std::string> >("cutsToIgnore") );
@@ -112,6 +150,13 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     indexCHF_ = index_type (&bits_, "CHF");
     indexNCH_ = index_type (&bits_, "NCH");
     if(version_ == RUNIISTARTUP){
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
+    }
+    if(version_ == WINTER16){
+      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
+      indexNEF_EC_ = index_type (&bits_, "NEF_EC");
+      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
       indexNEF_FW_ = index_type (&bits_, "NEF_FW");
       indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
     }
@@ -136,6 +181,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       push_back("NEF_FW");
       push_back("nNeutrals_FW");
     }
+    if(version_ == WINTER16){
+      push_back("NHF_EC");
+      push_back("NEF_EC");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW");
+    }
+
 
     // Set some default cuts for LOOSE, TIGHT
     if ( quality_ == LOOSE ) {
@@ -149,6 +202,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	set("NEF_FW",0.90);
 	set("nNeutrals_FW",10);
       }
+      if(version_ == WINTER16){
+	set("NHF_EC",0.98);
+	set("NEF_EC",0.01);
+	set("nNeutrals_EC",2);
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+
     } else if ( quality_ == TIGHT ) {
       set("CHF", 0.0);
       set("NHF", 0.9);
@@ -157,6 +218,13 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       set("NCH", 0);
       set("nConstituents", 1);
       if(version_ == RUNIISTARTUP){
+	set("NEF_FW",0.90);
+	set("nNeutrals_FW",10);
+      }
+      if(version_ == WINTER16){
+	set("NHF_EC",0.98);
+	set("NEF_EC",0.01);
+	set("nNeutrals_EC",2);
 	set("NEF_FW",0.90);
 	set("nNeutrals_FW",10);
       }
@@ -173,6 +241,14 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       indexNEF_FW_ = index_type (&bits_, "NEF_FW");
       indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
     }
+    if(version_ == WINTER16){
+      indexNHF_EC_ = index_type (&bits_, "NHF_EC");
+      indexNEF_EC_ = index_type (&bits_, "NEF_EC");
+      indexNNeutrals_EC_ = index_type (&bits_, "nNeutrals_EC");
+      indexNEF_FW_ = index_type (&bits_, "NEF_FW");
+      indexNNeutrals_FW_ = index_type (&bits_, "nNeutrals_FW");
+    }
+
 
     retInternal_ = getBitTemplate();
  }
@@ -183,7 +259,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   bool operator()( const pat::Jet & jet, pat::strbitset & ret )
   {
-    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP ) {
+    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16) {
       if ( jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable() )
 	return firstDataCuts( jet, ret, version_);
       else
@@ -201,7 +277,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
   //
   bool operator()( const reco::PFJet & jet, pat::strbitset & ret )
   {
-    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP ){ return firstDataCuts( jet, ret, version_);
+    if ( version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16  ){ return firstDataCuts( jet, ret, version_);
     }
     else {
       return false;
@@ -333,7 +409,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
 
 
-   // Cuts for |eta| < 2.4 for FIRSTDATA and RUNIISTARTUP
+   // Cuts for |eta| < 2.4 for FIRSTDATA, RUNIISTARTUP and WINTER16
     if ( ignoreCut(indexCEF_)           || ( cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCEF_);
     if ( ignoreCut(indexCHF_)           || ( chf > cut(indexCHF_, double()) || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexCHF_);
     if ( ignoreCut(indexNCH_)           || ( nch > cut(indexNCH_, int())    || std::abs(jet.eta()) > 2.4 ) ) passCut( ret, indexNCH_);
@@ -351,6 +427,23 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       if ( ignoreCut(indexNEF_FW_)           || ( nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNEF_FW_);
       if ( ignoreCut(indexNNeutrals_FW_) || ( nneutrals > cut(indexNNeutrals_FW_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_);
     }
+    else if(version_ == WINTER16){
+      // Cuts for |eta| <= 2.7 for WINTER16 scenario
+      if ( ignoreCut(indexNConstituents_) || ( nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNConstituents_);
+      if ( ignoreCut(indexNEF_)           || ( nef < cut(indexNEF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNEF_);
+      if ( ignoreCut(indexNHF_)           || ( nhf < cut(indexNHF_, double())  || std::abs(jet.eta()) > 2.7 ) ) passCut( ret, indexNHF_);
+
+      // Cuts for 2.7 < |eta| <= 3.0 for WINTER16 scenario
+      if ( ignoreCut(indexNHF_EC_)        || ( nhf < cut(indexNHF_EC_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNHF_EC_);
+      if ( ignoreCut(indexNEF_EC_)        || ( nef > cut(indexNEF_EC_, double())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNEF_EC_);
+      if ( ignoreCut(indexNNeutrals_EC_)  || ( nneutrals > cut(indexNNeutrals_EC_, int())  || std::abs(jet.eta()) <= 2.7 || std::abs(jet.eta()) > 3.0)  ) passCut( ret, indexNNeutrals_EC_);
+
+      // Cuts for |eta| > 3.0 for WINTER16 scenario
+      if ( ignoreCut(indexNEF_FW_)           || ( nef < cut(indexNEF_FW_, double()) || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNEF_FW_);
+      if ( ignoreCut(indexNNeutrals_FW_) || ( nneutrals > cut(indexNNeutrals_FW_, int())    || std::abs(jet.eta()) <= 3.0 ) ) passCut( ret, indexNNeutrals_FW_);
+    }
+
+
     //std::cout << "<PFJetIDSelectionFunctor::firstDataCuts>:" << std::endl;
     //std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
     //ret.print(std::cout);
@@ -373,6 +466,11 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 
   index_type indexNEF_FW_;
   index_type indexNNeutrals_FW_;
+
+  index_type indexNHF_EC_;
+  index_type indexNEF_EC_;
+  index_type indexNNeutrals_EC_;
+
 
 };
 

--- a/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
+++ b/PhysicsTools/SelectorUtils/python/pfJetIDSelector_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 
 pfJetIDSelector = cms.PSet(
-        version = cms.string('RUNIISTARTUP'),
+        version = cms.string('WINTER16'),
         quality = cms.string('LOOSE')
     )


### PR DESCRIPTION
Current JetID recommendations are available at: [1]

This PR brings the PFJetIDSelectionFunctor up to date with them.

Verified on ~1k jets: all jets for which the JetID changes are in 2.7 < abs(eta) <= 3.0 and the new JetID 
agrees with the requirements in the table.

There are still a few places in DQM where the old RUNIISTARTUP version is used (see [2]). Who is responsible to update these? Or can I just go ahead?

[1] https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016
[2] https://github.com/cms-sw/cmssw/search?utf8=%E2%9C%93&q=RUNIISTARTUP
 