### PR TITLE
Add 2023D4 trackingOnly workflow to be run in IBs

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2023.py
+++ b/Configuration/PyReleaseValidation/python/relval_2023.py
@@ -33,3 +33,17 @@ for i,key in enumerate(upgradeKeys[2023]):
         if numWF in numWFIB:
 	    workflows[numWF] = [ upgradeDatasetFromFragment[frag], stepList]
         numWF+=1
+
+# Tracking-specific special workflows
+def _trackingOnly(stepList):
+    res = []
+    for step in stepList:
+        s = step
+        if 'RecoFullGlobal' in step or 'HARVESTFullGlobal' in step:
+            s = s.replace('FullGlobal', 'Full_trackingOnly')
+        if 'ALCA' in s:
+            continue
+        #print step, s
+        res.append(s)
+    return res
+workflows[21234.1] = [ workflows[21234.0][0], _trackingOnly(workflows[21234.0][1]) ] # 2023D4


### PR DESCRIPTION
The title says it all. The motivation is to ensure that trackingOnly workflow runs also for phase2 (and in case of breakage, catch it early).

Tested in 9_0_0_pre4, only expected change is the appearance of workflow 21234.1 in the default matrix.

@rovere @VinInn @ebrondol 