### PR TITLE
bsunanda:Run2 hcx112 Codes modified to make Plan1 workflow to run

### DIFF
--- a/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
+++ b/DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h
@@ -105,6 +105,8 @@ class HcalRecHitsAnalyzer : public DQMEDAnalyzer {
   int iz;
   int imc;
 
+  //Hcal topology
+  const HcalTopology* theHcalTopology;
   // for checking the status of ECAL and HCAL channels stored in the DB 
   const HcalChannelQuality* theHcalChStatus;
   // calculator of severety level for HCAL

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -1,5 +1,6 @@
 #include "DQMOffline/Hcal/interface/HcalRecHitsAnalyzer.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 HcalRecHitsAnalyzer::HcalRecHitsAnalyzer(edm::ParameterSet const& conf) {
@@ -474,6 +475,11 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const& ev, edm::EventSetup const& c
 
   //   previously was:  c.get<IdealGeometryRecord>().get (geometry);
   c.get<CaloGeometryRecord>().get (geometry);
+
+  // HCAL Topology **************************************************
+  edm::ESHandle<HcalTopology> topo;
+  c.get<HcalRecNumberingRecord>().get(topo);
+  theHcalTopology = topo.product();
 
   // HCAL channel status map ****************************************
   edm::ESHandle<HcalChannelQuality> hcalChStatus;
@@ -1037,7 +1043,10 @@ double HcalRecHitsAnalyzer::dPhiWsign(double phi1, double phi2) {
 
 int HcalRecHitsAnalyzer::hcalSevLvl(const CaloRecHit* hit){
 
-   const DetId id = hit->detid();
+   HcalDetId id = hit->detid();
+   if (theHcalTopology->withSpecialRBXHBHE() && id.subdet() == HcalEndcap) {
+     id = theHcalTopology->idFront(id);
+   }
 
    const uint32_t recHitFlag = hit->flags();
    const uint32_t dbStatusFlag = theHcalChStatus->getValues(id)->getValue();

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -54,6 +54,10 @@ public:
   bool validHcal(const HcalDetId& id) const;
   bool validDetId(HcalSubdetector subdet, int ieta, int iphi, int depth) const;
   bool validHT(const HcalTrigTowerDetId& id) const;
+  /** Is this a valid cell in context of Plan1 */
+  bool validHcal(const HcalDetId& id, const unsigned int flag) const;
+  /** Flag=0 for unmerged Id's; =1 for for merged Id's; =2 for either */
+
   /** Get the neighbors of the given cell in east direction*/
   virtual std::vector<DetId> east(const DetId& id) const;
   /** Get the neighbors of the given cell in west direction*/
@@ -162,6 +166,8 @@ public:
 			  std::vector<HcalDetId>& ids) const {
     hcons_->unmergeDepthDetId(id, ids);
   }
+  // Returns the DetId of the front Id if it is a merged RecHit in "Plan 1"
+  HcalDetId idFront(const HcalDetId& id) const {return hcons_->idFront(id);}
 
 private:
   /** Get the neighbors of the given cell with higher absolute ieta */

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -225,6 +225,19 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
   return true;
 }
 
+bool HcalTopology::validHcal(const HcalDetId& id, const unsigned int flag) const {
+  // check the raw rules
+  bool ok = validHcal(id);
+  if (flag == 0) { // This is all what is needed
+  } else if (flag == 1) { // See if it is in the to be merged list and merged list
+    if (hcons_->isPlan1MergedId(id))          ok = true;
+    else if (hcons_->isPlan1ToBeMergedId(id)) ok = false;
+  } else if (!ok) {
+    ok = hcons_->isPlan1MergedId(id);
+  }
+  return ok;
+}
+
 bool HcalTopology::isExcluded(const HcalDetId& id) const {
   bool exed=false;
   // first, check the full detector exclusions...  (fast)

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -105,11 +105,14 @@ public:
   unsigned int              nCells(HcalSubdetector) const;
   unsigned int              nCells() const;
   HcalDetId                 mergedDepthDetId(const HcalDetId& id) const;
+  HcalDetId                 idFront(const HcalDetId& id) const;
   void                      unmergeDepthDetId(const HcalDetId& id,
 					      std::vector<HcalDetId>& ids) const;
   void                      specialRBXHBHE(const std::vector<HcalDetId>&,
 					   std::vector<HcalDetId> &) const;
   bool                      withSpecialRBXHBHE() const {return (hcons.ldMap()->getSubdet() != 0);}
+  bool                      isPlan1ToBeMergedId(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
+  bool                      isPlan1MergedId(const HcalDetId& id) const { return detIdSpR_.find(id) != detIdSpR_.end(); };
        
 private:
   void                      getOneEtaBin(int subdet, int ieta, int zside,

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -552,6 +552,15 @@ HcalDetId HcalDDDRecConstants::mergedDepthDetId(const HcalDetId& id) const {
   else                       return itr->second;
 }
 
+HcalDetId HcalDDDRecConstants::idFront(const HcalDetId& id) const {
+
+  HcalDetId hid(id);
+  std::map<HcalDetId,std::vector<HcalDetId>>::const_iterator itr = detIdSpR_.find(id);
+  if (itr != detIdSpR_.end())
+    hid = HcalDetId(id.subdet(),id.ieta(),id.iphi(),(itr->second)[0].depth());
+  return hid;
+}
+
 void HcalDDDRecConstants::unmergeDepthDetId(const HcalDetId& id,
 					    std::vector<HcalDetId>& ids) const {
 

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -59,7 +59,7 @@ void HcalTopologyIdealEP::fillDescriptions( edm::ConfigurationDescriptions & des
 
   edm::ParameterSetDescription desc;
   desc.addUntracked<std::string>( "Exclude", "" );
-  desc.addUntracked<bool>("MergePosition", false);
+  desc.addUntracked<bool>("MergePosition", true);
   descriptions.add( "hcalTopologyIdeal", desc );
 }
 

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -147,9 +147,7 @@ GlobalPoint HcalGeometry::getPosition(const DetId& id) const {
   if (!m_mergePosition) {
     return (getGeometry(id)->getPosition());
   } else {
-    std::vector<HcalDetId> ids;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
-    return (getGeometry(ids.front())->getPosition());
+    return (getGeometry(m_topology.idFront(id))->getPosition());
   }
 }
 
@@ -160,6 +158,23 @@ GlobalPoint HcalGeometry::getBackPosition(const DetId& id) const {
     std::vector<HcalDetId> ids;
     m_topology.unmergeDepthDetId(HcalDetId(id),ids);
     return (getGeometry(ids.back())->getBackPoint());
+  }
+}
+
+CaloCellGeometry::CornersVec HcalGeometry::getCorners(const DetId& id) const {
+  if (!m_mergePosition) {
+    return (getGeometry(id)->getCorners());
+  } else {
+    std::vector<HcalDetId> ids;
+    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
+    CaloCellGeometry::CornersVec mcorners;
+    CaloCellGeometry::CornersVec mcf = getGeometry(ids.front())->getCorners();
+    CaloCellGeometry::CornersVec mcb = getGeometry(ids.back())->getCorners();
+    for (unsigned int k=0; k<4; ++k) {
+      mcorners[k]   = mcf[k];
+      mcorners[k+4] = mcb[k+4];
+    }
+    return mcorners;
   }
 }
 

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -546,8 +546,7 @@ void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit * recHit) {
   DetId detId = recHit->detid();
   if (detId.det() == DetId::Hcal && theHcalTopology->withSpecialRBXHBHE()) {
     HcalDetId hid(detId);
-    theHcalTopology->unmergeDepthDetId(hid, ids_);
-    if (ids_.size() > 0) detId = DetId(ids_[0]);
+    detId = theHcalTopology->idFront(hid);
 #ifdef EDM_ML_DEBUG
     std::cout << "AssignHitHcal change " << hid << " to " << HcalDetId(detId)
 	      << std::endl;
@@ -1526,13 +1525,11 @@ GlobalPoint CaloTowersCreationAlgo::hadShwPosFromCells(DetId frontCellId, DetId 
 
   HcalDetId hid1(frontCellId), hid2(backCellId);
   if (theHcalTopology->withSpecialRBXHBHE()) {
-    theHcalTopology->unmergeDepthDetId(hid1, ids_);
-    if (ids_.size() > 0) hid1 = ids_[0];
+    hid1 = theHcalTopology->idFront(frontCellId);
 #ifdef EDM_ML_DEBUG
     std::cout << "Front " << HcalDetId(frontCellId) << " " << hid1 << "\n";
 #endif
-    theHcalTopology->unmergeDepthDetId(hid2, ids_);
-    if (ids_.size() > 0) hid2 = ids_[0];
+    hid2 = theHcalTopology->idFront(backCellId);
 #ifdef EDM_ML_DEBUG
     std::cout << "Back  " << HcalDetId(backCellId) << " " << hid2 << "\n";
 #endif
@@ -1647,10 +1644,12 @@ void CaloTowersCreationAlgo::makeHcalDropChMap() {
   hcalDropChMap.clear();
   std::vector<DetId> allChanInStatusCont = theHcalChStatus->getAllChannels();
 
+#ifdef EDM_ML_DEBUG
+  std::cout << "DropChMap with " << allChanInStatusCont.size() << " channels"
+	    << std::endl;
+#endif
   for (std::vector<DetId>::iterator it = allChanInStatusCont.begin(); it!=allChanInStatusCont.end(); ++it) {
-
     const uint32_t dbStatusFlag = theHcalChStatus->getValues(*it)->getValue();
-
     if (theHcalSevLvlComputer->dropChannel(dbStatusFlag)) {
 
       CaloTowerDetId twrId = theTowerConstituentsMap->towerOf(*it);
@@ -1677,7 +1676,6 @@ void CaloTowersCreationAlgo::makeHcalDropChMap() {
     }
 
   }
-  
 }
 
 
@@ -1732,8 +1730,13 @@ void CaloTowersCreationAlgo::makeEcalBadChs() {
 
 unsigned int CaloTowersCreationAlgo::hcalChanStatusForCaloTower(const CaloRecHit* hit) {
 
-  const DetId id = hit->detid();
-
+  DetId id = hit->detid();
+  HcalDetId hid(id);
+  id = theHcalTopology->idFront(hid);
+#ifdef EDM_ML_DEBUG
+  std::cout << "ChanStatusForCaloTower for " << hid << " to " << HcalDetId(id) 
+	    << std::endl;
+#endif
   const uint32_t recHitFlag = hit->flags();
   const uint32_t dbStatusFlag = theHcalChStatus->getValues(id)->getValue();
   

--- a/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
+++ b/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
@@ -37,6 +37,8 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+
 namespace reco {
 
   //
@@ -91,7 +93,9 @@ namespace reco {
     double minTrackPt_;         // minimum track Pt
     double maxNHF_;
     int maxjetindex_;
-    
+
+    const HcalTopology* theHcalTopology_;    
+
     std::string digiCollName_;         // name of the digi collection
     std::string recHitCollName_;       // name of the rechit collection
     std::string caloTowerCollName_;    // name of the caloTower collection

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
@@ -20,6 +20,7 @@
 #include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "DataFormats/HcalRecHit/interface/HFRecHit.h"
@@ -57,7 +58,7 @@ class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
   const HcalChannelQuality* theHcalChStatus;
   const EcalChannelStatus* theEcalChStatus;
   const CaloTowerConstituentsMap* theTowerConstituentsMap;
-
+  const HcalTopology* theHcalTopology;
 
   // ----------access to event data
   edm::EDGetTokenT<HBHERecHitCollection> hcalToken_;


### PR DESCRIPTION
Plan1 operation needs additional channels for 1 RBX but these are grouped into Plan0 channels at LocalReco level. As a result accessing any condition object or geometry for downstream software need to use pre-merged channel information. This affects CaloTower, ParticleFLow, DQM, NoiseFiltering and Skimming. These modifications will not affect non-plan1 operations