### PR TITLE
Pfmuon fix 90x

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
@@ -366,8 +366,7 @@ ME0GeometryBuilderFromDDD10EtaPart::boundPlane(const DDFilteredView& fv,
   Basic3DVector<float> newX(1.,0.,0.);
   Basic3DVector<float> newY(0.,0.,1.);
   Basic3DVector<float> newZ(0.,1.,0.);
-  // Odd chambers are inverted in gem.xml
-  if (isOddChamber) newY *= -1;
+  newY *= -1;
 
   rotResult.rotateAxes(newX, newY, newZ);
 

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
@@ -366,7 +366,8 @@ ME0GeometryBuilderFromDDD10EtaPart::boundPlane(const DDFilteredView& fv,
   Basic3DVector<float> newX(1.,0.,0.);
   Basic3DVector<float> newY(0.,0.,1.);
   Basic3DVector<float> newZ(0.,1.,0.);
-  newY *= -1;
+  // Odd chambers are inverted in gem.xml
+  if (isOddChamber) newY *= -1;
 
   rotResult.rotateAxes(newX, newY, newZ);
 

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -145,16 +145,17 @@ def _findIndicesByModule(name):
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 # kill tracks in the HGCal
-_insertGeneralTracksImporter = {}
-for idx in _findIndicesByModule('GeneralTracksImporter'):
-    _insertGeneralTracksImporter[idx] = dict(
-        importerName = cms.string('GeneralTracksImporterWithVeto'),
-        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
-    )
-phase2_hgcal.toModify(
-    particleFlowBlock,
-    elementImporters = _insertGeneralTracksImporter
-)
+# this is currently killing pfmuons - add fix later
+#_insertGeneralTracksImporter = {}
+#for idx in _findIndicesByModule('GeneralTracksImporter'):
+#    _insertGeneralTracksImporter[idx] = dict(
+#        importerName = cms.string('GeneralTracksImporterWithVeto'),
+#        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
+#    )
+#phase2_hgcal.toModify(
+#    particleFlowBlock,
+#    elementImporters = _insertGeneralTracksImporter
+#)
 ### for later
 #_phase2_hgcal_Linkers.append( 
 #    cms.PSet( linkerName = cms.string("SCAndHGCalLinker"),

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -143,7 +143,7 @@ def _findIndicesByModule(name):
             ret.append(i)
    return ret
 
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+# from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 # kill tracks in the HGCal
 # this is currently killing pfmuons - add fix later
 #_insertGeneralTracksImporter = {}


### PR DESCRIPTION
low tight and loose muon ID efficiency due to low pfmuon efficiency due to GeneralTracksImporterWithVeto killing pftracks
This issue was noticed in #16797 
pfmuon temp fix - hgcal will fix later 

fix rotation in me0geometry - in me0 even and odd chambers are not inverted

@calabria @lgray @pietverwilligen @kpedro88 