### PR TITLE
HCAL TP for Plan 1

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -202,8 +202,12 @@ CaloTPGTranscoderULUT::getOutputLUTSize(const HcalTrigTowerDetId& id) const
    switch (theTopology->triggerMode()) {
       case HcalTopologyMode::TriggerMode_2009:
       case HcalTopologyMode::TriggerMode_2016:
-      case HcalTopologyMode::TriggerMode_2017:
          return QIE8_OUTPUT_LUT_SIZE;
+      case HcalTopologyMode::TriggerMode_2017:
+         else if (id.ietaAbs() <= theTopology->lastHERing())
+            return QIE8_OUTPUT_LUT_SIZE;
+         else
+            return QIE10_OUTPUT_LUT_SIZE;
       case HcalTopologyMode::TriggerMode_2017plan1:
       case HcalTopologyMode::TriggerMode_2018:
          if (id.ietaAbs() <= theTopology->lastHBRing())

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -215,6 +215,7 @@ CaloTPGTranscoderULUT::getOutputLUTSize(const HcalTrigTowerDetId& id) const
             return QIE8_OUTPUT_LUT_SIZE;
          else
             return QIE10_OUTPUT_LUT_SIZE;
+      case HcalTopologyMode::TriggerMode_2018legacy:
       case HcalTopologyMode::TriggerMode_2018:
          if (id.ietaAbs() <= theTopology->lastHBRing())
             return QIE8_OUTPUT_LUT_SIZE;

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -209,6 +209,12 @@ CaloTPGTranscoderULUT::getOutputLUTSize(const HcalTrigTowerDetId& id) const
          else
             return QIE10_OUTPUT_LUT_SIZE;
       case HcalTopologyMode::TriggerMode_2017plan1:
+         if (theTopology->dddConstants()->isPlan1(id))
+            return QIE11_OUTPUT_LUT_SIZE;
+         else if (id.ietaAbs() <= theTopology->lastHERing())
+            return QIE8_OUTPUT_LUT_SIZE;
+         else
+            return QIE10_OUTPUT_LUT_SIZE;
       case HcalTopologyMode::TriggerMode_2018:
          if (id.ietaAbs() <= theTopology->lastHBRing())
             return QIE8_OUTPUT_LUT_SIZE;

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -204,7 +204,7 @@ CaloTPGTranscoderULUT::getOutputLUTSize(const HcalTrigTowerDetId& id) const
       case HcalTopologyMode::TriggerMode_2016:
          return QIE8_OUTPUT_LUT_SIZE;
       case HcalTopologyMode::TriggerMode_2017:
-         else if (id.ietaAbs() <= theTopology->lastHERing())
+         if (id.ietaAbs() <= theTopology->lastHERing())
             return QIE8_OUTPUT_LUT_SIZE;
          else
             return QIE10_OUTPUT_LUT_SIZE;

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -202,11 +202,18 @@ CaloTPGTranscoderULUT::getOutputLUTSize(const HcalTrigTowerDetId& id) const
    switch (theTopology->triggerMode()) {
       case HcalTopologyMode::TriggerMode_2009:
       case HcalTopologyMode::TriggerMode_2016:
-         return QIE8_OUTPUT_LUT_SIZE;
       case HcalTopologyMode::TriggerMode_2017:
+         return QIE8_OUTPUT_LUT_SIZE;
+      case HcalTopologyMode::TriggerMode_2017plan1:
+      case HcalTopologyMode::TriggerMode_2018:
          if (id.ietaAbs() <= theTopology->lastHBRing())
             return QIE8_OUTPUT_LUT_SIZE;
          else if (id.ietaAbs() <= theTopology->lastHERing())
+            return QIE11_OUTPUT_LUT_SIZE;
+         else
+            return QIE10_OUTPUT_LUT_SIZE;
+      case HcalTopologyMode::TriggerMode_2019:
+         if (id.ietaAbs() <= theTopology->lastHERing())
             return QIE11_OUTPUT_LUT_SIZE;
          else
             return QIE10_OUTPUT_LUT_SIZE;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -254,7 +254,7 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
      unsigned int mipMax = 0;
      unsigned int mipMin = 0;
 
-     if (topo_->triggerMode() >= HcalTopologyMode::TriggerMode_2017) {
+     if (topo_->triggerMode() >= HcalTopologyMode::TriggerMode_2018 or topo_->dddConstants()->isPlan1(cell)) {
         const HcalTPChannelParameter *channelParameters = conditions.getHcalTPChannelParameter(cell);
         mipMax = channelParameters->getFGBitInfo() >> 16;
         mipMin = channelParameters->getFGBitInfo() & 0xFFFF;

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -239,10 +239,12 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
   }
 
   for (const auto& id: metadata->getAllChannels()) {
-     HcalDetId cell(id);
-     if (!topo_->valid(cell))
+     if (not (id.det() == DetId::Hcal and topo_->valid(id)))
         continue;
+     HcalDetId cell(id);
      HcalSubdetector subdet = cell.subdet();
+     if (subdet != HcalBarrel and subdet != HcalEndcap and subdet != HcalForward)
+        continue;
 
      const HcalQIECoder* channelCoder = conditions.getHcalCoder (cell);
      const HcalQIEShape* shape = conditions.getHcalShape(cell);

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -254,7 +254,9 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
      unsigned int mipMax = 0;
      unsigned int mipMin = 0;
 
-     if (topo_->triggerMode() >= HcalTopologyMode::TriggerMode_2018 or topo_->dddConstants()->isPlan1(cell)) {
+     if (topo_->triggerMode() >= HcalTopologyMode::TriggerMode_2018 or
+           topo_->triggerMode() == HcalTopologyMode::TriggerMode_2018legacy or
+           topo_->dddConstants()->isPlan1(cell)) {
         const HcalTPChannelParameter *channelParameters = conditions.getHcalTPChannelParameter(cell);
         mipMax = channelParameters->getFGBitInfo() >> 16;
         mipMin = channelParameters->getFGBitInfo() & 0xFFFF;

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -212,10 +212,11 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
   if (id.iphi()<1 || id.iphi()>IPHI_MAX || id.ieta()==0)  return false;
   if (id.depth() != 0)                              return false;
   if (id.version()==0) {
-    if ((triggerMode_>=HcalTopologyMode::TriggerMode_2017 && id.ietaAbs()>28) ||
-	(id.ietaAbs()>32))                          return false;
-    int ietaMax = (triggerMode_>=HcalTopologyMode::TriggerMode_2017) ? 29 : 28;
-    if (id.ietaAbs()>ietaMax && ((id.iphi()%4)!=1)) return false;
+    if (id.ietaAbs() > 28) {
+       if (triggerMode_ >= HcalTopologyMode::TriggerMode_2017) return false;
+       if ((id.iphi() % 4) != 1)                               return false;
+       if (id.ietaAbs() > 32)                                  return false;
+    }
   } else {
     if (triggerMode_==HcalTopologyMode::TriggerMode_2009) return false;
     if (id.ietaAbs()<30 || id.ietaAbs()>41)         return false;

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -212,9 +212,9 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
   if (id.iphi()<1 || id.iphi()>IPHI_MAX || id.ieta()==0)  return false;
   if (id.depth() != 0)                              return false;
   if (id.version()==0) {
-    if ((triggerMode_==HcalTopologyMode::TriggerMode_2017 && id.ietaAbs()>28) ||
+    if ((triggerMode_>=HcalTopologyMode::TriggerMode_2017 && id.ietaAbs()>28) ||
 	(id.ietaAbs()>32))                          return false;
-    int ietaMax = (triggerMode_==HcalTopologyMode::TriggerMode_2017) ? 29 : 28;
+    int ietaMax = (triggerMode_>=HcalTopologyMode::TriggerMode_2017) ? 29 : 28;
     if (id.ietaAbs()>ietaMax && ((id.iphi()%4)!=1)) return false;
   } else {
     if (triggerMode_==HcalTopologyMode::TriggerMode_2009) return false;

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -214,6 +214,7 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
   if (id.version()==0) {
     if (id.ietaAbs() > 28) {
        if (triggerMode_ >= HcalTopologyMode::TriggerMode_2017) return false;
+       if (triggerMode_ == HcalTopologyMode::TriggerMode_2018legacy) return false;
        if ((id.iphi() % 4) != 1)                               return false;
        if (id.ietaAbs() > 32)                                  return false;
     }

--- a/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalRecNumbering.xml
@@ -34,7 +34,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2019" eval="false"/>
   </SpecPar>
 </SpecParSection>
 </DDDefinition>

--- a/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalRecNumberingRebuild.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalRecNumberingRebuild.xml
@@ -28,7 +28,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2019" eval="false"/>
   </SpecPar>
 </SpecParSection>
 </DDDefinition>

--- a/Geometry/HcalCommonData/data/PhaseII/NoHE/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/NoHE/hcalRecNumbering.xml
@@ -21,7 +21,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2019" eval="false"/>
   </SpecPar>
 </SpecParSection>
 

--- a/Geometry/HcalCommonData/data/PhaseII/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/hcalRecNumbering.xml
@@ -28,7 +28,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2019" eval="false"/>
   </SpecPar>
 </SpecParSection>
 

--- a/Geometry/HcalCommonData/data/PhaseII/hcalRecNumberingEta4.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/hcalRecNumberingEta4.xml
@@ -32,7 +32,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2019" eval="false"/>
   </SpecPar>
 </SpecParSection>
 </DDDefinition>

--- a/Geometry/HcalCommonData/data/PhaseII/hcalRecNumberingRebuild.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/hcalRecNumberingRebuild.xml
@@ -36,7 +36,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2019" eval="false"/>
   </SpecPar>
 </SpecParSection>
 

--- a/Geometry/HcalCommonData/data/PhaseII/hcalRecNumberingRebuildHE.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/hcalRecNumberingRebuildHE.xml
@@ -37,7 +37,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2019" eval="false"/>
   </SpecPar>
 </SpecParSection>
 </DDDefinition>

--- a/Geometry/HcalCommonData/data/Run2/hcalRecNumbering17Plan01.xml
+++ b/Geometry/HcalCommonData/data/Run2/hcalRecNumbering17Plan01.xml
@@ -38,7 +38,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017plan1" eval="false"/>
   </SpecPar>
 </SpecParSection>
 </DDDefinition>

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -100,6 +100,7 @@ public:
   int                       getTriggerMode() const {return (((hpar->topologyMode)>>8)&0xFF);}
   std::vector<HcalCellType> HcalCellTypes(HcalSubdetector) const;
   bool                      isBH() const {return hcons.isBH();}
+  bool                      isPlan1(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
   int                       maxHFDepth(int ieta, int iphi) const {return hcons.maxHFDepth(ieta,iphi);}
   unsigned int              numberOfCells(HcalSubdetector) const;
   unsigned int              nCells(HcalSubdetector) const;

--- a/Geometry/HcalCommonData/interface/HcalTopologyMode.h
+++ b/Geometry/HcalCommonData/interface/HcalTopologyMode.h
@@ -28,8 +28,11 @@ namespace HcalTopologyMode {
 
   enum TriggerMode {
     TriggerMode_2009=0,         // HF is summed in 3x2 regions
-    TriggerMode_2016=1,         // HF is summed in both 3x2 and 1x1 regions 
-    TriggerMode_2017=2          // HF is summed in 1x1 regions
+    TriggerMode_2016=1,         // HF is summed in both 3x2 and 1x1 regions
+    TriggerMode_2017=2,         // HF upgraded to QIE10
+    TriggerMode_2017plan1=3,    // HF upgraded to QIE10, 1 RBX of HE to QIE11
+    TriggerMode_2018=4,         // HF upgraded to QIE10, HE to QIE11
+    TriggerMode_2019=5          // HF upgraded to QIE10, HBHE to QIE11
   };
 }
 

--- a/Geometry/HcalCommonData/interface/HcalTopologyMode.h
+++ b/Geometry/HcalCommonData/interface/HcalTopologyMode.h
@@ -29,9 +29,10 @@ namespace HcalTopologyMode {
   enum TriggerMode {
     TriggerMode_2009=0,         // HF is summed in 3x2 regions
     TriggerMode_2016=1,         // HF is summed in both 3x2 and 1x1 regions
-    TriggerMode_2017=2,         // HF upgraded to QIE10
-    TriggerMode_2017plan1=3,    // HF upgraded to QIE10, 1 RBX of HE to QIE11
-    TriggerMode_2018=4,         // HF upgraded to QIE10, HE to QIE11
+    TriggerMode_2017=3,         // HF upgraded to QIE10
+    TriggerMode_2017plan1=4,    // HF upgraded to QIE10, 1 RBX of HE to QIE11
+    // For database purposes, 2018 is 2!  This was the old 2017 scenario!
+    TriggerMode_2018=2,         // HF upgraded to QIE10, HE to QIE11
     TriggerMode_2019=5          // HF upgraded to QIE10, HBHE to QIE11
   };
 }

--- a/Geometry/HcalCommonData/interface/HcalTopologyMode.h
+++ b/Geometry/HcalCommonData/interface/HcalTopologyMode.h
@@ -29,11 +29,11 @@ namespace HcalTopologyMode {
   enum TriggerMode {
     TriggerMode_2009=0,         // HF is summed in 3x2 regions
     TriggerMode_2016=1,         // HF is summed in both 3x2 and 1x1 regions
+    TriggerMode_2018legacy=2,   // For the database, before 2017 and 2017plan1 was introduced
     TriggerMode_2017=3,         // HF upgraded to QIE10
     TriggerMode_2017plan1=4,    // HF upgraded to QIE10, 1 RBX of HE to QIE11
-    // For database purposes, 2018 is 2!  This was the old 2017 scenario!
-    TriggerMode_2018=2,         // HF upgraded to QIE10, HE to QIE11
-    TriggerMode_2019=5          // HF upgraded to QIE10, HBHE to QIE11
+    TriggerMode_2018=5,         // HF upgraded to QIE10, HE to QIE11
+    TriggerMode_2019=6          // HF upgraded to QIE10, HBHE to QIE11
   };
 }
 

--- a/Geometry/HcalCommonData/src/HcalTopologyMode.cc
+++ b/Geometry/HcalCommonData/src/HcalTopologyMode.cc
@@ -13,4 +13,7 @@ StringToEnumParser<HcalTopologyMode::TriggerMode>::StringToEnumParser() {
   enumMap["HcalTopologyMode::TriggerMode_2009"] = HcalTopologyMode::TriggerMode_2009;
   enumMap["HcalTopologyMode::TriggerMode_2016"] = HcalTopologyMode::TriggerMode_2016;
   enumMap["HcalTopologyMode::TriggerMode_2017"] = HcalTopologyMode::TriggerMode_2017;
+  enumMap["HcalTopologyMode::TriggerMode_2017plan1"] = HcalTopologyMode::TriggerMode_2017plan1;
+  enumMap["HcalTopologyMode::TriggerMode_2018"] = HcalTopologyMode::TriggerMode_2018;
+  enumMap["HcalTopologyMode::TriggerMode_2019"] = HcalTopologyMode::TriggerMode_2019;
 }

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -11,7 +11,7 @@ HcalTrigTowerGeometry::HcalTrigTowerGeometry( const HcalTopology* topology )
    auto tmode = theTopology->triggerMode();
    useRCT_ = tmode <= HcalTopologyMode::TriggerMode_2016;
    use1x1_ = tmode >= HcalTopologyMode::TriggerMode_2016;
-   use2017_ = tmode == HcalTopologyMode::TriggerMode_2017;
+   use2017_ = tmode >= HcalTopologyMode::TriggerMode_2017;
 }
 
 std::vector<HcalTrigTowerDetId> 

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -11,7 +11,8 @@ HcalTrigTowerGeometry::HcalTrigTowerGeometry( const HcalTopology* topology )
    auto tmode = theTopology->triggerMode();
    useRCT_ = tmode <= HcalTopologyMode::TriggerMode_2016;
    use1x1_ = tmode >= HcalTopologyMode::TriggerMode_2016;
-   use2017_ = tmode >= HcalTopologyMode::TriggerMode_2017;
+   use2017_ = tmode >= HcalTopologyMode::TriggerMode_2017 or
+              tmode == HcalTopologyMode::TriggerMode_2018legacy;
 }
 
 std::vector<HcalTrigTowerDetId> 


### PR DESCRIPTION
Contains several previous PR, fixed:

* #17523, this PR supercedes that one.
* #17469 with enum `TriggerMode` meaning of the enumeration values unchanged.
* #17260, which got reverted with one of the L1T PR that was reverted.

@davidlange6 I fixed the RelVal 10826.0 by keeping the meaning of the trigger mode consistent, I had added the new 2016 and Plan 1 definition and changed the underlying values, which had already been saved in the geometry DB.