### PR TITLE
Pcc 90 x

### DIFF
--- a/RecoLuminosity/LumiProducer/test/analysis/plugins/PCCNTupler.h
+++ b/RecoLuminosity/LumiProducer/test/analysis/plugins/PCCNTupler.h
@@ -71,7 +71,7 @@ class PCCNTupler : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::o
     edm::InputTag   fPixelClusterLabel;
     edm::InputTag   fPileUpInfoLabel;
   
-    static const int MAX_VERTICES=200;
+    static const int MAX_VERTICES=300;
 
     // saving events per LS, LN or event
     std::string saveType = "LumiSect"; // LumiSect or LumiNib or Event

--- a/RecoLuminosity/LumiProducer/test/analysis/plugins/PCCNTupler.h
+++ b/RecoLuminosity/LumiProducer/test/analysis/plugins/PCCNTupler.h
@@ -100,6 +100,7 @@ class PCCNTupler : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::o
     bool includePixels;
     bool includeJets;
     bool splitByBX;
+    bool pixelPhase2Geometry;
 
     int nPU;
     int nVtx;

--- a/RecoLuminosity/LumiProducer/test/analysis/test/Run_PixVertex_Event.py
+++ b/RecoLuminosity/LumiProducer/test/analysis/test/Run_PixVertex_Event.py
@@ -16,8 +16,6 @@ process.MessageLogger.categories.append('L1GtTrigReport')
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
 # -- Database configuration
-#process.load("CondCore.DBCommon.CondDBCommon_cfi")
-#process.load("CondCore.DBCommon.CondDBSetup_cfi")
 process.load("CondCore.CondDB.CondDB_cfi")
 
 # -- Conditions
@@ -58,7 +56,7 @@ process.lumi = cms.EDAnalyzer(
     globalTag                    = process.GlobalTag.globaltag,
     dumpAllEvents                = cms.untracked.int32(0),
     vertexCollLabel              = cms.untracked.InputTag('offlinePrimaryVertices'),
-    pixelClusterLabel            = cms.untracked.InputTag('siPixelClusters'),
+    pixelClusterLabel            = cms.untracked.InputTag('siPixelClusters'), # even in Phase2, for now.
     saveType                     = cms.untracked.string('Event'), # LumiSect, LumiNib, Event
     sampleType                   = cms.untracked.string('MC'), # MC, DATA
     includeVertexInformation     = cms.untracked.bool(True),
@@ -66,7 +64,8 @@ process.lumi = cms.EDAnalyzer(
     splitByBX                    = cms.untracked.bool(True),
     L1GTReadoutRecordLabel       = cms.untracked.InputTag('gtDigis'), 
     hltL1GtObjectMap             = cms.untracked.InputTag('hltL1GtObjectMap'), 
-    HLTResultsLabel              = cms.untracked.InputTag('TriggerResults::HLT')
+    HLTResultsLabel              = cms.untracked.InputTag('TriggerResults::HLT'),
+    pixelPhase2Geometry          = cms.untracked.bool(True),
     )
 
 # -- Path
@@ -82,7 +81,12 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles) 
 readFiles.extend([
-'/store/relval/CMSSW_9_0_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4Timing-v1/10000/36D3D8CD-3BC2-E611-908A-0025905A6088.root', # 80X file
-#'/store/mc/RunIISummer16DR80/MinBias_TuneCUETP8M1_13TeV-pythia8/GEN-SIM-RECO/NoPU_RECO_80X_mcRun2_asymptotic_v14-v1/100000/00150044-D075-E611-AAE8-001E67505A2D.root', # 90X file
-#'/store/data/Run2015A/ZeroBias1/RECO/PromptReco-v1/000/250/786/00000/B4CDEBBC-F52A-E511-808D-02163E011CE8.root', # data, havent tried
+# Min Bias 90X files with 2023D4 geometry and timing. no pu.
+ '/store/relval/CMSSW_9_0_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4Timing-v1/10000/28088B65-66C2-E611-BF89-0CC47A7C347A.root',
+ '/store/relval/CMSSW_9_0_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4Timing-v1/10000/20D68D58-3CC2-E611-B15B-0CC47A4C8F18.root',
+ '/store/relval/CMSSW_9_0_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4Timing-v1/10000/94242929-30C3-E611-B3E0-0025905B85DC.root',
+ '/store/relval/CMSSW_9_0_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4Timing-v1/10000/F46D98E7-EAC2-E611-936E-0CC47A7452D0.root',
+ '/store/relval/CMSSW_9_0_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4Timing-v1/10000/36D3D8CD-3BC2-E611-908A-0025905A6088.root',
+#'/store/mc/RunIISummer16DR80/MinBias_TuneCUETP8M1_13TeV-pythia8/GEN-SIM-RECO/NoPU_RECO_80X_mcRun2_asymptotic_v14-v1/100000/00150044-D075-E611-AAE8-001E67505A2D.root', # 80X file
+#'/store/data/Run2015A/ZeroBias1/RECO/PromptReco-v1/000/250/786/00000/B4CDEBBC-F52A-E511-808D-02163E011CE8.root', 
 ])

--- a/RecoLuminosity/LumiProducer/test/analysis/test/Run_PixVertex_Event.py
+++ b/RecoLuminosity/LumiProducer/test/analysis/test/Run_PixVertex_Event.py
@@ -16,21 +16,24 @@ process.MessageLogger.categories.append('L1GtTrigReport')
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
 # -- Database configuration
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
+#process.load("CondCore.DBCommon.CondDBCommon_cfi")
+#process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.load("CondCore.CondDB.CondDB_cfi")
 
 # -- Conditions
+
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff") # works for MC & data
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff") #
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_GRun', '')
 
-process.load("Configuration.StandardSequences.Reconstruction_cff")
+#process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_v14', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '90X_upgrade2023_realistic_v1', '')
 
+
+process.load("Configuration.StandardSequences.Reconstruction_cff") # 
 # -- number of events
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
@@ -57,7 +60,7 @@ process.lumi = cms.EDAnalyzer(
     vertexCollLabel              = cms.untracked.InputTag('offlinePrimaryVertices'),
     pixelClusterLabel            = cms.untracked.InputTag('siPixelClusters'),
     saveType                     = cms.untracked.string('Event'), # LumiSect, LumiNib, Event
-    sampleType                   = cms.untracked.string('DATA'), # MC, DATA
+    sampleType                   = cms.untracked.string('MC'), # MC, DATA
     includeVertexInformation     = cms.untracked.bool(True),
     includePixels                = cms.untracked.bool(True),
     splitByBX                    = cms.untracked.bool(True),
@@ -73,11 +76,13 @@ process.p = cms.Path(
     )
 
 
-outFile = 'pcc_Data_PixVtx_Event.root'
+outFile = 'pcc_Data_PixVtx_Event_90X.root'
 process.TFileService = cms.Service("TFileService",fileName = cms.string(outFile)) 
 readFiles = cms.untracked.vstring() 
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles) 
 readFiles.extend([
-'/store/data/Run2015A/ZeroBias1/RECO/PromptReco-v1/000/250/786/00000/B4CDEBBC-F52A-E511-808D-02163E011CE8.root',
+'/store/relval/CMSSW_9_0_0_pre2/RelValMinBias_14TeV/GEN-SIM-RECO/90X_upgrade2023_realistic_v1_2023D4Timing-v1/10000/36D3D8CD-3BC2-E611-908A-0025905A6088.root', # 80X file
+#'/store/mc/RunIISummer16DR80/MinBias_TuneCUETP8M1_13TeV-pythia8/GEN-SIM-RECO/NoPU_RECO_80X_mcRun2_asymptotic_v14-v1/100000/00150044-D075-E611-AAE8-001E67505A2D.root', # 90X file
+#'/store/data/Run2015A/ZeroBias1/RECO/PromptReco-v1/000/250/786/00000/B4CDEBBC-F52A-E511-808D-02163E011CE8.root', # data, havent tried
 ])

--- a/RecoLuminosity/LumiProducer/test/analysis/test/Run_template.py
+++ b/RecoLuminosity/LumiProducer/test/analysis/test/Run_template.py
@@ -16,9 +16,9 @@ process.MessageLogger.categories.append('L1GtTrigReport')
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
 # -- Database configuration
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
-
+#process.load("CondCore.DBCommon.CondDBCommon_cfi")
+#process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.load("CondCore.CondDB.CondDB_cfi")
 # -- Conditions
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff") # works for MC & data
@@ -27,7 +27,8 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_GRun', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '90X_upgrade2023_realistic_v1', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_GRun', '')
 
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
@@ -79,7 +80,7 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles) 
 readFiles.extend([
-'/store/mc/Spring14dr/Neutrino_Pt-2to20_gun/AODSIM/Flat0to10_POSTLS170_V5-v2/10000/00AE7E7E-6153-E411-9565-002590D0AFBE.root'
+#'/store/mc/Spring14dr/Neutrino_Pt-2to20_gun/AODSIM/Flat0to10_POSTLS170_V5-v2/10000/00AE7E7E-6153-E411-9565-002590D0AFBE.root'
 #'/store/data/Run2012D/ZeroBias1/RECO/PromptReco-v1/000/206/251/F28DAF8D-7723-E211-80A1-BCAEC5364C4C.root'
 #'/store/relval/CMSSW_7_4_0_pre8/RelValMinBias_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/08A7F47B-B9BD-E411-97B0-0025905B85D6.root'
 ])


### PR DESCRIPTION
This PR affects only the Pixel Cluster Counting method. In this PR we:
- add a switch to be respectful of the Phase2 tracker geometry (number of pixel barrel layers)
- remove some Run 1 unused stuff (commented out already)
- replace the TrackerGeometry::DetContainer loop, with an edmNew::DetSet<SiPixelCluster> loop that has the same effect. 