### PR TITLE
Package of several technical changes: downgrade of edm::Warnings to edm::Info, removal of an unused parameter from cfi file, upward move of jet selection for tau seeding, switch off of production of null taus

### DIFF
--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -36,7 +36,6 @@ pfTauPFJets08Region = recoTauAK4PFJets08Region.clone()
 pfTauPFJets08Region.src = cms.InputTag("ak4PFJets")
 pfTauPFJetsRecoTauChargedHadrons = ak4PFJetsRecoTauChargedHadrons.clone()
 pfTauPFJets08Region.pfSrc = cms.InputTag("particleFlow")
-pfTauPFJetsRecoTauChargedHadrons.jetRegionSrc = 'pfTauPFJets08Region'
 
 pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone()
 pfTauTagInfoProducer.PFCandidateProducer = jetConfig.ak4PFJets.src

--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -29,13 +29,9 @@ selection is constructed by:
 # PiZeroProducers
 
 pfJetsLegacyHPSPiZeros = ak4PFJetsLegacyHPSPiZeros.clone()
-
 pfJetsLegacyHPSPiZeros.jetSrc = cms.InputTag("ak4PFJets")
 
-#pfTauPFJets08Region = recoTauAK4PFJets08Region.clone()
-#pfTauPFJets08Region.src = cms.InputTag("ak4PFJets")
 pfTauPFJetsRecoTauChargedHadrons = ak4PFJetsRecoTauChargedHadrons.clone()
-#pfTauPFJets08Region.pfSrc = cms.InputTag("particleFlow")
 
 pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone()
 pfTauTagInfoProducer.PFCandidateProducer = jetConfig.ak4PFJets.src
@@ -46,7 +42,6 @@ pfTausProducer = hpsPFTauProducer.clone()
 pfTausCombiner = combinatoricRecoTaus.clone()
 pfTausCombiner.jetSrc= cms.InputTag("ak4PFJets")
 pfTausCombiner.piZeroSrc= "pfJetsLegacyHPSPiZeros"
-#pfTausCombiner.jetRegionSrc='pfTauPFJets08Region'
 pfTausCombiner.chargedHadronSrc='pfTauPFJetsRecoTauChargedHadrons'
 pfTausCombiner.modifiers[3].pfTauTagInfoSrc=cms.InputTag("pfTauTagInfoProducer")
 pfTausSelectionDiscriminator = hpsSelectionDiscriminator.clone()
@@ -126,7 +121,6 @@ pfTauTagInfoProducer.PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVer
 
 pfTausPreSequence = cms.Sequence(
     pfJetTracksAssociatorAtVertex +
-    #pfTauPFJets08Region +
     pfTauPileUpVertices +
     pfTauTagInfoProducer
 )

--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -32,10 +32,10 @@ pfJetsLegacyHPSPiZeros = ak4PFJetsLegacyHPSPiZeros.clone()
 
 pfJetsLegacyHPSPiZeros.jetSrc = cms.InputTag("ak4PFJets")
 
-pfTauPFJets08Region = recoTauAK4PFJets08Region.clone()
-pfTauPFJets08Region.src = cms.InputTag("ak4PFJets")
+#pfTauPFJets08Region = recoTauAK4PFJets08Region.clone()
+#pfTauPFJets08Region.src = cms.InputTag("ak4PFJets")
 pfTauPFJetsRecoTauChargedHadrons = ak4PFJetsRecoTauChargedHadrons.clone()
-pfTauPFJets08Region.pfSrc = cms.InputTag("particleFlow")
+#pfTauPFJets08Region.pfSrc = cms.InputTag("particleFlow")
 
 pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone()
 pfTauTagInfoProducer.PFCandidateProducer = jetConfig.ak4PFJets.src
@@ -46,7 +46,7 @@ pfTausProducer = hpsPFTauProducer.clone()
 pfTausCombiner = combinatoricRecoTaus.clone()
 pfTausCombiner.jetSrc= cms.InputTag("ak4PFJets")
 pfTausCombiner.piZeroSrc= "pfJetsLegacyHPSPiZeros"
-pfTausCombiner.jetRegionSrc='pfTauPFJets08Region'
+#pfTausCombiner.jetRegionSrc='pfTauPFJets08Region'
 pfTausCombiner.chargedHadronSrc='pfTauPFJetsRecoTauChargedHadrons'
 pfTausCombiner.modifiers[3].pfTauTagInfoSrc=cms.InputTag("pfTauTagInfoProducer")
 pfTausSelectionDiscriminator = hpsSelectionDiscriminator.clone()
@@ -126,7 +126,7 @@ pfTauTagInfoProducer.PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVer
 
 pfTausPreSequence = cms.Sequence(
     pfJetTracksAssociatorAtVertex +
-    pfTauPFJets08Region +
+    #pfTauPFJets08Region +
     pfTauPileUpVertices +
     pfTauTagInfoProducer
 )

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
@@ -19,7 +19,7 @@ def addBoostedTaus(process):
     process.combinatoricRecoTausBoosted.modifiers.remove(process.combinatoricRecoTausBoosted.modifiers[3])
     #process.combinatoricRecoTausBoosted.builders[0].pfCandSrc = cms.InputTag('pfNoPileUpForBoostedTaus')
     process.combinatoricRecoTausBoosted.builders[0].pfCandSrc = cms.InputTag('particleFlow')
-    #Note JetArea is not defined for subjects and restiction to jetArea is turned to dRMatch=0.1, so better use the latter explicitely
+    #Note JetArea is not defined for subjets and restiction to jetArea is turned to dRMatch=0.1, so better use the latter explicitely
     #process.hpsPFTauDiscriminationByLooseMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
     #process.hpsPFTauDiscriminationByTightMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
     process.hpsPFTauDiscriminationByLooseMuonRejection3Boosted.dRmuonMatch = 0.1

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cfi.py
@@ -19,8 +19,11 @@ def addBoostedTaus(process):
     process.combinatoricRecoTausBoosted.modifiers.remove(process.combinatoricRecoTausBoosted.modifiers[3])
     #process.combinatoricRecoTausBoosted.builders[0].pfCandSrc = cms.InputTag('pfNoPileUpForBoostedTaus')
     process.combinatoricRecoTausBoosted.builders[0].pfCandSrc = cms.InputTag('particleFlow')
-    process.hpsPFTauDiscriminationByLooseMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
-    process.hpsPFTauDiscriminationByTightMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
+    #Note JetArea is not defined for subjects and restiction to jetArea is turned to dRMatch=0.1, so better use the latter explicitely
+    #process.hpsPFTauDiscriminationByLooseMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
+    #process.hpsPFTauDiscriminationByTightMuonRejection3Boosted.dRmuonMatchLimitedToJetArea = cms.bool(True)
+    process.hpsPFTauDiscriminationByLooseMuonRejection3Boosted.dRmuonMatch = 0.1
+    process.hpsPFTauDiscriminationByTightMuonRejection3Boosted.dRmuonMatch = 0.1
     massSearchReplaceAnyInputTag(process.PATTauSequenceBoosted,cms.InputTag("ak4PFJets"),cms.InputTag("boostedTauSeeds"))  
     process.slimmedTausBoosted = process.slimmedTaus.clone(src = cms.InputTag("selectedPatTausBoosted"))
     

--- a/RecoTauTag/Configuration/test/ZTT-validation.txt
+++ b/RecoTauTag/Configuration/test/ZTT-validation.txt
@@ -1,2 +1,2 @@
-/store/relval/CMSSW_8_1_0/RelValProdTTbar/AODSIM/81X_mcRun1_realistic_v5-v1/10000/8A6B8BF1-43BB-E611-BC7D-0025905A611E.root
-/store/relval/CMSSW_8_1_0/RelValProdTTbar/AODSIM/81X_mcRun1_realistic_v5-v1/10000/9C6B15F6-43BB-E611-BE34-0025905B858E.root
+/store/relval/CMSSW_9_0_0_pre4/RelValTTbar_13/GEN-SIM-RECO/PUpmx25ns_90X_mcRun2_asymptotic_v1-v1/10000/5C714DBC-65EE-E611-BCFB-0CC47A78A426.root
+/store/relval/CMSSW_9_0_0_pre4/RelValTTbar_13/GEN-SIM-RECO/PUpmx25ns_90X_mcRun2_asymptotic_v1-v1/10000/A40BB4B4-65EE-E611-A3C2-0CC47A7C3412.root

--- a/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PATTauDiscriminationByMVAIsolationRun2.cc
@@ -270,10 +270,10 @@ double PATTauDiscriminationByMVAIsolationRun2::discriminate(const TauRef& tau) c
       mvaInput_[12] = std::min((float)100., leadingTrackChi2);
       mvaInput_[13] = std::min((float)1., eRatio);
       mvaInput_[14]  = TMath::Sign((float)+1., tau->dxy());
-      mvaInput_[15]  = std::sqrt(std::fabs(std::min((float)1., std::fabs(tau->dxy()))));
+      mvaInput_[15]  = std::sqrt(std::min((float)1., std::fabs(tau->dxy())));
       mvaInput_[16]  = std::min((float)10., std::fabs(tau->dxy_Sig()));
       mvaInput_[17]  = TMath::Sign((float)+1., tau->ip3d());
-      mvaInput_[18]  = std::sqrt(std::fabs(std::min((float)1., std::fabs(tau->ip3d()))));
+      mvaInput_[18]  = std::sqrt(std::min((float)1., std::fabs(tau->ip3d())));
       mvaInput_[19]  = std::min((float)10., std::fabs(tau->ip3d_Sig()));
       mvaInput_[20]  = ( tau->hasSecondaryVertex() ) ? 1. : 0.;
       mvaInput_[21] = std::sqrt(decayDistMag);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -74,6 +74,8 @@ public:
   // input jet collection
   edm::InputTag srcJets_;
   edm::EDGetTokenT<reco::CandidateView> Jets_token;
+  double minJetPt_;
+  double maxJetAbsEta_;
 
   // plugins for building and ranking ChargedHadron candidates
   builderList builders_;
@@ -93,6 +95,8 @@ PFRecoTauChargedHadronProducer::PFRecoTauChargedHadronProducer(const edm::Parame
 {
   srcJets_ = cfg.getParameter<edm::InputTag>("jetSrc");
   Jets_token = consumes<reco::CandidateView>(srcJets_);
+  minJetPt_ = ( cfg.exists("minJetPt") ) ? cfg.getParameter<double>("minJetPt") : -1.0;
+  maxJetAbsEta_ = ( cfg.exists("maxJetAbsEta") ) ? cfg.getParameter<double>("maxJetAbsEta") : 99.0;
   verbosity_ = ( cfg.exists("verbosity") ) ?
     cfg.getParameter<int>("verbosity") : 0;
   
@@ -164,6 +168,9 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
   // loop over our jets
   BOOST_FOREACH( const reco::PFJetRef& pfJet, pfJets ) {
     
+    if(pfJet->pt() - minJetPt_ < 1e-5) continue;
+    if(std::abs(pfJet->eta()) - maxJetAbsEta_ > -1e-5) continue;
+
     // build global list of ChargedHadron candidates for each jet
     ChargedHadronList uncleanedChargedHadrons;
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationAgainstMuon2.cc
@@ -206,7 +206,7 @@ double PFRecoTauDiscriminationAgainstMuon2::discriminate(const reco::PFTauRef& p
 	  dRmatch = TMath::Min(dRmatch, TMath::Sqrt(jetArea/TMath::Pi()));
 	} else {
 	  if ( numWarnings_ < maxWarnings_ ) {
-	    edm::LogWarning("PFRecoTauDiscriminationAgainstMuon2::discriminate") 
+	    edm::LogInfo("PFRecoTauDiscriminationAgainstMuon2::discriminate") 
 	      << "Jet associated to Tau: Pt = " << pfTau->pt() << ", eta = " << pfTau->eta() << ", phi = " << pfTau->phi() << " has area = " << jetArea << " !!" ;
 	    ++numWarnings_;
 	  }

--- a/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
@@ -153,7 +153,7 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
   size_t nNewJets = 0;
   for ( size_t ijet = 0; ijet < nJets; ++ijet ) {
     // Get a ref to jet
-    const reco::PFJetRef jetRef = jets[ijet];
+    const reco::PFJetRef& jetRef = jets[ijet];
     if(jetRef->pt() - minJetPt_ < 1e-5) continue;
     if(std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
     // Make an initial copy.

--- a/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauJetRegionProducer.cc
@@ -50,6 +50,8 @@ class RecoTauJetRegionProducer : public edm::stream::EDProducer<>
   edm::EDGetTokenT<reco::CandidateView> Jets_token;
   edm::EDGetTokenT<JetToPFCandidateAssociation> pfCandAssocMap_token;
 
+  double minJetPt_;
+  double maxJetAbsEta_;
   double deltaR2_;
 
   int verbosity_;
@@ -68,6 +70,8 @@ RecoTauJetRegionProducer::RecoTauJetRegionProducer(const edm::ParameterSet& cfg)
   
   double deltaR = cfg.getParameter<double>("deltaR"); 
   deltaR2_ = deltaR*deltaR;
+  minJetPt_ = ( cfg.exists("minJetPt") ) ? cfg.getParameter<double>("minJetPt") : -1.0;
+  maxJetAbsEta_ = ( cfg.exists("maxJetAbsEta") ) ? cfg.getParameter<double>("maxJetAbsEta") : 99.0;
   
   verbosity_ = ( cfg.exists("verbosity") ) ?
     cfg.getParameter<int>("verbosity") : 0;
@@ -91,10 +95,10 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
   // Build Ptrs for all the PFCandidates
   typedef edm::Ptr<reco::PFCandidate> PFCandPtr;
   std::vector<PFCandPtr> pfCands;
-  pfCands.reserve(pfCandsHandle->size());  
+  pfCands.reserve(pfCandsHandle->size());
   for ( size_t icand = 0; icand < pfCandsHandle->size(); ++icand ) {
-    pfCands.push_back(PFCandPtr(pfCandsHandle, icand));    
-  }  
+    pfCands.push_back(PFCandPtr(pfCandsHandle, icand));
+  }
 
   // Get the jets
   edm::Handle<reco::CandidateView> jetView;
@@ -106,18 +110,8 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
   // Get the association map matching jets to PFCandidates
   // (needed for recinstruction of boosted taus)
   edm::Handle<JetToPFCandidateAssociation> jetToPFCandMap;
-  std::vector<std::unordered_set<unsigned> > fastJetToPFCandMap;
   if ( pfCandAssocMapSrc_.label() != "" ) {
     evt.getByToken(pfCandAssocMap_token, jetToPFCandMap);
-    fastJetToPFCandMap.resize(nJets);
-    for ( size_t ijet = 0; ijet < nJets; ++ijet ) {
-      // Get a ref to jet
-      const reco::PFJetRef& jetRef = jets[ijet];
-      const auto& pfCandsMappedToJet = (*jetToPFCandMap)[jetRef];
-      for ( const auto& pfCandMappedToJet : pfCandsMappedToJet ) {
-	fastJetToPFCandMap[ijet].emplace(pfCandMappedToJet.key());
-      }
-    }
   }
 
   // Get the original product, so we can match against it - otherwise the
@@ -143,32 +137,42 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
   auto newJets = std::make_unique<reco::PFJetCollection>();
 
   // Keep track of the indices of the current jet and the old (original) jet
-  // -1 indicates no match.  
+  // -1 indicates no match.
   std::vector<int> matchInfo(nOriginalJets, -1);
   newJets->reserve(nJets);
-  
+  size_t nNewJets = 0;
   for ( size_t ijet = 0; ijet < nJets; ++ijet ) {
     // Get a ref to jet
-    const reco::PFJetRef& jetRef = jets[ijet];
+    reco::PFJetRef jetRef = jets[ijet];
+    if(jetRef->pt() - minJetPt_ < 1e-5) continue;
+    if(std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
     // Make an initial copy.
     newJets->emplace_back(*jetRef);
     reco::PFJet& newJet = newJets->back();
     // Clear out all the constituents
     newJet.clearDaughters();
     // Loop over all the PFCands
-    for ( const auto& pfCand : pfCands ) {
+    for ( std::vector<PFCandPtr>::const_iterator pfCand = pfCands.begin();
+	  pfCand != pfCands.end(); ++pfCand ) {
       bool isMappedToJet = false;
-      if ( jetToPFCandMap.isValid() ) {
+      if ( pfCandAssocMapSrc_.label() != "" ) {
 	auto temp = jetToPFCandMap->find(jetRef);
 	if( temp == jetToPFCandMap->end() ) {
 	  edm::LogWarning("WeirdCandidateMap") << "Candidate map for jet " << jetRef.key() << " is empty!";
 	  continue;
 	}
-	isMappedToJet = fastJetToPFCandMap[ijet].count(pfCand.key());	
+	edm::RefVector<reco::PFCandidateCollection> pfCandsMappedToJet = (*jetToPFCandMap)[jetRef];
+	for ( edm::RefVector<reco::PFCandidateCollection>::const_iterator pfCandMappedToJet = pfCandsMappedToJet.begin();
+	      pfCandMappedToJet != pfCandsMappedToJet.end(); ++pfCandMappedToJet ) {
+	  if ( reco::deltaR2(**pfCandMappedToJet, **pfCand) < 1.e-8 ) {
+	    isMappedToJet = true;
+	    break;
+	  }
+	}
       } else {
 	isMappedToJet = true;
       }
-      if ( reco::deltaR2(*jetRef, *pfCand) < deltaR2_ && isMappedToJet ) newJet.addDaughter(pfCand);
+      if ( reco::deltaR2(*jetRef, **pfCand) < deltaR2_ && isMappedToJet ) newJet.addDaughter(*pfCand);
     }
     if ( verbosity_ ) {
       std::cout << "jet #" << ijet << ": Pt = " << jetRef->pt() << ", eta = " << jetRef->eta() << ", phi = " << jetRef->eta() << ","
@@ -182,7 +186,9 @@ void RecoTauJetRegionProducer::produce(edm::Event& evt, const edm::EventSetup& e
     }
     // Match the index of the jet we just made to the index into the original
     // collection.
-    matchInfo[jetRef.key()] = ijet;
+    //matchInfo[jetRef.key()] = ijet;
+    matchInfo[jetRef.key()] = nNewJets;
+    nNewJets++;
   }
 
   // Put our new jets into the event

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroProducer.cc
@@ -69,12 +69,17 @@ class RecoTauPiZeroProducer : public edm::stream::EDProducer<> {
     //consumes interface
     edm::EDGetTokenT<reco::CandidateView> cand_token;
 
+    double minJetPt_;
+    double maxJetAbsEta_;
+
     int verbosity_;
 };
 
 RecoTauPiZeroProducer::RecoTauPiZeroProducer(const edm::ParameterSet& pset) 
 {
   cand_token = consumes<reco::CandidateView>( pset.getParameter<edm::InputTag>("jetSrc"));
+  minJetPt_ = ( pset.exists("minJetPt") ) ? pset.getParameter<double>("minJetPt") : -1.0;
+  maxJetAbsEta_ = ( pset.exists("maxJetAbsEta") ) ? pset.getParameter<double>("maxJetAbsEta") : 99.0;
 
   typedef std::vector<edm::ParameterSet> VPSet;
   // Get the mass hypothesis for the pizeros
@@ -148,6 +153,9 @@ void RecoTauPiZeroProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
   // Loop over our jets
   BOOST_FOREACH(const reco::PFJetRef& jet, jetRefs) {
+
+    if(jet->pt() - minJetPt_ < 1e-5) continue;
+    if(std::abs(jet->eta()) - maxJetAbsEta_ > -1e-5) continue;
     // Build our global list of RecoTauPiZero
     PiZeroList dirtyPiZeros;
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -166,7 +166,7 @@ void RecoTauProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   BOOST_FOREACH( reco::PFJetRef jetRef, jets ) {
     // Get the jet with extra constituents from an area around the jet
     if(jetRef->pt() - minJetPt_ < 1e-5) continue;
-    if(fabs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
+    if(std::abs(jetRef->eta()) - maxJetAbsEta_ > -1e-5) continue;
     reco::PFJetRef jetRegionRef = (*jetRegionHandle)[jetRef];
     if ( jetRegionRef.isNull() ) {
       throw cms::Exception("BadJetRegionRef") 

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
@@ -8,7 +8,10 @@ from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 
 ak4PFJetsRecoTauChargedHadrons = cms.EDProducer("PFRecoTauChargedHadronProducer",
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
-    jetRegionSrc = cms.InputTag("recoTauAK4PFJets08Region"),
+    minJetPt = PFRecoTauPFJetInputs.minJetPt,
+    maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
+    #jetRegionSrc = cms.InputTag("recoTauAK4PFJets08Region"),
+    jetRegionSrc = cms.InputTag("unused"),
     outputSelection = cms.string('pt > %1.1f' % PFTauQualityCuts.signalQualityCuts.minTrackPt.value()), # CV: apply minimum Pt cut as sanity check
     builders = cms.VPSet(
         builders.chargedPFCandidates,

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
@@ -10,8 +10,6 @@ ak4PFJetsRecoTauChargedHadrons = cms.EDProducer("PFRecoTauChargedHadronProducer"
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    #jetRegionSrc = cms.InputTag("recoTauAK4PFJets08Region"),
-    jetRegionSrc = cms.InputTag("unused"),
     outputSelection = cms.string('pt > %1.1f' % PFTauQualityCuts.signalQualityCuts.minTrackPt.value()), # CV: apply minimum Pt cut as sanity check
     builders = cms.VPSet(
         builders.chargedPFCandidates,

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstMuon2_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationAgainstMuon2_cfi.py
@@ -22,6 +22,7 @@ pfRecoTauDiscriminationAgainstMuon2 = cms.EDProducer("PFRecoTauDiscriminationAga
     # optional collection of muons to check for overlap with taus
     srcMuons = cms.InputTag('muons'),
     dRmuonMatch = cms.double(0.3),
+    # JetArea is not defined for subjects and restiction to jetArea is turned to dRMatch=0.1, so better use the latter explicitely
     dRmuonMatchLimitedToJetArea = cms.bool(False),
     minPtMatchedMuon = cms.double(5.),
 

--- a/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
@@ -137,7 +137,7 @@ combinatoricRecoTaus = cms.EDProducer("RecoTauProducer",
     jetRegionSrc = cms.InputTag("recoTauAK4PFJets08Region"),
     chargedHadronSrc = cms.InputTag('ak4PFJetsRecoTauChargedHadrons'),                                
     piZeroSrc = cms.InputTag("ak4PFJetsRecoTauPiZeros"),
-    buildNullTaus = cms.bool(True),
+    buildNullTaus = cms.bool(False),
     # Make maximum size from which to collect isolation cone objects, w.r.t to
     # the axis of the signal cone objects
     builders = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
@@ -137,7 +137,7 @@ combinatoricRecoTaus = cms.EDProducer("RecoTauProducer",
     jetRegionSrc = cms.InputTag("recoTauAK4PFJets08Region"),
     chargedHadronSrc = cms.InputTag('ak4PFJetsRecoTauChargedHadrons'),                                
     piZeroSrc = cms.InputTag("ak4PFJetsRecoTauPiZeros"),
-    buildNullTaus = cms.bool(False),
+    buildNullTaus = cms.bool(True),
     # Make maximum size from which to collect isolation cone objects, w.r.t to
     # the axis of the signal cone objects
     builders = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/RecoTauJetRegionProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauJetRegionProducer_cfi.py
@@ -6,6 +6,8 @@ RecoTauJetRegionProducer = cms.EDProducer(
         "RecoTauJetRegionProducer",
             deltaR = cms.double(0.8),
             src = PFRecoTauPFJetInputs.inputJetCollection,
+            minJetPt = PFRecoTauPFJetInputs.minJetPt,
+            maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
             pfCandSrc = cms.InputTag("particleFlow"),
             pfCandAssocMapSrc = cms.InputTag("")
         )

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
@@ -8,6 +8,8 @@ from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 ak4PFJetsLegacyHPSPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
+    minJetPt = PFRecoTauPFJetInputs.minJetPt,
+    maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 0'),
     builders = cms.VPSet(
@@ -23,6 +25,8 @@ ak4PFJetsLegacyHPSPiZeros = cms.EDProducer(
 
 ak4PFJetsRecoTauGreedyPiZeros = ak4PFJetsLegacyHPSPiZeros.clone( 
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
+    minJetPt = PFRecoTauPFJetInputs.minJetPt,
+    maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -35,6 +39,8 @@ ak4PFJetsRecoTauGreedyPiZeros = ak4PFJetsLegacyHPSPiZeros.clone(
 
 ak4PFJetsRecoTauPiZeros = ak4PFJetsLegacyHPSPiZeros.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
+    minJetPt = PFRecoTauPFJetInputs.minJetPt,
+    maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -52,6 +58,8 @@ ak4PFJetsRecoTauPiZeros = ak4PFJetsLegacyHPSPiZeros.clone(
 
 ak4PFJetsLegacyTaNCPiZeros = ak4PFJetsLegacyHPSPiZeros.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
+    minJetPt = PFRecoTauPFJetInputs.minJetPt,
+    maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(


### PR DESCRIPTION
Hi,

I am citing Michal's comment to this pull request below (*). Matrix tests have been performed and were positive. This is pure technical work that should not touch the physics performance. This is also what our tests indicated. Runtime performance might change e.g. since edm::Warnings are dowgrade to edm::Infos. 

Cheers,
Roger
 

(*)
The following issues are fixed with this PR:

 * Warning messages about null jet area are downgraded in the PFRecoTauDiscriminationAgainstMuon2. In addition settings of the discriminant for boosted tau reconstruction are corrected.
 * A selection is added for jets seeding production of JetRegions, TauChargedHadron and PiZero candidates identical to the one used by TauProducer. This avoids production of JetRegions, TauChargedHadrons and PiZeros which are then unused by Tau producer module which is more economical (less products stored in memory, less loops over PFCandidates, etc.)
 * Unused configuration parameter is removed from PFRecoTauChargedHadronProducer_cfi.py
 * Production of null taus, i.e. jets which are not all compatible with tau, is switched off in RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py

