### PR TITLE
HE Plan1 workflow for 2017

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -62,6 +62,7 @@ class HcalDbHardcode {
     void useHOUpgrade(bool b) { useHOUpgrade_ = b; }
     void useHFUpgrade(bool b) { useHFUpgrade_ = b; }
     void testHFQIE10(bool b) { testHFQIE10_ = b; }
+    void testHEPlan1(bool b) { testHEPlan1_ = b; }
     void setSiPMCharacteristics(std::vector<edm::ParameterSet> vps) { theSiPMCharacteristics_ = vps; }
     void setKillHE(bool b) { killHE_ = b; } 
     
@@ -92,6 +93,7 @@ class HcalDbHardcode {
     HcalTPChannelParameter makeHardcodeTPChannelParameter (HcalGenericDetId fId);
     void makeHardcodeTPParameters (HcalTPParameters& tppar);
     int getLayersInDepth(int ieta, int depth, const HcalTopology* topo);
+    bool isHEPlan1(HcalGenericDetId fId);
     
   private:
     //member variables
@@ -99,7 +101,7 @@ class HcalDbHardcode {
     HcalHardcodeParameters theHBParameters_, theHEParameters_, theHFParameters_, theHOParameters_;
     HcalHardcodeParameters theHBUpgradeParameters_, theHEUpgradeParameters_, theHFUpgradeParameters_;
     bool setHB_, setHE_, setHF_, setHO_, setHBUpgrade_, setHEUpgrade_, setHFUpgrade_, killHE_;
-    bool useHBUpgrade_, useHEUpgrade_, useHOUpgrade_, useHFUpgrade_, testHFQIE10_;
+    bool useHBUpgrade_, useHEUpgrade_, useHOUpgrade_, useHFUpgrade_, testHFQIE10_, testHEPlan1_;
     std::vector<edm::ParameterSet> theSiPMCharacteristics_;
     std::map<std::pair<int,int>,int> theLayersInDepths_;
 };

--- a/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/Hcal_Conditions_forGlobalTag_cff.py
@@ -23,6 +23,7 @@ es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
     useHFUpgrade = cms.bool(False),
     useHOUpgrade = cms.bool(True),
     testHFQIE10  = cms.bool(False),
+    testHEPlan1  = cms.bool(False),
     killHE = cms.bool(False),
     useLayer0Weight = cms.bool(False),
     hb = cms.PSet(

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -144,6 +144,7 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iC
   dbHardcode.useHFUpgrade(iConfig.getParameter<bool>("useHFUpgrade"));
   dbHardcode.useHOUpgrade(iConfig.getParameter<bool>("useHOUpgrade"));
   dbHardcode.testHFQIE10(iConfig.getParameter<bool>("testHFQIE10"));
+  dbHardcode.testHEPlan1(iConfig.getParameter<bool>("testHEPlan1"));
   dbHardcode.setKillHE(iConfig.getParameter<bool>("killHE"));
   dbHardcode.setSiPMCharacteristics(iConfig.getParameter<std::vector<edm::ParameterSet>>("SiPMCharacteristics"));
 
@@ -857,6 +858,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc.add<bool>("useHFUpgrade",false);
 	desc.add<bool>("useHOUpgrade",true);
 	desc.add<bool>("testHFQIE10",false);
+	desc.add<bool>("testHEPlan1",false);
 	desc.add<bool>("killHE",false);
 	desc.add<bool>("useLayer0Weight",false);
 	desc.addUntracked<std::vector<std::string> >("toGet",std::vector<std::string>());

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,12 +37,12 @@ autoCond = {
     'run2_hlt_relval'   :   '90X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v2',
-    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v11',
-    # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '90X_upgrade2017_realistic_v11',
-    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v11',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 HE-Plan1 detector (and 0,0,~0-centred beamspot)
+    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v12',
+    # GlobalTag for MC production with realistic conditions for Phase1 2017 HE-Plan1 detector
+    'phase1_2017_realistic': '90X_upgrade2017_realistic_v12',
+    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 HE-Plan1 detector, Strip tracker in peak mode
+    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v12',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v12',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,11 +38,11 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v14',
+    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v15',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '90X_upgrade2017_realistic_v14',
+    'phase1_2017_realistic': '90X_upgrade2017_realistic_v15',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v14',
+    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v15',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v12',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,12 +37,12 @@ autoCond = {
     'run2_hlt_relval'   :   '90X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v2',
-    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 HE-Plan1 detector (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v12',
-    # GlobalTag for MC production with realistic conditions for Phase1 2017 HE-Plan1 detector
-    'phase1_2017_realistic': '90X_upgrade2017_realistic_v12',
-    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 HE-Plan1 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v12',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
+    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v14',
+    # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
+    'phase1_2017_realistic': '90X_upgrade2017_realistic_v14',
+    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
+    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v14',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v12',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/Eras/python/ModifierChain_run2_2017_core_cff.py
+++ b/Configuration/Eras/python/ModifierChain_run2_2017_core_cff.py
@@ -4,6 +4,8 @@ from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 
-run2_2017_core = cms.ModifierChain(Run2_2016, phase1Pixel, run2_HF_2017, run2_HCAL_2017)
+run2_2017_core = cms.ModifierChain(Run2_2016, phase1Pixel, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017)
 

--- a/Configuration/Eras/python/Modifier_run2_HEPlan1_2017_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_HEPlan1_2017_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for Plan1-specific changes for sim, reco, etc.
+
+run2_HEPlan1_2017 =  cms.Modifier()
+

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -91,17 +91,19 @@ upgradeProperties = {}
 
 upgradeProperties[2017] = {
     '2017' : {
-        'Geom' : 'DB:Extended',
+        'Geom' : 'Extended2017Plan1',
         'GT' : 'auto:phase1_2017_realistic',
         'HLTmenu': '@relval2016',
         'Era' : 'Run2_2017',
+        'Custom' : 'SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Plan1',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','ALCAFull','HARVESTFull'],
     },
     '2017Design' : {
-        'Geom' : 'DB:Extended',
+        'Geom' : 'Extended2017Plan1',
         'GT' : 'auto:phase1_2017_design',
         'HLTmenu': '@relval2016',
         'Era' : 'Run2_2017',
+        'Custom' : 'SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Plan1',
         'BeamSpot': 'GaussSigmaZ4cm',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
     },

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -91,19 +91,17 @@ upgradeProperties = {}
 
 upgradeProperties[2017] = {
     '2017' : {
-        'Geom' : 'Extended2017Plan1',
+        'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2017_realistic',
         'HLTmenu': '@relval2016',
         'Era' : 'Run2_2017',
-        'Custom' : 'SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Plan1',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','ALCAFull','HARVESTFull'],
     },
     '2017Design' : {
-        'Geom' : 'Extended2017Plan1',
+        'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2017_design',
         'HLTmenu': '@relval2016',
         'Era' : 'Run2_2017',
-        'Custom' : 'SLHCUpgradeSimulations/Configuration/HCalCustoms.customise_Hcal2017Plan1',
         'BeamSpot': 'GaussSigmaZ4cm',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
     },

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -35,7 +35,7 @@ class Eras (object):
                            'stage1L1Trigger', 'fastSim',
                            'peripheralPbPb', 'pA_2016',
                            'run2_HE_2017', 'stage2L1Trigger',
-                           'run2_HF_2017', 'run2_HCAL_2017',
+                           'run2_HF_2017', 'run2_HCAL_2017', 'run2_HEPlan1_2017',
                            'run3_HB',
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
                            'phase2_common', 'phase2_tracker',

--- a/Configuration/StandardSequences/python/GeometryConf.py
+++ b/Configuration/StandardSequences/python/GeometryConf.py
@@ -24,6 +24,7 @@ GeometryConf={
     'Extended2016'   : 'Extended2016,Extended2016Reco',
     'Extended2017'   : 'Extended2017,Extended2017Reco',
     'Extended2018'   : 'Extended2018,Extended2018Reco',
+    'Extended2017Plan1' : 'Extended2017Plan1,Extended2017Plan1Reco',
     'Extended2019'   : 'Extended2019,Extended2019Reco',
     'ExtendedGFlash' : 'ExtendedGFlash,ExtendedGFlashReco',
     'All'         : 'Configuration.Geometry.GeometrySimAll_cff,Reco',

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -51,7 +51,7 @@ zdcreco = _hcalLocalReco_cff.zdcreco.clone(
 )
 
 # 2017 customs
-from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 
 _phase1_hbheprereco = _hcalLocalReco_cff._phase1_hbheprereco.clone(
@@ -74,7 +74,7 @@ _phase1_hfreco = _hcalLocalReco_cff._phase1_hfreco.clone(
 )
 
 
-run2_HE_2017.toReplaceWith(hbheprereco, _phase1_hbheprereco )
+run2_HCAL_2017.toReplaceWith(hbheprereco, _phase1_hbheprereco )
 run2_HF_2017.toReplaceWith(hfreco, _phase1_hfreco )
 
 hfprereco = _hcalLocalReco_cff.hfprereco.clone(

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -81,12 +81,19 @@ hfprereco = _hcalLocalReco_cff.hfprereco.clone(
     sumAllTimeSlices = cms.bool(True)
 )
 
+hbheplan1 = _hcalLocalReco_cff.hbheplan1.clone()
+
 # redefine hcal sequence
 hcalLocalRecoSequence = cms.Sequence(hbheprereco+hfreco+horeco+zdcreco)
 
 _phase1_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
 _phase1_hcalLocalRecoSequence.insert(0,hfprereco)
 run2_HF_2017.toReplaceWith(hcalLocalRecoSequence, _phase1_hcalLocalRecoSequence)
+
+_plan1_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy() 
+_plan1_hcalLocalRecoSequence += hbheplan1
+from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequence, _plan1_hcalLocalRecoSequence)
 
 calolocalrecoCosmics = cms.Sequence(ecalLocalRecoSequenceCosmics+hcalLocalRecoSequence)
 

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -81,7 +81,7 @@ hfprereco = _hcalLocalReco_cff.hfprereco.clone(
     sumAllTimeSlices = cms.bool(True)
 )
 
-hbheplan1 = _hcalLocalReco_cff.hbheplan1.clone()
+from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 
 # redefine hcal sequence
 hcalLocalRecoSequence = cms.Sequence(hbheprereco+hfreco+horeco+zdcreco)

--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -39,6 +39,7 @@ _phase1_hfrecoMB = RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi.hfre
         rejectAllFailures = cms.bool(False)
     ),
 )
+from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 
 _phase1_hcalLocalRecoSequenceNZS = hcalLocalRecoSequenceNZS.copy()
 _phase1_hcalLocalRecoSequenceNZS.insert(0,hfprerecoMB)
@@ -48,3 +49,8 @@ run2_HF_2017.toReplaceWith( hcalLocalRecoSequenceNZS, _phase1_hcalLocalRecoSeque
 run2_HF_2017.toReplaceWith( hfrecoMB, _phase1_hfrecoMB )
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toReplaceWith( hbherecoMB, _phase1_hbherecoMB )
+
+_plan1_hcalLocalRecoSequenceNZS = _phase1_hcalLocalRecoSequenceNZS.copy()
+_plan1_hcalLocalRecoSequenceNZS += hbheplan1
+from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequenceNZS, _plan1_hcalLocalRecoSequenceNZS)

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -12,6 +12,7 @@ hcalLocalRecoSequence = cms.Sequence(hbheprereco+hfreco+horeco+zdcreco)
 from RecoLocalCalo.HcalRecProducers.hfprereco_cfi import hfprereco
 from RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi import hfreco as _phase1_hfreco
 from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprereco as _phase1_hbheprereco
+from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 
 # copies for cosmics
 _default_hbheprereco = hbheprereco.clone()
@@ -25,6 +26,11 @@ run2_HF_2017.toReplaceWith( hcalLocalRecoSequence, _phase1_hcalLocalRecoSequence
 run2_HF_2017.toReplaceWith( hfreco, _phase1_hfreco )
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toReplaceWith( hbheprereco, _phase1_hbheprereco )
+
+_plan1_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy()
+_plan1_hcalLocalRecoSequence += hbheplan1
+from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequence, _plan1_hcalLocalRecoSequence)
 
 _phase2_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
 _phase2_hcalLocalRecoSequence.remove(hbheprereco)

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEIsolatedNoiseReflagger_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEIsolatedNoiseReflagger_cfi.py
@@ -59,3 +59,6 @@ hbhereco = cms.EDProducer(
     MinValidTrackNHits = cms.int32(5),
 
  )
+
+from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+run2_HEPlan1_2017.toModify(hbhereco, hbheInput = cms.InputTag('hbheplan1'))

--- a/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py
@@ -110,6 +110,12 @@ def customise_Hcal2017(process):
         process.AllHcalDigisValidation.digiLabel = cms.string("simHcalDigis")
 
     return process
+
+#customization for Plan1
+def customise_Hcal2017Plan1(process):
+    process = customise_Hcal2017(process)
+    process.es_hardcode.testHEPlan1 = cms.bool(True)
+    return process
     
 #intermediate customization (HCAL 2017, HE and HF upgrades - w/ SiPMs & QIE11)
 def customise_Hcal2017Full(process):

--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -21,7 +21,7 @@ hcalSimBlock = cms.PSet(
     hitsProducer = cms.string('g4SimHits'),
     DelivLuminosity = cms.double(0),
     TestNumbering = cms.bool(False),
-    doNeutralDensityFilter = cms.bool(False),
+    doNeutralDensityFilter = cms.bool(True),
     HEDarkening = cms.bool(False),
     HFDarkening = cms.bool(False),
     minFCToDelay=cms.double(5.), # old TC model! set to 5 for the new one
@@ -50,3 +50,6 @@ run2_HCAL_2017.toModify( hcalSimBlock, TestNumbering = cms.bool(True) )
 # remove HE processing for phase 2, completely put in HGCal land
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(hcalSimBlock, killHE = cms.bool(True) )
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(hcalSimBlock, doNeutralDensityFilter = cms.bool(False))

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -290,7 +290,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         UsePMTHits                = cms.bool(False),
         UseFibreBundleHits        = cms.bool(False),
         TestNumberingScheme       = cms.bool(False),
-        doNeutralDensityFilter    = cms.bool(True),
+        doNeutralDensityFilter    = cms.bool(False),
         EminHitHB                 = cms.double(0.0),
         EminHitHE                 = cms.double(0.0),
         EminHitHO                 = cms.double(0.0),
@@ -473,4 +473,5 @@ from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify( g4SimHits.ECalSD,
                              StoreLayerTimeSim = cms.untracked.bool(True),
                              TimeSliceUnit = cms.double(0.001) )
-
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(g4SimHits.HCalSD, doNeutralDensityFilter = cms.bool(True))


### PR DESCRIPTION
This PR changes the 2017 workflow to include HE Plan1 (upgrade of single RBX).

A new Era, `run2_HEPlan1_2017`, is introduced to handle RecHit merging, which restores the Phase0 depth segmentation for reco geometry. @Dr15Jones is there a way to remove this modifier (included in `run2_2017_core`) from subsequent Eras like `run2_2018`?

Currently, the workflow uses hardcoded conditions for HCAL (which are updated to handle the Plan1 simulation geometry) and XML geometry. These will be replaced with a new GT when ready.

Other minor changes:
* Update era usage in cosmic 2017 workflow
* Apply layer0 weight (NDF simulation) in digitization step by default (except for phase2, temporarily)

attn: @abdoulline, @hatakeyamak, @deguio, @franzoni, @ianna, @bsunanda, @igv4321