### PR TITLE
Migrating to the new Online DB schema

### DIFF
--- a/L1Trigger/L1TCommon/src/TriggerSystem.cc
+++ b/L1Trigger/L1TCommon/src/TriggerSystem.cc
@@ -34,6 +34,7 @@ void TriggerSystem::addProcessor (const char *processor, const char *role, const
         procToRole [processor] = role;
         procToSlot [processor] = slot;
         procParameters.insert( make_pair(string(processor),std::map<std::string,Parameter>()) ) ;
+        procMasks.     insert( make_pair(string(processor),std::map<std::string,Mask>()) ) ;
         roleForProcs [role]. insert(processor);
         crateForProcs[crate].insert(processor);
     }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -280,8 +280,10 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
     
     l1t::CaloParamsHelper m_params_helper( *(baseSettings.product()) );
 
-    readCaloLayer1OnlineSettings(m_params_helper, calol1_conf, calol1_rs);
-    readCaloLayer2OnlineSettings(m_params_helper, calol2_conf, calol2_rs);
+    if( !readCaloLayer1OnlineSettings(m_params_helper, calol1_conf, calol1_rs) )
+        throw std::runtime_error("Parsing error for CaloLayer1");
+    if( !readCaloLayer2OnlineSettings(m_params_helper, calol2_conf, calol2_rs) )
+        throw std::runtime_error("Parsing error for CaloLayer2");
 
     std::shared_ptr< l1t::CaloParams > retval = std::make_shared< l1t::CaloParams >( m_params_helper ) ;
     return retval;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -11,6 +11,7 @@
 #include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
 #include "L1Trigger/L1TCommon/interface/ConvertToLUT.h"
 #include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
+#include "OnlineDBqueryHelper.h"
 
 #include "xercesc/util/PlatformUtils.hpp"
 using namespace XERCES_CPP_NAMESPACE;
@@ -163,277 +164,93 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
     std::string tscKey = objectKey.substr(0, objectKey.find(":") );
     std::string  rsKey = objectKey.substr(   objectKey.find(":")+1, std::string::npos );
 
+    edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Producing L1TCaloParamsOnlineProd with TSC key = " << tscKey << " and RS key = " << rsKey ;
 
-    std::string stage2Schema = "CMS_TRG_L1_CONF" ;
-    edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Producing L1TCaloParamsOnlineProd with TSC key =" << tscKey << " and RS key = " << rsKey ;
+    std::string calol1_top_key, calol1_algo_key;
+    std::string calol1_algo_payload;
+    std::string calol2_top_key, calol2_algo_key, calol2_hw_key;
+    std::string calol2_hw_payload;
+    std::map<std::string,std::string> calol2_algo_payloads;  // key -> XML payload
+    try {
+        std::map<std::string,std::string> topKeys =
+            l1t::OnlineDBqueryHelper::fetch( {"CALOL1_KEY","CALOL2_KEY"},
+                                             "L1_TRG_CONF_KEYS",
+                                             tscKey,
+                                             m_omdsReader
+                                           );
+        calol1_top_key = topKeys["CALOL1_KEY"];
 
-    // first, find keys for the algo and RS tables
+        calol1_algo_key = l1t::OnlineDBqueryHelper::fetch( {"ALGO"},
+                                                           "CALOL1_KEYS",
+                                                           calol1_top_key,
+                                                           m_omdsReader
+                                                         ) ["ALGO"];
 
-    // ALGO
-    std::vector< std::string > queryStrings ;
-    queryStrings.push_back( "CALOL1_KEY" ) ;
-    queryStrings.push_back( "CALOL2_KEY" ) ;
+        calol1_algo_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                                               "CALOL1_CLOBS",
+                                                                calol1_algo_key,
+                                                                m_omdsReader
+                                                             ) ["CONF"];
 
-    std::string calol1_conf_key, calol2_conf_key;
+        calol2_top_key = topKeys["CALOL2_KEY"];
 
-    // select CALOL1_KEY,CALOL2_KEY from CMS_TRG_L1_CONF.L1_TRG_CONF_KEYS where ID = tscKey ;
-    l1t::OMDSReader::QueryResults queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "L1_TRG_CONF_KEYS",
-                                     "L1_TRG_CONF_KEYS.ID",
-                                     m_omdsReader.singleAttribute(tscKey)
-                                   ) ;
+        std::map<std::string,std::string> calol2_keys =
+            l1t::OnlineDBqueryHelper::fetch( {"ALGO","HW"},
+                                             "CALOL2_KEYS",
+                                             calol2_top_key,
+                                             m_omdsReader
+                                           );
 
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O" ) << "Cannot get L1_TRG_CONF_KEYS.{CALOL1_KEY,CALOL2_KEY} for ID = " << tscKey ;
-        throw std::runtime_error("Broken tscKey");
-    }
+        calol2_hw_key = calol2_keys["HW"];
+        calol2_hw_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                                             "CALOL2_CLOBS",
+                                                              calol2_hw_key,
+                                                              m_omdsReader
+                                                           ) ["CONF"];
 
-    if( !queryResult.fillVariable( "CALOL1_KEY", calol1_conf_key) ) calol1_conf_key = "";
-    if( !queryResult.fillVariable( "CALOL2_KEY", calol2_conf_key) ) calol2_conf_key = "";
+        calol2_algo_key = calol2_keys["ALGO"];
 
-    // At this point we have two config keys; now query the payloads' keys for these config keys
-    std::string calol1_algo_key, calol2_algo_key;
-    queryStrings.clear();
-    queryStrings.push_back( "ALGO" );
+        std::map<std::string,std::string> calol2_algo_keys =
+            l1t::OnlineDBqueryHelper::fetch( {"DEMUX","MPS_COMMON","MPS_JET","MP_EGAMMA","MP_SUM","MP_TAU"},
+                                             "CALOL2_ALGO_KEYS",
+                                             calol2_algo_key,
+                                             m_omdsReader
+                                           );
 
-    // query ALGO configurations
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL1_KEYS",
-                                     "CALOL1_KEYS.ID",
-                                     m_omdsReader.singleAttribute(calol1_conf_key)
-                                   ) ;
+        for(auto &key : calol2_algo_keys)
+            calol2_algo_payloads[ key.second ] = 
+                l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                                 "CALOL2_CLOBS",
+                                                 key.second,
+                                                 m_omdsReader
+                                               ) ["CONF"];
 
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL1_KEYS.ALGO for ID="<<calol1_conf_key;
+    } catch ( std::runtime_error &e ) {
+        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << e.what();
         throw std::runtime_error("Broken key");
     }
-
-    if( !queryResult.fillVariable( "ALGO", calol1_algo_key ) ) calol1_algo_key = "";
-
-    queryStrings.push_back( "HW" );
-//  No Layer2 for the moment
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_KEYS",
-                                     "CALOL2_KEYS.ID",
-                                     m_omdsReader.singleAttribute(calol2_conf_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_KEYS.ALGO for ID="<<calol2_conf_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    std::string calol2_hw_key;
-    if( !queryResult.fillVariable( "ALGO", calol2_algo_key ) ) calol2_algo_key = "";
-    if( !queryResult.fillVariable( "HW",   calol2_hw_key   ) ) calol2_hw_key   = "";
-
-
-    // Now querry the actual payloads
-    enum {kCONF=0, kRS, kHW, NUM_TYPES};
-    std::map<std::string,std::string> payloads[NUM_TYPES];  // associates key -> XML payload for a given type of payloads
-    std::string xmlPayload;
-
-    queryStrings.clear();
-    queryStrings.push_back( "CONF" );
-
-    // query CALOL1 ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL1_ALGO",
-                                     "CALOL1_ALGO.ID",
-                                     m_omdsReader.singleAttribute(calol1_algo_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL1_ALGO.CONF for ID="<<calol1_algo_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kCONF][calol1_algo_key.append("_L1")] = xmlPayload;
-
-    std::string calol2_demux_key, calol2_mps_common_key, calol2_mps_jet_key, calol2_mp_egamma_key, calol2_mp_sum_key, calol2_mp_tau_key;
-
-    queryStrings.clear();
-    queryStrings.push_back( "DEMUX"      );
-    queryStrings.push_back( "MPS_COMMON" );
-    queryStrings.push_back( "MPS_JET"    );
-    queryStrings.push_back( "MP_EGAMMA"  );
-    queryStrings.push_back( "MP_SUM"     );
-    queryStrings.push_back( "MP_TAU"     );
-
-    // No CALOL2 ALGO configuration for the moment
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_ALGO_KEYS",
-                                     "CALOL2_ALGO_KEYS.ID",
-                                     m_omdsReader.singleAttribute(calol2_algo_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_ALGO_KEYS.{DEMUX,MPS_COMMON,MPS_JET,MP_EGAMMA,MP_SUM,MP_TAU} for ID="<<calol2_algo_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "DEMUX",      calol2_demux_key      ) ) calol2_demux_key      = "";
-    if( !queryResult.fillVariable( "MPS_COMMON", calol2_mps_common_key ) ) calol2_mps_common_key = "";
-    if( !queryResult.fillVariable( "MPS_JET",    calol2_mps_jet_key    ) ) calol2_mps_jet_key    = "";
-    if( !queryResult.fillVariable( "MP_EGAMMA",  calol2_mp_egamma_key  ) ) calol2_mp_egamma_key  = "";
-    if( !queryResult.fillVariable( "MP_SUM",     calol2_mp_sum_key     ) ) calol2_mp_sum_key     = "";
-    if( !queryResult.fillVariable( "MP_TAU",     calol2_mp_tau_key     ) ) calol2_mp_tau_key     = "";
-
-    queryStrings.clear();
-    queryStrings.push_back( "CONF" );
-
-    // query CALOL2 ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_ALGO",
-                                     "CALOL2_ALGO.ID",
-                                     m_omdsReader.singleAttribute(calol2_demux_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_ALGO.CONF for ID="<<calol2_demux_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kCONF][calol2_demux_key.append("_L2")] = xmlPayload;
-
-    // query CALOL2 ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_ALGO",
-                                     "CALOL2_ALGO.ID",
-                                     m_omdsReader.singleAttribute(calol2_mps_common_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_ALGO.CONF for ID="<<calol2_mps_common_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kCONF][calol2_mps_common_key.append("_L2")] = xmlPayload;
-
-    // query CALOL2 ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_ALGO",
-                                     "CALOL2_ALGO.ID",
-                                     m_omdsReader.singleAttribute(calol2_mps_jet_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_ALGO.CONF for ID="<<calol2_mps_jet_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kCONF][calol2_mps_jet_key.append("_L2")] = xmlPayload;
-
-    // query CALOL2 ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_ALGO",
-                                     "CALOL2_ALGO.ID",
-                                     m_omdsReader.singleAttribute(calol2_mp_egamma_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_ALGO.CONF for ID="<<calol2_mp_egamma_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kCONF][calol2_mp_egamma_key.append("_L2")] = xmlPayload;
-
-    // query CALOL2 ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_ALGO",
-                                     "CALOL2_ALGO.ID",
-                                     m_omdsReader.singleAttribute(calol2_mp_sum_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_ALGO.CONF for ID="<<calol2_mp_sum_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kCONF][calol2_mp_sum_key.append("_L2")] = xmlPayload;
-
-    // query CALOL2 ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_ALGO",
-                                     "CALOL2_ALGO.ID",
-                                     m_omdsReader.singleAttribute(calol2_mp_tau_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_ALGO.CONF for ID="<<calol2_mp_tau_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kCONF][calol2_mp_tau_key.append("_L2")] = xmlPayload;
-
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "CALOL2_HW",
-                                     "CALOL2_HW.ID",
-                                     m_omdsReader.singleAttribute(calol2_hw_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Cannot get CALOL2_HW.CONF for ID="<<calol2_hw_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember HW configuration
-    payloads[kHW][calol2_hw_key] = xmlPayload;
 
     // for debugging purposes dump the configs to local files
-    for(auto &conf : payloads[kCONF]){ 
+    for(auto &conf : calol2_algo_payloads){ 
         std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
         output<<conf.second;
         output.close();
     }
-    for(auto &conf : payloads[kHW]){ 
-        std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
-        output<<conf.second;
+    { 
+        std::ofstream output(std::string("/tmp/").append(calol2_hw_key.substr(0,calol2_hw_key.find("/"))).append(".xml"));
+        output << calol2_hw_payload;
         output.close();
     }
+    { 
+        std::ofstream output(std::string("/tmp/").append(calol1_algo_key.substr(0,calol1_algo_key.find("/"))).append(".xml"));
+        output << calol1_algo_payload;
+        output.close();
+    }
+
 
 
     l1t::XmlConfigParser xmlReader1;
-    xmlReader1.readDOMFromString( payloads[kCONF][calol1_algo_key] );
+    xmlReader1.readDOMFromString( calol1_algo_payload );
 
     l1t::TriggerSystem calol1;
     calol1.addProcessor("processors", "processors","-1","-1");
@@ -444,17 +261,14 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
     std::map<std::string, l1t::Mask>      calol1_rs   ;//= calol1.getMasks   ("processors");
 
     l1t::TriggerSystem calol2;
-//    calol2.addProcRole("processors", "MainProcessor");
 
     l1t::XmlConfigParser xmlReader2;
-    xmlReader2.readDOMFromString( payloads[kHW].begin()->second );
+    xmlReader2.readDOMFromString( calol2_hw_payload );
     xmlReader2.readRootElement( calol2, "calol2" );
 
-    for(auto &conf : payloads[kCONF]){ 
-        if( conf.first.find("_L2") != std::string::npos ){
-            xmlReader2.readDOMFromString( conf.second );
-            xmlReader2.readRootElement( calol2, "calol2" );
-        }
+    for(auto &conf : calol2_algo_payloads){ 
+        xmlReader2.readDOMFromString( conf.second );
+        xmlReader2.readRootElement( calol2, "calol2" );
     }
 
 //    calol2.setSystemId("calol2");
@@ -464,7 +278,7 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
     std::map<std::string, l1t::Parameter> calol2_conf = calol2.getParameters("MP1");
     std::map<std::string, l1t::Mask>      calol2_rs   ;//= calol2.getMasks   ("processors");
     
-    l1t::CaloParamsHelper m_params_helper(*(baseSettings.product()));
+    l1t::CaloParamsHelper m_params_helper( *(baseSettings.product()) );
 
     readCaloLayer1OnlineSettings(m_params_helper, calol1_conf, calol1_rs);
     readCaloLayer2OnlineSettings(m_params_helper, calol2_conf, calol2_rs);

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -58,14 +58,14 @@ std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(co
 
         hw_payload =
             l1t::OnlineDBqueryHelper::fetch( {"CONF"},
-                                             "BMTF_COLBS",
+                                             "BMTF_CLOBS",
                                              hw_key,
                                              m_omdsReader
                                            ) ["CONF"];
 
         algo_payload =
             l1t::OnlineDBqueryHelper::fetch( {"CONF"},
-                                             "BMTF_COLBS",
+                                             "BMTF_CLOBS",
                                              algo_key,
                                              m_omdsReader
                                            ) ["CONF"];
@@ -81,13 +81,13 @@ std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(co
 
         mp7_payload =
             l1t::OnlineDBqueryHelper::fetch( {"CONF"},
-                                             "BMTF_COLBS",
+                                             "BMTF_CLOBS",
                                              mp7_key,
                                              m_omdsReader
                                            ) ["CONF"];
         amc13_payload =
             l1t::OnlineDBqueryHelper::fetch( {"CONF"},
-                                             "BMTF_COLBS",
+                                             "BMTF_CLOBS",
                                              amc13_key,
                                              m_omdsReader
                                            ) ["CONF"];

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -8,6 +8,7 @@
 #include "L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelParamsHelper.h"
 #include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
 #include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
+#include "OnlineDBqueryHelper.h"
 
 #include "xercesc/util/PlatformUtils.hpp"
 using namespace XERCES_CPP_NAMESPACE;
@@ -40,193 +41,110 @@ std::shared_ptr<L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(co
     std::string  rsKey = objectKey.substr(   objectKey.find(":")+1, std::string::npos );
 
 
-    std::string stage2Schema = "CMS_TRG_L1_CONF" ;
-    edm::LogInfo( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "Producing L1TMuonBarrelParams with TSC key =" << tscKey << " and RS key = " << rsKey ;
+    edm::LogInfo( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "Producing L1TMuonBarrelParams with TSC key = " << tscKey << " and RS key = " << rsKey ;
 
-        // first, find keys for the algo and RS tables
+    std::string algo_key, hw_key;
+    std::string mp7_key, amc13_key;
+    std::string hw_payload, algo_payload, mp7_payload, amc13_payload;
+    try {
+        std::map<std::string,std::string> keys =
+            l1t::OnlineDBqueryHelper::fetch( {"ALGO","HW"},
+                                             "BMTF_KEYS",
+                                             tscKey,
+                                             m_omdsReader
+                                           );
+        algo_key = keys["ALGO"];
+        hw_key   = keys["HW"];
 
-        // ALGO and HW
-        std::vector< std::string > queryStrings ;
-        queryStrings.push_back( "ALGO" ) ;
-        queryStrings.push_back( "HW"   ) ;
+        hw_payload =
+            l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                             "BMTF_COLBS",
+                                             hw_key,
+                                             m_omdsReader
+                                           ) ["CONF"];
 
-        std::string algo_key, hw_key;
+        algo_payload =
+            l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                             "BMTF_COLBS",
+                                             algo_key,
+                                             m_omdsReader
+                                           ) ["CONF"];
 
-        // select ALGO,HW from CMS_TRG_L1_CONF.BMTF_KEYS where ID = tscKey ;
-        l1t::OMDSReader::QueryResults queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "BMTF_KEYS",
-                                     "BMTF_KEYS.ID",
-                                     m_omdsReader.singleAttribute(tscKey)
-                                   ) ;
+        std::map<std::string,std::string> rsKeys =
+            l1t::OnlineDBqueryHelper::fetch( {"MP7","AMC13"},
+                                             "BMTF_RS_KEYS",
+                                             rsKey,
+                                             m_omdsReader
+                                           );
+        mp7_key   = rsKeys["MP7"];
+        amc13_key = rsKeys["AMC13"];
 
-        if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-            edm::LogError( "L1-O2O" ) << "Cannot get BMTF_KEYS.{ALGO,HW}" ;
-            throw std::runtime_error("Broken key");
-        }
+        mp7_payload =
+            l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                             "BMTF_COLBS",
+                                             mp7_key,
+                                             m_omdsReader
+                                           ) ["CONF"];
+        amc13_payload =
+            l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                             "BMTF_COLBS",
+                                             amc13_key,
+                                             m_omdsReader
+                                           ) ["CONF"];
 
-        if( !queryResult.fillVariable( "ALGO", algo_key) ) algo_key = "";
-        if( !queryResult.fillVariable( "HW",   hw_key  ) ) hw_key   = "";
-
-
-        // RS
-        queryStrings.clear() ;
-        queryStrings.push_back( "MP7"    ) ;
-        queryStrings.push_back( "DAQTTC" ) ;
-
-        std::string rs_mp7_key, rs_amc13_key;
-
-        // select RS from CMS_TRG_L1_CONF.BMTF_RS_KEYS where ID = rsKey ;
-        queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "BMTF_RS_KEYS",
-                                     "BMTF_RS_KEYS.ID",
-                                     m_omdsReader.singleAttribute(rsKey)
-                                   ) ;
-
-        if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-            edm::LogError( "L1-O2O" ) << "Cannot get BMTF_RS_KEYS.{MP7,DAQTTC}" ;
-            throw std::runtime_error("Broken key");
-        }
-
-        if( !queryResult.fillVariable( "MP7",    rs_mp7_key  ) ) rs_mp7_key   = "";
-        if( !queryResult.fillVariable( "DAQTTC", rs_amc13_key) ) rs_amc13_key = "";
+    } catch ( std::runtime_error &e ) {
+        edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << e.what();
+        throw std::runtime_error("Broken key");
+    }
 
 
-        // At this point we have four keys: one ALGO key, one HW key, and two RS keys; now query the payloads for these keys
-        // Now querry the actual payloads
-        enum {kALGO=0, kRS, kHW, NUM_TYPES};
-        std::map<std::string,std::string> payloads[NUM_TYPES];  // associates key -> XML payload for a given type of payloads
-        std::string xmlPayload;
+    // for debugging dump the configs to local files
+    {
+        std::ofstream output(std::string("/tmp/").append(hw_key.substr(0,hw_key.find("/"))).append(".xml"));
+        output << hw_payload;
+        output.close();
+    }
+    {
+        std::ofstream output(std::string("/tmp/").append(algo_key.substr(0,algo_key.find("/"))).append(".xml"));
+        output << algo_payload;
+        output.close();
+    }
+    {
+        std::ofstream output(std::string("/tmp/").append(mp7_key.substr(0,mp7_key.find("/"))).append(".xml"));
+        output << mp7_payload;
+        output.close();
+    }
+    {
+        std::ofstream output(std::string("/tmp/").append(amc13_key.substr(0,amc13_key.find("/"))).append(".xml"));
+        output << amc13_payload;
+        output.close();
+    }
 
-        queryStrings.clear();
-        queryStrings.push_back( "CONF" );
+    // finally, push all payloads to the XML parser and construct the TrigSystem objects with each of those
+    l1t::XmlConfigParser xmlRdr;
+    l1t::TriggerSystem parsedXMLs;
 
-        // query ALGO configuration
-        queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "BMTF_ALGO",
-                                     "BMTF_ALGO.ID",
-                                     m_omdsReader.singleAttribute(algo_key)
-                                   ) ;
+    // HW settings should always go first
+    xmlRdr.readDOMFromString( hw_payload );
+    xmlRdr.readRootElement  ( parsedXMLs );
 
-        if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-            edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "Cannot get BMTF_ALGO.CONF for ID="<<algo_key;
-            throw std::runtime_error("Broken key");
-        }
+    // now let's parse ALGO settings 
+    xmlRdr.readDOMFromString( algo_payload );
+    xmlRdr.readRootElement  ( parsedXMLs   );
 
-        if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-        // remember ALGO configuration
-        payloads[kALGO][algo_key] = xmlPayload;
+    // remaining RS settings 
+    xmlRdr.readDOMFromString( mp7_payload );
+    xmlRdr.readRootElement  ( parsedXMLs  );
 
-        // query HW configuration
-        queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "BMTF_HW",
-                                     "BMTF_HW.ID",
-                                     m_omdsReader.singleAttribute(hw_key)
-                                   ) ;
+    xmlRdr.readDOMFromString( amc13_payload );
+    xmlRdr.readRootElement  ( parsedXMLs    );
+    parsedXMLs.setConfigured();
 
-        if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-            edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "Cannot get BMTF_HW.CONF for ID="<<hw_key;
-            throw std::runtime_error("Broken key");
-        }
-
-        if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-        // remember HW configuration
-        payloads[kHW][hw_key] = xmlPayload;
-
-        // query MP7 RS configuration
-        queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "BMTF_RS",
-                                     "BMTF_RS.ID",
-                                     m_omdsReader.singleAttribute(rs_mp7_key)
-                                   ) ;
-
-        if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-            edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "Cannot get BMTF_RS.CONF for ID="<<rs_mp7_key;
-            throw std::runtime_error("Broken key");
-        }
-
-        if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-        // remember MP7 RS configuration
-        payloads[kRS][rs_mp7_key] = xmlPayload;
-
-        // query AMC13 RS configuration
-        queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "BMTF_RS",
-                                     "BMTF_RS.ID",
-                                     m_omdsReader.singleAttribute(rs_amc13_key)
-                                   ) ;
-
-        if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-            edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "Cannot get BMTF_RS.CONF for ID="<<rs_amc13_key;
-            throw std::runtime_error("Broken key");
-        }
-
-        if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-        // remember AMC13 RS configuration
-        payloads[kRS][rs_amc13_key] = xmlPayload;
-
-// for debugging dump the configs to local files
-for(auto &conf : payloads[kHW]){ 
-    std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
-    output<<conf.second;
-    output.close();
-}
-for(auto &conf : payloads[kALGO]){ 
-    std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
-    output<<conf.second;
-    output.close();
-}
-for(auto &conf : payloads[kRS]){ 
-    std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
-    output<<conf.second;
-    output.close();
-}
-
-        // finally, push all payloads to the XML parser and construct the TrigSystem objects with each of those
-        l1t::XmlConfigParser xmlRdr;
-        l1t::TriggerSystem parsedXMLs;
-//        parsedXMLs.addProcRole("processors", "procMP7");
-        // HW settings should always go first
-        for(auto &conf : payloads[ kHW ]){
-            xmlRdr.readDOMFromString( conf.second );
-            xmlRdr.readRootElement  ( parsedXMLs  );
-        }
-        // now let's parse ALGO and then RS settings 
-        for(auto &conf : payloads[ kALGO ]){
-            xmlRdr.readDOMFromString( conf.second );
-            xmlRdr.readRootElement  ( parsedXMLs  );
-        }
-        for(auto &conf : payloads[ kRS ]){
-            xmlRdr.readDOMFromString( conf.second );
-            xmlRdr.readRootElement  ( parsedXMLs  );
-        }
-        parsedXMLs.setConfigured();
-
-        // for debugging also dump the configs to local files
-        for(size_t type=0; type<NUM_TYPES; type++)
-            for(auto &conf : payloads[ type ]){
-                std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
-                output<<conf.second;
-                output.close();
-            }
-
-        L1TMuonBarrelParamsHelper m_params_helper(*(baseSettings.product()) );
-        m_params_helper.configFromDB(parsedXMLs);
-        std::shared_ptr< L1TMuonBarrelParams > retval = std::make_shared< L1TMuonBarrelParams>(m_params_helper);
+    L1TMuonBarrelParamsHelper m_params_helper( *(baseSettings.product()) );
+    m_params_helper.configFromDB( parsedXMLs );
+    std::shared_ptr< L1TMuonBarrelParams > retval = std::make_shared< L1TMuonBarrelParams>( m_params_helper );
  
-        return retval;
-
+    return retval;
 }
 
 //define this as a plug-in

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndcapParamsOnlineProd.cc
@@ -15,7 +15,6 @@
 
 class L1TMuonEndcapParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonEndcapParamsO2ORcd,L1TMuonEndCapParams> {
 private:
-    bool handleObsolteKeys;
 public:
     virtual std::shared_ptr<L1TMuonEndCapParams> newObject(const std::string& objectKey, const L1TMuonEndcapParamsO2ORcd& record) override ;
 
@@ -23,9 +22,7 @@ public:
     ~L1TMuonEndcapParamsOnlineProd(void){}
 };
 
-L1TMuonEndcapParamsOnlineProd::L1TMuonEndcapParamsOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TMuonEndcapParamsO2ORcd,L1TMuonEndCapParams>(iConfig) {
-    handleObsolteKeys = iConfig.getUntrackedParameter<bool>("handleObsolteKeys",true);
-}
+L1TMuonEndcapParamsOnlineProd::L1TMuonEndcapParamsOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TMuonEndcapParamsO2ORcd,L1TMuonEndCapParams>(iConfig){}
 
 std::shared_ptr<L1TMuonEndCapParams> L1TMuonEndcapParamsOnlineProd::newObject(const std::string& objectKey, const L1TMuonEndcapParamsO2ORcd& record) {
     using namespace edm::es;
@@ -57,27 +54,6 @@ std::shared_ptr<L1TMuonEndCapParams> L1TMuonEndcapParamsOnlineProd::newObject(co
 
         hw_key   = keys["HW"];
         algo_key = keys["ALGO"];
-
-        // all EMTF ALGO keys before "EMTF_ALGO_BASE/v6" are broken and will crash the code below, let's promote them to v6
-        if( handleObsolteKeys ){
-            size_t pos = algo_key.find("EMTF_ALGO_BASE/v");
-            if( pos != std::string::npos ){
-                int v = atoi(algo_key.c_str()+16);
-                if( v>0 && v<6 ){
-                    algo_key = "EMTF_ALGO_BASE/v6";
-                    edm::LogError( "L1-O2O" ) << "Inconsistent old ALGO key -> changing to " << algo_key ;
-                }
-            }
-            // HW has to be consistent with the ALGO: promote everything to EMTF_HW/v8
-            pos = hw_key.find("EMTF_HW/v");
-            if( pos != std::string::npos ){
-                int v = atoi(hw_key.c_str()+9);
-                if( v>0 && v<8 ){
-                    hw_key = "EMTF_HW/v8";
-                    edm::LogError( "L1-O2O" ) << "Inconsistent old HW key -> changing to " << hw_key ;
-                }
-            }
-        }
 
         hw_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
                                                       "EMTF_CLOBS",

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -10,6 +10,7 @@
 #include "L1Trigger/L1TMuon/interface/L1TMuonGlobalParams_PUBLIC.h"
 #include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
 #include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
+#include "OnlineDBqueryHelper.h"
 
 class L1TMuonGlobalParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd,L1TMuonGlobalParams> {
 private:
@@ -37,213 +38,74 @@ std::shared_ptr<L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(co
     std::string tscKey = objectKey.substr(0, objectKey.find(":") );
     std::string  rsKey = objectKey.substr(   objectKey.find(":")+1, std::string::npos );
 
-    std::string stage2Schema = "CMS_TRG_L1_CONF" ;
     edm::LogInfo( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Producing L1TMuonGlobalParams with TSC key =" << tscKey << " and RS key = " << rsKey ;
 
-    // ALGO and HW
-    std::vector< std::string > queryStrings ;
-    queryStrings.push_back( "ALGO" ) ;
-    queryStrings.push_back( "HW"   ) ;
-
     std::string algo_key, hw_key;
+    std::string hw_payload;
+    std::map<std::string,std::string> rs_payloads, algo_payloads;
+    try {
+        std::map<std::string,std::string> keys =
+            l1t::OnlineDBqueryHelper::fetch( {"ALGO","HW"},
+                                             "UGMT_KEYS",
+                                             tscKey,
+                                             m_omdsReader
+                                           );
+        algo_key = keys["ALGO"];
+        hw_key   = keys["HW"];
 
-    // select ALGO,HW from CMS_TRG_L1_CONF.UGMT_KEYS where ID = tscKey ;
-    l1t::OMDSReader::QueryResults queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_KEYS",
-                                     "UGMT_KEYS.ID",
-                                     m_omdsReader.singleAttribute(tscKey)
-                                   ) ;
+        hw_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                                      "UGMT_CLOBS",
+                                                      hw_key,
+                                                      m_omdsReader
+                                                    ) ["CONF"];
 
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_KEYS.{ALGO,HW} for ID = " << tscKey ;
+        std::map<std::string,std::string> rsKeys =
+            l1t::OnlineDBqueryHelper::fetch( {"MP7","MP7_MONI","AMC13_MONI"},
+                                             "UGMT_RS_KEYS",
+                                             rsKey,
+                                             m_omdsReader
+                                           );
+
+        std::map<std::string,std::string> algoKeys =
+            l1t::OnlineDBqueryHelper::fetch( {"MP7","LUTS"},
+                                             "UGMT_ALGO_KEYS",
+                                             algo_key,
+                                             m_omdsReader
+                                           );
+
+        for(auto &key : rsKeys)
+            rs_payloads[ key.second ] = 
+                l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                                 "UGMT_CLOBS",
+                                                 key.second,
+                                                 m_omdsReader
+                                               ) ["CONF"];
+
+        for(auto &key : algoKeys)
+            algo_payloads[ key.second ] = 
+                l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                                 "UGMT_CLOBS",
+                                                 key.second,
+                                                 m_omdsReader
+                                               ) ["CONF"];
+    } catch ( std::runtime_error &e ) {
+        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << e.what();
         throw std::runtime_error("Broken key");
     }
-
-    if( !queryResult.fillVariable( "ALGO", algo_key) ) algo_key = "";
-    if( !queryResult.fillVariable( "HW",   hw_key  ) ) hw_key   = "";
-
-    // RS
-    queryStrings.clear();
-    queryStrings.push_back( "MP7"       );
-    queryStrings.push_back( "MP7_MONI"  );
-    queryStrings.push_back( "AMC13_MONI");
-
-    std::string rs_mp7_key, rs_mp7moni_key, rs_amc13moni_key;
-
-    // select MP7, MP&_MONI, AMC13_MONI from CMS_TRG_L1_CONF.UGMT_RS_KEYS where ID = rsKey ;
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_RS_KEYS",
-                                     "UGMT_RS_KEYS.ID",
-                                     m_omdsReader.singleAttribute(rsKey)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_RS_KEYS.{MP7,MP7_MONI,AMC13_MONI} for ID = " << rsKey ;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "MP7",        rs_mp7_key      ) ) rs_mp7_key       = "";
-    if( !queryResult.fillVariable( "MP7_MONI",   rs_mp7moni_key  ) ) rs_mp7moni_key   = "";
-    if( !queryResult.fillVariable( "AMC13_MONI", rs_amc13moni_key) ) rs_amc13moni_key = "";
-
-
-    std::string algo_mp7_key, algo_luts_key;
-
-    queryStrings.clear();
-    queryStrings.push_back( "MP7"  );
-    queryStrings.push_back( "LUTS" );
-
-    // query ALGO configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_ALGO_KEYS",
-                                     "UGMT_ALGO_KEYS.ID",
-                                     m_omdsReader.singleAttribute(algo_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_ALGO.{MP7,LUTS} for ID = " << algo_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "MP7",  algo_mp7_key  ) ) algo_mp7_key  = "";
-    if( !queryResult.fillVariable( "LUTS", algo_luts_key ) ) algo_luts_key = "";
-    // remember ALGO configuration
-
-    // At this point we have four keys: one ALGO key, one HW key, and two RS keys; now query the payloads for these keys
-    // Now querry the actual payloads
-    enum {kALGO=0, kRS, kHW, NUM_TYPES};
-    std::map<std::string,std::string> payloads[NUM_TYPES];  // associates key -> XML payload for a given type of payloads
-    std::string xmlPayload;
-
-    queryStrings.clear();
-    queryStrings.push_back( "CONF" );
-
-    // query ALGO configurations
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_ALGO",
-                                     "UGMT_ALGO.ID",
-                                     m_omdsReader.singleAttribute(algo_mp7_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_ALGO.CONF for ID = " << algo_mp7_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember MP7 ALGO configuration
-    payloads[kALGO][algo_mp7_key] = xmlPayload;
-
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_ALGO",
-                                     "UGMT_ALGO.ID",
-                                     m_omdsReader.singleAttribute(algo_luts_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_ALGO.CONF for ID = " << algo_luts_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember ALGO configuration
-    payloads[kALGO][algo_luts_key] = xmlPayload;
-
-
-    // query HW configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_HW",
-                                     "UGMT_HW.ID",
-                                     m_omdsReader.singleAttribute(hw_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_HW.CONF for ID = " << hw_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember HW configuration
-    payloads[kHW][hw_key] = xmlPayload;
-
-    // query MP7 and AMC13 RS configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_RS",
-                                     "UGMT_RS.ID",
-                                     m_omdsReader.singleAttribute(rs_mp7_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_RS.CONF for ID = " << rs_mp7_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember MP7 RS configuration
-    payloads[kRS][rs_mp7_key] = xmlPayload;
-
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_RS",
-                                     "UGMT_RS.ID",
-                                     m_omdsReader.singleAttribute(rs_mp7moni_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonGlobalParamsOnlineProd" ) << "Cannot get UGMT_RS.CONF for ID = " << rs_mp7moni_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember MP7 RS configuration
-    payloads[kRS][rs_mp7moni_key] = xmlPayload;
-
-    // query AMC13 RS configuration
-    queryResult =
-            m_omdsReader.basicQuery( queryStrings,
-                                     stage2Schema,
-                                     "UGMT_RS",
-                                     "UGMT_RS.ID",
-                                     m_omdsReader.singleAttribute(rs_amc13moni_key)
-                                   ) ;
-
-    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
-        edm::LogError( "L1-O2O: L1TMuonBarrelParamsOnlineProd" ) << "Cannot get UGMT_RS.CONF for ID = " << rs_amc13moni_key;
-        throw std::runtime_error("Broken key");
-    }
-
-    if( !queryResult.fillVariable( "CONF", xmlPayload ) ) xmlPayload = "";
-    // remember AMC13 RS configuration
-    payloads[kRS][rs_amc13moni_key] = xmlPayload;
 
 
     // for debugging dump the configs to local files
-    for(auto &conf : payloads[kHW]){
+    {
+        std::ofstream output(std::string("/tmp/").append(hw_key.substr(0,hw_key.find("/"))).append(".xml"));
+        output << hw_payload;
+        output.close();
+    }
+    for(auto &conf : rs_payloads){
         std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
         output<<conf.second;
         output.close();
     }
-    for(auto &conf : payloads[kALGO]){
-        std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
-        output<<conf.second;
-        output.close();
-    }
-    for(auto &conf : payloads[kRS]){
+    for(auto &conf : algo_payloads){
         std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
         output<<conf.second;
         output.close();
@@ -252,17 +114,17 @@ std::shared_ptr<L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(co
     // finally, push all payloads to the XML parser and construct the TrigSystem objects with each of those
     l1t::XmlConfigParser xmlRdr;
     l1t::TriggerSystem trgSys;
+
     // HW settings should always go first
-    for(auto &conf : payloads[ kHW ]){
-        xmlRdr.readDOMFromString( conf.second );
-        xmlRdr.readRootElement  ( trgSys      );
-    }
+    xmlRdr.readDOMFromString( hw_payload );
+    xmlRdr.readRootElement  ( trgSys     );
+
     // now let's parse ALGO and then RS settings 
-    for(auto &conf : payloads[ kALGO ]){
+    for(auto &conf : algo_payloads){
         xmlRdr.readDOMFromString( conf.second );
         xmlRdr.readRootElement  ( trgSys      );
     }
-    for(auto &conf : payloads[ kRS ]){
+    for(auto &conf : rs_payloads){
         xmlRdr.readDOMFromString( conf.second );
         xmlRdr.readRootElement  ( trgSys      );
     }

--- a/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.cc
@@ -1,0 +1,51 @@
+#include "OnlineDBqueryHelper.h"
+
+std::map<std::string,std::string> l1t::OnlineDBqueryHelper::fetch(
+        const std::vector<std::string> &queryColumns,
+        const std::string              &table,
+        const std::string              &key,
+        l1t::OMDSReader                &m_omdsReader)
+    {
+        if( queryColumns.size() == 0 || table.length() == 0 )
+           return std::map<std::string,std::string>();
+
+        l1t::OMDSReader::QueryResults queryResult =
+            m_omdsReader.basicQuery( queryColumns,
+                                     "CMS_TRG_L1_CONF",
+                                     table,
+                                     table + ".ID",
+                                     m_omdsReader.singleAttribute(key)
+                                   ) ;
+
+        if( queryResult.queryFailed() || queryResult.numberRows() != 1 )
+            throw std::runtime_error( std::string("Cannot get ") +
+                                      table + 
+                                      ".{" + 
+                                      std::accumulate( std::next( queryColumns.begin() ),
+                                                       queryColumns.end(),
+                                                       std::string( queryColumns[0] ),
+                                                       [] (const std::string &a, const std::string &b) { return a + "," + b; }
+                                                     ) +
+                                      "} for ID = " + 
+                                      key
+                                    );
+
+        std::vector<std::string> retval( queryColumns.size() );
+
+        std::transform( queryColumns.begin(),
+                        queryColumns.end(),
+                        retval.begin(),
+                        [ queryResult ] ( const std::string &a )
+                        {
+                            std::string res;
+                            if( !queryResult.fillVariable(a, res) ) res = "";
+                            return res;
+                        }
+                      );
+
+        std::map<std::string,std::string> retvalMap;
+        for(unsigned int i=0; i<queryColumns.size(); i++)
+            retvalMap.insert( make_pair( queryColumns[i], retval[i] ) );
+
+        return retvalMap;
+    }

--- a/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/OnlineDBqueryHelper.h
@@ -1,0 +1,27 @@
+#ifndef L1TriggerConfig_L1TConfigProducers_QueryHelper_h
+#define L1TriggerConfig_L1TConfigProducers_QueryHelper_h
+
+#include <map>
+#include <vector>
+#include <string>
+#include <numeric>
+#include <algorithm>
+#include "CondTools/L1Trigger/interface/OMDSReader.h"
+
+namespace l1t {
+
+// The following class encloses some of the conventions for the online DB model:
+//  https://indico.cern.ch/event/591003/contributions/2384788/attachments/1378957/2095301/L1TriggerDatabase_v2.pdf
+
+class OnlineDBqueryHelper {
+public:
+
+    static std::map<std::string,std::string> fetch(
+        const std::vector<std::string> &queryColumns,
+        const std::string              &table,
+        const std::string              &key,
+        l1t::OMDSReader                &m_omdsReader);
+};
+
+} // end of namespace
+#endif


### PR DESCRIPTION
The Swatch team has replaced the last year's schema in the online trigger configuration database with a new schema (e.g. https://indico.cern.ch/event/591003/contributions/2384788/attachments/1378957/2095301/L1TriggerDatabase_v2.pdf). This change was accommodated in this PR.