### PR TITLE
Convert HLTTauRefProducer from legacy filter to global filter

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTauRefProducer.h
+++ b/DQMOffline/Trigger/interface/HLTTauRefProducer.h
@@ -50,22 +50,21 @@
 #include <string>
 
 class HLTTauRefProducer : public edm::EDProducer {
-
 public:
-  explicit HLTTauRefProducer(const edm::ParameterSet&);
-  ~HLTTauRefProducer();
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  explicit HLTTauRefProducer(const edm::ParameterSet&);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  typedef math::XYZTLorentzVectorD LorentzVector;
-  typedef std::vector<LorentzVector> LorentzVectorCollection;
+
+  using LorentzVector = math::XYZTLorentzVectorD;
+  using LorentzVectorCollection = std::vector<LorentzVector>;
 
   edm::EDGetTokenT<reco::PFTauCollection> PFTaus_;
-  std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator> > PFTauDis_;
+  std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator>> PFTauDis_;
   bool doPFTaus_;
   double ptMinPFTau_;
-
 
   edm::EDGetTokenT<reco::GsfElectronCollection> Electrons_;
   bool doElectrons_;
@@ -81,7 +80,8 @@ private:
   double e_maxIsoDR_;
   double e_isoMaxSumPt_;
   bool doElecFromZ_;
-  double e_zMmin_,e_zMmax_;
+  double e_zMmin_;
+  double e_zMmax_;
   double e_FromZet_;
 
   edm::EDGetTokenT<reco::PhotonCollection> Photons_;
@@ -89,11 +89,9 @@ private:
   double photonEcalIso_;
   double ptMinPhoton_;
 
-
   edm::EDGetTokenT<reco::MuonCollection> Muons_;
   bool doMuons_;
   double ptMinMuon_;
-
 
   edm::EDGetTokenT<reco::CaloJetCollection> Jets_;
   bool doJets_;
@@ -108,17 +106,15 @@ private:
   bool doMET_;
   double ptMinMET_;
 
-  double etaMax;
+  double etaMax_;
 
-  void doPFTaus(edm::Event&,const edm::EventSetup&);
-  void doMuons(edm::Event&,const edm::EventSetup&);
-  void doElectrons(edm::Event&,const edm::EventSetup&);
-  void doElectronsFromZ(edm::Event&,const edm::EventSetup&,std::unique_ptr<LorentzVectorCollection>&);
-  double ElectronTrkIsolation(const reco::TrackCollection*, const reco::GsfElectron&);
-  void doJets(edm::Event&,const edm::EventSetup&);
-  void doPhotons(edm::Event&,const edm::EventSetup&);
-  void doTowers(edm::Event&,const edm::EventSetup&);
-  void doMET(edm::Event&,const edm::EventSetup&);
+  void doPFTaus(edm::Event&) const;
+  void doMuons(edm::Event&) const;
+  void doElectrons(edm::Event&) const;
+  void doJets(edm::Event&) const;
+  void doPhotons(edm::Event&) const;
+  void doTowers(edm::Event&) const;
+  void doMET(edm::Event&) const;
 };
 
 #endif

--- a/DQMOffline/Trigger/interface/HLTTauRefProducer.h
+++ b/DQMOffline/Trigger/interface/HLTTauRefProducer.h
@@ -8,8 +8,8 @@
 #define HLTTauRefProducer_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -49,12 +49,12 @@
 #include <vector>
 #include <string>
 
-class HLTTauRefProducer : public edm::EDProducer {
+class HLTTauRefProducer : public edm::global::EDProducer<> {
 public:
 
   explicit HLTTauRefProducer(const edm::ParameterSet&);
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
 private:
 

--- a/DQMOffline/Trigger/interface/HLTTauRefProducer.h
+++ b/DQMOffline/Trigger/interface/HLTTauRefProducer.h
@@ -1,7 +1,7 @@
 /*HLTTauRefProducer
-Producer that creates LorentzVector Collections
-from offline reconstructed quantities to be used
-in Offline Trigger DQM etc
+  Producer that creates LorentzVector Collections
+  from offline reconstructed quantities to be used
+  in Offline Trigger DQM etc
 */
 
 #ifndef HLTTauRefProducer_h
@@ -50,23 +50,23 @@ in Offline Trigger DQM etc
 #include <string>
 
 class HLTTauRefProducer : public edm::EDProducer {
-  
+
 public:
   explicit HLTTauRefProducer(const edm::ParameterSet&);
   ~HLTTauRefProducer();
 
   virtual void produce(edm::Event&, const edm::EventSetup&);
-  
- private:
+
+private:
   typedef math::XYZTLorentzVectorD LorentzVector;
   typedef std::vector<LorentzVector> LorentzVectorCollection;
-  
+
   edm::EDGetTokenT<reco::PFTauCollection> PFTaus_;
   std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator> > PFTauDis_;
   bool doPFTaus_;
   double ptMinPFTau_;
-  
-  
+
+
   edm::EDGetTokenT<reco::GsfElectronCollection> Electrons_;
   bool doElectrons_;
   edm::EDGetTokenT<reco::ElectronIDAssociationCollection> e_idAssocProd_;

--- a/DQMOffline/Trigger/src/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/src/HLTTauRefProducer.cc
@@ -112,7 +112,7 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig)
 
 }
 
-void HLTTauRefProducer::produce(edm::Event& iEvent, edm::EventSetup const&)
+void HLTTauRefProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const
 {
   if(doPFTaus_)
     doPFTaus(iEvent);

--- a/DQMOffline/Trigger/src/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/src/HLTTauRefProducer.cc
@@ -25,73 +25,81 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerFwd.h"
 #include "Math/GenVector/VectorUtil.h"
 
-
 using namespace edm;
 using namespace reco;
 using namespace std;
 
 HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig)
 {
-
-
   //One Parameter Set per Collection
-
-  ParameterSet pfTau = iConfig.getUntrackedParameter<edm::ParameterSet>("PFTaus");
-  PFTaus_ = consumes<reco::PFTauCollection>(pfTau.getUntrackedParameter<InputTag>("PFTauProducer"));
-  auto discs = pfTau.getUntrackedParameter<std::vector<InputTag> >("PFTauDiscriminators");
-  for(edm::InputTag& tag: discs) {
-    PFTauDis_.push_back(consumes<reco::PFTauDiscriminator>(tag));
+  {
+    auto const& pfTau = iConfig.getUntrackedParameter<edm::ParameterSet>("PFTaus");
+    PFTaus_ = consumes<reco::PFTauCollection>(pfTau.getUntrackedParameter<InputTag>("PFTauProducer"));
+    auto discs = pfTau.getUntrackedParameter<vector<InputTag>>("PFTauDiscriminators");
+    for (edm::InputTag& tag: discs) {
+      PFTauDis_.push_back(consumes<reco::PFTauDiscriminator>(tag));
+    }
+    doPFTaus_ = pfTau.getUntrackedParameter<bool>("doPFTaus",false);
+    ptMinPFTau_= pfTau.getUntrackedParameter<double>("ptMin",15.);
   }
-  doPFTaus_ = pfTau.getUntrackedParameter<bool>("doPFTaus",false);
-  ptMinPFTau_= pfTau.getUntrackedParameter<double>("ptMin",15.);
 
-  ParameterSet  electrons = iConfig.getUntrackedParameter<edm::ParameterSet>("Electrons");
-  Electrons_ = consumes<reco::GsfElectronCollection>(electrons.getUntrackedParameter<InputTag>("ElectronCollection"));
-  doElectrons_ = electrons.getUntrackedParameter<bool>("doElectrons",false);
-  e_doID_ = electrons.getUntrackedParameter<bool>("doID",false);
-  if(e_doID_) {
-    e_idAssocProd_ = consumes<reco::ElectronIDAssociationCollection>(electrons.getUntrackedParameter<InputTag>("IdCollection"));
+  {
+    auto const& electrons = iConfig.getUntrackedParameter<edm::ParameterSet>("Electrons");
+    Electrons_ = consumes<reco::GsfElectronCollection>(electrons.getUntrackedParameter<InputTag>("ElectronCollection"));
+    doElectrons_ = electrons.getUntrackedParameter<bool>("doElectrons",false);
+    e_doID_ = electrons.getUntrackedParameter<bool>("doID",false);
+    if(e_doID_) {
+      e_idAssocProd_ = consumes<reco::ElectronIDAssociationCollection>(electrons.getUntrackedParameter<InputTag>("IdCollection"));
+    }
+    e_ctfTrackCollectionSrc_ = electrons.getUntrackedParameter<InputTag>("TrackCollection");
+    e_ctfTrackCollection_ = consumes<reco::TrackCollection>(e_ctfTrackCollectionSrc_);
+    ptMinElectron_= electrons.getUntrackedParameter<double>("ptMin",15.);
+    e_doTrackIso_ = electrons.getUntrackedParameter<bool>("doTrackIso",false);
+    e_trackMinPt_= electrons.getUntrackedParameter<double>("ptMinTrack",1.5);
+    e_lipCut_= electrons.getUntrackedParameter<double>("lipMinTrack",1.5);
+    e_minIsoDR_= electrons.getUntrackedParameter<double>("InnerConeDR",0.02);
+    e_maxIsoDR_= electrons.getUntrackedParameter<double>("OuterConeDR",0.6);
+    e_isoMaxSumPt_= electrons.getUntrackedParameter<double>("MaxIsoVar",0.02);
   }
-  e_ctfTrackCollectionSrc_ = electrons.getUntrackedParameter<InputTag>("TrackCollection");
-  e_ctfTrackCollection_ = consumes<reco::TrackCollection>(e_ctfTrackCollectionSrc_);
-  ptMinElectron_= electrons.getUntrackedParameter<double>("ptMin",15.);
-  e_doTrackIso_ = electrons.getUntrackedParameter<bool>("doTrackIso",false);
-  e_trackMinPt_= electrons.getUntrackedParameter<double>("ptMinTrack",1.5);
-  e_lipCut_= electrons.getUntrackedParameter<double>("lipMinTrack",1.5);
-  e_minIsoDR_= electrons.getUntrackedParameter<double>("InnerConeDR",0.02);
-  e_maxIsoDR_= electrons.getUntrackedParameter<double>("OuterConeDR",0.6);
-  e_isoMaxSumPt_= electrons.getUntrackedParameter<double>("MaxIsoVar",0.02);
 
-  ParameterSet  muons = iConfig.getUntrackedParameter<edm::ParameterSet>("Muons");
-  Muons_ = consumes<reco::MuonCollection>(muons.getUntrackedParameter<InputTag>("MuonCollection"));
-  doMuons_ = muons.getUntrackedParameter<bool>("doMuons",false);
-  ptMinMuon_= muons.getUntrackedParameter<double>("ptMin",15.);
+  {
+    auto const& muons = iConfig.getUntrackedParameter<edm::ParameterSet>("Muons");
+    Muons_ = consumes<reco::MuonCollection>(muons.getUntrackedParameter<InputTag>("MuonCollection"));
+    doMuons_ = muons.getUntrackedParameter<bool>("doMuons",false);
+    ptMinMuon_= muons.getUntrackedParameter<double>("ptMin",15.);
+  }
 
-  ParameterSet  jets = iConfig.getUntrackedParameter<edm::ParameterSet>("Jets");
-  Jets_ = consumes<reco::CaloJetCollection>(jets.getUntrackedParameter<InputTag>("JetCollection"));
-  doJets_ = jets.getUntrackedParameter<bool>("doJets");
-  ptMinJet_= jets.getUntrackedParameter<double>("etMin");
+  {
+    auto const& jets = iConfig.getUntrackedParameter<edm::ParameterSet>("Jets");
+    Jets_ = consumes<reco::CaloJetCollection>(jets.getUntrackedParameter<InputTag>("JetCollection"));
+    doJets_ = jets.getUntrackedParameter<bool>("doJets");
+    ptMinJet_= jets.getUntrackedParameter<double>("etMin");
+  }
 
-  ParameterSet  towers = iConfig.getUntrackedParameter<edm::ParameterSet>("Towers");
-  Towers_ = consumes<CaloTowerCollection>(towers.getUntrackedParameter<InputTag>("TowerCollection"));
-  doTowers_ = towers.getUntrackedParameter<bool>("doTowers");
-  ptMinTower_= towers.getUntrackedParameter<double>("etMin");
-  towerIsol_= towers.getUntrackedParameter<double>("towerIsolation");
+  {
+    auto const& towers = iConfig.getUntrackedParameter<edm::ParameterSet>("Towers");
+    Towers_ = consumes<CaloTowerCollection>(towers.getUntrackedParameter<InputTag>("TowerCollection"));
+    doTowers_ = towers.getUntrackedParameter<bool>("doTowers");
+    ptMinTower_= towers.getUntrackedParameter<double>("etMin");
+    towerIsol_= towers.getUntrackedParameter<double>("towerIsolation");
+  }
 
-  ParameterSet  photons = iConfig.getUntrackedParameter<edm::ParameterSet>("Photons");
-  Photons_ = consumes<reco::PhotonCollection>(photons.getUntrackedParameter<InputTag>("PhotonCollection"));
-  doPhotons_ = photons.getUntrackedParameter<bool>("doPhotons");
-  ptMinPhoton_= photons.getUntrackedParameter<double>("etMin");
-  photonEcalIso_= photons.getUntrackedParameter<double>("ECALIso");
+  {
+    auto const& photons = iConfig.getUntrackedParameter<edm::ParameterSet>("Photons");
+    Photons_ = consumes<reco::PhotonCollection>(photons.getUntrackedParameter<InputTag>("PhotonCollection"));
+    doPhotons_ = photons.getUntrackedParameter<bool>("doPhotons");
+    ptMinPhoton_= photons.getUntrackedParameter<double>("etMin");
+    photonEcalIso_= photons.getUntrackedParameter<double>("ECALIso");
+  }
 
-  ParameterSet  met = iConfig.getUntrackedParameter<edm::ParameterSet>("MET");
-  MET_ = consumes<reco::CaloMETCollection>(met.getUntrackedParameter<InputTag>("METCollection"));
-  doMET_ = met.getUntrackedParameter<bool>("doMET",false);
-  ptMinMET_= met.getUntrackedParameter<double>("ptMin",15.);
+  {
+    auto const& met = iConfig.getUntrackedParameter<edm::ParameterSet>("MET");
+    MET_ = consumes<reco::CaloMETCollection>(met.getUntrackedParameter<InputTag>("METCollection"));
+    doMET_ = met.getUntrackedParameter<bool>("doMET",false);
+    ptMinMET_= met.getUntrackedParameter<double>("ptMin",15.);
+  }
 
-
-  etaMax = iConfig.getUntrackedParameter<double>("EtaMax",2.5);
-
+  etaMax_ = iConfig.getUntrackedParameter<double>("EtaMax",2.5);
 
   //recoCollections
   produces<LorentzVectorCollection>("PFTaus");
@@ -104,236 +112,213 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig)
 
 }
 
-HLTTauRefProducer::~HLTTauRefProducer(){ }
-
-void HLTTauRefProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
+void HLTTauRefProducer::produce(edm::Event& iEvent, edm::EventSetup const&)
 {
   if(doPFTaus_)
-    doPFTaus(iEvent,iES);
+    doPFTaus(iEvent);
   if(doElectrons_)
-    doElectrons(iEvent,iES);
+    doElectrons(iEvent);
   if(doMuons_)
-    doMuons(iEvent,iES);
+    doMuons(iEvent);
   if(doJets_)
-    doJets(iEvent,iES);
+    doJets(iEvent);
   if(doPhotons_)
-    doPhotons(iEvent,iES);
+    doPhotons(iEvent);
   if(doTowers_)
-    doTowers(iEvent,iES);
+    doTowers(iEvent);
   if(doMET_)
-    doMET(iEvent,iES);
+    doMET(iEvent);
 }
 
 void
-HLTTauRefProducer::doPFTaus(edm::Event& iEvent,const edm::EventSetup& iES)
+HLTTauRefProducer::doPFTaus(edm::Event& iEvent) const
 {
-  unique_ptr<LorentzVectorCollection> product_PFTaus(new LorentzVectorCollection);
-  //Retrieve the collection
+  auto product_PFTaus = make_unique<LorentzVectorCollection>();
+
   edm::Handle<PFTauCollection> pftaus;
-  if(iEvent.getByToken(PFTaus_,pftaus)) {
-    for(unsigned int i=0; i<pftaus->size(); ++i) {
-      if((*pftaus)[i].pt()>ptMinPFTau_&&fabs((*pftaus)[i].eta())<etaMax)
-        {
-          reco::PFTauRef thePFTau(pftaus,i);
-          bool passAll = true;
-          for(edm::EDGetTokenT<reco::PFTauDiscriminator>& token: PFTauDis_) {
-            edm::Handle<reco::PFTauDiscriminator> pftaudis;
-            if(iEvent.getByToken(token, pftaudis)) {
-              if((*pftaudis)[thePFTau] < 0.5) {
-                passAll = false;
-                break;
-              }
-            }else{
+  if (iEvent.getByToken(PFTaus_,pftaus)) {
+    for (unsigned int i=0; i<pftaus->size(); ++i) {
+      auto const& pftau = (*pftaus)[i];
+      if (pftau.pt()>ptMinPFTau_&&fabs(pftau.eta())<etaMax_) {
+        reco::PFTauRef thePFTau {pftaus,i};
+        bool passAll {true};
+        for (edm::EDGetTokenT<reco::PFTauDiscriminator> const& token: PFTauDis_) {
+          edm::Handle<reco::PFTauDiscriminator> pftaudis;
+          if (iEvent.getByToken(token, pftaudis)) {
+            if ((*pftaudis)[thePFTau] < 0.5) {
               passAll = false;
               break;
             }
           }
-          if(passAll) {
-            LorentzVector vec((*pftaus)[i].px(),(*pftaus)[i].py(),(*pftaus)[i].pz(),(*pftaus)[i].energy());
-            product_PFTaus->push_back(vec);
+          else{
+            passAll = false;
+            break;
           }
         }
+        if (passAll) {
+          product_PFTaus->emplace_back(pftau.px(), pftau.py(), pftau.pz(), pftau.energy());
+        }
+      }
     }
   }
-  iEvent.put(std::move(product_PFTaus),"PFTaus");
+  iEvent.put(move(product_PFTaus),"PFTaus");
 }
 
 
 void
-HLTTauRefProducer::doElectrons(edm::Event& iEvent,const edm::EventSetup& iES)
+HLTTauRefProducer::doElectrons(edm::Event& iEvent) const
 {
-  unique_ptr<LorentzVectorCollection> product_Electrons(new LorentzVectorCollection);
-  //Retrieve the collections
+  auto product_Electrons = make_unique<LorentzVectorCollection>();
 
   edm::Handle<reco::ElectronIDAssociationCollection> pEleID;
-  if(e_doID_){//UGLY HACK UNTIL GET ELETRON ID WORKING IN 210
-
-    iEvent.getByToken(e_idAssocProd_, pEleID);
-
-    if (!pEleID.isValid()){
-      edm::LogInfo("")<< "Error! Can't get electronIDAssocProducer by label. ";
-      e_doID_ = false;
+  bool doID {e_doID_};
+  if (doID) {//UGLY HACK UNTIL GET ELETRON ID WORKING IN 210
+    if (!iEvent.getByToken(e_idAssocProd_, pEleID)) {
+      edm::LogInfo("") << "Error! Can't get electronIDAssocProducer by label. ";
+      doID = false;
     }
   }
+
   edm::Handle<reco::TrackCollection> pCtfTracks;
-  iEvent.getByToken(e_ctfTrackCollection_, pCtfTracks);
-  if (!pCtfTracks.isValid()) {
-    edm::LogInfo("")<< "Error! Can't get " << e_ctfTrackCollectionSrc_.label() << " by label. ";
-    iEvent.put(std::move(product_Electrons),"Electrons");
+  if (!iEvent.getByToken(e_ctfTrackCollection_, pCtfTracks)) {
+    edm::LogInfo("") << "Error! Can't get " << e_ctfTrackCollectionSrc_.label() << " by label. ";
+    iEvent.put(move(product_Electrons),"Electrons");
     return;
   }
-  const reco::TrackCollection * ctfTracks = pCtfTracks.product();
+
   edm::Handle<GsfElectronCollection> electrons;
-  if(iEvent.getByToken(Electrons_,electrons))
-    for(size_t i=0;i<electrons->size();++i)
-      {
-        edm::Ref<reco::GsfElectronCollection> electronRef(electrons,i);
-        bool idDec=false;
-        if(e_doID_){
-          reco::ElectronIDAssociationCollection::const_iterator tagIDAssocItr;
-          tagIDAssocItr = pEleID->find(electronRef);
-          const reco::ElectronIDRef& id_tag = tagIDAssocItr->val;
-          idDec=id_tag->cutBasedDecision();
-        }else idDec=true;
-        if((*electrons)[i].pt()>ptMinElectron_&&fabs((*electrons)[i].eta())<etaMax&&idDec)
-          {
-            if(e_doTrackIso_){
-              reco::TrackCollection::const_iterator tr = ctfTracks->begin();
-              double sum_of_pt_ele=0;
-              for(;tr != ctfTracks->end();++tr)
-                {
-                  double lip = (*electrons)[i].gsfTrack()->dz() - tr->dz();
-                  if(tr->pt() > e_trackMinPt_ && fabs(lip) < e_lipCut_){
-                    double dphi=fabs(tr->phi()-(*electrons)[i].trackMomentumAtVtx().phi());
-                    if(dphi>acos(-1.))dphi=2*acos(-1.)-dphi;
-                    double deta=fabs(tr->eta()-(*electrons)[i].trackMomentumAtVtx().eta());
-                    double dr_ctf_ele = sqrt(deta*deta+dphi*dphi);
-                    if((dr_ctf_ele>e_minIsoDR_) && (dr_ctf_ele<e_maxIsoDR_)){
-                      double cft_pt_2 = (tr->pt())*(tr->pt());
-                      sum_of_pt_ele += cft_pt_2;
-                    }
-                  }
-                }
-              double isolation_value_ele = sum_of_pt_ele/((*electrons)[i].trackMomentumAtVtx().Rho()*(*electrons)[i].trackMomentumAtVtx().Rho());
-              if(isolation_value_ele<e_isoMaxSumPt_){
-                LorentzVector vec((*electrons)[i].px(),(*electrons)[i].py(),(*electrons)[i].pz(),(*electrons)[i].energy());
-                product_Electrons->push_back(vec);
+  if (iEvent.getByToken(Electrons_,electrons)) {
+    for (size_t i=0 ; i<electrons->size(); ++i) {
+      edm::Ref<reco::GsfElectronCollection> electronRef (electrons,i);
+      bool idDec {false};
+      if (doID) {
+        reco::ElectronIDAssociationCollection::const_iterator tagIDAssocItr;
+        tagIDAssocItr = pEleID->find(electronRef);
+        const reco::ElectronIDRef& id_tag = tagIDAssocItr->val;
+        idDec=id_tag->cutBasedDecision();
+      }
+      else {
+        idDec=true;
+      }
+      auto const& electron = (*electrons)[i];
+      if (electron.pt()>ptMinElectron_&&fabs(electron.eta())<etaMax_&&idDec) {
+        if (e_doTrackIso_) {
+          double sum_of_pt_ele {};
+          for (auto const& tr : *pCtfTracks) {
+            double const lip {electron.gsfTrack()->dz() - tr.dz()};
+            if (tr.pt() > e_trackMinPt_ && fabs(lip) < e_lipCut_) {
+              double dphi {fabs(tr.phi()-electron.trackMomentumAtVtx().phi())};
+              if (dphi>acos(-1.)) {
+                dphi=2*acos(-1.)-dphi;
               }
-
-            }
-            else{
-              LorentzVector vec((*electrons)[i].px(),(*electrons)[i].py(),(*electrons)[i].pz(),(*electrons)[i].energy());
-              product_Electrons->push_back(vec);
+              double const deta {fabs(tr.eta()-electron.trackMomentumAtVtx().eta())};
+              double const dr_ctf_ele {sqrt(deta*deta+dphi*dphi)};
+              if((dr_ctf_ele>e_minIsoDR_) && (dr_ctf_ele<e_maxIsoDR_)){
+                double const cft_pt_2 {tr.pt()*tr.pt()};
+                sum_of_pt_ele += cft_pt_2;
+              }
             }
           }
-      }
-
-  iEvent.put(std::move(product_Electrons),"Electrons");
-}
-
-void
-HLTTauRefProducer::doMuons(edm::Event& iEvent,const edm::EventSetup& iES)
-{
-  unique_ptr<LorentzVectorCollection> product_Muons(new LorentzVectorCollection);
-  //Retrieve the collection
-  edm::Handle<MuonCollection> muons;
-  if(iEvent.getByToken(Muons_,muons))
-
-    for(size_t i = 0 ;i<muons->size();++i)
-      {
-
-        if((*muons)[i].pt()>ptMinMuon_&&fabs((*muons)[i].eta())<etaMax)
-          {
-            LorentzVector vec((*muons)[i].px(),(*muons)[i].py(),(*muons)[i].pz(),(*muons)[i].energy());
-            product_Muons->push_back(vec);
+          double const isolation_value_ele {sum_of_pt_ele/(electron.trackMomentumAtVtx().Rho()*electron.trackMomentumAtVtx().Rho())};
+          if (isolation_value_ele<e_isoMaxSumPt_) {
+            product_Electrons->emplace_back(electron.px(),electron.py(),electron.pz(),electron.energy());
           }
-      }
-
-
-  iEvent.put(std::move(product_Muons),"Muons");
-
-}
-
-
-void
-HLTTauRefProducer::doJets(edm::Event& iEvent,const edm::EventSetup& iES)
-{
-  unique_ptr<LorentzVectorCollection> product_Jets(new LorentzVectorCollection);
-  //Retrieve the collection
-  edm::Handle<CaloJetCollection> jets;
-  if(iEvent.getByToken(Jets_,jets))
-    for(size_t i = 0 ;i<jets->size();++i)
-      {
-        if((*jets)[i].et()>ptMinJet_&&fabs((*jets)[i].eta())<etaMax)
-          {
-            LorentzVector vec((*jets)[i].px(),(*jets)[i].py(),(*jets)[i].pz(),(*jets)[i].energy());
-            product_Jets->push_back(vec);
-          }
-      }
-  iEvent.put(std::move(product_Jets),"Jets");
-}
-
-void
-HLTTauRefProducer::doTowers(edm::Event& iEvent,const edm::EventSetup& iES)
-{
-  unique_ptr<LorentzVectorCollection> product_Towers(new LorentzVectorCollection);
-  //Retrieve the collection
-  edm::Handle<CaloTowerCollection> towers;
-  if(iEvent.getByToken(Towers_,towers))
-    for(size_t i = 0 ;i<towers->size();++i)
-      {
-        if((*towers)[i].pt()>ptMinTower_&&fabs((*towers)[i].eta())<etaMax)
-          {
-            //calculate isolation
-            double isolET=0;
-            for(unsigned int j=0;j<towers->size();++j)
-              {
-                if(ROOT::Math::VectorUtil::DeltaR((*towers)[i].p4(),(*towers)[j].p4())<0.5)
-                  isolET+=(*towers)[j].pt();
-              }
-            isolET-=(*towers)[i].pt();
-            if(isolET<towerIsol_)
-              {
-                LorentzVector vec((*towers)[i].px(),(*towers)[i].py(),(*towers)[i].pz(),(*towers)[i].energy());
-                product_Towers->push_back(vec);
-              }
-          }
-      }
-  iEvent.put(std::move(product_Towers),"Towers");
-}
-
-
-void
-HLTTauRefProducer::doPhotons(edm::Event& iEvent,const edm::EventSetup& iES)
-{
-  unique_ptr<LorentzVectorCollection> product_Gammas(new LorentzVectorCollection);
-  //Retrieve the collection
-  edm::Handle<PhotonCollection> photons;
-  if(iEvent.getByToken(Photons_,photons))
-    for(size_t i = 0 ;i<photons->size();++i)
-      if((*photons)[i].ecalRecHitSumEtConeDR04()<photonEcalIso_)
-        {
-          if((*photons)[i].et()>ptMinPhoton_&&fabs((*photons)[i].eta())<etaMax)
-            {
-              LorentzVector vec((*photons)[i].px(),(*photons)[i].py(),(*photons)[i].pz(),(*photons)[i].energy());
-              product_Gammas->push_back(vec);
-            }
         }
-  iEvent.put(std::move(product_Gammas),"Photons");
+        else {
+          product_Electrons->emplace_back(electron.px(),electron.py(),electron.pz(),electron.energy());
+        }
+      }
+    }
+  }
+  iEvent.put(move(product_Electrons),"Electrons");
 }
 
 void
-HLTTauRefProducer::doMET(edm::Event& iEvent,const edm::EventSetup& iES)
+HLTTauRefProducer::doMuons(edm::Event& iEvent) const
 {
-  unique_ptr<LorentzVectorCollection> product_MET(new LorentzVectorCollection);
-  //Retrieve the collection
-  edm::Handle<reco::CaloMETCollection> met;
-  if(iEvent.getByToken(MET_,met)){
-    double px = met->front().p4().Px();
-    double py = met->front().p4().Py();
-    double pt = met->front().p4().Pt();
-    LorentzVector vec(px,py,0,pt);
-    product_MET->push_back(vec);
+  auto product_Muons = make_unique<LorentzVectorCollection>();
+
+  edm::Handle<MuonCollection> muons;
+  if (iEvent.getByToken(Muons_,muons)) {
+    for (auto const& muon : *muons) {
+      if (muon.pt()>ptMinMuon_ && fabs(muon.eta())<etaMax_) {
+        product_Muons->emplace_back(muon.px(),muon.py(),muon.pz(),muon.energy());
+      }
+    }
   }
-  iEvent.put(std::move(product_MET),"MET");
+  iEvent.put(move(product_Muons),"Muons");
+}
+
+
+void
+HLTTauRefProducer::doJets(edm::Event& iEvent) const
+{
+  auto product_Jets = make_unique<LorentzVectorCollection>();
+
+  edm::Handle<CaloJetCollection> jets;
+  if (iEvent.getByToken(Jets_,jets)) {
+    for (auto const& jet : *jets) {
+      if (jet.et()>ptMinJet_ && fabs(jet.eta())<etaMax_) {
+        product_Jets->emplace_back(jet.px(),jet.py(),jet.pz(),jet.energy());
+      }
+    }
+  }
+  iEvent.put(move(product_Jets),"Jets");
+}
+
+void
+HLTTauRefProducer::doTowers(edm::Event& iEvent) const
+{
+  auto product_Towers = make_unique<LorentzVectorCollection>();
+
+  edm::Handle<CaloTowerCollection> towers;
+  if (iEvent.getByToken(Towers_,towers)) {
+    for (auto const& tower1 : *towers) {
+      if (tower1.pt()>ptMinTower_ && fabs(tower1.eta())<etaMax_) {
+        //calculate isolation
+        double isolET {};
+        for (auto const& tower2 : *towers) {
+          if (ROOT::Math::VectorUtil::DeltaR(tower1.p4(),tower2.p4())<0.5) {
+            isolET+=tower2.pt();
+          }
+          isolET-=tower1.pt();
+        }
+        if (isolET<towerIsol_) {
+          product_Towers->emplace_back(tower1.px(),tower1.py(),tower1.pz(),tower1.energy());
+        }
+      }
+    }
+  }
+  iEvent.put(move(product_Towers),"Towers");
+}
+
+
+void
+HLTTauRefProducer::doPhotons(edm::Event& iEvent) const
+{
+  auto product_Gammas = make_unique<LorentzVectorCollection>();
+
+  edm::Handle<PhotonCollection> photons;
+  if (iEvent.getByToken(Photons_,photons)) {
+    for (auto const& photon : *photons) {
+      if (photon.ecalRecHitSumEtConeDR04()<photonEcalIso_ &&
+          photon.et()>ptMinPhoton_ && fabs(photon.eta())<etaMax_) {
+        product_Gammas->emplace_back(photon.px(),photon.py(),photon.pz(),photon.energy());
+      }
+    }
+  }
+  iEvent.put(move(product_Gammas),"Photons");
+}
+
+void
+HLTTauRefProducer::doMET(edm::Event& iEvent) const
+{
+  auto product_MET = make_unique<LorentzVectorCollection>();
+
+  edm::Handle<reco::CaloMETCollection> met;
+  if(iEvent.getByToken(MET_,met) && !met->empty()){
+    auto const& metMom = met->front().p4();
+    product_MET->emplace_back(metMom.Px(), metMom.Py(), 0, metMom.Pt());
+  }
+  iEvent.put(move(product_MET),"MET");
 }

--- a/DQMOffline/Trigger/src/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/src/HLTTauRefProducer.cc
@@ -33,7 +33,7 @@ using namespace std;
 HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig)
 {
 
- 
+
   //One Parameter Set per Collection
 
   ParameterSet pfTau = iConfig.getUntrackedParameter<edm::ParameterSet>("PFTaus");
@@ -91,7 +91,7 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig)
 
 
   etaMax = iConfig.getUntrackedParameter<double>("EtaMax",2.5);
-  
+
 
   //recoCollections
   produces<LorentzVectorCollection>("PFTaus");
@@ -124,52 +124,52 @@ void HLTTauRefProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
     doMET(iEvent,iES);
 }
 
-void 
+void
 HLTTauRefProducer::doPFTaus(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      unique_ptr<LorentzVectorCollection> product_PFTaus(new LorentzVectorCollection);
-      //Retrieve the collection
-      edm::Handle<PFTauCollection> pftaus;
-      if(iEvent.getByToken(PFTaus_,pftaus)) {
-        for(unsigned int i=0; i<pftaus->size(); ++i) {
-	    if((*pftaus)[i].pt()>ptMinPFTau_&&fabs((*pftaus)[i].eta())<etaMax)
-	      {
-		reco::PFTauRef thePFTau(pftaus,i);
-                bool passAll = true;
-                for(edm::EDGetTokenT<reco::PFTauDiscriminator>& token: PFTauDis_) {
-		  edm::Handle<reco::PFTauDiscriminator> pftaudis;
-		  if(iEvent.getByToken(token, pftaudis)) {
-                    if((*pftaudis)[thePFTau] < 0.5) {
-                      passAll = false;
-                      break;
-                    }
-                  }else{
-                      passAll = false;
-                      break;
-                  }
-                }
-                if(passAll) {
-                  LorentzVector vec((*pftaus)[i].px(),(*pftaus)[i].py(),(*pftaus)[i].pz(),(*pftaus)[i].energy());
-                  product_PFTaus->push_back(vec);
-                }
+  unique_ptr<LorentzVectorCollection> product_PFTaus(new LorentzVectorCollection);
+  //Retrieve the collection
+  edm::Handle<PFTauCollection> pftaus;
+  if(iEvent.getByToken(PFTaus_,pftaus)) {
+    for(unsigned int i=0; i<pftaus->size(); ++i) {
+      if((*pftaus)[i].pt()>ptMinPFTau_&&fabs((*pftaus)[i].eta())<etaMax)
+        {
+          reco::PFTauRef thePFTau(pftaus,i);
+          bool passAll = true;
+          for(edm::EDGetTokenT<reco::PFTauDiscriminator>& token: PFTauDis_) {
+            edm::Handle<reco::PFTauDiscriminator> pftaudis;
+            if(iEvent.getByToken(token, pftaudis)) {
+              if((*pftaudis)[thePFTau] < 0.5) {
+                passAll = false;
+                break;
               }
+            }else{
+              passAll = false;
+              break;
+            }
+          }
+          if(passAll) {
+            LorentzVector vec((*pftaus)[i].px(),(*pftaus)[i].py(),(*pftaus)[i].pz(),(*pftaus)[i].energy());
+            product_PFTaus->push_back(vec);
+          }
         }
-      }
-      iEvent.put(std::move(product_PFTaus),"PFTaus");
+    }
+  }
+  iEvent.put(std::move(product_PFTaus),"PFTaus");
 }
 
 
-void 
+void
 HLTTauRefProducer::doElectrons(edm::Event& iEvent,const edm::EventSetup& iES)
 {
   unique_ptr<LorentzVectorCollection> product_Electrons(new LorentzVectorCollection);
   //Retrieve the collections
-  
+
   edm::Handle<reco::ElectronIDAssociationCollection> pEleID;
   if(e_doID_){//UGLY HACK UNTIL GET ELETRON ID WORKING IN 210
-   
-      iEvent.getByToken(e_idAssocProd_, pEleID);
-    
+
+    iEvent.getByToken(e_idAssocProd_, pEleID);
+
     if (!pEleID.isValid()){
       edm::LogInfo("")<< "Error! Can't get electronIDAssocProducer by label. ";
       e_doID_ = false;
@@ -178,148 +178,148 @@ HLTTauRefProducer::doElectrons(edm::Event& iEvent,const edm::EventSetup& iES)
   edm::Handle<reco::TrackCollection> pCtfTracks;
   iEvent.getByToken(e_ctfTrackCollection_, pCtfTracks);
   if (!pCtfTracks.isValid()) {
-  edm::LogInfo("")<< "Error! Can't get " << e_ctfTrackCollectionSrc_.label() << " by label. ";
-  iEvent.put(std::move(product_Electrons),"Electrons"); 
-  return;
+    edm::LogInfo("")<< "Error! Can't get " << e_ctfTrackCollectionSrc_.label() << " by label. ";
+    iEvent.put(std::move(product_Electrons),"Electrons");
+    return;
   }
   const reco::TrackCollection * ctfTracks = pCtfTracks.product();
   edm::Handle<GsfElectronCollection> electrons;
   if(iEvent.getByToken(Electrons_,electrons))
     for(size_t i=0;i<electrons->size();++i)
       {
-	edm::Ref<reco::GsfElectronCollection> electronRef(electrons,i);
-	bool idDec=false;
-	if(e_doID_){
-	  reco::ElectronIDAssociationCollection::const_iterator tagIDAssocItr;
-	  tagIDAssocItr = pEleID->find(electronRef);
-	  const reco::ElectronIDRef& id_tag = tagIDAssocItr->val;
-	  idDec=id_tag->cutBasedDecision();
-	}else idDec=true;
-	if((*electrons)[i].pt()>ptMinElectron_&&fabs((*electrons)[i].eta())<etaMax&&idDec)
-	  {
-	    if(e_doTrackIso_){
-	      reco::TrackCollection::const_iterator tr = ctfTracks->begin();
-	      double sum_of_pt_ele=0;
-	      for(;tr != ctfTracks->end();++tr)
-		{
-		  double lip = (*electrons)[i].gsfTrack()->dz() - tr->dz();
-		  if(tr->pt() > e_trackMinPt_ && fabs(lip) < e_lipCut_){
-		    double dphi=fabs(tr->phi()-(*electrons)[i].trackMomentumAtVtx().phi());
-		    if(dphi>acos(-1.))dphi=2*acos(-1.)-dphi;
-		    double deta=fabs(tr->eta()-(*electrons)[i].trackMomentumAtVtx().eta());
-		    double dr_ctf_ele = sqrt(deta*deta+dphi*dphi);
-		    if((dr_ctf_ele>e_minIsoDR_) && (dr_ctf_ele<e_maxIsoDR_)){
-		      double cft_pt_2 = (tr->pt())*(tr->pt());
-		      sum_of_pt_ele += cft_pt_2;
-		    }
-		  }
-		}
-	      double isolation_value_ele = sum_of_pt_ele/((*electrons)[i].trackMomentumAtVtx().Rho()*(*electrons)[i].trackMomentumAtVtx().Rho());
-	      if(isolation_value_ele<e_isoMaxSumPt_){
-		LorentzVector vec((*electrons)[i].px(),(*electrons)[i].py(),(*electrons)[i].pz(),(*electrons)[i].energy());
-		product_Electrons->push_back(vec);
-	      } 
-	      
-	    }
-	    else{ 
-	      LorentzVector vec((*electrons)[i].px(),(*electrons)[i].py(),(*electrons)[i].pz(),(*electrons)[i].energy());
-	      product_Electrons->push_back(vec);
-	    }
-	  }
+        edm::Ref<reco::GsfElectronCollection> electronRef(electrons,i);
+        bool idDec=false;
+        if(e_doID_){
+          reco::ElectronIDAssociationCollection::const_iterator tagIDAssocItr;
+          tagIDAssocItr = pEleID->find(electronRef);
+          const reco::ElectronIDRef& id_tag = tagIDAssocItr->val;
+          idDec=id_tag->cutBasedDecision();
+        }else idDec=true;
+        if((*electrons)[i].pt()>ptMinElectron_&&fabs((*electrons)[i].eta())<etaMax&&idDec)
+          {
+            if(e_doTrackIso_){
+              reco::TrackCollection::const_iterator tr = ctfTracks->begin();
+              double sum_of_pt_ele=0;
+              for(;tr != ctfTracks->end();++tr)
+                {
+                  double lip = (*electrons)[i].gsfTrack()->dz() - tr->dz();
+                  if(tr->pt() > e_trackMinPt_ && fabs(lip) < e_lipCut_){
+                    double dphi=fabs(tr->phi()-(*electrons)[i].trackMomentumAtVtx().phi());
+                    if(dphi>acos(-1.))dphi=2*acos(-1.)-dphi;
+                    double deta=fabs(tr->eta()-(*electrons)[i].trackMomentumAtVtx().eta());
+                    double dr_ctf_ele = sqrt(deta*deta+dphi*dphi);
+                    if((dr_ctf_ele>e_minIsoDR_) && (dr_ctf_ele<e_maxIsoDR_)){
+                      double cft_pt_2 = (tr->pt())*(tr->pt());
+                      sum_of_pt_ele += cft_pt_2;
+                    }
+                  }
+                }
+              double isolation_value_ele = sum_of_pt_ele/((*electrons)[i].trackMomentumAtVtx().Rho()*(*electrons)[i].trackMomentumAtVtx().Rho());
+              if(isolation_value_ele<e_isoMaxSumPt_){
+                LorentzVector vec((*electrons)[i].px(),(*electrons)[i].py(),(*electrons)[i].pz(),(*electrons)[i].energy());
+                product_Electrons->push_back(vec);
+              }
+
+            }
+            else{
+              LorentzVector vec((*electrons)[i].px(),(*electrons)[i].py(),(*electrons)[i].pz(),(*electrons)[i].energy());
+              product_Electrons->push_back(vec);
+            }
+          }
       }
-  
-  iEvent.put(std::move(product_Electrons),"Electrons"); 
+
+  iEvent.put(std::move(product_Electrons),"Electrons");
 }
 
-void 
+void
 HLTTauRefProducer::doMuons(edm::Event& iEvent,const edm::EventSetup& iES)
 {
   unique_ptr<LorentzVectorCollection> product_Muons(new LorentzVectorCollection);
   //Retrieve the collection
   edm::Handle<MuonCollection> muons;
-      if(iEvent.getByToken(Muons_,muons))
-   
-      for(size_t i = 0 ;i<muons->size();++i)
-	{
-	 
-	    if((*muons)[i].pt()>ptMinMuon_&&fabs((*muons)[i].eta())<etaMax)
-	      {
-		LorentzVector vec((*muons)[i].px(),(*muons)[i].py(),(*muons)[i].pz(),(*muons)[i].energy());
-		product_Muons->push_back(vec);
-	      }
-	}
+  if(iEvent.getByToken(Muons_,muons))
+
+    for(size_t i = 0 ;i<muons->size();++i)
+      {
+
+        if((*muons)[i].pt()>ptMinMuon_&&fabs((*muons)[i].eta())<etaMax)
+          {
+            LorentzVector vec((*muons)[i].px(),(*muons)[i].py(),(*muons)[i].pz(),(*muons)[i].energy());
+            product_Muons->push_back(vec);
+          }
+      }
 
 
-      iEvent.put(std::move(product_Muons),"Muons");
- 
+  iEvent.put(std::move(product_Muons),"Muons");
+
 }
 
 
-void 
+void
 HLTTauRefProducer::doJets(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      unique_ptr<LorentzVectorCollection> product_Jets(new LorentzVectorCollection);
-      //Retrieve the collection
-      edm::Handle<CaloJetCollection> jets;
-      if(iEvent.getByToken(Jets_,jets))
-      for(size_t i = 0 ;i<jets->size();++i)
-	{
-	     if((*jets)[i].et()>ptMinJet_&&fabs((*jets)[i].eta())<etaMax)
-	      {
-		LorentzVector vec((*jets)[i].px(),(*jets)[i].py(),(*jets)[i].pz(),(*jets)[i].energy());
-		product_Jets->push_back(vec);
-	      }
-	}
-      iEvent.put(std::move(product_Jets),"Jets");
+  unique_ptr<LorentzVectorCollection> product_Jets(new LorentzVectorCollection);
+  //Retrieve the collection
+  edm::Handle<CaloJetCollection> jets;
+  if(iEvent.getByToken(Jets_,jets))
+    for(size_t i = 0 ;i<jets->size();++i)
+      {
+        if((*jets)[i].et()>ptMinJet_&&fabs((*jets)[i].eta())<etaMax)
+          {
+            LorentzVector vec((*jets)[i].px(),(*jets)[i].py(),(*jets)[i].pz(),(*jets)[i].energy());
+            product_Jets->push_back(vec);
+          }
+      }
+  iEvent.put(std::move(product_Jets),"Jets");
 }
 
-void 
+void
 HLTTauRefProducer::doTowers(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      unique_ptr<LorentzVectorCollection> product_Towers(new LorentzVectorCollection);
-      //Retrieve the collection
-      edm::Handle<CaloTowerCollection> towers;
-      if(iEvent.getByToken(Towers_,towers))
-      for(size_t i = 0 ;i<towers->size();++i)
-	{
-	     if((*towers)[i].pt()>ptMinTower_&&fabs((*towers)[i].eta())<etaMax)
-	      {
-		//calculate isolation
-		double isolET=0;
-		for(unsigned int j=0;j<towers->size();++j)
-		  {
-		    if(ROOT::Math::VectorUtil::DeltaR((*towers)[i].p4(),(*towers)[j].p4())<0.5)
-		      isolET+=(*towers)[j].pt();
-		  }
-		isolET-=(*towers)[i].pt();
-		if(isolET<towerIsol_)
-		  {
-		    LorentzVector vec((*towers)[i].px(),(*towers)[i].py(),(*towers)[i].pz(),(*towers)[i].energy());
-		    product_Towers->push_back(vec);
-		  }
-	      }
-	}
-      iEvent.put(std::move(product_Towers),"Towers");
+  unique_ptr<LorentzVectorCollection> product_Towers(new LorentzVectorCollection);
+  //Retrieve the collection
+  edm::Handle<CaloTowerCollection> towers;
+  if(iEvent.getByToken(Towers_,towers))
+    for(size_t i = 0 ;i<towers->size();++i)
+      {
+        if((*towers)[i].pt()>ptMinTower_&&fabs((*towers)[i].eta())<etaMax)
+          {
+            //calculate isolation
+            double isolET=0;
+            for(unsigned int j=0;j<towers->size();++j)
+              {
+                if(ROOT::Math::VectorUtil::DeltaR((*towers)[i].p4(),(*towers)[j].p4())<0.5)
+                  isolET+=(*towers)[j].pt();
+              }
+            isolET-=(*towers)[i].pt();
+            if(isolET<towerIsol_)
+              {
+                LorentzVector vec((*towers)[i].px(),(*towers)[i].py(),(*towers)[i].pz(),(*towers)[i].energy());
+                product_Towers->push_back(vec);
+              }
+          }
+      }
+  iEvent.put(std::move(product_Towers),"Towers");
 }
 
 
-void 
+void
 HLTTauRefProducer::doPhotons(edm::Event& iEvent,const edm::EventSetup& iES)
 {
-      unique_ptr<LorentzVectorCollection> product_Gammas(new LorentzVectorCollection);
-      //Retrieve the collection
-      edm::Handle<PhotonCollection> photons;
-      if(iEvent.getByToken(Photons_,photons))
-      for(size_t i = 0 ;i<photons->size();++i)
-	if((*photons)[i].ecalRecHitSumEtConeDR04()<photonEcalIso_)
-	{
-	     if((*photons)[i].et()>ptMinPhoton_&&fabs((*photons)[i].eta())<etaMax)
-	      {
-		LorentzVector vec((*photons)[i].px(),(*photons)[i].py(),(*photons)[i].pz(),(*photons)[i].energy());
-		product_Gammas->push_back(vec);
-	      }
-	}
-      iEvent.put(std::move(product_Gammas),"Photons");
+  unique_ptr<LorentzVectorCollection> product_Gammas(new LorentzVectorCollection);
+  //Retrieve the collection
+  edm::Handle<PhotonCollection> photons;
+  if(iEvent.getByToken(Photons_,photons))
+    for(size_t i = 0 ;i<photons->size();++i)
+      if((*photons)[i].ecalRecHitSumEtConeDR04()<photonEcalIso_)
+        {
+          if((*photons)[i].et()>ptMinPhoton_&&fabs((*photons)[i].eta())<etaMax)
+            {
+              LorentzVector vec((*photons)[i].px(),(*photons)[i].py(),(*photons)[i].pz(),(*photons)[i].energy());
+              product_Gammas->push_back(vec);
+            }
+        }
+  iEvent.put(std::move(product_Gammas),"Photons");
 }
 
 void
@@ -335,6 +335,5 @@ HLTTauRefProducer::doMET(edm::Event& iEvent,const edm::EventSetup& iES)
     LorentzVector vec(px,py,0,pt);
     product_MET->push_back(vec);
   }
-  iEvent.put(std::move(product_MET),"MET");  
+  iEvent.put(std::move(product_MET),"MET");
 }
-


### PR DESCRIPTION
Very few actual changes required to convert from legacy to global.

- Removed unused functions.
- Adjusted `doXYZ(...)` functions to be `const`-qualified and take only a reference to an `edm::Event`.
- Made local variable `doID` for `doElectrons` so as to avoid changing values of class members during a multi-threaded context.
- General C++ improvements: use range-for's, automatic type deduction, replace `push_back` with `emplace_back`, etc.