### PR TITLE
pr90 simHCALTPDigis Back in phase2_hcal Sequence.

### DIFF
--- a/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
+++ b/SimCalorimetry/Configuration/python/hcalDigiSequence_cff.py
@@ -8,8 +8,3 @@ from SimCalorimetry.HcalTrigPrimProducers.hcalTTPDigis_cfi import *
 hcalDigiSequence = cms.Sequence(simHcalTriggerPrimitiveDigis
                                 +simHcalDigis
                                 *simHcalTTPDigis)
-
-_phase2_hcalDigiSequence = hcalDigiSequence.copyAndExclude([simHcalTriggerPrimitiveDigis,simHcalTTPDigis])
-
-from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
-phase2_hcal.toReplaceWith( hcalDigiSequence, _phase2_hcalDigiSequence )


### PR DESCRIPTION
90x...Now that simHCALTPDigis  is fixed for LUT generation and trigger modes for phase2, leave simHCALTriggerPrimitivesDigis and simHCALTTPDigis in default phase2_hcal sequence .