### PR TITLE
Reduce TIB Rail Width to Avoid Overlap with TOB

### DIFF
--- a/Geometry/TrackerCommonData/data/v2/tob.xml
+++ b/Geometry/TrackerCommonData/data/v2/tob.xml
@@ -14,7 +14,7 @@
 		<Constant name="StiffenerR" value="0.400*cm"/>
 		<Constant name="RailTopDy" value="8.5*mm"/>
 		<Constant name="RailBottomDy" value="15*mm"/>
-		<Constant name="RailDx" value="3.65*mm"/>
+		<Constant name="RailDx" value="3.25*mm"/>
 		<Constant name="RailL" value="1.100*m"/>
 		<Constant name="RailInX" value="54.433*cm"/>
 		<Constant name="StiffenerY" value="2.700*cm"/>


### PR DESCRIPTION
* Reduce TIB rail width to avoid extrusion