### PR TITLE
First version of merging duplicate tracks caused by module overlaps

### DIFF
--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -6,11 +6,18 @@ import FWCore.ParameterSet.Config as cms
 
 from  RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
 
+from TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi import Chi2MeasurementEstimator as _Chi2MeasurementEstimator
+duplicateDisplaceTrackCandidatesChi2Est = _Chi2MeasurementEstimator.clone(
+    ComponentName = "duplicateDisplacedTrackCandidatesChi2Est",
+    MaxChi2 = 100,
+)
+
 #for displaced global muons                                      
 duplicateDisplacedTrackCandidates = DuplicateTrackMerger.clone(
     source=cms.InputTag("preDuplicateMergingDisplacedTracks"),
     useInnermostState  = cms.bool(True),
-    ttrhBuilderName    = cms.string("WithAngleAndTemplate")
+    ttrhBuilderName    = cms.string("WithAngleAndTemplate"),
+    chi2EstimatorName = "duplicateDisplacedTrackCandidatesChi2Est"
     )
 #for displaced global muons
 mergedDuplicateDisplacedTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -27,6 +27,8 @@
 <use   name="TrackingTools/PatternTools"/>
 <use   name="RecoLocalTracker/SiStripClusterizer"/>
 <use   name="TrackingTools/TransientTrack"/>
+<use   name="TrackingTools/GeomPropagators"/>
+<use   name="TrackingTools/KalmanUpdators"/>
 <use   name="CondFormats/EgammaObjects"/>
 <use   name="CommonTools/Utils"/>
 <use   name="CommonTools/Statistics"/>

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -10,6 +10,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -27,6 +28,18 @@
 #include <atomic>
 
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
+
+// Having this macro reduces the need to pollute the code with
+// #ifdefs. The idea is that the condition is checked only if
+// debugging is enabled. That way the condition expression may use
+// variables that are declared only if EDM_ML_DEBUG is enabled. If it
+// is disabled, rely on the fact that LogTrace should compile to
+// no-op.
+#ifdef EDM_ML_DEBUG
+#define IfLogTrace(cond, cat) if(cond) LogTrace(cat)
+#else
+#define IfLogTrace(cond, cat) LogTrace(cat)
+#endif
 
 using namespace reco;
 namespace {
@@ -232,14 +245,50 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
   auto out_candidateMap = std::make_unique<CandidateToDuplicate>();
   LogDebug("DuplicateTrackMerger") << "Number of tracks to be checked for merging: " << tracks.size();
 
+#ifdef EDM_ML_DEBUG
+  auto test = [&](const reco::Track *a, const reco::Track *b) {
+    const auto ev = iEvent.id().event();
+    const auto aOriAlgo = a->originalAlgo();
+    const auto bOriAlgo = b->originalAlgo();
+    const auto aSeed = a->seedRef().key();
+    const auto bSeed = b->seedRef().key();
+    return ((ev == 2003 && ((aOriAlgo == 4 && aSeed == 366 && bOriAlgo == 22 && bSeed == 207) ||
+                            (aOriAlgo == 23 && aSeed == 113 && bOriAlgo == 5 && bSeed == 276) ||
+                            (aOriAlgo == 23 && aSeed == 712 && bOriAlgo == 23 && bSeed == 705) ||
+                            (aOriAlgo == 4 && aSeed == 454 && bOriAlgo == 23 && bSeed == 476) ||
+                            (aOriAlgo == 5 && aSeed == 523 && bOriAlgo == 5 && bSeed == 524))) ||
+            (ev == 2002 && ((aOriAlgo == 4 && aSeed == 22 && bOriAlgo == 8 && bSeed == 2) ||
+                            (aOriAlgo == 4 && aSeed == 626 && bOriAlgo == 5 && bSeed == 552) ||
+                            (aOriAlgo == 4 && aSeed == 973 && bOriAlgo == 5 && bSeed == 679) ||
+                            (aOriAlgo == 4 && aSeed == 532 && bOriAlgo == 5 && bSeed == 507) ||
+                            (aOriAlgo == 4 && aSeed == 1015 && bOriAlgo == 22 && bSeed == 456) ||
+                            (aOriAlgo == 4 && aSeed == 709 && bOriAlgo == 23 && bSeed == 636) ||
+                            (aOriAlgo == 4 && aSeed == 617 && bOriAlgo == 5 && bSeed == 571) ||
+                            (aOriAlgo == 4 && aSeed == 807 && bOriAlgo == 23 && bSeed == 23) ||
+                            (aOriAlgo == 4 && aSeed == 908 && bOriAlgo == 5 && bSeed == 707))));
+  };
+#endif
+
   for(int i = 0; i < (int)tracks.size(); i++){
     const reco::Track *rt1 = &tracks[i];
+
     if(rt1->innerMomentum().perp2() < minpT2_)continue;
     // if(rt1->innerMomentum().R() < minP_)continue;
     for(int j = i+1; j < (int)tracks.size();j++){
       const reco::Track *rt2 = &tracks[j];
+
+#ifdef EDM_ML_DEBUG
+      bool debug = false;
+      if(test(rt1, rt2) || test(rt2, rt1)) {
+        debug = true;
+        LogTrace("DuplicateTrackMerger") << "Track1 " << i << " originalAlgo " << rt1->originalAlgo() << " seed " << rt1->seedRef().key() << " pT " << std::sqrt(rt1->innerMomentum().perp2()) << " charge " << rt1->charge() << " outerPosition2 " << rt1->outerPosition().perp2() << "\n"
+                                         << "Track2 " << j << " originalAlgo " << rt2->originalAlgo() << " seed " << rt2->seedRef().key() << " pT " << std::sqrt(rt2->innerMomentum().perp2()) << " charge " << rt2->charge() << " outerPosition2 " << rt2->outerPosition().perp2();
+      }
+#endif
+
       if(rt1->charge() != rt2->charge())continue;
       auto cosT = (*rt1).momentum().unit().Dot((*rt2).momentum().unit());
+      IfLogTrace(debug, "DuplicateTrackMerger") << " cosT " << cosT;
       if (cosT<0.) continue;
       if(rt2->innerMomentum().perp2() < minpT2_)continue;
       // if(rt2->innerMomentum().R() < minP_)continue;
@@ -252,8 +301,10 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
 	t2 = rt1;
       }
       auto deltaR3d2 = (t1->outerPosition() - t2->innerPosition()).mag2();
-      
+
       if(t1->outerPosition().perp2() > t2->innerPosition().perp2()) deltaR3d2 *= -1.0;
+      IfLogTrace(debug, "DuplicateTrackMerger") << " deltaR3d2 " << deltaR3d2 << " t1.outerPos2 " << t1->outerPosition().perp2() << " t2.innerPos2 " << t2->innerPosition().perp2();
+
       if(deltaR3d2 < minDeltaR3d2_)continue;
       
       FreeTrajectoryState fts1 = trajectoryStateTransform::outerFreeState(*t1, &*magfield_,false);
@@ -261,17 +312,20 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
       GlobalPoint avgPoint((t1->outerPosition().x()+t2->innerPosition().x())*0.5,(t1->outerPosition().y()+t2->innerPosition().y())*0.5,(t1->outerPosition().z()+t2->innerPosition().z())*0.5);
       TrajectoryStateClosestToPoint TSCP1 = tscpBuilder(fts1, avgPoint);
       TrajectoryStateClosestToPoint TSCP2 = tscpBuilder(fts2, avgPoint);
+      IfLogTrace(debug, "DuplicateTrackMerger") << " TSCP1.isValid " << TSCP1.isValid() << " TSCP2.isValid " << TSCP2.isValid();
       if(!TSCP1.isValid())continue;
       if(!TSCP2.isValid())continue;
 
       const FreeTrajectoryState ftsn1 = TSCP1.theState();
       const FreeTrajectoryState ftsn2 = TSCP2.theState();
  
+      IfLogTrace(debug, "DuplicateTrackMerger") << " DCA2 " << (ftsn2.position()-ftsn1.position()).mag2();
       if ( (ftsn2.position()-ftsn1.position()).mag2() > maxDCA2_ ) continue;
 
       auto qoverp1 = ftsn1.signedInverseMomentum();
       auto qoverp2 = ftsn2.signedInverseMomentum();
       float tmva_dqoverp_ = qoverp1-qoverp2;
+      IfLogTrace(debug, "DuplicateTrackMerger") << " dqoverp " << tmva_dqoverp_;
       if ( std::abs(tmva_dqoverp_) > maxDQoP_ ) continue;
 
 
@@ -281,17 +335,20 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
       auto lambda1 =  M_PI/2 - ftsn1.momentum().theta();
       auto lambda2 =  M_PI/2 - ftsn2.momentum().theta();
       float tmva_dlambda_ = lambda1-lambda2;
+      IfLogTrace(debug, "DuplicateTrackMerger") << " dlambda " << tmva_dlambda_;
       if ( std::abs(tmva_dlambda_) > maxDLambda_ ) continue;
 
       auto phi1 = ftsn1.momentum().phi();
       auto phi2 = ftsn2.momentum().phi();
       float tmva_dphi_ = phi1-phi2;
       if(std::abs(tmva_dphi_) > float(M_PI)) tmva_dphi_ = 2.f*float(M_PI) - std::abs(tmva_dphi_);
+      IfLogTrace(debug, "DuplicateTrackMerger") << " dphi " << tmva_dphi_;
       if (std::abs(tmva_dphi_) > maxDPhi_ ) continue;
 
       auto dxy1 = (-ftsn1.position().x() * ftsn1.momentum().y() + ftsn1.position().y() * ftsn1.momentum().x())/TSCP1.pt();
       auto dxy2 = (-ftsn2.position().x() * ftsn2.momentum().y() + ftsn2.position().y() * ftsn2.momentum().x())/TSCP2.pt();
       float tmva_ddxy_ = dxy1-dxy2;
+      IfLogTrace(debug, "DuplicateTrackMerger") << " ddxy " << tmva_ddxy_;
       if ( std::abs(tmva_ddxy_) > maxDdxy_ ) continue;
 
       auto dsz1 = ftsn1.position().z() * TSCP1.pt() / TSCP1.momentum().mag()
@@ -299,6 +356,7 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
       auto dsz2 = ftsn2.position().z() * TSCP2.pt() / TSCP2.momentum().mag()
 	- (ftsn2.position().x() * ftsn2.momentum().y() + ftsn2.position().y() * ftsn2.momentum().x())/TSCP2.pt() * ftsn2.momentum().z()/ftsn2.momentum().mag();
       float tmva_ddsz_ = dsz1-dsz2;
+      IfLogTrace(debug, "DuplicateTrackMerger") << " ddsz " << tmva_ddsz_;
       if ( std::abs(tmva_ddsz_) > maxDdsz_ ) continue;
 
       float tmva_d3dr_ = avgPoint.perp();
@@ -319,10 +377,12 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
 
       auto mvaBDTG = forest_->GetClassifier(gbrVals_);
+      IfLogTrace(debug, "DuplicateTrackMerger") << " mvaBDTG " << mvaBDTG;
       if(mvaBDTG < minBDTG_)continue;
 
       //  std::cout << "to merge " << mvaBDTG << ' ' << std::copysign(std::sqrt(std::abs(deltaR3d2)),deltaR3d2) << ' ' << tmva_dphi_ << ' ' << TSCP1.pt() <<'/'<<TSCP2.pt() << std::endl;
       
+      IfLogTrace(debug, "DuplicateTrackMerger") << " marking as duplicates";
       out_duplicateCandidates->push_back(merger_.merge(*t1,*t2));
       out_candidateMap->emplace_back(i,j);
 

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -109,7 +109,6 @@ namespace {
     
 #include "FWCore/Framework/interface/Event.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
-#include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
@@ -244,7 +243,6 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
   auto const & tracks = *handle;
   
   iSetup.get<IdealMagneticFieldRecord>().get(magfield_);
-  TwoTrackMinimumDistance ttmd;
   TSCPBuilderNoMaterial tscpBuilder;
   auto out_duplicateCandidates = std::make_unique<std::vector<TrackCandidate>>();
 

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -615,6 +615,12 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
       // Propagate longer track to the shorter track hit surface, check compatibility
       TrajectoryStateOnSurface tsosPropagated = propagator_->propagate(tsosInner, (*t1HitIter)->det()->surface());
+      if(!tsosPropagated.isValid()) { // reject immediately if TSOS is not valid
+        IfLogTrace(debug_, "DuplicateTrackMerger") << " t1 hit " << std::distance(t1->recHitsBegin(), t1HitIter)
+                                                   << " t2 hit " << std::distance(t2->recHitsBegin(), t2HitIter)
+                                                   << " TSOS not valid";
+        return false;
+      }
       auto passChi2Pair = chi2Estimator_->estimate(tsosPropagated, **t1HitIter);
       if(!passChi2Pair.first) {
         IfLogTrace(debug_, "DuplicateTrackMerger") << " t1 hit " << std::distance(t1->recHitsBegin(), t1HitIter)

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -125,6 +125,7 @@ namespace {
 #include "TFile.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 
 #include "DuplicateTrackType.h"
 
@@ -497,6 +498,15 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
     ++t1HitIter; ++t2HitIter;
     unsigned int missedLayers = 0;
     while(t1HitIter != t1->recHitsEnd() && t2HitIter != t2->recHitsEnd()) {
+      // in case of invalid hits, reject immediately
+      if((*t1HitIter)->getType() != TrackingRecHit::valid || trackerHitRTTI::isUndef(**t1HitIter) ||
+         (*t2HitIter)->getType() != TrackingRecHit::valid || trackerHitRTTI::isUndef(**t2HitIter)) {
+        IfLogTrace(debug_, "DuplicateTrackMerger") << " t1 hit " << std::distance(t1->recHitsBegin(), t1HitIter)
+                                                   << " t2 hit " << std::distance(t2->recHitsBegin(), t2HitIter)
+                                                   << " either is invalid, types t1 " << (*t1HitIter)->getType() << " t2 " << (*t2HitIter)->getType();
+        return false;
+      }
+
       const auto& t1DetId = (*t1HitIter)->geographicalId();
       const auto& t2DetId = (*t2HitIter)->geographicalId();
 

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackType.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackType.h
@@ -1,0 +1,10 @@
+#ifndef RecoTracker_FinalTrackSelectors_DuplicateTrackType_h
+#define RecoTracker_FinalTrackSelectors_DuplicateTrackType_h
+
+enum class DuplicateTrackType {
+  NotDuplicate=0, // default
+  Disjoint,       // tracks are disjoint
+  Overlapping,    // tracks overlap
+};
+
+#endif

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackMerger.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackMerger.h
@@ -9,6 +9,8 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
+#include "DuplicateTrackType.h"
+
 class dso_hidden TrackMerger {
     public:
         TrackMerger(const edm::ParameterSet &iConfig) ;
@@ -16,7 +18,7 @@ class dso_hidden TrackMerger {
 
         void init(const edm::EventSetup &iSetup) ;
 
-        TrackCandidate merge(const reco::Track &inner, const reco::Track &outer) const;
+        TrackCandidate merge(const reco::Track &inner, const reco::Track &outer, DuplicateTrackType duplicateType) const;
     private:
         edm::ESHandle<TrackerGeometry> theGeometry;
         edm::ESHandle<MagneticField>   theMagField;
@@ -25,6 +27,9 @@ class dso_hidden TrackMerger {
         std::string theBuilderName;
         edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
 	edm::ESHandle<TrackerTopology> theTrkTopo;
+
+        void addSecondTrackHits(std::vector<const TrackingRecHit *>& hits, const reco::Track& outer) const;
+        void sortByHitPosition(const GlobalVector& v, const std::vector<const TrackingRecHit *>& hits, TrackCandidate::RecHitContainer& ownHits) const;
 
         class GlobalMomentumSort {
             public: 

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -3,10 +3,17 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.FinalTrackSelectors.DuplicateTrackMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.DuplicateListMerger_cfi import *
 
+from TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi import Chi2MeasurementEstimator as _Chi2MeasurementEstimator
+duplicateTrackCandidatesChi2Est = _Chi2MeasurementEstimator.clone(
+    ComponentName = "duplicateTrackCandidatesChi2Est",
+    MaxChi2 = 100,
+)
+
 duplicateTrackCandidates = DuplicateTrackMerger.clone()
 duplicateTrackCandidates.source = cms.InputTag("preDuplicateMergingGeneralTracks")
 duplicateTrackCandidates.useInnermostState  = True
 duplicateTrackCandidates.ttrhBuilderName   = "WithAngleAndTemplate"
+duplicateTrackCandidates.chi2EstimatorName = "duplicateTrackCandidatesChi2Est"
                                      
 import RecoTracker.TrackProducer.TrackProducer_cfi
 mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone()


### PR DESCRIPTION
This PR enhances `DuplicateTrackMerger` to identify duplicate tracks caused by hits from overlapping modules. The development targets phase1 FPix, but is agnostic to actual geometry. Idea is to
* find track pairs with close-enough parameters (using parts of the existing logic)
* go over simultaneously the hits of the two tracks
  * require that hits from the same layer come from different modules (unless the hits are the same)
    * this alone is very effective to reduce duplicate rate, but is too aggressive (efficiency decreases and fake rate increases)
  * propagate the starting state of the longer track to the hit of the shorter track, require chi2 compatibility

There is certainly room for further improvement, to be studied later.

Here are MTV plots for phase0, phase1, phase1CA (all with ttbar+25PU) and phase2 D4Timing (ttbar+200PU)
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_9_0_0_pre4_duplicateMerge/
(for phase1 the reference is 900pre4 + re-trained track selection MVA, without the new MVA the effect is likely a bit different; the difference between the red and black is purely technical, not even in a separate commit)

Timing of the module increases by a factor of 2-3 (for PU35-200), being still at most a few percent of total tracking time.

Tested in 9_0_0_pre4, expecting changes as indicated above.

@rovere @VinInn @felicepantaleo @ebrondol 