### PR TITLE
PoolOutputModule reads branch provenance only at input file open

### DIFF
--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -169,6 +169,7 @@ namespace edm {
     unsigned int numberOfDigitsInIndex_;
     BranchParents branchParents_;
     BranchChildren branchChildren_;
+    std::vector<BranchID> branchChildrenReadFromInput_;
     bool overrideInputFileSplitLevels_;
     edm::propagate_const<std::unique_ptr<RootOutputFile>> rootOutputFile_;
     std::string statusFileName_;


### PR DESCRIPTION
The PoolOutputModule was previously reading the per data product
provenance from the input file each event. This required the
per event provenance to be delay read from the file even in the
case where the per event provenance was not going to be stored
(such as when writing miniAOD). In a multi-threaded environment
this caused lock contention.
The code now reads the summary of the per data product provenance
when the input file is opened and only requests it per event
if it is going to be stored per event.

Also found a bug where the meta data branch ProductDependencies
was always empty because the stored object was cleared too early.