### PR TITLE
L1 online DQM histograms for uGMT intermediate muons

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
@@ -1,0 +1,62 @@
+#ifndef DQM_L1TMonitor_L1TStage2uGMTMuon_h
+#define DQM_L1TMonitor_L1TStage2uGMTMuon_h
+
+
+#include "DataFormats/L1Trigger/interface/Muon.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+class L1TStage2uGMTMuon : public DQMEDAnalyzer {
+
+ public:
+
+  L1TStage2uGMTMuon(const edm::ParameterSet& ps);
+  virtual ~L1TStage2uGMTMuon();
+
+ protected:
+
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  virtual void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+ private:  
+
+  edm::EDGetTokenT<l1t::MuonBxCollection> ugmtMuonToken;
+  std::string monitorDir;
+  std::string titlePrefix;
+  bool verbose;
+
+  MonitorElement* ugmtMuonBX;
+  MonitorElement* ugmtnMuons;
+  MonitorElement* ugmtMuonhwPt;
+  MonitorElement* ugmtMuonhwEta;
+  MonitorElement* ugmtMuonhwPhi;
+  MonitorElement* ugmtMuonhwCharge;
+  MonitorElement* ugmtMuonhwChargeValid;
+  MonitorElement* ugmtMuonhwQual;
+
+  MonitorElement* ugmtMuonPt;
+  MonitorElement* ugmtMuonEta;
+  MonitorElement* ugmtMuonPhi;
+  MonitorElement* ugmtMuonCharge;
+
+  MonitorElement* ugmtMuonPtvsEta;
+  MonitorElement* ugmtMuonPtvsPhi;
+  MonitorElement* ugmtMuonPhivsEta;
+
+  MonitorElement* ugmtMuonBXvshwPt;
+  MonitorElement* ugmtMuonBXvshwEta;
+  MonitorElement* ugmtMuonBXvshwPhi;
+  MonitorElement* ugmtMuonBXvshwCharge;
+  MonitorElement* ugmtMuonBXvshwChargeValid;
+  MonitorElement* ugmtMuonBXvshwQual;
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -33,6 +33,9 @@ DEFINE_FWK_MODULE(L1TStage2CaloLayer2);
 #include <DQM/L1TMonitor/interface/L1TStage2uGMT.h>
 DEFINE_FWK_MODULE(L1TStage2uGMT);
 
+#include <DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h>
+DEFINE_FWK_MODULE(L1TStage2uGMTMuon);
+
 #include <DQM/L1TMonitor/interface/L1TStage2MuonComp.h>
 DEFINE_FWK_MODULE(L1TStage2MuonComp);
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -144,6 +144,11 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2Emtf +
     l1tdeStage2EmtfComp +
     l1tStage2uGMTEmul +
+    l1tStage2uGMTIntermediateBMTFEmul +
+    l1tStage2uGMTIntermediateOMTFNegEmul +
+    l1tStage2uGMTIntermediateOMTFPosEmul +
+    l1tStage2uGMTIntermediateEMTFNegEmul +
+    l1tStage2uGMTIntermediateEMTFPosEmul +
     l1tdeStage2uGMT +
     l1tStage2uGtEmul
 )

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -75,6 +75,11 @@ l1tStage2OnlineDQM = cms.Sequence(
     #l1tStage2Omtf +
     l1tStage2Emtf +
     l1tStage2uGMT +
+    l1tStage2uGMTIntermediateBMTF +
+    l1tStage2uGMTIntermediateOMTFNeg +
+    l1tStage2uGMTIntermediateOMTFPos +
+    l1tStage2uGMTIntermediateEMTFNeg +
+    l1tStage2uGMTIntermediateEMTFPos +
     l1tStage2uGMTZeroSupp +
     l1tStage2BmtfOutVsuGMTIn +
     l1tStage2EmtfOutVsuGMTIn +

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -12,6 +12,48 @@ l1tStage2uGMT = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
+# the uGMT intermediate muon DQM modules
+l1tStage2uGMTIntermediateBMTF = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsBMTF"),
+    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/BMTF"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateOMTFNeg = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFNeg"),
+    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/OMTF_neg"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateOMTFPos = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFPos"),
+    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/OMTF_pos"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateEMTFNeg = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFNeg"),
+    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/EMTF_neg"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateEMTFPos = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFPos"),
+    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/EMTF_pos"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
+    verbose = cms.untracked.bool(False),
+)
+
+# zero suppression DQM
 l1tStage2uGMTZeroSupp = cms.EDAnalyzer(
     "L1TMP7ZeroSupp",
     fedIds = cms.vint32(1402),

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cfi.py
@@ -13,6 +13,47 @@ l1tStage2uGMTEmul = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
+# the uGMT intermediate muon DQM modules
+l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsBMTF"),
+    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/BMTF"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFNeg"),
+    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFPos"),
+    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFNeg"),
+    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTIntermediateEMTFPosEmul = cms.EDAnalyzer(
+    "L1TStage2uGMTMuon",
+    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFPos"),
+    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos"),
+    titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
+    verbose = cms.untracked.bool(False),
+)
+
 # compares the unpacked uGMT muon collection to the emulated uGMT muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2uGMT = cms.EDAnalyzer(

--- a/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
@@ -1,0 +1,134 @@
+#include "DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h"
+
+
+L1TStage2uGMTMuon::L1TStage2uGMTMuon(const edm::ParameterSet& ps)
+    : ugmtMuonToken(consumes<l1t::MuonBxCollection>(ps.getParameter<edm::InputTag>("muonProducer"))),
+      monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
+      titlePrefix(ps.getUntrackedParameter<std::string>("titlePrefix", "")),
+      verbose(ps.getUntrackedParameter<bool>("verbose", false))
+{
+}
+
+L1TStage2uGMTMuon::~L1TStage2uGMTMuon() {}
+
+void L1TStage2uGMTMuon::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {}
+
+void L1TStage2uGMTMuon::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
+
+void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
+
+  // Subsystem Monitoring and Muon Output
+  ibooker.setCurrentFolder(monitorDir);
+
+  ugmtMuonBX = ibooker.book1D("ugmtMuonBX", (titlePrefix+"BX").c_str(), 5, -2.5, 2.5);
+  ugmtMuonBX->setAxisTitle("BX", 1);
+
+  ugmtnMuons = ibooker.book1D("ugmtnMuons", (titlePrefix+"Multiplicity").c_str(), 9, -0.5, 8.5);
+  ugmtnMuons->setAxisTitle("Muon Multiplicity (BX == 0)", 1);
+
+  ugmtMuonhwPt = ibooker.book1D("ugmtMuonhwPt", (titlePrefix+"p_{T}").c_str(), 512, -0.5, 511.5);
+  ugmtMuonhwPt->setAxisTitle("Hardware p_{T}", 1);
+
+  ugmtMuonhwEta = ibooker.book1D("ugmtMuonhwEta", (titlePrefix+"#eta").c_str(), 461, -230.5, 230.5);
+  ugmtMuonhwEta->setAxisTitle("Hardware Eta", 1);
+
+  ugmtMuonhwPhi = ibooker.book1D("ugmtMuonhwPhi", (titlePrefix+"#phi").c_str(), 576, -0.5, 575.5);
+  ugmtMuonhwPhi->setAxisTitle("Hardware Phi", 1);
+
+  ugmtMuonhwCharge = ibooker.book1D("ugmtMuonhwCharge", (titlePrefix+"Charge").c_str(), 2, -0.5, 1.5);
+  ugmtMuonhwCharge->setAxisTitle("Hardware Charge", 1);
+
+  ugmtMuonhwChargeValid = ibooker.book1D("ugmtMuonhwChargeValid", (titlePrefix+"ChargeValid").c_str(), 2, -0.5, 1.5);
+  ugmtMuonhwChargeValid->setAxisTitle("ChargeValid", 1);
+
+  ugmtMuonhwQual = ibooker.book1D("ugmtMuonhwQual", (titlePrefix+"Quality").c_str(), 16, -0.5, 15.5);
+  ugmtMuonhwQual->setAxisTitle("Quality", 1);
+
+  ugmtMuonPt = ibooker.book1D("ugmtMuonPt", (titlePrefix+"p_{T}").c_str(), 256, -0.5, 255.5);
+  ugmtMuonPt->setAxisTitle("p_{T} [GeV]", 1);
+
+  ugmtMuonEta = ibooker.book1D("ugmtMuonEta", (titlePrefix+"#eta").c_str(), 100, -2.5, 2.5);
+  ugmtMuonEta->setAxisTitle("#eta", 1);
+
+  ugmtMuonPhi = ibooker.book1D("ugmtMuonPhi", (titlePrefix+"#phi").c_str(), 126, -3.15, 3.15);
+  ugmtMuonPhi->setAxisTitle("#phi", 1);
+
+  ugmtMuonCharge = ibooker.book1D("ugmtMuonCharge", (titlePrefix+"Charge").c_str(), 3, -1.5, 1.5);
+  ugmtMuonCharge->setAxisTitle("Charge", 1);
+
+  ugmtMuonPtvsEta = ibooker.book2D("ugmtMuonPtvsEta", (titlePrefix+"p_{T} vs #eta").c_str(), 100, -2.5, 2.5, 256, -0.5, 255.5);
+  ugmtMuonPtvsEta->setAxisTitle("#eta", 1);
+  ugmtMuonPtvsEta->setAxisTitle("p_{T} [GeV]", 2);
+
+  ugmtMuonPtvsPhi = ibooker.book2D("ugmtMuonPtvsPhi", (titlePrefix+"p_{T} vs #phi").c_str(), 64, -3.2, 3.2, 256, -0.5, 255.5);
+  ugmtMuonPtvsPhi->setAxisTitle("#phi", 1);
+  ugmtMuonPtvsPhi->setAxisTitle("p_{T} [GeV]", 2);
+
+  ugmtMuonPhivsEta = ibooker.book2D("ugmtMuonPhivsEta", (titlePrefix+"#phi vs #eta").c_str(), 100, -2.5, 2.5, 64, -3.2, 3.2);
+  ugmtMuonPhivsEta->setAxisTitle("#eta", 1);
+  ugmtMuonPhivsEta->setAxisTitle("#phi", 2);
+
+  ugmtMuonBXvshwPt = ibooker.book2D("ugmtMuonBXvshwPt", (titlePrefix+"BX vs p_{T}").c_str(), 256, -0.5, 511.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwPt->setAxisTitle("Hardware p_{T}", 1);
+  ugmtMuonBXvshwPt->setAxisTitle("BX", 2);
+
+  ugmtMuonBXvshwEta = ibooker.book2D("ugmtMuonBXvshwEta", (titlePrefix+"BX vs #eta").c_str(), 93, -232.5, 232.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwEta->setAxisTitle("Hardware #eta", 1);
+  ugmtMuonBXvshwEta->setAxisTitle("BX", 2);
+
+  ugmtMuonBXvshwPhi = ibooker.book2D("ugmtMuonBXvshwPhi", (titlePrefix+"BX vs #phi").c_str(), 116, -2.5, 577.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwPhi->setAxisTitle("Hardware #phi", 1);
+  ugmtMuonBXvshwPhi->setAxisTitle("BX", 2);
+
+  ugmtMuonBXvshwCharge = ibooker.book2D("ugmtMuonBXvshwCharge", (titlePrefix+"BX vs Charge").c_str(), 2, -0.5, 1.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwCharge->setAxisTitle("Hardware Charge", 1);
+  ugmtMuonBXvshwCharge->setAxisTitle("BX", 2);
+
+  ugmtMuonBXvshwChargeValid = ibooker.book2D("ugmtMuonBXvshwChargeValid", (titlePrefix+"BX vs ChargeValid").c_str(), 2, -0.5, 1.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwChargeValid->setAxisTitle("ChargeValid", 1);
+  ugmtMuonBXvshwChargeValid->setAxisTitle("BX", 2);
+
+  ugmtMuonBXvshwQual = ibooker.book2D("ugmtMuonBXvshwQual", (titlePrefix+"BX vs Quality").c_str(), 16, -0.5, 15.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwQual->setAxisTitle("Quality", 1);
+  ugmtMuonBXvshwQual->setAxisTitle("BX", 2);
+}
+
+void L1TStage2uGMTMuon::analyze(const edm::Event& e, const edm::EventSetup& c) {
+
+  if (verbose) edm::LogInfo("L1TStage2uGMTMuon") << "L1TStage2uGMTMuon: analyze..." << std::endl;
+
+  edm::Handle<l1t::MuonBxCollection> MuonBxCollection;
+  e.getByToken(ugmtMuonToken, MuonBxCollection);
+
+  ugmtnMuons->Fill(MuonBxCollection->size(0));
+
+  for (int itBX = MuonBxCollection->getFirstBX(); itBX <= MuonBxCollection->getLastBX(); ++itBX) {
+    for (l1t::MuonBxCollection::const_iterator Muon = MuonBxCollection->begin(itBX); Muon != MuonBxCollection->end(itBX); ++Muon) {
+
+      ugmtMuonBX->Fill(itBX);
+      ugmtMuonhwPt->Fill(Muon->hwPt());
+      ugmtMuonhwEta->Fill(Muon->hwEta());
+      ugmtMuonhwPhi->Fill(Muon->hwPhi());
+      ugmtMuonhwCharge->Fill(Muon->hwCharge());
+      ugmtMuonhwChargeValid->Fill(Muon->hwChargeValid());
+      ugmtMuonhwQual->Fill(Muon->hwQual());
+
+      ugmtMuonPt->Fill(Muon->pt());
+      ugmtMuonEta->Fill(Muon->eta());
+      ugmtMuonPhi->Fill(Muon->phi());
+      ugmtMuonCharge->Fill(Muon->charge());
+
+      ugmtMuonPtvsEta->Fill(Muon->eta(), Muon->pt());
+      ugmtMuonPtvsPhi->Fill(Muon->phi(), Muon->pt());
+      ugmtMuonPhivsEta->Fill(Muon->eta(), Muon->phi());
+
+      ugmtMuonBXvshwPt->Fill(Muon->hwPt(), itBX);
+      ugmtMuonBXvshwEta->Fill(Muon->hwEta(), itBX);
+      ugmtMuonBXvshwPhi->Fill(Muon->hwPhi(), itBX);
+      ugmtMuonBXvshwCharge->Fill(Muon->hwCharge(), itBX);
+      ugmtMuonBXvshwChargeValid->Fill(Muon->hwChargeValid(), itBX);
+      ugmtMuonBXvshwQual->Fill(Muon->hwQual(), itBX);
+    }
+  }
+}
+


### PR DESCRIPTION
In 2017 the L1 uGMT starts to send intermediate muons from between its two sorter stages to the DAQ.

This PR adds intermediate muon DQM histograms coming from data and emulator to the online DQM under the L1T2016 and L1T2016EMU directories, respectively.