### PR TITLE
HBHE M3 = resynch offline with online setting

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMethod3Parameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMethod3Parameters_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 m3Parameters = cms.PSet(
     applyTimeSlewM3         = cms.bool(True),
     pedestalUpperLimit      = cms.double(2.7),
-    timeSlewParsType        = cms.int32(1),     # 0: TestStand, 1:Data, 2:MC, 3:InputPars. Parametrization function is par0 + par1*log(fC+par2).
+    timeSlewParsType        = cms.int32(3),     # 0: TestStand, 1:Data, 2:MC, 3:InputPars. Parametrization function is par0 + par1*log(fC+par2).
     timeSlewPars            = cms.vdouble(12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0), # HB par0, HB par1, HB par2, BE par0, BE par1, BE par2, HE par0, HE par1, HE par2
     respCorrM3              = cms.double(0.95) # This factor is used to align the the Method3 with the Method2 response
 )


### PR DESCRIPTION
This PR resynch the offline auxiliary information of the M3 with what is effectively runned in the HLT.
https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_0_pre4/HLTrigger/Configuration/python/customizeHLTforHCALPhaseI.py#L91

Doesn't change the M3 algo neither the HLT content. 
It only fix the content of the auxiliary information in the HBHE recHit, that is used as reference for any development and diagnose.

This is the effect 
http://dalfonso.web.cern.ch/dalfonso/M2M3_PRresynch.png
and the difference is traceable to a difference in the timeslew parameters.
As far as I can see this mismatch is there since 2015