### PR TITLE
Fix GCC 7 errors (inc. buffer size and fix TString conversion)

### DIFF
--- a/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
+++ b/Alignment/CocoaModel/src/CocoaDaqReaderRoot.cc
@@ -8,6 +8,7 @@
 #include "CondFormats/OptAlignObjects/interface/OpticalAlignMeasurements.h"
 
 #include <iostream>
+#include <string>
 
 #include "TClonesArray.h"
 
@@ -128,7 +129,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPosition2D( AliDaqPos
   OpticalAlignMeasurementInfo meas;
   
   meas.type_ = "SENSOR2D";
-  meas.name_ = pos2D->GetID();
+  meas.name_ = std::string(pos2D->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
   for( size_t jj = 0; jj < 2; jj++ ){
@@ -160,7 +161,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromPositionCOPS( AliDaqP
   OpticalAlignMeasurementInfo meas;
   
   meas.type_ = "COPS";
-  meas.name_ = posCOPS->GetID();
+  meas.name_ = std::string(posCOPS->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
   for( size_t jj = 0; jj < 4; jj++ ){
@@ -205,7 +206,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromTilt( AliDaqTilt* til
   OpticalAlignMeasurementInfo meas;
   
   meas.type_ = "TILTMETER";
-  meas.name_ = tilt->GetID();
+  meas.name_ = std::string(tilt->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
   for( size_t jj = 0; jj < 2; jj++ ){
@@ -232,7 +233,7 @@ OpticalAlignMeasurementInfo CocoaDaqReaderRoot::GetMeasFromDist( AliDaqDistance*
   OpticalAlignMeasurementInfo meas;
   
   meas.type_ = "DISTANCEMETER";
-  meas.name_ = dist->GetID();
+  meas.name_ = std::string(dist->GetID().Data());
   //-   std::vector<std::string> measObjectNames_;
   std::vector<bool> isSimu;
   for( size_t jj = 0; jj < 2; jj++ ){

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorGeneric.cc
@@ -55,7 +55,7 @@ void AlignmentMonitorGeneric::book()
 			alignableObjectId.idToString(type),
 			id, DetId(id).subdetId());
 
-      hists[n] = book1D(std::string("/iterN/") + std::string(name) + std::string("/"), std::string(histName), std::string(histTitle), nBin_, -5., 5.);
+      hists[n] = book1D(std::string("/iterN/") + std::string(name) + std::string("/"), std::string(histName.Data()), std::string(histTitle.Data()), nBin_, -5., 5.);
     }
   }
 

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -1090,7 +1090,7 @@ HIPAlignmentAlgorithm::calcAPE(double* par, int iter, double function)
 void HIPAlignmentAlgorithm::bookRoot(void)
 {
   TString tname="T1";
-  char iterString[5];
+  char iterString[15];
   snprintf(iterString, sizeof(iterString), "%i",theIteration);
   tname.Append("_");
   tname.Append(iterString);

--- a/Alignment/OfflineValidation/plugins/MuonAlignmentAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/MuonAlignmentAnalyzer.cc
@@ -837,7 +837,7 @@ void MuonAlignmentAnalyzer::endJob(){
 
 
 
-        char binLabel[15];
+        char binLabel[40];
 
         for(unsigned int i=0 ; i<unitsLocalX.size() ; i++)
         {


### PR DESCRIPTION
TString supports conversions to `std::string` and `std::string_view` in
C++17 which causes ambiguity as `std::string` ctors and operators support
both also. Compiler cannot decide which one to use. We have either call
explicitly conversion operatator on `TString` (e.g., via `static_cast`) or
use other methods (e.g. construct `std::string` from `const char *
TString::Data()`).

In some cases compiler says that buffers are too small.

`TString`s could also be removed and replaced with C++ standard functions.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>