### PR TITLE
Revert Provenance Prefetching

### DIFF
--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -361,8 +361,6 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
@@ -505,8 +503,6 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
@@ -637,8 +633,6 @@ PathContext: pathName = e pathID = 0 (EndPath)
 ++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
 ++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
 ++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -379,6 +379,8 @@ namespace edm {
 
   void
   PoolOutputModule::preActionBeforeRunEventAsync(WaitingTask* iTask, ModuleCallingContext const& iModuleCallingContext, Principal const& iPrincipal) const {
+    /* For the moment, there appears to be a race condition when 
+      using this code.
     if(DropAll != dropMetaData_ ) {
       auto const* ep = dynamic_cast<EventPrincipal const*>(&iPrincipal);
       if(ep)
@@ -389,6 +391,7 @@ namespace edm {
         }
       }
     }
+     */
   }
 
   void


### PR DESCRIPTION
When running on very many threads it appears that the framework sometimes thinks the prefetching for the PoolOutputModule never finishes and therefore the module is never run. Until the problem is found, we need to not do the prefetching.

The problem was seen when running on KNL for 48 or 64 threads. Reverting only this part avoids large recompilation and allows the fix to be added with only minor recompilation later.