### PR TITLE
bsunanda:Run2-hcx111 Correct CaloTower code to account for merged RecHits due to Plan1

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
@@ -360,7 +360,7 @@ private:
   int              subdetOne;
   std::vector<std::pair<int,int>> phizOne;
 
-
+  std::vector<HcalDetId>          ids_;
 };
 
 #endif


### PR DESCRIPTION
RecHit for Plan 1 could be a combination of several DetID's and while accessing any condition information it is better be done with the first of the DetId's being used. This is being done in the AssignHit class for HCAL.