### PR TITLE
MB tune fragments for PU studies within the LUMI group

### DIFF
--- a/Configuration/Generator/python/Pythia8CUEP8M3Settings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUEP8M3Settings_cfi.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CUEP8M3SettingsBlock = cms.PSet(
+    pythia8CUEP8M3Settings = cms.vstring(
+        'Tune:pp 14',
+	      'Tune:ee 7',
+	      'Diffraction:PomFlux=5',
+	      'Diffraction:MBRepsilon=0.0903',
+	      'Diffraction:MBRalpha=0.0633',
+	      'Diffraction:MBRdyminDD = 0.',
+	      'Diffraction:MBRdyminSigDD = 0.001',
+	      'Diffraction:MBRdyminDDflux = 1.35',
+	      'MultipartonInteractions:ecmRef=13000.0',
+	      'MultipartonInteractions:ecmPow=0.25208',
+	      'SpaceShower:alphaSvalue=0.1108',
+	      'PDF:pSet=LHAPDF6:NNPDF30_lo_as_0130',
+	      'MultipartonInteractions:bProfile=2',
+	      'MultipartonInteractions:pT0Ref=2.675',
+	      'MultipartonInteractions:coreRadius=0.2924',
+	      'MultipartonInteractions:coreFraction=0.3356',
+	      'ColourReconnection:range=1.956',
+    )
+)

--- a/Configuration/Generator/python/Pythia8CUEP8M3Settings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUEP8M3Settings_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 pythia8CUEP8M3SettingsBlock = cms.PSet(
     pythia8CUEP8M3Settings = cms.vstring(
-        'Tune:pp 14',
+              'Tune:pp 14',
 	      'Tune:ee 7',
 	      'Diffraction:PomFlux=5',
 	      'Diffraction:MBRepsilon=0.0903',
-	      'Diffraction:MBRalpha=0.0633',
+	      'Diffraction:MBRalpha=0.1',
 	      'Diffraction:MBRdyminDD = 0.',
 	      'Diffraction:MBRdyminSigDD = 0.001',
 	      'Diffraction:MBRdyminDDflux = 1.35',

--- a/Configuration/Generator/python/Pythia8CUEP8M4Settings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUEP8M4Settings_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+pythia8CUEP8M4SettingsBlock = cms.PSet(
+    pythia8CUEP8M4Settings = cms.vstring(
+        'Tune:pp 14',
+	      'Tune:ee 7',
+        'Diffraction:PomFlux=4',
+	      'Diffraction:PomFluxEpsilon=0.1195',
+	      'Diffraction:PomFluxAlphaPrime=0.1417',
+	      'MultipartonInteractions:ecmRef=13000.0',
+	      'MultipartonInteractions:ecmPow=0.25208',
+	      'SpaceShower:alphaSvalue=0.1108',
+	      'SigmaTotal:zeroAXB=off',
+	      'PDF:pSet=LHAPDF6:NNPDF30_lo_as_0130',
+	      'MultipartonInteractions:bProfile=2',
+	      'MultipartonInteractions:pT0Ref=2.481',
+	      'MultipartonInteractions:coreFraction=0.5457',
+	      'MultipartonInteractions:coreRadius=0.7195',
+	      'ColourReconnection:range=2.921',
+    )
+)

--- a/Configuration/Generator/python/Pythia8CUEP8M4Settings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CUEP8M4Settings_cfi.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 pythia8CUEP8M4SettingsBlock = cms.PSet(
     pythia8CUEP8M4Settings = cms.vstring(
-        'Tune:pp 14',
+              'Tune:pp 14',
 	      'Tune:ee 7',
-        'Diffraction:PomFlux=4',
+              'Diffraction:PomFlux=4',
 	      'Diffraction:PomFluxEpsilon=0.1195',
 	      'Diffraction:PomFluxAlphaPrime=0.1417',
 	      'MultipartonInteractions:ecmRef=13000.0',


### PR DESCRIPTION
They should be backported to 7_1_X for GEN-SIM MB sample production, if possible