### PR TITLE
HBHE M2 = HPD old code cleanup

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -122,7 +122,7 @@ namespace FitterFuncs{
 	//Interpolate the fit (Quickly)
 	funcHPDShape(pulse_shape_, pars[0],pars[1],psFit_slew[time]);
 	for (j=0; j<nbins; ++j) {
-	  psFit_erry2[j]  = psFit_erry[j]*psFit_erry[j] + pulse_shape_[j]*pulse_shape_[j]*pulseJitter_;
+	  psFit_erry2[j]  = psFit_erry2[j] + pulse_shape_[j]*pulse_shape_[j]*pulseJitter_;
 	  pulse_shape_sum_[j] = pulse_shape_[j] + pars[nPars-1];
 	}
 
@@ -130,7 +130,7 @@ namespace FitterFuncs{
 	while (i<parBy2) {  
 	  time = (pars[i*2]+timeShift_-timeMean_)*HcalConst::invertnsPerBx;
 	  //Interpolate the fit (Quickly)
-	  funcHPDShape(pulse_shape_, pars[i+2],pars[i*2+1],psFit_slew[time]);
+	  funcHPDShape(pulse_shape_, pars[i*2],pars[i*2+1],psFit_slew[time]);
 	  // add an uncertainty from the pulse (currently noise * pulse height =>Ecal uses full cov)
 	 /////
 	  for (j=0; j<nbins; ++j) {


### PR DESCRIPTION
Given that we are switching the legacy re-reco to the "Phase1"code with the #17676.
I also removed the various if statement for the HPD-QIE8.

Now take the noise from the database instead of a flat numbers from the python code
the ADCquantization noise  use the exact definition instead of a parametrized version

expect minor changes in the noise hits