### PR TITLE
bsunanda:Run2-HCX107 Add a useful method fro HBHERecHit and its usage for Plan1

### DIFF
--- a/DataFormats/HcalRecHit/interface/HBHERecHit.h
+++ b/DataFormats/HcalRecHit/interface/HBHERecHit.h
@@ -47,6 +47,8 @@ public:
   // For normal (i.e., not merged) rechits the vector will be cleared.
   void getMergedIds(std::vector<HcalDetId>* ids) const;
 
+  // Returns the DetId of the front Id if it is a merged RecHit in "Plan 1"
+  HcalDetId idFront() const;
 private:
   float timeFalling_;
   float chiSquared_;

--- a/DataFormats/HcalRecHit/src/HBHERecHit.cc
+++ b/DataFormats/HcalRecHit/src/HBHERecHit.cc
@@ -65,18 +65,9 @@ void HBHERecHit::getMergedIds(std::vector<HcalDetId>* ids) const
 
 
 HcalDetId HBHERecHit::idFront() const {
-  if (isMerged()) {
-    HcalDetId myId(id());
-    if (auxPhase1_ & (1U << HBHERecHitAuxSetter::OFF_COMBINED)) {
-      const unsigned nMerged = CaloRecHitAuxSetter::getField(auxPhase1_,
-							     HBHERecHitAuxSetter::MASK_NSAMPLES,
-							     HBHERecHitAuxSetter::OFF_NSAMPLES);
-      if (nMerged > 0) {
-	const unsigned depth = CaloRecHitAuxSetter::getField(auxHBHE_, 0xf, 0);
-	myId = HcalDetId(myId.subdet(), myId.ieta(), myId.iphi(), depth);
-      }
-    }
-    return myId;
+  if (auxPhase1_ & (1U << HBHERecHitAuxSetter::OFF_COMBINED)) {
+    const HcalDetId myId(id());
+    return HcalDetId(myId.subdet(), myId.ieta(), myId.iphi(), auxHBHE_ & 0xf);
   } else {
     return id();
   }

--- a/DataFormats/HcalRecHit/src/HBHERecHit.cc
+++ b/DataFormats/HcalRecHit/src/HBHERecHit.cc
@@ -62,3 +62,22 @@ void HBHERecHit::getMergedIds(std::vector<HcalDetId>* ids) const
         }
     }
 }
+
+
+HcalDetId HBHERecHit::idFront() const {
+  if (isMerged()) {
+    HcalDetId myId(id());
+    if (auxPhase1_ & (1U << HBHERecHitAuxSetter::OFF_COMBINED)) {
+      const unsigned nMerged = CaloRecHitAuxSetter::getField(auxPhase1_,
+							     HBHERecHitAuxSetter::MASK_NSAMPLES,
+							     HBHERecHitAuxSetter::OFF_NSAMPLES);
+      if (nMerged > 0) {
+	const unsigned depth = CaloRecHitAuxSetter::getField(auxHBHE_, 0xf, 0);
+	myId = HcalDetId(myId.subdet(), myId.ieta(), myId.iphi(), depth);
+      }
+    }
+    return myId;
+  } else {
+    return id();
+  }
+}

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h
@@ -42,7 +42,7 @@ class PFHBHERecHitCreator :  public  PFRecHitCreatorBase {
 
       iEvent.getByToken(recHitToken_,recHitHandle);
       for( const auto& erh : *recHitHandle ) {      
-	const HcalDetId& detid = (HcalDetId)erh.detid();
+	const HcalDetId detid = erh.idFront();
 	HcalSubdetector esd=(HcalSubdetector)detid.subdetId();
 	
 	auto energy = erh.energy();
@@ -68,8 +68,8 @@ class PFHBHERecHitCreator :  public  PFRecHitCreatorBase {
 	// find rechit geometry
 	if(!thisCell) {
 	  edm::LogError("PFHBHERecHitCreator")
-	    <<"warning detid "<<detid.rawId()
-	    <<" not found in geometry"<<std::endl;
+	    <<"warning detid "<<std::hex<<detid.rawId()<<std::dec<< " "
+	    <<detid<<" not found in geometry"<<std::endl;
 	  continue;
 	}
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
@@ -64,7 +64,7 @@ class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
 
       iEvent.getByToken(recHitToken_,recHitHandle);
       for( const auto& erh : *recHitHandle ) {      
-	const HcalDetId& detid = (HcalDetId)erh.detid();
+	const HcalDetId detid = erh.idFront();
 	HcalSubdetector esd=(HcalSubdetector)detid.subdetId();
 	
 	


### PR DESCRIPTION
The front cell of a merged rechit is used for PFRecHit geometry in 2 PF classes. For other PF classes, one may need to utilize information of all the DetId's which are merged and those classes are not modified.