### PR TITLE
Tuning of iterative Tracking at HLT using Cellular Automaton

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -111,19 +111,13 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         CAHardPtCut = cms.double(0),
         SeedComparitorPSet = cms.PSet(
             ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
+	    clusterShapeHitFilter = cms.string('ClusterShapeHitFilter'),
             clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
         )
     )
 
     process.hltPixelTracks.SeedingHitSets = "hltPixelTracksHitQuadruplets"
 
-    process.HLTDoRecoPixelTracksSequence = cms.Sequence(
-        process.hltPixelLayerQuadruplets +
-        process.hltPixelTracksTrackingRegions +
-        process.hltPixelTracksHitDoublets +
-        process.hltPixelTracksHitQuadruplets +
-        process.hltPixelTracks
-    )
     
     process.HLTIter0PSetTrajectoryFilterIT.minimumNumberOfHits = cms.int32( 4 )
     process.HLTIter0PSetTrajectoryFilterIT.minHitsMinPt        = cms.int32( 4 )
@@ -159,7 +153,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	        doSeedingRegionRebuilding = cms.bool( False )
     )
 
-    process.hltIter0PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('HLTIter0GroupedCkfTrajectoryBuilderIT')
+    process.hltIter0PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('')
     process.hltIter0PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter0GroupedCkfTrajectoryBuilderIT'))
 
 
@@ -200,45 +194,38 @@ def customizeHLTForPFTrackingPhaseI2017(process):
     )
 
 
-
-
-    process.hltIter1PixelTracks = process.hltPixelTracks.clone()
-
-    process.hltIter1PixelTracks.SeedingHitSets = "hltIter1PFlowPixelHitQuadruplets"
     process.hltIter1PFlowPixelHitDoublets.layerPairs = [0,1,2] # layer pairs (0,1), (1,2), (2,3)
     process.hltIter1PFlowPixelHitDoublets.seedingLayers = "hltIter1PixelLayerQuadruplets"
 
-
-    from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cfi import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
-    process.hltIter1PFlowPixelTrackingRegions = _globalTrackingRegionWithVertices.clone() 
-    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.sigmaZVertex = cms.double(4.0)
-    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.nSigmaZ = cms.double(4.0)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.nSigmaZVertex = cms.double(4.0)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.nSigmaZBeamSpot = cms.double(4.0)
     process.hltIter1PFlowPixelTrackingRegions.RegionPSet.originRadius = cms.double(0.05)
     process.hltIter1PFlowPixelTrackingRegions.RegionPSet.ptMin = cms.double(0.3)
-    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.fixedError = cms.double(0.2)
-    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.useFakeVertices = cms.bool(True)
-    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.useMultipleScattering = cms.bool(True)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.zErrorVetex = cms.double(0.1)
     process.hltIter1PFlowPixelTrackingRegions.RegionPSet.beamSpot = cms.InputTag( "hltOnlineBeamSpot" )
-    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.VertexCollection = cms.InputTag( "hltTrimmedPixelVertices" )
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.vertexCollection = cms.InputTag( "hltTrimmedPixelVertices" )
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.deltaEta = cms.double(1.0)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.deltaPhi = cms.double(1.0)
 
     process.hltIter1PFlowPixelHitQuadruplets = _caHitQuadrupletEDProducer.clone(
         doublets = "hltIter1PFlowPixelHitDoublets",
         extraHitRPhitolerance = cms.double(0.032),
         maxChi2 = dict(
-            pt1    = 0.8,
+            pt1    = 0.7,
             pt2    = 2,
             value1 = 2000,
-            value2 = 100,
+            value2 = 150,
             enabled = True,
         ),
         useBendingCorrection = True,
         fitFastCircle = True,
         fitFastCircleChi2Cut = True,
         CAThetaCut = cms.double(0.004),
-        CAPhiCut = cms.double(0.1),
+        CAPhiCut = cms.double(0.3),
         CAHardPtCut = cms.double(0),
         SeedComparitorPSet = cms.PSet( 
-            ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
+            ComponentName = cms.string( "none" ),
+	    clusterShapeHitFilter = cms.string('ClusterShapeHitFilter'),
             clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
         )
 
@@ -247,43 +234,33 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 
 
  
-    process.hltIter1PFlowPixelSeeds = cms.EDProducer( "SeedGeneratorFromProtoTracksEDProducer",
-        useEventsWithNoVertex = cms.bool( True ),
-        originHalfLength = cms.double( 0.3 ), 
-        useProtoTrackKinematics = cms.bool( False ),
-        usePV = cms.bool( True ),
-        SeedCreatorPSet = cms.PSet(  refToPSet_ = cms.string( "HLTSeedFromProtoTracks" ) ),
-        InputVertexCollection = cms.InputTag( "hltTrimmedPixelVertices" ),
-        TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-        InputCollection = cms.InputTag( "hltIter1PixelTracks" ),
-        originRadius = cms.double( 0.1 )
+    from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
+    replace_with(process.hltIter1PFlowPixelSeeds,_seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
+	 seedingHitSets = "hltIter1PFlowPixelHitQuadruplets",
+	 TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
+    ))
+    process.HLTIter1PSetTrajectoryFilterIT = cms.PSet(
+	  minPt = cms.double( 0.2 ),
+	  minHitsMinPt = cms.int32( 3 ),
+	  ComponentType = cms.string( "CkfBaseTrajectoryFilter" ),
+	  maxLostHits = cms.int32( 1 ),
+	  maxNumberOfHits = cms.int32( 100 ),
+	  maxConsecLostHits = cms.int32( 1 ),
+	  minimumNumberOfHits = cms.int32( 3 ),
+	  nSigmaMinPt = cms.double( 5.0 ),
+	  chargeSignificance = cms.double( -1.0 ),
+	  minGoodStripCharge = cms.PSet(  refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+	  maxCCCLostHits = cms.int32( 0 ),
+	  seedExtension = cms.int32( 0 ),
+	  strictSeedExtension = cms.bool( False ),
+	  minNumberOfHitsForLoopers = cms.int32( 13 ),
+	  minNumberOfHitsPerLoop = cms.int32( 4 ),
+	  extraNumberOfHitsBeforeTheFirstLoop = cms.int32( 4 ),
+	  maxLostHitsFraction = cms.double( 999.0 ),
+	  constantValueForLostHitsFractionFilter = cms.double( 1.0 ),
+	  seedPairPenalty = cms.int32( 0 ),
+	  pixelSeedExtension = cms.bool( False )
     )
-    process.HLTIter1PSetTrajectoryBuilderIT.strictSeedExtension = cms.bool(True)
-  
-
-    process.HLTIter1PSetTrajectoryFilterIT = cms.PSet( 
-	    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-	    chargeSignificance = cms.double(-1.0),
-	    constantValueForLostHitsFractionFilter = cms.double(2.0),
-	    extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-	    maxCCCLostHits = cms.int32(0),
-	    maxConsecLostHits = cms.int32(1),
-	    maxLostHits = cms.int32(1),  
-	    maxLostHitsFraction = cms.double(0.1),
-	    maxNumberOfHits = cms.int32(100),
-	    minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-	    minHitsMinPt = cms.int32(3),
-	     minNumberOfHitsForLoopers = cms.int32(13),
-	    minNumberOfHitsPerLoop = cms.int32(4),
-	    minPt = cms.double(0.2),
-	    minimumNumberOfHits = cms.int32(4), 
-	    nSigmaMinPt = cms.double(5.0),
-	    pixelSeedExtension = cms.bool(True),
-	    seedExtension = cms.int32(1),
-	    seedPairPenalty = cms.int32(0),
-	    strictSeedExtension = cms.bool(True)
-    )
-
     process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
 	ComponentType = cms.string('CkfBaseTrajectoryFilter'),
 	chargeSignificance = cms.double(-1.0),
@@ -292,7 +269,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	maxCCCLostHits = cms.int32(0),
 	maxConsecLostHits = cms.int32(1),
 	maxLostHits = cms.int32(1),  
-	maxLostHitsFraction = cms.double(0.1),
+	maxLostHitsFraction = cms.double(999),
 	maxNumberOfHits = cms.int32(100),
 	minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
 	minHitsMinPt = cms.int32(3),
@@ -301,10 +278,10 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	minPt = cms.double(0.2),
 	minimumNumberOfHits = cms.int32(4),
 	nSigmaMinPt = cms.double(5.0),
-	pixelSeedExtension = cms.bool(True),
-	seedExtension = cms.int32(1),
+	pixelSeedExtension = cms.bool(False),
+	seedExtension = cms.int32(0),
 	seedPairPenalty = cms.int32(0),
-	strictSeedExtension = cms.bool(True)
+	strictSeedExtension = cms.bool(False)
     )
 
     process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet( 
@@ -346,11 +323,11 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	minNrOfHitsForRebuild = cms.int32(5)
     )
 
-    process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('HLTIter1GroupedCkfTrajectoryBuilderIT')
+    process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('')
     process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter1GroupedCkfTrajectoryBuilderIT'))
 
 
-    process.HLTIterativeTrackingIteration1 = cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerQuadruplets + process.hltIter1PFlowPixelTrackingRegions + process.hltIter1PFlowPixelClusterCheck + process.hltIter1PFlowPixelHitDoublets + process.hltIter1PFlowPixelHitQuadruplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity )
+    replace_with(process.HLTIterativeTrackingIteration1 , cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerQuadruplets + process.hltIter1PFlowPixelTrackingRegions + process.hltIter1PFlowPixelClusterCheck + process.hltIter1PFlowPixelHitDoublets + process.hltIter1PFlowPixelHitQuadruplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity ))
 
     process.hltIter2PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
         layerList = cms.vstring( 
@@ -459,49 +436,41 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	        doSeedingRegionRebuilding = cms.bool( False )
     )	
 
-    process.hltIter2PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('HLTIter2GroupedCkfTrajectoryBuilderIT')
+    process.hltIter2PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('')
     process.hltIter2PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter2GroupedCkfTrajectoryBuilderIT'))
 
 
 
-    process.HLTIterativeTrackingIteration2 = cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelTrackingRegions + process.hltIter2PFlowPixelClusterCheck + process.hltIter2PFlowPixelHitDoublets + process.hltIter2PFlowPixelHitTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity )
+    replace_with(process.HLTIterativeTrackingIteration2 , cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelTrackingRegions + process.hltIter2PFlowPixelClusterCheck + process.hltIter2PFlowPixelHitDoublets + process.hltIter2PFlowPixelHitTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity ))
+    # replace hltPixelLayerTriplets and hltPixelTracksHitTriplets with hltPixelLayerQuadruplets and hltPixelTracksHitQuadruplets
+    # in any Sequence, Paths or EndPath that contains the former and not the latter
+    from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
+    for sequence in itertools.chain(
+        process._Process__sequences.itervalues(),
+        process._Process__paths.itervalues(),
+        process._Process__endpaths.itervalues()
+    ):
+        modules = list()
+        sequence.visit(ModuleNodeVisitor(modules))
 
-    # Need to operate on Paths as well...
-    for seqs in [process.sequences_(), process.paths_()]:
-        for seqName, seq in seqs.iteritems():
-            from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
-            l = list()
-            v = ModuleNodeVisitor(l)
-            seq.visit(v)
+        if process.hltPixelTracks in modules and not process.hltPixelLayerQuadruplets in modules:
+            # note that this module does not necessarily exist in sequence 'sequence', if it doesn't, it does not get removed
+            sequence.remove(process.hltPixelLayerTriplets)
+            index = sequence.index(process.hltPixelTracksHitDoublets)
+            sequence.insert(index,process.hltPixelLayerQuadruplets)
+            index = sequence.index(process.hltPixelTracksHitTriplets)
+            sequence.remove(process.hltPixelTracksHitTriplets)
+            sequence.insert(index, process.hltPixelTracksHitQuadruplets)
 
-            if process.hltPixelTracks in l and not process.hltPixelLayerQuadruplets in l:
-                seq.remove(process.hltPixelLayerTriplets) # note that this module does not necessarily exist in sequence 'seq', if it doesn't, it does not get removed
-                index = seq.index(process.hltPixelTracksHitDoublets)
-                seq.insert(index,process.hltPixelLayerQuadruplets)
-                index = seq.index(process.hltPixelTracksHitTriplets)
-                seq.remove(process.hltPixelTracksHitTriplets)
-                seq.insert(index, process.hltPixelTracksHitQuadruplets)
+	if process.hltIter1PFlowPixelHitTriplets in modules and not process.hltIter1PFlowPixelHitQuadruplets in modules:
+            index = sequence.index(process.hltIter1PFlowPixelHitTriplets)
+            sequence.insert(index, process.hltIter1PixelTracks)
+            sequence.insert(index, process.hltIter1PFlowPixelHitQuadruplets)
+            sequence.remove(process.hltIter1PFlowPixelHitTriplets)
+
 
     # Remove entirely to avoid warning from the early deleter
     del process.hltPixelTracksHitTriplets
-
-    for producer in producers_by_type(process,"PixelTripletHLTEDProducer"):
-        if "hltIter1PFlowPixelHitTriplets" in producer.label():
-
-    	   	for seqs in [process.sequences_(), process.paths_()]:
-        		for seqName, seq in seqs.iteritems():
-            			from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
-            			l = list()
-            			v = ModuleNodeVisitor(l)
-            			seq.visit(v)
-
-            			if process.hltIter1PFlowPixelHitTriplets in l and not process.hltIter1PFlowPixelHitQuadruplets in l:
-                			index = seq.index(process.hltIter1PFlowPixelHitTriplets)
-                			seq.insert(index, process.hltIter1PixelTracks)
-                			seq.insert(index, process.hltIter1PFlowPixelHitQuadruplets)
-                			seq.remove(process.hltIter1PFlowPixelHitTriplets)
-
-    # Remove entirely to avoid warning from the early deleter
     del process.hltIter1PFlowPixelHitTriplets
 
 

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -153,7 +153,6 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	        doSeedingRegionRebuilding = cms.bool( False )
     )
 
-    process.hltIter0PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('')
     process.hltIter0PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter0GroupedCkfTrajectoryBuilderIT'))
 
 
@@ -261,31 +260,9 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	  seedPairPenalty = cms.int32( 0 ),
 	  pixelSeedExtension = cms.bool( False )
     )
-    process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
-	ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-	chargeSignificance = cms.double(-1.0),
-	constantValueForLostHitsFractionFilter = cms.double(2.0),
-	extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-	maxCCCLostHits = cms.int32(0),
-	maxConsecLostHits = cms.int32(1),
-	maxLostHits = cms.int32(1),  
-	maxLostHitsFraction = cms.double(999),
-	maxNumberOfHits = cms.int32(100),
-	minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-	minHitsMinPt = cms.int32(3),
-	minNumberOfHitsForLoopers = cms.int32(13),
-	minNumberOfHitsPerLoop = cms.int32(4),
-	minPt = cms.double(0.2),
-	minimumNumberOfHits = cms.int32(4),
-	nSigmaMinPt = cms.double(5.0),
-	pixelSeedExtension = cms.bool(False),
-	seedExtension = cms.int32(0),
-	seedPairPenalty = cms.int32(0),
-	strictSeedExtension = cms.bool(False)
-    )
+   
 
     process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet( 
-	inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
 	propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
 	trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
 	maxCand = cms.int32( 2 ),
@@ -298,15 +275,14 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	alwaysUseInvalidHits = cms.bool( False ),
 	intermediateCleaning = cms.bool( True ),
 	lostHitPenalty = cms.double( 30.0 ),
-	useSameTrajFilter = cms.bool(False) 
+	useSameTrajFilter = cms.bool(True) 
     )
     process.HLTIter1GroupedCkfTrajectoryBuilderIT = cms.PSet(
 	ComponentType = cms.string('GroupedCkfTrajectoryBuilder'),
 	bestHitOnly = cms.bool(True),
 	propagatorAlong = cms.string('PropagatorWithMaterialParabolicMf'),
 	trajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterIT')),
-	inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT')),
-	useSameTrajFilter = cms.bool(False),
+	useSameTrajFilter = cms.bool(True),
 	maxCand = cms.int32(2),
 	intermediateCleaning = cms.bool(True),
 	lostHitPenalty = cms.double(30.0),
@@ -323,7 +299,6 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	minNrOfHitsForRebuild = cms.int32(5)
     )
 
-    process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('')
     process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter1GroupedCkfTrajectoryBuilderIT'))
 
 
@@ -404,7 +379,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
             if key not in skipSet:
                 setattr(new, key, getattr(old, key))
     from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cfi import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
-    process.hltIter2PFlowPixelSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(seedingHitSets="hltIter2PFlowPixelHitTriplets")
+    replace_with(process.hltIter2PFlowPixelSeeds, _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(seedingHitSets="hltIter2PFlowPixelHitTriplets"))
     _copy(process.HLTSeedFromConsecutiveHitsTripletOnlyCreator, process.hltIter2PFlowPixelSeeds, skip=["ComponentName"])
 
     process.HLTIter2GroupedCkfTrajectoryBuilderIT = cms.PSet(
@@ -436,7 +411,6 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	        doSeedingRegionRebuilding = cms.bool( False )
     )	
 
-    process.hltIter2PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('')
     process.hltIter2PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter2GroupedCkfTrajectoryBuilderIT'))
 
 

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -284,7 +284,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	    strictSeedExtension = cms.bool(True)
     )
 
-    process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet
+    process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
 	ComponentType = cms.string('CkfBaseTrajectoryFilter'),
 	chargeSignificance = cms.double(-1.0),
 	constantValueForLostHitsFractionFilter = cms.double(2.0),

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+import itertools
+
 # customisation functions for the HLT configuration
 from HLTrigger.Configuration.common import *
 
@@ -40,8 +42,9 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         'BPix1+FPix1_pos+FPix2_pos',
         'BPix1+FPix1_neg+FPix2_neg',
         'FPix1_pos+FPix2_pos+FPix3_pos',
-        'FPix1_neg+FPix2_neg+FPix3_neg' 
+        'FPix1_neg+FPix2_neg+FPix3_neg'
     )
+
     process.hltPixelLayerQuadruplets = cms.EDProducer("SeedingLayersEDProducer",
          BPix = cms.PSet(
             useErrorsFromParam = cms.bool( True ),
@@ -66,12 +69,12 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         TID = cms.PSet( ),
         TOB = cms.PSet( ),
         layerList = cms.vstring(
-            'BPix1+BPix2+BPix3+BPix4', 
-            'BPix1+BPix2+BPix3+FPix1_pos', 
-            'BPix1+BPix2+BPix3+FPix1_neg', 
-            'BPix1+BPix2+FPix1_pos+FPix2_pos', 
-            'BPix1+BPix2+FPix1_neg+FPix2_neg', 
-            'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 
+            'BPix1+BPix2+BPix3+BPix4',
+            'BPix1+BPix2+BPix3+FPix1_pos',
+            'BPix1+BPix2+BPix3+FPix1_neg',
+            'BPix1+BPix2+FPix1_pos+FPix2_pos',
+            'BPix1+BPix2+FPix1_neg+FPix2_neg',
+            'BPix1+FPix1_pos+FPix2_pos+FPix3_pos',
             'BPix1+FPix1_neg+FPix2_neg+FPix3_neg'
         )
     )
@@ -106,7 +109,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         CAThetaCut = cms.double(0.002),
         CAPhiCut = cms.double(0.2),
         CAHardPtCut = cms.double(0),
-        SeedComparitorPSet = cms.PSet( 
+        SeedComparitorPSet = cms.PSet(
             ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
             clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
         )
@@ -281,66 +284,66 @@ def customizeHLTForPFTrackingPhaseI2017(process):
 	    strictSeedExtension = cms.bool(True)
     )
 
-    process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
-	    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-	    chargeSignificance = cms.double(-1.0),
-	    constantValueForLostHitsFractionFilter = cms.double(2.0),
-	    extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-	    maxCCCLostHits = cms.int32(0),
-	    maxConsecLostHits = cms.int32(1),
-	    maxLostHits = cms.int32(1),  
-	    maxLostHitsFraction = cms.double(0.1),
-	    maxNumberOfHits = cms.int32(100),
-	    minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-	    minHitsMinPt = cms.int32(3),
-	    minNumberOfHitsForLoopers = cms.int32(13),
-	    minNumberOfHitsPerLoop = cms.int32(4),
-	    minPt = cms.double(0.2),
-	    minimumNumberOfHits = cms.int32(4),
-	    nSigmaMinPt = cms.double(5.0),
-	    pixelSeedExtension = cms.bool(True),
-	    seedExtension = cms.int32(1),
-	    seedPairPenalty = cms.int32(0),
-	    strictSeedExtension = cms.bool(True)
+    process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet
+	ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+	chargeSignificance = cms.double(-1.0),
+	constantValueForLostHitsFractionFilter = cms.double(2.0),
+	extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+	maxCCCLostHits = cms.int32(0),
+	maxConsecLostHits = cms.int32(1),
+	maxLostHits = cms.int32(1),  
+	maxLostHitsFraction = cms.double(0.1),
+	maxNumberOfHits = cms.int32(100),
+	minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+	minHitsMinPt = cms.int32(3),
+	minNumberOfHitsForLoopers = cms.int32(13),
+	minNumberOfHitsPerLoop = cms.int32(4),
+	minPt = cms.double(0.2),
+	minimumNumberOfHits = cms.int32(4),
+	nSigmaMinPt = cms.double(5.0),
+	pixelSeedExtension = cms.bool(True),
+	seedExtension = cms.int32(1),
+	seedPairPenalty = cms.int32(0),
+	strictSeedExtension = cms.bool(True)
     )
 
     process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet( 
-	  inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
-	  propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
-	  trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
-	  maxCand = cms.int32( 2 ),
-	  ComponentType = cms.string( "CkfTrajectoryBuilder" ),
-	  propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
-	  MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
-	  estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
-	  TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
-	  updator = cms.string( "hltESPKFUpdator" ),
-	  alwaysUseInvalidHits = cms.bool( False ),
-	  intermediateCleaning = cms.bool( True ),
-	  lostHitPenalty = cms.double( 30.0 ),
-	  useSameTrajFilter = cms.bool(False) 
+	inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
+	propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
+	trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
+	maxCand = cms.int32( 2 ),
+	ComponentType = cms.string( "CkfTrajectoryBuilder" ),
+	propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
+	MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
+	estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
+	TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
+	updator = cms.string( "hltESPKFUpdator" ),
+	alwaysUseInvalidHits = cms.bool( False ),
+	intermediateCleaning = cms.bool( True ),
+	lostHitPenalty = cms.double( 30.0 ),
+	useSameTrajFilter = cms.bool(False) 
     )
     process.HLTIter1GroupedCkfTrajectoryBuilderIT = cms.PSet(
-        	ComponentType = cms.string('GroupedCkfTrajectoryBuilder'),
-	        bestHitOnly = cms.bool(True),
-	        propagatorAlong = cms.string('PropagatorWithMaterialParabolicMf'),
-	        trajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterIT')),
-	        inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT')),
-	        useSameTrajFilter = cms.bool(False),
-	        maxCand = cms.int32(2),
-	        intermediateCleaning = cms.bool(True),
-	        lostHitPenalty = cms.double(30.0),
-	        MeasurementTrackerName = cms.string('hltIter1ESPMeasurementTracker'),
-	        lockHits = cms.bool(True),
-	        TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
-	        foundHitBonus = cms.double(5.0),
-	        updator = cms.string('hltESPKFUpdator'),
-	        alwaysUseInvalidHits = cms.bool(False),
-	        requireSeedHitsInRebuild = cms.bool(True),
-	        keepOriginalIfRebuildFails = cms.bool(False),
-	        estimator = cms.string('hltESPChi2ChargeMeasurementEstimator16'),
-	        propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
-	        minNrOfHitsForRebuild = cms.int32(5)
+	ComponentType = cms.string('GroupedCkfTrajectoryBuilder'),
+	bestHitOnly = cms.bool(True),
+	propagatorAlong = cms.string('PropagatorWithMaterialParabolicMf'),
+	trajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterIT')),
+	inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT')),
+	useSameTrajFilter = cms.bool(False),
+	maxCand = cms.int32(2),
+	intermediateCleaning = cms.bool(True),
+	lostHitPenalty = cms.double(30.0),
+	MeasurementTrackerName = cms.string('hltIter1ESPMeasurementTracker'),
+	lockHits = cms.bool(True),
+	TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
+	foundHitBonus = cms.double(5.0),
+	updator = cms.string('hltESPKFUpdator'),
+	alwaysUseInvalidHits = cms.bool(False),
+	requireSeedHitsInRebuild = cms.bool(True),
+	keepOriginalIfRebuildFails = cms.bool(False),
+	estimator = cms.string('hltESPChi2ChargeMeasurementEstimator16'),
+	propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
+	minNrOfHitsForRebuild = cms.int32(5)
     )
 
     process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('HLTIter1GroupedCkfTrajectoryBuilderIT')
@@ -369,7 +372,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         MTOB = cms.PSet( ),
         TEC = cms.PSet( ),
         MTID = cms.PSet( ),
-        FPix = cms.PSet( 
+        FPix = cms.PSet(
             HitProducer = cms.string( "hltSiPixelRecHits" ),
             hitErrorRZ = cms.double( 0.0036 ),
             useErrorsFromParam = cms.bool( True ),
@@ -381,7 +384,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         MTIB = cms.PSet( ),
         TID = cms.PSet( ),
         TOB = cms.PSet( ),
-        BPix = cms.PSet( 
+        BPix = cms.PSet(
             HitProducer = cms.string( "hltSiPixelRecHits" ),
             hitErrorRZ = cms.double( 0.006 ),
             useErrorsFromParam = cms.bool( True ),

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-import itertools
-
 # customisation functions for the HLT configuration
 from HLTrigger.Configuration.common import *
 
@@ -42,9 +40,8 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         'BPix1+FPix1_pos+FPix2_pos',
         'BPix1+FPix1_neg+FPix2_neg',
         'FPix1_pos+FPix2_pos+FPix3_pos',
-        'FPix1_neg+FPix2_neg+FPix3_neg'
+        'FPix1_neg+FPix2_neg+FPix3_neg' 
     )
-
     process.hltPixelLayerQuadruplets = cms.EDProducer("SeedingLayersEDProducer",
          BPix = cms.PSet(
             useErrorsFromParam = cms.bool( True ),
@@ -69,12 +66,12 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         TID = cms.PSet( ),
         TOB = cms.PSet( ),
         layerList = cms.vstring(
-            'BPix1+BPix2+BPix3+BPix4',
-            'BPix1+BPix2+BPix3+FPix1_pos',
-            'BPix1+BPix2+BPix3+FPix1_neg',
-            'BPix1+BPix2+FPix1_pos+FPix2_pos',
-            'BPix1+BPix2+FPix1_neg+FPix2_neg',
-            'BPix1+FPix1_pos+FPix2_pos+FPix3_pos',
+            'BPix1+BPix2+BPix3+BPix4', 
+            'BPix1+BPix2+BPix3+FPix1_pos', 
+            'BPix1+BPix2+BPix3+FPix1_neg', 
+            'BPix1+BPix2+FPix1_pos+FPix2_pos', 
+            'BPix1+BPix2+FPix1_neg+FPix2_neg', 
+            'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 
             'BPix1+FPix1_neg+FPix2_neg+FPix3_neg'
         )
     )
@@ -86,7 +83,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         precise = cms.bool( True ),
         beamSpot = cms.InputTag( "hltOnlineBeamSpot" ),
         originRadius = cms.double(0.02),
-        ptMin = cms.double(0.9),
+        ptMin = cms.double(0.8),
         nSigmaZ = cms.double(4.0),
     )
 
@@ -106,135 +103,273 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         useBendingCorrection = True,
         fitFastCircle = True,
         fitFastCircleChi2Cut = True,
-        CAThetaCut = cms.double(0.0012),
+        CAThetaCut = cms.double(0.002),
         CAPhiCut = cms.double(0.2),
         CAHardPtCut = cms.double(0),
-        SeedComparitorPSet = cms.PSet(
+        SeedComparitorPSet = cms.PSet( 
             ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
-            clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" ),
-            clusterShapeHitFilter = cms.string('ClusterShapeHitFilter')
+            clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
         )
     )
 
     process.hltPixelTracks.SeedingHitSets = "hltPixelTracksHitQuadruplets"
 
+    process.HLTDoRecoPixelTracksSequence = cms.Sequence(
+        process.hltPixelLayerQuadruplets +
+        process.hltPixelTracksTrackingRegions +
+        process.hltPixelTracksHitDoublets +
+        process.hltPixelTracksHitQuadruplets +
+        process.hltPixelTracks
+    )
+    
     process.HLTIter0PSetTrajectoryFilterIT.minimumNumberOfHits = cms.int32( 4 )
     process.HLTIter0PSetTrajectoryFilterIT.minHitsMinPt        = cms.int32( 4 )
     process.hltIter0PFlowTrackCutClassifier.mva.minLayers    = cms.vint32( 3, 3, 4 )
     process.hltIter0PFlowTrackCutClassifier.mva.min3DLayers  = cms.vint32( 0, 3, 4 )
     process.hltIter0PFlowTrackCutClassifier.mva.minPixelHits = cms.vint32( 0, 3, 4 )
 
-    replace_with(process.hltIter1PixelLayerTriplets, cms.EDProducer( "SeedingLayersEDProducer",
-        layerList = cms.vstring(
-            'BPix1+BPix2+BPix3',
-            'BPix1+BPix2+FPix1_pos',
-            'BPix1+BPix2+FPix1_neg',
-            'BPix1+FPix1_pos+FPix2_pos',
-            'BPix1+FPix1_neg+FPix2_neg'
+    process.HLTIter0GroupedCkfTrajectoryBuilderIT = cms.PSet(
+	        ComponentType = cms.string('GroupedCkfTrajectoryBuilder'),
+	        bestHitOnly = cms.bool(True),
+        	propagatorAlong = cms.string('PropagatorWithMaterialParabolicMf'),
+        	trajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter0PSetTrajectoryFilterIT')),
+        	inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter0PSetTrajectoryFilterIT')),
+	        useSameTrajFilter = cms.bool(True),
+	        maxCand = cms.int32(2),
+	        intermediateCleaning = cms.bool(True),
+	        lostHitPenalty = cms.double(30.0),
+	        MeasurementTrackerName = cms.string('hltESPMeasurementTracker'),
+	        lockHits = cms.bool(True),
+	        TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
+	        foundHitBonus = cms.double(5.0),
+	        updator = cms.string('hltESPKFUpdator'),
+	        alwaysUseInvalidHits = cms.bool(False),
+	        requireSeedHitsInRebuild = cms.bool(True),
+	        keepOriginalIfRebuildFails = cms.bool(False),
+	        estimator = cms.string('hltESPChi2ChargeMeasurementEstimator9'),
+     		propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
+	        minNrOfHitsForRebuild = cms.int32(5),
+	        maxDPhiForLooperReconstruction = cms.double(2.0),
+	        maxPtForLooperReconstruction = cms.double(0.7),
+	        cleanTrajectoryAfterInOut = cms.bool( False ),
+	        useHitsSplitting = cms.bool( False ),
+	        doSeedingRegionRebuilding = cms.bool( False )
+    )
+
+    process.hltIter0PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('HLTIter0GroupedCkfTrajectoryBuilderIT')
+    process.hltIter0PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter0GroupedCkfTrajectoryBuilderIT'))
+
+
+    process.hltIter1PixelLayerQuadruplets = cms.EDProducer("SeedingLayersEDProducer",
+        BPix = cms.PSet(
+          useErrorsFromParam = cms.bool( True ),
+          hitErrorRPhi = cms.double( 0.0027 ),
+          TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+          HitProducer = cms.string( "hltSiPixelRecHits" ),
+          hitErrorRZ = cms.double( 0.006 ),
+          skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
         ),
-        MTOB = cms.PSet( ),
-        TEC = cms.PSet( ),
-        MTID = cms.PSet( ),
         FPix = cms.PSet(
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.0036 ),
-            useErrorsFromParam = cms.bool( True ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
-            hitErrorRPhi = cms.double( 0.0051 )
+          useErrorsFromParam = cms.bool( True ),
+          hitErrorRPhi = cms.double( 0.0051 ),
+          TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+          HitProducer = cms.string( "hltSiPixelRecHits" ),
+          hitErrorRZ = cms.double( 0.0036 ),
+          skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
         ),
         MTEC = cms.PSet( ),
         MTIB = cms.PSet( ),
+        MTID = cms.PSet( ),
+        MTOB = cms.PSet( ),
+        TEC = cms.PSet( ),
+        TIB = cms.PSet( ),
         TID = cms.PSet( ),
         TOB = cms.PSet( ),
-        BPix = cms.PSet(
-            HitProducer = cms.string( "hltSiPixelRecHits" ),
-            hitErrorRZ = cms.double( 0.006 ),
-            useErrorsFromParam = cms.bool( True ),
-            TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
-            skipClusters = cms.InputTag( "hltIter1ClustersRefRemoval" ),
-            hitErrorRPhi = cms.double( 0.0027 )
-        ),
-        TIB = cms.PSet( )
-    ))
+        layerList = cms.vstring(
+            'BPix1+BPix2+BPix3+BPix4', 
+            'BPix1+BPix2+BPix3+FPix1_pos', 
+            'BPix1+BPix2+BPix3+FPix1_neg', 
+            'BPix1+BPix2+FPix1_pos+FPix2_pos', 
+            'BPix1+BPix2+FPix1_neg+FPix2_neg', 
+            'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 
+            'BPix1+FPix1_neg+FPix2_neg+FPix3_neg'
+        )
+    )
 
-    process.HLTIter1PSetTrajectoryFilterIT = cms.PSet(
-        ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-        chargeSignificance = cms.double(-1.0),
-        constantValueForLostHitsFractionFilter = cms.double(2.0),
-        extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-        maxCCCLostHits = cms.int32(0), # offline (2),
-        maxConsecLostHits = cms.int32(1),
-        maxLostHits = cms.int32(1),  # offline (999),
-        maxLostHitsFraction = cms.double(0.1),
-        maxNumberOfHits = cms.int32(100),
-        minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-        minHitsMinPt = cms.int32(3),
-        minNumberOfHitsForLoopers = cms.int32(13),
-        minNumberOfHitsPerLoop = cms.int32(4),
-        minPt = cms.double(0.2),
-        minimumNumberOfHits = cms.int32(4), # 3 online
-        nSigmaMinPt = cms.double(5.0),
-        pixelSeedExtension = cms.bool(True),
-        seedExtension = cms.int32(1),
-        seedPairPenalty = cms.int32(0),
-        strictSeedExtension = cms.bool(True)
+
+
+
+    process.hltIter1PixelTracks = process.hltPixelTracks.clone()
+
+    process.hltIter1PixelTracks.SeedingHitSets = "hltIter1PFlowPixelHitQuadruplets"
+    process.hltIter1PFlowPixelHitDoublets.layerPairs = [0,1,2] # layer pairs (0,1), (1,2), (2,3)
+    process.hltIter1PFlowPixelHitDoublets.seedingLayers = "hltIter1PixelLayerQuadruplets"
+
+
+    from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cfi import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
+    process.hltIter1PFlowPixelTrackingRegions = _globalTrackingRegionWithVertices.clone() 
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.sigmaZVertex = cms.double(4.0)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.nSigmaZ = cms.double(4.0)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.originRadius = cms.double(0.05)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.ptMin = cms.double(0.3)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.fixedError = cms.double(0.2)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.useFakeVertices = cms.bool(True)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.useMultipleScattering = cms.bool(True)
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.beamSpot = cms.InputTag( "hltOnlineBeamSpot" )
+    process.hltIter1PFlowPixelTrackingRegions.RegionPSet.VertexCollection = cms.InputTag( "hltTrimmedPixelVertices" )
+
+    process.hltIter1PFlowPixelHitQuadruplets = _caHitQuadrupletEDProducer.clone(
+        doublets = "hltIter1PFlowPixelHitDoublets",
+        extraHitRPhitolerance = cms.double(0.032),
+        maxChi2 = dict(
+            pt1    = 0.8,
+            pt2    = 2,
+            value1 = 2000,
+            value2 = 100,
+            enabled = True,
+        ),
+        useBendingCorrection = True,
+        fitFastCircle = True,
+        fitFastCircleChi2Cut = True,
+        CAThetaCut = cms.double(0.004),
+        CAPhiCut = cms.double(0.1),
+        CAHardPtCut = cms.double(0),
+        SeedComparitorPSet = cms.PSet( 
+            ComponentName = cms.string( "LowPtClusterShapeSeedComparitor" ),
+            clusterShapeCacheSrc = cms.InputTag( "hltSiPixelClustersCache" )
+        )
+
+
+    )
+
+
+ 
+    process.hltIter1PFlowPixelSeeds = cms.EDProducer( "SeedGeneratorFromProtoTracksEDProducer",
+        useEventsWithNoVertex = cms.bool( True ),
+        originHalfLength = cms.double( 0.3 ), 
+        useProtoTrackKinematics = cms.bool( False ),
+        usePV = cms.bool( True ),
+        SeedCreatorPSet = cms.PSet(  refToPSet_ = cms.string( "HLTSeedFromProtoTracks" ) ),
+        InputVertexCollection = cms.InputTag( "hltTrimmedPixelVertices" ),
+        TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
+        InputCollection = cms.InputTag( "hltIter1PixelTracks" ),
+        originRadius = cms.double( 0.1 )
+    )
+    process.HLTIter1PSetTrajectoryBuilderIT.strictSeedExtension = cms.bool(True)
+  
+
+    process.HLTIter1PSetTrajectoryFilterIT = cms.PSet( 
+	    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+	    chargeSignificance = cms.double(-1.0),
+	    constantValueForLostHitsFractionFilter = cms.double(2.0),
+	    extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+	    maxCCCLostHits = cms.int32(0),
+	    maxConsecLostHits = cms.int32(1),
+	    maxLostHits = cms.int32(1),  
+	    maxLostHitsFraction = cms.double(0.1),
+	    maxNumberOfHits = cms.int32(100),
+	    minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+	    minHitsMinPt = cms.int32(3),
+	     minNumberOfHitsForLoopers = cms.int32(13),
+	    minNumberOfHitsPerLoop = cms.int32(4),
+	    minPt = cms.double(0.2),
+	    minimumNumberOfHits = cms.int32(4), 
+	    nSigmaMinPt = cms.double(5.0),
+	    pixelSeedExtension = cms.bool(True),
+	    seedExtension = cms.int32(1),
+	    seedPairPenalty = cms.int32(0),
+	    strictSeedExtension = cms.bool(True)
     )
 
     process.HLTIter1PSetTrajectoryFilterInOutIT = cms.PSet(
-        ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-        chargeSignificance = cms.double(-1.0),
-        constantValueForLostHitsFractionFilter = cms.double(2.0),
-        extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
-        maxCCCLostHits = cms.int32(0), # offline (2),
-        maxConsecLostHits = cms.int32(1),
-        maxLostHits = cms.int32(1),  # offline (999),
-        maxLostHitsFraction = cms.double(0.1),
-        maxNumberOfHits = cms.int32(100),
-        minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
-        minHitsMinPt = cms.int32(3),
-        minNumberOfHitsForLoopers = cms.int32(13),
-        minNumberOfHitsPerLoop = cms.int32(4),
-        minPt = cms.double(0.2),
-        minimumNumberOfHits = cms.int32(4), # 3 online
-        nSigmaMinPt = cms.double(5.0),
-        pixelSeedExtension = cms.bool(True),
-        seedExtension = cms.int32(1),
-        seedPairPenalty = cms.int32(0),
-        strictSeedExtension = cms.bool(True)
+	    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+	    chargeSignificance = cms.double(-1.0),
+	    constantValueForLostHitsFractionFilter = cms.double(2.0),
+	    extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+	    maxCCCLostHits = cms.int32(0),
+	    maxConsecLostHits = cms.int32(1),
+	    maxLostHits = cms.int32(1),  
+	    maxLostHitsFraction = cms.double(0.1),
+	    maxNumberOfHits = cms.int32(100),
+	    minGoodStripCharge = cms.PSet( refToPSet_ = cms.string( "HLTSiStripClusterChargeCutNone" ) ),
+	    minHitsMinPt = cms.int32(3),
+	    minNumberOfHitsForLoopers = cms.int32(13),
+	    minNumberOfHitsPerLoop = cms.int32(4),
+	    minPt = cms.double(0.2),
+	    minimumNumberOfHits = cms.int32(4),
+	    nSigmaMinPt = cms.double(5.0),
+	    pixelSeedExtension = cms.bool(True),
+	    seedExtension = cms.int32(1),
+	    seedPairPenalty = cms.int32(0),
+	    strictSeedExtension = cms.bool(True)
     )
 
-    process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet(
-        inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
-        propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
-        trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
-        maxCand = cms.int32( 2 ),
-        ComponentType = cms.string( "CkfTrajectoryBuilder" ),
-        propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
-        MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
-        estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
-        TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
-        updator = cms.string( "hltESPKFUpdator" ),
-        alwaysUseInvalidHits = cms.bool( False ),
-        intermediateCleaning = cms.bool( True ),
-        lostHitPenalty = cms.double( 30.0 ),
-        useSameTrajFilter = cms.bool(False) # new ! other iteration should have it set to True
+    process.HLTIter1PSetTrajectoryBuilderIT = cms.PSet( 
+	  inOutTrajectoryFilter = cms.PSet( refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT') ),
+	  propagatorAlong = cms.string( "PropagatorWithMaterialParabolicMf" ),
+	  trajectoryFilter = cms.PSet(  refToPSet_ = cms.string( "HLTIter1PSetTrajectoryFilterIT" ) ),
+	  maxCand = cms.int32( 2 ),
+	  ComponentType = cms.string( "CkfTrajectoryBuilder" ),
+	  propagatorOpposite = cms.string( "PropagatorWithMaterialParabolicMfOpposite" ),
+	  MeasurementTrackerName = cms.string( "hltIter1ESPMeasurementTracker" ),
+	  estimator = cms.string( "hltESPChi2ChargeMeasurementEstimator16" ),
+	  TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
+	  updator = cms.string( "hltESPKFUpdator" ),
+	  alwaysUseInvalidHits = cms.bool( False ),
+	  intermediateCleaning = cms.bool( True ),
+	  lostHitPenalty = cms.double( 30.0 ),
+	  useSameTrajFilter = cms.bool(False) 
+    )
+    process.HLTIter1GroupedCkfTrajectoryBuilderIT = cms.PSet(
+        	ComponentType = cms.string('GroupedCkfTrajectoryBuilder'),
+	        bestHitOnly = cms.bool(True),
+	        propagatorAlong = cms.string('PropagatorWithMaterialParabolicMf'),
+	        trajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterIT')),
+	        inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter1PSetTrajectoryFilterInOutIT')),
+	        useSameTrajFilter = cms.bool(False),
+	        maxCand = cms.int32(2),
+	        intermediateCleaning = cms.bool(True),
+	        lostHitPenalty = cms.double(30.0),
+	        MeasurementTrackerName = cms.string('hltIter1ESPMeasurementTracker'),
+	        lockHits = cms.bool(True),
+	        TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
+	        foundHitBonus = cms.double(5.0),
+	        updator = cms.string('hltESPKFUpdator'),
+	        alwaysUseInvalidHits = cms.bool(False),
+	        requireSeedHitsInRebuild = cms.bool(True),
+	        keepOriginalIfRebuildFails = cms.bool(False),
+	        estimator = cms.string('hltESPChi2ChargeMeasurementEstimator16'),
+	        propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
+	        minNrOfHitsForRebuild = cms.int32(5)
     )
 
-    replace_with(process.HLTIterativeTrackingIteration1, cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerTriplets + process.hltIter1PFlowPixelTrackingRegions + process.hltIter1PFlowPixelClusterCheck + process.hltIter1PFlowPixelHitDoublets + process.hltIter1PFlowPixelHitTriplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity ))
+    process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('HLTIter1GroupedCkfTrajectoryBuilderIT')
+    process.hltIter1PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter1GroupedCkfTrajectoryBuilderIT'))
+
+
+    process.HLTIterativeTrackingIteration1 = cms.Sequence( process.hltIter1ClustersRefRemoval + process.hltIter1MaskedMeasurementTrackerEvent + process.hltIter1PixelLayerQuadruplets + process.hltIter1PFlowPixelTrackingRegions + process.hltIter1PFlowPixelClusterCheck + process.hltIter1PFlowPixelHitDoublets + process.hltIter1PFlowPixelHitQuadruplets + process.hltIter1PFlowPixelSeeds + process.hltIter1PFlowCkfTrackCandidates + process.hltIter1PFlowCtfWithMaterialTracks + process.hltIter1PFlowTrackCutClassifierPrompt + process.hltIter1PFlowTrackCutClassifierDetached + process.hltIter1PFlowTrackCutClassifierMerged + process.hltIter1PFlowTrackSelectionHighPurity )
 
     process.hltIter2PixelLayerTriplets = cms.EDProducer( "SeedingLayersEDProducer",
-        layerList = cms.vstring(
-            'BPix1+BPix2+BPix3',
-            'BPix1+BPix2+FPix1_pos',
-            'BPix1+BPix2+FPix1_neg',
-            'BPix1+FPix1_pos+FPix2_pos',
-            'BPix1+FPix1_neg+FPix2_neg'
+        layerList = cms.vstring( 
+	      	'BPix1+BPix2+BPix3',
+		'BPix2+BPix3+BPix4',
+      		'BPix1+BPix3+BPix4',
+      		'BPix1+BPix2+BPix4',
+      		'BPix2+BPix3+FPix1_pos',
+      		'BPix2+BPix3+FPix1_neg',
+      		'BPix1+BPix2+FPix1_pos',
+      		'BPix1+BPix2+FPix1_neg',
+      		'BPix2+FPix1_pos+FPix2_pos',
+      		'BPix2+FPix1_neg+FPix2_neg',
+      		'BPix1+FPix1_pos+FPix2_pos',
+      		'BPix1+FPix1_neg+FPix2_neg',
+      		'FPix1_pos+FPix2_pos+FPix3_pos',
+      		'FPix1_neg+FPix2_neg+FPix3_neg' 
         ),
         MTOB = cms.PSet( ),
         TEC = cms.PSet( ),
         MTID = cms.PSet( ),
-        FPix = cms.PSet(
+        FPix = cms.PSet( 
             HitProducer = cms.string( "hltSiPixelRecHits" ),
             hitErrorRZ = cms.double( 0.0036 ),
             useErrorsFromParam = cms.bool( True ),
@@ -246,7 +381,7 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         MTIB = cms.PSet( ),
         TID = cms.PSet( ),
         TOB = cms.PSet( ),
-        BPix = cms.PSet(
+        BPix = cms.PSet( 
             HitProducer = cms.string( "hltSiPixelRecHits" ),
             hitErrorRZ = cms.double( 0.006 ),
             useErrorsFromParam = cms.bool( True ),
@@ -257,22 +392,30 @@ def customizeHLTForPFTrackingPhaseI2017(process):
         TIB = cms.PSet( )
     )
 
-    from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+ 
+    process.hltIter2PFlowPixelTrackingRegions.RegionPSet.ptMin = cms.double(0.8)
+    process.hltIter2PFlowPixelTrackingRegions.RegionPSet.originRadius = cms.double(0.025)
+    process.hltIter2PFlowPixelTrackingRegions.RegionPSet.nSigmaZVertex = cms.double(4.0)
+
+    from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
+
     process.hltIter2PFlowPixelHitDoublets.seedingLayers = "hltIter2PixelLayerTriplets"
     process.hltIter2PFlowPixelHitDoublets.produceIntermediateHitDoublets = True
     process.hltIter2PFlowPixelHitDoublets.produceSeedingHitSets = False
-    process.hltIter2PFlowPixelHitDoublets.seedingLayers = "hltIter2PixelLayerTriplets"
-    process.hltIter2PFlowPixelHitTriplets = _pixelTripletHLTEDProducer.clone(
-        doublets = "hltIter2PFlowPixelHitDoublets",
-        useBending = cms.bool( True ),
-        useFixedPreFiltering = cms.bool( False ),
-        maxElement = cms.uint32( 100000 ),
-        phiPreFiltering = cms.double( 0.3 ),
-        extraHitRPhitolerance = cms.double( 0.032 ),
-        useMultScattering = cms.bool( True ),
-        extraHitRZtolerance = cms.double( 0.037 ),
-        SeedComparitorPSet = cms.PSet(  ComponentName = cms.string( "none" ) ),
-        produceSeedingHitSets = True,
+    process.hltIter2PFlowPixelHitDoublets.layerPairs = [0,1]
+    process.hltIter2PFlowPixelHitTriplets = _caHitTripletEDProducer.clone(
+        doublets = cms.InputTag("hltIter2PFlowPixelHitDoublets"),
+        extraHitRPhitolerance = cms.double(0.032),
+    	maxChi2 = cms.PSet(
+        	pt1    = cms.double(0.8), pt2    = cms.double(8),
+        	value1 = cms.double(100), value2 = cms.double(6),
+        	enabled = cms.bool(True),
+    	),
+    	useBendingCorrection = cms.bool(True),
+    	CAThetaCut = cms.double(0.004),
+    	CAPhiCut = cms.double(0.1),
+    	CAHardPtCut = cms.double(0.3),
+
     )
 
     def _copy(old, new, skip=[]):
@@ -281,49 +424,89 @@ def customizeHLTForPFTrackingPhaseI2017(process):
             if key not in skipSet:
                 setattr(new, key, getattr(old, key))
     from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cfi import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
-    replace_with(process.hltIter2PFlowPixelSeeds, _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(seedingHitSets="hltIter2PFlowPixelHitTriplets"))
+    process.hltIter2PFlowPixelSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(seedingHitSets="hltIter2PFlowPixelHitTriplets")
     _copy(process.HLTSeedFromConsecutiveHitsTripletOnlyCreator, process.hltIter2PFlowPixelSeeds, skip=["ComponentName"])
 
-    replace_with(process.HLTIterativeTrackingIteration2, cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelTrackingRegions + process.hltIter2PFlowPixelClusterCheck + process.hltIter2PFlowPixelHitDoublets + process.hltIter2PFlowPixelHitTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity ))
+    process.HLTIter2GroupedCkfTrajectoryBuilderIT = cms.PSet(
 
-    # replace hltPixelLayerTriplets and hltPixelTracksHitTriplets with hltPixelLayerQuadruplets and hltPixelTracksHitQuadruplets
-    # in any Sequence, Paths or EndPath that contains the former and not the latter
-    from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
-    for sequence in itertools.chain(
-        process._Process__sequences.itervalues(),
-        process._Process__paths.itervalues(),
-        process._Process__endpaths.itervalues()
-    ):
-        modules = list()
-        sequence.visit(ModuleNodeVisitor(modules))
+        	ComponentType = cms.string('GroupedCkfTrajectoryBuilder'),
+	        bestHitOnly = cms.bool(True),
+	        propagatorAlong = cms.string('PropagatorWithMaterialParabolicMf'),
+	        trajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter2PSetTrajectoryFilterIT')),
+	        inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('HLTIter2PSetTrajectoryFilterIT')),
+	        useSameTrajFilter = cms.bool(True),
+	        maxCand = cms.int32(2),
+	        intermediateCleaning = cms.bool(True),
+	        lostHitPenalty = cms.double(30.0),
+	        MeasurementTrackerName = cms.string('hltESPMeasurementTracker'),
+	        lockHits = cms.bool(True),
+	        TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
+	        foundHitBonus = cms.double(5.0),
+	        updator = cms.string('hltESPKFUpdator'),
+	        alwaysUseInvalidHits = cms.bool(False),
+	        requireSeedHitsInRebuild = cms.bool(True),
+	        keepOriginalIfRebuildFails = cms.bool(False),
+	        estimator = cms.string('hltESPChi2ChargeMeasurementEstimator16'),
+	        propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
+	        minNrOfHitsForRebuild = cms.int32(5),
+	        maxDPhiForLooperReconstruction = cms.double(2.0),
+	        maxPtForLooperReconstruction = cms.double(0.7),
+	        cleanTrajectoryAfterInOut = cms.bool( False ),
+	        useHitsSplitting = cms.bool( False ),
+	        doSeedingRegionRebuilding = cms.bool( False )
+    )	
 
-        if process.hltPixelTracks in modules and not process.hltPixelLayerQuadruplets in modules:
-            # note that this module does not necessarily exist in sequence 'sequence', if it doesn't, it does not get removed
-            sequence.remove(process.hltPixelLayerTriplets)
-            index = sequence.index(process.hltPixelTracksHitDoublets)
-            sequence.insert(index,process.hltPixelLayerQuadruplets)
-            index = sequence.index(process.hltPixelTracksHitTriplets)
-            sequence.remove(process.hltPixelTracksHitTriplets)
-            sequence.insert(index, process.hltPixelTracksHitQuadruplets)
+    process.hltIter2PFlowCkfTrackCandidates.TrajectoryBuilder = cms.string('HLTIter2GroupedCkfTrajectoryBuilderIT')
+    process.hltIter2PFlowCkfTrackCandidates.TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('HLTIter2GroupedCkfTrajectoryBuilderIT'))
+
+
+
+    process.HLTIterativeTrackingIteration2 = cms.Sequence( process.hltIter2ClustersRefRemoval + process.hltIter2MaskedMeasurementTrackerEvent + process.hltIter2PixelLayerTriplets + process.hltIter2PFlowPixelTrackingRegions + process.hltIter2PFlowPixelClusterCheck + process.hltIter2PFlowPixelHitDoublets + process.hltIter2PFlowPixelHitTriplets + process.hltIter2PFlowPixelSeeds + process.hltIter2PFlowCkfTrackCandidates + process.hltIter2PFlowCtfWithMaterialTracks + process.hltIter2PFlowTrackCutClassifier + process.hltIter2PFlowTrackSelectionHighPurity )
+
+    # Need to operate on Paths as well...
+    for seqs in [process.sequences_(), process.paths_()]:
+        for seqName, seq in seqs.iteritems():
+            from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
+            l = list()
+            v = ModuleNodeVisitor(l)
+            seq.visit(v)
+
+            if process.hltPixelTracks in l and not process.hltPixelLayerQuadruplets in l:
+                seq.remove(process.hltPixelLayerTriplets) # note that this module does not necessarily exist in sequence 'seq', if it doesn't, it does not get removed
+                index = seq.index(process.hltPixelTracksHitDoublets)
+                seq.insert(index,process.hltPixelLayerQuadruplets)
+                index = seq.index(process.hltPixelTracksHitTriplets)
+                seq.remove(process.hltPixelTracksHitTriplets)
+                seq.insert(index, process.hltPixelTracksHitQuadruplets)
 
     # Remove entirely to avoid warning from the early deleter
     del process.hltPixelTracksHitTriplets
 
-    return process
+    for producer in producers_by_type(process,"PixelTripletHLTEDProducer"):
+        if "hltIter1PFlowPixelHitTriplets" in producer.label():
 
-# modify the HLT configuration to run the Phase I tracking in the particle flow sequence
-def customizeHLTForPFTrackingPhaseI2017tuningIter0(process):
-    process.hltPixelTracksHitQuadruplets.maxChi2.pt1    = cms.double( 0.8 ) # lowpt
-    process.hltPixelTracksHitQuadruplets.maxChi2.pt2    = cms.double( 2   ) # highpt
-    process.hltPixelTracksHitQuadruplets.maxChi2.value1 = cms.double( 150 ) # chi2lowpt
-    process.hltPixelTracksHitQuadruplets.maxChi2.value2 = cms.double(  50 ) # chi2highpt
-    process.hltPixelTracksHitQuadruplets.CAThetaCut  = cms.double( 0.002 )
-    process.hltPixelTracksHitQuadruplets.CAPhiCut    = cms.double( 0.2   )
-    process.hltPixelTracksHitQuadruplets.CAHardPtCut = cms.double( 0     )
-    
+    	   	for seqs in [process.sequences_(), process.paths_()]:
+        		for seqName, seq in seqs.iteritems():
+            			from FWCore.ParameterSet.SequenceTypes import ModuleNodeVisitor
+            			l = list()
+            			v = ModuleNodeVisitor(l)
+            			seq.visit(v)
+
+            			if process.hltIter1PFlowPixelHitTriplets in l and not process.hltIter1PFlowPixelHitQuadruplets in l:
+                			index = seq.index(process.hltIter1PFlowPixelHitTriplets)
+                			seq.insert(index, process.hltIter1PixelTracks)
+                			seq.insert(index, process.hltIter1PFlowPixelHitQuadruplets)
+                			seq.remove(process.hltIter1PFlowPixelHitTriplets)
+
+    # Remove entirely to avoid warning from the early deleter
+    del process.hltIter1PFlowPixelHitTriplets
+
+
+
+
+
     return process
 
 # attach `customizeHLTForPFTrackingPhaseI2017` to the `phase1Pixel` era
 def modifyHLTForPFTrackingPhaseI2017(process):
     phase1Pixel.toModify(process, customizeHLTForPFTrackingPhaseI2017)
-    phase1Pixel.toModify(process, customizeHLTForPFTrackingPhaseI2017tuningIter0)


### PR DESCRIPTION
This PR is a cumulative update of the customization function for the iterative tracking to use CA seeing at HLT. 

Main features of this update: 
- Switches iterations 1 and 2 to use CA Quadruplets and Triplets, respectively
- Switches from CkfTrajectoryBuilder to GroupedCkfTrajectoryBuilder for all iterations, as promised at the last TSG workshop in the beginning of November, but so far not actually put into the release
- Tuning of the configuration in 9_0_0_pre4 to maximize performance

Detailed performance comparisons can be found here: https://cernbox.cern.ch/index.php/s/iF6QrRMTcqxPyB8
Compared are the performance of the new configuration to what is in pre4 right now, and also to the 2016 performance for reference. 

In summary, efficiency is significantly increased for no cost in fake rate. Timing improves from 220ms for 2016 to about 180ms for the new configuration, a speedup of about 20%. Note that this timing measurements have been done in 8_1_0_pre16 because the FastTimerService works in that release. 