### PR TITLE
[90X] Add Lumiscaler information in shallow tree producer

### DIFF
--- a/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+#include "DataFormats/Scalers/interface/LumiScalers.h"
 #include <string>
 
 class ShallowEventDataProducer : public edm::EDProducer {
@@ -12,6 +13,7 @@ class ShallowEventDataProducer : public edm::EDProducer {
  private: 
   void produce( edm::Event &, const edm::EventSetup & );
 	edm::EDGetTokenT< L1GlobalTriggerReadoutRecord > trig_token_;
+	edm::EDGetTokenT< LumiScalersCollection > scalerToken_; 
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/python/ShallowEventDataProducer_cfi.py
+++ b/CalibTracker/SiStripCommon/python/ShallowEventDataProducer_cfi.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 shallowEventRun = cms.EDProducer(
    "ShallowEventDataProducer",
-   trigRecord = cms.InputTag('gtDigis')
+   trigRecord = cms.InputTag('gtDigis'),
+   lumiScalers = cms.InputTag("scalersRawToDigi")
    )


### PR DESCRIPTION
Greeting,
this is a follow-up of https://github.com/cms-sw/cmssw/pull/17419 in which some useful products stored in the `LumiScalers`  are added to the event content of SiStrip calibration trees.
Tested on a privately produced `SiStripCalMinBias` sample via:
`runTheMatrix.py -l 136.772 --command='-n 100'`
to create appropriate branches:

![screenshot 2017-02-20 14 11 29](https://cloud.githubusercontent.com/assets/5082376/23126377/a36e59f2-f776-11e6-9e6e-0654215675e9.png)

![screenshot 2017-02-20 14 12 17](https://cloud.githubusercontent.com/assets/5082376/23126378/a5cc7c38-f776-11e6-8a0d-38c315c3c4e5.png)

attn: @dimattia 

