### PR TITLE
Reject 0 pt Puppi candidates in jet-track association

### DIFF
--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -116,7 +116,7 @@ namespace IPProducerHelpers {
 				      else
 				      {
 					  for(size_t j=0;j<cands->size();++j) {
-						  if( (*cands)[j].bestTrack()!=0 && (*cands)[j].charge() !=0 && Geom::deltaR2((*cands)[j],(*jets)[i]) < maxDeltaR2  ){
+						  if( (*cands)[j].bestTrack()!=0 && (*cands)[j].charge() !=0 && (*cands)[j].pt() > 0 && Geom::deltaR2((*cands)[j],(*jets)[i]) < maxDeltaR2  ){
 							  m_map[i].push_back(cands->ptrAt(j));
 						  }
 					  }


### PR DESCRIPTION
Charged PF candidates identified by the Puppi algorithm as pileup have their momenta scaled to 0. Consequently, eta and phi of such candidates are reset to 0 which can lead to spurious association of these candidates to jets whose axes point in the vicinity of (eta,phi)=(0,0). To reject such spurious associations, the candidate momentum is required to be greater than 0.

This change is completely transparent to all existing b-tagging algorithms and all monitored quantities. It manifests itself only in non-default setups where Puppi candidates are set as input for b tagging.