### PR TITLE
pr90x L1T for Phase2 reduce size of FEVTHLTDEBUG  - only signalTrackingPartcles saved by the mixing module.

### DIFF
--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -79,4 +79,6 @@ phase2_hgcal.toModify( theDigitizersValid,
 
 phase2_timing.toModify( theDigitizersValid.mergedtruth,
                         createInitialVertexCollection = cms.bool(True) )
+phase2_timing.toModify( theDigitizersValid.mergedtruth.select,
+                        signalOnlyTP = cms.bool(True) )
 


### PR DESCRIPTION
90x PR: reduces the size of FEVTHLTDEBUG event content.

- in case of 200 PU from 70 to 20 MB/evt.

Details: In case of Phase2_timing era (Track TDR MC) only save the initial event's TrackingPparticles in the collection made by the mixing module.



