### PR TITLE
B/D hadron track monitoring for offline DQM

### DIFF
--- a/Validation/RecoB/BuildFile.xml
+++ b/Validation/RecoB/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
+<use name="TrackingTools/IPTools"/>
 <export>
   <lib name="1"/>
 </export>

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
@@ -1,9 +1,5 @@
 #include "Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h"
 
-// intialize category map
-std::map<unsigned int, std::string> TrkHistCat(map_start_values, map_start_values + map_start_values_size);
-
-
 const reco::TrackBaseRef toTrackRef(const edm::Ptr<reco::Candidate> & cnd)
 {
     const reco::PFCandidate * pfcand = dynamic_cast<const reco::PFCandidate *>(cnd.get());
@@ -17,8 +13,11 @@ const reco::TrackBaseRef toTrackRef(const edm::Ptr<reco::Candidate> & cnd)
 }
 
 
-// ---------- Constructor -----------
+// ---------- Static member declaration -----------
+const std::vector<std::string> BDHadronTrackMonitoringAnalyzer::TrkHistCat = {"BCWeakDecay", "BWeakDecay", "CWeakDecay", "PU", "Other", "Fake"};
 
+
+// ---------- Constructor -----------
 BDHadronTrackMonitoringAnalyzer::BDHadronTrackMonitoringAnalyzer(const edm::ParameterSet& pSet) :
     distJetAxis_ ( pSet.getParameter<double>("distJetAxisCut") ),
     decayLength_ ( pSet.getParameter<double>("decayLengthCut") ),
@@ -36,7 +35,9 @@ BDHadronTrackMonitoringAnalyzer::BDHadronTrackMonitoringAnalyzer(const edm::Para
     TrackCollectionTag_ = consumes<reco::TrackCollection>(TrackSrc_);
     PrimaryVertexColl_ = consumes<reco::VertexCollection>(PVSrc_);
     clusterTPMapToken_ = consumes<ClusterTPAssociation>(ClusterTPMapSrc_);
+    //TrkHistCat = {"BCWeakDecay", "BWeakDecay", "CWeakDecay", "PU", "Other", "Fake"};
 }
+
 
 
 
@@ -51,28 +52,22 @@ void BDHadronTrackMonitoringAnalyzer::bookHistograms(DQMStore::IBooker & ibook, 
 
 
   nTrkAll_bjet = ibook.book1D("nTrkAll_bjet","Number of selected tracks in b jets;number of selected tracks;jets",16,-0.5,15.5);
-  //nTrkTruthAll_bjet = ibook.book1D("nTrkTruthAll_bjet","Number of selected TrackingParticles in b jets;number of selected truth tracks;jets",16,-0.5,15.5);
 
   nTrkAll_cjet = ibook.book1D("nTrkAll_cjet","Number of selected tracks in c jets;number of selected tracks;jets",16,-0.5,15.5);
-  //nTrkTruthAll_cjet = ibook.book1D("nTrkTruthAll_cjet","Number of selected TrackingParticles in c jets;number of selected truth tracks;jets",16,-0.5,15.5);
 
   nTrkAll_dusgjet = ibook.book1D("nTrkAll_dusgjet","Number of selected tracks in dusg jets;number of selected tracks;jets",16,-0.5,15.5);
-  //nTrkTruthAll_dusgjet = ibook.book1D("nTrkTruthAll_dusgjet","Number of selected TrackingParticles in dusg jets;number of selected truth tracks;jets",16,-0.5,15.5);
 
   // Loop over different Track History Categories
   for (unsigned int i = 0; i < TrkHistCat.size(); i++){
     // b jets
     nTrk_bjet[i] = ibook.book1D("nTrk_bjet_"+TrkHistCat[i],"Number of selected tracks in b jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
-    //nTrkTruth_bjet[i] = ibook.book1D("nTrkTruth_bjet_"+TrkHistCat[i],"Number of selected trackingparticles in b jets ("+TrkHistCat[i]+" Truth);number of selected tracks ("+TrkHistCat[i]+" Truth);jets",16,-0.5,15.5);
-
+ 
     // c jets
     nTrk_cjet[i] = ibook.book1D("nTrk_cjet_"+TrkHistCat[i],"Number of selected tracks in c jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
-    //nTrkTruth_cjet[i] = ibook.book1D("nTrkTruth_cjet_"+TrkHistCat[i],"Number of selected trackingparticles in c jets ("+TrkHistCat[i]+" Truth);number of selected tracks ("+TrkHistCat[i]+" Truth);jets",16,-0.5,15.5);
-
+ 
     // dusg jets
     nTrk_dusgjet[i] = ibook.book1D("nTrk_dusgjet_"+TrkHistCat[i],"Number of selected tracks in dusg jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
-    //nTrkTruth_dusgjet[i] = ibook.book1D("nTrkTruth_dusgjet_"+TrkHistCat[i],"Number of selected trackingparticles in dusg jets ("+TrkHistCat[i]+" Truth);number of selected tracks ("+TrkHistCat[i]+" Truth);jets",16,-0.5,15.5);
-
+ 
 
     // track properties for all flavours combined
     TrkPt_alljets[i] = ibook.book1D("TrkPt_"+TrkHistCat[i],"Track pT ("+TrkHistCat[i]+");track p_{T} ("+TrkHistCat[i]+");tracks",30,0,100);
@@ -156,7 +151,6 @@ void BDHadronTrackMonitoringAnalyzer::analyze(const edm::Event& iEvent, const ed
     unsigned int flav = abs(jet->hadronFlavour());
 
 
-    //std::cout << "is there a taginfo? " << jet->hasTagInfo(ipTagInfos_.c_str()) << std::endl;
     const CandIPTagInfo *trackIpTagInfo = jet->tagInfoCandIP(ipTagInfos_.c_str());
     const std::vector<edm::Ptr<reco::Candidate> > & selectedTracks( trackIpTagInfo->selectedTracks() );
 
@@ -253,125 +247,125 @@ void BDHadronTrackMonitoringAnalyzer::analyze(const edm::Event& iEvent, const ed
     
         //BCWeakDecay
         if ( theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::BWeakDecay] && theFlag[TrackCategories::CWeakDecay] ) {
-            nseltracksCat[0] += 1;
-            TrkPt_alljets[0]->Fill(TrkPt);
-            TrkEta_alljets[0]->Fill(TrkEta);
-            TrkPhi_alljets[0]->Fill(TrkPhi);
-            TrkDxy_alljets[0]->Fill(TrkDxy);
-            TrkDz_alljets[0]->Fill(TrkDz);
-            TrkHitAll_alljets[0]->Fill(TrknHitAll);
-            TrkHitPixel_alljets[0]->Fill(TrknHitPixel);
-            TrkHitStrip_alljets[0]->Fill(TrknHitStrip);
+            nseltracksCat[BDHadronTrackMonitoringAnalyzer::BCWeakDecay] += 1;
+            TrkPt_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkPt);
+            TrkEta_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkEta);
+            TrkPhi_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkPhi);
+            TrkDxy_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkDxy);
+            TrkDz_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkDz);
+            TrkHitAll_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrknHitStrip);
             if (quality_tpr != 0) {
-                TrkTruthPt_alljets[0]->Fill(TrkTruthPt);
-                TrkTruthEta_alljets[0]->Fill(TrkTruthEta);
-                TrkTruthPhi_alljets[0]->Fill(TrkTruthPhi);
-                TrkTruthDxy_alljets[0]->Fill(TrkTruthDxy);
-                TrkTruthDz_alljets[0]->Fill(TrkTruthDz);
-                TrkTruthHitAll_alljets[0]->Fill(TrkTruthnHitAll);
-                TrkTruthHitPixel_alljets[0]->Fill(TrkTruthnHitPixel);
-                TrkTruthHitStrip_alljets[0]->Fill(TrkTruthnHitStrip);
+                TrkTruthPt_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::BCWeakDecay]->Fill(TrkTruthnHitStrip);
             }
         }
         //BWeakDecay
         else if ( theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::BWeakDecay] && !theFlag[TrackCategories::CWeakDecay] ) {
-            nseltracksCat[1] += 1;
-            TrkPt_alljets[1]->Fill(TrkPt);
-            TrkEta_alljets[1]->Fill(TrkEta);
-            TrkPhi_alljets[1]->Fill(TrkPhi);
-            TrkDxy_alljets[1]->Fill(TrkDxy);
-            TrkDz_alljets[1]->Fill(TrkDz);
-            TrkHitAll_alljets[1]->Fill(TrknHitAll);
-            TrkHitPixel_alljets[1]->Fill(TrknHitPixel);
-            TrkHitStrip_alljets[1]->Fill(TrknHitStrip);
+            nseltracksCat[BDHadronTrackMonitoringAnalyzer::BWeakDecay] += 1;
+            TrkPt_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkPt);
+            TrkEta_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkEta);
+            TrkPhi_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkPhi);
+            TrkDxy_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkDxy);
+            TrkDz_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkDz);
+            TrkHitAll_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrknHitStrip);
             if (quality_tpr != 0) {
-                TrkTruthPt_alljets[1]->Fill(TrkTruthPt);
-                TrkTruthEta_alljets[1]->Fill(TrkTruthEta);
-                TrkTruthPhi_alljets[1]->Fill(TrkTruthPhi);
-                TrkTruthDxy_alljets[1]->Fill(TrkTruthDxy);
-                TrkTruthDz_alljets[1]->Fill(TrkTruthDz);
-                TrkTruthHitAll_alljets[1]->Fill(TrkTruthnHitAll);
-                TrkTruthHitPixel_alljets[1]->Fill(TrkTruthnHitPixel);
-                TrkTruthHitStrip_alljets[1]->Fill(TrkTruthnHitStrip);
+                TrkTruthPt_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::BWeakDecay]->Fill(TrkTruthnHitStrip);
             }
         }
         //CWeakDecay
         else if ( theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::BWeakDecay] && theFlag[TrackCategories::CWeakDecay] ) {
-            nseltracksCat[2] += 1;
-            TrkPt_alljets[2]->Fill(TrkPt);
-            TrkEta_alljets[2]->Fill(TrkEta);
-            TrkPhi_alljets[2]->Fill(TrkPhi);
-            TrkDxy_alljets[2]->Fill(TrkDxy);
-            TrkDz_alljets[2]->Fill(TrkDz);
-            TrkHitAll_alljets[2]->Fill(TrknHitAll);
-            TrkHitPixel_alljets[2]->Fill(TrknHitPixel);
-            TrkHitStrip_alljets[2]->Fill(TrknHitStrip);
+            nseltracksCat[BDHadronTrackMonitoringAnalyzer::CWeakDecay] += 1;
+            TrkPt_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkPt);
+            TrkEta_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkEta);
+            TrkPhi_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkPhi);
+            TrkDxy_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkDxy);
+            TrkDz_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkDz);
+            TrkHitAll_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrknHitStrip);
             if (quality_tpr != 0) {
-                TrkTruthPt_alljets[2]->Fill(TrkTruthPt);
-                TrkTruthEta_alljets[2]->Fill(TrkTruthEta);
-                TrkTruthPhi_alljets[2]->Fill(TrkTruthPhi);
-                TrkTruthDxy_alljets[2]->Fill(TrkTruthDxy);
-                TrkTruthDz_alljets[2]->Fill(TrkTruthDz);
-                TrkTruthHitAll_alljets[2]->Fill(TrkTruthnHitAll);
-                TrkTruthHitPixel_alljets[2]->Fill(TrkTruthnHitPixel);
-                TrkTruthHitStrip_alljets[2]->Fill(TrkTruthnHitStrip);
+                TrkTruthPt_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::CWeakDecay]->Fill(TrkTruthnHitStrip);
             }
         }
         //PU
         else if ( !theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::Fake] ) {
-            nseltracksCat[3] += 1;
-            TrkPt_alljets[3]->Fill(TrkPt);
-            TrkEta_alljets[3]->Fill(TrkEta);
-            TrkPhi_alljets[3]->Fill(TrkPhi);
-            TrkDxy_alljets[3]->Fill(TrkDxy);
-            TrkDz_alljets[3]->Fill(TrkDz);
-            TrkHitAll_alljets[3]->Fill(TrknHitAll);
-            TrkHitPixel_alljets[3]->Fill(TrknHitPixel);
-            TrkHitStrip_alljets[3]->Fill(TrknHitStrip);
+            nseltracksCat[BDHadronTrackMonitoringAnalyzer::PU] += 1;
+            TrkPt_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkPt);
+            TrkEta_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkEta);
+            TrkPhi_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkPhi);
+            TrkDxy_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkDxy);
+            TrkDz_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkDz);
+            TrkHitAll_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrknHitStrip);
             if (quality_tpr != 0) {
-                TrkTruthPt_alljets[3]->Fill(TrkTruthPt);
-                TrkTruthEta_alljets[3]->Fill(TrkTruthEta);
-                TrkTruthPhi_alljets[3]->Fill(TrkTruthPhi);
-                TrkTruthDxy_alljets[3]->Fill(TrkTruthDxy);
-                TrkTruthDz_alljets[3]->Fill(TrkTruthDz);
-                TrkTruthHitAll_alljets[3]->Fill(TrkTruthnHitAll);
-                TrkTruthHitPixel_alljets[3]->Fill(TrkTruthnHitPixel);
-                TrkTruthHitStrip_alljets[3]->Fill(TrkTruthnHitStrip);
+                TrkTruthPt_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::PU]->Fill(TrkTruthnHitStrip);
             }
         }
         //Other
         else if ( theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::BWeakDecay] && !theFlag[TrackCategories::CWeakDecay] ){
-            nseltracksCat[4] += 1;
-            TrkPt_alljets[4]->Fill(TrkPt);
-            TrkEta_alljets[4]->Fill(TrkEta);
-            TrkPhi_alljets[4]->Fill(TrkPhi);
-            TrkDxy_alljets[4]->Fill(TrkDxy);
-            TrkDz_alljets[4]->Fill(TrkDz);
-            TrkHitAll_alljets[4]->Fill(TrknHitAll);
-            TrkHitPixel_alljets[4]->Fill(TrknHitPixel);
-            TrkHitStrip_alljets[4]->Fill(TrknHitStrip);
+            nseltracksCat[BDHadronTrackMonitoringAnalyzer::Other] += 1;
+            TrkPt_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkPt);
+            TrkEta_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkEta);
+            TrkPhi_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkPhi);
+            TrkDxy_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkDxy);
+            TrkDz_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkDz);
+            TrkHitAll_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrknHitStrip);
             if (quality_tpr != 0) {
-                TrkTruthPt_alljets[4]->Fill(TrkTruthPt);
-                TrkTruthEta_alljets[4]->Fill(TrkTruthEta);
-                TrkTruthPhi_alljets[4]->Fill(TrkTruthPhi);
-                TrkTruthDxy_alljets[4]->Fill(TrkTruthDxy);
-                TrkTruthDz_alljets[4]->Fill(TrkTruthDz);
-                TrkTruthHitAll_alljets[4]->Fill(TrkTruthnHitAll);
-                TrkTruthHitPixel_alljets[4]->Fill(TrkTruthnHitPixel);
-                TrkTruthHitStrip_alljets[4]->Fill(TrkTruthnHitStrip);
+                TrkTruthPt_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::Other]->Fill(TrkTruthnHitStrip);
             }
         }
         //Fake
         else if ( !theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::Fake] ) {
-            nseltracksCat[5] += 1;
-            TrkPt_alljets[5]->Fill(TrkPt);
-            TrkEta_alljets[5]->Fill(TrkEta);
-            TrkPhi_alljets[5]->Fill(TrkPhi);
-            TrkDxy_alljets[5]->Fill(TrkDxy);
-            TrkDz_alljets[5]->Fill(TrkDz);
-            TrkHitAll_alljets[5]->Fill(TrknHitAll);
-            TrkHitPixel_alljets[5]->Fill(TrknHitPixel);
-            TrkHitStrip_alljets[5]->Fill(TrknHitStrip);
+            nseltracksCat[BDHadronTrackMonitoringAnalyzer::Fake] += 1;
+            TrkPt_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrkPt);
+            TrkEta_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrkEta);
+            TrkPhi_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrkPhi);
+            TrkDxy_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrkDxy);
+            TrkDz_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrkDz);
+            TrkHitAll_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[BDHadronTrackMonitoringAnalyzer::Fake]->Fill(TrknHitStrip);
             // NO TRUTH FOR FAKES!!!
         }
     

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
@@ -1,0 +1,458 @@
+#include "Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+
+#include "DQMOffline/RecoB/interface/Tools.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+#include "RecoVertex/VertexPrimitives/interface/ConvertToFromReco.h"
+
+#include <iostream>
+#include <fstream>
+
+using namespace reco;
+using namespace edm;
+using namespace std;
+
+
+std::map<unsigned int, std::string> TrkHistCat{
+    {0, "BCWeakDecay"},
+    {1, "BWeakDecay"},
+    {2, "CWeakDecay"},
+    {3, "PU"},
+    {4, "Other"},
+    {5, "Fake"} 
+};
+
+const reco::TrackBaseRef toTrackRef(const edm::Ptr<reco::Candidate> & cnd)
+{
+    const reco::PFCandidate * pfcand = dynamic_cast<const reco::PFCandidate *>(cnd.get());
+
+    if ( (std::abs(pfcand->pdgId()) == 11 || pfcand->pdgId() == 22) && pfcand->gsfTrackRef().isNonnull() && pfcand->gsfTrackRef().isAvailable() )
+      return reco::TrackBaseRef(pfcand->gsfTrackRef());
+    else if ( pfcand->trackRef().isNonnull() && pfcand->trackRef().isAvailable() )
+      return reco::TrackBaseRef(pfcand->trackRef());
+    else
+      return reco::TrackBaseRef();
+}
+
+
+// ---------- Constructor -----------
+
+BDHadronTrackMonitoringAnalyzer::BDHadronTrackMonitoringAnalyzer(const edm::ParameterSet& pSet) :
+    distJetAxis_ ( pSet.getParameter<double>("distJetAxisCut") ),
+    decayLength_ ( pSet.getParameter<double>("decayLengthCut") ),
+    minJetPt_ ( pSet.getParameter<double>("minJetPt") ),
+    maxJetEta_ ( pSet.getParameter<double>("maxJetEta") ),
+    ipTagInfos_ ( pSet.getParameter<std::string>("ipTagInfos") ),
+    PatJetSrc_ ( pSet.getParameter<InputTag>("PatJetSource") ),
+    TrackSrc_ ( pSet.getParameter<InputTag>("TrackSource") ),
+    PVSrc_ ( pSet.getParameter<InputTag>("PrimaryVertexSource") ),
+    ClusterTPMapSrc_ ( pSet.getParameter<InputTag>("clusterTPMap") ),
+    classifier_(pSet, consumesCollector())
+
+{
+    PatJetCollectionTag_ = consumes<pat::JetCollection>(PatJetSrc_);
+    TrackCollectionTag_ = consumes<reco::TrackCollection>(TrackSrc_);
+    PrimaryVertexColl_ = consumes<reco::VertexCollection>(PVSrc_);
+    clusterTPMapToken_ = consumes<ClusterTPAssociation>(ClusterTPMapSrc_);
+}
+
+
+
+// ---------- BookHistograms -----------
+
+void BDHadronTrackMonitoringAnalyzer::bookHistograms(DQMStore::IBooker & ibook, edm::Run const & run, edm::EventSetup const & es)
+{
+  //
+  // Book all histograms.
+  //
+  RecoBTag::setTDRStyle();
+
+
+  nTrkAll_bjet = ibook.book1D("nTrkAll_bjet","Number of selected tracks in b jets;number of selected tracks;jets",16,-0.5,15.5);
+  //nTrkTruthAll_bjet = ibook.book1D("nTrkTruthAll_bjet","Number of selected TrackingParticles in b jets;number of selected truth tracks;jets",16,-0.5,15.5);
+
+  nTrkAll_cjet = ibook.book1D("nTrkAll_cjet","Number of selected tracks in c jets;number of selected tracks;jets",16,-0.5,15.5);
+  //nTrkTruthAll_cjet = ibook.book1D("nTrkTruthAll_cjet","Number of selected TrackingParticles in c jets;number of selected truth tracks;jets",16,-0.5,15.5);
+
+  nTrkAll_dusgjet = ibook.book1D("nTrkAll_dusgjet","Number of selected tracks in dusg jets;number of selected tracks;jets",16,-0.5,15.5);
+  //nTrkTruthAll_dusgjet = ibook.book1D("nTrkTruthAll_dusgjet","Number of selected TrackingParticles in dusg jets;number of selected truth tracks;jets",16,-0.5,15.5);
+
+  // Loop over different Track History Categories
+  for (unsigned int i = 0; i < TrkHistCat.size(); i++){
+    // b jets
+    nTrk_bjet[i] = ibook.book1D("nTrk_bjet_"+TrkHistCat[i],"Number of selected tracks in b jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
+    //nTrkTruth_bjet[i] = ibook.book1D("nTrkTruth_bjet_"+TrkHistCat[i],"Number of selected trackingparticles in b jets ("+TrkHistCat[i]+" Truth);number of selected tracks ("+TrkHistCat[i]+" Truth);jets",16,-0.5,15.5);
+
+    // c jets
+    nTrk_cjet[i] = ibook.book1D("nTrk_cjet_"+TrkHistCat[i],"Number of selected tracks in c jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
+    //nTrkTruth_cjet[i] = ibook.book1D("nTrkTruth_cjet_"+TrkHistCat[i],"Number of selected trackingparticles in c jets ("+TrkHistCat[i]+" Truth);number of selected tracks ("+TrkHistCat[i]+" Truth);jets",16,-0.5,15.5);
+
+    // dusg jets
+    nTrk_dusgjet[i] = ibook.book1D("nTrk_dusgjet_"+TrkHistCat[i],"Number of selected tracks in dusg jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
+    //nTrkTruth_dusgjet[i] = ibook.book1D("nTrkTruth_dusgjet_"+TrkHistCat[i],"Number of selected trackingparticles in dusg jets ("+TrkHistCat[i]+" Truth);number of selected tracks ("+TrkHistCat[i]+" Truth);jets",16,-0.5,15.5);
+
+
+    // track properties for all flavours combined
+    TrkPt_alljets[i] = ibook.book1D("TrkPt_"+TrkHistCat[i],"Track pT ("+TrkHistCat[i]+");track p_{T} ("+TrkHistCat[i]+");tracks",30,0,100);
+    TrkEta_alljets[i] = ibook.book1D("TrkEta_"+TrkHistCat[i],"Track #eta ("+TrkHistCat[i]+");track #eta ("+TrkHistCat[i]+");tracks",30,-2.5,2.5);
+    TrkPhi_alljets[i] = ibook.book1D("TrkPhi_"+TrkHistCat[i],"Track #phi ("+TrkHistCat[i]+");track #phi ("+TrkHistCat[i]+");tracks",30,-3.15,3.15);
+    TrkDxy_alljets[i] = ibook.book1D("TrkDxy_"+TrkHistCat[i],"Track dxy ("+TrkHistCat[i]+");track dxy ("+TrkHistCat[i]+");tracks",30,-0.1,0.1);
+    TrkDz_alljets[i] = ibook.book1D("TrkDz_"+TrkHistCat[i],"Track dz ("+TrkHistCat[i]+");track dz ("+TrkHistCat[i]+");tracks",30,-0.1,0.1);
+    TrkHitAll_alljets[i] = ibook.book1D("TrkHitAll_"+TrkHistCat[i],"Number of tracker hits ("+TrkHistCat[i]+");track number of all hits ("+TrkHistCat[i]+");tracks",31,-0.5,30.5);
+    TrkHitStrip_alljets[i] = ibook.book1D("TrkHitStrip_"+TrkHistCat[i],"Number of strip hits ("+TrkHistCat[i]+");track number of strip hits ("+TrkHistCat[i]+");tracks",31,-0.5,30.5);
+    TrkHitPixel_alljets[i] = ibook.book1D("TrkHitPixel_"+TrkHistCat[i],"Number of pixel hits ("+TrkHistCat[i]+");track number of pixel hits ("+TrkHistCat[i]+");tracks",9,-0.5,8.5);
+    if (i < 5){ // Fakes (i == 5) have no truth by definition!
+        TrkTruthPt_alljets[i] = ibook.book1D("TrkTruthPt_"+TrkHistCat[i],"Track pT ("+TrkHistCat[i]+" Truth);track p_{T} ("+TrkHistCat[i]+" Truth);tracks",30,0,100);
+        TrkTruthEta_alljets[i] = ibook.book1D("TrkTruthEta_"+TrkHistCat[i],"Track #eta ("+TrkHistCat[i]+" Truth);track #eta ("+TrkHistCat[i]+" Truth);tracks",30,-2.5,2.5);
+        TrkTruthPhi_alljets[i] = ibook.book1D("TrkTruthPhi_"+TrkHistCat[i],"Track #phi ("+TrkHistCat[i]+" Truth);track #phi ("+TrkHistCat[i]+" Truth);tracks",30,-3.15,3.15);
+        TrkTruthDxy_alljets[i] = ibook.book1D("TrkTruthDxy_"+TrkHistCat[i],"Track dxy ("+TrkHistCat[i]+" Truth);track dxy ("+TrkHistCat[i]+" Truth);tracks",30,-0.1,0.1);
+        TrkTruthDz_alljets[i] = ibook.book1D("TrkTruthDz_"+TrkHistCat[i],"Track dz ("+TrkHistCat[i]+" Truth);track dz ("+TrkHistCat[i]+" Truth);tracks",30,-0.1,0.1);
+        TrkTruthHitAll_alljets[i] = ibook.book1D("TrkTruthHitAll_"+TrkHistCat[i],"Number of tracker hits ("+TrkHistCat[i]+" Truth);track number of all hits ("+TrkHistCat[i]+" Truth);tracks",31,-0.5,30.5);
+        TrkTruthHitStrip_alljets[i] = ibook.book1D("TrkTruthHitStrip_"+TrkHistCat[i],"Number of strip hits ("+TrkHistCat[i]+" Truth);track number of strip hits ("+TrkHistCat[i]+" Truth);tracks",31,-0.5,30.5);
+        TrkTruthHitPixel_alljets[i] = ibook.book1D("TrkTruthHitPixel_"+TrkHistCat[i],"Number of pixel hits ("+TrkHistCat[i]+" Truth);track number of pixel hits ("+TrkHistCat[i]+" Truth);tracks",9,-0.5,8.5);
+    }
+  }
+}
+
+
+// ---------- Destructor -----------
+
+BDHadronTrackMonitoringAnalyzer::~BDHadronTrackMonitoringAnalyzer()
+{  
+}
+
+
+// ---------- Analyze -----------
+// This is needed to get a TrackingParticle --> Cluster match (instead of Cluster-->TP) 
+using P = std::pair<OmniClusterRef, TrackingParticleRef>;
+bool compare(const P& i, const P& j) {
+    return i.second.index() > j.second.index();
+}
+
+void BDHadronTrackMonitoringAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  edm::Handle<pat::JetCollection> patJetsColl;
+  iEvent.getByToken(PatJetCollectionTag_, patJetsColl);
+
+  edm::Handle<reco::TrackCollection> tracksHandle;
+  iEvent.getByToken(TrackCollectionTag_,tracksHandle);
+
+  edm::Handle<ClusterTPAssociation> pCluster2TPListH;
+  iEvent.getByToken(clusterTPMapToken_, pCluster2TPListH);
+  const ClusterTPAssociation& clusterToTPMap = *pCluster2TPListH;
+
+  edm::ESHandle<TransientTrackBuilder> trackBuilder ;
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
+
+  classifier_.newEvent(iEvent, iSetup);
+
+  // -----Primary Vertex-----
+  const reco::Vertex *pv;
+
+  edm::Handle<reco::VertexCollection> primaryVertex ;
+  iEvent.getByToken(PrimaryVertexColl_,primaryVertex);
+
+  bool pvFound = (primaryVertex->size() != 0);
+  if ( pvFound ) {
+    pv = &(*primaryVertex->begin());
+  }
+  else {
+    reco::Vertex::Error e;
+    e(0,0)=0.0015*0.0015;
+    e(1,1)=0.0015*0.0015;
+    e(2,2)=15.*15.;
+    reco::Vertex::Point p(0,0,0);
+    pv=  new reco::Vertex(p,e,1,1,1);
+  }
+  // -----------------------
+
+
+  // -------- Loop Over Jets ----------
+  for ( pat::JetCollection::const_iterator jet = patJetsColl->begin(); jet != patJetsColl->end(); ++jet ) {
+    if ( ( jet->pt() < minJetPt_ || std::fabs( jet->eta() ) > maxJetEta_ ) ) continue;
+
+    unsigned int flav = abs(jet->hadronFlavour());
+
+
+    //std::cout << "is there a taginfo? " << jet->hasTagInfo(ipTagInfos_.c_str()) << std::endl;
+    const CandIPTagInfo *trackIpTagInfo = jet->tagInfoCandIP(ipTagInfos_.c_str());
+    const std::vector<edm::Ptr<reco::Candidate> > & selectedTracks( trackIpTagInfo->selectedTracks() );
+
+
+    unsigned int nseltracks = 0;
+    int nseltracksCat[6] = {0,0,0,0,0,0}; // following the order of TrkHistCat
+    //int nseltracksTruthCat[6] = {0,0,0,0,0,0}; // following the order of TrkHistCat
+    //unsigned int nseltracksTruth = 0;
+
+    unsigned int nTrackSize = selectedTracks.size(); // number of tracks from IPInfos to loop over
+    // -------- Loop Over (selected) Tracks ----------
+    for (unsigned int itt=0; itt < nTrackSize; ++itt)
+    {
+        const TrackBaseRef ptrackRef = toTrackRef(selectedTracks[itt]);
+        const reco::Track * ptrackPtr = reco::btag::toTrack(ptrackRef);
+        const reco::Track & ptrack = *ptrackPtr;
+    
+        reco::TransientTrack transientTrack = trackBuilder->build(ptrackPtr);
+        GlobalVector direction(jet->px(), jet->py(), jet->pz());
+    
+        Double_t distJetAxis = IPTools::jetTrackDistance(transientTrack, direction, *pv).second.value();
+    
+        Double_t decayLength=999;
+        TrajectoryStateOnSurface closest = IPTools::closestApproachToJet(transientTrack.impactPointState(), *pv, direction, transientTrack.field());
+        if (closest.isValid())
+            decayLength =  (closest.globalPosition() - RecoVertex::convertPos(pv->position())).mag();
+        else
+            decayLength = 999;
+    
+        // extra cut ons the tracks
+        if (std::fabs(distJetAxis) > distJetAxis_ || decayLength > decayLength_){
+            continue;
+        }
+        nseltracks+=1; // if it passed these cuts, nselectedtracks +1
+    
+    
+        TrackCategories::Flags theFlag = classifier_.evaluate( toTrackRef(selectedTracks[itt]) ).flags();
+    
+        double TrkPt = ptrack.pt();
+        double TrkEta = ptrack.eta();
+        double TrkPhi = ptrack.phi();
+        double TrkDxy = ptrack.dxy(pv->position());
+        double TrkDz = ptrack.dz(pv->position());
+        int TrknHitAll = ptrack.numberOfValidHits();
+        int TrknHitPixel = ptrack.hitPattern().numberOfValidPixelHits();
+        int TrknHitStrip = ptrack.hitPattern().numberOfValidStripHits();
+
+    
+        double TrkTruthPt=-99;
+        double TrkTruthEta=-99;
+        double TrkTruthPhi=-99;
+        double TrkTruthDxy=-1;
+        double TrkTruthDz=-1;
+        int TrkTruthnHitAll=-1;
+        int TrkTruthnHitPixel=-1;
+        int TrkTruthnHitStrip=-1;
+    
+        // Get corresponding Trackingparticle
+        std::pair<TrackingParticleRef, double> res = classifier_.history().getMatchedTrackingParticle();
+        TrackingParticleRef tpr = res.first;
+        double quality_tpr = res.second;
+    
+        // Match TP to hit-cluster (re-ordering according to TP rather than clusters and look for equal_range of a given tpr)
+        auto clusterTPmap = clusterToTPMap.map();
+        std::sort(clusterTPmap.begin(), clusterTPmap.end(), compare);
+        auto clusterRange = std::equal_range(clusterTPmap.begin(), clusterTPmap.end(),std::make_pair(OmniClusterRef(), tpr), compare);
+        if (quality_tpr != 0) {
+            //nseltracksTruth +=1;
+        
+            TrkTruthPt = tpr->pt();
+            TrkTruthEta = tpr->eta();
+            TrkTruthPhi = tpr->phi();
+        
+            TrackingParticle::Point vertex_pv = pv->position();
+            TrackingParticle::Point vertex_tpr = tpr->vertex();
+            TrackingParticle::Vector momentum_tpr = tpr->momentum();
+            TrkTruthDxy = (-(vertex_tpr.x()-vertex_pv.x())*momentum_tpr.y()+(vertex_tpr.y()-vertex_pv.y())*momentum_tpr.x())/tpr->pt();
+            TrkTruthDz = (vertex_tpr.z()-vertex_pv.z()) - ((vertex_tpr.x()-vertex_pv.x())*momentum_tpr.x()+(vertex_tpr.y()-vertex_pv.y())*momentum_tpr.y())/sqrt(momentum_tpr.perp2()) * momentum_tpr.z()/sqrt(momentum_tpr.perp2());
+
+            TrkTruthnHitAll = 0;
+            TrkTruthnHitPixel = 0;
+            TrkTruthnHitStrip = 0;
+            if( clusterRange.first != clusterRange.second ) {
+                for( auto ip=clusterRange.first; ip != clusterRange.second; ++ip ) {
+                    const OmniClusterRef& cluster = ip->first;
+                    if (cluster.isPixel() && cluster.isValid()){ TrkTruthnHitPixel+=1;}
+                    if (cluster.isStrip() && cluster.isValid()){ TrkTruthnHitStrip+=1;}
+                }
+            }
+            TrkTruthnHitAll = TrkTruthnHitPixel + TrkTruthnHitStrip;
+        
+            /*
+            if ( theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::BWeakDecay] && theFlag[TrackCategories::CWeakDecay] ) {nseltracksTruthCat[0] += 1;}
+            else if ( theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::BWeakDecay] && !theFlag[TrackCategories::CWeakDecay] ) {nseltracksTruthCat[1] += 1;}
+            else if ( theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::BWeakDecay] && theFlag[TrackCategories::CWeakDecay] ) {nseltracksTruthCat[2] += 1;}
+            else if ( !theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::Fake] ) {nseltracksTruthCat[3] += 1;}
+            else if ( !theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::Fake] ) {nseltracksTruthCat[4] += 1;}
+            else{ nseltracksTruthCat[5] += 1; }
+            */
+        
+        }
+    
+    
+    
+        // ----------- Filling the correct histograms based on jet flavour and Track history Category --------
+    
+    
+        //BCWeakDecay
+        if ( theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::BWeakDecay] && theFlag[TrackCategories::CWeakDecay] ) {
+            nseltracksCat[0] += 1;
+            TrkPt_alljets[0]->Fill(TrkPt);
+            TrkEta_alljets[0]->Fill(TrkEta);
+            TrkPhi_alljets[0]->Fill(TrkPhi);
+            TrkDxy_alljets[0]->Fill(TrkDxy);
+            TrkDz_alljets[0]->Fill(TrkDz);
+            TrkHitAll_alljets[0]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[0]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[0]->Fill(TrknHitStrip);
+            if (quality_tpr != 0) {
+                TrkTruthPt_alljets[0]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[0]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[0]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[0]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[0]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[0]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[0]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[0]->Fill(TrkTruthnHitStrip);
+            }
+        }
+        //BWeakDecay
+        else if ( theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::BWeakDecay] && !theFlag[TrackCategories::CWeakDecay] ) {
+            nseltracksCat[1] += 1;
+            TrkPt_alljets[1]->Fill(TrkPt);
+            TrkEta_alljets[1]->Fill(TrkEta);
+            TrkPhi_alljets[1]->Fill(TrkPhi);
+            TrkDxy_alljets[1]->Fill(TrkDxy);
+            TrkDz_alljets[1]->Fill(TrkDz);
+            TrkHitAll_alljets[1]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[1]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[1]->Fill(TrknHitStrip);
+            if (quality_tpr != 0) {
+                TrkTruthPt_alljets[1]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[1]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[1]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[1]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[1]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[1]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[1]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[1]->Fill(TrkTruthnHitStrip);
+            }
+        }
+        //CWeakDecay
+        else if ( theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::BWeakDecay] && theFlag[TrackCategories::CWeakDecay] ) {
+            nseltracksCat[2] += 1;
+            TrkPt_alljets[2]->Fill(TrkPt);
+            TrkEta_alljets[2]->Fill(TrkEta);
+            TrkPhi_alljets[2]->Fill(TrkPhi);
+            TrkDxy_alljets[2]->Fill(TrkDxy);
+            TrkDz_alljets[2]->Fill(TrkDz);
+            TrkHitAll_alljets[2]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[2]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[2]->Fill(TrknHitStrip);
+            if (quality_tpr != 0) {
+                TrkTruthPt_alljets[2]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[2]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[2]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[2]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[2]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[2]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[2]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[2]->Fill(TrkTruthnHitStrip);
+            }
+        }
+        //PU
+        else if ( !theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::Fake] ) {
+            nseltracksCat[3] += 1;
+            TrkPt_alljets[3]->Fill(TrkPt);
+            TrkEta_alljets[3]->Fill(TrkEta);
+            TrkPhi_alljets[3]->Fill(TrkPhi);
+            TrkDxy_alljets[3]->Fill(TrkDxy);
+            TrkDz_alljets[3]->Fill(TrkDz);
+            TrkHitAll_alljets[3]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[3]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[3]->Fill(TrknHitStrip);
+            if (quality_tpr != 0) {
+                TrkTruthPt_alljets[3]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[3]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[3]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[3]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[3]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[3]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[3]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[3]->Fill(TrkTruthnHitStrip);
+            }
+        }
+        //Other
+        else if ( theFlag[TrackCategories::SignalEvent] && !theFlag[TrackCategories::BWeakDecay] && !theFlag[TrackCategories::CWeakDecay] ){
+            nseltracksCat[4] += 1;
+            TrkPt_alljets[4]->Fill(TrkPt);
+            TrkEta_alljets[4]->Fill(TrkEta);
+            TrkPhi_alljets[4]->Fill(TrkPhi);
+            TrkDxy_alljets[4]->Fill(TrkDxy);
+            TrkDz_alljets[4]->Fill(TrkDz);
+            TrkHitAll_alljets[4]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[4]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[4]->Fill(TrknHitStrip);
+            if (quality_tpr != 0) {
+                TrkTruthPt_alljets[4]->Fill(TrkTruthPt);
+                TrkTruthEta_alljets[4]->Fill(TrkTruthEta);
+                TrkTruthPhi_alljets[4]->Fill(TrkTruthPhi);
+                TrkTruthDxy_alljets[4]->Fill(TrkTruthDxy);
+                TrkTruthDz_alljets[4]->Fill(TrkTruthDz);
+                TrkTruthHitAll_alljets[4]->Fill(TrkTruthnHitAll);
+                TrkTruthHitPixel_alljets[4]->Fill(TrkTruthnHitPixel);
+                TrkTruthHitStrip_alljets[4]->Fill(TrkTruthnHitStrip);
+            }
+        }
+        //Fake
+        else if ( !theFlag[TrackCategories::SignalEvent] && theFlag[TrackCategories::Fake] ) {
+            nseltracksCat[5] += 1;
+            TrkPt_alljets[5]->Fill(TrkPt);
+            TrkEta_alljets[5]->Fill(TrkEta);
+            TrkPhi_alljets[5]->Fill(TrkPhi);
+            TrkDxy_alljets[5]->Fill(TrkDxy);
+            TrkDz_alljets[5]->Fill(TrkDz);
+            TrkHitAll_alljets[5]->Fill(TrknHitAll);
+            TrkHitPixel_alljets[5]->Fill(TrknHitPixel);
+            TrkHitStrip_alljets[5]->Fill(TrknHitStrip);
+            // NO TRUTH FOR FAKES!!!
+        }
+    
+    
+
+    }
+    // -------- END Loop Over (selected) Tracks ----------
+
+    // Still have to fill some jet-flavour specific variables
+    if (flav == 5){
+        nTrkAll_bjet->Fill(nseltracks);
+        //nTrkTruthAll_bjet->Fill(nseltracksTruth);
+        for (unsigned int i = 0; i < TrkHistCat.size(); i++){
+            nTrk_bjet[i]->Fill(nseltracksCat[i]);
+            //nTrkTruth_bjet[i]->Fill(nseltracksTruthCat[i]);
+        }
+    }
+    else if (flav == 4){
+        nTrkAll_cjet->Fill(nseltracks);
+        //nTrkTruthAll_cjet->Fill(nseltracksTruth);
+        for (unsigned int i = 0; i < TrkHistCat.size(); i++){
+            nTrk_cjet[i]->Fill(nseltracksCat[i]);
+            //nTrkTruth_cjet[i]->Fill(nseltracksTruthCat[i]);
+        }
+    }
+    else {
+        nTrkAll_dusgjet->Fill(nseltracks);
+        //nTrkTruthAll_dusgjet->Fill(nseltracksTruth);
+        for (unsigned int i = 0; i < TrkHistCat.size(); i++){
+            nTrk_dusgjet[i]->Fill(nseltracksCat[i]);
+            //nTrkTruth_dusgjet[i]->Fill(nseltracksTruthCat[i]);
+        }
+    }
+
+  }
+  // -------- END Loop Over Jets ----------
+
+
+}
+
+
+
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BDHadronTrackMonitoringAnalyzer);

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
@@ -41,22 +41,6 @@ using namespace reco;
 using namespace edm;
 using namespace std;
 
-typedef std::pair<unsigned int, std::string> intstrpair;
-const intstrpair map_start_values[] = {
-  intstrpair(0, "BCWeakDecay"),
-  intstrpair(1, "BWeakDecay"),
-  intstrpair(2, "CWeakDecay"),
-  intstrpair(3, "PU"),
-  intstrpair(4, "Other"),
-  intstrpair(5, "Fake") 
-};
-const int map_start_values_size = sizeof(map_start_values) / sizeof(map_start_values[0]);
-
-extern std::map<unsigned int, std::string> TrkHistCat;
-
-
-
-
 
 
 /** \class BDHadronTrackMonitoringAnalyzer
@@ -76,6 +60,9 @@ class BDHadronTrackMonitoringAnalyzer : public DQMEDAnalyzer {
     virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
     virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;     
 
+   
+    enum HistoryClasses{ BCWeakDecay=0, BWeakDecay=1, CWeakDecay=2, PU=3, Other=4, Fake=5};
+    static const std::vector<std::string> TrkHistCat;
 
    private:
 

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
@@ -1,0 +1,97 @@
+#ifndef BDHadronTrackMonitoringAnalyzer_H
+#define BDHadronTrackMonitoringAnalyzer_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/BTauReco/interface/TrackIPTagInfo.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+
+#include "SimTracker/TrackHistory/interface/TrackCategories.h"
+#include "SimTracker/TrackHistory/interface/TrackClassifier.h"
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
+
+
+
+
+
+/** \class BDHadronTrackMonitoringAnalyzer
+ *
+ *  Top level steering routine for B + D hadron track monitoring tool from RECODEBUG samples.
+ *
+ */
+
+class BDHadronTrackMonitoringAnalyzer : public DQMEDAnalyzer {
+   public:
+    explicit BDHadronTrackMonitoringAnalyzer(const edm::ParameterSet& pSet);
+
+    ~BDHadronTrackMonitoringAnalyzer();
+
+    virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+    virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;     
+
+
+   private:
+
+    //cut values
+    double distJetAxis_;
+    double decayLength_;
+    double minJetPt_;
+    double maxJetEta_;
+
+    // strings
+    std::string ipTagInfos_;
+
+    // InputTags
+    edm::InputTag PatJetSrc_;
+    edm::InputTag TrackSrc_;
+    edm::InputTag PVSrc_;
+    edm::InputTag ClusterTPMapSrc_;
+
+    // Tokens
+    edm::EDGetTokenT<pat::JetCollection> PatJetCollectionTag_;
+    edm::EDGetTokenT<reco::TrackCollection> TrackCollectionTag_;
+    edm::EDGetTokenT<reco::VertexCollection> PrimaryVertexColl_;
+    edm::EDGetTokenT<ClusterTPAssociation> clusterTPMapToken_;
+
+    // TrackClassifier
+    TrackClassifier classifier_;
+
+
+    // Histograms
+    // b jets
+    MonitorElement *nTrkAll_bjet; // total number of selected tracks (or TrackingParticles)
+    MonitorElement *nTrk_bjet[6]; // total number of selected tracks (or TrackingParticles) in each TrackHistory category
+    // c jets
+    MonitorElement *nTrkAll_cjet; // total number of selected tracks (or TrackingParticles)
+    MonitorElement *nTrk_cjet[6]; // total number of selected tracks (or TrackingParticles) in each TrackHistory category
+    // dusg jets
+    MonitorElement *nTrkAll_dusgjet; // total number of selected tracks (or TrackingParticles)
+    MonitorElement *nTrk_dusgjet[6]; // total number of selected tracks (or TrackingParticles) in each TrackHistory category
+    
+    // track properties for all flavours combined
+    MonitorElement *TrkPt_alljets[6], *TrkTruthPt_alljets[5]; // Pt of selected tracks (or TrackingParticles)
+    MonitorElement *TrkEta_alljets[6], *TrkTruthEta_alljets[5]; // Eta of selected tracks (or TrackingParticles)
+    MonitorElement *TrkPhi_alljets[6], *TrkTruthPhi_alljets[5]; // Phi of selected tracks (or TrackingParticles)
+    MonitorElement *TrkDxy_alljets[6], *TrkTruthDxy_alljets[5]; // Transverse IP of selected tracks (or TrackingParticles)
+    MonitorElement *TrkDz_alljets[6], *TrkTruthDz_alljets[5]; // Longitudinal IP of selected tracks (or TrackingParticles)
+    MonitorElement *TrkHitAll_alljets[6], *TrkTruthHitAll_alljets[5]; // total number Tracker hits of selected tracks (or TrackingParticles)
+    MonitorElement *TrkHitStrip_alljets[6], *TrkTruthHitStrip_alljets[5]; // number of strip hits of of selected tracks (or TrackingParticles)
+    MonitorElement *TrkHitPixel_alljets[6], *TrkTruthHitPixel_alljets[5]; // number of pixel hits of selected tracks (or TrackingParticles)
+
+
+};
+
+
+#endif

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h
@@ -22,6 +22,39 @@
 #include "SimTracker/TrackHistory/interface/TrackClassifier.h"
 #include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
 
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+
+#include "DQMOffline/RecoB/interface/Tools.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+#include "RecoVertex/VertexPrimitives/interface/ConvertToFromReco.h"
+
+#include <iostream>
+#include <fstream>
+
+using namespace reco;
+using namespace edm;
+using namespace std;
+
+typedef std::pair<unsigned int, std::string> intstrpair;
+const intstrpair map_start_values[] = {
+  intstrpair(0, "BCWeakDecay"),
+  intstrpair(1, "BWeakDecay"),
+  intstrpair(2, "CWeakDecay"),
+  intstrpair(3, "PU"),
+  intstrpair(4, "Other"),
+  intstrpair(5, "Fake") 
+};
+const int map_start_values_size = sizeof(map_start_values) / sizeof(map_start_values[0]);
+
+extern std::map<unsigned int, std::string> TrkHistCat;
+
+
 
 
 
@@ -31,6 +64,8 @@
  *  Top level steering routine for B + D hadron track monitoring tool from RECODEBUG samples.
  *
  */
+
+
 
 class BDHadronTrackMonitoringAnalyzer : public DQMEDAnalyzer {
    public:

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
@@ -1,0 +1,226 @@
+#include "Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DQMOffline/RecoB/interface/Tools.h"
+#include "DQMOffline/RecoB/interface/TagInfoPlotterFactory.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+using namespace edm;
+using namespace std;
+using namespace RecoBTag;
+
+std::map<unsigned int, std::string> TrkHistCategories{
+    {0, "BCWeakDecay"},
+    {1, "BWeakDecay"},
+    {2, "CWeakDecay"},
+    {3, "PU"},
+    {4, "Other"},
+    {5, "Fake"}    
+};
+
+typedef std::map<unsigned int, std::string>::iterator it_type;
+
+BDHadronTrackMonitoringHarvester::BDHadronTrackMonitoringHarvester(const edm::ParameterSet& pSet) 
+{
+}
+
+
+BDHadronTrackMonitoringHarvester::~BDHadronTrackMonitoringHarvester()
+{
+}
+
+void BDHadronTrackMonitoringHarvester::beginJob()
+{
+}
+
+void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IGetter & iget)
+{
+    // ***********************
+    //
+    // Book all new histograms.
+    //
+    // ***********************
+    RecoBTag::setTDRStyle();
+
+    // b jets
+    // absolute average number of tracks
+    nTrk_absolute_bjet = ibook.book1D("nTrk_absolute_bjet","absolute average number of tracks in b jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_absolute_bjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_absolute_bjet->setAxisRange(0, 5, 2);
+    nTrk_absolute_bjet->setAxisTitle("average number of tracks",2);
+
+    // relative (in percent) average number of tracks
+    nTrk_relative_bjet = ibook.book1D("nTrk_relative_bjet","relative average number of tracks in b jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_relative_bjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_relative_bjet->setAxisRange(0, 1, 2);
+    nTrk_relative_bjet->setAxisTitle("average fraction of tracks",2);
+
+    // standard deviation of number of tracks
+    nTrk_std_bjet = ibook.book1D("nTrk_std_bjet","RMS of number of tracks in b jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_std_bjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_std_bjet->setAxisRange(0, 3, 2);
+    nTrk_std_bjet->setAxisTitle("RMS of number of tracks",2);
+
+
+
+
+    // c jets
+    nTrk_absolute_cjet = ibook.book1D("nTrk_absolute_cjet","absolute average number of tracks in c jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_absolute_cjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_absolute_cjet->setAxisRange(0, 5, 2);
+    nTrk_absolute_cjet->setAxisTitle("average number of tracks",2);
+
+    nTrk_relative_cjet = ibook.book1D("nTrk_relative_cjet","relative average number of tracks in c jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_relative_cjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_relative_cjet->setAxisRange(0, 1, 2);
+    nTrk_relative_cjet->setAxisTitle("average fraction of tracks",2);
+
+    nTrk_std_cjet = ibook.book1D("nTrk_std_cjet","RMS of number of tracks in c jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_std_cjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_std_cjet->setAxisRange(0, 3, 2);
+    nTrk_std_cjet->setAxisTitle("RMS of number of tracks",2);
+
+
+
+    // udsg jets
+    nTrk_absolute_dusgjet = ibook.book1D("nTrk_absolute_dusgjet","absolute average number of tracks in dusg jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_absolute_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_absolute_dusgjet->setAxisRange(0, 5, 2);
+    nTrk_absolute_dusgjet->setAxisTitle("average number of tracks",2);
+
+    nTrk_relative_dusgjet = ibook.book1D("nTrk_relative_dusgjet","relative average number of tracks in dusg jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_relative_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_relative_dusgjet->setAxisRange(0, 1, 2);
+    nTrk_relative_dusgjet->setAxisTitle("average fraction of tracks",2);
+
+    nTrk_std_dusgjet = ibook.book1D("nTrk_std_dusgjet","RMS of number of tracks in dusg jets",6,-0.5,5.5);
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_std_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
+    }
+    nTrk_std_dusgjet->setAxisRange(0, 3, 2);
+    nTrk_std_dusgjet->setAxisTitle("RMS of number of tracks",2);
+
+
+    // ***********************
+    //
+    // get all the old histograms
+    //
+    // ***********************
+
+    // b jets
+    MonitorElement *nTrk_bjet[6];
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_bjet[iterator->first] = iget.get("nTrk_bjet_"+iterator->second);
+    }
+    MonitorElement *nTrkAll_bjet = iget.get("nTrkAll_bjet");
+
+    // c jets
+    MonitorElement *nTrk_cjet[6];
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_cjet[iterator->first] = iget.get("nTrk_cjet_"+iterator->second);
+    }
+    MonitorElement *nTrkAll_cjet = iget.get("nTrkAll_cjet");
+
+    // dusg jets
+    MonitorElement *nTrk_dusgjet[6];
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        nTrk_dusgjet[iterator->first] = iget.get("nTrk_dusgjet_"+iterator->second);
+    }
+    MonitorElement *nTrkAll_dusgjet = iget.get("nTrkAll_dusgjet");
+
+
+
+    // ***********************
+    //
+    // Calculate contents of new histograms
+    //
+    // ***********************
+
+    // b jets
+    float mean_bjets[6];
+    float std_bjets[6];
+    float meanAll_bjets;
+    meanAll_bjets = nTrkAll_bjet->getMean(1);
+    for (unsigned int i = 0; i< TrkHistCategories.size(); i++){
+        mean_bjets[i] = nTrk_bjet[i]->getMean(1); // mean number of tracks per category
+        std_bjets[i] = nTrk_bjet[i]->getRMS(1);
+        nTrk_absolute_bjet->setBinContent(i+1,mean_bjets[i]);
+        nTrk_relative_bjet->setBinContent(i+1,mean_bjets[i]/meanAll_bjets);
+        nTrk_std_bjet->setBinContent(i+1,std_bjets[i]);
+    }
+
+    // c jets
+    float mean_cjets[6];
+    float std_cjets[6];
+    float meanAll_cjets;
+    meanAll_cjets = nTrkAll_cjet->getMean(1);
+    for (unsigned int i = 0; i< TrkHistCategories.size(); i++){
+        mean_cjets[i] = nTrk_cjet[i]->getMean(1); // mean number of tracks per category
+        std_cjets[i] = nTrk_cjet[i]->getRMS(1);
+        nTrk_absolute_cjet->setBinContent(i+1,mean_cjets[i]);
+        nTrk_relative_cjet->setBinContent(i+1,mean_cjets[i]/meanAll_cjets);
+        nTrk_std_cjet->setBinContent(i+1,std_cjets[i]);
+    }
+
+
+    // dusg jets
+    float mean_dusgjets[6];
+    float std_dusgjets[6];
+    float meanAll_dusgjets;
+    meanAll_dusgjets = nTrkAll_dusgjet->getMean(1);
+    for (unsigned int i = 0; i< TrkHistCategories.size(); i++){
+        mean_dusgjets[i] = nTrk_dusgjet[i]->getMean(1); // mean number of tracks per category
+        std_dusgjets[i] = nTrk_dusgjet[i]->getRMS(1);
+        nTrk_absolute_dusgjet->setBinContent(i+1,mean_dusgjets[i]);
+        nTrk_relative_dusgjet->setBinContent(i+1,mean_dusgjets[i]/meanAll_dusgjets);
+        nTrk_std_dusgjet->setBinContent(i+1,std_dusgjets[i]);
+    }
+
+
+    // ***********************
+    //
+    // Remove histograms with nTracks that we do not want to show
+    //
+    // ***********************
+
+    // b jets
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        iget.removeElement("nTrk_bjet_"+iterator->second);
+    }
+    iget.removeElement("nTrkAll_bjet");
+
+    // c jets
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        iget.removeElement("nTrk_cjet_"+iterator->second);
+    }
+    iget.removeElement("nTrkAll_cjet");
+
+    // dusg jets
+    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+        iget.removeElement("nTrk_dusgjet_"+iterator->second);
+    }
+    iget.removeElement("nTrkAll_dusgjet");
+
+
+
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BDHadronTrackMonitoringHarvester);

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
@@ -1,10 +1,10 @@
 #include "Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.h"
 
 // intialize category map
-//std::map<unsigned int, std::string> TrkHistCat(map_start_values, map_start_values + map_start_values_size);
+//std::map<unsigned int, std::string> BDHadronTrackMonitoringAnalyzer::TrkHistCat(map_start_values, map_start_values + map_start_values_size);
 
 
-typedef std::map<unsigned int, std::string>::iterator it_type;
+//typedef std::map<unsigned int, std::string>::iterator it_type;
 
 BDHadronTrackMonitoringHarvester::BDHadronTrackMonitoringHarvester(const edm::ParameterSet& pSet) 
 {
@@ -31,24 +31,24 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     // b jets
     // absolute average number of tracks
     nTrk_absolute_bjet = ibook.book1D("nTrk_absolute_bjet","absolute average number of tracks in b jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_absolute_bjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_absolute_bjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_absolute_bjet->setAxisRange(0, 5, 2);
     nTrk_absolute_bjet->setAxisTitle("average number of tracks",2);
 
     // relative (in percent) average number of tracks
     nTrk_relative_bjet = ibook.book1D("nTrk_relative_bjet","relative average number of tracks in b jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_relative_bjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_relative_bjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_relative_bjet->setAxisRange(0, 1, 2);
     nTrk_relative_bjet->setAxisTitle("average fraction of tracks",2);
 
     // standard deviation of number of tracks
     nTrk_std_bjet = ibook.book1D("nTrk_std_bjet","RMS of number of tracks in b jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_std_bjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_std_bjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_std_bjet->setAxisRange(0, 3, 2);
     nTrk_std_bjet->setAxisTitle("RMS of number of tracks",2);
@@ -58,22 +58,22 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // c jets
     nTrk_absolute_cjet = ibook.book1D("nTrk_absolute_cjet","absolute average number of tracks in c jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_absolute_cjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_absolute_cjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_absolute_cjet->setAxisRange(0, 5, 2);
     nTrk_absolute_cjet->setAxisTitle("average number of tracks",2);
 
     nTrk_relative_cjet = ibook.book1D("nTrk_relative_cjet","relative average number of tracks in c jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_relative_cjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_relative_cjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_relative_cjet->setAxisRange(0, 1, 2);
     nTrk_relative_cjet->setAxisTitle("average fraction of tracks",2);
 
     nTrk_std_cjet = ibook.book1D("nTrk_std_cjet","RMS of number of tracks in c jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_std_cjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_std_cjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_std_cjet->setAxisRange(0, 3, 2);
     nTrk_std_cjet->setAxisTitle("RMS of number of tracks",2);
@@ -82,22 +82,22 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // udsg jets
     nTrk_absolute_dusgjet = ibook.book1D("nTrk_absolute_dusgjet","absolute average number of tracks in dusg jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_absolute_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_absolute_dusgjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_absolute_dusgjet->setAxisRange(0, 5, 2);
     nTrk_absolute_dusgjet->setAxisTitle("average number of tracks",2);
 
     nTrk_relative_dusgjet = ibook.book1D("nTrk_relative_dusgjet","relative average number of tracks in dusg jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_relative_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_relative_dusgjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_relative_dusgjet->setAxisRange(0, 1, 2);
     nTrk_relative_dusgjet->setAxisTitle("average fraction of tracks",2);
 
     nTrk_std_dusgjet = ibook.book1D("nTrk_std_dusgjet","RMS of number of tracks in dusg jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_std_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_std_dusgjet->setBinLabel(i+1,BDHadronTrackMonitoringAnalyzer::TrkHistCat[i],1);
     }
     nTrk_std_dusgjet->setAxisRange(0, 3, 2);
     nTrk_std_dusgjet->setAxisTitle("RMS of number of tracks",2);
@@ -111,22 +111,22 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // b jets
     MonitorElement *nTrk_bjet[6];
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_bjet[iterator->first] = iget.get("nTrk_bjet_"+iterator->second);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_bjet[i] = iget.get("nTrk_bjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
     MonitorElement *nTrkAll_bjet = iget.get("nTrkAll_bjet");
 
     // c jets
     MonitorElement *nTrk_cjet[6];
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_cjet[iterator->first] = iget.get("nTrk_cjet_"+iterator->second);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_cjet[i] = iget.get("nTrk_cjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
     MonitorElement *nTrkAll_cjet = iget.get("nTrkAll_cjet");
 
     // dusg jets
     MonitorElement *nTrk_dusgjet[6];
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        nTrk_dusgjet[iterator->first] = iget.get("nTrk_dusgjet_"+iterator->second);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        nTrk_dusgjet[i] = iget.get("nTrk_dusgjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
     MonitorElement *nTrkAll_dusgjet = iget.get("nTrkAll_dusgjet");
 
@@ -143,7 +143,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     float std_bjets[6];
     float meanAll_bjets;
     meanAll_bjets = nTrkAll_bjet->getMean(1);
-    for (unsigned int i = 0; i< TrkHistCat.size(); i++){
+    for (unsigned int i = 0; i< BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++){
         mean_bjets[i] = nTrk_bjet[i]->getMean(1); // mean number of tracks per category
         std_bjets[i] = nTrk_bjet[i]->getRMS(1);
         nTrk_absolute_bjet->setBinContent(i+1,mean_bjets[i]);
@@ -156,7 +156,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     float std_cjets[6];
     float meanAll_cjets;
     meanAll_cjets = nTrkAll_cjet->getMean(1);
-    for (unsigned int i = 0; i< TrkHistCat.size(); i++){
+    for (unsigned int i = 0; i< BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++){
         mean_cjets[i] = nTrk_cjet[i]->getMean(1); // mean number of tracks per category
         std_cjets[i] = nTrk_cjet[i]->getRMS(1);
         nTrk_absolute_cjet->setBinContent(i+1,mean_cjets[i]);
@@ -170,7 +170,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     float std_dusgjets[6];
     float meanAll_dusgjets;
     meanAll_dusgjets = nTrkAll_dusgjet->getMean(1);
-    for (unsigned int i = 0; i< TrkHistCat.size(); i++){
+    for (unsigned int i = 0; i< BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++){
         mean_dusgjets[i] = nTrk_dusgjet[i]->getMean(1); // mean number of tracks per category
         std_dusgjets[i] = nTrk_dusgjet[i]->getRMS(1);
         nTrk_absolute_dusgjet->setBinContent(i+1,mean_dusgjets[i]);
@@ -186,20 +186,20 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     // ***********************
 
     // b jets
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        iget.removeElement("nTrk_bjet_"+iterator->second);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        iget.removeElement("nTrk_bjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
     iget.removeElement("nTrkAll_bjet");
 
     // c jets
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        iget.removeElement("nTrk_cjet_"+iterator->second);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        iget.removeElement("nTrk_cjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
     iget.removeElement("nTrkAll_cjet");
 
     // dusg jets
-    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
-        iget.removeElement("nTrk_dusgjet_"+iterator->second);
+    for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
+        iget.removeElement("nTrk_dusgjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
     iget.removeElement("nTrkAll_dusgjet");
 

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
@@ -1,22 +1,8 @@
 #include "Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "DQMOffline/RecoB/interface/Tools.h"
-#include "DQMOffline/RecoB/interface/TagInfoPlotterFactory.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
-using namespace edm;
-using namespace std;
-using namespace RecoBTag;
+// intialize category map
+//std::map<unsigned int, std::string> TrkHistCat(map_start_values, map_start_values + map_start_values_size);
 
-std::map<unsigned int, std::string> TrkHistCategories{
-    {0, "BCWeakDecay"},
-    {1, "BWeakDecay"},
-    {2, "CWeakDecay"},
-    {3, "PU"},
-    {4, "Other"},
-    {5, "Fake"}    
-};
 
 typedef std::map<unsigned int, std::string>::iterator it_type;
 
@@ -45,7 +31,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     // b jets
     // absolute average number of tracks
     nTrk_absolute_bjet = ibook.book1D("nTrk_absolute_bjet","absolute average number of tracks in b jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_absolute_bjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_absolute_bjet->setAxisRange(0, 5, 2);
@@ -53,7 +39,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // relative (in percent) average number of tracks
     nTrk_relative_bjet = ibook.book1D("nTrk_relative_bjet","relative average number of tracks in b jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_relative_bjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_relative_bjet->setAxisRange(0, 1, 2);
@@ -61,7 +47,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // standard deviation of number of tracks
     nTrk_std_bjet = ibook.book1D("nTrk_std_bjet","RMS of number of tracks in b jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_std_bjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_std_bjet->setAxisRange(0, 3, 2);
@@ -72,21 +58,21 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // c jets
     nTrk_absolute_cjet = ibook.book1D("nTrk_absolute_cjet","absolute average number of tracks in c jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_absolute_cjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_absolute_cjet->setAxisRange(0, 5, 2);
     nTrk_absolute_cjet->setAxisTitle("average number of tracks",2);
 
     nTrk_relative_cjet = ibook.book1D("nTrk_relative_cjet","relative average number of tracks in c jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_relative_cjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_relative_cjet->setAxisRange(0, 1, 2);
     nTrk_relative_cjet->setAxisTitle("average fraction of tracks",2);
 
     nTrk_std_cjet = ibook.book1D("nTrk_std_cjet","RMS of number of tracks in c jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_std_cjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_std_cjet->setAxisRange(0, 3, 2);
@@ -96,21 +82,21 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // udsg jets
     nTrk_absolute_dusgjet = ibook.book1D("nTrk_absolute_dusgjet","absolute average number of tracks in dusg jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_absolute_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_absolute_dusgjet->setAxisRange(0, 5, 2);
     nTrk_absolute_dusgjet->setAxisTitle("average number of tracks",2);
 
     nTrk_relative_dusgjet = ibook.book1D("nTrk_relative_dusgjet","relative average number of tracks in dusg jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_relative_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_relative_dusgjet->setAxisRange(0, 1, 2);
     nTrk_relative_dusgjet->setAxisTitle("average fraction of tracks",2);
 
     nTrk_std_dusgjet = ibook.book1D("nTrk_std_dusgjet","RMS of number of tracks in dusg jets",6,-0.5,5.5);
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_std_dusgjet->setBinLabel(iterator->first+1,iterator->second,1);
     }
     nTrk_std_dusgjet->setAxisRange(0, 3, 2);
@@ -125,21 +111,21 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
 
     // b jets
     MonitorElement *nTrk_bjet[6];
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_bjet[iterator->first] = iget.get("nTrk_bjet_"+iterator->second);
     }
     MonitorElement *nTrkAll_bjet = iget.get("nTrkAll_bjet");
 
     // c jets
     MonitorElement *nTrk_cjet[6];
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_cjet[iterator->first] = iget.get("nTrk_cjet_"+iterator->second);
     }
     MonitorElement *nTrkAll_cjet = iget.get("nTrkAll_cjet");
 
     // dusg jets
     MonitorElement *nTrk_dusgjet[6];
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         nTrk_dusgjet[iterator->first] = iget.get("nTrk_dusgjet_"+iterator->second);
     }
     MonitorElement *nTrkAll_dusgjet = iget.get("nTrkAll_dusgjet");
@@ -157,7 +143,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     float std_bjets[6];
     float meanAll_bjets;
     meanAll_bjets = nTrkAll_bjet->getMean(1);
-    for (unsigned int i = 0; i< TrkHistCategories.size(); i++){
+    for (unsigned int i = 0; i< TrkHistCat.size(); i++){
         mean_bjets[i] = nTrk_bjet[i]->getMean(1); // mean number of tracks per category
         std_bjets[i] = nTrk_bjet[i]->getRMS(1);
         nTrk_absolute_bjet->setBinContent(i+1,mean_bjets[i]);
@@ -170,7 +156,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     float std_cjets[6];
     float meanAll_cjets;
     meanAll_cjets = nTrkAll_cjet->getMean(1);
-    for (unsigned int i = 0; i< TrkHistCategories.size(); i++){
+    for (unsigned int i = 0; i< TrkHistCat.size(); i++){
         mean_cjets[i] = nTrk_cjet[i]->getMean(1); // mean number of tracks per category
         std_cjets[i] = nTrk_cjet[i]->getRMS(1);
         nTrk_absolute_cjet->setBinContent(i+1,mean_cjets[i]);
@@ -184,7 +170,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     float std_dusgjets[6];
     float meanAll_dusgjets;
     meanAll_dusgjets = nTrkAll_dusgjet->getMean(1);
-    for (unsigned int i = 0; i< TrkHistCategories.size(); i++){
+    for (unsigned int i = 0; i< TrkHistCat.size(); i++){
         mean_dusgjets[i] = nTrk_dusgjet[i]->getMean(1); // mean number of tracks per category
         std_dusgjets[i] = nTrk_dusgjet[i]->getRMS(1);
         nTrk_absolute_dusgjet->setBinContent(i+1,mean_dusgjets[i]);
@@ -200,19 +186,19 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     // ***********************
 
     // b jets
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         iget.removeElement("nTrk_bjet_"+iterator->second);
     }
     iget.removeElement("nTrkAll_bjet");
 
     // c jets
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         iget.removeElement("nTrk_cjet_"+iterator->second);
     }
     iget.removeElement("nTrkAll_cjet");
 
     // dusg jets
-    for(it_type iterator = TrkHistCategories.begin(); iterator != TrkHistCategories.end(); iterator++) {
+    for(it_type iterator = TrkHistCat.begin(); iterator != TrkHistCat.end(); iterator++) {
         iget.removeElement("nTrk_dusgjet_"+iterator->second);
     }
     iget.removeElement("nTrkAll_dusgjet");

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.h
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.h
@@ -4,6 +4,17 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DQMOffline/RecoB/interface/Tools.h"
+#include "DQMOffline/RecoB/interface/TagInfoPlotterFactory.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+using namespace edm;
+using namespace std;
+using namespace RecoBTag;
+
 /** \class BDHadronTrackMonitoringHarvester
  *
  *  Top level steering routine for b tag performance harvesting.

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.h
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.h
@@ -1,0 +1,37 @@
+#ifndef BDHadronTrackMonitoringHarvester_H
+#define BDHadronTrackMonitoringHarvester_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+/** \class BDHadronTrackMonitoringHarvester
+ *
+ *  Top level steering routine for b tag performance harvesting.
+ *
+ */
+
+class BDHadronTrackMonitoringHarvester : public DQMEDHarvester {
+    public:
+        explicit BDHadronTrackMonitoringHarvester(const edm::ParameterSet& pSet);
+        ~BDHadronTrackMonitoringHarvester();
+
+    private:
+        void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
+        void beginJob();
+
+
+        // Histograms
+        // b jets
+        MonitorElement *nTrk_absolute_bjet, *nTrk_relative_bjet, *nTrk_std_bjet; // number of selected tracks (absolute or in percents) in different track history categories for b jets
+
+        // c jets
+        MonitorElement *nTrk_absolute_cjet, *nTrk_relative_cjet, *nTrk_std_cjet; // number of selected tracks (absolute or in percents) in different track history categories for c jets
+
+
+        // dusg jets
+        MonitorElement *nTrk_absolute_dusgjet, *nTrk_relative_dusgjet, *nTrk_std_dusgjet; // number of selected tracks (absolute or in percents) in different track history categories for light jets
+
+
+};
+
+#endif

--- a/Validation/RecoB/plugins/BuildFile.xml
+++ b/Validation/RecoB/plugins/BuildFile.xml
@@ -17,6 +17,7 @@
 <use name="DQMServices/Core"/>
 <use name="DQMOffline/RecoB"/>
 <use name="Validation/RecoB"/>
+<use name="DataFormats/PatCandidates"/>
 <use name="boost"/>
 <use name="clhep"/>
 <use name="rootcore"/>

--- a/Validation/RecoB/python/BDHadronTrackMonitoring_cfi.py
+++ b/Validation/RecoB/python/BDHadronTrackMonitoring_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimTracker.TrackHistory.TrackClassifier_cff import *
+
+BDHadronTrackMonitoringAnalyze = cms.EDAnalyzer("BDHadronTrackMonitoringAnalyzer",
+								trackClassifier,
+								distJetAxisCut = cms.double(0.07),
+								decayLengthCut = cms.double(5.0),
+								minJetPt = cms.double(20),
+								maxJetEta = cms.double(2.5),
+								PatJetSource = cms.InputTag('selectedPatJets'),
+								ipTagInfos = cms.string('pfImpactParameter'),
+								TrackSource = cms.InputTag('generalTracks'),
+								PrimaryVertexSource = cms.InputTag('offlinePrimaryVertices'),
+								clusterTPMap = cms.InputTag("tpClusterProducer"),
+                                )
+
+
+BDHadronTrackMonitoringHarvest = cms.EDAnalyzer("BDHadronTrackMonitoringHarvester"
+								)

--- a/Validation/RecoB/test/test_BDHadronTrackMonitoringAnalyzer_cfg.py
+++ b/Validation/RecoB/test/test_BDHadronTrackMonitoringAnalyzer_cfg.py
@@ -1,0 +1,136 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('BDHadronTrackMonitorAnalyzerDQM')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# load DQM
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring()
+)
+
+
+process.PoolSource.fileNames = [
+	'/store/relval/CMSSW_8_1_0_pre16/RelValTTbar_13/GEN-SIM-RECODEBUG/PU25ns_81X_upgrade2017_realistic_v22_HS_rsb-v1/10000/002033F7-36B9-E611-A30B-0025905A48EC.root'
+    	#'root://xrootd-cms.infn.it//store/relval/CMSSW_8_1_0_pre16/RelValTTbar_13/GEN-SIM-RECODEBUG/PU25ns_81X_upgrade2017_realistic_v22_HS_rsb-v1/10000/002033F7-36B9-E611-A30B-0025905A48EC.root',
+	#'root://xrootd-cms.infn.it//store/relval/CMSSW_8_1_0_pre16/RelValTTbar_13/GEN-SIM-RECODEBUG/PU25ns_81X_upgrade2017_realistic_v22_HS_rsb-v1/10000/00A6E94A-3DB9-E611-AAAD-0CC47A4D7604.root',
+	#'root://xrootd-cms.infn.it//store/relval/CMSSW_8_1_0_pre16/RelValTTbar_13/GEN-SIM-RECODEBUG/PU25ns_81X_upgrade2017_realistic_v22_HS_rsb-v1/10000/00EB8925-41B9-E611-BF1E-0CC47A78A456.root',
+	#'root://xrootd-cms.infn.it//store/relval/CMSSW_8_1_0_pre16/RelValTTbar_13/GEN-SIM-RECODEBUG/PU25ns_81X_upgrade2017_realistic_v22_HS_rsb-v1/10000/020F6DD1-36B9-E611-B893-0CC47A4D7604.root',
+	#'root://xrootd-cms.infn.it//store/relval/CMSSW_8_1_0_pre16/RelValTTbar_13/GEN-SIM-RECODEBUG/PU25ns_81X_upgrade2017_realistic_v22_HS_rsb-v1/10000/027E621E-3FB9-E611-9415-0025905A6104.root'
+	]
+
+
+from PhysicsTools.PatAlgos.patEventContent_cff import patEventContent, patEventContentNoCleaning
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+                                     fileName = cms.untracked.string("OUT.root")
+                                     )
+                            
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(False),
+    allowUnscheduled = cms.untracked.bool(True)
+)
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')  #for MC
+process.GlobalTag.globaltag = "80X_mcRun2_asymptotic_v4"
+
+
+
+postfix = "PFlow"
+
+from PhysicsTools.PatAlgos.tools.pfTools import *
+
+usePF2PAT(
+            process,
+            runPF2PAT=True,
+            jetAlgo="AK4",
+            runOnMC=True,
+            postfix=postfix,
+            jetCorrections=('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+            pvCollection=cms.InputTag('offlinePrimaryVertices')
+)
+
+ ## Top projections in PF2PAT
+getattr(process,"pfPileUpJME"+postfix).checkClosestZVertex = False
+getattr(process,"pfNoPileUpJME"+postfix).enable = True
+getattr(process,"pfNoMuonJMEPFBRECO"+postfix).enable = False
+getattr(process,"pfNoElectronJMEPFBRECO"+postfix).enable = False
+
+
+# switch jet collection to make PAT collection
+from PhysicsTools.PatAlgos.tools.jetTools import *
+switchJetCollection(
+        process,
+        jetSource = cms.InputTag('ak4PFJetsCHS'),
+        #'ak4PFJets'
+        pfCandidates = cms.InputTag('particleFlow'),
+        pvSource = cms.InputTag('offlinePrimaryVertices'),
+        svSource = cms.InputTag('inclusiveCandidateSecondaryVertices'),
+        muSource = cms.InputTag('muons'),
+        elSource = cms.InputTag('gedGsfElectrons'),
+        btagInfos = [
+                    'pfImpactParameterTagInfos'
+                    ,'pfSecondaryVertexTagInfos'
+                    ,'pfInclusiveSecondaryVertexFinderTagInfos'
+                    ,'pfSecondaryVertexNegativeTagInfos'
+                    ,'pfInclusiveSecondaryVertexFinderNegativeTagInfos'
+                    ,'softPFMuonsTagInfos'
+                    ,'softPFElectronsTagInfos'
+                    ,'pfInclusiveSecondaryVertexFinderCvsLTagInfos'
+                    ,'pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos'
+        ],
+        btagDiscriminators = ['pfJetBProbabilityBJetTags'
+                            ,'pfJetProbabilityBJetTags'
+                            ,'pfCombinedSecondaryVertexV2BJetTags'
+        ],
+        jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'None'),
+        genJetCollection = cms.InputTag('ak4GenJetsNoNu'),
+        genParticles = cms.InputTag('genParticles'),
+        postfix=postfix
+)
+
+
+## Add TagInfos to PAT jets
+if hasattr(process,'patJets'+postfix) and getattr( getattr(process,'patJets'+postfix), 'addBTagInfo' ):
+    setattr( getattr(process,'patJets'+postfix), 'addTagInfos', cms.bool(True) )
+
+
+# my analyzer
+process.load('Validation.RecoB.BDHadronTrackMonitoring_cfi')
+process.BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('selectedPatJets'+postfix)
+
+process.load("SimTracker.TrackHistory.TrackHistory_cff")
+process.load("SimTracker.TrackHistory.TrackClassifier_cff")
+process.load("SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi")
+process.load("SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi")
+process.load("SimTracker.TrackerHitAssociation.tpClusterProducer_cfi")
+
+process.BDHadronTrackMonitoringAnalyzer = cms.Path(process.BDHadronTrackMonitoringAnalyze)
+#process.dqmsave_step = cms.Path(process.DQMSaver)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+
+
+# Schedule definition
+process.schedule = cms.Schedule(
+    process.BDHadronTrackMonitoringAnalyzer,
+    process.DQMoutput_step
+#    process.dqmsave_step
+    )

--- a/Validation/RecoB/test/test_BDHadronTrackMonitoringHarvester_cfg.py
+++ b/Validation/RecoB/test/test_BDHadronTrackMonitoringHarvester_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('BDHadronTrackMonitorHarvesterDQM')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# load DQM
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+# my Harvester
+process.load('Validation.RecoB.BDHadronTrackMonitoring_cfi')
+
+
+process.maxEvents = cms.untracked.PSet(
+	input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("DQMRootSource",
+                            fileNames = cms.untracked.vstring("file:OUT.root"))
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  #for MC
+
+
+
+# Path and EndPath definitions
+process.BDHadronTrackMonitoringHarvester = cms.Path(process.BDHadronTrackMonitoringHarvest)
+#process.myEff = cms.Path(process.DQMExample_GenericClient)
+#process.myTest = cms.Path(process.DQMExample_qTester)
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(
+                                process.BDHadronTrackMonitoringHarvester,
+                                process.dqmsave_step
+    )
+
+process.DQMStore.verbose =  cms.untracked.int32(1)
+process.DQMStore.verboseQT =  cms.untracked.int32(1)
+
+#process.DQMStore.collateHistograms = cms.untracked.bool(True)
+#process.dqmSaver.saveAtJobEnd = cms.untracked.bool(True)
+#process.dqmSaver.forceRunNumber = cms.untracked.int32(123456)
+
+#process.dqmSaver.workflow = '/TTbarLepton/myTest/DQM'


### PR DESCRIPTION
This PR contains currently a standalone version of a DQM tool to monitor track properties of tracks from B and D hadron decays (or more generally bottom and charmed hadron decays).
This information is needed by the BTV POG to monitor any possible effects on b-tagging (and c-tagging) performance.

We would like to add this to the standard DQM sequence for release validation to be able to compare between pre-releases.

Note 1: As already discussed over e-mail, this code should be ran over a TTbar RECODEBUG sample, since it uses track history information (TrackingParticles). Therefore a small TTbar RECODEBUG sample should be produced for every new release on which this code will be ran. Previous tests have shown that it would already be sufficient to run over only 1000 events. I was told this was something that should be looked into by the PDMV group.

Note 2: I have no previous experience in DQM code, but I managed to run my code in a standalone way (first the Analyzer, then the Harvester) and produce the required output histograms. You can see my standalone test configuration in:
Analyzer:  Validation/RecoB/test/test_BDHadronTrackMonitoringAnalyzer_cfg.py
Harvester:  Validation/RecoB/test/test_BDHadronTrackMonitoringHarvester_cfg.py
As you can see I require PAT to be ran (I use PF2PAT followed by switchJetCollection, which follows as close as possible the code used by the BTV POG to make testing ntuples, called the BTagAnalyzer). I just mention this since this might not be the usual procedure in DQM applications.

I am looking forward to your feedback on how to proceed in order to finally get this tool included in the standard DQM sequence.

@imarches, @JyothsnaKomaragiri, @mverzett you might want to follow this discussion as well.

Thanks,
Cheers,
Seth Moortgat