### PR TITLE
pr90x L1T Phase2: Add  Stage2 products To RawCollector

### DIFF
--- a/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
+++ b/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
@@ -16,6 +16,9 @@ stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list
 stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gmtStage2Raw")) )
 stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gtStage2Raw")) )
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("caloStage2Raw")) )
+phase2_common.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gmtStage2Raw")) )
+phase2_common.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("gtStage2Raw")) )
 
 #
 # Legacy Trigger:


### PR DESCRIPTION
This PR is an addendum to already merged and then reverted PR #17248.
When re-reverted #17248, complement it with this PR.

Details:
Add CaloLaye2, uGMT, and uGT products to the RawCollector (previously missed).
