### PR TITLE
Resolve missing-braces error (GCC 7, C++17)

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -203,9 +203,9 @@ struct Rot3 {
   Vec  axis[3];
   
   constexpr Rot3() :
-    axis{ (Vec){T(1),0,0,0},
-      (Vec){0,T(1),0,0},
-	(Vec){0,0,T(1),0}
+    axis{{(Vec){T(1),0,0,0}},
+         {(Vec){0,T(1),0,0}},
+         {(Vec){0,0,T(1),0}}
   }{}
     
   constexpr Rot3( Vec4<T> ix,  Vec4<T> iy,  Vec4<T> iz) :


### PR DESCRIPTION
This is same issue as here: 7d049b86bb8f0645ae8253acaba1cdfa4f18ffed

See #17426

This showed up in `slc7_aarch64_gcc700` build.

Signed-off-by: David Abdurachmanov <davidlt@cern.ch>