### PR TITLE
Retrained track selection MVA for phase1

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -424,6 +424,10 @@ trackingPhase1.toReplaceWith(detachedQuadStep, detachedQuadStepClassifier1.clone
      GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1',
      qualityCuts = [-0.5,0.0,0.5],
 ))
+trackingPhase1QuadProp.toReplaceWith(detachedQuadStep, detachedQuadStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1',
+     qualityCuts = [-0.5,0.0,0.5],
+))
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 trackingPhase1PU70.toReplaceWith(detachedQuadStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -420,6 +420,11 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 detachedQuadStep = ClassifierMerger.clone()
 detachedQuadStep.inputClassifiers=['detachedQuadStepClassifier1','detachedQuadStepClassifier2']
 
+trackingPhase1.toReplaceWith(detachedQuadStep, detachedQuadStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorDetachedQuadStep_Phase1',
+     qualityCuts = [-0.5,0.0,0.5],
+))
+
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 trackingPhase1PU70.toReplaceWith(detachedQuadStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = [

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -197,6 +197,10 @@ trackingPhase1.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1
      GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1',
      qualityCuts = [-0.2,0.3,0.8],
 ))
+trackingPhase1QuadProp.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1',
+     qualityCuts = [-0.2,0.3,0.8],
+))
 
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -193,6 +193,11 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 detachedTripletStep = ClassifierMerger.clone()
 detachedTripletStep.inputClassifiers=['detachedTripletStepClassifier1','detachedTripletStepClassifier2']
 
+trackingPhase1.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1',
+     qualityCuts = [-0.2,0.3,0.8],
+))
+
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 detachedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -191,11 +191,13 @@ highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProdu
     Fitter = 'FlexibleKFFittingSmoother',
 )
 
+
 # Final selection
 # MVA selection to be enabled after re-training, for time being we go with cut-based selector
-#from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 #from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 #
+
 #highPtTripletStepClassifier1 = TrackMVAClassifierPrompt.clone()
 #highPtTripletStepClassifier1.src = 'highPtTripletStepTracks'
 #highPtTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
@@ -238,6 +240,14 @@ highPtTripletStep = TrackCutClassifier.clone(
         )
     )
 )
+
+#Retrained weights allow the use of MVA for Phase1
+trackingPhase1.toReplaceWith(highPtTripletStep,	TrackMVAClassifierPrompt.clone(
+    src	= 'highPtTripletStepTracks',
+    GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1',
+    qualityCuts	= [0.2,0.3,0.4],
+))
+
 
 # For Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -193,29 +193,7 @@ highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProdu
 
 
 # Final selection
-# MVA selection to be enabled after re-training, for time being we go with cut-based selector
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
-#from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
-#
-
-#highPtTripletStepClassifier1 = TrackMVAClassifierPrompt.clone()
-#highPtTripletStepClassifier1.src = 'highPtTripletStepTracks'
-#highPtTripletStepClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
-#highPtTripletStepClassifier1.qualityCuts = [-0.9,-0.8,-0.7]
-#
-#from RecoTracker.IterativeTracking.Phase1_DetachedTripletStep_cff import detachedTripletStepClassifier1
-#from RecoTracker.IterativeTracking.Phase1_LowPtTripletStep_cff import lowPtTripletStep
-#highPtTripletStepClassifier2 = detachedTripletStepClassifier1.clone()
-#highPtTripletStepClassifier2.src = 'highPtTripletStepTracks'
-#highPtTripletStepClassifier3 = lowPtTripletStep.clone()
-#highPtTripletStepClassifier3.src = 'highPtTripletStepTracks'
-#
-#
-#from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
-#highPtTripletStep = ClassifierMerger.clone()
-#highPtTripletStep.inputClassifiers=['highPtTripletStepClassifier1','highPtTripletStepClassifier2','highPtTripletStepClassifier3']
-#highPtTripletStep.inputClassifiers=['highPtTripletStepClassifier1','highPtTripletStepClassifier2','highPtTripletStepClassifier3']
-
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier
 highPtTripletStep = TrackCutClassifier.clone(
     src = "highPtTripletStepTracks",
@@ -241,8 +219,13 @@ highPtTripletStep = TrackCutClassifier.clone(
     )
 )
 
-#Retrained weights allow the use of MVA for Phase1
 trackingPhase1.toReplaceWith(highPtTripletStep,	TrackMVAClassifierPrompt.clone(
+    src	= 'highPtTripletStepTracks',
+    GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1',
+    qualityCuts	= [0.2,0.3,0.4],
+))
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toReplaceWith(highPtTripletStep,	TrackMVAClassifierPrompt.clone(
     src	= 'highPtTripletStepTracks',
     GBRForestLabel = 'MVASelectorHighPtTripletStep_Phase1',
     qualityCuts	= [0.2,0.3,0.4],

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -242,6 +242,7 @@ firstStepPrimaryVertices.vertexCollections = cms.VPSet(
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 
+
 initialStepClassifier1 = TrackMVAClassifierPrompt.clone()
 initialStepClassifier1.src = 'initialStepTracks'
 initialStepClassifier1.GBRForestLabel = 'MVASelectorIter0_13TeV'
@@ -254,11 +255,15 @@ initialStepClassifier2.src = 'initialStepTracks'
 initialStepClassifier3 = lowPtTripletStep.clone()
 initialStepClassifier3.src = 'initialStepTracks'
 
-
-
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 initialStep = ClassifierMerger.clone()
 initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
+
+# Retrained weights for Phase1
+trackingPhase1.toReplaceWith(initialStep, initialStepClassifier1.clone(
+        GBRForestLabel = 'MVASelectorInitialStep_Phase1',
+        qualityCuts = [-0.95,-0.85,-0.75],
+))
 
 # For LowPU and Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
@@ -390,6 +395,8 @@ trackingLowPU.toReplaceWith(InitialStep, _InitialStep_LowPU)
 _InitialStep_Phase1 = InitialStep.copy()
 _InitialStep_Phase1.replace(initialStepHitTriplets, initialStepHitQuadruplets)
 trackingPhase1.toReplaceWith(InitialStep, _InitialStep_Phase1)
+_InitialStep_Phase1.remove(initialStepClassifier2)
+_InitialStep_Phase1.remove(initialStepClassifier3)
 _InitialStep_Phase1PU70 = _InitialStep_LowPU.copy()
 _InitialStep_Phase1PU70.replace(initialStepHitTriplets, initialStepHitTriplets+initialStepHitQuadruplets)
 trackingPhase1PU70.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -259,8 +259,11 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 initialStep = ClassifierMerger.clone()
 initialStep.inputClassifiers=['initialStepClassifier1','initialStepClassifier2','initialStepClassifier3']
 
-# Retrained weights for Phase1
 trackingPhase1.toReplaceWith(initialStep, initialStepClassifier1.clone(
+        GBRForestLabel = 'MVASelectorInitialStep_Phase1',
+        qualityCuts = [-0.95,-0.85,-0.75],
+))
+trackingPhase1QuadProp.toReplaceWith(initialStep, initialStepClassifier1.clone(
         GBRForestLabel = 'MVASelectorInitialStep_Phase1',
         qualityCuts = [-0.95,-0.85,-0.75],
 ))
@@ -392,11 +395,13 @@ InitialStep = cms.Sequence(initialStepSeedLayers*
 _InitialStep_LowPU = InitialStep.copyAndExclude([firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])
 _InitialStep_LowPU.replace(initialStep, initialStepSelector)
 trackingLowPU.toReplaceWith(InitialStep, _InitialStep_LowPU)
-_InitialStep_Phase1 = InitialStep.copy()
+_InitialStep_Phase1QuadProp = InitialStep.copy()
+_InitialStep_Phase1QuadProp.remove(initialStepClassifier2)
+_InitialStep_Phase1QuadProp.remove(initialStepClassifier3)
+trackingPhase1QuadProp.toReplaceWith(InitialStep, _InitialStep_Phase1QuadProp)
+_InitialStep_Phase1 = _InitialStep_Phase1QuadProp.copy()
 _InitialStep_Phase1.replace(initialStepHitTriplets, initialStepHitQuadruplets)
 trackingPhase1.toReplaceWith(InitialStep, _InitialStep_Phase1)
-_InitialStep_Phase1.remove(initialStepClassifier2)
-_InitialStep_Phase1.remove(initialStepClassifier3)
 _InitialStep_Phase1PU70 = _InitialStep_LowPU.copy()
 _InitialStep_Phase1PU70.replace(initialStepHitTriplets, initialStepHitTriplets+initialStepHitQuadruplets)
 trackingPhase1PU70.toReplaceWith(InitialStep, _InitialStep_Phase1PU70)

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -172,6 +172,14 @@ jetCoreRegionalStep.mva.maxDz = [0.5,0.35,0.2];
 jetCoreRegionalStep.mva.maxDr = [0.3,0.2,0.1];
 jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
 
+#Retrained MVA weights for Phase1
+
+from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
+trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
+     src = 'jetCoreRegionalStepTracks',
+     GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1',
+     qualityCuts = [-0.2,0.0,0.4],
+))
 
 # Final sequence
 JetCoreRegionalStep = cms.Sequence(initialStepTrackRefsForJets*caloJetsForTrk*jetsForCoreTracking*

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -172,10 +172,13 @@ jetCoreRegionalStep.mva.maxDz = [0.5,0.35,0.2];
 jetCoreRegionalStep.mva.maxDr = [0.3,0.2,0.1];
 jetCoreRegionalStep.vertices = 'firstStepGoodPrimaryVertices'
 
-#Retrained MVA weights for Phase1
-
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
+     src = 'jetCoreRegionalStepTracks',
+     GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1',
+     qualityCuts = [-0.2,0.0,0.4],
+))
+trackingPhase1QuadProp.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone(
      src = 'jetCoreRegionalStepTracks',
      GBRForestLabel = 'MVASelectorJetCoreRegionalStep_Phase1',
      qualityCuts = [-0.2,0.0,0.4],

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -217,6 +217,12 @@ lowPtQuadStep =  TrackMVAClassifierPrompt.clone(
     GBRForestLabel = 'MVASelectorIter1_13TeV',
     qualityCuts = [-0.6,-0.3,-0.1]
 )
+
+#Retrained weights for Phase1
+trackingPhase1.toReplaceWith(lowPtQuadStep, lowPtQuadStep.clone(
+    GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1',
+    qualityCuts = [-0.65,-0.35,-0.15],
+))
 # For Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 lowPtQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -218,11 +218,15 @@ lowPtQuadStep =  TrackMVAClassifierPrompt.clone(
     qualityCuts = [-0.6,-0.3,-0.1]
 )
 
-#Retrained weights for Phase1
 trackingPhase1.toReplaceWith(lowPtQuadStep, lowPtQuadStep.clone(
     GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1',
     qualityCuts = [-0.65,-0.35,-0.15],
 ))
+trackingPhase1QuadProp.toReplaceWith(lowPtQuadStep, lowPtQuadStep.clone(
+    GBRForestLabel = 'MVASelectorLowPtQuadStep_Phase1',
+    qualityCuts = [-0.65,-0.35,-0.15],
+))
+
 # For Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 lowPtQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -206,8 +206,16 @@ lowPtTripletStep.src = 'lowPtTripletStepTracks'
 lowPtTripletStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
 lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 
-# For Phase1
-# MVA selection to be enabled after re-training, for time being we go with cut-based selector
+
+
+# Retrained weights for Phase1
+trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
+     GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1',
+     qualityCuts = [0.0,0.2,0.4],
+))
+
+
+# Cut based selector for Phase1
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier as _TrackCutClassifier
 _cutClassifierForPhase1 = _TrackCutClassifier.clone(
     src = "lowPtTripletStepTracks",
@@ -232,7 +240,7 @@ _cutClassifierForPhase1 = _TrackCutClassifier.clone(
         ),
     )
 )
-trackingPhase1.toReplaceWith(lowPtTripletStep, _cutClassifierForPhase1)
+
 trackingPhase1QuadProp.toReplaceWith(lowPtTripletStep, _cutClassifierForPhase1)
 
 # For LowPU and Phase1PU70

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -197,51 +197,21 @@ trackingPhase1PU70.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fract
 trackingPhase2PU140.toModify(lowPtTripletStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
 
 # Final selection
-
-
-
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 lowPtTripletStep =  TrackMVAClassifierPrompt.clone()
 lowPtTripletStep.src = 'lowPtTripletStepTracks'
 lowPtTripletStep.GBRForestLabel = 'MVASelectorIter1_13TeV'
 lowPtTripletStep.qualityCuts = [-0.6,-0.3,-0.1]
 
-
-
-# Retrained weights for Phase1
 trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
      GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1',
      qualityCuts = [0.0,0.2,0.4],
 ))
+trackingPhase1QuadProp.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
+     GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1',
+     qualityCuts = [0.0,0.2,0.4],
+))
 
-
-# Cut based selector for Phase1
-from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cfi import TrackCutClassifier as _TrackCutClassifier
-_cutClassifierForPhase1 = _TrackCutClassifier.clone(
-    src = "lowPtTripletStepTracks",
-    vertices = "firstStepPrimaryVertices",
-    mva = dict (
-        minPixelHits = [1,1,1],
-        maxChi2 = [9999.,9999.,9999.],
-        maxChi2n = [2.0,0.9,0.5],
-        minLayers = [3,3,3],
-        min3DLayers = [3,3,3],
-        maxLostLayers = [2,2,2],
-        dz_par = dict(
-            dz_par1 = [0.7,0.6,0.45],
-            dz_par2 = [0.5,0.4,0.4],
-            dz_exp = [4,4,4],
-        ),
-        dr_par = dict(
-            dr_par1 = [0.8,0.7,0.6],
-            dr_par2 = [0.5,0.4,0.3],
-            dr_exp = [4,4,4],
-            d0err_par = [0.002,0.002,0.001],
-        ),
-    )
-)
-
-trackingPhase1QuadProp.toReplaceWith(lowPtTripletStep, _cutClassifierForPhase1)
 
 # For LowPU and Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -289,6 +289,12 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 mixedTripletStep = ClassifierMerger.clone()
 mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
 
+#Retrained MVA weights for Phase1
+trackingPhase1.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1',
+     qualityCuts = [-0.5,0.0,0.5],
+))
+
 # For LowPU and Phase1PU70
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 # First LowPU

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -289,8 +289,11 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 mixedTripletStep = ClassifierMerger.clone()
 mixedTripletStep.inputClassifiers=['mixedTripletStepClassifier1','mixedTripletStepClassifier2']
 
-#Retrained MVA weights for Phase1
 trackingPhase1.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1',
+     qualityCuts = [-0.5,0.0,0.5],
+))
+trackingPhase1QuadProp.toReplaceWith(mixedTripletStep, mixedTripletStepClassifier1.clone(
      GBRForestLabel = 'MVASelectorMixedTripletStep_Phase1',
      qualityCuts = [-0.5,0.0,0.5],
 ))

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -100,8 +100,6 @@ trackingLowPU.toModify(pixelLessStepSeedLayers,
     MTEC = None,
 )
 
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 pixelLessStepTrackingRegions = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
@@ -252,7 +250,13 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 pixelLessStep = ClassifierMerger.clone()
 pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
 
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 trackingPhase1.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorPixelLessStep_Phase1',
+     qualityCuts = [-0.4,0.0,0.4],
+))
+trackingPhase1QuadProp.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
      GBRForestLabel = 'MVASelectorPixelLessStep_Phase1',
      qualityCuts = [-0.4,0.0,0.4],
 ))

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -9,6 +9,8 @@ pixelLessStepClusters = _cfg.clusterRemoverForIter("PixelLessStep")
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
     _era.toReplaceWith(pixelLessStepClusters, _cfg.clusterRemoverForIter("PixelLessStep", _eraName, _postfix))
 
+
+
 # SEEDING LAYERS
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterChargeCut_cfi import *
 pixelLessStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
@@ -97,6 +99,8 @@ trackingLowPU.toModify(pixelLessStepSeedLayers,
     MTID = None,
     MTEC = None,
 )
+
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 
 # TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
@@ -248,6 +252,11 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 pixelLessStep = ClassifierMerger.clone()
 pixelLessStep.inputClassifiers=['pixelLessStepClassifier1','pixelLessStepClassifier2']
 
+trackingPhase1.toReplaceWith(pixelLessStep, pixelLessStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorPixelLessStep_Phase1',
+     qualityCuts = [-0.4,0.0,0.4],
+))
+
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 pixelLessStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
@@ -297,7 +306,6 @@ pixelLessStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.m
     vertices = cms.InputTag("pixelVertices")#end of vpset
 ) #end of clone
 
-
 PixelLessStep = cms.Sequence(pixelLessStepClusters*
                              pixelLessStepSeedLayers*
                              pixelLessStepTrackingRegions*
@@ -311,3 +319,4 @@ PixelLessStep = cms.Sequence(pixelLessStepClusters*
 _PixelLessStep_LowPU = PixelLessStep.copyAndExclude([pixelLessStepHitTriplets, pixelLessStepClassifier1, pixelLessStepClassifier2])
 _PixelLessStep_LowPU.replace(pixelLessStep, pixelLessStepSelector)
 trackingLowPU.toReplaceWith(PixelLessStep, _PixelLessStep_LowPU)
+

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -38,6 +38,8 @@ tobTecStepSeedLayersTripl = cms.EDProducer("SeedingLayersEDProducer",
     )
 )
 
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+
 # Triplet TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 tobTecStepTrackingRegionsTripl = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
@@ -330,6 +332,11 @@ tobTecStepClassifier2.qualityCuts = [0.0,0.0,0.0]
 from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 tobTecStep = ClassifierMerger.clone()
 tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
+
+trackingPhase1.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorTobTecStep_Phase1',
+     qualityCuts = [-0.6,-0.45,-0.3],
+))
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 trackingLowPU.toReplaceWith(tobTecStep, RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -38,8 +38,6 @@ tobTecStepSeedLayersTripl = cms.EDProducer("SeedingLayersEDProducer",
     )
 )
 
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-
 # Triplet TrackingRegion
 from RecoTracker.TkTrackingRegions.globalTrackingRegionFromBeamSpotFixedZ_cfi import globalTrackingRegionFromBeamSpotFixedZ as _globalTrackingRegionFromBeamSpotFixedZ
 tobTecStepTrackingRegionsTripl = _globalTrackingRegionFromBeamSpotFixedZ.clone(RegionPSet = dict(
@@ -333,7 +331,13 @@ from RecoTracker.FinalTrackSelectors.ClassifierMerger_cfi import *
 tobTecStep = ClassifierMerger.clone()
 tobTecStep.inputClassifiers=['tobTecStepClassifier1','tobTecStepClassifier2']
 
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
 trackingPhase1.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
+     GBRForestLabel = 'MVASelectorTobTecStep_Phase1',
+     qualityCuts = [-0.6,-0.45,-0.3],
+))
+trackingPhase1QuadProp.toReplaceWith(tobTecStep, tobTecStepClassifier1.clone(
      GBRForestLabel = 'MVASelectorTobTecStep_Phase1',
      qualityCuts = [-0.6,-0.45,-0.3],
 ))


### PR DESCRIPTION
This PR makes use of the retrained track selection MVA (by @hajohajo). The training was done with CA-seeded tracking, but is here applied also for the default tracking, as the training improves performance also there. ~~The MVA payloads are in the GT of #17530, hence it is added here as well for time being (will rebase after #17530 is merged).~~

Here are MTV plots for 1k ttbar+PU35 events in 900pre4 for phase1 (default) and phase1 (CA)
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_0_0_pre4_PR17537/
In summary (phase1 default HP tracks):
* efficiency (w/o pT cut in denominator) increases by ~1 % (especially in |eta|>2.5)
* fake rate decreases by ~40 %
* duplicate rate increases by ~60 % (mostly in |eta|>2.5)

Presentations in tracking POG:
* https://indico.cern.ch/event/604571/contributions/2437905/attachments/1396167/2128415/TrackingMVA_16_1_2017.pdf
* https://indico.cern.ch/event/589546/contributions/2377505/attachments/1374526/2086791/TrackingMVA_21_11_2016.pdf

Tested in CMSSW_9_0_X_2017-02-15-1100 (rebased on top of CMSSW_9_0_X_2017-02-19-1100), expecting changes in phase1 workflows as indicated above. Phase0/2 should have no effect ~~(except possibly because of #17530)~~.

@rovere @VinInn @hajohajo @felicepantaleo 