### PR TITLE
Moving CaloRecHitAuxSetter.h and HBHERecHitAuxSetter.h

### DIFF
--- a/DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h
+++ b/DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h
@@ -1,5 +1,5 @@
-#ifndef RecoLocalCalo_HcalRecAlgos_CaloRecHitAuxSetter_h_
-#define RecoLocalCalo_HcalRecAlgos_CaloRecHitAuxSetter_h_
+#ifndef DataFormats_HcalRecHit_CaloRecHitAuxSetter_h_
+#define DataFormats_HcalRecHit_CaloRecHitAuxSetter_h_
 
 #include <cstdint>
 
@@ -27,4 +27,4 @@ namespace CaloRecHitAuxSetter
         {return u & (1U << bitnum);}
 }
 
-#endif // RecoLocalCalo_HcalRecAlgos_CaloRecHitAuxSetter_h_
+#endif // DataFormats_HcalRecHit_CaloRecHitAuxSetter_h_

--- a/DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h
+++ b/DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h
@@ -1,5 +1,5 @@
-#ifndef RecoLocalCalo_HcalRecAlgos_HBHERecHitAuxSetter_h_
-#define RecoLocalCalo_HcalRecAlgos_HBHERecHitAuxSetter_h_
+#ifndef DataFormats_HcalRecHit_HBHERecHitAuxSetter_h_
+#define DataFormats_HcalRecHit_HBHERecHitAuxSetter_h_
 
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 #include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
@@ -45,4 +45,4 @@ struct HBHERecHitAuxSetter
                        HBHERecHit* rechit);
 };
 
-#endif // RecoLocalCalo_HcalRecAlgos_HBHERecHitAuxSetter_h_
+#endif // DataFormats_HcalRecHit_HBHERecHitAuxSetter_h_

--- a/DataFormats/HcalRecHit/src/HBHERecHit.cc
+++ b/DataFormats/HcalRecHit/src/HBHERecHit.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
-
-#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
 
 HBHERecHit::HBHERecHit()
     : CaloRecHit(),

--- a/DataFormats/HcalRecHit/src/HBHERecHitAuxSetter.cc
+++ b/DataFormats/HcalRecHit/src/HBHERecHitAuxSetter.cc
@@ -1,5 +1,5 @@
-#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
 
 void HBHERecHitAuxSetter::setAux(const HBHEChannelInfo& info,
                                  HBHERecHit* rechit)

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHEIsolatedNoiseAlgos.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHEIsolatedNoiseAlgos.cc
@@ -21,6 +21,8 @@ Original Author: John Paul Chou (Brown University)
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -31,8 +33,6 @@ Original Author: John Paul Chou (Brown University)
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
 
 ////////////////////////////////////////////////////////////
 //

--- a/RecoLocalCalo/HcalRecAlgos/src/HFRecHitAuxSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFRecHitAuxSetter.cc
@@ -1,9 +1,10 @@
 #include <algorithm>
 #include <type_traits>
 
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
+
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFAnodeStatus.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HFRecHitAuxSetter.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
 
 
 void HFRecHitAuxSetter::setAux(const HFPreRecHit& prehit,

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -4,10 +4,10 @@
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalCorrectionFunctions.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
 
 #include "FWCore/Framework/interface/Run.h"
 
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
 #include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
 
 

--- a/RecoLocalCalo/HcalRecAlgos/src/SimplePlan1RechitCombiner.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimplePlan1RechitCombiner.cc
@@ -2,14 +2,14 @@
 #include <algorithm>
 
 #include "DataFormats/HcalRecHit/interface/HcalSpecialTimes.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
 
 #include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
 
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/SimplePlan1RechitCombiner.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
 
 SimplePlan1RechitCombiner::SimplePlan1RechitCombiner()
     : topo_(nullptr)

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPlan1Combiner.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPlan1Combiner.cc
@@ -27,8 +27,9 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "RecoLocalCalo/HcalRecAlgos/interface/HBHERecHitAuxSetter.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/CaloRecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHitAuxSetter.h"
+#include "DataFormats/HcalRecHit/interface/CaloRecHitAuxSetter.h"
+
 #include "RecoLocalCalo/HcalRecAlgos/interface/parsePlan1RechitCombiner.h"
 
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"


### PR DESCRIPTION
Moved the headers CaloRecHitAuxSetter.h and HBHERecHitAuxSetter.h to DataFormats/HcalRecHit so that HBHERecHit class can use them
