### PR TITLE
Replace throw() dynamic exception specifier with noxcept

### DIFF
--- a/CondTools/Ecal/interface/EcalErrorMask.h
+++ b/CondTools/Ecal/interface/EcalErrorMask.h
@@ -19,7 +19,7 @@ class EcalErrorMask {
 
  public:
 
-  static void readDB( EcalCondDBInterface* eConn, RunIOV* runIOV ) throw( std::runtime_error );
+  static void readDB( EcalCondDBInterface* eConn, RunIOV* runIOV ) noexcept(false);
 
   static void fetchDataSet( std::map< EcalLogicID, RunCrystalErrorsDat>* fillMap );
   static void fetchDataSet( std::map< EcalLogicID, RunTTErrorsDat>* fillMap );

--- a/CondTools/Ecal/src/EcalErrorMask.cc
+++ b/CondTools/Ecal/src/EcalErrorMask.cc
@@ -23,7 +23,7 @@ std::map<EcalLogicID, RunPNErrorsDat>      EcalErrorMask::mapPNErrors_;
 std::map<EcalLogicID, RunMemChErrorsDat>   EcalErrorMask::mapMemChErrors_;
 std::map<EcalLogicID, RunMemTTErrorsDat>   EcalErrorMask::mapMemTTErrors_;
 
-void EcalErrorMask::readDB( EcalCondDBInterface* eConn, RunIOV* runIOV ) throw( std::runtime_error ) {
+void EcalErrorMask::readDB( EcalCondDBInterface* eConn, RunIOV* runIOV ) noexcept(false) {
 
   if( eConn ) {
 


### PR DESCRIPTION
`throw()` specifier was deprecated in C++11 and removed in C++17.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>