### PR TITLE
organize HLT trigger rate plots in directories

### DIFF
--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -136,6 +136,7 @@ private:
 
   // HLT triggers
   std::vector<HLTRatesPlots>    m_hlt_counts;
+  std::vector<std::vector<HLTRatesPlots> > m_hlt_by_dataset_counts;
 
   // datasets
   std::vector<TH1F *>           m_dataset_counts;
@@ -179,6 +180,7 @@ TriggerRatesMonitor::TriggerRatesMonitor(edm::ParameterSet const & config) :
   m_l1t_counts(),
   // HLT triggers
   m_hlt_counts(),
+  m_hlt_by_dataset_counts(),
   // datasets
   m_dataset_counts(),
   // streams
@@ -215,13 +217,18 @@ void TriggerRatesMonitor::dqmBeginRun(edm::Run const & run, edm::EventSetup cons
     m_hltIndices.resize( m_hltConfig.size(), HLTIndices() );
 
     unsigned int datasets = m_hltConfig.datasetNames().size();
+    m_hlt_by_dataset_counts.clear();
+    m_hlt_by_dataset_counts.resize( datasets, {} );
+    
     m_datasets.clear();
     m_datasets.resize( datasets, {} );
     for (unsigned int i = 0; i < datasets; ++i) {
       auto const & paths = m_hltConfig.datasetContent(i);
+      m_hlt_by_dataset_counts[i].resize( paths.size(), HLTRatesPlots() );
       m_datasets[i].reserve(paths.size());
-      for (auto const & path: paths)
+      for (auto const & path: paths) {
         m_datasets[i].push_back(m_hltConfig.triggerIndex(path));
+      }
     }
     m_dataset_counts.clear();
     m_dataset_counts.resize( datasets, nullptr );
@@ -272,46 +279,62 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run co
   }
 
   if (m_hltConfig.inited()) {
-    // book the rate histograms for the HLT triggers
-    booker.setCurrentFolder( m_dqm_path + "/HLT" );
-    for (unsigned int i = 0; i < m_hltConfig.size(); ++i) {
-      std::string const & name = m_hltConfig.triggerName(i);
-      m_hlt_counts[i].pass_l1_seed  = booker.book1D(name + " pass L1 seed",     name + " pass L1 seed, vs. lumisection",     m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-      m_hlt_counts[i].pass_prescale = booker.book1D(name + " pass prescaler",   name + " pass prescaler, vs. lumisection",   m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-      m_hlt_counts[i].accept        = booker.book1D(name + " accept",           name + " accept, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-      m_hlt_counts[i].reject        = booker.book1D(name + " reject",           name + " reject, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-      m_hlt_counts[i].error         = booker.book1D(name + " error",            name + " error, vs. lumisection",            m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-      // look for the index of the (last) L1 seed and prescale module in each path
-      m_hltIndices[i].index_l1_seed  = m_hltConfig.size(i);
-      m_hltIndices[i].index_prescale = m_hltConfig.size(i);
-      for (unsigned int j = 0; j < m_hltConfig.size(i); ++j) {
-        std::string const & label = m_hltConfig.moduleLabel(i, j);
-        std::string const & type  = m_hltConfig.moduleType(label);
-        if (type == "HLTL1TSeed" or type == "HLTLevel1GTSeed" or type == "HLTLevel1Activity" or type == "HLTLevel1Pattern") {
-          // there might be more L1 seed filters in sequence
-          // keep looking and store the index of the last one
-          m_hltIndices[i].index_l1_seed  = j;
-        } else if (type == "HLTPrescaler") {
-          // there should be only one prescaler in a path, and it should follow all L1 seed filters
-          m_hltIndices[i].index_prescale = j;
-          break;
-        }
 
+    auto const & datasets = m_hltConfig.datasetNames();
+
+    // book the rate histograms for the HLT triggers
+    for (unsigned int d = 0; d < datasets.size(); ++d) {
+      booker.setCurrentFolder( m_dqm_path + "/HLT/" + datasets[d]);
+      for (unsigned int i = 0; i < m_datasets[d].size(); ++i) {
+	unsigned int index = m_datasets[d][i];
+	std::string const & name = m_hltConfig.triggerName(index);
+	m_hlt_by_dataset_counts[d][i].pass_l1_seed  = booker.book1D(name + "_pass_L1_seed",     name + " pass L1 seed, vs. lumisection",     m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+	m_hlt_by_dataset_counts[d][i].pass_prescale = booker.book1D(name + "_pass_prescaler",   name + " pass prescaler, vs. lumisection",   m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+	m_hlt_by_dataset_counts[d][i].accept        = booker.book1D(name + "_accept",           name + " accept, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+	m_hlt_by_dataset_counts[d][i].reject        = booker.book1D(name + "_reject",           name + " reject, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+	m_hlt_by_dataset_counts[d][i].error         = booker.book1D(name + "_error",            name + " error, vs. lumisection",            m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+      }
+
+      //      booker.setCurrentFolder( m_dqm_path + "/HLT/" + datasets[d]);
+      for (unsigned int i: m_datasets[d]) {
+//	std::string const & name = m_hltConfig.triggerName(i) + "_old";
+//	m_hlt_counts[i].pass_l1_seed  = booker.book1D(name + "_pass_L1_seed",     name + " pass L1 seed, vs. lumisection",     m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+//	m_hlt_counts[i].pass_prescale = booker.book1D(name + "_pass_prescaler",   name + " pass prescaler, vs. lumisection",   m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+//	m_hlt_counts[i].accept        = booker.book1D(name + "_accept",           name + " accept, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+//	m_hlt_counts[i].reject        = booker.book1D(name + "_reject",           name + " reject, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+//	m_hlt_counts[i].error         = booker.book1D(name + "_error",            name + " error, vs. lumisection",            m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
+
+	// look for the index of the (last) L1 seed and prescale module in each path
+	m_hltIndices[i].index_l1_seed  = m_hltConfig.size(i);
+	m_hltIndices[i].index_prescale = m_hltConfig.size(i);
+	for (unsigned int j = 0; j < m_hltConfig.size(i); ++j) {
+	  std::string const & label = m_hltConfig.moduleLabel(i, j);
+	  std::string const & type  = m_hltConfig.moduleType(label);
+	  if (type == "HLTL1TSeed" or type == "HLTLevel1GTSeed" or type == "HLTLevel1Activity" or type == "HLTLevel1Pattern") {
+	    // there might be more L1 seed filters in sequence
+	    // keep looking and store the index of the last one
+	    m_hltIndices[i].index_l1_seed  = j;
+	  } else if (type == "HLTPrescaler") {
+	    // there should be only one prescaler in a path, and it should follow all L1 seed filters
+	    m_hltIndices[i].index_prescale = j;
+	    break;
+	  }
+	}
       }
     }
 
     // book the HLT datasets rate histograms
     booker.setCurrentFolder( m_dqm_path + "/Datasets" );
-    auto const & datasets = m_hltConfig.datasetNames();
     for (unsigned int i = 0; i < datasets.size(); ++i)
       m_dataset_counts[i] = booker.book1D(datasets[i], datasets[i], m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5)->getTH1F();
-
+   
     // book the HLT streams rate histograms
     booker.setCurrentFolder( m_dqm_path + "/Streams" );
     auto const & streams = m_hltConfig.streamNames();
     for (unsigned int i = 0; i < streams.size(); ++i)
       m_stream_counts[i]  = booker.book1D(streams[i],  streams[i],  m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5)->getTH1F();
   }
+
 }
 
 
@@ -340,30 +363,50 @@ void TriggerRatesMonitor::analyze(edm::Event const & event, edm::EventSetup cons
   if (m_hltConfig.inited()) {
     edm::TriggerResults const & hltResults = get<edm::TriggerResults>(event, m_hlt_results);
     if (hltResults.size() == m_hlt_counts.size()) {
-      for (unsigned int i = 0; i < m_hlt_counts.size(); ++i) {
-        edm::HLTPathStatus const & path = hltResults.at(i);
-        if (path.index() > m_hltIndices[i].index_l1_seed)
-          m_hlt_counts[i].pass_l1_seed->Fill(lumisection);
-        if  (path.index() > m_hltIndices[i].index_prescale)
-          m_hlt_counts[i].pass_prescale->Fill(lumisection);
-        if (path.accept())
-          m_hlt_counts[i].accept->Fill(lumisection);
-        else if (path.error())
-          m_hlt_counts[i].error ->Fill(lumisection);
-        else
-          m_hlt_counts[i].reject->Fill(lumisection);
-      }
+//      for (unsigned int i = 0; i < m_hlt_counts.size(); ++i) {
+//        edm::HLTPathStatus const & path = hltResults.at(i);
+//
+//	std::string const & name = m_hltConfig.triggerName(i);
+//	if ( name == "HLTriggerFirstPath" ) continue;
+//	if ( name == "HLTriggerFinalPath" ) continue;
+//        if (path.index() > m_hltIndices[i].index_l1_seed)
+//          m_hlt_counts[i].pass_l1_seed->Fill(lumisection);
+//        if  (path.index() > m_hltIndices[i].index_prescale)
+//          m_hlt_counts[i].pass_prescale->Fill(lumisection);
+//        if (path.accept())
+//          m_hlt_counts[i].accept->Fill(lumisection);
+//        else if (path.error())
+//          m_hlt_counts[i].error ->Fill(lumisection);
+//        else
+//          m_hlt_counts[i].reject->Fill(lumisection);
+//      }
     } else {
       edm::LogWarning("TriggerRatesMonitor") << "This should never happen: the number of HLT paths has changed since the beginning of the run";
     }
 
-    for (unsigned int i = 0; i < m_datasets.size(); ++i)
-      for (unsigned int j: m_datasets[i])
-        if (hltResults.at(j).accept()) {
-          m_dataset_counts[i]->Fill(lumisection);
+    for (unsigned int d = 0; d < m_datasets.size(); ++d) {
+      for (unsigned int i: m_datasets[d])
+        if (hltResults.at(i).accept()) {
+          m_dataset_counts[d]->Fill(lumisection);
           // ensure each dataset is incremented only once per event
           break;
         }
+      for (unsigned int i = 0; i < m_datasets[d].size(); ++i) {
+	unsigned int index = m_datasets[d][i];
+	edm::HLTPathStatus const & path = hltResults.at(index);
+
+        if (path.index() > m_hltIndices[index].index_l1_seed)
+          m_hlt_by_dataset_counts[d][i].pass_l1_seed->Fill(lumisection);
+        if  (path.index() > m_hltIndices[index].index_prescale)
+          m_hlt_by_dataset_counts[d][i].pass_prescale->Fill(lumisection);
+        if (path.accept())
+          m_hlt_by_dataset_counts[d][i].accept->Fill(lumisection);
+        else if (path.error())
+          m_hlt_by_dataset_counts[d][i].error ->Fill(lumisection);
+        else
+          m_hlt_by_dataset_counts[d][i].reject->Fill(lumisection);
+      }
+    }
 
     for (unsigned int i = 0; i < m_streams.size(); ++i)
       for (unsigned int j: m_streams[i])

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -135,7 +135,6 @@ private:
   std::vector<TH1F *>           m_l1t_counts;
 
   // HLT triggers
-  std::vector<HLTRatesPlots>    m_hlt_counts;
   std::vector<std::vector<HLTRatesPlots> > m_hlt_by_dataset_counts;
 
   // datasets
@@ -179,7 +178,6 @@ TriggerRatesMonitor::TriggerRatesMonitor(edm::ParameterSet const & config) :
   // L1T triggers
   m_l1t_counts(),
   // HLT triggers
-  m_hlt_counts(),
   m_hlt_by_dataset_counts(),
   // datasets
   m_dataset_counts(),
@@ -212,8 +210,6 @@ void TriggerRatesMonitor::dqmBeginRun(edm::Run const & run, edm::EventSetup cons
   edm::EDConsumerBase::Labels labels;
   labelsForToken(m_hlt_results, labels);
   if (m_hltConfig.init(run, setup, labels.process, changed)) {
-    m_hlt_counts.clear();
-    m_hlt_counts.resize( m_hltConfig.size(), HLTRatesPlots() );
     m_hltIndices.resize( m_hltConfig.size(), HLTIndices() );
 
     unsigned int datasets = m_hltConfig.datasetNames().size();
@@ -297,12 +293,6 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker & booker, edm::Run co
 
       //      booker.setCurrentFolder( m_dqm_path + "/HLT/" + datasets[d]);
       for (unsigned int i: m_datasets[d]) {
-//	std::string const & name = m_hltConfig.triggerName(i) + "_old";
-//	m_hlt_counts[i].pass_l1_seed  = booker.book1D(name + "_pass_L1_seed",     name + " pass L1 seed, vs. lumisection",     m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-//	m_hlt_counts[i].pass_prescale = booker.book1D(name + "_pass_prescaler",   name + " pass prescaler, vs. lumisection",   m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-//	m_hlt_counts[i].accept        = booker.book1D(name + "_accept",           name + " accept, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-//	m_hlt_counts[i].reject        = booker.book1D(name + "_reject",           name + " reject, vs. lumisection",           m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
-//	m_hlt_counts[i].error         = booker.book1D(name + "_error",            name + " error, vs. lumisection",            m_lumisections_range + 1,   -0.5,   m_lumisections_range + 0.5)->getTH1F();
 
 	// look for the index of the (last) L1 seed and prescale module in each path
 	m_hltIndices[i].index_l1_seed  = m_hltConfig.size(i);
@@ -362,24 +352,7 @@ void TriggerRatesMonitor::analyze(edm::Event const & event, edm::EventSetup cons
   // monitor the HLT triggers and datsets rates
   if (m_hltConfig.inited()) {
     edm::TriggerResults const & hltResults = get<edm::TriggerResults>(event, m_hlt_results);
-    if (hltResults.size() == m_hlt_counts.size()) {
-//      for (unsigned int i = 0; i < m_hlt_counts.size(); ++i) {
-//        edm::HLTPathStatus const & path = hltResults.at(i);
-//
-//	std::string const & name = m_hltConfig.triggerName(i);
-//	if ( name == "HLTriggerFirstPath" ) continue;
-//	if ( name == "HLTriggerFinalPath" ) continue;
-//        if (path.index() > m_hltIndices[i].index_l1_seed)
-//          m_hlt_counts[i].pass_l1_seed->Fill(lumisection);
-//        if  (path.index() > m_hltIndices[i].index_prescale)
-//          m_hlt_counts[i].pass_prescale->Fill(lumisection);
-//        if (path.accept())
-//          m_hlt_counts[i].accept->Fill(lumisection);
-//        else if (path.error())
-//          m_hlt_counts[i].error ->Fill(lumisection);
-//        else
-//          m_hlt_counts[i].reject->Fill(lumisection);
-//      }
+    if (hltResults.size() == m_hltIndices.size()) {
     } else {
       edm::LogWarning("TriggerRatesMonitor") << "This should never happen: the number of HLT paths has changed since the beginning of the run";
     }

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
@@ -37,9 +37,9 @@ void TriggerRatesMonitorClient::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore:
     std::cout << "dir: " << dir << std::endl;
     ibooker_.setCurrentFolder(m_dqm_path + "/" + dir);
 
-    std::vector<std::string> all_mes = igetter_.getMEs();
+    std::vector<std::string> const & all_mes = igetter_.getMEs();
     std::vector<std::string> mes;
-    for ( auto const & me : mes ) 
+    for ( auto const & me : all_mes ) 
       if ( me.find("accept") != std::string::npos ) mes.push_back(me); 
 
     int    nbinsY = mes.size();

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
@@ -1,0 +1,101 @@
+#include "DQM/HLTEvF/plugins/TriggerRatesMonitorClient.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// -------------------------------------- Constructor --------------------------------------------
+//
+TriggerRatesMonitorClient::TriggerRatesMonitorClient(const edm::ParameterSet& iConfig) 
+  : m_dqm_path( iConfig.getUntrackedParameter<std::string>("dqmPath") )
+{
+  edm::LogInfo("TriggerRatesMonitorClient") <<  "Constructor  TriggerRatesMonitorClient::TriggerRatesMonitorClient " << std::endl;
+
+}
+
+//
+// -------------------------------------- beginJob --------------------------------------------
+//
+void TriggerRatesMonitorClient::beginJob()
+{
+  edm::LogInfo("TriggerRatesMonitorClient") <<  "TriggerRatesMonitorClient::beginJob " << std::endl;
+}
+
+//
+// -------------------------------------- get and book in the endJob --------------------------------------------
+//
+void TriggerRatesMonitorClient::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_)
+{
+  // create and cd into new folder
+  ibooker_.setCurrentFolder(m_dqm_path);
+
+  //get available histograms
+  std::vector<std::string> directories = igetter_.getSubdirs();
+  m_hltXpd_counts.resize( directories.size() );
+
+  int i = 0;
+  for ( auto const & dir : directories) {
+    std::cout << "dir: " << dir << std::endl;
+    ibooker_.setCurrentFolder(m_dqm_path + "/" + dir);
+
+    std::vector<std::string> all_mes = igetter_.getMEs();
+    std::vector<std::string> mes;
+    for ( auto const & me : mes ) 
+      if ( me.find("accept") != std::string::npos ) mes.push_back(me); 
+
+    int    nbinsY = mes.size();
+    double xminY  = 0.;
+    double xmaxY  = xminY + 1.*nbinsY;
+    int    nbinsX = 0;
+    int ibinY = 1;
+    for ( auto const & me : mes ) {
+      std::cout << "me: " << me << std::endl;
+      ibooker_.setCurrentFolder(m_dqm_path + "/" + dir);
+      TH1F* histo = igetter_.get( me )->getTH1F();
+
+      if (m_hltXpd_counts[i] == nullptr ) {
+	// get range and binning for new MEs
+	nbinsX = histo->GetNbinsX();
+	double xminX  = histo->GetXaxis()->GetXmin();
+	double xmaxX  = histo->GetXaxis()->GetXmax();
+	
+	//book new histogram
+	std::string hname = dir + "_summary";
+	ibooker_.setCurrentFolder(m_dqm_path);
+	m_hltXpd_counts[i] = ibooker_.book2D(hname,hname,nbinsX,xminX,xmaxX,nbinsY,xminY,xmaxY)->getTH2F();
+      } else {
+	m_hltXpd_counts[i]->GetYaxis()->SetBinLabel(ibinY,me.c_str());
+      }
+
+      // handle mes
+      for ( int ibinX=1; ibinX <= nbinsX; ++ibinX ) {
+	float rate = histo->GetBinContent(ibinX);
+	m_hltXpd_counts[i]->SetBinContent(ibinX,ibinY,rate);
+      }
+      ibinY++;
+    }
+    
+    i++;
+  }
+
+}
+
+//
+// -------------------------------------- get in the endLumi if needed --------------------------------------------
+//
+void TriggerRatesMonitorClient::dqmEndLuminosityBlock(DQMStore::IBooker & ibooker_, DQMStore::IGetter & igetter_, edm::LuminosityBlock const & iLumi, edm::EventSetup const& iSetup) 
+{
+  edm::LogInfo("TriggerRatesMonitorClient") <<  "TriggerRatesMonitorClient::endLumi " << std::endl;
+}
+
+void TriggerRatesMonitorClient::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
+{
+
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("dqmPath","HLT/Datasets");
+  descriptions.add("dqmCorrelationClient", desc);
+
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TriggerRatesMonitorClient);

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
@@ -34,7 +34,7 @@ void TriggerRatesMonitorClient::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore:
 
   int i = 0;
   for ( auto const & dir : directories) {
-    std::cout << "dir: " << dir << std::endl;
+    //    std::cout << "dir: " << dir << std::endl;
     ibooker_.setCurrentFolder(m_dqm_path + "/" + dir);
 
     std::vector<std::string> const & all_mes = igetter_.getMEs();
@@ -48,7 +48,7 @@ void TriggerRatesMonitorClient::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore:
     int    nbinsX = 0;
     int ibinY = 1;
     for ( auto const & me : mes ) {
-      std::cout << "me: " << me << std::endl;
+      //      std::cout << "me: " << me << std::endl;
       ibooker_.setCurrentFolder(m_dqm_path + "/" + dir);
       TH1F* histo = igetter_.get( me )->getTH1F();
 

--- a/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.h
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.h
@@ -1,0 +1,43 @@
+#ifndef TRIGGERRATESMONITORCLIENT_H
+#define TRIGGERRATESMONITORCLIENT_H
+
+//Framework
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+ 
+class TriggerRatesMonitorClient: public DQMEDHarvester{
+
+ public:
+
+  TriggerRatesMonitorClient(const edm::ParameterSet& ps);
+  virtual ~TriggerRatesMonitorClient() = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+      
+ protected:
+
+  void beginJob() override;
+  void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) override;  //performed in the endLumi
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
+  
+ private:
+
+//private variables
+  std::string m_dqm_path;
+
+  // Histograms
+  std::vector<TH2F *> m_hltXpd_counts;
+
+};
+
+
+#endif // TRIGGERRATESMONITORCLIENT_H


### PR DESCRIPTION
as requested in JIRA [#1158](https://its.cern.ch/jira/browse/CMSHLT-1158)
this update is meant to re-organize HLT trigger paths in sub-directories
in order to speed up the displaying on the GUI

plots are created in directories depending on the PD the trigger belongs to

because the same trigger might be used in different PDs,
extra plots are created w.r.t. previous implementation

2 set of plots are dropped, instead,
they correspond to the paths HLTriggerFirstPath and HLTriggerFirstPath,
which are not needed to be monitored


the new TriggerMonitorRateClient is currently not used