### PR TITLE
Add -Wno-format-contains-nul if we have -Wno-format

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -267,8 +267,8 @@ struct Rot2 {
   Vec2<T>  axis[2];
   
   constexpr Rot2() :
-    axis{ (Vec){T(1),0},
-      (Vec){0,T(1)}
+    axis{{(Vec){T(1),0}},
+         {(Vec){0,T(1)}}
   }{}
     
   constexpr Rot2( Vec2<T> ix,  Vec2<T> iy) :

--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -11,19 +11,22 @@
 <bin   file="ProjectMatrix_t.cpp" name="DataFormatsProjectMatrix_t">
 </bin>
 <bin   file="FastMath_t.cpp" name="DataFormatsFastMath_t">
-  <flags CXXFLAGS="-std=gnu++11 -Wno-error=format -Wno-format"/>
+  <flags CXXFLAGS="-std=gnu++11 -Wno-error=format -Wno-format -Wno-format-contains-nul"/>
   <flags REM_CXXFLAGS="-Wformat -ansi"/>
+  <flags REM_CXXFLAGS="-Wformat-contains-nul"/>
 </bin>
 <bin   file="testApproximations.cpp" name="testMathApproximations">
-  <flags CXXFLAGS="-std=gnu++11 -Wno-error=format -Wno-format"/>
+  <flags CXXFLAGS="-std=gnu++11 -Wno-error=format -Wno-format -Wno-format-contains-nul"/>
   <flags REM_CXXFLAGS="-std=c++%"/>
   <flags REM_CXXFLAGS="-Wformat"/>
+  <flags REM_CXXFLAGS="-Wformat-contains-nul"/>
   <flags REM_CXXFLAGS="-ansi"/>
 </bin>
 <bin   file="testApproxMath.cpp" name="testMathApproxMath">
-  <flags CXXFLAGS="-std=gnu++11 -Wno-error=format -Wno-format"/>
+  <flags CXXFLAGS="-std=gnu++11 -Wno-error=format -Wno-format -Wno-format-contains-nul"/>
   <flags REM_CXXFLAGS="-std=c++%"/>
   <flags REM_CXXFLAGS="-Wformat"/>
+  <flags REM_CXXFLAGS="-Wformat-contains-nul"/>
   <flags REM_CXXFLAGS="-ansi"/>
 </bin>
 
@@ -48,9 +51,10 @@
 </bin>
 
 <bin   file="deltaR_t.cpp" name="DataFormatsDeltaR_t">
-  <flags CXXFLAGS="-ffast-math -std=gnu++11 -Wno-error=format -Wno-format"/>
+  <flags CXXFLAGS="-ffast-math -std=gnu++11 -Wno-error=format -Wno-format -Wno-format-contains-nul"/>
   <flags REM_CXXFLAGS="-std=c++%"/>
   <flags REM_CXXFLAGS="-Wformat"/>
+  <flags REM_CXXFLAGS="-Wformat-contains-nul"/>
   <flags REM_CXXFLAGS="-ansi"/>
 </bin>
 <bin   file="Similarity_t.cpp" name="DataFormatsSimilarity_t">

--- a/MagneticField/Interpolation/BuildFile.xml
+++ b/MagneticField/Interpolation/BuildFile.xml
@@ -4,5 +4,4 @@
 <export>
   <lib   name="1"/>
 </export>
-<flags   CXXFLAGS="-Wno-format"/>
-
+<flags   CXXFLAGS="-Wno-format -Wno-format-contains-nul"/>

--- a/MagneticField/Interpolation/test/BuildFile.xml
+++ b/MagneticField/Interpolation/test/BuildFile.xml
@@ -15,4 +15,4 @@
   <use   name="clhep"/>
   <use   name="MagneticField/Interpolation"/>
 </bin>
-<flags   CXXFLAGS="-Wno-format"/>
+<flags   CXXFLAGS="-Wno-format -Wno-format-contains-nul"/>


### PR DESCRIPTION
A recent change in GCC 7.0.1 now requires `-Wformat` if
`-Wformat-contains-nul` is used.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>