### PR TITLE
Replace throw() dynamic exception specifier with noexcept

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/interface/BackgroundHandler.h
+++ b/MuonAnalysis/MomentumScaleCalibration/interface/BackgroundHandler.h
@@ -100,7 +100,7 @@ private:
   /// Used to check the consistency of passed parameters
   void consistencyCheck( const std::vector<int> & identifiers,
                          const std::vector<double> & leftWindowBorders,
-                         const std::vector<double> & rightWindowBorders ) const throw(cms::Exception);
+                         const std::vector<double> & rightWindowBorders ) const noexcept(false);
 
   // Correspondence between regions and halfWidths used:
   // - for the Upsilons region we use the Upsilon

--- a/MuonAnalysis/MomentumScaleCalibration/src/BackgroundHandler.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/src/BackgroundHandler.cc
@@ -273,7 +273,7 @@ void BackgroundHandler::countEventsInAllWindows(const std::vector<std::pair<reco
 
 void BackgroundHandler::consistencyCheck(const std::vector<int> & identifiers,
                                          const std::vector<double> & leftWindowBorders,
-                                         const std::vector<double> & rightWindowBorders) const throw(cms::Exception)
+                                         const std::vector<double> & rightWindowBorders) const noexcept(false)
 {
   if( leftWindowBorders.size() != rightWindowBorders.size() ) {
     throw cms::Exception("Configuration") << "BackgroundHandler::BackgroundHandler: leftWindowBorders.size() = " << leftWindowBorders.size()


### PR DESCRIPTION
throw() dynamic exeption specifier was deprecated in C++11 and finally
removed in C++17. Use noexcept / noexcept(expression) instead.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>