### PR TITLE
DQM clean up GCC 7 errors

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
@@ -229,7 +229,7 @@ void BeamMonitorBx::BookTrendHistos(bool plotPV,int nBx,map<string,string> & vMa
       string tmpDir_ = subDir_ + "/All_" + varName->first;
       dbe_->cd(monitorName_+tmpDir_);
       TString histTitle(varName->first);
-      string tmpName;
+      TString tmpName;
       if (prefix_ != "") tmpName = prefix_ + "_" + varName->first;
       if (suffix_ != "") tmpName = tmpName + "_" + suffix_;
       tmpName = tmpName + "_" + ss.str();
@@ -286,7 +286,7 @@ void BeamMonitorBx::BookTrendHistos(bool plotPV,int nBx,map<string,string> & vMa
 	break;
       }
       // check if already exist
-      if (dbe_->get(monitorName_+tmpDir_+"/"+string(histName))) continue;
+      if (dbe_->get(monitorName_+tmpDir_+"/"+string(histName.Data()))) continue;
 
       if (createHisto) {
 	edm::LogInfo("BX|BeamMonitorBx") << "histName = " << histName << "; histTitle = " << histTitle << std::endl;

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Utility.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Utility.cc
@@ -173,7 +173,7 @@ namespace cscdqm {
     TString s(message); 
     TPRegexp *re = const_cast<TPRegexp*>(&re_expression);
     re->Substitute(s, replace);
-    message = s;
+    message = static_cast<const char *>(s);
   }
 
   /**

--- a/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
+++ b/DQM/EcalMonitorDbModule/interface/MonitorXMLParser.h
@@ -174,7 +174,7 @@ public:
 
   const std::vector< DB_ME > & getDB_ME( void ) const { return (DBMonitoringElements_ ); }
 
-  void load() throw( std::runtime_error ); 
+  void load() noexcept(false);
 
 }; // class MonitorXMLParser
 

--- a/DQM/EcalMonitorDbModule/src/MonitorXMLParser.cc
+++ b/DQM/EcalMonitorDbModule/src/MonitorXMLParser.cc
@@ -391,7 +391,7 @@ void MonitorXMLParser::handleElement( xercesc::DOMElement* element ){
 
 // - - - - - - - - - - - - - - - - - - -
 
-void MonitorXMLParser::load() throw( std::runtime_error ) {
+void MonitorXMLParser::load() noexcept(false) {
 
   parser_->setValidationScheme( xercesc::XercesDOMParser::Val_Never );
   parser_->setDoNamespaces( false );

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
@@ -188,7 +188,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
 						unsigned int mc, bool createProfile, DQMStore::IGetter & iget) :
   // BaseFlavourHistograms2D () ,
   // theVariable ( variable_ ) ,
-  theMaxDimension(-1), theIndexToPlot(-1), theBaseNameTitle ( baseNameTitle_ ) , theBaseNameDescription ( baseNameDescription_ ) ,
+  theMaxDimension(-1), theIndexToPlot(-1), theBaseNameTitle ( baseNameTitle_.Data() ) , theBaseNameDescription ( baseNameDescription_.Data() ) ,
   theNBinsX ( nBinsX_ ) , theNBinsY (nBinsY_), 
   theLowerBoundX ( lowerBoundX_ ) , theUpperBoundX ( upperBoundX_ ) ,
   theLowerBoundY ( lowerBoundY_ ) , theUpperBoundY ( upperBoundY_ ) ,
@@ -291,7 +291,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
 						int nBinsY_ , double lowerBoundY_ , double upperBoundY_ ,
 						bool statistics_ , std::string folder, 
 						unsigned int mc, bool createProfile, DQMStore::IBooker & ibook) :
-  theMaxDimension(-1), theIndexToPlot(-1), theBaseNameTitle ( baseNameTitle_ ) , theBaseNameDescription ( baseNameDescription_ ) ,
+  theMaxDimension(-1), theIndexToPlot(-1), theBaseNameTitle ( baseNameTitle_.Data() ) , theBaseNameDescription ( baseNameDescription_.Data() ) ,
   theNBinsX ( nBinsX_ ) , theNBinsY (nBinsY_), 
   theLowerBoundX ( lowerBoundX_ ) , theUpperBoundX ( upperBoundX_ ) ,
   theLowerBoundY ( lowerBoundY_ ) , theUpperBoundY ( upperBoundY_ ) ,

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -66,7 +66,7 @@ HLTMuonMatchAndPlot::HLTMuonMatchAndPlot(const ParameterSet & pset,
   //  size_t nModules = moduleLabels_.size();
   TObjArray * levelArray = levelRegexp.MatchS(moduleLabel_);
   if (levelArray->GetEntriesFast() > 0) {
-    triggerLevel_ = static_cast<std::string>(((TObjString *)levelArray->At(0))->GetString());
+    triggerLevel_ = static_cast<const char *>(((TObjString *)levelArray->At(0))->GetString());
   }
   delete levelArray;
 


### PR DESCRIPTION
- Replace throw() dynamic exception specifier with noexcept /
  noexcept(expression) as throw() was deprecated in C++11 and finally
  removed in C++17.
- TString in C++17 has conversion operators for const char * and
  std::string_view and the same are available in std::string ctor and
  operators. This creates ambiguities for the compiler. Either use
  std::string(TString::Data()) or static_cast<const char * or
  std::string_view>(TString) to force one particular conversion.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>