### PR TITLE
Customise functions reducing the list of tracking particles saved by the mixing module

### DIFF
--- a/SimGeneral/MixingModule/python/customiseStoredTPConfig.py
+++ b/SimGeneral/MixingModule/python/customiseStoredTPConfig.py
@@ -27,6 +27,15 @@ def inTimeOnlyTP(process) :
 
     return process
 
+def higherPtTP(process) :
+
+    if hasattr(process,"mix"):
+        
+        process.mix.digitizers.mergedtruth.select.ptMinTP = 1.
+
+    return process
+
+
     
     
         

--- a/SimGeneral/MixingModule/python/customiseStoredTPConfig.py
+++ b/SimGeneral/MixingModule/python/customiseStoredTPConfig.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+def tpInM3P1BXRange(process) :
+
+    if hasattr(process,"mix"):
+        
+        process.mix.digitizers.mergedtruth.maximumPreviousBunchCrossing   = 3
+        process.mix.digitizers.mergedtruth.maximumSubsequentBunchCrossing = 1
+
+    return process
+
+
+def signalOnlyTP(process) :
+
+    if hasattr(process,"mix"):
+        
+        process.mix.digitizers.mergedtruth.select.signalOnlyTP = True
+
+    return process
+
+
+def inTimeOnlyTP(process) :
+
+    if hasattr(process,"mix"):
+        
+        process.mix.digitizers.mergedtruth.select.intimeOnlyTP = True
+
+    return process
+
+    
+    
+        
+


### PR DESCRIPTION
This PR adds a set of functions to reduce the size of the FEVTHLTDEBUG event content.
It is intended to be used for the production L1T/HLT Phase2 samples.

All changes to the event content definition are applied in customization function to avoid any interference with standard workflows.

The PR superseeds [PR 17446](https://github.com/cms-sw/cmssw/pull/17446)

@rekovic 
