### PR TITLE
Switching BoostedDoubleSV tagger to v4 training for AK8 jets (80X)

### DIFF
--- a/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
@@ -4,7 +4,7 @@ from RecoBTag.SecondaryVertex.trackSelection_cff import *
 
 candidateBoostedDoubleSecondaryVertexAK8Computer = cms.ESProducer("CandidateBoostedDoubleSecondaryVertexESProducer",
     useCondDB = cms.bool(False),
-    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_v3.weights.xml.gz'),
+    weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_v4.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(False)
 )


### PR DESCRIPTION
80X backport of #17294 for legacy 80X re-MiniAOD.

@cvernier 