### PR TITLE
HCAL dqm updates 

### DIFF
--- a/DQM/HcalTasks/python/OfflineSourceSequence_cosmic.py
+++ b/DQM/HcalTasks/python/OfflineSourceSequence_cosmic.py
@@ -39,7 +39,9 @@ hcalOfflineSourceSequence = cms.Sequence(
 	+rawTask)
 
 _phase1_hcalOfflineSourceSequence = hcalOfflineSourceSequence.copy() 
-_phase1_hcalOfflineSourceSequence.insert(0,digiPhase1Task)
+#_phase1_hcalOfflineSourceSequence.insert(0,digiPhase1Task)
+_phase1_hcalOfflineSourceSequence.remove(recHitTask)
+_phase1_hcalOfflineSourceSequence.remove(digiTask)
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toReplaceWith( hcalOfflineSourceSequence, _phase1_hcalOfflineSourceSequence )

--- a/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
+++ b/DQM/HcalTasks/python/OfflineSourceSequence_pp.py
@@ -29,13 +29,17 @@ hcalOfflineSourceSequence = cms.Sequence(
 	+rawTask)
 
 _phase1_hcalOfflineSourceSequence = hcalOfflineSourceSequence.copy()
-_phase1_hcalOfflineSourceSequence.insert(0,digiPhase1Task)
+#_phase1_hcalOfflineSourceSequence.insert(0,digiPhase1Task)
+_phase1_hcalOfflineSourceSequence.remove(digiTask)
+_phase1_hcalOfflineSourceSequence.remove(recHitTask)
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toReplaceWith( hcalOfflineSourceSequence, _phase1_hcalOfflineSourceSequence )
 
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-_phase2_hcalOfflineSourceSequence = hcalOfflineSourceSequence.copyAndExclude([digiTask,tpTask,rawTask])
+#for now there is nothing left...
+#_phase2_hcalOfflineSourceSequence = hcalOfflineSourceSequence.copyAndExclude([digiTask,tpTask,rawTask])
+_phase2_hcalOfflineSourceSequence = cms.Sequence(recHitTask)
 phase2_hcal.toReplaceWith(hcalOfflineSourceSequence, _phase2_hcalOfflineSourceSequence)
 phase2_hcal.toModify(digiPhase1Task,
     tagHBHE = cms.untracked.InputTag("simHcalDigis","HBHEQIE11DigiCollection"),


### PR DESCRIPTION
removing printouts that indicate likely issues with histogram construction of plan0/plan1 scenarios using method suggested by hcal dpg. Checked for both pp and cosmics scenarios as these are what should be working in the short term.

See #17335 