### PR TITLE
New methods in GsfElectron and Photon classes, and 90X EGM regression

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -58,6 +58,7 @@ class GsfElectron : public RecoCandidate
     struct IsolationVariables ;
     struct ConversionRejection ;
     struct ClassificationVariables ;
+    struct SaturationInfo ;
 
     GsfElectron() ;
     GsfElectron( const GsfElectronCoreRef & ) ;
@@ -98,7 +99,8 @@ class GsfElectron : public RecoCandidate
       const FiducialFlags &,
       const ShowerShape &,
       const ShowerShape &,
-      const ConversionRejection &
+      const ConversionRejection &,
+      const SaturationInfo &
      ) ;
     GsfElectron * clone() const ;
     GsfElectron * clone
@@ -358,7 +360,15 @@ class GsfElectron : public RecoCandidate
     bool isEEDeeGap() const { return fiducialFlags_.isEEDeeGap ; }
     bool isEERingGap() const { return fiducialFlags_.isEERingGap ; }
     const FiducialFlags & fiducialFlags() const { return fiducialFlags_ ; }
-
+    // setters... not necessary in regular situations
+    // but handy for late stage modifications of electron objects
+    void setFFlagIsEB(const bool &b)        { fiducialFlags_.isEB = b; }
+    void setFFlagIsEE(const bool &b)        { fiducialFlags_.isEE = b; }
+    void setFFlagIsEBEEGap(const bool &b)   { fiducialFlags_.isEBEEGap = b; }
+    void setFFlagIsEBEtaGap(const bool &b)  { fiducialFlags_.isEBEtaGap = b; }
+    void setFFlagIsEBPhiGap(const bool &b)  { fiducialFlags_.isEBPhiGap = b; }
+    void setFFlagIsEEDeeGap(const bool &b)  { fiducialFlags_.isEEDeeGap = b; }
+    void setFFlagIsEERingGap(const bool &b) { fiducialFlags_.isEERingGap = b; }
 
   private:
 
@@ -393,6 +403,10 @@ class GsfElectron : public RecoCandidate
       float eLeft;
       float eRight;
       float eBottom; 
+      float e2x5Top;
+      float e2x5Left;
+      float e2x5Right;
+      float e2x5Bottom; 
       ShowerShape()
        : sigmaEtaEta(std::numeric_limits<float>::max()),
        sigmaIetaIeta(std::numeric_limits<float>::max()),
@@ -407,7 +421,11 @@ class GsfElectron : public RecoCandidate
        eTop(0.f),
        eLeft(0.f),
        eRight(0.f),
-       eBottom(0.f)
+       eBottom(0.f),
+       e2x5Top(0.f),
+       e2x5Left(0.f),
+       e2x5Right(0.f),
+       e2x5Bottom(0.f)
        {}
      } ;
 
@@ -425,7 +443,11 @@ class GsfElectron : public RecoCandidate
     const std::vector<CaloTowerDetId> & hcalTowersBehindClusters() const { return showerShape_.hcalTowersBehindClusters ; }
     float hcalDepth1OverEcalBc() const { return showerShape_.hcalDepth1OverEcalBc ; }
     float hcalDepth2OverEcalBc() const { return showerShape_.hcalDepth2OverEcalBc ; }
-    float hcalOverEcalBc() const { return hcalDepth1OverEcalBc() + hcalDepth2OverEcalBc() ; }
+    float hcalOverEcalBc() const { return hcalDepth1OverEcalBc() + hcalDepth2OverEcalBc() ; } 
+    float eLeft() const { return showerShape_.eLeft; }
+    float eRight() const { return showerShape_.eRight; }
+    float eTop() const { return showerShape_.eTop; }
+    float eBottom() const { return showerShape_.eBottom; }
     const ShowerShape & showerShape() const { return showerShape_ ; }
     // non-zero-suppressed and no-fractions shower shapes
     // ecal energy is always that from the full 5x5 
@@ -442,6 +464,14 @@ class GsfElectron : public RecoCandidate
     float full5x5_hcalDepth1OverEcalBc() const { return full5x5_showerShape_.hcalDepth1OverEcalBc ; }
     float full5x5_hcalDepth2OverEcalBc() const { return full5x5_showerShape_.hcalDepth2OverEcalBc ; }
     float full5x5_hcalOverEcalBc() const { return full5x5_hcalDepth1OverEcalBc() + full5x5_hcalDepth2OverEcalBc() ; }
+    float full5x5_e2x5Left() const { return full5x5_showerShape_.e2x5Left; }
+    float full5x5_e2x5Right() const { return full5x5_showerShape_.e2x5Right; }
+    float full5x5_e2x5Top() const { return full5x5_showerShape_.e2x5Top; }
+    float full5x5_e2x5Bottom() const { return full5x5_showerShape_.e2x5Bottom; }
+    float full5x5_eLeft() const { return full5x5_showerShape_.eLeft; }
+    float full5x5_eRight() const { return full5x5_showerShape_.eRight; }
+    float full5x5_eTop() const { return full5x5_showerShape_.eTop; }
+    float full5x5_eBottom() const { return full5x5_showerShape_.eBottom; }
     const ShowerShape & full5x5_showerShape() const { return full5x5_showerShape_ ; }
 
     // setters (if you know what you're doing)
@@ -465,6 +495,28 @@ class GsfElectron : public RecoCandidate
     ShowerShape showerShape_ ;
     ShowerShape full5x5_showerShape_ ;
 
+  //=======================================================
+  // SaturationInfo
+  //=======================================================
+
+  public :
+
+    struct SaturationInfo {
+      int nSaturatedXtals;
+      bool isSeedSaturated;
+      SaturationInfo() 
+      : nSaturatedXtals(0), isSeedSaturated(false) {};
+     } ;
+
+    // accessors
+    float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
+    float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
+    const SaturationInfo& saturationInfo() const { return saturationInfo_; }
+    void setSaturationInfo(const SaturationInfo &s) { saturationInfo_ = s; }
+
+  private:
+    
+    SaturationInfo saturationInfo_;
 
   //=======================================================
   // Isolation Variables

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -362,13 +362,13 @@ class GsfElectron : public RecoCandidate
     const FiducialFlags & fiducialFlags() const { return fiducialFlags_ ; }
     // setters... not necessary in regular situations
     // but handy for late stage modifications of electron objects
-    void setFFlagIsEB(const bool &b)        { fiducialFlags_.isEB = b; }
-    void setFFlagIsEE(const bool &b)        { fiducialFlags_.isEE = b; }
-    void setFFlagIsEBEEGap(const bool &b)   { fiducialFlags_.isEBEEGap = b; }
-    void setFFlagIsEBEtaGap(const bool &b)  { fiducialFlags_.isEBEtaGap = b; }
-    void setFFlagIsEBPhiGap(const bool &b)  { fiducialFlags_.isEBPhiGap = b; }
-    void setFFlagIsEEDeeGap(const bool &b)  { fiducialFlags_.isEEDeeGap = b; }
-    void setFFlagIsEERingGap(const bool &b) { fiducialFlags_.isEERingGap = b; }
+    void setFFlagIsEB(const bool b)        { fiducialFlags_.isEB = b; }
+    void setFFlagIsEE(const bool b)        { fiducialFlags_.isEE = b; }
+    void setFFlagIsEBEEGap(const bool b)   { fiducialFlags_.isEBEEGap = b; }
+    void setFFlagIsEBEtaGap(const bool b)  { fiducialFlags_.isEBEtaGap = b; }
+    void setFFlagIsEBPhiGap(const bool b)  { fiducialFlags_.isEBPhiGap = b; }
+    void setFFlagIsEEDeeGap(const bool b)  { fiducialFlags_.isEEDeeGap = b; }
+    void setFFlagIsEERingGap(const bool b) { fiducialFlags_.isEERingGap = b; }
 
   private:
 

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -26,6 +26,7 @@ namespace reco {
     struct  IsolationVariables;
     struct  ShowerShape;
     struct  MIPVariables;  
+    struct  SaturationInfo;
     
     /// default constructor
     Photon() : RecoCandidate() { pixelSeed_=false; }
@@ -237,6 +238,23 @@ namespace reco {
     float full5x5_r1x5 ()           const {return full5x5_showerShapeBlock_.e1x5/full5x5_showerShapeBlock_.e5x5;}
     float full5x5_r2x5 ()           const {return full5x5_showerShapeBlock_.e2x5/full5x5_showerShapeBlock_.e5x5;}
     float full5x5_r9 ()             const {return full5x5_showerShapeBlock_.e3x3/this->superCluster()->rawEnergy();}      
+
+  //=======================================================
+  // SaturationInfo
+  //=======================================================
+
+    struct SaturationInfo {
+      int nSaturatedXtals;
+      bool isSeedSaturated;
+      SaturationInfo() 
+      : nSaturatedXtals(0), isSeedSaturated(false) {};
+     } ;
+
+    // accessors
+    float nSaturatedXtals() const { return saturationInfo_.nSaturatedXtals; }
+    float isSeedSaturated() const { return saturationInfo_.isSeedSaturated; }
+    const SaturationInfo& saturationInfo() const { return saturationInfo_; }
+    void setSaturationInfo(const SaturationInfo &s) { saturationInfo_ = s; }
 
     //=======================================================
     // Energy Determinations
@@ -516,6 +534,7 @@ namespace reco {
     IsolationVariables isolationR03_;
     ShowerShape        showerShapeBlock_;
     ShowerShape        full5x5_showerShapeBlock_;
+    SaturationInfo saturationInfo_;
     EnergyCorrections eCorrections_; 
     MIPVariables        mipVariableBlock_; 
     PflowIsolationVariables pfIsolation_;

--- a/DataFormats/EgammaCandidates/src/GsfElectron.cc
+++ b/DataFormats/EgammaCandidates/src/GsfElectron.cc
@@ -45,6 +45,7 @@ GsfElectron::GsfElectron
   //  assert(ctfInfo.ctfTrack==(GsfElectron::core()->ctfTrack())) ;
   //  assert(ctfInfo.shFracInnerHits==(GsfElectron::core()->ctfGsfOverlap())) ;
  }
+
 GsfElectron::GsfElectron
  ( int charge, const ChargeInfo & chargeInfo,
    const GsfElectronCoreRef & core,
@@ -52,22 +53,20 @@ GsfElectron::GsfElectron
    const ClosestCtfTrack & ctfInfo,
    const FiducialFlags & ff, const ShowerShape & ss,
    const ShowerShape& full5x5_ss,
-   const ConversionRejection & crv
+   const ConversionRejection & crv, 
+   const SaturationInfo& si
  )
  : chargeInfo_(chargeInfo),
    core_(core),
    trackClusterMatching_(tcm), trackExtrapolations_(te),
-   //closestCtfTrack_(ctfInfo),
-   fiducialFlags_(ff), showerShape_(ss), full5x5_showerShape_(full5x5_ss),
+   fiducialFlags_(ff), showerShape_(ss), full5x5_showerShape_(full5x5_ss), saturationInfo_(si),
    conversionRejection_(crv)
  {
   init() ;
   setCharge(charge) ;
   setVertex(math::XYZPoint(te.positionAtVtx.x(),te.positionAtVtx.y(),te.positionAtVtx.z())) ;
   setPdgId(-11*charge) ;
-  /*if (ecalDrivenSeed())*/ corrections_.correctedEcalEnergy = superCluster()->energy() ;
-  //assert(ctfInfo.ctfTrack==(GsfElectron::core()->ctfTrack())) ;
-  //assert(ctfInfo.shFracInnerHits==(GsfElectron::core()->ctfGsfOverlap())) ;
+  corrections_.correctedEcalEnergy = superCluster()->energy() ;
  }
 
 GsfElectron::GsfElectron
@@ -82,6 +81,7 @@ GsfElectron::GsfElectron
    fiducialFlags_(electron.fiducialFlags_),
    showerShape_(electron.showerShape_),
    full5x5_showerShape_(electron.full5x5_showerShape_),
+   saturationInfo_(electron.saturationInfo_),
    dr03_(electron.dr03_), dr04_(electron.dr04_),
    conversionRejection_(electron.conversionRejection_),
    pfIso_(electron.pfIso_),
@@ -117,6 +117,7 @@ GsfElectron::GsfElectron
    fiducialFlags_(electron.fiducialFlags_),
    showerShape_(electron.showerShape_),
    full5x5_showerShape_(electron.full5x5_showerShape_),
+   saturationInfo_(electron.saturationInfo_),
    dr03_(electron.dr03_), dr04_(electron.dr04_),
    conversionRejection_(electron.conversionRejection_),
    pfIso_(electron.pfIso_),

--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -24,6 +24,7 @@ Photon::Photon( const Photon& rhs ) :
   isolationR03_ ( rhs.isolationR03_),
   showerShapeBlock_ ( rhs.showerShapeBlock_),
   full5x5_showerShapeBlock_ ( rhs.full5x5_showerShapeBlock_),
+  saturationInfo_ ( rhs.saturationInfo_ ),
   eCorrections_(rhs.eCorrections_),
   mipVariableBlock_ (rhs.mipVariableBlock_),
   pfIsolation_ ( rhs.pfIsolation_ )

--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -83,6 +83,7 @@ namespace DataFormats_EgammaCandidates {
 
     reco::Photon::FiducialFlags pff ;
     reco::Photon::ShowerShape pss ;
+    reco::Photon::SaturationInfo psi ;
     reco::Photon::IsolationVariables piv ;
     reco::Photon::PflowIsolationVariables ppfiv ;
     reco::Photon::PflowIDVariables ppfid ;
@@ -122,6 +123,7 @@ namespace DataFormats_EgammaCandidates {
     reco::GsfElectron::ClosestCtfTrack gecct ;
     reco::GsfElectron::FiducialFlags geff ;
     reco::GsfElectron::ShowerShape gess ;
+    reco::GsfElectron::SaturationInfo gesi ;
     reco::GsfElectron::IsolationVariables geiv ;
     reco::GsfElectron::ConversionRejection gecr ;
     reco::GsfElectron::Corrections gec ;

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -9,7 +9,8 @@
   </ioread>
 
 
-  <class name="reco::Photon" ClassVersion="16">
+  <class name="reco::Photon" ClassVersion="17">
+   <version ClassVersion="17" checksum="4077732720"/>
    <version ClassVersion="16" checksum="3459546220"/>
    <version ClassVersion="15" checksum="577991108"/>
    <version ClassVersion="13" checksum="2963666409"/>
@@ -40,6 +41,9 @@
   <class name="reco::Photon::ShowerShape" ClassVersion="12">
    <version ClassVersion="12" checksum="1586705784"/>
    <version ClassVersion="11" checksum="2494542444"/>
+  </class>
+  <class name="reco::Photon::SaturationInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2679714023"/>
   </class>
   <class name="reco::Photon::MIPVariables" ClassVersion="10">
    <version ClassVersion="10" checksum="1613378413"/>
@@ -156,7 +160,8 @@
   <class name="reco::GsfElectron::FiducialFlags" ClassVersion="10">
    <version ClassVersion="10" checksum="2564471186"/>
   </class>
-  <class name="reco::GsfElectron::ShowerShape" ClassVersion="12">
+  <class name="reco::GsfElectron::ShowerShape" ClassVersion="13">
+   <version ClassVersion="13" checksum="1955217576"/>
    <version ClassVersion="12" checksum="1486422105"/>
    <version ClassVersion="11" checksum="3451347438"/>
    <version ClassVersion="10" checksum="3070677812"/>
@@ -220,8 +225,12 @@
   <class name="reco::GsfElectron::PixelMatchVariables" ClassVersion="2">
     <version ClassVersion="2" checksum="3522539867"/>
   </class>
+  <class name="reco::GsfElectron::SaturationInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="3868678681"/>
+  </class>
 
-  <class name="reco::GsfElectron" ClassVersion="19">
+  <class name="reco::GsfElectron" ClassVersion="20">
+   <version ClassVersion="20" checksum="2375747450"/>
    <version ClassVersion="19" checksum="1682285704"/>
    <version ClassVersion="18" checksum="2072747263"/>
    <version ClassVersion="17" checksum="1861965703"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -16,7 +16,8 @@
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
-  <class name="pat::Electron"  ClassVersion="34">
+  <class name="pat::Electron"  ClassVersion="35">
+   <version ClassVersion="35" checksum="482655666"/>
    <version ClassVersion="34" checksum="3720919820"/>
    <version ClassVersion="33" checksum="459924678"/>
    <version ClassVersion="32" checksum="3508125821"/>
@@ -193,7 +194,8 @@
   </ioread>
 
   <class name="std::vector<pat::tau::TauPFEssential>" />
-  <class name="pat::Photon"  ClassVersion="19">
+  <class name="pat::Photon"  ClassVersion="20">
+   <version ClassVersion="20" checksum="1579185367"/>
    <version ClassVersion="19" checksum="4285818507"/>
    <version ClassVersion="18" checksum="1413598928"/>
    <version ClassVersion="17" checksum="2394457997"/>

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -35,7 +35,7 @@ namespace pat {
     const edm::EDGetTokenT<edm::View<pat::Electron> > src_;
     
     const StringCutObjectSelector<pat::Electron> dropSuperClusters_, dropBasicClusters_, dropPFlowClusters_, dropPreshowerClusters_, dropSeedCluster_, dropRecHits_;
-    const StringCutObjectSelector<pat::Electron> dropCorrections_,dropIsolations_,dropShapes_,dropExtrapolations_,dropClassifications_;
+    const StringCutObjectSelector<pat::Electron> dropCorrections_,dropIsolations_,dropShapes_,dropSaturation_,dropExtrapolations_,dropClassifications_;
     
     const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > reco2pf_;
     const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > pf2pc_;
@@ -60,6 +60,7 @@ pat::PATElectronSlimmer::PATElectronSlimmer(const edm::ParameterSet & iConfig) :
     dropCorrections_(iConfig.getParameter<std::string>("dropCorrections")),
     dropIsolations_(iConfig.getParameter<std::string>("dropIsolations")),
     dropShapes_(iConfig.getParameter<std::string>("dropShapes")),
+    dropSaturation_(iConfig.getParameter<std::string>("dropSaturation")),
     dropExtrapolations_(iConfig.getParameter<std::string>("dropExtrapolations")),
     dropClassifications_(iConfig.getParameter<std::string>("dropClassifications")),
     reco2pf_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>("recoToPFMap"))),
@@ -132,6 +133,7 @@ pat::PATElectronSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iS
         if (dropCorrections_(electron)) { electron.setCorrections(reco::GsfElectron::Corrections()); }
         if (dropIsolations_(electron)) { electron.setDr03Isolation(reco::GsfElectron::IsolationVariables()); electron.setDr04Isolation(reco::GsfElectron::IsolationVariables()); electron.setPfIsolationVariables(reco::GsfElectron::PflowIsolationVariables()); electron.setEcalPFClusterIso(0); electron.setHcalPFClusterIso(0); }
         if (dropShapes_(electron)) { electron.setShowerShape(reco::GsfElectron::ShowerShape()); }
+        if (dropSaturation_(electron)) { electron.setSaturationInfo(reco::GsfElectron::SaturationInfo()); }
         if (dropExtrapolations_(electron)) { electron.setTrackExtrapolations(reco::GsfElectron::TrackExtrapolations());  }
         if (dropClassifications_(electron)) { electron.setClassificationVariables(reco::GsfElectron::ClassificationVariables()); electron.setClassification(reco::GsfElectron::Classification()); }
         if (linkToPackedPF_) {

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -36,7 +36,7 @@ namespace pat {
     private:
       const edm::EDGetTokenT<edm::View<pat::Photon> > src_;
 
-      const StringCutObjectSelector<pat::Photon> dropSuperClusters_, dropBasicClusters_, dropPreshowerClusters_, dropSeedCluster_, dropRecHits_;
+      const StringCutObjectSelector<pat::Photon> dropSuperClusters_, dropBasicClusters_, dropPreshowerClusters_, dropSeedCluster_, dropRecHits_, dropSaturation_;
 
       const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > reco2pf_;
       const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > pf2pc_;
@@ -57,6 +57,7 @@ pat::PATPhotonSlimmer::PATPhotonSlimmer(const edm::ParameterSet & iConfig) :
     dropPreshowerClusters_(iConfig.getParameter<std::string>("dropPreshowerClusters")),
     dropSeedCluster_(iConfig.getParameter<std::string>("dropSeedCluster")),
     dropRecHits_(iConfig.getParameter<std::string>("dropRecHits")),
+    dropSaturation_(iConfig.getParameter<std::string>("dropSaturation")),
     reco2pf_(mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(iConfig.getParameter<edm::InputTag>("recoToPFMap"))),
     pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
     pc_(mayConsume<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
@@ -122,6 +123,7 @@ pat::PATPhotonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
 	if (dropPreshowerClusters_(photon)) { photon.preshowerClusters_.clear(); }
 	if (dropSeedCluster_(photon)) { photon.seedCluster_.clear(); photon.embeddedSeedCluster_ = false; }
         if (dropRecHits_(photon)) { photon.recHits_ = EcalRecHitCollection(); photon.embeddedRecHits_ = false; }
+        if (dropSaturation_(photon)) { photon.setSaturationInfo(reco::Photon::SaturationInfo()); }
 
         if (linkToPackedPF_) {
             //std::cout << " PAT  photon in  " << src.id() << " comes from " << photon.refToOrig_.id() << ", " << photon.refToOrig_.key() << std::endl;

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -11,6 +11,7 @@ slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
    dropCorrections = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropIsolations = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropShapes = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSaturation = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropExtrapolations  = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    dropClassifications  = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    linkToPackedPFCandidates = cms.bool(True),

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedPhotons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedPhotons_cfi.py
@@ -7,6 +7,7 @@ slimmedPhotons = cms.EDProducer("PATPhotonSlimmer",
     dropPreshowerClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
     dropSeedCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
     dropRecHits = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+    dropSaturation = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
     linkToPackedPFCandidates = cms.bool(True),
     recoToPFMap = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap"),
     packedPFCandidates = cms.InputTag("packedPFCandidates"),

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -253,7 +253,7 @@ class GsfElectronAlgo {
                                reco::GsfElectron::ShowerShape & ) ;
     void calculateShowerShape_full5x5( const reco::SuperClusterRef &, bool pflow,
                                        reco::GsfElectron::ShowerShape & ) ;
-
+    void calculateSaturationInfo(const reco::SuperClusterRef&, reco::GsfElectron::SaturationInfo&);
 
     // associations
     const reco::SuperClusterRef getTrSuperCluster( const reco::GsfTrackRef & trackRef ) ;

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -604,6 +604,27 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     const float sigmaRR =  toolsforES.eseffsirir( *scRef );
     showerShape.effSigmaRR = sigmaRR;
     newCandidate.setShowerShapeVariables ( showerShape ); 
+
+    reco::Photon::SaturationInfo saturationInfo;
+    const reco::CaloCluster& seedCluster = *(scRef->seed()) ;
+    DetId seedXtalId = seedCluster.seed();
+    int nSaturatedXtals = 0;
+    bool isSeedSaturated = false;
+    if (hits != nullptr) {
+      const auto hitsAndFractions = scRef->hitsAndFractions();
+      for (auto&& hitFractionPair : hitsAndFractions) {    
+	auto&& ecalRecHit = hits->find(hitFractionPair.first);
+	if (ecalRecHit == hits->end()) continue;
+	if (ecalRecHit->checkFlag(EcalRecHit::Flags::kSaturated)) {
+	  nSaturatedXtals++;
+	  if (seedXtalId == ecalRecHit->detid())
+	    isSeedSaturated = true;
+	}
+      }
+    }
+    saturationInfo.nSaturatedXtals = nSaturatedXtals;
+    saturationInfo.isSeedSaturated = isSeedSaturated;
+    newCandidate.setSaturationInfo(saturationInfo);
     
     /// fill full5x5 shower shape block
     reco::Photon::ShowerShape  full5x5_showerShape;

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -444,7 +444,7 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
 
   
   size_t coridx = 0;
-  float raw_pt = raw_energy*the_sc->position().perp()/the_sc->position().r();
+  float raw_pt = raw_energy*the_sc->position().rho()/the_sc->position().r();
 
   if (iseb && raw_pt < lowEnergy_ECALonlyThr_)
     coridx = 0;
@@ -638,7 +638,7 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
   
   size_t coridx = 0;
-  float raw_pt = raw_energy*the_sc->position().perp()/the_sc->position().r();
+  float raw_pt = raw_energy*the_sc->position().rho()/the_sc->position().r();
 
   if (iseb && raw_pt < lowEnergy_ECALonlyThr_)
     coridx = 0;

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -459,7 +459,11 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
   double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
   double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
 
-  // Correct the energy
+  // Correct the energy. A negative energy means that the correction went
+  // outside the boundaries of the training. In this case uses raw.
+  // The resolution estimation, on the other hand should be ok.
+  if (mean < 0.) mean = 1.0;
+
   const double ecor = mean*(raw_energy + raw_es_energy);
   const double sigmacor = sigma*ecor;
   
@@ -515,6 +519,11 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
     double sigma_trk = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma_trk);
     
     // Final correction
+    // A negative energy means that the correction went
+    // outside the boundaries of the training. In this case uses raw.
+    // The resolution estimation, on the other hand should be ok.
+    if (mean_trk < 0.) mean_trk = 1.0;
+
     combinedEnergy = mean_trk*rawcomb;
     combinedEnergyError = sigma_trk*rawcomb;
   }
@@ -639,7 +648,11 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
   double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
   
-  // Correct the energy
+  // Correct the energy. A negative energy means that the correction went
+  // outside the boundaries of the training. In this case uses raw.
+  // The resolution estimation, on the other hand should be ok.
+  if (mean < 0.) mean = 1.0;
+
   const double ecor = mean*(raw_energy + raw_es_energy);
   const double sigmacor = sigma*ecor;
   

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -3,18 +3,13 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
 #include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
 #include "CondFormats/EgammaObjects/interface/GBRForestD.h"
-#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
-#include "CondFormats/EgammaObjects/interface/GBRForest.h"
-
-#include "DataFormats/EcalDetId/interface/EBDetId.h"
-#include "DataFormats/EcalDetId/interface/EEDetId.h"
-
 #include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
 
 #include <vdt/vdtMath.h>
@@ -38,12 +33,10 @@ public:
     std::unordered_map<std::string, ValMapFloatTagTokenPair> tag_float_token_map;
     std::unordered_map<std::string, ValMapIntTagTokenPair> tag_int_token_map;
 
-    std::vector<std::string> condnames_mean_50ns;
-    std::vector<std::string> condnames_sigma_50ns;
-    std::vector<std::string> condnames_mean_25ns;
-    std::vector<std::string> condnames_sigma_25ns;
-    std::string condnames_weight_50ns;
-    std::string condnames_weight_25ns;
+    std::vector<std::string> condnames_ecalonly_mean;
+    std::vector<std::string> condnames_ecalonly_sigma;
+    std::vector<std::string> condnames_ecaltrk_mean;
+    std::vector<std::string> condnames_ecaltrk_sigma;
   };
 
   struct photon_config {
@@ -52,14 +45,12 @@ public:
     std::unordered_map<std::string, ValMapFloatTagTokenPair> tag_float_token_map;
     std::unordered_map<std::string, ValMapIntTagTokenPair> tag_int_token_map;
 
-    std::vector<std::string> condnames_mean_50ns;
-    std::vector<std::string> condnames_sigma_50ns;
-    std::vector<std::string> condnames_mean_25ns;
-    std::vector<std::string> condnames_sigma_25ns;
+    std::vector<std::string> condnames_ecalonly_mean;
+    std::vector<std::string> condnames_ecalonly_sigma;
   };
 
   EGExtraInfoModifierFromDB(const edm::ParameterSet& conf);
-  ~EGExtraInfoModifierFromDB() {};
+  ~EGExtraInfoModifierFromDB();
     
   void setEvent(const edm::Event&) override final;
   void setEventContent(const edm::EventSetup&) override final;
@@ -81,27 +72,26 @@ private:
   std::unordered_map<unsigned,edm::Ptr<reco::Photon> > phos_by_oop;
   std::unordered_map<unsigned,edm::Handle<edm::ValueMap<float> > > pho_vmaps;
   std::unordered_map<unsigned,edm::Handle<edm::ValueMap<int> > > pho_int_vmaps;
-
-  bool autoDetectBunchSpacing_;
-  int bunchspacing_;
-  edm::InputTag bunchspacingTag_;
-  edm::EDGetTokenT<unsigned int> bunchSpacingToken_;
+  
   float rhoValue_;
   edm::InputTag rhoTag_;
   edm::EDGetTokenT<double> rhoToken_;
-  int nVtx_;
-  edm::InputTag vtxTag_;
-  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
-  edm::Handle<reco::VertexCollection> vtxH_;
-  bool applyExtraHighEnergyProtection_;
 
   const edm::EventSetup* iSetup_;
 
   std::vector<const GBRForestD*> ph_forestH_mean_;
   std::vector<const GBRForestD*> ph_forestH_sigma_; 
   std::vector<const GBRForestD*> e_forestH_mean_;
-  std::vector<const GBRForestD*> e_forestH_sigma_; 
-  const GBRForest* ep_forestH_weight_;
+  std::vector<const GBRForestD*> e_forestH_sigma_;
+
+  double lowEnergy_ECALonlyThr_; // 300
+  double lowEnergy_ECALTRKThr_;  // 50
+  double highEnergy_ECALTRKThr_; // 200
+  double eOverP_ECALTRKThr_;     // 0.025
+  double epDiffSig_ECALTRKThr_;  // 15
+  double epSig_ECALTRKThr_;      // 10
+  
+  
 };
 
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
@@ -111,22 +101,18 @@ DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
 EGExtraInfoModifierFromDB::EGExtraInfoModifierFromDB(const edm::ParameterSet& conf) :
   ModifyObjectValueBase(conf) {
 
-  bunchspacing_ = 450;
-  autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
-  applyExtraHighEnergyProtection_ = conf.getParameter<bool>("applyExtraHighEnergyProtection");
+  lowEnergy_ECALonlyThr_ = conf.getParameter<double>("lowEnergy_ECALonlyThr");
+  lowEnergy_ECALTRKThr_ = conf.getParameter<double>("lowEnergy_ECALTRKThr");
+  highEnergy_ECALTRKThr_ = conf.getParameter<double>("highEnergy_ECALTRKThr");
+  eOverP_ECALTRKThr_ = conf.getParameter<double>("eOverP_ECALTRKThr");
+  epDiffSig_ECALTRKThr_ = conf.getParameter<double>("epDiffSig_ECALTRKThr");
+  epSig_ECALTRKThr_ = conf.getParameter<double>("epSig_ECALTRKThr");
 
   rhoTag_ = conf.getParameter<edm::InputTag>("rhoCollection");
-  vtxTag_ = conf.getParameter<edm::InputTag>("vertexCollection");
-  
-  if (autoDetectBunchSpacing_) {
-    bunchspacingTag_ = conf.getParameter<edm::InputTag>("bunchSpacingTag");
-  } else {
-    bunchspacing_ = conf.getParameter<int>("manualBunchSpacing");
-  }
 
   constexpr char electronSrc[] =  "electronSrc";
   constexpr char photonSrc[] =  "photonSrc";
-
+    
   if(conf.exists("electron_config")) {
     const edm::ParameterSet& electrons = conf.getParameter<edm::ParameterSet>("electron_config");
     if( electrons.exists(electronSrc) ) 
@@ -151,12 +137,15 @@ EGExtraInfoModifierFromDB::EGExtraInfoModifierFromDB(const edm::ParameterSet& co
       }
     }
     
-    e_conf.condnames_mean_50ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_50ns");
-    e_conf.condnames_sigma_50ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_50ns");
-    e_conf.condnames_mean_25ns  = electrons.getParameter<std::vector<std::string> >("regressionKey_25ns");
-    e_conf.condnames_sigma_25ns = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_25ns");
-    e_conf.condnames_weight_50ns  = electrons.getParameter<std::string>("combinationKey_50ns");
-    e_conf.condnames_weight_25ns  = electrons.getParameter<std::string>("combinationKey_25ns");
+    e_conf.condnames_ecalonly_mean  = electrons.getParameter<std::vector<std::string> >("regressionKey_ecalonly");
+    e_conf.condnames_ecalonly_sigma = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_ecalonly");
+    e_conf.condnames_ecaltrk_mean   = electrons.getParameter<std::vector<std::string> >("regressionKey_ecaltrk");
+    e_conf.condnames_ecaltrk_sigma  = electrons.getParameter<std::vector<std::string> >("uncertaintyKey_ecaltrk");
+
+    unsigned int encor = e_conf.condnames_ecalonly_mean.size();
+    e_forestH_mean_.reserve(2*encor);
+    e_forestH_sigma_.reserve(2*encor);
+
   }
   
   if( conf.exists("photon_config") ) { 
@@ -184,11 +173,16 @@ EGExtraInfoModifierFromDB::EGExtraInfoModifierFromDB(const edm::ParameterSet& co
       }
     }
 
-    ph_conf.condnames_mean_50ns = photons.getParameter<std::vector<std::string>>("regressionKey_50ns");
-    ph_conf.condnames_sigma_50ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_50ns");
-    ph_conf.condnames_mean_25ns = photons.getParameter<std::vector<std::string>>("regressionKey_25ns");
-    ph_conf.condnames_sigma_25ns = photons.getParameter<std::vector<std::string>>("uncertaintyKey_25ns");
+    ph_conf.condnames_ecalonly_mean  = photons.getParameter<std::vector<std::string>>("regressionKey_ecalonly");
+    ph_conf.condnames_ecalonly_sigma = photons.getParameter<std::vector<std::string>>("uncertaintyKey_ecalonly");
+
+    unsigned int ncor = ph_conf.condnames_ecalonly_mean.size();
+    ph_forestH_mean_.reserve(ncor);
+    ph_forestH_sigma_.reserve(ncor);
+
   }
+
+
 }
 
 namespace {
@@ -200,7 +194,10 @@ namespace {
   }
 }
 
+EGExtraInfoModifierFromDB::~EGExtraInfoModifierFromDB() {}
+
 void EGExtraInfoModifierFromDB::setEvent(const edm::Event& evt) {
+
   eles_by_oop.clear();
   phos_by_oop.clear();  
   ele_vmaps.clear();
@@ -253,18 +250,10 @@ void EGExtraInfoModifierFromDB::setEvent(const edm::Event& evt) {
     get_product(evt, imap->second.second, pho_int_vmaps);
   }
   
-  if (autoDetectBunchSpacing_) {
-      edm::Handle<unsigned int> bunchSpacingH;
-      evt.getByToken(bunchSpacingToken_,bunchSpacingH);
-      bunchspacing_ = *bunchSpacingH;
-  }
-
   edm::Handle<double> rhoH;
   evt.getByToken(rhoToken_, rhoH);
   rhoValue_ = *rhoH;
-  
-  evt.getByToken(vtxToken_, vtxH_);
-  nVtx_ = vtxH_->size();
+   
 }
 
 void EGExtraInfoModifierFromDB::setEventContent(const edm::EventSetup& evs) {
@@ -272,33 +261,37 @@ void EGExtraInfoModifierFromDB::setEventContent(const edm::EventSetup& evs) {
   iSetup_ = &evs;
 
   edm::ESHandle<GBRForestD> forestDEH;
-  edm::ESHandle<GBRForest> forestEH;
+  
+  const std::vector<std::string> ph_condnames_ecalonly_mean  = ph_conf.condnames_ecalonly_mean;
+  const std::vector<std::string> ph_condnames_ecalonly_sigma = ph_conf.condnames_ecalonly_sigma;
 
-  const std::vector<std::string> ph_condnames_mean  = (bunchspacing_ == 25) ? ph_conf.condnames_mean_25ns  : ph_conf.condnames_mean_50ns;
-  const std::vector<std::string> ph_condnames_sigma = (bunchspacing_ == 25) ? ph_conf.condnames_sigma_25ns : ph_conf.condnames_sigma_50ns;
-
-  unsigned int ncor = ph_condnames_mean.size();
+  unsigned int ncor = ph_condnames_ecalonly_mean.size();
   for (unsigned int icor=0; icor<ncor; ++icor) {
-    evs.get<GBRDWrapperRcd>().get(ph_condnames_mean[icor], forestDEH);
-    ph_forestH_mean_.push_back(forestDEH.product());
-    evs.get<GBRDWrapperRcd>().get(ph_condnames_sigma[icor], forestDEH);
-    ph_forestH_sigma_.push_back(forestDEH.product());
-  } 
-
-  const std::vector<std::string> e_condnames_mean  = (bunchspacing_ == 25) ? e_conf.condnames_mean_25ns  : e_conf.condnames_mean_50ns;
-  const std::vector<std::string> e_condnames_sigma = (bunchspacing_ == 25) ? e_conf.condnames_sigma_25ns : e_conf.condnames_sigma_50ns;
-  const std::string ep_condnames_weight  = (bunchspacing_ == 25) ? e_conf.condnames_weight_25ns  : e_conf.condnames_weight_50ns;
-
-  unsigned int encor = e_condnames_mean.size();
-  evs.get<GBRWrapperRcd>().get(ep_condnames_weight, forestEH);
-  ep_forestH_weight_ = forestEH.product(); 
-    
-  for (unsigned int icor=0; icor<encor; ++icor) {
-    evs.get<GBRDWrapperRcd>().get(e_condnames_mean[icor], forestDEH);
-    e_forestH_mean_.push_back(forestDEH.product());
-    evs.get<GBRDWrapperRcd>().get(e_condnames_sigma[icor], forestDEH);
-    e_forestH_sigma_.push_back(forestDEH.product());
+    evs.get<GBRDWrapperRcd>().get(ph_condnames_ecalonly_mean[icor], forestDEH);
+    ph_forestH_mean_[icor] = forestDEH.product();
+    evs.get<GBRDWrapperRcd>().get(ph_condnames_ecalonly_sigma[icor], forestDEH);
+    ph_forestH_sigma_[icor] = forestDEH.product();
   }
+
+  const std::vector<std::string> e_condnames_ecalonly_mean  = e_conf.condnames_ecalonly_mean;
+  const std::vector<std::string> e_condnames_ecalonly_sigma = e_conf.condnames_ecalonly_sigma;
+  const std::vector<std::string> e_condnames_ecaltrk_mean  = e_conf.condnames_ecaltrk_mean;
+  const std::vector<std::string> e_condnames_ecaltrk_sigma = e_conf.condnames_ecaltrk_sigma;
+
+  unsigned int encor = e_condnames_ecalonly_mean.size();  
+  for (unsigned int icor=0; icor<encor; ++icor) {
+    evs.get<GBRDWrapperRcd>().get(e_condnames_ecalonly_mean[icor], forestDEH);
+    e_forestH_mean_[icor] = forestDEH.product();
+    evs.get<GBRDWrapperRcd>().get(e_condnames_ecalonly_sigma[icor], forestDEH);
+    e_forestH_sigma_[icor] = forestDEH.product();
+  } 
+  for (unsigned int icor=0; icor<encor; ++icor) {
+    evs.get<GBRDWrapperRcd>().get(e_condnames_ecaltrk_mean[icor], forestDEH);
+    e_forestH_mean_[icor+encor] = forestDEH.product();
+    evs.get<GBRDWrapperRcd>().get(e_condnames_ecaltrk_sigma[icor], forestDEH);
+    e_forestH_sigma_[icor+encor] = forestDEH.product();
+  }
+    
 }
 
 namespace {
@@ -318,10 +311,6 @@ namespace {
 void EGExtraInfoModifierFromDB::setConsumes(edm::ConsumesCollector& sumes) {
  
   rhoToken_ = sumes.consumes<double>(rhoTag_);
-  vtxToken_ = sumes.consumes<reco::VertexCollection>(vtxTag_);
-
-  if (autoDetectBunchSpacing_)
-    bunchSpacingToken_ = sumes.consumes<unsigned int>(bunchspacingTag_);
 
   //setup electrons
   if(!(empty_tag == e_conf.electron_src))
@@ -364,118 +353,83 @@ namespace {
 }
 
 void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
+
   // regression calculation needs no additional valuemaps
 
   const reco::SuperClusterRef& the_sc = ele.superCluster();
   const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
-
-
-  //skip HGCal for now
-  if( theseed->seed().det() == DetId::Forward ) return;
   if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
-  
-  std::array<float, 33> eval;  
-  const double raw_energy = the_sc->rawEnergy(); 
-  const auto& ess = ele.showerShape();
 
-  // SET INPUTS
-  eval[0]  = nVtx_;  
-  eval[1]  = raw_energy;
-  eval[2]  = the_sc->eta();
-  eval[3]  = the_sc->phi();
-  eval[4]  = the_sc->etaWidth();
-  eval[5]  = the_sc->phiWidth(); 
-  eval[6]  = ess.r9;
-  eval[7]  = theseed->energy()/raw_energy;
-  eval[8]  = ess.eMax/raw_energy;
-  eval[9]  = ess.e2nd/raw_energy;
-  eval[10] = (ess.eLeft + ess.eRight != 0.f  ? (ess.eLeft-ess.eRight)/(ess.eLeft+ess.eRight) : 0.f);
-  eval[11] = (ess.eTop  + ess.eBottom != 0.f ? (ess.eTop-ess.eBottom)/(ess.eTop+ess.eBottom) : 0.f);
-  eval[12] = ess.sigmaIetaIeta;
-  eval[13] = ess.sigmaIetaIphi;
-  eval[14] = ess.sigmaIphiIphi;
-  eval[15] = std::max(0,numberOfClusters-1);
-  
-  // calculate sub-cluster variables
-  std::vector<float> clusterRawEnergy;
-  clusterRawEnergy.resize(std::max(3, numberOfClusters), 0);
-  std::vector<float> clusterDEtaToSeed;
-  clusterDEtaToSeed.resize(std::max(3, numberOfClusters), 0);
-  std::vector<float> clusterDPhiToSeed;
-  clusterDPhiToSeed.resize(std::max(3, numberOfClusters), 0);
-  float clusterMaxDR     = 999.;
-  float clusterMaxDRDPhi = 999.;
-  float clusterMaxDRDEta = 999.;
-  float clusterMaxDRRawEnergy = 0.;
-  
-  size_t iclus = 0;
-  float maxDR = 0;
-  edm::Ptr<reco::CaloCluster> pclus;
-  // loop over all clusters that aren't the seed  
-  auto clusend = the_sc->clustersEnd();
-  for( auto clus = the_sc->clustersBegin(); clus != clusend; ++clus ) {
-    pclus = *clus;
-    
-    if(theseed == pclus ) 
-      continue;
-    clusterRawEnergy[iclus]  = pclus->energy();
-    clusterDPhiToSeed[iclus] = reco::deltaPhi(pclus->phi(),theseed->phi());
-    clusterDEtaToSeed[iclus] = pclus->eta() - theseed->eta();
-    
-    // find cluster with max dR
-    const auto the_dr = reco::deltaR(*pclus, *theseed);
-    if(the_dr > maxDR) {
-      maxDR = the_dr;
-      clusterMaxDR = maxDR;
-      clusterMaxDRDPhi = clusterDPhiToSeed[iclus];
-      clusterMaxDRDEta = clusterDEtaToSeed[iclus];
-      clusterMaxDRRawEnergy = clusterRawEnergy[iclus];
-    }      
-    ++iclus;
-  }
-  
-  eval[16] = clusterMaxDR;
-  eval[17] = clusterMaxDRDPhi;
-  eval[18] = clusterMaxDRDEta;
-  eval[19] = clusterMaxDRRawEnergy/raw_energy;
-  eval[20] = clusterRawEnergy[0]/raw_energy;
-  eval[21] = clusterRawEnergy[1]/raw_energy;
-  eval[22] = clusterRawEnergy[2]/raw_energy;
-  eval[23] = clusterDPhiToSeed[0];
-  eval[24] = clusterDPhiToSeed[1];
-  eval[25] = clusterDPhiToSeed[2];
-  eval[26] = clusterDEtaToSeed[0];
-  eval[27] = clusterDEtaToSeed[1];
-  eval[28] = clusterDEtaToSeed[2];
-  
-  // calculate coordinate variables
   const bool iseb = ele.isEB();  
-  float dummy;
-  int iPhi;
-  int iEta;
-  float cryPhi;
-  float cryEta;
-  EcalClusterLocal _ecalLocal;
-  if (ele.isEB()) 
-    _ecalLocal.localCoordsEB(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
-  else 
-    _ecalLocal.localCoordsEE(*theseed, *iSetup_, cryEta, cryPhi, iEta, iPhi, dummy, dummy);
 
+  std::array<float, 32> eval;  
+  const double raw_energy = the_sc->rawEnergy(); 
+  const double raw_es_energy = the_sc->preshowerEnergy();
+  const auto& full5x5_ess = ele.full5x5_showerShape();
+
+  float e5x5Inverse = full5x5_ess.e5x5 != 0. ? vdt::fast_inv(full5x5_ess.e5x5) : 0.;
+
+  eval[0]  = raw_energy;
+  eval[1]  = the_sc->etaWidth();
+  eval[2]  = the_sc->phiWidth(); 
+  eval[3]  = the_sc->seed()->energy()/raw_energy;
+  eval[4]  = full5x5_ess.e5x5/raw_energy;
+  eval[5]  = ele.hcalOverEcalBc();
+  eval[6]  = rhoValue_;
+  eval[7]  = theseed->eta() - the_sc->position().Eta();
+  eval[8]  = reco::deltaPhi( theseed->phi(),the_sc->position().Phi());
+  eval[9]  = full5x5_ess.r9;
+  eval[10]  = full5x5_ess.sigmaIetaIeta;
+  eval[11]  = full5x5_ess.sigmaIetaIphi;
+  eval[12]  = full5x5_ess.sigmaIphiIphi;
+  eval[13]  = full5x5_ess.eMax*e5x5Inverse;
+  eval[14]  = full5x5_ess.e2nd*e5x5Inverse;
+  eval[15]  = full5x5_ess.eTop*e5x5Inverse;
+  eval[16]  = full5x5_ess.eBottom*e5x5Inverse;
+  eval[17]  = full5x5_ess.eLeft*e5x5Inverse;
+  eval[18]  = full5x5_ess.eRight*e5x5Inverse;
+  eval[19]  = full5x5_ess.e2x5Max*e5x5Inverse;
+  eval[20]  = full5x5_ess.e2x5Left*e5x5Inverse;
+  eval[21]  = full5x5_ess.e2x5Right*e5x5Inverse;
+  eval[22]  = full5x5_ess.e2x5Top*e5x5Inverse;
+  eval[23]  = full5x5_ess.e2x5Bottom*e5x5Inverse;
+  eval[24]  = ele.nSaturatedXtals();
+  eval[25]  = std::max(0,numberOfClusters);
+      
+  // calculate coordinate variables
+  EcalClusterLocal _ecalLocal;
   if (iseb) {
-    eval[29] = cryEta;
-    eval[30] = cryPhi;
-    eval[31] = iEta;
-    eval[32] = iPhi;
+
+    float dummy;
+    int ieta;
+    int iphi;
+    _ecalLocal.localCoordsEB(*theseed, *iSetup_, dummy, dummy, ieta, iphi, dummy, dummy);
+    eval[26] = ieta;
+    eval[27] = iphi;
+    int signieta = ieta > 0 ? +1 : -1;
+    eval[28] = (ieta-signieta)%5;
+    eval[29] = (iphi-1)%2;
+    eval[30] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);  
+    eval[31] = (iphi-1)%20;
+
   } else {
-    eval[29] = the_sc->preshowerEnergy()/the_sc->rawEnergy();
+
+    float dummy;
+    int ix;
+    int iy;
+    _ecalLocal.localCoordsEE(*theseed, *iSetup_, dummy, dummy, ix, iy, dummy, dummy);
+    eval[26] = ix;
+    eval[27] = iy;
+    eval[28] = raw_es_energy/raw_energy;
+
   }
 
   //magic numbers for MINUIT-like transformation of BDT output onto limited range
   //(These should be stored inside the conditions object in the future as well)
-  constexpr double meanlimlow  = 0.2;
-  constexpr double meanlimhigh = 2.0;
+  constexpr double meanlimlow  = -1.0;
+  constexpr double meanlimhigh = 3.0;
   constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
   constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
   
@@ -483,11 +437,20 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
   constexpr double sigmalimhigh = 0.5;
   constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
   constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
+
   
-  int coridx = 0;
-  if (!iseb)
+  size_t coridx = 0;
+  float raw_pt = raw_energy/cosh(the_sc->eta());
+
+  if (iseb && raw_pt < lowEnergy_ECALonlyThr_)
+    coridx = 0;
+  else if (iseb && raw_pt >= lowEnergy_ECALonlyThr_)
     coridx = 1;
-    
+  else if (!iseb && raw_pt < lowEnergy_ECALonlyThr_)
+    coridx = 2;
+  else if (!iseb && raw_pt >= lowEnergy_ECALonlyThr_)
+    coridx = 3;
+  
   //these are the actual BDT responses
   double rawmean = e_forestH_mean_[coridx]->GetResponse(eval.data());
   double rawsigma = e_forestH_sigma_[coridx]->GetResponse(eval.data());
@@ -495,69 +458,74 @@ void EGExtraInfoModifierFromDB::modifyObject(reco::GsfElectron& ele) const {
   //apply transformation to limited output range (matching the training)
   double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
   double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
-  
-  //regression target is ln(Etrue/Eraw)
-  //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
-  double ecor = mean*(eval[1]);
-  if (!iseb)  
-    ecor = mean*(eval[1]+the_sc->preshowerEnergy());
+
+  // Correct the energy
+  const double ecor = mean*(raw_energy + raw_es_energy);
   const double sigmacor = sigma*ecor;
   
   ele.setCorrectedEcalEnergy(ecor);
   ele.setCorrectedEcalEnergyError(sigmacor);
-    
-  // E-p combination 
-  //std::array<float, 11> eval_ep;
-  float eval_ep[11];
 
-  const float ep = ele.trackMomentumAtVtx().R();
-  const float tot_energy = the_sc->rawEnergy()+the_sc->preshowerEnergy();
-  const float momentumError = ele.trackMomentumError();
-  const float trkMomentumRelError = ele.trackMomentumError()/ep;
-  const float eOverP = tot_energy*mean/ep;
-  eval_ep[0] = tot_energy*mean;
-  eval_ep[1] = sigma/mean;
-  eval_ep[2] = ep; 
-  eval_ep[3] = trkMomentumRelError;
-  eval_ep[4] = sigma/mean/trkMomentumRelError;
-  eval_ep[5] = tot_energy*mean/ep;
-  eval_ep[6] = tot_energy*mean/ep*sqrt(sigma/mean*sigma/mean+trkMomentumRelError*trkMomentumRelError);
-  eval_ep[7] = ele.ecalDriven();
-  eval_ep[8] = ele.trackerDrivenSeed();
-  eval_ep[9] = int(ele.classification());//eleClass;
-  eval_ep[10] = iseb;
+  double combinedEnergy = ecor;
+  double combinedEnergyError = sigmacor;
+
+  auto el_track = ele.gsfTrack();
+  const float trkMomentum = el_track->pMode();
+  const float trkEta      = el_track->etaMode();
+  const float trkPhi      = el_track->phiMode();  
+  const float trkMomentumError = std::abs(el_track->qoverpModeError())*trkMomentum*trkMomentum;  
+
+  const float eOverP = (raw_energy+raw_es_energy)*mean/trkMomentum;
+  const float fbrem = ele.fbrem();
+
+  // E-p combination
+  if (ecor < highEnergy_ECALTRKThr_ &&
+      eOverP > eOverP_ECALTRKThr_ && 
+      std::abs(ecor - trkMomentum) < epDiffSig_ECALTRKThr_*std::sqrt(trkMomentumError*trkMomentumError+sigmacor*sigmacor) && 
+      trkMomentumError < epSig_ECALTRKThr_*trkMomentum) { 
+
+    raw_pt = ecor/cosh(trkEta);
+    if (iseb && raw_pt < lowEnergy_ECALTRKThr_)
+      coridx = 4;
+    else if (iseb && raw_pt >= lowEnergy_ECALTRKThr_)
+      coridx = 5;
+    else if (!iseb && raw_pt < lowEnergy_ECALTRKThr_)
+      coridx = 6;
+    else if (!iseb && raw_pt >= lowEnergy_ECALTRKThr_)
+      coridx = 7;
   
-  // CODE FOR FUTURE SEMI_PARAMETRIC
-  //double rawweight = ep_forestH_mean_[coridx]->GetResponse(eval_ep.data());
-  ////rawsigma = ep_forestH_sigma_[coridx]->GetResponse(eval.data());
-  //double weight = meanoffset + meanscale*vdt::fast_sin(rawweight);
-  ////sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+    eval[0] = ecor;
+    eval[1] = sigma/mean;
+    eval[2] = trkMomentumError/trkMomentum;
+    eval[3] = eOverP;
+    eval[4] = ele.ecalDrivenSeed();
+    eval[5] = full5x5_ess.r9;
+    eval[6] = fbrem;
+    eval[7] = trkEta; 
+    eval[8] = trkPhi; 
+    
+    float rawcomb = ( ecor*trkMomentumError*trkMomentumError + trkMomentum*(raw_energy+raw_es_energy)*(raw_energy+raw_es_energy)*sigma*sigma ) / ( trkMomentumError*trkMomentumError + (raw_energy + raw_es_energy)*(raw_energy + raw_es_energy)*sigma*sigma );
 
-  // CODE FOR STANDARD BDT
-  double weight = 0.;
-  if ( eOverP > 0.025 && 
-       std::abs(ep-ecor) < 15.*std::sqrt( momentumError*momentumError + sigmacor*sigmacor ) &&
-       (!applyExtraHighEnergyProtection_ || ((momentumError < 10.*ep) || (ecor < 200.)))
-       ) {
-    // protection against crazy track measurement
-    weight = ep_forestH_weight_->GetResponse(eval_ep);
-    if(weight>1.) 
-      weight = 1.;
-    else if(weight<0.) 
-      weight = 0.;
+    //these are the actual BDT responses
+    double rawmean_trk = e_forestH_mean_[coridx]->GetResponse(eval.data());
+    double rawsigma_trk = e_forestH_sigma_[coridx]->GetResponse(eval.data());
+    
+    //apply transformation to limited output range (matching the training)
+    double mean_trk = meanoffset + meanscale*vdt::fast_sin(rawmean_trk);
+    double sigma_trk = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma_trk);
+    
+    // Final correction
+    combinedEnergy = mean_trk*rawcomb;
+    combinedEnergyError = sigma_trk*rawcomb;
   }
 
-  double combinedMomentum = weight*ele.trackMomentumAtVtx().R() + (1.-weight)*ecor;
-  double combinedMomentumError = sqrt(weight*weight*ele.trackMomentumError()*ele.trackMomentumError() + (1.-weight)*(1.-weight)*sigmacor*sigmacor);
-
-  math::XYZTLorentzVector oldMomentum = ele.p4();
-  math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector(oldMomentum.x()*combinedMomentum/oldMomentum.t(),
-								oldMomentum.y()*combinedMomentum/oldMomentum.t(),
-								oldMomentum.z()*combinedMomentum/oldMomentum.t(),
-								combinedMomentum);
+  math::XYZTLorentzVector oldFourMomentum = ele.p4();
+  math::XYZTLorentzVector newFourMomentum = math::XYZTLorentzVector(oldFourMomentum.x()*combinedEnergy/oldFourMomentum.t(),
+								    oldFourMomentum.y()*combinedEnergy/oldFourMomentum.t(),
+								    oldFourMomentum.z()*combinedEnergy/oldFourMomentum.t(),
+								    combinedEnergy);
  
-  //ele.correctEcalEnergy(combinedMomentum, combinedMomentumError);
-  ele.correctMomentum(newMomentum, ele.trackMomentumError(), combinedMomentumError);
+  ele.correctMomentum(newFourMomentum, ele.trackMomentumError(), combinedEnergyError);
 }
 
 void EGExtraInfoModifierFromDB::modifyObject(pat::Electron& ele) const {
@@ -567,103 +535,114 @@ void EGExtraInfoModifierFromDB::modifyObject(pat::Electron& ele) const {
 void EGExtraInfoModifierFromDB::modifyObject(reco::Photon& pho) const {
   // regression calculation needs no additional valuemaps
   
-  std::array<float, 35> eval;
+
   const reco::SuperClusterRef& the_sc = pho.superCluster();
-  const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();
-  
+  const edm::Ptr<reco::CaloCluster>& theseed = the_sc->seed();  
   const int numberOfClusters =  the_sc->clusters().size();
   const bool missing_clusters = !the_sc->clusters()[numberOfClusters-1].isAvailable();
-
-  // skip HGCal for now
-  if( theseed->seed().det() == DetId::Forward ) return;
   if( missing_clusters ) return ; // do not apply corrections in case of missing info (slimmed MiniAOD electrons)
 
+  const bool iseb = pho.isEB();  
+  
+  std::array<float, 32> eval;  
   const double raw_energy = the_sc->rawEnergy(); 
-  const auto& ess = pho.showerShapeVariables();
+  const double raw_es_energy = the_sc->preshowerEnergy();
+  const auto& full5x5_pss = pho.full5x5_showerShapeVariables();
 
-  // SET INPUTS
+  float e5x5Inverse = full5x5_pss.e5x5 != 0. ? vdt::fast_inv(full5x5_pss.e5x5) : 0.;
+
   eval[0]  = raw_energy;
-  eval[1]  = pho.r9();
-  eval[2]  = the_sc->etaWidth();
-  eval[3]  = the_sc->phiWidth(); 
-  eval[4]  = std::max(0,numberOfClusters - 1);
+  eval[1]  = the_sc->etaWidth();
+  eval[2]  = the_sc->phiWidth(); 
+  eval[3]  = the_sc->seed()->energy()/raw_energy;
+  eval[4]  = full5x5_pss.e5x5/raw_energy;
   eval[5]  = pho.hadronicOverEm();
   eval[6]  = rhoValue_;
-  eval[7]  = nVtx_;  
-  eval[8] = theseed->eta()-the_sc->position().Eta();
-  eval[9] = reco::deltaPhi(theseed->phi(),the_sc->position().Phi());
-  eval[10] = theseed->energy()/raw_energy;
-  eval[11] = ess.e3x3/ess.e5x5;
-  eval[12] = ess.sigmaIetaIeta;  
-  eval[13] = ess.sigmaIphiIphi;
-  eval[14] = ess.sigmaIetaIphi/(ess.sigmaIphiIphi*ess.sigmaIetaIeta);
-  eval[15] = ess.maxEnergyXtal/ess.e5x5;
-  eval[16] = ess.e2nd/ess.e5x5;
-  eval[17] = ess.eTop/ess.e5x5;
-  eval[18] = ess.eBottom/ess.e5x5;
-  eval[19] = ess.eLeft/ess.e5x5;
-  eval[20] = ess.eRight/ess.e5x5;  
-  eval[21] = ess.e2x5Max/ess.e5x5;
-  eval[22] = ess.e2x5Left/ess.e5x5;
-  eval[23] = ess.e2x5Right/ess.e5x5;
-  eval[24] = ess.e2x5Top/ess.e5x5;
-  eval[25] = ess.e2x5Bottom/ess.e5x5;
+  eval[7]  = theseed->eta() - the_sc->position().Eta();
+  eval[8]  = reco::deltaPhi( theseed->phi(),the_sc->position().Phi());
+  eval[9]  = pho.full5x5_r9();
+  eval[10]  = full5x5_pss.sigmaIetaIeta;
+  eval[11]  = full5x5_pss.sigmaIetaIphi;
+  eval[12]  = full5x5_pss.sigmaIphiIphi;
+  eval[13]  = full5x5_pss.maxEnergyXtal*e5x5Inverse;
+  eval[14]  = full5x5_pss.e2nd*e5x5Inverse;
+  eval[15]  = full5x5_pss.eTop*e5x5Inverse;
+  eval[16]  = full5x5_pss.eBottom*e5x5Inverse;
+  eval[17]  = full5x5_pss.eLeft*e5x5Inverse;
+  eval[18]  = full5x5_pss.eRight*e5x5Inverse;
+  eval[19]  = full5x5_pss.e2x5Max/full5x5_pss.e5x5;
+  eval[20]  = full5x5_pss.e2x5Left/full5x5_pss.e5x5;
+  eval[21]  = full5x5_pss.e2x5Right/full5x5_pss.e5x5;
+  eval[22]  = full5x5_pss.e2x5Top/full5x5_pss.e5x5;
+  eval[23]  = full5x5_pss.e2x5Bottom/full5x5_pss.e5x5;
+  eval[24]  = pho.nSaturatedXtals();
+  eval[25]  = std::max(0,numberOfClusters);
+      
+  // calculate coordinate variables
+  EcalClusterLocal _ecalLocal;
 
-  const bool iseb = pho.isEB();
   if (iseb) {
-    EBDetId ebseedid(theseed->seed());
-    eval[26] = pho.e5x5()/theseed->energy();
-    int ieta = ebseedid.ieta();
-    int iphi = ebseedid.iphi();
-    eval[27] = ieta;
-    eval[28] = iphi;
-    int signieta = ieta > 0 ? +1 : -1; /// this is 1*abs(ieta)/ieta in original training
-    eval[29] = (ieta-signieta)%5;
-    eval[30] = (iphi-1)%2;
-    //    eval[31] = (abs(ieta)<=25)*((ieta-signieta)%25) + (abs(ieta)>25)*((ieta-26*signieta)%20); //%25 is unnescessary in this formula
-    eval[31] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);  
-    eval[32] = (iphi-1)%20;
-    eval[33] = ieta;  /// duplicated variables but this was trained like that
-    eval[34] = iphi;  /// duplicated variables but this was trained like that
+
+    float dummy;
+    int ieta;
+    int iphi;
+    _ecalLocal.localCoordsEB(*theseed, *iSetup_, dummy, dummy, ieta, iphi, dummy, dummy);
+    eval[26] = ieta;
+    eval[27] = iphi;
+    int signieta = ieta > 0 ? +1 : -1;
+    eval[28] = (ieta-signieta)%5;
+    eval[29] = (iphi-1)%2;
+    eval[30] = (abs(ieta)<=25)*((ieta-signieta)) + (abs(ieta)>25)*((ieta-26*signieta)%20);  
+    eval[31] = (iphi-1)%20;
+
   } else {
-    EEDetId eeseedid(theseed->seed());
-    eval[26] = the_sc->preshowerEnergy()/raw_energy;
-    eval[27] = the_sc->preshowerEnergyPlane1()/raw_energy;
-    eval[28] = the_sc->preshowerEnergyPlane2()/raw_energy;
-    eval[29] = eeseedid.ix();
-    eval[30] = eeseedid.iy();
+
+    float dummy;
+    int ix;
+    int iy;
+    _ecalLocal.localCoordsEE(*theseed, *iSetup_, dummy, dummy, ix, iy, dummy, dummy);
+    eval[26] = ix;
+    eval[27] = iy;
+    eval[28] = raw_es_energy/raw_energy;
+
   }
 
   //magic numbers for MINUIT-like transformation of BDT output onto limited range
   //(These should be stored inside the conditions object in the future as well)
-  const double meanlimlow  = 0.2;
-  const double meanlimhigh = 2.0;
-  const double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
-  const double meanscale   = 0.5*(meanlimhigh-meanlimlow);
+  constexpr double meanlimlow  = -1.0;
+  constexpr double meanlimhigh = 3.0;
+  constexpr double meanoffset  = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
+  constexpr double meanscale   = 0.5*(meanlimhigh-meanlimlow);
   
-  const double sigmalimlow  = 0.0002;
-  const double sigmalimhigh = 0.5;
-  const double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-  const double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
- 
-  int coridx = 0;
-  if (!iseb)
-    coridx = 1;
+  constexpr double sigmalimlow  = 0.0002;
+  constexpr double sigmalimhigh = 0.5;
+  constexpr double sigmaoffset  = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
+  constexpr double sigmascale   = 0.5*(sigmalimhigh-sigmalimlow);  
+  
+  size_t coridx = 0;
+  float raw_pt = raw_energy/cosh(the_sc->eta());
 
+  if (iseb && raw_pt < lowEnergy_ECALonlyThr_)
+    coridx = 0;
+  else if (iseb && raw_pt >= lowEnergy_ECALonlyThr_)
+    coridx = 1;
+  else if (!iseb && raw_pt < lowEnergy_ECALonlyThr_)
+    coridx = 2;
+  else if (!iseb && raw_pt >= lowEnergy_ECALonlyThr_)
+    coridx = 3;
+  
   //these are the actual BDT responses
   double rawmean = ph_forestH_mean_[coridx]->GetResponse(eval.data());
   double rawsigma = ph_forestH_sigma_[coridx]->GetResponse(eval.data());
+  
   //apply transformation to limited output range (matching the training)
   double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
   double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
-
-  //regression target is ln(Etrue/Eraw)
-  //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
-  double ecor = mean*eval[0];
-  if (!iseb) 
-    ecor = mean*(eval[0]+the_sc->preshowerEnergy());
-
-  double sigmacor = sigma*ecor;
+  
+  // Correct the energy
+  const double ecor = mean*(raw_energy + raw_es_energy);
+  const double sigmacor = sigma*ecor;
+  
   pho.setCorrectedEnergy(reco::Photon::P4type::regression2, ecor, sigmacor, true);     
 }
 

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -2,28 +2,27 @@ import FWCore.ParameterSet.Config as cms
 
 regressionModifier = \
     cms.PSet( modifierName    = cms.string('EGExtraInfoModifierFromDB'),  
-              autoDetectBunchSpacing = cms.bool(True),
-              applyExtraHighEnergyProtection = cms.bool(True),
-              bunchSpacingTag = cms.InputTag("bunchSpacingProducer"),
-              manualBunchSpacing = cms.int32(50),              
-              rhoCollection = cms.InputTag("fixedGridRhoFastjetAll"),
-              vertexCollection = cms.InputTag("offlinePrimaryVertices"),
+
+              rhoCollection = cms.InputTag('fixedGridRhoFastjetAll'),
+              
               electron_config = cms.PSet( # EB, EE
-                                          regressionKey_25ns  = cms.vstring('gedelectron_EBCorrection_25ns', 'gedelectron_EECorrection_25ns'),
-                                          uncertaintyKey_25ns = cms.vstring('gedelectron_EBUncertainty_25ns', 'gedelectron_EEUncertainty_25ns'),
-                                          combinationKey_25ns   = cms.string('gedelectron_p4combination_25ns'),
-                                          
-                                          regressionKey_50ns  = cms.vstring('gedelectron_EBCorrection_50ns', 'gedelectron_EECorrection_50ns'),
-                                          uncertaintyKey_50ns = cms.vstring('gedelectron_EBUncertainty_50ns', 'gedelectron_EEUncertainty_50ns'),
-                                          combinationKey_50ns   = cms.string('gedelectron_p4combination_50ns'),
+                regressionKey_ecalonly  = cms.vstring('electron_eb_ECALonly_lowpt', 'electron_eb_ECALonly', 'electron_ee_ECALonly_lowpt', 'electron_ee_ECALonly'),
+                uncertaintyKey_ecalonly = cms.vstring('electron_eb_ECALonly_lowpt_var', 'electron_eb_ECALonly_var', 'electron_ee_ECALonly_lowpt_var', 'electron_ee_ECALonly_var'),
+                regressionKey_ecaltrk  = cms.vstring('electron_eb_ECALTRK_lowpt', 'electron_eb_ECALTRK', 'electron_ee_ECALTRK_lowpt', 'electron_ee_ECALTRK'),
+                uncertaintyKey_ecaltrk = cms.vstring('electron_eb_ECALTRK_lowpt_var', 'electron_eb_ECALTRK_var', 'electron_ee_ECALTRK_lowpt_var', 'electron_ee_ECALTRK_var'),
                                           ),
               
               photon_config   = cms.PSet( # EB, EE
-                                          regressionKey_25ns  = cms.vstring('gedphoton_EBCorrection_25ns', 'gedphoton_EECorrection_25ns'),
-                                          uncertaintyKey_25ns = cms.vstring('gedphoton_EBUncertainty_25ns', 'gedphoton_EEUncertainty_25ns'),
-                                          
-                                          regressionKey_50ns  = cms.vstring('gedphoton_EBCorrection_50ns', 'gedphoton_EECorrection_50ns'),
-                                          uncertaintyKey_50ns = cms.vstring('gedphoton_EBUncertainty_50ns', 'gedphoton_EEUncertainty_50ns'),
-                                          )
+                regressionKey_ecalonly  = cms.vstring('photon_eb_ECALonly_lowpt', 'photon_eb_ECALonly', 'photon_ee_ECALonly_lowpt', 'photon_ee_ECALonly'),
+                uncertaintyKey_ecalonly = cms.vstring('photon_eb_ECALonly_lowpt_var', 'photon_eb_ECALonly_var', 'photon_ee_ECALonly_lowpt_var', 'photon_ee_ECALonly_var'),
+                                          ),
+
+              lowEnergy_ECALonlyThr = cms.double(300.),
+              lowEnergy_ECALTRKThr = cms.double(50.),
+              highEnergy_ECALTRKThr = cms.double(200.),
+              eOverP_ECALTRKThr = cms.double(0.025),
+              epDiffSig_ECALTRKThr = cms.double(15.),
+              epSig_ECALTRKThr = cms.double(10.),
+
               )
     

--- a/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFPhotonTranslator.cc
@@ -911,6 +911,7 @@ void PFPhotonTranslator::createPhotons(reco::VertexCollection &vertexCollection,
 
 
       reco::Photon::ShowerShape  showerShape;
+      reco::Photon::SaturationInfo saturationInfo;
       reco::Photon::FiducialFlags fiducialFlags;
       reco::Photon::IsolationVariables isolationVariables03;
       reco::Photon::IsolationVariables isolationVariables04;
@@ -925,7 +926,12 @@ void PFPhotonTranslator::createPhotons(reco::VertexCollection &vertexCollection,
       showerShape.hcalDepth1OverEcal = egPhotonRef_[iphot]->hadronicDepth1OverEm();
       showerShape.hcalDepth2OverEcal = egPhotonRef_[iphot]->hadronicDepth2OverEm();
       myPhoton.setShowerShapeVariables ( showerShape ); 
-	  
+
+      
+      saturationInfo.nSaturatedXtals = egPhotonRef_[iphot]->nSaturatedXtals();
+      saturationInfo.isSeedSaturated = egPhotonRef_[iphot]->isSeedSaturated();
+      myPhoton.setSaturationInfo(saturationInfo);
+
       fiducialFlags.isEB = egPhotonRef_[iphot]->isEB();
       fiducialFlags.isEE = egPhotonRef_[iphot]->isEE();
       fiducialFlags.isEBEtaGap = egPhotonRef_[iphot]->isEBEtaGap();


### PR DESCRIPTION
This is a merge, correction, rebase, and implementation of code review requests from the following two PRs:

#17370 (2x5 variables, saturation info, Fiducial Flag setters)
#17101 (new regression into 90X reco sequence)

Both PRs have already been presented in the RECO and AT meeting (the Fiducial Flags have not, but it is trivial).

The 2x5 variables and saturation info are to avoid recalculation of variables inside the regression Modifier code. The fiducial flag setters is opportunistic (I am working on porting a version of the supercluster update code developed for the miniAOD into 90X and this will help, as discussed during the review of #17296).

The 90X regression has the same modifications as implemented in user analysis for 80X (#17318), namely, complete semi-parametric cluster-track energy estimation, improvement of high-energy cluster energy estimation, unified set of variables for electrons and photons, ...

This PR depends on #17479 to pass validation.