### PR TITLE
data processing setup for 2017 era

### DIFF
--- a/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2017.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_2017_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.DataProcessing.Impl.cosmics import cosmics
+
+class cosmicsEra_Run2_2017(cosmics):
+    def __init__(self):
+        cosmics.__init__(self)
+        self.eras = Run2_2017
+    """
+    _cosmicsEra_Run2_2017_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2017.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+_hcalnzsEra_Run2_2017_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.hcalnzs import hcalnzs
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+class hcalnzsEra_Run2_2017(hcalnzs):
+    def __init__(self):
+        hcalnzs.__init__(self)
+        self.recoSeq=':reconstruction_HcalNZS'
+        self.cbSc='pp'
+        self.eras = Run2_2017
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+    """
+    _hcalnzsEra_Run2_2017_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2017(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run2_2017
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+    """
+    _ppEra_Run2_2017_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingLowPU.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingLowPU.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_trackingLowPU_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2017_trackingLowPU_cff import Run2_2017_trackingLowPU
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2017_trackingLowPU(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run2_2017_trackingLowPU
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+    """
+    _ppEra_Run2_2017_trackingLowPU_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -43,6 +43,10 @@ def customisePostEra_Run2_2016(process):
     _hcalCustoms25ns(process)
     return process
 
+def customisePostEra_Run2_2017(process):
+    _hcalCustoms25ns(process)
+    return process
+
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -9,6 +9,7 @@ testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -76,9 +77,24 @@ class RunAlcaHarvesting:
         process.source.fileNames.append(self.inputLFN)
 
 
+        pklFile = open("RunAlcaHarvestingCfg.pkl", "w")
         psetFile = open("RunAlcaHarvestingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunAlcaHarvestingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -j FrameworkJobReport.xml RunAlcaHarvestingCfg.py"
         print "Now do:\n%s" % cmsRun
         

--- a/Configuration/DataProcessing/test/RunAlcaSkimming.py
+++ b/Configuration/DataProcessing/test/RunAlcaSkimming.py
@@ -9,6 +9,7 @@ testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -66,9 +67,24 @@ class RunAlcaSkimming:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunAlcaSkimmingCfg.pkl", "w")
         psetFile = open("RunAlcaSkimmingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunAlcaSkimmingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunAlcaSkimmingCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/RunDQMHarvesting.py
+++ b/Configuration/DataProcessing/test/RunDQMHarvesting.py
@@ -9,6 +9,7 @@ testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -72,9 +73,24 @@ class RunDQMHarvesting:
         process.source.fileNames.append(self.inputLFN)
 
 
+        pklFile = open("RunDQMHarvestingCfg.pkl", "w")
         psetFile = open("RunDQMHarvestingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunDQMHarvestingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -j FrameworkJobReport.xml RunDQMHarvestingCfg.py"
         print "Now do:\n%s" % cmsRun
         

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -10,6 +10,7 @@ it into cmsRun for testing with a few input files etc from the command line
 import sys
 import getopt
 import traceback
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -105,9 +106,24 @@ class RunExpressProcessing:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunExpressProcessingCfg.pkl", "w")
         psetFile = open("RunExpressProcessingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunExpressProcessingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunExpressProcessingCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -10,6 +10,7 @@ testing with a few input files etc from the command line
 import sys
 import getopt
 import traceback
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -115,9 +116,24 @@ class RunPromptReco:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunPromptRecoCfg.pkl", "w")
         psetFile = open("RunPromptRecoCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunPromptRecoCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunPromptRecoCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/RunVisualizationProcessing.py
+++ b/Configuration/DataProcessing/test/RunVisualizationProcessing.py
@@ -9,6 +9,7 @@ it into cmsRun for testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -108,9 +109,24 @@ class RunVisualizationProcessing:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunVisualizationProcessingCfg.pkl", "w")
         psetFile = open("RunVisualizationProcessingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunVisualizationProcessingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunVisualizationProcessingCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/cosmicsEra_Run2_2017_t.py
+++ b/Configuration/DataProcessing/test/cosmicsEra_Run2_2017_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_2017_
+
+Test for CosmicsRun2 Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class cosmicsEra_Run2_2017ScenarioTest(unittest.TestCase):
+    """
+    unittest for cosmicsEra_Run2_2017 scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("cosmicsEra_Run2_2017")
+        except Exception as ex:
+            msg = "Failed to get cosmicsEra_Run2_2017 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception as ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for cosmicsEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception as ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for cosmicsEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception as ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for cosmicsEra_Run2_2017 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception as ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for cosmicsEra_Run2_2017 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/ppEra_Run2_2017_t.py
+++ b/Configuration/DataProcessing/test/ppEra_Run2_2017_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_
+
+Test for Collision Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class ppEra_Run2_2017ScenarioTest(unittest.TestCase):
+    """
+    unittest for ppEra_Run2_2017 collisions scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("ppEra_Run2_2017")
+        except Exception as ex:
+            msg = "Failed to get ppEra_Run2_2017 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception as ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for ppEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception as ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for ppEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception as ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for ppEra_Run2_2017 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception as ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for ppEra_Run2_2017 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -36,14 +36,14 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA")
+declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/Eras/python/Era_Run2_2017_trackingLowPU_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingLowPU_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
+
+Run2_2017_trackingLowPU = cms.ModifierChain(Run2_2017, trackingLowPU)
+

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -27,6 +27,9 @@ def modifyHLTPhaseIPixelGeom(process):
 
 # modify the HLT configuration to run the Phase I tracking in the particle flow sequence
 def customizeHLTForPFTrackingPhaseI2017(process):
+    if not hasattr(process, 'hltPixelLayerTriplets'):
+        #there could also be a message here that the call is done for non-HLT stuff
+        return process;
 
     process.hltPixelLayerTriplets.layerList = cms.vstring(
         'BPix1+BPix2+BPix3',


### PR DESCRIPTION
Added scenarios:
- cosmicsEra_Run2_2017
- hcalnzsEra_Run2_2017
- ppEra_Run2_2017
- ppEra_Run2_2017_trackingLowPU  this can be used for runs with strips and no pixel tracker (as long as the pileup is reasonably low)

Additional changes to make dataProcessing to work:
- switch to using pickle instead of python.dump in local test config generators to get runnable configuration; pickle is used in T0 config generation already
- skip calls in customizeHLTForPFTrackingPhaseI2017 if hltPixelLayerTriplets are not available (to resolve https://github.com/cms-sw/cmssw/issues/17634). It looks like the load of HLT_Fake1_cff is clean otherwise, in a sense that it does not modify the main process object

Tested with an "uber-config"
2016 era:
```
python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario ppEra_Run2_2016\
 --reco --aod --miniaod --dqmio --global-tag 90X_dataRun2_relval_v4 \
--lfn=file:JetHT_Run2016B_RAW_274199_2C69107A-BD26-E611-911C-02163E0146B3.root  \
--alcareco SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+HcalCalDijets+HcalCalIsoTrkFilter+HcalCalNoise+TkAlUpsilonMuMu+TkAlJpsiMuMu+EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym+TkAlZMuMu+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+DtCalib+HcalCalDijets+EcalCalWElectron+EcalUncalWElectron+EcalESAlign+TkAlMuonIsolated+HcalCalHO+HcalCalGammaJet \
 --dqmSeq @common+@muon+@jetmet+@hcal  \
--PhysicsSkim=TopMuEG+LogError+LogErrorMonitor+HighMET+ZMu+MuTau
```

Similar config for 2017 parses OK but doesn't run for data due to GT inconsistencies.
Similar config for 2017 with MC runs OK (with HcalCalIterativePhiSym removed)