### PR TITLE
Bug fix in HLT btag validation

### DIFF
--- a/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
@@ -80,6 +80,8 @@ void HLTVertexPerformanceAnalyzer::analyze(const edm::Event& iEvent, const edm::
 
 	Handle<std::vector<SimVertex> > simVertexCollection;
 	iEvent.getByToken(simVertexCollection_, simVertexCollection);
+	if (!simVertexCollection.isValid()) { edm::LogInfo("NoSimVertex") << "SimVertex collection is invalid"; return;}
+	if (simVertexCollection->size()==0) { edm::LogInfo("NoSimVertex") << "SimVertex collection is empty"; return;}
 	const SimVertex simPVh = *(simVertexCollection->begin());
 	simPV=simPVh.position().z();
 	


### PR DESCRIPTION
The validation step of few files of CMSSW_9_0_0_pre4 RelValNuGun_UP15 RelVals crashed  because of HLTVertexPerformanceAnalyzer (HLT BTag validation code).
The reason was that in such events there was no simVertex and hence the code crashed trying to access to the first simVertex.
This PR fixes this bug.

cc: @XavierAtCERN  @mtosi @heppye 