### PR TITLE
Cleanup of mis-matched xerces init/terminate calls

### DIFF
--- a/L1Trigger/RPCTrigger/interface/RPCPacManager.h
+++ b/L1Trigger/RPCTrigger/interface/RPCPacManager.h
@@ -23,7 +23,6 @@
 
 #include "CondFormats/L1TObjects/interface/L1RPCConfig.h"
 
-#include "FWCore/Concurrency/interface/Xerces.h"
 #include <cstdlib>
 #ifndef _STAND_ALONE
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -88,7 +87,6 @@ public:
         }
       } 
     } 
-    cms::concurrency::xercesTerminate();
   };
 
   
@@ -164,7 +162,6 @@ public:
         }
       } 
     } 
-    cms::concurrency::xercesTerminate();
   };
   
   /** Returns the pointer to m_PAC for given LogCone defined by m_tower, logSector, logSegment.

--- a/L1Trigger/RPCTrigger/src/MuonsGrabber.cc
+++ b/L1Trigger/RPCTrigger/src/MuonsGrabber.cc
@@ -121,10 +121,7 @@ MuonsGrabber::~MuonsGrabber()
   delete theSerializer;
   delete myFormTarget;
   m_doc->release();
-      
-
-       
-
+  cms::concurrency::xercesTerminate();
 }
 
 void MuonsGrabber::startNewEvent(int event, int bx) {

--- a/L1Trigger/RPCTrigger/src/RPCPatternsParser.cc
+++ b/L1Trigger/RPCTrigger/src/RPCPatternsParser.cc
@@ -125,6 +125,7 @@ RPCPatternsParser::RPCPatternsParser()
 
 
 RPCPatternsParser::~RPCPatternsParser() {
+   cms::concurrency::xercesTerminate();
 }
 
 void RPCPatternsParser::parse(std::string fileName)


### PR DESCRIPTION
RPCPacManager::init() (both versions) call

    cms::concurrency::xercesTerminate();

which can result in Xerces cleanup being called without a matching call to initialize it.  If another package is using Xerces at the same time, Xerces cleanup will be called when the use count goes to zero, crashing the other package.  This PR moves the calls to xercesTerminate() from RPCPacManager to the destructors of the classes that call xercesInitialize() so the calls will be matched.

AFAICT, this bug has been there since the beginning of time, but only matters with the multi-threaded framework and multiple packages using Xerces at the same time.  Details in issue #17288 