### PR TITLE
Fix pixelTracks imports

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
@@ -23,7 +23,7 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi impor
 from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjections_cfi import pixelFitterByHelixProjections
 from RecoPixelVertexing.PixelTrackFitting.pixelTrackFilterByKinematics_cfi import pixelTrackFilterByKinematics
 from RecoPixelVertexing.PixelTrackFitting.pixelTrackCleanerBySharedHits_cfi import pixelTrackCleanerBySharedHits
-from RecoPixelVertexing.PixelTrackFitting.pixelTracksDefault_cfi import pixelTracksDefault as _pixelTracksDefault
+from RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi import pixelTracks
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpot_cfi import globalTrackingRegionFromBeamSpot as _globalTrackingRegionFromBeamSpot
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
@@ -68,12 +68,6 @@ pixelTracksHitQuadruplets = _pixelQuadrupletMergerEDProducer.clone(
     triplets = "pixelTracksHitTriplets",
     layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
 )
-
-# Pixel tracks
-pixelTracks = _pixelTracksDefault.clone()
-_SeedingHitSets = dict(SeedingHitSets = "pixelTracksHitQuadruplets")
-trackingPhase1PU70.toModify(pixelTracks, **_SeedingHitSets)
-trackingPhase2PU140.toModify(pixelTracks, **_SeedingHitSets)
 
 pixelTracksSequence = cms.Sequence(
     pixelTracksTrackingRegions +

--- a/RecoPixelVertexing/PixelTrackFitting/python/pixelTracks_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/pixelTracks_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+from RecoPixelVertexing.PixelTrackFitting.pixelTracksDefault_cfi import pixelTracksDefault as _pixelTracksDefault
+pixelTracks = _pixelTracksDefault.clone()
+
+from Configuration.Eras.Modifier_trackingPhase1PU70_cff import trackingPhase1PU70
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+_SeedingHitSets = dict(SeedingHitSets = "pixelTracksHitQuadruplets")
+trackingPhase1PU70.toModify(pixelTracks, **_SeedingHitSets)
+trackingPhase2PU140.toModify(pixelTracks, **_SeedingHitSets)

--- a/RecoTauTag/HLTProducers/python/PixelTracksL2Tau_cfi.py
+++ b/RecoTauTag/HLTProducers/python/PixelTracksL2Tau_cfi.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoPixelVertexing.PixelTrackFitting.pixelTracksDefault_cfi import *
+from RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi import pixelTracks as _pixelTracks
 from RecoTauTag.HLTProducers.TrackingRegionsFromBeamSpotAndL2Tau_cfi import *
 
-pixelTracksL2Tau = pixelTracksDefault.clone()
+pixelTracksL2Tau = _pixelTracks.clone()
 pixelTracksL2Tau.RegionFactoryPSet = cms.PSet(
     TrackingRegionsFromBeamSpotAndL2TauBlock,
     ComponentName = cms.string( "TrackingRegionsFromBeamSpotAndL2Tau" )

--- a/RecoTauTag/HLTProducers/python/PixelTracksL2Tau_cfi.py
+++ b/RecoTauTag/HLTProducers/python/PixelTracksL2Tau_cfi.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi import pixelTracks as _pixelTracks
-from RecoTauTag.HLTProducers.TrackingRegionsFromBeamSpotAndL2Tau_cfi import *
+from RecoTauTag.HLTProducers.trackingRegionsFromBeamSpotAndL2Tau_cfi import trackingRegionsFromBeamSpotAndL2Tau
+
+# Note from new seeding framework migration
+# Previously the TrackingRegion was set as a parameter of PixelTrackProducer
+# Now the TrackingRegion EDProducer must be inserted in a sequence, and set as an input to HitPairEDProducer
 
 pixelTracksL2Tau = _pixelTracks.clone()
-pixelTracksL2Tau.RegionFactoryPSet = cms.PSet(
-    TrackingRegionsFromBeamSpotAndL2TauBlock,
-    ComponentName = cms.string( "TrackingRegionsFromBeamSpotAndL2Tau" )
-)
 pixelTracksL2Tau.passLabel  = cms.string('pixelTracksL2Tau')
 

--- a/RecoTauTag/HLTProducers/src/SealModule.cc
+++ b/RecoTauTag/HLTProducers/src/SealModule.cc
@@ -29,6 +29,8 @@ using TauRegionalPixelSeedTrackingRegionEDProducer = TrackingRegionEDProducerT<T
 DEFINE_FWK_MODULE(TauRegionalPixelSeedTrackingRegionEDProducer);
 using CandidateSeededTrackingRegionsEDProducer = TrackingRegionEDProducerT<CandidateSeededTrackingRegionsProducer>;
 DEFINE_FWK_MODULE(CandidateSeededTrackingRegionsEDProducer);
+using TrackingRegionsFromBeamSpotAndL2TauEDProducer = TrackingRegionEDProducerT<TrackingRegionsFromBeamSpotAndL2Tau>;
+DEFINE_FWK_MODULE(TrackingRegionsFromBeamSpotAndL2TauEDProducer);
 
 DEFINE_FWK_MODULE(L2TauJetsMerger);
 DEFINE_FWK_MODULE(L1HLTJetsMatching);

--- a/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
+++ b/RecoTauTag/HLTProducers/src/TrackingRegionsFromBeamSpotAndL2Tau.h
@@ -56,6 +56,29 @@ public:
   
   virtual ~TrackingRegionsFromBeamSpotAndL2Tau() {}
     
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+
+    desc.add<double>("ptMin", 5.0);
+    desc.add<double>("originRadius", 0.2);
+    desc.add<double>("originHalfLength", 24.0);
+    desc.add<double>("deltaEta", 0.3);
+    desc.add<double>("deltaPhi", 0.3);
+    desc.add<edm::InputTag>("JetSrc", edm::InputTag("hltFilterL2EtCutDoublePFIsoTau25Trk5"));
+    desc.add<double>("JetMinPt", 25.0);
+    desc.add<double>("JetMaxEta", 2.1);
+    desc.add<int>("JetMaxN", 10);
+    desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
+    desc.add<bool>("precise", true);
+    desc.add<std::string>("howToUseMeasurementTracker", "Never");
+    desc.add<edm::InputTag>("measurementTrackerName", edm::InputTag("MeasurementTrackerEvent"));
+
+    // Only for backwards-compatibility
+    edm::ParameterSetDescription descRegion;
+    descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
+
+    descriptions.add("trackingRegionsFromBeamSpotAndL2Tau", descRegion);
+  }
 
   virtual std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& e, const edm::EventSetup& es) const override
   {

--- a/RecoTracker/TkSeedGenerator/python/SeedGeneratorFromProtoTracksEDProducer_cff.py
+++ b/RecoTracker/TkSeedGenerator/python/SeedGeneratorFromProtoTracksEDProducer_cff.py
@@ -12,7 +12,7 @@ from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi impo
 pixelTTRHBuilderWithoutAngle = copy.deepcopy(ttrhbwr)
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
 from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
-from RecoPixelVertexing.PixelTrackFitting.pixelTracksDefault_cfi import *
+from RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi import pixelTracks
 from RecoTracker.TkSeedGenerator.SeedGeneratorFromProtoTracksEDProducer_cfi import *
 pixelTTRHBuilderWithoutAngle.StripCPE = 'Fake'
 pixelTTRHBuilderWithoutAngle.ComponentName = 'PixelTTRHBuilderWithoutAngle'


### PR DESCRIPTION
This PR is a follow-up to #17438 adding a `pixelTracks_cfi` that imports from descriptions-generated `pixelTracksDefault_cfi`, and changing all affected files to import from `pixelTracks_cfi. This should have been done already in #17170, but somehow I missed it.

The `PixelTracksL2Tau_cfi` (*) referenced `TrackingRegionsFromBeamSpotAndL2Tau` (in pre-#17170 way), so I added `TrackingRegionsFromBeamSpotAndL2TauEDProducer` to produce the `TrackingRegion`s to event as required by the new seeding framework. I'm not sure how useful `PixelTracksL2Tau_cfi` is anymore though, as now it has just a clone of `PixelTracksProducer` and a `TrackingRegionsFromBeamSpotAndL2TauEDProducer` module via import (i.e. hit doublet/triplet/quadruplet producers and filter+fitter+cleaner are missing).

(*) I guess this is being used for ConfDB parsing since it was modified in #17438. 

Tested in 9_0_0_pre3, no changes expected.

@rovere @VinInn @Martin-Grunewald 