### PR TITLE
Adjust seeding region rebuilding parameters for phase1 initialStep

### DIFF
--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -196,7 +196,13 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     maxPtForLooperReconstruction = cms.double(0.7)
     )
 trackingLowPU.toModify(initialStepTrajectoryBuilder, maxCand = 5)
+trackingPhase1.toModify(initialStepTrajectoryBuilder,
+    minNrOfHitsForRebuild = 1,
+    keepOriginalIfRebuildFails = True,
+)
 trackingPhase1QuadProp.toModify(initialStepTrajectoryBuilder,
+    minNrOfHitsForRebuild = 1,
+    keepOriginalIfRebuildFails = True,
     inOutTrajectoryFilter = dict(refToPSet_ = "initialStepTrajectoryFilterInOut"),
     useSameTrajFilter = False
 )


### PR DESCRIPTION
This PR reduces the high-eta duplicates as the seeding region is rebuilt more aggressively. Inspired by the phase2 configuration.

Here are MTV plots for phase1 default tracking in 9_0_0_pre4+#17537+#17511
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_9_0_0_pre4_phase1SeedRegionRebuild/

Tested in 9_0_0_pre4, expecting changes indicated above in phase1 workflows. No changes are expected in phase0/2.

@rovere @VinInn @felicepantaleo @ebrondol 