### PR TITLE
narrower anode time window switched to True

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
+++ b/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
@@ -29,8 +29,8 @@ csc2DRecHits = cms.EDProducer("CSCRecHitDProducer",
     #
     #    wire time window used for reconstruction
     CSCUseReducedWireTimeWindow = cms.bool(True),
-    CSCWireTimeWindowLow = cms.int32(0),
-    CSCWireTimeWindowHigh = cms.int32(15),
+    CSCWireTimeWindowLow = cms.int32(6),
+    CSCWireTimeWindowHigh = cms.int32(10),
     #
     #    Calibration info:
     CSCUseCalibrations = cms.bool(True),

--- a/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
+++ b/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
@@ -28,7 +28,7 @@ csc2DRecHits = cms.EDProducer("CSCRecHitDProducer",
     CSCWireClusterDeltaT = cms.int32(1),
     #
     #    wire time window used for reconstruction
-    CSCUseReducedWireTimeWindow = cms.bool(False),
+    CSCUseReducedWireTimeWindow = cms.bool(True),
     CSCWireTimeWindowLow = cms.int32(0),
     CSCWireTimeWindowHigh = cms.int32(15),
     #


### PR DESCRIPTION
Use a narrower anode time window to build CSC recHits.
The flag CSCUseReducedWireTimeWindow switched to True.
