### PR TITLE
Extend tracking DQM eta range for phase1 and phase2

### DIFF
--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -404,3 +404,8 @@ LongDCABins = cms.int32(100),
 LongDCAMin = cms.double(-8.0),
 LongDCAMax = cms.double(8.0),          
 )
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase1Pixel.toModify(TrackMon, EtaBin=30, EtaMin=-3, EtaMax=3)
+phase2_tracker.toModify(TrackMon, EtaBin=46, EtaMin=-4.5, EtaMax=4.5)


### PR DESCRIPTION
This PR extends the eta range of tracking DQM histograms to +-3 for phase1, and +-4.5 for phase2 (as in MTV).

Tested in 9_0_0_pre3, expecting changes only in histograms vs. eta in tracking DQM.

@rovere @VinInn @ebrondol @mtosi 