### PR TITLE
Keeping the z ordering in the NavigationSchool sorting and fix analyzer

### DIFF
--- a/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.cc
@@ -314,8 +314,8 @@ SimpleNavigationSchool::splitForwardLayers()
   FDLI begin = myRightLayers.begin();
   FDLI end   = myRightLayers.end();
 
-  // sort according to inner radius
-  sort ( begin, end, DiskLessInnerRadius()); 
+  // sort according to inner radius, but keeping the ordering in z!
+  stable_sort ( begin, end, DiskLessInnerRadius());
 
   // partition in cylinders
   vector<FDLC> result;

--- a/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/SimpleNavigationSchool.cc
@@ -344,7 +344,7 @@ SimpleNavigationSchool::splitForwardLayers()
       LogDebug("TkNavigation") << "found break between groups" ;
 
       // sort layers in group along Z
-      sort ( current.begin(), current.end(), DetLessZ());
+      stable_sort ( current.begin(), current.end(), DetLessZ());
 
       result.push_back(current);
       current.clear();
@@ -356,7 +356,7 @@ SimpleNavigationSchool::splitForwardLayers()
   // now sort subsets in Z
   for ( vector<FDLC>::iterator ivec = result.begin();
 	ivec != result.end(); ivec++) {
-    sort( ivec->begin(), ivec->end(), DetLessZ());
+    stable_sort( ivec->begin(), ivec->end(), DetLessZ());
   }
 
   return result;

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -264,9 +264,9 @@ void NavigationSchoolAnalyzer::analyze(const edm::Event& iEvent, const edm::Even
 }
 
 void NavigationSchoolAnalyzer::beginRun(edm::Run const & run, const edm::EventSetup& iSetup) {
-//  edm::ESHandle<TrackerTopology> tTopoHandle;
-//  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-//  tTopo = tTopoHandle.product();
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  tTopo = tTopoHandle.product();
 
   //get the navigation school
   edm::ESHandle<NavigationSchool> nav;

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+# set the geometry and the GlobalTag
+
 process = cms.Process("NavigationSchoolAnalyze")
 
 # process.load("Configuration.StandardSequences.Geometry_cff")
@@ -9,7 +11,7 @@ process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 # process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("RecoTracker.TkNavigation.NavigationSchoolESProducer_cff")
 


### PR DESCRIPTION
- The sorting process need to keep the order in z otherwise the `if` condition afterwards can also not be satisfied as it should. The `stable_sort` has been also propagated to the other sorting processes.
- The bug in the analyzer was is caused by the PR #16993. Thanks to @makortel to spot the issue!