### PR TITLE
Mitigation action for fakerate at high PU - HighPurity only

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -312,14 +312,17 @@ trackingPhase2PU140.toModify(highPtTripletStepSelector,
             d0_par2 = ( 0.5, 4.0 ),
             dz_par2 = ( 0.5, 4.0 )
             ),
+        #FIXME: the cuts on min_nhits and minNumber*Layers are introduced to mitigate
+        #the cluster shape filter cut not working properly yet. To be remove in the future.
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'highPtTripletStep',
             preFilterName = 'highPtTripletStepTight',
             chi2n_par = 0.6,
             res_par = ( 0.003, 0.001 ),
-            minNumberLayers = 3,
+            min_nhits = 5,
+            minNumberLayers = 5,
             maxNumberLostLayers = 2,
-            minNumber3DLayers = 3,
+            minNumber3DLayers = 5,
             d0_par1 = ( 0.5, 4.0 ),
             dz_par1 = ( 0.6, 4.0 ),
             d0_par2 = ( 0.45, 4.0 ),

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -329,14 +329,17 @@ trackingPhase2PU140.toModify(lowPtTripletStepSelector,
             d0_par2 = ( 0.5, 4.0 ),
             dz_par2 = ( 0.5, 4.0 )
             ),
+        #FIXME: the cuts on min_nhits and minNumber*Layers are introduced to mitigate
+        #the cluster shape filter cut not working properly yet. To be remove in the future.
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'lowPtTripletStep',
             preFilterName = 'lowPtTripletStepTight',
             chi2n_par = 0.4,
             res_par = ( 0.003, 0.001 ),
-            minNumberLayers = 3,
+            min_nhits = 5,
+            minNumberLayers = 5,
             maxNumberLostLayers = 2,
-            minNumber3DLayers = 3,
+            minNumber3DLayers = 5,
             d0_par1 = ( 0.5, 4.0 ),
             dz_par1 = ( 0.4, 4.0 ),
             d0_par2 = ( 0.45, 4.0 ),


### PR DESCRIPTION
Some cuts in the triplets iterations have been applied in order to mitigate the fakerate in the _HighPurity_ tracks collection keeping high the efficiency - even if it is getting a bit worse. This is not a definitive solution, of course.
I have presented the problem in the [UPSG meeting](https://indico.cern.ch/event/611574/contributions/2466083/attachments/1409597/2155452/EricaBrondolin_20170208_UPSGmeeting_NearFuturePlansPhase2.pdf).
Here reported the effect on the fakes for PU200: in red the fakes for 900pre2, in blue 819pre12 and in black 900pre2+PR.
![screenshot from 2017-02-13 19-43-14](https://cloud.githubusercontent.com/assets/5331004/22898112/6098a60a-f226-11e6-8204-0de939657ae3.png)
It should **not** affect timing significantly.