### PR TITLE
wrap filters on end paths in cms.ignore

### DIFF
--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
@@ -83,7 +83,7 @@ caloMetDQMAnalyzerMC=caloMetDQMAnalyzer.clone(JetCorrections    = cms.InputTag("
 pfMetDQMAnalyzerMC=pfMetDQMAnalyzer.clone(JetCorrections      = cms.InputTag("dqmAk4PFL1FastL2L3Corrector"))
 pfMetT1DQMAnalyzerMC=pfMetT1DQMAnalyzer.clone(JetCorrections    = cms.InputTag("dqmAk4PFCHSL1FastL2L3Corrector"))
 
-jetMETDQMOfflineSource = cms.Sequence(goodOfflinePrimaryVerticesDQM*AnalyzeSUSYDQM*QGTagger*
+jetMETDQMOfflineSource = cms.Sequence(cms.ignore(goodOfflinePrimaryVerticesDQM)*AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -105,7 +105,7 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*
                                       dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
-                                      cms.clone(goodOfflinePrimaryVerticesDQM)*                                                                            
+                                      cms.ignore(goodOfflinePrimaryVerticesDQM)*                                                                            
                                       dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*
                                       cms.ignore(CSCTightHaloFilterDQM)*cms.ignore(CSCTightHalo2015FilterDQM)*cms.ignore(eeBadScFilterDQM)*cms.ignore(EcalDeadCellTriggerPrimitiveFilterDQM)*cms.ignore(EcalDeadCellBoundaryEnergyFilterDQM)*cms.ignore(HcalStripHaloFilterDQM)                                      
                                       *METDQMAnalyzerSequence
@@ -113,6 +113,6 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
-jetMETDQMOfflineRedoProductsMiniAOD = cms.Sequence(goodOfflinePrimaryVerticesDQMforMiniAOD)
+jetMETDQMOfflineRedoProductsMiniAOD = cms.Sequence(cms.ignore(goodOfflinePrimaryVerticesDQMforMiniAOD))
 
 jetMETDQMOfflineSourceMiniAOD = cms.Sequence(jetDQMAnalyzerSequenceMiniAOD*METDQMAnalyzerSequenceMiniAOD*packedCandidateDQMAnalyzerMiniAOD)

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -105,9 +105,9 @@ jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
                                       jetPreDQMSeq*
                                       dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
-                                      goodOfflinePrimaryVerticesDQM*                                                                            
+                                      cms.clone(goodOfflinePrimaryVerticesDQM)*                                                                            
                                       dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*
-                                      CSCTightHaloFilterDQM*CSCTightHalo2015FilterDQM*eeBadScFilterDQM*EcalDeadCellTriggerPrimitiveFilterDQM*EcalDeadCellBoundaryEnergyFilterDQM*HcalStripHaloFilterDQM                                      
+                                      cms.ignore(CSCTightHaloFilterDQM)*cms.ignore(CSCTightHalo2015FilterDQM)*cms.ignore(eeBadScFilterDQM)*cms.ignore(EcalDeadCellTriggerPrimitiveFilterDQM)*cms.ignore(EcalDeadCellBoundaryEnergyFilterDQM)*cms.ignore(HcalStripHaloFilterDQM)                                      
                                       *METDQMAnalyzerSequence
                                       *pfCandidateDQMAnalyzer)
 

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealData_cff.py
@@ -57,8 +57,8 @@ for newAttr in newProcAttributes:
 
 
 produceDenominatorRealData = cms.Sequence(
-      kinematicSelectedPFJets *
-      PFJetsId *
+      cms.ignore(kinematicSelectedPFJets) *
+      cms.ignore(PFJetsId) *
       CleanedPFJets
       )
 

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealElectronsData_cff.py
@@ -130,9 +130,9 @@ newProcAttributes = filter( lambda x: (x not in procAttributes) and (x.find('Rea
 for newAttr in newProcAttributes:
     locals()[newAttr] = getattr(proc,newAttr)
 
-produceDenominatorRealElectronsData = cms.Sequence( ElPrimaryVertexFilter * ElBestPV *
-                                                    ( (selectedElectrons * ElectronsFromPV * idElectrons * trackElectrons * isolatedElectrons) +
-                                                      (ElGoodTracks * ElIsoTracks * ElTrackFromPV * ElTrackCands) ) *
+produceDenominatorRealElectronsData = cms.Sequence( cms.ignore(ElPrimaryVertexFilter) * ElBestPV *
+                                                    ( (cms.ignore(selectedElectrons) * ElectronsFromPV * cms.ignore(idElectrons) * cms.ignore(trackElectrons) * cms.ignore(isolatedElectrons)) +
+                                                      (cms.ignore(ElGoodTracks) * ElIsoTracks * ElTrackFromPV * ElTrackCands) ) *
                                                     ZeeCandElectronTrack *
                                                     BestZee *
                                                     ElZLegs 

--- a/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
+++ b/Validation/RecoTau/python/dataTypes/ValidateTausOnRealMuonsData_cff.py
@@ -113,9 +113,9 @@ for newAttr in newProcAttributes:
     locals()[newAttr] = getattr(proc,newAttr)
 
 produceDenominatorRealMuonsData = cms.Sequence(
-                            MuPrimaryVertexFilter * MuBestPV *
-                            ( ( selectedMuons * selectedMuonsIso * MuonsFromPV ) +
-                              ( MuGoodTracks * MuIsoTracks * MuTrackFromPV * MuTrackCands ) ) *
+                            cms.ignore(MuPrimaryVertexFilter) * MuBestPV *
+                            ( ( cms.ignore(selectedMuons) * cms.ignore(selectedMuonsIso) * MuonsFromPV ) +
+                              ( cms.ignore(MuGoodTracks) * MuIsoTracks * MuTrackFromPV * MuTrackCands ) ) *
                             ZmmCandMuonTrack *
                             BestZmm *
                             MuZLegs 


### PR DESCRIPTION
this should reduce the noise at start of jobs. the tracking sequences are less obvious so maybe @makortel can help there

%MSG
%MSG-w FilterOnEndPath:  AfterModConstruction 20-Feb-2017 17:01:58 CET  pre-events
The EDFilter 'TrackSelector' with module label 'highPurityPtRange0to1' appears on EndPath 'dqmoffline_step'.
The return value of the filter will be ignored.
To suppress this warning, either remove the filter from the endpath,
or explicitly ignore it in the configuration by using cms.ignore().

%MSG
