### PR TITLE
fixing the absence of const specifiers

### DIFF
--- a/DQM/HcalCommon/interface/Mapper.h
+++ b/DQM/HcalCommon/interface/Mapper.h
@@ -27,14 +27,14 @@ namespace hcaldqm
 				{}
 				virtual ~Mapper() {}
 
-				virtual uint32_t getHash(HcalDetId const&) {return 0;}
-				virtual uint32_t getHash(HcalElectronicsId const&) {return 0;}
-				virtual uint32_t getHash(HcalTrigTowerDetId const&) {return 0;}
+				virtual uint32_t getHash(HcalDetId const&) const{return 0;}
+				virtual uint32_t getHash(HcalElectronicsId const&) const {return 0;}
+				virtual uint32_t getHash(HcalTrigTowerDetId const&) const {return 0;}
 
-				virtual std::string getName(HcalDetId const&) {return "";}
-				virtual std::string getName(HcalElectronicsId const&) 
+				virtual std::string getName(HcalDetId const&) const {return "";}
+				virtual std::string getName(HcalElectronicsId const&) const 
 				{return "";}
-				virtual std::string getName(HcalTrigTowerDetId const&)
+				virtual std::string getName(HcalTrigTowerDetId const&) const
 				{return "";}
 
 			protected:


### PR DESCRIPTION
fixes warnings observed in https://github.com/cms-sw/cmssw/pull/17335
it is the result of https://github.com/cms-sw/cmssw/pull/17015

mismatch in function declaration between base and derived.
this pr fixes that

VK