### PR TITLE
[90X] AlCaRecoTriggerBits updates

### DIFF
--- a/CondTools/HLT/python/AlCaRecoTriggerBitsRcdUpdate_cfi.py
+++ b/CondTools/HLT/python/AlCaRecoTriggerBitsRcdUpdate_cfi.py
@@ -22,6 +22,14 @@ AlCaRecoTriggerBitsRcdUpdate = cms.EDAnalyzer(
       cms.PSet(listName = cms.string('TkAlMinBias'),
                hltPaths = cms.vstring('path_1', 'path_3')
                )
-      )
-
+      ),
+    
+    alcarecoToReplace = cms.VPSet(
+        cms.PSet(oldKey = cms.string('TkAlZMuMu'),
+                 newKey = cms.string('testKey1')
+                 ),
+        cms.PSet(oldKey = cms.string('TkAlMinBias'),
+                 newKey = cms.string('testKey2')
+                 )
+        )
     )

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -141,7 +141,8 @@ bool AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap(const std::vector<edm::Par
 {
   
   std::vector<std::pair<std::string,std::string> > keyPairs;
-  
+  keyPairs.reserve(alcarecoReplace.size());
+
   for(auto &iSet : alcarecoReplace ){
     const std::string oldKey(iSet.getParameter<std::string>("oldKey"));
     const std::string newKey(iSet.getParameter<std::string>("newKey"));

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -40,6 +40,8 @@ private:
   typedef std::map<std::string, std::string> TriggerMap;
   AlCaRecoTriggerBits* createStartTriggerBits(bool startEmpty, const edm::EventSetup& evtSetup) const;
   bool removeKeysFromMap(const std::vector<std::string> &keys, TriggerMap &triggerMap) const;
+  bool replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace,
+			  TriggerMap &triggerMap) const;
   bool addTriggerLists(const std::vector<edm::ParameterSet> &triggerListsAdd,
 		       AlCaRecoTriggerBits &bits) const;
   /// Takes over memory uresponsibility for 'bitsToWrite'. 
@@ -51,6 +53,7 @@ private:
   const bool startEmpty_; 
   const std::vector<std::string> listNamesRemove_;
   const std::vector<edm::ParameterSet> triggerListsAdd_;
+  const std::vector<edm::ParameterSet> alcarecoReplace_; 
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -63,7 +66,8 @@ AlCaRecoTriggerBitsRcdUpdate::AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterS
     lastRunIOV_(cfg.getParameter<int>("lastRunIOV")),
     startEmpty_(cfg.getParameter<bool>("startEmpty")),
     listNamesRemove_(cfg.getParameter<std::vector<std::string> >("listNamesRemove")),
-    triggerListsAdd_(cfg.getParameter<std::vector<edm::ParameterSet> >("triggerListsAdd"))
+    triggerListsAdd_(cfg.getParameter<std::vector<edm::ParameterSet> >("triggerListsAdd")),
+    alcarecoReplace_(cfg.getParameter<std::vector<edm::ParameterSet> >("alcarecoToReplace"))
 {
 }
   
@@ -86,6 +90,9 @@ void AlCaRecoTriggerBitsRcdUpdate::analyze(const edm::Event& evt, const edm::Eve
 
   // now add new entries
   this->addTriggerLists(triggerListsAdd_, *bitsToWrite);
+
+  // now replace keys 
+  this->replaceKeysFromMap(alcarecoReplace_,bitsToWrite->m_alcarecoToTrig);
 
   // finally write to DB
   this->writeBitsToDB(bitsToWrite);
@@ -122,6 +129,34 @@ bool AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap(const std::vector<std::stri
       throw cms::Exception("BadConfig") << "[AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap] "
 					<< "Cannot remove key '" << *iKey << "' since not in "
 					<< "list - typo in configuration?\n";
+      return false;
+    }
+  }
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////
+bool AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace,
+						      TriggerMap &triggerMap) const
+{
+  
+  std::vector<std::pair<std::string,std::string> > keyPairs;
+  
+  for(auto &iSet : alcarecoReplace ){
+    const std::string oldKey(iSet.getParameter<std::string>("oldKey"));
+    const std::string newKey(iSet.getParameter<std::string>("newKey"));
+    keyPairs.push_back(std::make_pair(oldKey,newKey));
+  }
+
+  for(auto& iKey : keyPairs){
+    if(triggerMap.find(iKey.first) != triggerMap.end() ){
+      std::string bitsToReplace = triggerMap[iKey.first];
+      triggerMap.erase(iKey.first);
+      triggerMap[iKey.second] = bitsToReplace;
+    } else { // not in list ==> misconfiguration!
+      edm::LogWarning("AlCaRecoTriggerBitsRcdUpdate") << "[AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap] "
+						      << "Cannot replace key '" << iKey.first << "with " << iKey.second << " since not in "
+						      << "list - typo in configuration?\n";
       return false;
     }
   }

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing 
+
+process = cms.Process("READ")
+
+options = VarParsing.VarParsing()
+options.register( "inputDB", 
+                  "frontier://FrontierProd/CMS_CONDITIONS",  #default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,
+                  "the input DB"
+                  )
+
+options.register( "inputTag", 
+                  "AlCaRecoHLTpaths8e29_1e31_v7_hlt",  #default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,
+                  "the input tag"
+                  )
+
+options.parseArguments()
+
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr = cms.untracked.PSet(placeholder = cms.untracked.bool(True))
+process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(1000)
+    ))
+
+# the module writing to DB
+process.load("CondTools.HLT.AlCaRecoTriggerBitsRcdRead_cfi")
+# 'twiki' is default - others are text, python (future: html?)
+#process.AlCaRecoTriggerBitsRcdRead.outputType = 'twiki'
+# If rawFileName stays empty (default), use the message logger for output.
+# Otherwise use the file name specified, adding a suffix according to outputType:
+process.AlCaRecoTriggerBitsRcdRead.rawFileName = 'triggerBits'+options.inputTag
+
+# No data, but might want to specify the 'firstRun' to check (default is 1):
+process.source = cms.Source("EmptySource",
+                            numberEventsInRun = cms.untracked.uint32(1), # do not change!
+                            firstRun = cms.untracked.uint32(1)
+                            )
+# With 'numberEventsInRun = 1' above,
+# this will check IOVs until run (!) number specified as 'input' here,
+# so take care to choose a one that is not too small...:
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(500000) )
+
+# Input for AlCaRecoTriggerBitsRcd,
+# either via GlobalTag
+# (loading of Configuration.StandardSequences.CondDBESSource_cff equivalent to CondCore.ESSources.CondDBESSource_cfi
+# as entry point for condition records in the EventSetup,
+# but sufficient and faster than Configuration.StandardSequences.FrontierConditions_GlobalTag_cff):
+#from Configuration.AlCa.autoCond import autoCond
+#process.load("Configuration.StandardSequences.CondDBESSource_cff")
+#process.GlobalTag.globaltag = autoCond['run2_data'] #choose your tag
+
+# ...or specify database and tag:  
+from CondCore.CondDB.CondDB_cfi import *
+#CondDBTriggerBits = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_COND_31X_HLT'))
+CondDBTriggerBits = CondDB.clone(connect = cms.string(options.inputDB))
+process.dbInput = cms.ESSource("PoolDBESSource",
+                              CondDBTriggerBits,
+                              toGet = cms.VPSet(cms.PSet(record = cms.string('AlCaRecoTriggerBitsRcd'),
+                                                         tag = cms.string(options.inputTag) # choose tag you want
+                                                         )
+                                                )
+                              )
+
+# Put module in path:
+process.p = cms.Path(process.AlCaRecoTriggerBitsRcdRead)

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
@@ -24,7 +24,7 @@ process.source = cms.Source("EmptySource",
 # With 'numberEventsInRun = 1' above,
 # this will check IOVs until run (!) number specified as 'input' here,
 # so take care to choose a one that is not too small...:
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(250000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(350000) )
 
 # Input for AlCaRecoTriggerBitsRcd,
 # either via GlobalTag

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_TEMPL_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_TEMPL_cfg.py
@@ -1,0 +1,139 @@
+# Config file template to write new/update AlCaRecoTriggerBits stored
+# in AlCaRecoTriggerBitsRcd that is used to get selected HLT paths for
+# the HLTHighLevel filter for AlCaReco production.
+#
+# Please understand that there are two IOVs involved:
+# 1) One for the output tag. Here the usually used default is 1->inf,
+#    changed by process.AlCaRecoTriggerBitsRcdUpdate.firstRunIOV
+#    and process.AlCaRecoTriggerBitsRcdUpdate.lastRunIOV.
+# 2) The IOV of the tag of the input AlCaRecoTriggerBitsRcd.
+#    That is chosen by process.source.firstRun (but irrelevant if 
+#    process.AlCaRecoTriggerBitsRcdUpdate.startEmpty = True)
+#
+# See also further comments below, especially the WARNING.
+#
+#  Author    : Gero Flucke
+#  Date      : February 2009
+#  $Revision: 1.3 $
+#  $Date: 2009/04/21 14:42:50 $
+#  (last update by $Author: flucke $)
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing 
+
+process = cms.Process("UPDATEDB")
+
+options = VarParsing.VarParsing()
+options.register( "inputDB", 
+                  "frontier://FrontierProd/CMS_CONDITIONS",  #default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,
+                  "the input DB"
+                  )
+
+options.register( "inputTag", 
+                  "AlCaRecoHLTpaths8e29_1e31_v7_hlt",  #default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,
+                  "the input tag"
+                  )
+
+options.register( "outputDB", 
+                  "sqlite_file:AlCaRecoTriggerBits.db",  #default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,
+                  "the output DB"
+                  )
+
+options.register( "outputTag", 
+                  "testTag",  #default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,
+                  "the input DB"
+                  )
+
+options.register( "firstRun", 
+                  1,  #default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.int,
+                  "the first run"
+                  )
+
+options.parseArguments()
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr = cms.untracked.PSet(placeholder = cms.untracked.bool(True))
+process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(1)
+    ))
+
+# the module writing to DB
+process.load("CondTools.HLT.AlCaRecoTriggerBitsRcdUpdate_cfi")
+# The IOV that you want to write out, defaut is 1 to -1/inf. 
+process.AlCaRecoTriggerBitsRcdUpdate.firstRunIOV = options.firstRun # docu see...
+#process.AlCaRecoTriggerBitsRcdUpdate.lastRunIOV = -1 # ...cfi
+# If you want to start from scratch, comment the next line:
+process.AlCaRecoTriggerBitsRcdUpdate.startEmpty = False
+# In case you want to remove 'keys', use this possibly comma separated list.
+# Also if you want to replace settings for one 'key', you have to remove it first.
+#process.AlCaRecoTriggerBitsRcdUpdate.listNamesRemove = ["SiStripCalZeroBias"]
+# Here specifiy 'key' and corresponding paths for new entries or updated ones:
+# process.AlCaRecoTriggerBitsRcdUpdate.triggerListsAdd = [
+#     cms.PSet(listName = cms.string('AlCaEcalTrg'), # to be updated
+#              hltPaths = cms.vstring('AlCa_EcalPhiSym*')
+#              )
+#     ]
+
+process.AlCaRecoTriggerBitsRcdUpdate.triggerListsAdd = []
+process.AlCaRecoTriggerBitsRcdUpdate.alcarecoToReplace = [
+    cms.PSet(oldKey = cms.string('SiStripCalMinBiasAfterAbortGap'),
+             newKey = cms.string('SiStripCalMinBiasAAG')
+             )
+    ]
+
+# No data, but have to specify run number if you do not want 1, see below:
+process.source = cms.Source("EmptySource",
+                            #numberEventsInRun = cms.untracked.uint32(1),
+                            firstRun = cms.untracked.uint32(options.firstRun) # 1 is default
+                            )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+# DB input - needed only for AlCaRecoTriggerBitsRcdUpdate.startEmpty = False
+# WARNING:
+# Take care in case the input tag has several IOVs: The run number that will be 
+# used to define which payload you get is defined by the run number in the
+# EmptySource above!
+# Either a global tag...
+# from Configuration.AlCa.autoCond import autoCond
+# process.load("Configuration.StandardSequences.CondDBESSource_cff")
+# process.GlobalTag.globaltag = autoCond['run2_data'] #choose your tag
+
+# ...or (recommended since simpler) directly from DB/sqlite
+
+process.load("CondCore.CondDB.CondDB_cfi")
+
+# DB input service: 
+process.CondDB.connect = options.inputDB
+process.dbInput = cms.ESSource("PoolDBESSource",
+                               process.CondDB,
+                               toGet = cms.VPSet(cms.PSet(record = cms.string('AlCaRecoTriggerBitsRcd'),
+                                                          tag = cms.string(options.inputTag)
+                                                          )
+                                                 )
+                               )
+
+# DB output service:
+process.CondDB.connect = options.outputDB
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('AlCaRecoTriggerBitsRcd'),
+                                                                     tag = cms.string(options.outputTag) # choose output tag you want
+                                                                     )
+                                                            )
+                                          )
+
+# Put module in path:
+process.p = cms.Path(process.AlCaRecoTriggerBitsRcdUpdate)
+
+

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_TEMPL_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_TEMPL_cfg.py
@@ -12,11 +12,8 @@
 #
 # See also further comments below, especially the WARNING.
 #
-#  Author    : Gero Flucke
-#  Date      : February 2009
-#  $Revision: 1.3 $
-#  $Date: 2009/04/21 14:42:50 $
-#  (last update by $Author: flucke $)
+#  Author    : Marco Musich
+#  Date      : Feb 2016
 
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing 

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
@@ -65,34 +65,37 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 # EmptySource above!
 # Either a global tag...
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-# process.GlobalTag.globaltag = "DESIGN_3X_V13::All" # may choose non-default tag
+# process.GlobalTag.globaltag = "90X_dataRun2_Express_v0" # may choose non-default tag
 # ...or (recommended since simpler) directly from DB/sqlite
-import CondCore.DBCommon.CondDBSetup_cfi
+
+process.load("CondCore.CondDB.CondDB_cfi")
+
+# from local sqlite file
+#process.CondDB.connect = 'sqlite_file:AlCaRecoTriggerBits.db'
+# from conditons Database
+process.CondDB.connect = 'frontier://FrontierProd/CMS_CONDITIONS'
+ 
 process.dbInput = cms.ESSource(
     "PoolDBESSource",
-    CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup,
-    #    connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'),
-    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('AlCaRecoTriggerBitsRcd'),
-        #        tag = cms.string('TestTag') # choose tag to update
-        tag = cms.string('AlCaRecoHLTpaths8e29_1e31_v7_hlt')
-        )
+    process.CondDB,
+    toGet = cms.VPSet(cms.PSet(record = cms.string('AlCaRecoTriggerBitsRcd'),
+                               # tag = cms.string('TestTag') # choose tag to update
+                               tag = cms.string('AlCaRecoHLTpaths8e29_1e31_v7_hlt')
+                               )
                       )
     )
 
 # DB output service:
-import CondCore.DBCommon.CondDBSetup_cfi
+process.CondDB.connect = 'sqlite_file:AlCaRecoTriggerBits.db'
+#process.CondDB.connect = 'sqlite_file:AlCaRecoTriggerBitsUpdate.db'
+
 process.PoolDBOutputService = cms.Service(
     "PoolDBOutputService",
-    CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup,
+    process.CondDB,
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'),
-    #    connect = cms.string('sqlite_file:AlCaRecoTriggerBitsUpdate.db'),
-    toPut = cms.VPSet(cms.PSet(
-        record = cms.string('AlCaRecoTriggerBitsRcd'),
-        tag = cms.string('TestTag') # choose output tag you want
-        )
+    toPut = cms.VPSet(cms.PSet(record = cms.string('AlCaRecoTriggerBitsRcd'),
+                               tag = cms.string('TestTag') # choose output tag you want
+                               )
                       )
     )
 

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
@@ -48,6 +48,9 @@ process.AlCaRecoTriggerBitsRcdUpdate.triggerListsAdd = [
              hltPaths = cms.vstring())
     ]
 
+# Here specify the 'keys' to be replaced 
+process.AlCaRecoTriggerBitsRcdUpdate.alcarecoToReplace = []
+
 # No data, but have to specify run number if you do not want 1, see below:
 process.source = cms.Source("EmptySource",
                             #numberEventsInRun = cms.untracked.uint32(1),
@@ -68,11 +71,11 @@ import CondCore.DBCommon.CondDBSetup_cfi
 process.dbInput = cms.ESSource(
     "PoolDBESSource",
     CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup,
-#    connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'),
+    #    connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'),
     connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('AlCaRecoTriggerBitsRcd'),
-#        tag = cms.string('TestTag') # choose tag to update
+        #        tag = cms.string('TestTag') # choose tag to update
         tag = cms.string('AlCaRecoHLTpaths8e29_1e31_v7_hlt')
         )
                       )
@@ -85,14 +88,13 @@ process.PoolDBOutputService = cms.Service(
     CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup,
     timetype = cms.untracked.string('runnumber'),
     connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'),
-#    connect = cms.string('sqlite_file:AlCaRecoTriggerBitsUpdate.db'),
+    #    connect = cms.string('sqlite_file:AlCaRecoTriggerBitsUpdate.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('AlCaRecoTriggerBitsRcd'),
         tag = cms.string('TestTag') # choose output tag you want
         )
                       )
     )
-
 
 # Put module in path:
 process.p = cms.Path(process.AlCaRecoTriggerBitsRcdUpdate)

--- a/CondTools/HLT/test/README.md
+++ b/CondTools/HLT/test/README.md
@@ -16,5 +16,5 @@ Options available:
 
 ## TO READ BACK
 ```
-cmsRun AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py inputDB=AlCaRecoHLTpaths_TEST.db inputTag=AlCaRecoHLTpaths_TEST
+cmsRun AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py inputDB=sqlite_file:AlCaRecoHLTpaths_TEST.db inputTag=AlCaRecoHLTpaths_TEST
 ```

--- a/CondTools/HLT/test/README.md
+++ b/CondTools/HLT/test/README.md
@@ -1,0 +1,20 @@
+Commands to run the workflow multi-IOV:
+
+## TO UPDATE
+```
+python run_wf.py -f frontier://PromptProd/CMS_CONDITIONS -i AlCaRecoHLTpaths8e29_1e31_v24_offline -d AlCaRecoHLTpaths_TEST
+```
+
+will create an update sqlite file called `AlCaRecoHLTpaths_TEST.db` with an updated tag ` AlCaRecoHLTpaths_TEST` (the same IOV structure will be preserved)
+
+Options available:
+   * `-f` specifies connection (allows both condDB and sqlite files)
+   * `-i` specifies input tag
+   * `-d` specifies the output tag
+   * `[-C]` (optional) if set to false leaves transient files IOV-by-IOV
+
+
+## TO READ BACK
+```
+cmsRun AlCaRecoTriggerBitsRcdRead_TEMPL_cfg.py inputDB=AlCaRecoHLTpaths_TEST.db inputTag=AlCaRecoHLTpaths_TEST
+```

--- a/CondTools/HLT/test/run_wf.py
+++ b/CondTools/HLT/test/run_wf.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+"""
+Example script to test reading from local sqlite db.
+"""
+import os
+import sys
+import ast
+import optparse
+import hashlib
+import tarfile
+import netrc
+import getpass
+import errno
+import sqlite3
+import json
+import tempfile
+from CondCore.Utilities.CondDBFW import querying
+
+##############################################
+def getCommandOutput(command):
+##############################################
+    """This function executes `command` and returns it output.
+    Arguments:
+    - `command`: Shell command to be invoked by this function.
+    """
+    child = os.popen(command)
+    data = child.read()
+    err = child.close()
+    if err:
+        print '%s failed w/ exit code %d' % (command, err)
+    return data
+
+##############################################
+def main():
+##############################################
+     
+     defaultFile  = 'mySqlite.db'
+     defaultInTag = 'myInTag'
+     defaultOutTag= 'myOutTag'
+
+     parser = optparse.OptionParser(usage = 'Usage: %prog [options] <file> [<file> ...]\n')
+     
+     parser.add_option('-f', '--file',
+                       dest = 'file',
+                       default = defaultFile,
+                       help = 'file to inspect',
+                       )
+     
+     parser.add_option('-i', '--inputTag',
+                       dest = 'InputTag',
+                       default = defaultInTag,
+                       help = 'tag to be inspected',
+                       )
+
+     parser.add_option('-d', '--destTag',
+                       dest = 'destTag',
+                       default = defaultOutTag,
+                       help = 'tag to be written',
+                       )
+
+     parser.add_option('-C', '--clean',
+                       dest = 'doTheCleaning',
+                       default = True,
+                       help = 'if true remove the transient files',
+                       )
+
+     (options, arguments) = parser.parse_args()
+
+     sqlite_db_url = options.file
+     db = sqlite3.connect(sqlite_db_url)
+     cursor = db.cursor()
+     cursor.execute("SELECT * FROM IOV;")
+     IOVs = cursor.fetchall()
+     sinces = []
+
+     for element in IOVs:
+          sinces.append(element[1])
+
+     print sinces
+
+     for i,since in enumerate(sinces):
+          #print i,since
+
+          print "============================================================"
+          if(i<len(sinces)-1):
+               command = 'conddb_import -c sqlite_file:'+sqlite_db_url.rstrip(".db")+"_IOV_"+str(sinces[i])+'.db -f sqlite_file:'+sqlite_db_url+" -i "+options.InputTag+" -t "+options.InputTag+" -b "+str(sinces[i])+" -e "+str(sinces[i+1]-1)
+               print command
+               getCommandOutput(command)
+          else:
+               command = 'conddb_import -c sqlite_file:'+sqlite_db_url.rstrip(".db")+"_IOV_"+str(sinces[i])+'.db -f sqlite_file:'+sqlite_db_url+" -i "+options.InputTag+" -t "+options.InputTag+" -b "+str(sinces[i])
+               print command
+               getCommandOutput(command)
+               
+          # update the trigger bits
+
+          cmsRunCommand="cmsRun AlCaRecoTriggerBitsRcdUpdate_TEMPL_cfg.py inputDB=sqlite_file:"+sqlite_db_url.rstrip(".db")+"_IOV_"+str(sinces[i])+".db inputTag="+options.InputTag+" outputDB=sqlite_file:"+sqlite_db_url.rstrip(".db")+"_IOV_"+str(sinces[i])+"_updated.db outputTag="+options.destTag+" firstRun="+str(sinces[i])
+          print cmsRunCommand
+          getCommandOutput(cmsRunCommand)
+     
+          # merge the output
+          
+          mergeCommand = 'conddb_import -f sqlite_file:'+sqlite_db_url.rstrip(".db")+"_IOV_"+str(sinces[i])+'_updated.db -c sqlite_file:'+options.destTag+".db -i "+options.destTag+" -t "+options.destTag+" -b "+str(sinces[i])
+          print mergeCommand
+          getCommandOutput(mergeCommand)
+
+          # clean the house
+     
+          if(ast.literal_eval(options.doTheCleaning)):
+              cleanCommand = 'rm -fr *updated*.db *IOV_*.db'
+              getCommandOutput(cleanCommand)
+          else:
+              print "======> keeping the transient files"
+          
+
+if __name__ == "__main__":        
+     main()


### PR DESCRIPTION
Greetings, in this PR:
   * allow the key replacement feature (leaving the list of attached trigger bit unchanged)
   * add a python wrapper script that allows the handling of multi-IOV changes in a single call (supports both condition DB and local sqlite file inputs)
   * refresh the configuration files in the `CondTools/HLT` folder to avoid warnings
   * add instructions to use the mult-IOV workflow