### PR TITLE
Prefetch Per-Event Provenance

### DIFF
--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -22,6 +22,8 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 
 namespace edm {
   class ProvenanceReaderBase;
+  class WaitingTask;
+  class ModuleCallingContext;
 
   struct ProductProvenanceHasher {
     size_t operator()(ProductProvenance const& tid) const {
@@ -36,6 +38,18 @@ namespace edm {
     bool operator()(ProductProvenance const& iLHS, ProductProvenance const iRHS) const {
       return iLHS.branchID().id()== iRHS.branchID().id();
     }
+  };
+
+  class ProvenanceReaderBase {
+  public:
+    ProvenanceReaderBase() {}
+    virtual ~ProvenanceReaderBase();
+    virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const = 0;
+    virtual void readProvenanceAsync(WaitingTask* task,
+                                     ModuleCallingContext const* moduleCallingContext,
+                                     unsigned int transitionIndex,
+                                     std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                     ) const = 0;
   };
 
   class ProductProvenanceRetriever {
@@ -56,6 +70,9 @@ namespace edm {
     void deepCopy(ProductProvenanceRetriever const&);
     
     void reset();
+    
+    void readProvenanceAsync(WaitingTask* task, ModuleCallingContext const* moduleCallingContext) const;
+    
   private:
     void readProvenance() const;
     void setTransitionIndex(unsigned int transitionIndex) {
@@ -67,13 +84,6 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<ProductProvenanceRetriever>> nextRetriever_;
     std::shared_ptr<const ProvenanceReaderBase> provenanceReader_;
     unsigned int transitionIndex_;
-  };
-
-  class ProvenanceReaderBase {
-  public:
-    ProvenanceReaderBase() {}
-    virtual ~ProvenanceReaderBase();
-    virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const = 0;
   };
   
 }

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -43,6 +43,17 @@ namespace edm {
     }
   }
 
+  void
+  ProductProvenanceRetriever::readProvenanceAsync(WaitingTask* task, ModuleCallingContext const* moduleCallingContext) const {
+    if(provenanceReader_ and nullptr == readEntryInfoSet_.load() ) {
+      provenanceReader_->readProvenanceAsync(task, moduleCallingContext,transitionIndex_,readEntryInfoSet_);
+    }
+    if(nextRetriever_) {
+      nextRetriever_->readProvenanceAsync(task,moduleCallingContext);
+    }
+  }
+
+  
   void ProductProvenanceRetriever::deepCopy(ProductProvenanceRetriever const& iFrom)
   {
     if(iFrom.readEntryInfoSet_) {

--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -40,14 +40,15 @@ namespace edm {
     }
     
 
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const = 0;
+    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const = 0;
+
     
   private:
     virtual std::unique_ptr<WrapperBase> getProduct_(BranchKey const& k, EDProductGetter const* ep) = 0;
     virtual void mergeReaders_(DelayedReader*) = 0;
     virtual void reset_() = 0;
     virtual std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> sharedResources_() const;
-    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal() const = 0;
-    virtual signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal() const = 0;
 
   };
 }

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -18,6 +18,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -47,6 +48,9 @@ namespace edm {
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
+    //Needed by Worker but not something supported
+    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -33,6 +33,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   class EDFilter : public ProducerBase, public EDConsumerBase {
   public:
@@ -55,6 +56,9 @@ namespace edm {
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
+    //Needed by WorkerT but not supported
+    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();    

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -26,6 +26,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -51,6 +52,9 @@ namespace edm {
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
+    //Needed by WorkerT but not supported
+    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
     void doEndJob();

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -40,6 +40,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -107,6 +108,9 @@ namespace edm {
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                  ActivityRegistry* act,
                  ModuleCallingContext const* mcc);
+    //Needed by WorkerT but not supported
+    void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
     bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                     ModuleCallingContext const* mcc);
     bool doEndRun(RunPrincipal const& rp, EventSetup const& c,

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -35,6 +35,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -64,6 +65,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -37,6 +37,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -66,6 +67,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -38,6 +38,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -117,6 +118,9 @@ namespace edm {
       std::string workerType() const {return "WorkerT<EDProducer>";}
       
       virtual void produce(StreamID, Event&, EventSetup const&) const= 0;
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       virtual void beginJob() {}
       virtual void endJob(){}
 

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -48,6 +48,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   template <typename T> class OutputModuleCommunicatorT;
   
@@ -132,6 +133,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
                       ModuleCallingContext const*);
       bool doEndRun(RunPrincipal const& rp, EventSetup const& c,

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -35,6 +35,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -68,6 +69,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       void doPreallocate(PreallocationConfiguration const&) {}
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -36,6 +36,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -66,6 +67,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -36,6 +36,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -66,6 +67,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*);
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -50,6 +50,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   template <typename T> class OutputModuleCommunicatorT;
   
@@ -221,6 +222,8 @@ namespace edm {
       virtual bool shouldWeCloseFile() const {return false;}
       
       virtual void write(EventForOutput const&) = 0;
+      virtual void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
       virtual void beginJob(){}
       virtual void endJob(){}
       virtual void writeLuminosityBlock(LuminosityBlockForOutput const&) = 0;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -46,6 +46,7 @@ namespace edm {
   class ActivityRegistry;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
+  class WaitingTask;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -109,6 +110,9 @@ namespace edm {
                    ActivityRegistry*,
                    ModuleCallingContext const*) ;
       void doPreallocate(PreallocationConfiguration const&);
+      
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
       
       virtual void setupStreamModules() = 0;
       void doBeginJob();

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -36,6 +36,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class ActivityRegistry;
+  class WaitingTask;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -70,6 +71,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*) ;
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
     };
   }
 }

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -36,6 +36,7 @@ namespace edm {
 
   class ModuleCallingContext;
   class ActivityRegistry;
+  class WaitingTask;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -70,6 +71,9 @@ namespace edm {
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
                    ActivityRegistry*,
                    ModuleCallingContext const*) ;
+      //For now this is a placeholder
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {}
+
     };
   }
 }

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -212,6 +212,9 @@ private:
         iPrincipal.prefetchAsync(iTask,productResolverIndex, skipCurrentProcess, &moduleCallingContext_);
       }
     }
+    
+    preActionBeforeRunEventAsync(iTask,moduleCallingContext_,iPrincipal);
+    
     if(0 == iTask->decrement_ref_count()) {
       //if everything finishes before we leave this routine, we need to launch the task
       tbb::task::spawn(*iTask);

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -211,6 +211,8 @@ namespace edm {
 
     virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const = 0;
 
+    virtual void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& moduleCallingContext, Principal const& iPrincipal) const = 0;
+    
     virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -132,7 +132,11 @@ namespace edm {
     
     virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
 
+    virtual void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const override {
+      module_->preActionBeforeRunEventAsync(iTask,iModuleCallingContext,iPrincipal);
+    }
 
+    
     edm::propagate_const<std::shared_ptr<T>> module_;
   };
 

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -361,6 +361,8 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
@@ -503,6 +505,8 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
@@ -633,6 +637,8 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -28,11 +28,13 @@
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/Framework/src/SharedResourcesRegistry.h"
+#include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Sources/interface/EventSkipperByID.h"
 #include "FWCore/Sources/interface/DaqProvenanceHelper.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/do_nothing_deleter.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -41,6 +43,9 @@
 #include "FWCore/Utilities/interface/ReleaseVersion.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "IOPool/Common/interface/getWrapperBasePtr.h"
+
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 
 //used for backward compatibility
 #include "DataFormats/Provenance/interface/EventAux.h"
@@ -1434,7 +1439,7 @@ namespace edm {
                                  std::move(eventSelectionIDs_),
                                  std::move(branchListIndexes_),
                                  *(makeProductProvenanceRetriever(principal.streamID().value())),
-                                 eventTree_.rootDelayedReader());
+                                 eventTree_.resetAndGetRootDelayedReader());
 
     // report event read from file
     filePtr_->eventReadFromFile();
@@ -1525,7 +1530,7 @@ namespace edm {
     }
     // End code for backward compatibility before the existence of run trees.
     runTree_.insertEntryForIndex(runPrincipal.transitionIndex());
-    runPrincipal.fillRunPrincipal(*processHistoryRegistry_, runTree_.rootDelayedReader());
+    runPrincipal.fillRunPrincipal(*processHistoryRegistry_, runTree_.resetAndGetRootDelayedReader());
     // Read in all the products now.
     runPrincipal.readAllFromSourceAndMergeImmediately();
   }
@@ -1581,7 +1586,7 @@ namespace edm {
     // End code for backward compatibility before the existence of lumi trees.
     lumiTree_.setEntryNumber(indexIntoFileIter_.entry());
     lumiTree_.insertEntryForIndex(lumiPrincipal.transitionIndex());
-    lumiPrincipal.fillLuminosityBlockPrincipal(*processHistoryRegistry_, lumiTree_.rootDelayedReader());
+    lumiPrincipal.fillLuminosityBlockPrincipal(*processHistoryRegistry_, lumiTree_.resetAndGetRootDelayedReader());
     // Read in all the products now.
     lumiPrincipal.readAllFromSourceAndMergeImmediately();
     ++indexIntoFileIter_;
@@ -1817,8 +1822,15 @@ namespace edm {
   class ReducedProvenanceReader : public ProvenanceReaderBase {
   public:
     ReducedProvenanceReader(RootTree* iRootTree, std::vector<ParentageID> const& iParentageIDLookup, DaqProvenanceHelper const* daqProvenanceHelper);
-  private:
+
     virtual std::set<ProductProvenance> readProvenance(unsigned int) const override;
+private:
+    virtual void readProvenanceAsync(WaitingTask* task,
+                                     ModuleCallingContext const* moduleCallingContext,
+                                     unsigned int transitionIndex,
+                                     std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                     ) const override;
+
     edm::propagate_const<RootTree*> rootTree_;
     edm::propagate_const<TBranch*> provBranch_;
     StoredProductProvenanceVector provVector_;
@@ -1826,6 +1838,7 @@ namespace edm {
     std::vector<ParentageID> const& parentageIDLookup_;
     DaqProvenanceHelper const* daqProvenanceHelper_;
     std::shared_ptr<std::recursive_mutex> mutex_;
+    SharedResourcesAcquirer acquirer_;
   };
 
   ReducedProvenanceReader::ReducedProvenanceReader(
@@ -1837,9 +1850,72 @@ namespace edm {
       pProvVector_(&provVector_),
       parentageIDLookup_(iParentageIDLookup),
       daqProvenanceHelper_(daqProvenanceHelper),
-      mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second)
+      mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+      acquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first)
   {
     provBranch_ = rootTree_->tree()->GetBranch(BranchTypeToProductProvenanceBranchName(rootTree_->branchType()).c_str());
+  }
+
+  namespace {
+    using SignalType = signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)>;
+    template<typename R>
+    void readProvenanceAsyncImpl(R const* iThis,
+                                 SerialTaskQueueChain& chain,
+                                 WaitingTask* task,
+                                 unsigned int transitionIndex,
+                                 std::atomic<const std::set<ProductProvenance>*>& writeTo,
+                                 ModuleCallingContext const* iContext,
+                                 SignalType const* pre,
+                                 SignalType const* post) {
+      if(nullptr == writeTo.load()) {
+        WaitingTaskHolder holder(task);
+        auto pWriteTo = &writeTo;
+        
+        auto serviceToken = ServiceRegistry::instance().presentToken();
+
+        chain.push([holder,pWriteTo,iThis,transitionIndex, iContext, pre,post, serviceToken]() {
+          auto nonConstHolder = holder;
+          ServiceRegistry::Operate operate(serviceToken);
+
+          if(nullptr == pWriteTo->load()) {
+            std::unique_ptr<const std::set<ProductProvenance>> prov;
+            try {
+              if(pre) {pre->emit(*(iContext->getStreamContext()),*iContext);}
+              prov = std::make_unique<const std::set<ProductProvenance>>(iThis->readProvenance(transitionIndex));
+              if(post) {post->emit(*(iContext->getStreamContext()),*iContext);}
+
+            }catch(...) {
+              if(post) {post->emit(*(iContext->getStreamContext()),*iContext);}
+
+              nonConstHolder.doneWaiting(std::current_exception());
+              return;
+            }
+            const std::set<ProductProvenance>* expected = nullptr;
+            
+            if(pWriteTo->compare_exchange_strong(expected,prov.get())) {
+              prov.release();
+            }
+          }
+          nonConstHolder.doneWaiting(std::exception_ptr());
+        });
+      }
+    }
+  }
+  
+  void
+  ReducedProvenanceReader::readProvenanceAsync(WaitingTask* task,
+                                   ModuleCallingContext const* moduleCallingContext,
+                                   unsigned int transitionIndex,
+                                   std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                               ) const {
+    readProvenanceAsyncImpl(this,
+                            acquirer_.serialQueueChain(),
+                            task,
+                            transitionIndex,
+                            writeTo,
+                            moduleCallingContext,
+                            rootTree_->rootDelayedReader()->preEventReadFromSourceSignal(),
+                            rootTree_->rootDelayedReader()->postEventReadFromSourceSignal());
   }
 
   std::set<ProductProvenance>
@@ -1876,13 +1952,20 @@ namespace edm {
   public:
     explicit FullProvenanceReader(RootTree* rootTree, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~FullProvenanceReader() {}
-  private:
     virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
+  private:
+    virtual void readProvenanceAsync(WaitingTask* task,
+                                     ModuleCallingContext const* moduleCallingContext,
+                                     unsigned int transitionIndex,
+                                     std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                     ) const override;
+
     RootTree* rootTree_;
     ProductProvenanceVector infoVector_;
     mutable ProductProvenanceVector* pInfoVector_;
     DaqProvenanceHelper const* daqProvenanceHelper_;
     std::shared_ptr<std::recursive_mutex> mutex_;
+    SharedResourcesAcquirer acquirer_;
   };
 
   FullProvenanceReader::FullProvenanceReader(RootTree* rootTree, DaqProvenanceHelper const* daqProvenanceHelper) :
@@ -1891,7 +1974,25 @@ namespace edm {
          infoVector_(),
          pInfoVector_(&infoVector_),
          daqProvenanceHelper_(daqProvenanceHelper),
-         mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second) {
+         mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+         acquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first)
+{
+  }
+
+  void
+  FullProvenanceReader::readProvenanceAsync(WaitingTask* task,
+                                            ModuleCallingContext const* moduleCallingContext,
+                                            unsigned int transitionIndex,
+                                            std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                               ) const {
+    readProvenanceAsyncImpl(this,
+                            acquirer_.serialQueueChain(),
+                            task,
+                            transitionIndex,
+                            writeTo,
+                            moduleCallingContext,
+                            rootTree_->rootDelayedReader()->preEventReadFromSourceSignal(),
+                            rootTree_->rootDelayedReader()->postEventReadFromSourceSignal());
   }
 
   std::set<ProductProvenance>
@@ -1919,14 +2020,21 @@ namespace edm {
   public:
     explicit OldProvenanceReader(RootTree* rootTree, EntryDescriptionMap const& theMap, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~OldProvenanceReader() {}
-  private:
     virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
+  private:
+    virtual void readProvenanceAsync(WaitingTask* task,
+                                     ModuleCallingContext const* moduleCallingContext,
+                                     unsigned int transitionIndex,
+                                     std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                     ) const override;
+
     edm::propagate_const<RootTree*> rootTree_;
     std::vector<EventEntryInfo> infoVector_;
     mutable std::vector<EventEntryInfo> *pInfoVector_;
     EntryDescriptionMap const& entryDescriptionMap_;
     DaqProvenanceHelper const* daqProvenanceHelper_;
     std::shared_ptr<std::recursive_mutex> mutex_;
+    SharedResourcesAcquirer acquirer_;
   };
 
   OldProvenanceReader::OldProvenanceReader(RootTree* rootTree, EntryDescriptionMap const& theMap, DaqProvenanceHelper const* daqProvenanceHelper) :
@@ -1936,7 +2044,25 @@ namespace edm {
          pInfoVector_(&infoVector_),
          entryDescriptionMap_(theMap),
          daqProvenanceHelper_(daqProvenanceHelper),
-         mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second) {
+         mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+         acquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first)
+{
+  }
+
+  void
+  OldProvenanceReader::readProvenanceAsync(WaitingTask* task,
+                                            ModuleCallingContext const* moduleCallingContext,
+                                            unsigned int transitionIndex,
+                                            std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                            ) const {
+    readProvenanceAsyncImpl(this,
+                            acquirer_.serialQueueChain(),
+                            task,
+                            transitionIndex,
+                            writeTo,
+                            moduleCallingContext,
+                            rootTree_->rootDelayedReader()->preEventReadFromSourceSignal(),
+                            rootTree_->rootDelayedReader()->postEventReadFromSourceSignal());
   }
 
   std::set<ProductProvenance>
@@ -1968,6 +2094,11 @@ namespace edm {
     virtual ~DummyProvenanceReader() {}
   private:
     virtual std::set<ProductProvenance> readProvenance(unsigned int) const override;
+    virtual void readProvenanceAsync(WaitingTask* task,
+                                     ModuleCallingContext const* moduleCallingContext,
+                                     unsigned int transitionIndex,
+                                     std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                     ) const override;
   };
 
   DummyProvenanceReader::DummyProvenanceReader() :
@@ -1979,7 +2110,21 @@ namespace edm {
     // Not providing parentage!!!
     return std::set<ProductProvenance>{};
   }
-
+  void
+  DummyProvenanceReader::readProvenanceAsync(WaitingTask* task,
+                                             ModuleCallingContext const* moduleCallingContext,
+                                             unsigned int transitionIndex,
+                                             std::atomic<const std::set<ProductProvenance>*>& writeTo
+                                             ) const {
+    if(nullptr == writeTo.load()) {
+      auto emptyProv = std::make_unique<const std::set<ProductProvenance>>();
+      const std::set<ProductProvenance>* expected = nullptr;
+      if(writeTo.compare_exchange_strong(expected,emptyProv.get())) {
+        emptyProv.release();
+      }
+    }
+  }
+  
   std::unique_ptr<ProvenanceReaderBase>
   MakeDummyProvenanceReader::makeReader(RootTree&, DaqProvenanceHelper const*) const {
      return std::make_unique<DummyProvenanceReader>();

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -115,8 +115,13 @@ namespace edm {
   }
 
   DelayedReader*
-  RootTree::rootDelayedReader() const {
+  RootTree::resetAndGetRootDelayedReader() const {
     rootDelayedReader_->reset();
+    return rootDelayedReader_.get();
+  }
+
+  DelayedReader*
+  RootTree::rootDelayedReader() const {
     return rootDelayedReader_.get();
   }  
 

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -106,6 +106,7 @@ namespace edm {
     void insertEntryForIndex(unsigned int index);
     std::vector<std::string> const& branchNames() const {return branchNames_;}
     DelayedReader* rootDelayedReader() const;
+    DelayedReader* resetAndGetRootDelayedReader() const;
     template <typename T>
     void fillAux(T*& pAux) {
       auxBranch_->SetAddress(&pAux);

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -114,6 +114,8 @@ namespace edm {
     virtual std::pair<std::string, std::string> physicalAndLogicalNameForNewFile();
     virtual void doExtrasAfterCloseFile();
   private:
+    virtual void preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const override;
+
     virtual void openFile(FileBlock const& fb) override;
     virtual void respondToOpenInputFile(FileBlock const& fb) override;
     virtual void respondToCloseInputFile(FileBlock const& fb) override;

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -378,6 +378,20 @@ namespace edm {
   }
 
   void
+  PoolOutputModule::preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {
+    if(DropAll != dropMetaData_ ) {
+      auto const* ep = dynamic_cast<EventPrincipal const*>(&iPrincipal);
+      if(ep)
+      {
+        auto pr = ep->productProvenanceRetrieverPtr();
+        if(pr) {
+          pr->readProvenanceAsync(iTask,&iModuleCallingContext);
+        }
+      }
+    }
+  }
+
+  void
   PoolOutputModule::fillDependencyGraph() {
     for(auto const& branchParent : branchParents_) {
       BranchID const& child = branchParent.first;


### PR DESCRIPTION
The PoolOutputModule can now prefetch the per-event provenance information. Measurements using many threads showed that the delayed read of the provenance information was causing a lock contention between the PoolOutputModule and the PoolSource.  Now the framework can properly schedule the provenance reading and avoid the contention.