### PR TITLE
Initialize sampleSize_ to 0u

### DIFF
--- a/PhysicsTools/Utilities/interface/Likelihood.h
+++ b/PhysicsTools/Utilities/interface/Likelihood.h
@@ -56,7 +56,7 @@ namespace fit {
     PDF * pdf_;
     Yield * yield_;
     Sample sample_;
-    mutable unsigned int sampleSize_;
+    mutable unsigned int sampleSize_ = 0u;
   };
 
   template<typename Sample, typename PDF>


### PR DESCRIPTION
This was noticed with GCC 7.0.1 (Stage 4).

    PhysicsTools/Utilities/interface/Likelihood.h: In function 'int main()':
      PhysicsTools/Utilities/interface/Likelihood.h:27:9: error: 'like.fit::Likelihood<std::vector<double>,funct::ProductStruct<funct::Parameter, funct::BreitWigner>, funct::Parameter>::sampleSize_' may be used uninitialized in this function [-Werror=maybe-uninitialized]
        class Likelihood {
             ^~~~~~~~~~
    PhysicsTools/Utilities/test/testZMassFitExtLikelihood.cpp:58:16: note: 'like.fit::Likelihood<std::vector<double>, funct::ProductStruct<funct::Parameter, funct::BreitWigner>, funct::Parameter>::sampleSize_' was declared here
         Likelihood like(sample, f, yield);
                    ^~~~
    cc1plus: some warnings being treated as errors
      gmake: *** [testZMassFitExtLikelihood.o] Error 1

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>