### PR TITLE
bsunanda:Run2-hcx108 Effect of Plan1 geometry on Calibration

### DIFF
--- a/Calibration/HcalCalibAlgos/test/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/test/BuildFile.xml
@@ -18,8 +18,9 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
-<use   name="Geometry/Records"/>
 <use   name="Geometry/CaloGeometry"/>
+<use   name="Geometry/HcalTowerAlgo"/>
+<use   name="Geometry/Records"/>
 <use   name="JetMETCorrections/Objects"/>
 <use   name="JetMETCorrections/Type1MET"/>
 <use   name="Geometry/CaloTopology"/>

--- a/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.cc
@@ -86,8 +86,8 @@ DiJetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup)
   // Get geometry
   edm::ESHandle<CaloGeometry> geoHandle;
   evSetup.get<CaloGeometryRecord>().get(geoHandle);
-  const HcalGeometry *HBGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 1));
-  const HcalGeometry *HEGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 2));
+  const HcalGeometry *HBGeom = dynamic_cast<const HcalGeometry*>(geoHandle->getSubdetectorGeometry(DetId::Hcal, 1));
+  const HcalGeometry *HEGeom = dynamic_cast<const HcalGeometry*>(geoHandle->getSubdetectorGeometry(DetId::Hcal, 2));
   const CaloSubdetectorGeometry *HOGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 3);
   const CaloSubdetectorGeometry *HFGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 4);
   

--- a/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.cc
@@ -86,8 +86,8 @@ DiJetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup)
   // Get geometry
   edm::ESHandle<CaloGeometry> geoHandle;
   evSetup.get<CaloGeometryRecord>().get(geoHandle);
-  const CaloSubdetectorGeometry *HBGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 1);
-  const CaloSubdetectorGeometry *HEGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 2);
+  const HcalGeometry *HBGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 1));
+  const HcalGeometry *HEGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 2));
   const CaloSubdetectorGeometry *HOGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 3);
   const CaloSubdetectorGeometry *HFGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 4);
   
@@ -486,8 +486,7 @@ DiJetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup)
 		    switch((*ith).id().subdet()){
 		    case HcalSubdetector::HcalBarrel:
 		      {
-			const CaloCellGeometry *thisCell = HBGeom->getGeometry((*ith).id().rawId());
-			const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
+			CaloCellGeometry::CornersVec cv = HBGeom->getCorners((*ith).id());
 			float avgeta = (cv[0].eta() + cv[2].eta())/2.0;
 			float avgphi = (static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
 			if(cv[0].phi() < cv[2].phi()) avgphi = (2.0*3.141592653 + static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
@@ -496,8 +495,7 @@ DiJetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup)
 		      }
 		    case HcalSubdetector::HcalEndcap:
 		      {
-			const CaloCellGeometry *thisCell = HEGeom->getGeometry((*ith).id().rawId());
-			const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
+			CaloCellGeometry::CornersVec cv = HEGeom->getCorners((*ith).id());
 			float avgeta = (cv[0].eta() + cv[2].eta())/2.0;
 			float avgphi = (static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
 			if(cv[0].phi() < cv[2].phi()) avgphi = (2.0*3.141592653 + static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
@@ -889,8 +887,7 @@ DiJetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup)
 		    switch((*ith).id().subdet()){
 		    case HcalSubdetector::HcalBarrel:
 		      {
-			const CaloCellGeometry *thisCell = HBGeom->getGeometry((*ith).id().rawId());
-			const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
+			CaloCellGeometry::CornersVec cv = HBGeom->getCorners((*ith).id());
 			float avgeta = (cv[0].eta() + cv[2].eta())/2.0;
 			float avgphi = (static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
 			if(cv[0].phi() < cv[2].phi()) avgphi = (2.0*3.141592653 + static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
@@ -899,8 +896,7 @@ DiJetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup)
 		      }
 		    case HcalSubdetector::HcalEndcap:
 		      {
-			const CaloCellGeometry *thisCell = HEGeom->getGeometry((*ith).id().rawId());
-			const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
+			CaloCellGeometry::CornersVec cv = HEGeom->getCorners((*ith).id());
 			float avgeta = (cv[0].eta() + cv[2].eta())/2.0;
 			float avgphi = (static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
 			if(cv[0].phi() < cv[2].phi()) avgphi = (2.0*3.141592653 + static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;

--- a/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.h
+++ b/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.h
@@ -38,6 +38,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -586,8 +586,8 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     // Get geometry
     edm::ESHandle<CaloGeometry> geoHandle;
     evSetup.get<CaloGeometryRecord>().get(geoHandle);
-    const HcalGeometry *HBGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 1));
-    const HcalGeometry *HEGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 2));
+    const HcalGeometry *HBGeom = dynamic_cast<const HcalGeometry*>(geoHandle->getSubdetectorGeometry(DetId::Hcal, 1));
+    const HcalGeometry *HEGeom = dynamic_cast<const HcalGeometry*>(geoHandle->getSubdetectorGeometry(DetId::Hcal, 2));
     const CaloSubdetectorGeometry *HOGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 3);
     const CaloSubdetectorGeometry *HFGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 4);
 

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -586,8 +586,8 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     // Get geometry
     edm::ESHandle<CaloGeometry> geoHandle;
     evSetup.get<CaloGeometryRecord>().get(geoHandle);
-    const CaloSubdetectorGeometry *HBGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 1);
-    const CaloSubdetectorGeometry *HEGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 2);
+    const HcalGeometry *HBGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 1));
+    const HcalGeometry *HEGeom = (HcalGeometry*)(geoHandle->getSubdetectorGeometry(DetId::Hcal, 2));
     const CaloSubdetectorGeometry *HOGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 3);
     const CaloSubdetectorGeometry *HFGeom = geoHandle->getSubdetectorGeometry(DetId::Hcal, 4);
 
@@ -1012,8 +1012,7 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 			switch((*ith).id().subdet()){
 			case HcalSubdetector::HcalBarrel:
 			  {
-			    const CaloCellGeometry *thisCell = HBGeom->getGeometry((*ith).id().rawId());
-			    const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
+			    CaloCellGeometry::CornersVec cv = HBGeom->getCorners((*ith).id());
 			    float avgeta = (cv[0].eta() + cv[2].eta())/2.0;
 			    float avgphi = (static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
 			    if((cv[0].phi() < cv[2].phi()) && (debug_>1)) edm::LogInfo("GammaJetAnalysis") << "pHB" << cv[0].phi() << " " << cv[2].phi();
@@ -1023,8 +1022,7 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 			  }
 			case HcalSubdetector::HcalEndcap:
 			  {
-			    const CaloCellGeometry *thisCell = HEGeom->getGeometry((*ith).id().rawId());
-			    const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
+			    CaloCellGeometry::CornersVec cv = HEGeom->getCorners((*ith).id());
 			    float avgeta = (cv[0].eta() + cv[2].eta())/2.0;
 			    float avgphi = (static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;
 			    if((cv[0].phi() < cv[2].phi()) && (debug_>1)) edm::LogInfo("GammaJetAnalysis") << "pHE" << cv[0].phi() << " " << cv[2].phi();
@@ -1060,7 +1058,7 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
 		for(edm::SortedCollection<HFRecHit,edm::StrictWeakOrdering<HFRecHit>>::const_iterator ith=hfreco->begin(); ith!=hfreco->end(); ++ith){
 		  if((*ith).id().depth() == 1) continue; // Remove long fibers
-		  const CaloCellGeometry *thisCell = HFGeom->getGeometry((*ith).id().rawId());
+		  const CaloCellGeometry *thisCell = HFGeom->getGeometry((*ith).id());
 		  const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
 		  
 		  bool passMatch = false;
@@ -1102,7 +1100,7 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 		
 		for(edm::SortedCollection<HFRecHit,edm::StrictWeakOrdering<HFRecHit>>::const_iterator ith=hfreco->begin(); ith!=hfreco->end(); ++ith){
 		  if((*ith).id().depth() == 2) continue; // Remove short fibers
-		  const CaloCellGeometry *thisCell = HFGeom->getGeometry((*ith).id().rawId());
+		  const CaloCellGeometry *thisCell = HFGeom->getGeometry((*ith).id());
 		  const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
 		  
 		  bool passMatch = false;
@@ -1178,7 +1176,7 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 			else{
 			  ppfjet_twr_candtrackind_.push_back(-1);
 			}
-			const CaloCellGeometry *thisCell = HOGeom->getGeometry((*ith).id().rawId());
+			const CaloCellGeometry *thisCell = HOGeom->getGeometry((*ith).id());
 			const CaloCellGeometry::CornersVec& cv = thisCell->getCorners();
 			float avgeta = (cv[0].eta() + cv[2].eta())/2.0;
 			float avgphi = (static_cast<double>(cv[0].phi()) + static_cast<double>(cv[2].phi()))/2.0;

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.h
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.h
@@ -41,6 +41,7 @@
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"

--- a/Geometry/CaloTopology/interface/HcalTopologyMode.h
+++ b/Geometry/CaloTopology/interface/HcalTopologyMode.h
@@ -1,5 +1,5 @@
 #ifndef CALO_TOPOLOGY_HCAL_TOPOLOGY_MODE_H
-# define CALO_TOPOLOGY_HCAL_TOPOLOGY_MODE_H
+#define CALO_TOPOLOGY_HCAL_TOPOLOGY_MODE_H
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include <map>

--- a/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
@@ -52,6 +52,7 @@ public:
 
   GlobalPoint                   getPosition(const DetId& id) const;
   GlobalPoint                   getBackPosition(const DetId& id) const;
+  CaloCellGeometry::CornersVec  getCorners(const DetId& id) const;
 
   static std::string producerTag() { return "HCAL" ; }
   

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -147,9 +147,9 @@ GlobalPoint HcalGeometry::getPosition(const DetId& id) const {
   if (!m_mergePosition) {
     return (getGeometry(id)->getPosition());
   } else {
-    std::vector<HcalDetId> ids;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
-    return (getGeometry(ids.front())->getPosition());
+    std::vector<HcalDetId> ids_;
+    m_topology.unmergeDepthDetId(HcalDetId(id),ids_);
+    return (getGeometry(ids_.front())->getPosition());
   }
 }
 
@@ -157,9 +157,26 @@ GlobalPoint HcalGeometry::getBackPosition(const DetId& id) const {
   if (!m_mergePosition) {
     return (getGeometry(id)->getBackPoint());
   } else {
-    std::vector<HcalDetId> ids;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
-    return (getGeometry(ids.back())->getBackPoint());
+    std::vector<HcalDetId> ids_;
+    m_topology.unmergeDepthDetId(HcalDetId(id),ids_);
+    return (getGeometry(ids_.back())->getBackPoint());
+  }
+}
+
+CaloCellGeometry::CornersVec HcalGeometry::getCorners(const DetId& id) const {
+  if (!m_mergePosition) {
+    return (getGeometry(id)->getCorners());
+  } else {
+    std::vector<HcalDetId> ids_;
+    m_topology.unmergeDepthDetId(HcalDetId(id),ids_);
+    CaloCellGeometry::CornersVec mcorners;
+    CaloCellGeometry::CornersVec mcf = getGeometry(ids_.front())->getCorners();
+    CaloCellGeometry::CornersVec mcb = getGeometry(ids_.back())->getCorners();
+    for (unsigned int k=0; k<8; ++k) {
+      mcorners[k]   = mcf[k];
+      mcorners[k+4] = mcb[k];
+    }
+    return mcorners;
   }
 }
 

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -147,9 +147,9 @@ GlobalPoint HcalGeometry::getPosition(const DetId& id) const {
   if (!m_mergePosition) {
     return (getGeometry(id)->getPosition());
   } else {
-    std::vector<HcalDetId> ids_;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids_);
-    return (getGeometry(ids_.front())->getPosition());
+    std::vector<HcalDetId> ids;
+    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
+    return (getGeometry(ids.front())->getPosition());
   }
 }
 
@@ -157,9 +157,9 @@ GlobalPoint HcalGeometry::getBackPosition(const DetId& id) const {
   if (!m_mergePosition) {
     return (getGeometry(id)->getBackPoint());
   } else {
-    std::vector<HcalDetId> ids_;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids_);
-    return (getGeometry(ids_.back())->getBackPoint());
+    std::vector<HcalDetId> ids;
+    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
+    return (getGeometry(ids.back())->getBackPoint());
   }
 }
 
@@ -167,11 +167,11 @@ CaloCellGeometry::CornersVec HcalGeometry::getCorners(const DetId& id) const {
   if (!m_mergePosition) {
     return (getGeometry(id)->getCorners());
   } else {
-    std::vector<HcalDetId> ids_;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids_);
+    std::vector<HcalDetId> ids;
+    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
     CaloCellGeometry::CornersVec mcorners;
-    CaloCellGeometry::CornersVec mcf = getGeometry(ids_.front())->getCorners();
-    CaloCellGeometry::CornersVec mcb = getGeometry(ids_.back())->getCorners();
+    CaloCellGeometry::CornersVec mcf = getGeometry(ids.front())->getCorners();
+    CaloCellGeometry::CornersVec mcb = getGeometry(ids.back())->getCorners();
     for (unsigned int k=0; k<4; ++k) {
       mcorners[k]   = mcf[k];
       mcorners[k+4] = mcb[k+4];

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -172,9 +172,9 @@ CaloCellGeometry::CornersVec HcalGeometry::getCorners(const DetId& id) const {
     CaloCellGeometry::CornersVec mcorners;
     CaloCellGeometry::CornersVec mcf = getGeometry(ids_.front())->getCorners();
     CaloCellGeometry::CornersVec mcb = getGeometry(ids_.back())->getCorners();
-    for (unsigned int k=0; k<8; ++k) {
+    for (unsigned int k=0; k<4; ++k) {
       mcorners[k]   = mcf[k];
-      mcorners[k+4] = mcb[k];
+      mcorners[k+4] = mcb[k+4];
     }
     return mcorners;
   }


### PR DESCRIPTION
Provide a few functions : getPosition, getCorners to HcalGeometry which can handle merged DetId's in addition to CaloCellGeometry functionalities. It does not affect any earlier functionalities