### PR TITLE
SiStripDQM : number of cluster trend in wheel/layer, number of cluster per ring and per layer

### DIFF
--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorCluster.h
@@ -71,6 +71,8 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
     MonitorElement* LayerLocalOccupancy = 0;
     MonitorElement* LayerLocalOccupancyTrend = 0;
     MonitorElement* LayerNumberOfClusterProfile = 0;
+    MonitorElement* LayerNumberOfClusterPerRingTrend = 0;
+    MonitorElement* LayerNumberOfClusterTrend = 0;
     MonitorElement* LayerClusterWidthProfile = 0;
     MonitorElement* LayerClusWidthVsAmpTH2 = 0;
     MonitorElement* LayerClusterPosition = 0;
@@ -88,6 +90,7 @@ class SiStripMonitorCluster : public DQMEDAnalyzer {
     MonitorElement* SubDetClusterChargeTH1 = 0;
     MonitorElement* SubDetClusterWidthTH1 = 0;
     MonitorElement* SubDetClusWidthVsAmpTH2 = 0;
+    MonitorElement* SubDetNumberOfClusterPerLayerTrend = 0;
   };
 
   struct ClusterProperties { // Cluster Properties

--- a/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
+++ b/DQM/SiStripMonitorCluster/python/SiStripMonitorCluster_cfi.py
@@ -334,6 +334,25 @@ SiStripMonitorCluster = cms.EDAnalyzer("SiStripMonitorCluster",
         ymax = cms.double(90*262144),
         globalswitchon = cms.bool(True)
         ),
+    NumberOfClusterPerRingVsTrendVarTH2 = cms.PSet(
+	Nbinsx = cms.int32(1000),
+	xmin = cms.double(0.),
+	xmax = cms.double(150.),
+	Nbinsy = cms.int32(9),
+	ymin = cms.double(0.5),
+	ymax = cms.double(9.5),
+	globalswitchon = cms.bool(True),
+	),
+
+    NumberOfClusterPerLayerTrendVarTH2 = cms.PSet(
+	Nbinsx = cms.int32(1000),
+	xmin = cms.double(0.),
+	xmax = cms.double(150.),
+	Nbinsy = cms.int32(11),
+	ymin = cms.double(0.5),
+	ymax = cms.double(11.5),
+	globalswitchon = cms.bool(True),
+	),
 
     ClusWidthVsAmpTH2 = cms.PSet(
         Nbinsx = cms.int32(2000),

--- a/DQM/SiStripMonitorDigi/python/SiStripMonitorDigi_cfi.py
+++ b/DQM/SiStripMonitorDigi/python/SiStripMonitorDigi_cfi.py
@@ -26,7 +26,7 @@ SiStripMonitorDigi = cms.EDAnalyzer("SiStripMonitorDigi",
        xmin = cms.double(0.5),
        xmax = cms.double(256.5),
        subdetswitchon = cms.bool(False),
-       globalswitchon = cms.bool(False)
+       globalswitchon = cms.bool(True)
     ),
 
    TH1NStripsApvShots = cms.PSet(


### PR DESCRIPTION
Implementation of several plots in SiStripMonitorCluster package: number of cluster trend in wheel/layer, number of cluster per ring and per layer. Change in apv charge median plot switch in SiStripMonitorDigi package

Backport of the same code from the already merged PR in 90X : #17304 

Would be great to have for the legacy Re-reco 