### PR TITLE
Sistrip cluster gain/raw cluster charge update

### DIFF
--- a/DQM/SiStripMonitorTrack/BuildFile.xml
+++ b/DQM/SiStripMonitorTrack/BuildFile.xml
@@ -16,4 +16,3 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="CommonTools/TriggerUtils"/>
-

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -21,7 +21,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"  
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
@@ -45,7 +45,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
 //******** Single include for the TkMap *************
-#include "DQM/SiStripCommon/interface/TkHistoMap.h" 
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
 //***************************************************
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
@@ -90,7 +90,7 @@ private:
   MonitorElement * bookMEProfile(DQMStore::IBooker & , const char*, const char*);
   MonitorElement * bookMETrend(DQMStore::IBooker & , const char*);
   // internal evaluation of monitorables
-  void AllClusters(const edm::Event& ev, const edm::EventSetup& es); 
+  void AllClusters(const edm::Event& ev, const edm::EventSetup& es);
   void trackStudyFromTrack(edm::Handle<reco::TrackCollection > trackCollectionHandle, const edm::EventSetup& es);
   void trackStudyFromTrajectory(edm::Handle<TrajTrackAssociationCollection> TItkAssociatorCollection, const edm::EventSetup& es);
   void trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es, bool track_ok);
@@ -104,10 +104,20 @@ private:
 		const SiStripRecHit1D*          hit1D,
 		      LocalVector               localMomentum,
 		const bool                      track_ok);
-  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, bool track_ok, LocalVector LV, const Det2MEs& MEs , const TrackerTopology* tTopo);	
+  bool clusterInfos(
+    SiStripClusterInfo* cluster,
+    const uint32_t detid,
+    enum ClusterFlags flags,
+    bool track_ok,
+    LocalVector LV,
+    const Det2MEs& MEs ,
+    const TrackerTopology* tTopo,
+    const SiStripGain*     stripGain,
+    const SiStripQuality*  stripQuality
+  );
   template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&, bool ok);
 
-  // fill monitorables 
+  // fill monitorables
 //  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, const uint32_t detid, const LocalVector LV);
 //  void fillMEs(SiStripClusterInfo*,const uint32_t detid, float,enum ClusterFlags,  const LocalVector LV, const Det2MEs& MEs);
 
@@ -121,22 +131,24 @@ private:
   // ----------member data ---------------------------
 private:
   edm::ParameterSet conf_;
-  std::string histname; 
+  std::string histname;
   LocalVector LV;
   float iOrbitSec , iLumisection;
 
   std::string topFolderName_;
-  
+
   //******* TkHistoMaps
   TkHistoMap *tkhisto_StoNCorrOnTrack, *tkhisto_NumOnTrack, *tkhisto_NumOffTrack;
   TkHistoMap *tkhisto_ClChPerCMfromOrigin, *tkhisto_ClChPerCMfromTrack;
-  TkHistoMap *tkhisto_NumMissingHits, *tkhisto_NumberInactiveHits, *tkhisto_NumberValidHits; 
+  TkHistoMap *tkhisto_NumMissingHits, *tkhisto_NumberInactiveHits, *tkhisto_NumberValidHits;
   //******** TkHistoMaps
   int numTracks;
- 
-  struct ModMEs{  
+
+  struct ModMEs{
     MonitorElement* ClusterStoNCorr;
+    MonitorElement* ClusterGain;
     MonitorElement* ClusterCharge;
+    MonitorElement* ClusterChargeRaw;
     MonitorElement* ClusterChargeCorr;
     MonitorElement* ClusterWidth;
     MonitorElement* ClusterPos;
@@ -146,10 +158,13 @@ private:
   };
 
   struct LayerMEs{
+    MonitorElement* ClusterGain;
     MonitorElement* ClusterStoNCorrOnTrack;
     MonitorElement* ClusterChargeCorrOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
+    MonitorElement* ClusterChargeRawOnTrack;
+    MonitorElement* ClusterChargeRawOffTrack;
     MonitorElement* ClusterNoiseOnTrack;
     MonitorElement* ClusterNoiseOffTrack;
     MonitorElement* ClusterWidthOnTrack;
@@ -161,10 +176,13 @@ private:
     MonitorElement* ClusterChargePerCMfromOriginOffTrack;
   };
   struct RingMEs{
+    MonitorElement* ClusterGain;
     MonitorElement* ClusterStoNCorrOnTrack;
     MonitorElement* ClusterChargeCorrOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
+    MonitorElement* ClusterChargeRawOnTrack;
+    MonitorElement* ClusterChargeRawOffTrack;
     MonitorElement* ClusterNoiseOnTrack;
     MonitorElement* ClusterNoiseOffTrack;
     MonitorElement* ClusterWidthOnTrack;
@@ -182,6 +200,7 @@ private:
     MonitorElement* nClustersTrendOnTrack;
     MonitorElement* nClustersOffTrack;
     MonitorElement* nClustersTrendOffTrack;
+    MonitorElement* ClusterGain;
     MonitorElement* ClusterStoNCorrOnTrack;
     MonitorElement* ClusterStoNCorrThinOnTrack;
     MonitorElement* ClusterStoNCorrThickOnTrack;
@@ -190,28 +209,30 @@ private:
     MonitorElement* ClusterChargeCorrThickOnTrack;
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
+    MonitorElement* ClusterChargeRawOnTrack;
+    MonitorElement* ClusterChargeRawOffTrack;
     MonitorElement* ClusterStoNOffTrack;
     MonitorElement* ClusterChargePerCMfromTrack;
     MonitorElement* ClusterChargePerCMfromOriginOnTrack;
     MonitorElement* ClusterChargePerCMfromOriginOffTrack;
-  };  
+  };
   std::map<std::string, ModMEs>       ModMEsMap;
   std::map<std::string, LayerMEs>     LayerMEsMap;
   std::map<std::string, RingMEs>      RingMEsMap;
-  std::map<std::string, SubDetMEs>    SubDetMEsMap;  
+  std::map<std::string, SubDetMEs>    SubDetMEsMap;
 
   struct Det2MEs {
       struct LayerMEs *iLayer;
       struct RingMEs *iRing;
       struct SubDetMEs *iSubdet;
   };
-  
+
   edm::ESHandle<TrackerGeometry> tkgeom_;
   edm::ESHandle<SiStripDetCabling> SiStripDetCabling_;
-  
+
   edm::ParameterSet Parameters;
   edm::InputTag Cluster_src_;
-  
+
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusterToken_;
   edm::EDGetTokenT<reco::TrackCollection> trackToken_;
   //  edm::EDGetTokenT<std::vector<Trajectory> > trajectoryToken_;
@@ -235,13 +256,13 @@ private:
   int firstEvent;
 
   bool   applyClusterQuality_;
-  double sToNLowerLimit_;  
-  double sToNUpperLimit_;  
+  double sToNLowerLimit_;
+  double sToNUpperLimit_;
   double widthLowerLimit_;
   double widthUpperLimit_;
 
   SiStripDCSStatus* dcsStatus_;
   GenericTriggerEventFlag* genTriggerEventFlag_;
-  SiStripFolderOrganizer folderOrganizer_;                                                                                                                                                                                                                                   
+  SiStripFolderOrganizer folderOrganizer_;
 };
 #endif

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -3,55 +3,71 @@ import FWCore.ParameterSet.Config as cms
 # MonitorTrackGlobal
 SiStripMonitorTrack = cms.EDAnalyzer(
     "SiStripMonitorTrack",
-    
+
     TopFolderName = cms.string('SiStrip'),
     TrackProducer = cms.string('generalTracks'),
     TrackLabel    = cms.string(''),
     TrajectoryInEvent = cms.bool(True),
     AlgoName      = cms.string('GenTk'),
-    
+
     RawDigis_On     = cms.bool(False),
     RawDigiProducer = cms.string('simSiStripDigis'),
     RawDigiLabel    = cms.string('VirginRaw'),
-    
+
     Cluster_src = cms.InputTag('siStripClusters'),
 
     genericTriggerEventPSet = cms.PSet(),
-    
+
     ModulesToBeExcluded = cms.vuint32(),
-    
+
     Mod_On        = cms.bool(False),
     OffHisto_On   = cms.bool(True),
     Trend_On      = cms.bool(False),
     HistoFlag_On  = cms.bool(False),
-    TkHistoMap_On = cms.bool(True),   
+    TkHistoMap_On = cms.bool(True),
     clchCMoriginTkHmap_On = cms.bool(False),
- 
+
     ClusterConditions = cms.PSet( On       = cms.bool(False),
                                   minStoN  = cms.double(0.0),
                                   maxStoN  = cms.double(2000.0),
                                   minWidth = cms.double(0.0),
                                   maxWidth = cms.double(200.0)
                                   ),
-    
+
     TH1nClustersOn = cms.PSet( Nbinx = cms.int32(150),
                              xmin  = cms.double(-0.5),
                              xmax  = cms.double(2999.5)
-                             ),   
+                             ),
 
     TH1nClustersOff = cms.PSet( Nbinx = cms.int32(150),
                              xmin  = cms.double(-0.5),
                              xmax  = cms.double(19999.5)
                              ),
-    
+
+    TH1ClusterGain = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(3.5)
+    ),
+
     TH1ClusterCharge = cms.PSet(
         layerView = cms.bool(True),
-        ringView  = cms.bool(False),        
+        ringView  = cms.bool(False),
         Nbinx = cms.int32(100),
         xmin  = cms.double(-0.5),
         xmax  = cms.double(999.5)
     ),
-    
+
+    TH1ClusterChargeRaw = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(999.5)
+    ),
+
     TH1ClusterStoN = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -59,7 +75,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(299.5)
     ),
-    
+
     TH1ClusterChargeCorr = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -67,8 +83,8 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(399.5)
     ),
-    
-    TH1ClusterStoNCorr = cms.PSet( 
+
+    TH1ClusterStoNCorr = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
         Nbinx = cms.int32(100),
@@ -81,7 +97,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(199.5)
     ),
-    
+
     TH1ClusterNoise = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -89,7 +105,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(9.5)
     ),
-    
+
     TH1ClusterWidth = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -97,27 +113,27 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(19.5)
     ),
-    
+
     TH1ClusterPos = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
     ),
-    
+
     TH1ClusterSymmEtaCC = cms.PSet( Nbinx = cms.int32(120),
                                     xmin  = cms.double(-0.1),
                                     xmax  = cms.double(1.1)
                                     ),
-    
+
     TH1ClusterWidthCC = cms.PSet( Nbinx = cms.int32(10),
                                   xmin  = cms.double(-0.5),
                                   xmax  = cms.double(9.5)
                                   ),
-    
+
     TH1ClusterEstimatorCC = cms.PSet( Nbinx = cms.int32(120),
                                       xmin  = cms.double(-0.1),
                                       xmax  = cms.double(1.1)
                                       ),
-    
+
     TProfileClusterPGV = cms.PSet( Nbinx = cms.int32(20),
                                    xmin = cms.double(-10.0),
                                    xmax = cms.double(10.0),
@@ -125,13 +141,13 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                                    ymin = cms.double(-0.1),
                                    ymax = cms.double(1.2)
                                    ),
-    
-    Trending = cms.PSet( 
+
+    Trending = cms.PSet(
         Nbins = cms.int32(2400),
         xmin = cms.double(0.0),
         xmax = cms.double(150)
         ),
-    
+
     TH1ClusterChargePerCM = cms.PSet(
         layerView = cms.bool(False),
         ringView  = cms.bool(True),
@@ -139,7 +155,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(9999.5)
     ),
-    
+
     UseDCSFiltering = cms.bool(True)
-    
+
     )

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -43,10 +43,10 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                              xmin  = cms.double(-0.5),
                              xmax  = cms.double(19999.5)
                              ),
-                             
+
     TH1ClusterGain = cms.PSet(
         layerView = cms.bool(True),
-        ringView  = cms.bool(False),
+        ringView  = cms.bool(True),
         Nbinx = cms.int32(100),
         xmin  = cms.double(-0.5),
         xmax  = cms.double(3.5)
@@ -62,7 +62,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
 
     TH1ClusterChargeRaw = cms.PSet(
         layerView = cms.bool(True),
-        ringView  = cms.bool(False),
+        ringView  = cms.bool(True),
         Nbinx = cms.int32(100),
         xmin  = cms.double(-0.5),
         xmax  = cms.double(999.5)

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -3,55 +3,72 @@ import FWCore.ParameterSet.Config as cms
 # MonitorTrackGlobal
 SiStripMonitorTrack = cms.EDAnalyzer(
     "SiStripMonitorTrack",
-    
+
     TopFolderName = cms.string('SiStrip'),
     TrackProducer = cms.string('generalTracks'),
     TrackLabel    = cms.string(''),
     TrajectoryInEvent = cms.bool(True),
     AlgoName      = cms.string('GenTk'),
-    
+
     RawDigis_On     = cms.bool(False),
     RawDigiProducer = cms.string('simSiStripDigis'),
     RawDigiLabel    = cms.string('VirginRaw'),
-    
+
     Cluster_src = cms.InputTag('siStripClusters'),
 
     genericTriggerEventPSet = cms.PSet(),
-    
+
     ModulesToBeExcluded = cms.vuint32(),
-    
+
     Mod_On        = cms.bool(False),
     OffHisto_On   = cms.bool(True),
     Trend_On      = cms.bool(False),
     HistoFlag_On  = cms.bool(False),
-    TkHistoMap_On = cms.bool(True),   
+    TkHistoMap_On = cms.bool(True),
     clchCMoriginTkHmap_On = cms.bool(False),
- 
+
     ClusterConditions = cms.PSet( On       = cms.bool(False),
                                   minStoN  = cms.double(0.0),
                                   maxStoN  = cms.double(2000.0),
                                   minWidth = cms.double(0.0),
                                   maxWidth = cms.double(200.0)
                                   ),
-    
+
     TH1nClustersOn = cms.PSet( Nbinx = cms.int32(150),
                              xmin  = cms.double(-0.5),
                              xmax  = cms.double(2999.5)
-                             ),   
+                             ),
 
     TH1nClustersOff = cms.PSet( Nbinx = cms.int32(150),
                              xmin  = cms.double(-0.5),
                              xmax  = cms.double(19999.5)
                              ),
-    
+                             
+    TH1ClusterGain = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(3.5)
+    ),
+
     TH1ClusterCharge = cms.PSet(
         layerView = cms.bool(True),
-        ringView  = cms.bool(False),        
+        ringView  = cms.bool(False),
         Nbinx = cms.int32(100),
         xmin  = cms.double(-0.5),
         xmax  = cms.double(999.5)
     ),
-    
+
+    TH1ClusterChargeRaw = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(999.5)
+    ),
+
+
     TH1ClusterStoN = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -59,7 +76,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(299.5)
     ),
-    
+
     TH1ClusterChargeCorr = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -67,8 +84,8 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(399.5)
     ),
-    
-    TH1ClusterStoNCorr = cms.PSet( 
+
+    TH1ClusterStoNCorr = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
         Nbinx = cms.int32(100),
@@ -81,7 +98,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(199.5)
     ),
-    
+
     TH1ClusterNoise = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -89,7 +106,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(9.5)
     ),
-    
+
     TH1ClusterWidth = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
@@ -97,27 +114,27 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(19.5)
     ),
-    
+
     TH1ClusterPos = cms.PSet(
         layerView = cms.bool(True),
         ringView  = cms.bool(False),
     ),
-    
+
     TH1ClusterSymmEtaCC = cms.PSet( Nbinx = cms.int32(120),
                                     xmin  = cms.double(-0.1),
                                     xmax  = cms.double(1.1)
                                     ),
-    
+
     TH1ClusterWidthCC = cms.PSet( Nbinx = cms.int32(10),
                                   xmin  = cms.double(-0.5),
                                   xmax  = cms.double(9.5)
                                   ),
-    
+
     TH1ClusterEstimatorCC = cms.PSet( Nbinx = cms.int32(120),
                                       xmin  = cms.double(-0.1),
                                       xmax  = cms.double(1.1)
                                       ),
-    
+
     TProfileClusterPGV = cms.PSet( Nbinx = cms.int32(20),
                                    xmin = cms.double(-10.0),
                                    xmax = cms.double(10.0),
@@ -125,13 +142,13 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                                    ymin = cms.double(-0.1),
                                    ymax = cms.double(1.2)
                                    ),
-    
-    Trending = cms.PSet( 
+
+    Trending = cms.PSet(
         Nbins = cms.int32(2400),
         xmin = cms.double(0.0),
         xmax = cms.double(150)
         ),
-    
+
     TH1ClusterChargePerCM = cms.PSet(
         layerView = cms.bool(False),
         ringView  = cms.bool(True),
@@ -139,7 +156,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
         xmin  = cms.double(-0.5),
         xmax  = cms.double(9999.5)
     ),
-    
+
     UseDCSFiltering = cms.bool(True)
-    
+
     )

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -900,26 +900,18 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 
-  // trajectory input
-  edm::Handle<TrajTrackAssociationCollection> TItkAssociatorCollection;
-  ev.getByToken(trackTrajToken_, TItkAssociatorCollection);
-  if( TItkAssociatorCollection.isValid()){
-    trackStudyFromTrajectory(TItkAssociatorCollection,es);
+
+  //    edm::Handle<std::vector<Trajectory> > trajectories;
+  //    ev.getByToken(trajectoryToken_, trajectories);
+
+  // track input
+  edm::Handle<reco::TrackCollection > trackCollectionHandle;
+  ev.getByToken(trackToken_, trackCollectionHandle);//takes the track collection
+  if (trackCollectionHandle.isValid()){
+    trackStudyFromTrack(trackCollectionHandle,es);
   } else {
-    edm::LogError("SiStripMonitorTrack")<<"Association not found ... try w/ track collection"<<std::endl;
-
-    //    edm::Handle<std::vector<Trajectory> > trajectories;
-    //    ev.getByToken(trajectoryToken_, trajectories);
-
-    // track input
-    edm::Handle<reco::TrackCollection > trackCollectionHandle;
-    ev.getByToken(trackToken_, trackCollectionHandle);//takes the track collection
-    if (trackCollectionHandle.isValid()){
-      trackStudyFromTrack(trackCollectionHandle,es);
-    } else {
-      edm::LogError("SiStripMonitorTrack")<<"also Track Collection is not valid !! " << TrackLabel_<<std::endl;
-      return;
-    }
+    edm::LogError("SiStripMonitorTrack")<<"also Track Collection is not valid !! " << TrackLabel_<<std::endl;
+    return;
   }
 }
 


### PR DESCRIPTION
Added DQM plots for the average gain of a SiStrip cluster, and the raw, non-gain corrected SiStrip cluster charges. 

Plots located in  
  * `RunXXX/SiStrip/RunSummary/MechanicalView/**/Summay_ClusterChargeRaw*`
  * `RunXXX/SiStrip  /RunSummary/MechanicalView/**/Summay_ClusterGain*`

ClusterChargeRaw also includes individual plots for on track and off track clusters.
Per layer/Per wheel plots are also made. 