### PR TITLE
Primary vertexing speed improvements

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ.cc
@@ -64,9 +64,7 @@ double DAClusterizerInZ::update(
   //update weights and vertex positions
   // mass constrained annealing without noise
   // returns the squared sum of changes of vertex positions
-
-  unsigned int nt=tks.size();
-
+  
   //initialize sums
   double sumpi=0;
   for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
@@ -76,29 +74,29 @@ double DAClusterizerInZ::update(
 
 
   // loop over tracks
-  for(unsigned int i=0; i<nt; i++){
-
+  for(auto && tk : tks ){
+  
     // update pik and Zi
     double Zi=0.;
     for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
-      k->ei=exp(-beta*Eik(tks[i],*k));// cache exponential for one track at a time
+      k->ei=exp(-beta*Eik(tk,*k));// cache exponential for one track at a time
       Zi += k->pk * k->ei;
     }
-    tks[i].Z=Zi;
+    tk.Z=Zi;
 
     // normalization for pk
-    if (tks[i].Z>0){
-      sumpi += tks[i].pi;
+    if (tk.Z>0){
+      sumpi += tk.pi;
       // accumulate weighted z and weights for vertex update
       for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
-	k->se += tks[i].pi* k->ei / Zi;
-	double w = k->pk * tks[i].pi* k->ei / Zi / tks[i].dz2;
+	k->se += tk.pi* k->ei / Zi;
+	double w = k->pk * tk.pi* k->ei / Zi / tk.dz2;
 	k->sw  += w;
-	k->swz += w * tks[i].z;
-	k->swE+= w*Eik(tks[i],*k);
+	k->swz += w * tk.z;
+	k->swE+= w*Eik(tk,*k);
       }
     }else{
-      sumpi += tks[i].pi;
+      sumpi += tk.pi;
     }
     
 
@@ -138,9 +136,7 @@ double DAClusterizerInZ::update(
 				)const{
   // MVF style, no more vertex weights, update tracks weights and vertex positions, with noise 
   // returns the squared sum of changes of vertex positions
-
-  unsigned int nt=tks.size();
-
+  
   //initialize sums
   for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
     k->se=0;    k->sw=0;   k->swz=0;
@@ -148,26 +144,28 @@ double DAClusterizerInZ::update(
   }
 
 
+  const double startZi = rho0*exp(-beta*dzCutOff_*dzCutOff_);
+
   // loop over tracks
-  for(unsigned int i=0; i<nt; i++){
+  for(auto&& tk : tks){
 
     // update pik and Zi
-    double Zi=rho0*exp(-beta*dzCutOff_*dzCutOff_);// cut-off
+    double Zi=startZi;// cut-off
     for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
-      k->ei=exp(-beta*Eik(tks[i],*k));// cache exponential for one track at a time
+      k->ei=exp(-beta*Eik(tk,*k));// cache exponential for one track at a time
       Zi += k->pk * k->ei;
     }
-    tks[i].Z=Zi;
+    tk.Z=Zi;
 
     // normalization
-    if (tks[i].Z>0){
+    if (tk.Z>0){
        // accumulate weighted z and weights for vertex update
       for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
-	k->se += tks[i].pi* k->ei / Zi;
-	double w = k->pk * tks[i].pi* k->ei / Zi / tks[i].dz2;
+	k->se += tk.pi* k->ei / Zi;
+	double w = k->pk * tk.pi* k->ei / Zi / tk.dz2;
 	k->sw  += w;
-	k->swz += w * tks[i].z;
-	k->swE+= w*Eik(tks[i],*k);
+	k->swz += w * tk.z;
+	k->swE+= w*Eik(tk,*k);
       }
     }
 
@@ -273,11 +271,11 @@ bool DAClusterizerInZ::purge(vector<vertex_t> & y, vector<track_t> & tks, double
     int nUnique=0;
     double sump=0;
     double pmax=k->pk/(k->pk+rho0exp);
-    for(unsigned int i=0; i<nt; ++i){
-      if(tks[i].Z>0){
-	double p=k->pk * exp(-beta*Eik(tks[i],*k)) / tks[i].Z;
+    for(auto&& tk : tks ) {    
+      if(tk.Z>0){
+	double p=k->pk * exp(-beta*Eik(tk,*k)) / tk.Z;
 	sump+=p;
-	if( (p > 0.9*pmax) && (tks[i].pi>0) ) { ++nUnique; }
+	if( (p > 0.9*pmax) && (tk.pi>0) ) { ++nUnique; }
 	if( nUnique >= maxUnique ) { break; }
       }
     }
@@ -309,26 +307,25 @@ double DAClusterizerInZ::beta0(
   
   double T0=0;  // max Tc for beta=0
   // estimate critical temperature from beta=0 (T=inf)
-  unsigned int nt=tks.size();
-
+  
   for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
 
     // vertex fit at T=inf 
     double sumwz=0;
     double sumw=0;
-    for(unsigned int i=0; i<nt; i++){
-      double w=tks[i].pi/tks[i].dz2;
-      sumwz+=w*tks[i].z;
+    for(auto&& tk : tks){
+      double w=tk.pi/tk.dz2;
+      sumwz+=w*tk.z;
       sumw +=w;
     }
     k->z=sumwz/sumw;
 
     // estimate Tcrit, eventually do this in the same loop
     double a=0, b=0;
-    for(unsigned int i=0; i<nt; i++){
-      double dx=tks[i].z-(k->z);
-      double w=tks[i].pi/tks[i].dz2;
-      a+=w*pow(dx,2)/tks[i].dz2;
+    for(auto&& tk : tks){
+      double dx=tk.z-(k->z);
+      double w=tk.pi/tk.dz2;
+      a+=w*pow(dx,2)/tk.dz2;
       b+=w;
     }
     double Tc= 2.*a/b;  // the critical temperature of this vertex

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ.cc
@@ -260,26 +260,29 @@ bool DAClusterizerInZ::merge(vector<vertex_t> & y, double & beta)const{
 
 
 
-bool DAClusterizerInZ::purge(vector<vertex_t> & y, vector<track_t> & tks, double & rho0, const double beta)const{
+bool DAClusterizerInZ::purge(vector<vertex_t> & y, vector<track_t> & tks, double & rho0, const double beta) const {
+  constexpr int maxUnique = 2;
   // eliminate clusters with only one significant/unique track
   if(y.size()<2)  return false;
   
   unsigned int nt=tks.size();
   double sumpmin=nt;
   vector<vertex_t>::iterator k0=y.end();
-  for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){ 
+  const double rho0exp = rho0*std::exp(-beta*dzCutOff_*dzCutOff_);
+  for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); ++k){ 
     int nUnique=0;
     double sump=0;
-    double pmax=k->pk/(k->pk+rho0*exp(-beta*dzCutOff_*dzCutOff_));
-    for(unsigned int i=0; i<nt; i++){
+    double pmax=k->pk/(k->pk+rho0exp);
+    for(unsigned int i=0; i<nt; ++i){
       if(tks[i].Z>0){
 	double p=k->pk * exp(-beta*Eik(tks[i],*k)) / tks[i].Z;
 	sump+=p;
-	if( (p > 0.9*pmax) && (tks[i].pi>0) ){ nUnique++; }
+	if( (p > 0.9*pmax) && (tks[i].pi>0) ) { ++nUnique; }
+	if( nUnique >= maxUnique ) { break; }
       }
     }
 
-    if((nUnique<2)&&(sump<sumpmin)){
+    if( ( nUnique < maxUnique ) && ( sump<sumpmin ) ){
       sumpmin=sump;
       k0=k;
     }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
@@ -83,8 +83,7 @@ double DAClusterizerInZT::update( double beta,
   // MVF style, no more vertex weights, update tracks weights and vertex positions, with noise 
   // returns the squared sum of changes of vertex positions
 
-  unsigned int nt=tks.size();
-
+  
   //initialize sums
   double sumpi = 0.;
   for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
@@ -92,30 +91,31 @@ double DAClusterizerInZT::update( double beta,
     k->swE = 0.;  k->tC=0.;
   }
 
+  const double startZi = rho0*std::exp(-beta*(dzCutOff_*dzCutOff_));
 
   // loop over tracks
-  for(unsigned int i=0; i<nt; i++){
+  for(auto&& tk : tks) {
 
     // update pik and Zi and Ti
-    double Zi = rho0*std::exp(-beta*(dzCutOff_*dzCutOff_));// cut-off (eventually add finite size in time)
+    double Zi = startZi; // cut-off (eventually add finite size in time)
     //double Ti = 0.; // dt0*std::exp(-beta*dtCutOff_);
     for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
-      k->ei = std::exp(-beta*e_ik(tks[i],*k));// cache exponential for one track at a time
+      k->ei = std::exp(-beta*e_ik(tk,*k));// cache exponential for one track at a time
       Zi   += k->pk * k->ei;
     }
-    tks[i].zi=Zi;
-    sumpi += tks[i].pi;
+    tk.zi=Zi;
+    sumpi += tk.pi;
     
     // normalization
-    if (tks[i].zi>0){
+    if (tk.zi>0){
       // accumulate weighted z and weights for vertex update
       for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
-	k->se += tks[i].pi* k->ei / Zi;
-	double w = k->pk * tks[i].pi * k->ei /( Zi * ( tks[i].dz2 * tks[i].dt2 ) );
+	k->se += tk.pi* k->ei / Zi;
+	double w = k->pk * tk.pi * k->ei /( Zi * ( tk.dz2 * tk.dt2 ) );
 	k->sw  += w;
-	k->swz += w * tks[i].z;
-        k->swt += w * tks[i].t;
-	k->swE += w * e_ik(tks[i],*k);
+	k->swz += w * tk.z;
+        k->swt += w * tk.t;
+	k->swE += w * e_ik(tk,*k);
       }
     }
   } // end of track loop
@@ -217,11 +217,11 @@ bool DAClusterizerInZT::purge(vector<vertex_t> & y, vector<track_t> & tks, doubl
     int nUnique=0;
     double sump=0;
     double pmax=k->pk/(k->pk+rho0exp);
-    for(unsigned int i=0; i<nt; ++i){
-      if(tks[i].zi > 0){
-	double p = k->pk * std::exp(-beta*e_ik(tks[i],*k)) / tks[i].zi ;
+    for(auto&& tk : tks){
+      if(tk.zi > 0){
+	double p = k->pk * std::exp(-beta*e_ik(tk,*k)) / tk.zi ;
 	sump+=p;
-	if( (p > 0.9*pmax) && (tks[i].pi>0) ){ ++nUnique; }
+	if( (p > 0.9*pmax) && (tk.pi>0) ){ ++nUnique; }
 	if( nUnique >= maxUnique ) { break; }
       }
     }
@@ -248,18 +248,17 @@ double DAClusterizerInZT::beta0( double betamax,
   
   double T0=0;  // max Tc for beta=0
   // estimate critical temperature from beta=0 (T=inf)
-  unsigned int nt=tks.size();
-
+  
   for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
 
     // vertex fit at T=inf 
     double sumwz=0.;
     double sumwt=0.;
     double sumw=0.;
-    for(unsigned int i=0; i<nt; i++){
-      double w = tks[i].pi/(tks[i].dz2 * tks[i].dt2);
-      sumwz += w*tks[i].z;
-      sumwt += w*tks[i].t;
+    for(auto&& tk : tks){
+      double w = tk.pi/(tk.dz2 * tk.dt2);
+      sumwz += w*tk.z;
+      sumwt += w*tk.t;
       sumw  += w;
     }
     k->z = sumwz/sumw;
@@ -267,11 +266,11 @@ double DAClusterizerInZT::beta0( double betamax,
 
     // estimate Tcrit, eventually do this in the same loop
     double a=0, b=0;
-    for(unsigned int i=0; i<nt; i++){
-      double dx = tks[i].z-(k->z);
-      double dt = tks[i].t-(k->t);
-      double w  = tks[i].pi/(tks[i].dz2 * tks[i].dt2);
-      a += w*(sqr(dx)/tks[i].dz2 + sqr(dt)/tks[i].dt2);
+    for(auto&& tk : tks){
+      double dx = tk.z-(k->z);
+      double dt = tk.t-(k->t);
+      double w  = tk.pi/(tk.dz2 * tk.dt2);
+      a += w*(sqr(dx)/tk.dz2 + sqr(dt)/tk.dt2);
       b += w;
     }
     double Tc= 2.*a/b;  // the critical temperature of this vertex

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
@@ -205,25 +205,28 @@ bool DAClusterizerInZT::merge(vector<vertex_t> & y, double & beta)const{
 }
 
 bool DAClusterizerInZT::purge(vector<vertex_t> & y, vector<track_t> & tks, double & rho0, const double beta)const{
+  constexpr int maxUnique = 2;
   // eliminate clusters with only one significant/unique track
   if(y.size()<2)  return false;
   
   unsigned int nt=tks.size();
   double sumpmin=nt;
   vector<vertex_t>::iterator k0=y.end();
-  for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){ 
+  const double rho0exp = rho0*std::exp(-beta*dzCutOff_*dzCutOff_);
+  for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); ++k){ 
     int nUnique=0;
     double sump=0;
-    double pmax=k->pk/(k->pk+rho0*exp(-beta*dzCutOff_*dzCutOff_));
-    for(unsigned int i=0; i<nt; i++){
+    double pmax=k->pk/(k->pk+rho0exp);
+    for(unsigned int i=0; i<nt; ++i){
       if(tks[i].zi > 0){
 	double p = k->pk * std::exp(-beta*e_ik(tks[i],*k)) / tks[i].zi ;
 	sump+=p;
-	if( (p > 0.9*pmax) && (tks[i].pi>0) ){ nUnique++; }
+	if( (p > 0.9*pmax) && (tks[i].pi>0) ){ ++nUnique; }
+	if( nUnique >= maxUnique ) { break; }
       }
     }
 
-    if((nUnique<2)&&(sump<sumpmin)){
+    if( (nUnique<maxUnique) && (sump<sumpmin) ) {
       sumpmin=sump;
       k0=k;
     }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -304,6 +304,7 @@ bool DAClusterizerInZ_vect::merge(vertex_t & y) const {
 
 bool 
 DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const double beta) const {
+  constexpr int maxUnique = 2;
   // eliminate clusters with only one significant/unique track
   const unsigned int nv = y.GetSize();
   const unsigned int nt = tks.GetSize();
@@ -314,25 +315,26 @@ DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const d
   double sumpmin = nt;
   unsigned int k0 = nv;
   
-  for (unsigned int k = 0; k < nv; k++) {
+  const double rho0exp = rho0 * local_exp(-beta * dzCutOff_* dzCutOff_);
+
+  for (unsigned int k = 0; k < nv; ++k) {
     
     int nUnique = 0;
     double sump = 0;
-    double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_* dzCutOff_));
+    double pmax = y._pk[k] / (y._pk[k] + rho0exp);
     
-    for (unsigned int i = 0; i < nt; i++) {
+    for (unsigned int i = 0; i < nt; ++i) {
       
       if (tks._Z_sum[i] > 0) {
 	//double p=pik(beta,tks[i],*k);
 	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
 	sump += p;
-	if ((p > 0.9 * pmax) && (tks._pi[i] > 0)) {
-	  nUnique++;
-	}
-			}
+	if((p > 0.9 * pmax) && (tks._pi[i] > 0)) { nUnique++; }
+	if(nUnique >= maxUnique) {break;}
+      }
     }
     
-    if ((nUnique < 2) && (sump < sumpmin)) {
+    if ((nUnique < maxUnique) && (sump < sumpmin)) {
       sumpmin = sump;
       k0 = k;
     }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -329,8 +329,8 @@ DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const d
 	//double p=pik(beta,tks[i],*k);
 	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
 	sump += p;
-	if((p > 0.9 * pmax) && (tks._pi[i] > 0)) { nUnique++; }
-	if(nUnique >= maxUnique) {break;}
+	if((p > 0.9 * pmax) && (tks._pi[i] > 0)) { ++nUnique; }
+	if(nUnique >= maxUnique) { break; }
       }
     }
     


### PR DESCRIPTION
Speed improvements for slowly converging cases in 140/200PU. First found in KNL runs but shown to be a problem in Xeon as well.

Primary fix here is to move an expensive calculation out of a loop and also to short circuit that loop when more than 2 tracks are found in the vertex.

Factor many speed improvement for problem events. Should also improve the typical vertexing time, from same short circuit.