### PR TITLE
Convert Validation/RecoTau modules from legacy to global producers

### DIFF
--- a/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
+++ b/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
 #include "DataFormats/Common/interface/View.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -14,12 +14,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-class CollectionFromZLegProducer : public edm::EDProducer
-{
+class CollectionFromZLegProducer : public edm::global::EDProducer<> {
 public:
 
   explicit CollectionFromZLegProducer(edm::ParameterSet const& iConfig);
-  void produce(edm::Event&, edm::EventSetup const&) override;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
 private:
   edm::EDGetTokenT<std::vector<reco::CompositeCandidate>> v_RecoCompositeCandidateToken_;
@@ -43,7 +42,7 @@ CollectionFromZLegProducer::CollectionFromZLegProducer(edm::ParameterSet const& 
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-void CollectionFromZLegProducer::produce(edm::Event& iEvent, edm::EventSetup const&)
+void CollectionFromZLegProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const
 {
   auto tagLegs = std::make_unique<std::vector<reco::CompositeCandidate>>();
   auto probeLegs = std::make_unique<std::vector<reco::CompositeCandidate>>();
@@ -54,8 +53,8 @@ void CollectionFromZLegProducer::produce(edm::Event& iEvent, edm::EventSetup con
   // this is specific for our 'tag and probe'
   for (auto const& z : *zs) {
     int c {};
-    for(auto const& leg : z) {
-      if (c == 0){
+    for (auto const& leg : z) {
+      if (c == 0) {
         tagLegs->emplace_back(leg);
       }
       else if (c == 1){

--- a/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
+++ b/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
@@ -1,19 +1,15 @@
-////////////////////////////////////////////////////////////////////////////////
-// Includes
-////////////////////////////////////////////////////////////////////////////////
+#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "DataFormats/Common/interface/View.h"
+
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/Candidate/interface/CompositeCandidate.h"
-
-#include "DataFormats/Common/interface/View.h"
 
 #include <memory>
 #include <vector>
 #include <sstream>
-
-//#include "Validation/RecoTau/interface/prettyPrint.h" debugging putpose
 
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
@@ -21,37 +17,25 @@
 class CollectionFromZLegProducer : public edm::EDProducer
 {
 public:
-  // construction/destruction
-  CollectionFromZLegProducer(const edm::ParameterSet& iConfig);
-  virtual ~CollectionFromZLegProducer();
-  
-  void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
 
-private:  
-  // member data
-  edm::EDGetTokenT< std::vector<reco::CompositeCandidate> >   v_RecoCompositeCandidateToken_;
-  std::string                                                 OutputCollection_ ;
-  
+  explicit CollectionFromZLegProducer(edm::ParameterSet const& iConfig);
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+private:
+  edm::EDGetTokenT<std::vector<reco::CompositeCandidate>> v_RecoCompositeCandidateToken_;
 };
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// construction/destruction
+// construction
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________
-CollectionFromZLegProducer::CollectionFromZLegProducer(const edm::ParameterSet& iConfig)
-  : v_RecoCompositeCandidateToken_( consumes< std::vector<reco::CompositeCandidate> >( iConfig.getParameter<edm::InputTag>( "ZCandidateCollection" ) ) )
+CollectionFromZLegProducer::CollectionFromZLegProducer(edm::ParameterSet const& iConfig)
+  : v_RecoCompositeCandidateToken_{consumes<std::vector<reco::CompositeCandidate>>(iConfig.getParameter<edm::InputTag>("ZCandidateCollection"))}
 {
-  produces<std::vector<reco::CompositeCandidate> >("theTagLeg"  );
-  produces<std::vector<reco::CompositeCandidate> >("theProbeLeg");
-}
-
-
-//______________________________________________________________________________
-CollectionFromZLegProducer::~CollectionFromZLegProducer()
-{
+  produces<std::vector<reco::CompositeCandidate>>("theTagLeg");
+  produces<std::vector<reco::CompositeCandidate>>("theProbeLeg");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -59,40 +43,32 @@ CollectionFromZLegProducer::~CollectionFromZLegProducer()
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-void CollectionFromZLegProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
-{  
-  std::unique_ptr<std::vector<reco::CompositeCandidate> > theTagLeg(new std::vector<reco::CompositeCandidate>) ;	     
-  std::unique_ptr<std::vector<reco::CompositeCandidate> > theProbeLeg(new std::vector<reco::CompositeCandidate>) ;	     
-  
-  edm::Handle< std::vector<reco::CompositeCandidate> > theZHandle;
-  iEvent.getByToken( v_RecoCompositeCandidateToken_,theZHandle );
-  
+void CollectionFromZLegProducer::produce(edm::Event& iEvent, edm::EventSetup const&)
+{
+  auto tagLegs = std::make_unique<std::vector<reco::CompositeCandidate>>();
+  auto probeLegs = std::make_unique<std::vector<reco::CompositeCandidate>>();
+
+  edm::Handle<std::vector<reco::CompositeCandidate>> zs;
+  iEvent.getByToken(v_RecoCompositeCandidateToken_, zs);
+
   // this is specific for our 'tag and probe'
-  
-  for (std::vector<reco::CompositeCandidate>::const_iterator Zit  = theZHandle->begin() ; 
-                                                             Zit != theZHandle->end()   ; 
-                                                             ++Zit                      )
-  {
-	int c = 0;
-	
-	for(reco::CompositeCandidate::const_iterator Daug =(*Zit).begin(); 
-                                                 Daug!=(*Zit).end()  ; 
-                                                 ++Daug              )
-	{
-	  if (c == 0){
-	    reco::CompositeCandidate candT(*Daug) ;
-	    theTagLeg->push_back(candT) ;
-	  }
-	  if (c == 1){
-	    reco::CompositeCandidate candP(*Daug) ;
-	    theProbeLeg->push_back(candP) ;
-	  }
-	  c++ ;
-	}
-  } 
-  iEvent.put(std::move(theTagLeg), "theTagLeg"   ) ;
-  iEvent.put(std::move(theProbeLeg), "theProbeLeg" ) ;
+  for (auto const& z : *zs) {
+    int c {};
+    for(auto const& leg : z) {
+      if (c == 0){
+        tagLegs->emplace_back(leg);
+      }
+      else if (c == 1){
+        probeLegs->emplace_back(leg);
+      }
+      else {
+        break;
+      }
+      ++c;
+    }
+  }
+  iEvent.put(std::move(tagLegs), "theTagLeg");
+  iEvent.put(std::move(probeLegs), "theProbeLeg");
 }
 
-#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(CollectionFromZLegProducer);

--- a/Validation/RecoTau/plugins/IsoTracks.cc
+++ b/Validation/RecoTau/plugins/IsoTracks.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -13,11 +13,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-class IsoTracks : public edm::EDProducer {
+class IsoTracks : public edm::global::EDProducer<> {
 public:
 
-  explicit IsoTracks(edm::ParameterSet const& iConfig);
-  void produce(edm::Event&, edm::EventSetup const&) override;
+  explicit IsoTracks(edm::ParameterSet const&);
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
 private:
 
@@ -43,7 +43,7 @@ IsoTracks::IsoTracks(edm::ParameterSet const& iConfig)
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-void IsoTracks::produce(edm::Event& iEvent, edm::EventSetup const&)
+void IsoTracks::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const
 {
   auto isoTracks = std::make_unique<std::vector<reco::Track>>();
 

--- a/Validation/RecoTau/plugins/IsoTracks.cc
+++ b/Validation/RecoTau/plugins/IsoTracks.cc
@@ -1,99 +1,74 @@
-////////////////////////////////////////////////////////////////////////////////
-// Includes
-////////////////////////////////////////////////////////////////////////////////
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "DataFormats/Math/interface/deltaR.h"
-
-#include "DataFormats/TrackReco/interface/Track.h"
-
 #include <memory>
 #include <vector>
-#include <sstream>
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-class IsoTracks : public edm::EDProducer
-{
+class IsoTracks : public edm::EDProducer {
 public:
-  // construction/destruction
-  IsoTracks(const edm::ParameterSet& iConfig);
-  virtual ~IsoTracks();
-  
-  // member functions
-  void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
 
-private:  
-  // member data
-  double                                         coneRadius_      ;
-  double                                         threshold_       ;
-  edm::EDGetTokenT< std::vector<reco::Track> >   v_recoTrackToken_;
+  explicit IsoTracks(edm::ParameterSet const& iConfig);
+  void produce(edm::Event&, edm::EventSetup const&) override;
 
+private:
+
+  double coneRadius_;
+  double threshold_;
+  edm::EDGetTokenT<std::vector<reco::Track>> v_recoTrackToken_;
 };
 
-
 ////////////////////////////////////////////////////////////////////////////////
-// construction/destruction
+// construction
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________
-IsoTracks::IsoTracks(const edm::ParameterSet& iConfig)
-  : coneRadius_      ( iConfig.getParameter<double>( "radius" ) )
-  , threshold_       ( iConfig.getParameter<double>( "SumPtFraction" ) )
-  , v_recoTrackToken_( consumes< std::vector<reco::Track> >( iConfig.getParameter<edm::InputTag>( "src" ) ) )
+IsoTracks::IsoTracks(edm::ParameterSet const& iConfig)
+  : coneRadius_{iConfig.getParameter<double>("radius")}
+  , threshold_{iConfig.getParameter<double>("SumPtFraction")}
+  , v_recoTrackToken_{consumes<std::vector<reco::Track>>(iConfig.getParameter<edm::InputTag>("src"))}
 {
-  produces<std::vector<reco::Track> >();
+  produces<std::vector<reco::Track>>();
 }
-
-//______________________________________________________________________________
-IsoTracks::~IsoTracks(){}
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
 //______________________________________________________________________________
-void IsoTracks::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
+void IsoTracks::produce(edm::Event& iEvent, edm::EventSetup const&)
 {
+  auto isoTracks = std::make_unique<std::vector<reco::Track>>();
 
-  std::unique_ptr<std::vector<reco::Track> > IsoTracks(new std::vector<reco::Track >);
-  
-  edm::Handle< std::vector<reco::Track> > dirtyTracks;
-  iEvent.getByToken( v_recoTrackToken_, dirtyTracks );
-  
-  if( dirtyTracks->size() == 0 ) 
-  {
-    iEvent.put(std::move(IsoTracks));
-    return ;
+  edm::Handle<std::vector<reco::Track>> dirtyTracks;
+  iEvent.getByToken(v_recoTrackToken_, dirtyTracks);
+
+  if (dirtyTracks->empty()) {
+    iEvent.put(std::move(isoTracks));
+    return;
   }
-  
-  std::vector<reco::Track>::const_iterator dirtyTrackIt    ;
-  std::vector<reco::Track>::const_iterator dirtyTrackIt2   ;
-//  typename std::vector<reco::Track>::const_iterator dirtyTrackIt    ;
-//  typename std::vector<reco::Track>::const_iterator dirtyTrackIt2   ;
-  double   sumPtInCone = 0 ;
 
-  for ( dirtyTrackIt = dirtyTracks->begin(); dirtyTrackIt != dirtyTracks->end(); ++dirtyTrackIt ) {
-    for ( dirtyTrackIt2 = dirtyTracks->begin(); dirtyTrackIt2 != dirtyTracks->end(); ++dirtyTrackIt2 ) {
-      if ( dirtyTrackIt == dirtyTrackIt2) continue ;
-      if ( deltaR(dirtyTrackIt  -> eta() , 
-                  dirtyTrackIt  -> phi() , 
-                  dirtyTrackIt2 -> eta() , 
-                  dirtyTrackIt2 -> phi() ) < coneRadius_ ){
-        sumPtInCone = sumPtInCone + dirtyTrackIt2 -> pt() ;
+  double sumPtInCone {};
+  for (auto it1 = dirtyTracks->begin(); it1 != dirtyTracks->end(); ++it1) {
+    for (auto it2 = dirtyTracks->begin(); it2 != dirtyTracks->end(); ++it2) {
+      if (it1 == it2) continue;
+      if (deltaR(it1->eta(), it1->phi(), it2->eta(), it2->phi()) < coneRadius_) {
+        sumPtInCone += it2->pt();
       }
-	}
-	if ( sumPtInCone <= threshold_*(dirtyTrackIt->pt()) ){
-	  IsoTracks -> push_back( *dirtyTrackIt ) ; 
-	}
+    }
+    if (sumPtInCone <= threshold_*it1->pt()) {
+      isoTracks->push_back(*it1);
+    }
   }
-  iEvent.put(std::move(IsoTracks));
+
+  iEvent.put(std::move(isoTracks));
 }
 
-#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(IsoTracks);

--- a/Validation/RecoTau/plugins/MuonFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/MuonFromPVSelector.cc
@@ -3,6 +3,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -15,88 +16,67 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include <memory>
+#include <numeric>
 #include <vector>
-#include <sstream>
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-class MuonFromPVSelector : public edm::EDProducer
-{
+class MuonFromPVSelector : public edm::EDProducer {
 public:
-  // construction/destruction
-  MuonFromPVSelector(const edm::ParameterSet& iConfig);
-  virtual ~MuonFromPVSelector();
-  
-  // member functions
-  void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
 
-private:  
-  // member data
-  double                                          max_dxy_           ;
-  double                                          max_dz_            ;
-  edm::EDGetTokenT< std::vector<reco::Vertex> >   v_recoVertexToken_ ;
-  edm::EDGetTokenT< std::vector<reco::Muon> >     v_recoMuonToken_   ;
+  explicit MuonFromPVSelector(edm::ParameterSet const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+private:
+
+  double max_dxy_;
+  double max_dz_;
+  edm::EDGetTokenT<std::vector<reco::Vertex>> v_recoVertexToken_;
+  edm::EDGetTokenT<std::vector<reco::Muon>> v_recoMuonToken_;
 };
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// construction/destruction
+// construction
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________
-MuonFromPVSelector::MuonFromPVSelector(const edm::ParameterSet& iConfig)
-  : max_dxy_          ( iConfig.getParameter<double>( "max_dxy" ) )
-  , max_dz_           ( iConfig.getParameter<double>( "max_dz" ) )
-  , v_recoVertexToken_( consumes< std::vector<reco::Vertex> >( iConfig.getParameter<edm::InputTag>( "srcVertex" ) ) )
-  , v_recoMuonToken_  ( consumes< std::vector<reco::Muon> >( iConfig.getParameter<edm::InputTag>( "srcMuon" ) ) )
+MuonFromPVSelector::MuonFromPVSelector(edm::ParameterSet const& iConfig)
+  : max_dxy_{iConfig.getParameter<double>("max_dxy")}
+  , max_dz_{iConfig.getParameter<double>("max_dz")}
+  , v_recoVertexToken_{consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("srcVertex"))}
+  , v_recoMuonToken_{consumes<std::vector<reco::Muon>>(iConfig.getParameter<edm::InputTag>("srcMuon"))}
 {
-  produces<std::vector<reco::Muon> >();
+  produces<std::vector<reco::Muon>>();
 }
-
-
-//______________________________________________________________________________
-MuonFromPVSelector::~MuonFromPVSelector(){}
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________
-void MuonFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
-{  
-  std::unique_ptr<std::vector<reco::Muon> > goodMuons(new std::vector<reco::Muon >);
-  
-  edm::Handle< std::vector<reco::Vertex> > VertexHandle;
-  iEvent.getByToken( v_recoVertexToken_, VertexHandle );
+void MuonFromPVSelector::produce(edm::Event& iEvent, edm::EventSetup const&)
+{
+  auto goodMuons = std::make_unique<std::vector<reco::Muon>>();
 
-  edm::Handle< std::vector<reco::Muon> > MuonHandle;
-  iEvent.getByToken( v_recoMuonToken_, MuonHandle );
-  
-  if( (VertexHandle->size() == 0) || (MuonHandle->size() == 0) ) 
-  {
-    iEvent.put(std::move(goodMuons));
-    return ;
+  edm::Handle<std::vector<reco::Vertex>> vertices;
+  iEvent.getByToken(v_recoVertexToken_, vertices);
+
+  edm::Handle<std::vector<reco::Muon>> muons;
+  iEvent.getByToken(v_recoMuonToken_, muons);
+
+  if (!vertices->empty()) {
+    auto const& pv = vertices->front();
+    std::copy_if(std::cbegin(*muons), std::cend(*muons), std::back_inserter(*goodMuons),
+                 [&pv, this](auto const& muon){
+                   return muon.innerTrack().isNonnull() &&
+                     std::abs(muon.innerTrack()->dxy(pv.position())) < max_dxy_ &&
+                     std::abs(muon.innerTrack()->dz(pv.position()))  < max_dz_;
+                 });
   }
-  
-  
-  reco::Vertex PV = VertexHandle->front();   
-  //typename std::vector<reco::Muon>::const_iterator MuonIt ;
-  std::vector<reco::Muon>::const_iterator MuonIt ;
 
-  for (MuonIt = MuonHandle->begin(); MuonIt != MuonHandle->end(); ++MuonIt) {
-    if ( MuonIt->innerTrack().isNonnull()                          &&
-         fabs(MuonIt->innerTrack()->dxy(PV.position())) < max_dxy_ &&
-         fabs(MuonIt->innerTrack()->dz(PV.position()))  < max_dz_  ){
-      goodMuons -> push_back(*MuonIt) ;
-    }
-  }  
-  
   iEvent.put(std::move(goodMuons));
-  
 }
 
-#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(MuonFromPVSelector);

--- a/Validation/RecoTau/plugins/MuonFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/MuonFromPVSelector.cc
@@ -1,7 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////
-// Includes
-////////////////////////////////////////////////////////////////////////////////
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,11 +20,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-class MuonFromPVSelector : public edm::EDProducer {
+class MuonFromPVSelector : public edm::global::EDProducer<> {
 public:
 
   explicit MuonFromPVSelector(edm::ParameterSet const&);
-  void produce(edm::Event&, edm::EventSetup const&) override;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
 private:
 
@@ -36,7 +33,6 @@ private:
   edm::EDGetTokenT<std::vector<reco::Vertex>> v_recoVertexToken_;
   edm::EDGetTokenT<std::vector<reco::Muon>> v_recoMuonToken_;
 };
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -56,7 +52,7 @@ MuonFromPVSelector::MuonFromPVSelector(edm::ParameterSet const& iConfig)
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-void MuonFromPVSelector::produce(edm::Event& iEvent, edm::EventSetup const&)
+void MuonFromPVSelector::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const
 {
   auto goodMuons = std::make_unique<std::vector<reco::Muon>>();
 

--- a/Validation/RecoTau/plugins/ZllArbitrator.cc
+++ b/Validation/RecoTau/plugins/ZllArbitrator.cc
@@ -1,115 +1,75 @@
-////////////////////////////////////////////////////////////////////////////////
-// Includes
-////////////////////////////////////////////////////////////////////////////////
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Math/interface/deltaR.h"
-
 #include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/Electron.h"
-#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
-#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "DataFormats/TrackReco/interface/Track.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
+#include <algorithm>
 #include <memory>
 #include <vector>
-#include <sstream>
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-template<typename T1>
-class ZllArbitrator : public edm::EDProducer
-{
+class ZllArbitrator : public edm::EDProducer {
 public:
-  // construction/destruction
-  ZllArbitrator(const edm::ParameterSet& iConfig);
-  virtual ~ZllArbitrator();
-  
-  // member functions
-  void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
-  void endJob() override;
 
-private:  
-  // member data
-  edm::EDGetTokenT<std::vector<T1> >   srcZCand_;  
+  explicit ZllArbitrator(edm::ParameterSet const&);
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+private:
+  edm::EDGetTokenT<std::vector<reco::CompositeCandidate>> srcZCand_;
 };
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // construction/destruction
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________
-template<typename T1>
-ZllArbitrator<T1>::ZllArbitrator(const edm::ParameterSet& iConfig)
-  : srcZCand_(consumes<std::vector<T1> >(iConfig.getParameter<edm::InputTag>("ZCandidateCollection")))
+ZllArbitrator::ZllArbitrator(edm::ParameterSet const& iConfig)
+  : srcZCand_{consumes<std::vector<reco::CompositeCandidate>>(iConfig.getParameter<edm::InputTag>("ZCandidateCollection"))}
 {
-  produces<std::vector<T1> >();
+  produces<std::vector<reco::CompositeCandidate>>();
 }
 
-
-//______________________________________________________________________________
-template<typename T1>
-ZllArbitrator<T1>::~ZllArbitrator(){}
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-//______________________________________________________________________________
-template<typename T1>
-void ZllArbitrator<T1>::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
+void ZllArbitrator::produce(edm::Event& iEvent, edm::EventSetup const&)
 {
-  std::stringstream ss ;
-  
-  std::unique_ptr<std::vector<T1> > TheBestZ(new std::vector<T1 >);
-  
-  edm::Handle< std::vector<T1> > ZCandidatesHandle;
-  iEvent.getByToken(srcZCand_,ZCandidatesHandle);
-  
-  if( ZCandidatesHandle->size() == 0 ) 
-  {
-    iEvent.put(std::move(TheBestZ));
-    return ;
-  }
-  
-  double ZmassPDG  = 91.18;
-  double DeltaMass = 10000;
-  
-  typename std::vector<T1>::const_iterator ZCandIt   ;
-  typename std::vector<T1>::const_iterator bestZCand ;
+  edm::Handle<std::vector<reco::CompositeCandidate>> zCandidates;
+  iEvent.getByToken(srcZCand_,zCandidates);
 
-  for (ZCandIt = ZCandidatesHandle->begin(); ZCandIt != ZCandidatesHandle->end(); ++ZCandIt) {
+  auto bestZ = std::make_unique<std::vector<reco::CompositeCandidate>>();
+  if (!zCandidates->empty()) {
+    // If you're going to hard-code numbers, at least make them constexpr.
+    double constexpr ZmassPDG  {91.18}; // GeV
 
-	if( fabs(ZCandIt->mass()-ZmassPDG) < DeltaMass ){
-	  DeltaMass = fabs(ZCandIt->mass()-ZmassPDG) ;
-	  bestZCand = ZCandIt; 
-	}
+    auto bestZCand = std::min_element(std::cbegin(*zCandidates), std::cend(*zCandidates),
+                                      [ZmassPDG](auto const& firstCand, auto const& secondCand) {
+                                        return std::abs(firstCand.mass()-ZmassPDG) < std::abs(secondCand.mass()-ZmassPDG);
+                                      });
+    bestZ->push_back(*bestZCand);
   }
 
-  TheBestZ->push_back( *bestZCand );  
-  iEvent.put(std::move(TheBestZ));
-  
+  iEvent.put(std::move(bestZ));
 }
 
-template<typename T1>
-void ZllArbitrator<T1>::endJob()
-{
-}
+using BestMassZArbitrationProducer = ZllArbitrator;
 
-typedef ZllArbitrator<reco::CompositeCandidate>      BestMassZArbitrationProducer;
-
-#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(BestMassZArbitrationProducer);

--- a/Validation/RecoTau/plugins/ZllArbitrator.cc
+++ b/Validation/RecoTau/plugins/ZllArbitrator.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,11 +24,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
-class ZllArbitrator : public edm::EDProducer {
+class ZllArbitrator : public edm::global::EDProducer<> {
 public:
 
   explicit ZllArbitrator(edm::ParameterSet const&);
-  void produce(edm::Event&, edm::EventSetup const&) override;
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
 private:
   edm::EDGetTokenT<std::vector<reco::CompositeCandidate>> srcZCand_;
@@ -50,7 +50,7 @@ ZllArbitrator::ZllArbitrator(edm::ParameterSet const& iConfig)
 // implementation of member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-void ZllArbitrator::produce(edm::Event& iEvent, edm::EventSetup const&)
+void ZllArbitrator::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const
 {
   edm::Handle<std::vector<reco::CompositeCandidate>> zCandidates;
   iEvent.getByToken(srcZCand_,zCandidates);


### PR DESCRIPTION
Straightforward conversion from legacy to global, with some C++ cleanups.