### PR TITLE
Convert ObjectViewCleaner from legacy producer to stream producer

### DIFF
--- a/Validation/RecoTau/plugins/ObjectViewCleaner.cc
+++ b/Validation/RecoTau/plugins/ObjectViewCleaner.cc
@@ -3,21 +3,12 @@
  *
  * Package: Validation/RecoTau
  *
- *
- * Authors:
- *
- *   Kalanand Mishra, Fermilab - kalanand@fnal.gov
- *
  * Description:
  *   - Cleans a given object collection of other
  *     cross-object candidates using deltaR-matching.
  *   - For example: can clean a muon collection by
  *      removing all jets in the muon collection.
  *   - Saves collection of the reference vectors of cleaned objects.
- * History:
- *   Generalized the existing CandViewCleaner
- *
- * 2010 FNAL
  *****************************************************************************/
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
@@ -32,7 +23,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -43,126 +34,120 @@
 #include <sstream>
 #include <vector>
 
-////////////////////////////////////////////////////////////////////////////////
-// class definition
-////////////////////////////////////////////////////////////////////////////////
-template <typename T>
-class ObjectViewCleaner : public edm::EDProducer {
-public:
+namespace {
 
-  // construction/destruction
-  explicit ObjectViewCleaner(edm::ParameterSet const& iConfig);
+  // Job-level data
+  struct Counters {
+    explicit Counters(std::string const& label) : moduleLabel{label} {}
+    std::string const moduleLabel;
+    mutable std::atomic<std::size_t> nObjectsTot {};
+    mutable std::atomic<std::size_t> nObjectsClean {};
+  };
 
-  // member functions
-  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override;
-  void endJob() override;
+  template <typename T>
+  class ObjectViewCleaner : public edm::stream::EDProducer<edm::GlobalCache<Counters>> {
+  public:
 
-private:
+    explicit ObjectViewCleaner(edm::ParameterSet const&, Counters const*);
 
-  // member data
-  edm::EDGetTokenT<edm::View<T>> srcCands_;
-  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> srcObjectsToRemove_;
-  double deltaRMin_;
-  std::string moduleLabel_;
-  StringCutObjectSelector<T,true> objKeepCut_; // lazy parsing, to allow cutting on variables not in reco::Candidate class
-  StringCutObjectSelector<reco::Candidate,true> objRemoveCut_; // lazy parsing, to allow cutting on variables
-
-  std::size_t nObjectsTot_ {};
-  std::size_t nObjectsClean_ {};
-
-  auto tagsToTokens(std::vector<edm::InputTag> const&) -> decltype(srcObjectsToRemove_);
-  bool isIsolated(edm::Event const&, T const&) const;
-
-};
-
-
-using namespace std;
-
-
-////////////////////////////////////////////////////////////////////////////////
-// construction/destruction
-////////////////////////////////////////////////////////////////////////////////
-
-template<typename T>
-ObjectViewCleaner<T>::ObjectViewCleaner(edm::ParameterSet const& iConfig)
-  : srcCands_{consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("srcObject"))}
-  , srcObjectsToRemove_{tagsToTokens(iConfig.getParameter<vector<edm::InputTag>>("srcObjectsToRemove"))}
-  , deltaRMin_{iConfig.getParameter<double>("deltaRMin")}
-  , moduleLabel_{iConfig.getParameter<string>("@module_label")}
-  , objKeepCut_{iConfig.existsAs<std::string>("srcObjectSelection") ? iConfig.getParameter<std::string>("srcObjectSelection") : "", true}
-  , objRemoveCut_{iConfig.existsAs<std::string>("srcObjectsToRemoveSelection") ? iConfig.getParameter<std::string>("srcObjectsToRemoveSelection") : "", true}
-{
-  produces<edm::RefToBaseVector<T>>();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// implementation of member functions
-////////////////////////////////////////////////////////////////////////////////
-
-//______________________________________________________________________________
-template <typename T>
-void ObjectViewCleaner<T>::produce(edm::Event& iEvent, edm::EventSetup const&)
-{
-  edm::Handle<edm::View<T>> candidates;
-  iEvent.getByToken(srcCands_,candidates);
-  nObjectsTot_ += candidates->size();
-
-  auto cleanObjects = std::make_unique<edm::RefToBaseVector<T>>();
-  for (unsigned int iCand {}; iCand < candidates->size(); ++iCand) {
-    auto const& candidate = candidates->at(iCand);
-    if (objKeepCut_(candidate) && isIsolated(iEvent, candidate)) {
-      cleanObjects->push_back(candidates->refAt(iCand));
+    void produce(edm::Event&, edm::EventSetup const&) override;
+    static auto initializeGlobalCache(edm::ParameterSet const& iConfig)
+    {
+      return std::make_unique<Counters>(iConfig.getParameter<std::string>("@module_label"));
     }
+    static void globalEndJob(Counters const*);
+
+  private:
+
+    // member data
+    edm::EDGetTokenT<edm::View<T>> srcCands_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> srcObjectsToRemove_;
+    double deltaRMin_;
+    StringCutObjectSelector<T,true> objKeepCut_; // lazy parsing, to allow cutting on variables not in reco::Candidate class
+    StringCutObjectSelector<reco::Candidate,true> objRemoveCut_; // lazy parsing, to allow cutting on variables
+
+    auto tagsToTokens(std::vector<edm::InputTag> const&) -> decltype(srcObjectsToRemove_);
+    bool isIsolated(edm::Event const&, T const&) const;
+
+  };
+
+  using namespace std;
+
+  template<typename T>
+  ObjectViewCleaner<T>::ObjectViewCleaner(edm::ParameterSet const& iConfig, Counters const*)
+    : srcCands_{consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("srcObject"))}
+    , srcObjectsToRemove_{tagsToTokens(iConfig.getParameter<vector<edm::InputTag>>("srcObjectsToRemove"))}
+    , deltaRMin_{iConfig.getParameter<double>("deltaRMin")}
+    , objKeepCut_{iConfig.existsAs<std::string>("srcObjectSelection") ? iConfig.getParameter<std::string>("srcObjectSelection") : "", true}
+    , objRemoveCut_{iConfig.existsAs<std::string>("srcObjectsToRemoveSelection") ? iConfig.getParameter<std::string>("srcObjectsToRemoveSelection") : "", true}
+  {
+    produces<edm::RefToBaseVector<T>>();
   }
-  nObjectsClean_ += cleanObjects->size();
 
-  iEvent.put(std::move(cleanObjects));
-}
+  //______________________________________________________________________________
+  template <typename T>
+  void ObjectViewCleaner<T>::produce(edm::Event& iEvent, edm::EventSetup const&)
+  {
+    edm::Handle<edm::View<T>> candidates;
+    iEvent.getByToken(srcCands_,candidates);
+    globalCache()->nObjectsTot += candidates->size();
 
-
-//______________________________________________________________________________
-template <typename T>
-void ObjectViewCleaner<T>::endJob()
-{
-  ostringstream oss;
-  oss << "nObjectsTot=" << nObjectsTot_ << " nObjectsClean=" << nObjectsClean_
-     << " fObjectsClean=" << 100*(nObjectsClean_/static_cast<double>(nObjectsTot_)) << "%\n";
-  edm::LogInfo("ObjectViewCleaner") << "++++++++++++++++++++++++++++++++++++++++++++++++++\n"
-                                    << moduleLabel_ << "(ObjectViewCleaner) SUMMARY:\n"
-                                    << oss.str() << '\n'
-                                    << "++++++++++++++++++++++++++++++++++++++++++++++++++";
-}
-
-//______________________________________________________________________________
-template <typename T>
-bool ObjectViewCleaner<T>::isIsolated(edm::Event const& iEvent, T const& candidate) const
-{
-  for (auto const& srcObject : srcObjectsToRemove_) {
-    edm::Handle<edm::View<reco::Candidate>> objects;
-    iEvent.getByToken(srcObject, objects);
-
-    for (unsigned int iObj {}; iObj < objects->size() ; ++iObj) {
-      auto const& obj = objects->at(iObj);
-      if (!objRemoveCut_(obj)) continue;
-
-      if (reco::deltaR(candidate,obj) < deltaRMin_) {
-        return false;
+    auto cleanObjects = std::make_unique<edm::RefToBaseVector<T>>();
+    for (unsigned int iCand {}; iCand < candidates->size(); ++iCand) {
+      auto const& candidate = candidates->at(iCand);
+      if (objKeepCut_(candidate) && isIsolated(iEvent, candidate)) {
+        cleanObjects->push_back(candidates->refAt(iCand));
       }
     }
+    globalCache()->nObjectsClean += cleanObjects->size();
+
+    iEvent.put(std::move(cleanObjects));
   }
-  return true;
-};
 
-//______________________________________________________________________________
-template <typename T>
-auto ObjectViewCleaner<T>::tagsToTokens(std::vector<edm::InputTag> const& tags) -> decltype(srcObjectsToRemove_)
-{
-  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> result;
-  std::transform(std::cbegin(tags), std::cend(tags), std::back_inserter(result),
-                 [this](auto const& tag) { return this->consumes<edm::View<reco::Candidate>>(tag); });
-  return result;
-}
+  //______________________________________________________________________________
+  template <typename T>
+  void ObjectViewCleaner<T>::globalEndJob(Counters const* counters)
+  {
+    ostringstream oss;
+    oss << "nObjectsTot=" << counters->nObjectsTot << " nObjectsClean=" << counters->nObjectsClean
+        << " fObjectsClean=" << 100*(counters->nObjectsClean/static_cast<double>(counters->nObjectsTot)) << "%\n";
+    edm::LogInfo("ObjectViewCleaner") << "++++++++++++++++++++++++++++++++++++++++++++++++++\n"
+                                      << counters->moduleLabel << "(ObjectViewCleaner) SUMMARY:\n"
+                                      << oss.str() << '\n'
+                                      << "++++++++++++++++++++++++++++++++++++++++++++++++++";
+  }
 
+  //______________________________________________________________________________
+  template <typename T>
+  bool ObjectViewCleaner<T>::isIsolated(edm::Event const& iEvent, T const& candidate) const
+  {
+    for (auto const& srcObject : srcObjectsToRemove_) {
+      edm::Handle<edm::View<reco::Candidate>> objects;
+      iEvent.getByToken(srcObject, objects);
+
+      for (unsigned int iObj {}; iObj < objects->size() ; ++iObj) {
+        auto const& obj = objects->at(iObj);
+        if (!objRemoveCut_(obj)) continue;
+
+        if (reco::deltaR(candidate,obj) < deltaRMin_) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  //______________________________________________________________________________
+  template <typename T>
+  auto ObjectViewCleaner<T>::tagsToTokens(std::vector<edm::InputTag> const& tags) -> decltype(srcObjectsToRemove_)
+  {
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> result;
+    std::transform(std::cbegin(tags), std::cend(tags), std::back_inserter(result),
+                   [this](auto const& tag) { return this->consumes<edm::View<reco::Candidate>>(tag); });
+    return result;
+  }
+
+} // anonymous namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 // plugin definitions

--- a/Validation/RecoTau/plugins/ObjectViewCleaner.cc
+++ b/Validation/RecoTau/plugins/ObjectViewCleaner.cc
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * Project: CMS detector at the CERN
  *
- * Package: PhysicsTools/TagAndProbe
+ * Package: Validation/RecoTau
  *
  *
  * Authors:
@@ -9,71 +9,70 @@
  *   Kalanand Mishra, Fermilab - kalanand@fnal.gov
  *
  * Description:
- *   - Cleans a given object collection of other 
+ *   - Cleans a given object collection of other
  *     cross-object candidates using deltaR-matching.
- *   - For example: can clean a muon collection by 
+ *   - For example: can clean a muon collection by
  *      removing all jets in the muon collection.
  *   - Saves collection of the reference vectors of cleaned objects.
  * History:
  *   Generalized the existing CandViewCleaner
  *
- * 2010 FNAL 
+ * 2010 FNAL
  *****************************************************************************/
-////////////////////////////////////////////////////////////////////////////////
-// Includes
-////////////////////////////////////////////////////////////////////////////////
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Math/interface/deltaR.h"
-
-#include "DataFormats/Candidate/interface/Candidate.h"
-#include "DataFormats/Candidate/interface/CandidateFwd.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaCandidates/interface/Electron.h"
-#include "DataFormats/JetReco/interface/Jet.h"
-#include "DataFormats/EgammaCandidates/interface/Photon.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include <memory>
-#include <vector>
 #include <sstream>
+#include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-template<typename T>
-class ObjectViewCleaner : public edm::EDProducer
-{
+template <typename T>
+class ObjectViewCleaner : public edm::EDProducer {
 public:
+
   // construction/destruction
-  ObjectViewCleaner(const edm::ParameterSet& iConfig);
-  virtual ~ObjectViewCleaner();
-  
+  explicit ObjectViewCleaner(edm::ParameterSet const& iConfig);
+
   // member functions
-  void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) override;
   void endJob() override;
 
-private:  
-  // member data
-  edm::EDGetTokenT<edm::View<T> >                             srcCands_;
-  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > srcObjects_;
-  double                     deltaRMin_;
-  
-  std::string  moduleLabel_;
-  StringCutObjectSelector<T,true> objKeepCut_; // lazy parsing, to allow cutting on variables not in reco::Candidate class
-  StringCutObjectSelector<reco::Candidate,true> objRemoveCut_; // lazy parsing, to allow cutting on variables 
+private:
 
-  unsigned int nObjectsTot_;
-  unsigned int nObjectsClean_;
+  // member data
+  edm::EDGetTokenT<edm::View<T>> srcCands_;
+  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> srcObjectsToRemove_;
+  double deltaRMin_;
+  std::string moduleLabel_;
+  StringCutObjectSelector<T,true> objKeepCut_; // lazy parsing, to allow cutting on variables not in reco::Candidate class
+  StringCutObjectSelector<reco::Candidate,true> objRemoveCut_; // lazy parsing, to allow cutting on variables
+
+  std::size_t nObjectsTot_ {};
+  std::size_t nObjectsClean_ {};
+
+  auto tagsToTokens(std::vector<edm::InputTag> const&) -> decltype(srcObjectsToRemove_);
+  bool isIsolated(edm::Event const&, T const&) const;
+
 };
 
 
@@ -84,99 +83,90 @@ using namespace std;
 // construction/destruction
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________
 template<typename T>
-ObjectViewCleaner<T>::ObjectViewCleaner(const edm::ParameterSet& iConfig)
-  : srcCands_   (consumes<edm::View<T> >(iConfig.getParameter<edm::InputTag>         ("srcObject")))
-  , srcObjects_ ()
-  , deltaRMin_  (iConfig.getParameter<double>                ("deltaRMin"))
-  , moduleLabel_(iConfig.getParameter<string>                ("@module_label"))
-  , objKeepCut_(iConfig.existsAs<std::string>("srcObjectSelection") ? iConfig.getParameter<std::string>("srcObjectSelection") : "", true)
-  ,objRemoveCut_(iConfig.existsAs<std::string>("srcObjectsToRemoveSelection") ? iConfig.getParameter<std::string>("srcObjectsToRemoveSelection") : "", true)
-  , nObjectsTot_(0)
-  , nObjectsClean_(0)
+ObjectViewCleaner<T>::ObjectViewCleaner(edm::ParameterSet const& iConfig)
+  : srcCands_{consumes<edm::View<T>>(iConfig.getParameter<edm::InputTag>("srcObject"))}
+  , srcObjectsToRemove_{tagsToTokens(iConfig.getParameter<vector<edm::InputTag>>("srcObjectsToRemove"))}
+  , deltaRMin_{iConfig.getParameter<double>("deltaRMin")}
+  , moduleLabel_{iConfig.getParameter<string>("@module_label")}
+  , objKeepCut_{iConfig.existsAs<std::string>("srcObjectSelection") ? iConfig.getParameter<std::string>("srcObjectSelection") : "", true}
+  , objRemoveCut_{iConfig.existsAs<std::string>("srcObjectsToRemoveSelection") ? iConfig.getParameter<std::string>("srcObjectsToRemoveSelection") : "", true}
 {
-  produces<edm::RefToBaseVector<T> >();
-  std::vector<edm::InputTag> srcTags = iConfig.getParameter<vector<edm::InputTag> >("srcObjectsToRemove");
-  srcObjects_.reserve(srcTags.size());
-  for (auto const& tag : srcTags) {
-    srcObjects_.emplace_back(consumes<edm::View<reco::Candidate> >(tag));
-  }
+  produces<edm::RefToBaseVector<T>>();
 }
-
-
-//______________________________________________________________________________
-template<typename T>
-ObjectViewCleaner<T>::~ObjectViewCleaner()
-{
-  
-}
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-template<typename T>
-void ObjectViewCleaner<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
+template <typename T>
+void ObjectViewCleaner<T>::produce(edm::Event& iEvent, edm::EventSetup const&)
 {
-  unique_ptr<edm::RefToBaseVector<T> >
-    cleanObjects(new edm::RefToBaseVector<T >());
-
-  edm::Handle<edm::View<T> > candidates;
+  edm::Handle<edm::View<T>> candidates;
   iEvent.getByToken(srcCands_,candidates);
-  
-  bool* isClean = new bool[candidates->size()];
-  for (unsigned int iObject=0;iObject<candidates->size();iObject++) isClean[iObject] = true;
-  
-  for (auto const& object : srcObjects_) {
-    edm::Handle<edm::View<reco::Candidate> > objects;
-    iEvent.getByToken(object,objects);
-    
-    for (unsigned int iObject=0;iObject<candidates->size();iObject++) {
-      const T& candidate = candidates->at(iObject);
-      if (!objKeepCut_(candidate)) isClean[iObject] = false;
+  nObjectsTot_ += candidates->size();
 
-      for (unsigned int iObj=0;iObj<objects->size();iObj++) {
-        const reco::Candidate& obj = objects->at(iObj);
-        if (!objRemoveCut_(obj)) continue;
-
-        double deltaR = reco::deltaR(candidate,obj);
-        if (deltaR<deltaRMin_)  isClean[iObject] = false;
-      }
+  auto cleanObjects = std::make_unique<edm::RefToBaseVector<T>>();
+  for (unsigned int iCand {}; iCand < candidates->size(); ++iCand) {
+    auto const& candidate = candidates->at(iCand);
+    if (objKeepCut_(candidate) && isIsolated(iEvent, candidate)) {
+      cleanObjects->push_back(candidates->refAt(iCand));
     }
   }
-  
-  for (unsigned int iObject=0;iObject<candidates->size();iObject++)
-    if (isClean[iObject]) cleanObjects->push_back(candidates->refAt(iObject));
-  
-  nObjectsTot_  +=candidates->size();
-  nObjectsClean_+=cleanObjects->size();
+  nObjectsClean_ += cleanObjects->size();
 
-  delete [] isClean;  
   iEvent.put(std::move(cleanObjects));
 }
 
 
 //______________________________________________________________________________
-template<typename T>
+template <typename T>
 void ObjectViewCleaner<T>::endJob()
 {
-  stringstream ss;
-  ss<<"nObjectsTot="<<nObjectsTot_<<" nObjectsClean="<<nObjectsClean_
-    <<" fObjectsClean="<<100.*(nObjectsClean_/(double)nObjectsTot_)<<"%\n";
-  edm::LogInfo("ObjectViewCleaner")<<"++++++++++++++++++++++++++++++++++++++++++++++++++"
-	      <<"\n"<<moduleLabel_<<"(ObjectViewCleaner) SUMMARY:\n"<<ss.str()
-	      <<"++++++++++++++++++++++++++++++++++++++++++++++++++";
+  ostringstream oss;
+  oss << "nObjectsTot=" << nObjectsTot_ << " nObjectsClean=" << nObjectsClean_
+     << " fObjectsClean=" << 100*(nObjectsClean_/static_cast<double>(nObjectsTot_)) << "%\n";
+  edm::LogInfo("ObjectViewCleaner") << "++++++++++++++++++++++++++++++++++++++++++++++++++\n"
+                                    << moduleLabel_ << "(ObjectViewCleaner) SUMMARY:\n"
+                                    << oss.str() << '\n'
+                                    << "++++++++++++++++++++++++++++++++++++++++++++++++++";
+}
+
+//______________________________________________________________________________
+template <typename T>
+bool ObjectViewCleaner<T>::isIsolated(edm::Event const& iEvent, T const& candidate) const
+{
+  for (auto const& srcObject : srcObjectsToRemove_) {
+    edm::Handle<edm::View<reco::Candidate>> objects;
+    iEvent.getByToken(srcObject, objects);
+
+    for (unsigned int iObj {}; iObj < objects->size() ; ++iObj) {
+      auto const& obj = objects->at(iObj);
+      if (!objRemoveCut_(obj)) continue;
+
+      if (reco::deltaR(candidate,obj) < deltaRMin_) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+//______________________________________________________________________________
+template <typename T>
+auto ObjectViewCleaner<T>::tagsToTokens(std::vector<edm::InputTag> const& tags) -> decltype(srcObjectsToRemove_)
+{
+  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate>>> result;
+  std::transform(std::cbegin(tags), std::cend(tags), std::back_inserter(result),
+                 [this](auto const& tag) { return this->consumes<edm::View<reco::Candidate>>(tag); });
+  return result;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// plugin definition
+// plugin definitions
 ////////////////////////////////////////////////////////////////////////////////
-
 
 typedef ObjectViewCleaner<reco::Candidate>   TauValCandViewCleaner;
 typedef ObjectViewCleaner<reco::Jet>         TauValJetViewCleaner;
@@ -186,7 +176,6 @@ typedef ObjectViewCleaner<reco::Electron>    TauValElectronViewCleaner;
 typedef ObjectViewCleaner<reco::Photon>      TauValPhotonViewCleaner;
 typedef ObjectViewCleaner<reco::Track>       TauValTrackViewCleaner;
 
-#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(TauValCandViewCleaner);
 DEFINE_FWK_MODULE(TauValJetViewCleaner);
 DEFINE_FWK_MODULE(TauValMuonViewCleaner);
@@ -194,4 +183,3 @@ DEFINE_FWK_MODULE(TauValGsfElectronViewCleaner);
 DEFINE_FWK_MODULE(TauValElectronViewCleaner);
 DEFINE_FWK_MODULE(TauValPhotonViewCleaner);
 DEFINE_FWK_MODULE(TauValTrackViewCleaner);
-


### PR DESCRIPTION
Significant changes were implemented during the conversion:

1. In the legacy version, a C-style array of Booleans was used in the determination of whether to consider a candidate "clean".  The array was necessary because of a set of nested loops that were inverted with respect to the natural logic of the module.  I removed the C-style array and placed the "candidates" loop on the outside, so that a simple `if (shouldKeep(candidate)...)` statement could be used to determine if a candidate is clean.

2. In one of the inner loops, the Boolean variable was being set to `false`, indicating that the candidate should not be considered clean.  However, instead of moving on to the next candidate, the loop continued until the entire container was traversed.  Since the `false` flag could never be turned back to `true`, this approach was inefficient.  I replaced that implementation with a function call where, if the candidate overlaps with a (e.g.) jet, instead of setting a flag, the function just returns `false`.

I would appreciate it if the maintainers can check the changes in logic.  I do not believe I have introduced errors, but that statement is based on just testing `runTheMatrix.py -l 9.0`, which may be insufficient.