### PR TITLE
CSC RU segment algorithm tuned for ME0

### DIFF
--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -1,0 +1,941 @@
+/** 
+ * \file ME0SegAlgRU.cc 
+ *  
+ *  \author M. Maggi for ME0
+ *  \from V.Palichik & N.Voytishin   
+ *  \some functions and structure taken from SK algo by M.Sani and SegFit class by T.Cox 
+ */ 
+
+#include "ME0SegAlgoRU.h" 
+#include "MuonSegFit.h"
+#include "Geometry/CSCGeometry/interface/CSCLayer.h" 
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h" 
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h" 
+#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+
+#include <algorithm> 
+#include <cmath> 
+#include <iostream> 
+#include <string> 
+
+ME0SegAlgoRU::ME0SegAlgoRU(const edm::ParameterSet& ps)
+  : ME0SegmentAlgorithmBase(ps), myName("ME0SegAlgoRU"), sfit_(nullptr) { 
+
+  doCollisions = ps.getParameter<bool>("doCollisions"); 
+  chi2_str_   = ps.getParameter<double>("chi2_str"); 
+  chi2Norm_2D_   = ps.getParameter<double>("chi2Norm_2D_");    
+  dRMax       = ps.getParameter<double>("dRMax"); 
+  dPhiMax        = ps.getParameter<double>("dPhiMax"); 
+  dRIntMax   = ps.getParameter<double>("dRIntMax"); 
+  dPhiIntMax    = ps.getParameter<double>("dPhiIntMax"); 
+  chi2Max        = ps.getParameter<double>("chi2Max"); 
+  wideSeg        = ps.getParameter<double>("wideSeg"); 
+  minLayersApart = ps.getParameter<int>("minLayersApart"); 
+
+  LogDebug("ME0") << myName << " has algorithm cuts set to: \n" 
+		  << "--------------------------------------------------------------------\n" 
+		  << "dRMax     = " << dRMax << '\n' 
+		  << "dPhiMax      = " << dPhiMax << '\n' 
+		  << "dRIntMax = " << dRIntMax << '\n' 
+		  << "dPhiIntMax  = " << dPhiIntMax << '\n' 
+		  << "chi2Max      = " << chi2Max << '\n' 
+		  << "wideSeg      = " << wideSeg << '\n' 
+		  << "minLayersApart = " << minLayersApart << std::endl; 
+
+  //reset the thresholds for non-collision data 
+  if(!doCollisions){ 
+    dRMax = 2.0; 
+    dPhiMax = 2*dPhiMax; 
+    dRIntMax = 2*dRIntMax; 
+    dPhiIntMax = 2*dPhiIntMax; 
+    chi2Norm_2D_ = 5*chi2Norm_2D_; 
+    chi2_str_ = 100; 
+    chi2Max = 2*chi2Max; 
+  } 
+} 
+
+std::vector<ME0Segment> ME0SegAlgoRU::run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits){ 
+  theEnsemble = ensemble;
+  return this->buildSegments(rechits);  
+} 
+
+std::vector<ME0Segment> ME0SegAlgoRU::buildSegments(const EnsembleHitContainer& urechits) { 
+  EnsembleHitContainer rechits = urechits; 
+  LayerIndex layerIndex(rechits.size()); 
+  // MM hard coded should work for <=6 layer..
+  int recHits_per_layer[6] = {0,0,0,0,0,0}; 
+
+  // MM this should be verified for ME0, noise and PU and high eta are difficult regions...
+  //skip events with high multiplicity of hits 
+  if (rechits.size()>300){ 
+    return std::vector<ME0Segment>(); 
+  } 
+
+  int iadd = 0; 
+  // determine if smaller layer correspong to smaller abs(z) nearest to IP
+  int minlayer = 99;
+  int maxlayer = -1;
+  float zmin = 0;
+  float zmax = 0;
+  for(unsigned int i = 0; i < rechits.size(); i++) {  
+    int layer = rechits[i]->me0Id().layer();
+    recHits_per_layer[layer-1]++;//count rh per chamber 
+    layerIndex[i] = layer;
+    if (layer > maxlayer ) {
+      maxlayer = layer;
+      const ME0EtaPartition * thePartition   = (theEnsemble.second).find(rechits[i]->me0Id())->second;
+      zmax = (thePartition->toGlobal(rechits[i]->localPosition())).z();
+    }
+    if (layer < minlayer ) {
+      minlayer = layer;
+      const ME0EtaPartition * thePartition   = (theEnsemble.second).find(rechits[i]->me0Id())->second;
+      zmin = (thePartition->toGlobal(rechits[i]->localPosition())).z();
+    }
+  }
+
+  if (std::abs(zmin) > std::abs(zmax)){ 
+    reverse(layerIndex.begin(), layerIndex.end()); 
+    reverse(rechits.begin(), rechits.end()); 
+  }     
+ 
+  if (rechits.size() < 2) { 
+    return std::vector<ME0Segment>();  
+  } 
+
+  // We have at least 2 hits. We intend to try all possible pairs of hits to start  
+  // segment building. 'All possible' means each hit lies on different layers in the chamber. 
+  // after all same size segs are build we get rid of the overcrossed segments using the chi2 criteria 
+  // the hits from the segs that are left are marked as used and are not added to segs in future iterations 
+  // the hits from 3p segs are marked as used separately in order to try to assamble them in longer segments  
+  // in case there is a second pass    
+
+  // Choose first hit (as close to IP as possible) h1 and second hit 
+  // (as far from IP as possible) h2 To do this we iterate over hits 
+  // in the chamber by layer - pick two layers.  Then we 
+  // iterate over hits within each of these layers and pick h1 and h2 
+  // these.  If they are 'close enough' we build an empty 
+  // segment.  Then try adding hits to this segment. 
+
+  // Initialize flags that a given hit has been allocated to a segment 
+  BoolContainer used(rechits.size(), false); 
+  BoolContainer used3p(rechits.size(), false); 
+
+  // This is going to point to fits to hits, and its content will be used to create a ME0Segment
+  sfit_ = 0;
+
+  // Define buffer for segments we build  
+  std::vector<ME0Segment> segments; 
+
+  EnsembleHitContainerCIt ib = rechits.begin(); 
+  EnsembleHitContainerCIt ie = rechits.end(); 
+
+  // Possibly allow 3 passes, second widening scale factor for cuts, third for segments from displaced vertices 
+  windowScale = 1.; // scale factor for cuts 
+
+  bool search_disp = false;	   
+  int npass = (wideSeg > 1.)? 3 : 2; 
+
+  for (int ipass = 0; ipass < npass; ++ipass) { 
+    if(windowScale >1.){ 
+      iadd = 1; 
+      strip_iadd = 2; 
+      chi2D_iadd = 2; 
+    } 
+
+    int used_rh = 0;
+    for (EnsembleHitContainerCIt i1 = ib; i1 != ie; ++i1) {
+      if(used[i1-ib])used_rh++;
+    }
+    //change the tresholds if it's time to look for displaced mu segments                                                                                                                                                          
+    if(doCollisions && search_disp && int(rechits.size()-used_rh)>2){//check if there are enough recHits left to build a segment from displaced vertices                                                                     
+      doCollisions = false;
+      windowScale = 1.; // scale factor for cuts   
+      dRMax = 2.*dRMax;
+      dPhiMax = 2*dPhiMax;
+      dRIntMax = 2*dRIntMax;
+      dPhiIntMax = 2*dPhiIntMax;
+      chi2Norm_2D_ = 5*chi2Norm_2D_;
+      //      chi2_str_ = 100;
+      chi2Max = 2*chi2Max;
+    }
+
+    for(unsigned int n_seg_min = 6u; n_seg_min > 2u + iadd; --n_seg_min){ 
+      BoolContainer common_used(rechits.size(),false); 
+      std::array<BoolContainer, 120> common_used_it = {}; 
+      for (unsigned int i = 0; i < common_used_it.size(); i++) { 
+	common_used_it[i] = common_used; 
+      } 
+      EnsembleHitContainer best_proto_segment[120]; 
+      float min_chi[120] = {9999}; 
+      int common_it = 0; 
+      bool first_proto_segment = true; 
+      // the first hit is taken from the back
+      
+      for (EnsembleHitContainerCIt i1 = ib; i1 != ie; ++i1) { 
+	  
+	//skip if rh is used and the layer tat has big rh multiplicity(>25RHs) 
+	if(used[i1-ib] || recHits_per_layer[int(layerIndex[i1-ib])-1]>25 || (n_seg_min == 3 && used3p[i1-ib])) continue; 
+
+	int layer1 = layerIndex[i1-ib];  
+	const ME0RecHit* h1 = *i1; 
+	// the second hit from the front
+	for (EnsembleHitContainerCIt i2 = ie-1; i2 != i1; --i2) { 
+	  bool segok = false; 
+	  if(used[i2-ib] || recHits_per_layer[int(layerIndex[i2-ib])-1]>25 || (n_seg_min == 3 && used3p[i2-ib])) continue; 
+
+	  int layer2 = layerIndex[i2-ib]; 
+	  if((abs(layer2 - layer1) + 1) < int(n_seg_min)) break;//decrease n_seg_min 
+          const ME0RecHit* h2 = *i2; 	
+	    if (this->areHitsCloseInEta(h1, h2) && this->areHitsCloseInGlobalPhi(h1, h2)) { 
+	    proto_segment.clear(); 
+	    if (!this->addHit(h1, layer1))continue; 
+	    if (!this->addHit(h2, layer2))continue; 
+
+	    // Can only add hits if already have a segment
+	    if ( sfit_ ) this->tryAddingHitsToSegment(rechits, used, layerIndex, i1, i2);  
+	    segok = this->isSegmentGood(rechits); 
+	    if (segok) { 
+	      if(proto_segment.size() > n_seg_min){
+		this->baseline(n_seg_min); 
+		this->updateParameters();
+	      }
+	      if(sfit_->chi2()/sfit_->ndof() > chi2Norm_2D_*chi2D_iadd || proto_segment.size() < n_seg_min) {
+		proto_segment.clear(); 
+	      }
+	      
+	      if (!proto_segment.empty()) { 
+		this->updateParameters(); 
+
+	        //add same-size overcrossed protosegments to the collection 
+		if(first_proto_segment){ 
+		  
+		  this->flagHitsAsUsed(rechits, common_used_it[0]); 
+		  min_chi[0] = sfit_->chi2()/sfit_->ndof(); 
+		  best_proto_segment[0] = proto_segment; 
+		  
+		  first_proto_segment = false; 
+		}else{  //for the rest of found proto_segments  
+		  common_it++; 
+		  this->flagHitsAsUsed(rechits, common_used_it[common_it]); 
+
+		  min_chi[common_it] = sfit_->chi2()/sfit_->ndof(); 
+		  best_proto_segment[common_it] = proto_segment; 
+		  EnsembleHitContainerCIt hi, iu, ik; 
+		  int iter = common_it; 
+		  for(iu = ib; iu != ie; ++iu) { 
+		    for(hi = proto_segment.begin(); hi != proto_segment.end(); ++hi) { 
+		      if(*hi == *iu) { 
+			int merge_nr = -1; 
+			for(int k = 0; k < iter+1; k++){ 
+			  if(common_used_it[k][iu-ib] == true){ 
+			    if(merge_nr != -1){ 
+
+			      //merge the k and merge_nr collections of flaged hits into the merge_nr collection and unmark the k collection hits                                   
+			      for(ik = ib; ik != ie; ++ik) { 
+				if(common_used_it[k][ik-ib] == true){ 
+				  common_used_it[merge_nr][ik-ib] = true; 
+				  common_used_it[k][ik-ib] = false; 
+				} 
+			      } 
+			      //change best_protoseg if min_chi_2 is smaller                                                                                                                       
+			      if(min_chi[k] < min_chi[merge_nr]){ 
+				min_chi[merge_nr] = min_chi[k]; 
+				best_proto_segment[merge_nr] = best_proto_segment[k]; 
+				best_proto_segment[k].clear(); 
+				min_chi[k] = 9999; 
+			      } 
+			      common_it--; 
+			    } 
+			    else{ 
+			      merge_nr = k; 
+			    } 
+			  }//if(common_used[k][iu-ib] == true)                                                                                                                                     
+			}//for k                                                                                                                                                                    
+		      }//if                                                                                                                                                                        
+		    }//for proto_seg                                                                                                                                                                 
+		  }//for rec_hits   
+		}//else 
+	      }//proto seg not empty 
+	    }
+	  }  //   h1 & h2 close 
+	  if (segok)  {
+	    //            break; 
+	  }
+	}  //  i2 
+      }  //  i1 
+
+      //add the reconstructed segments 
+      for(int j = 0;j < common_it+1; j++){ 
+	
+	proto_segment = best_proto_segment[j]; 
+	best_proto_segment[j].clear(); 
+	//SKIP empty proto-segments
+        if(proto_segment.size() == 0) continue;
+	this->updateParameters();   
+    
+	// Create an actual ME0Segment - retrieve all info from the fit
+	// calculate the timing fron rec hits associated to the TrackingRecHits used 
+	// to fit the segment 
+	float averageTime=0.;
+	for(EnsembleHitContainer::iterator ir=proto_segment.begin(); ir<proto_segment.end(); ++ir ) {
+	  averageTime += (*ir)->tof();
+	}
+	if(proto_segment.size() != 0)
+	  averageTime=averageTime/(proto_segment.size());
+	float timeUncrt=0.;
+	for(EnsembleHitContainer::iterator ir=proto_segment.begin(); ir<proto_segment.end(); ++ir ) {
+	  timeUncrt += pow( (*ir)->tof()-averageTime,2);
+	}
+	if(proto_segment.size() > 1)
+	  timeUncrt=timeUncrt/(proto_segment.size()-1);
+	timeUncrt = sqrt(timeUncrt);
+	std::sort(proto_segment.begin(),proto_segment.end(),sortByLayer());
+	ME0Segment temp(proto_segment, sfit_->intercept(),
+			sfit_->localdir(), sfit_->covarianceMatrix(), sfit_->chi2(), averageTime, timeUncrt);
+	sfit_ = 0;
+	segments.push_back(temp);                         
+	//if the segment has 3 hits flag them as used in a particular way 
+	if(proto_segment.size() == 3){ 
+	  this->flagHitsAsUsed(rechits, used3p); 
+	} 
+	else{ 
+	  this->flagHitsAsUsed(rechits, used);   
+	} 
+	proto_segment.clear(); 
+      }  
+    }//for n_seg_min 
+
+    if(!doCollisions && search_disp){
+
+      //reset params and flags for the next ensemble                                                                                                                           
+      search_disp = false;
+      doCollisions = true;
+      dRMax = dRMax/2.0;
+      dPhiMax = dPhiMax/2;
+      dRIntMax = dRIntMax/2;
+      dPhiIntMax = dPhiIntMax/2;
+      chi2Norm_2D_ = chi2Norm_2D_/5;
+      chi2_str_ = 100;
+      chi2Max = chi2Max/2;
+    }     
+
+    std::vector<ME0Segment>::iterator it =segments.begin(); 
+    bool good_segs = false; 
+    while(it != segments.end()) { 
+      if ((*it).nRecHits() > 3){ 
+	good_segs = true; 
+	break; 
+      } 
+      ++it;	 
+    }     
+
+    if (good_segs) {  // only change window if not enough good segments were found (bool can be changed to int if a >0 number of good segs is required) 
+      search_disp = true;
+      continue;//proceed to search the segs from displaced vertices
+    }
+
+    // Increase cut windows by factor of wideSeg only for collisions 
+    if(!doCollisions && !search_disp) break;     
+    windowScale = wideSeg; 
+  }  //  ipass 
+  /* Specific to CSC not used at the moment for ME0
+  //get rid of enchansed 3p segments 
+  std::vector<ME0Segment>::iterator it =segments.begin(); 
+  while(it != segments.end()) { 
+    if((*it).nRecHits() == 3){ 
+      bool found_common = false; 
+      const std::vector<ME0RecHit>& theseRH = (*it).specificRecHits(); 
+      for (EnsembleHitContainerCIt i1 = ib; i1 != ie; ++i1) { 
+	if(used[i1-ib] && used3p[i1-ib]){ 
+	  const ME0RecHit* sh1 = *i1; 
+
+	  ME0DetId id = sh1->me0Id(); 
+	  int sh1layer = id.layer(); 
+	  int RH_centerid     =  sh1->nStrips()/2; 
+	  int RH_centerStrip =  sh1->channels(RH_centerid); 
+	  int RH_wg = sh1->hitWire();
+	  std::vector<ME0RecHit>::const_iterator sh; 
+	  for(sh = theseRH.begin(); sh != theseRH.end(); ++sh){ 
+	    ME0DetId idRH = sh->me0Id();
+
+	    //find segment hit coord 
+	    int shlayer = idRH.layer(); 
+	    int SegRH_centerid     =  sh->nStrips()/2; 
+	    int SegRH_centerStrip =  sh->channels(SegRH_centerid); 
+	    int SegRH_wg = sh->hitWire(); 
+
+	    if(sh1layer == shlayer && SegRH_centerStrip == RH_centerStrip && SegRH_wg == RH_wg){ 
+	      //remove the enchansed 3p segment 
+	      segments.erase(it,(it+1)); 
+	      found_common = true; 
+	      break; 
+	    } 
+	  }//theserh 
+	} 
+	if(found_common) break;//current seg has already been erased 
+      }//camber hits 
+      if(!found_common)++it;  
+    }//its a 3p seg 
+    else{ 
+      ++it;//go to the next seg 
+    }  
+  }//while 
+  */
+  // Give the segments to the ME0Ensemble 
+  return segments; 
+}//build segments 
+
+void ME0SegAlgoRU::tryAddingHitsToSegment(const EnsembleHitContainer& rechits,  
+					  const BoolContainer& used, const LayerIndex& layerIndex, 
+					  const EnsembleHitContainerCIt i1, const EnsembleHitContainerCIt i2) { 
+
+  // Iterate over the layers with hits in the chamber 
+  // Skip the layers containing the segment endpoints 
+  // Test each hit on the other layers to see if it is near the segment 
+  // If it is, see whether there is already a hit on the segment from the same layer 
+  //    - if so, and there are more than 2 hits on the segment, copy the segment, 
+  //      replace the old hit with the new hit. If the new segment chi2 is better 
+  //      then replace the original segment with the new one (by swap) 
+  //    - if not, copy the segment, add the hit. If the new chi2/dof is still satisfactory 
+  //      then replace the original segment with the new one (by swap) 
+
+  EnsembleHitContainerCIt ib = rechits.begin(); 
+  EnsembleHitContainerCIt ie = rechits.end(); 
+  
+  for (EnsembleHitContainerCIt i = ib; i != ie; ++i) { 
+    if(layerIndex[i1-ib]<layerIndex[i2-ib]){ 
+      if (layerIndex[i-ib] <= layerIndex[i1-ib] || layerIndex[i-ib] >= layerIndex[i2-ib] || i  == i1 || i == i2 || used[i-ib]){  
+	if ( i  == i1 || i == i2 || used[i-ib]) 
+	  continue;  
+      } 
+    } 
+    else{ 
+      if (layerIndex[i-ib] >= layerIndex[i1-ib] || layerIndex[i-ib] <= layerIndex[i2-ib] || i  == i1 || i == i2 || used[i-ib]){ 
+	if ( i  == i1 || i == i2 || used[i-ib])                                                                                                              
+	  continue; 
+      }  
+    } 
+    int layer = layerIndex[i-ib]; 
+    const ME0RecHit* h = *i; 
+    if (this->isHitNearSegment(h)) {
+
+      // Don't consider alternate hits on layers holding the two starting points 
+      if (this->hasHitOnLayer(layer)) { 
+	if (proto_segment.size() <= 2) continue; 
+	this->compareProtoSegment(h, layer); 
+      }  
+      else{ 
+	this->increaseProtoSegment(h, layer, chi2D_iadd);  
+      }
+      
+    }   // h & seg close 
+  }   // i 
+} 
+
+bool ME0SegAlgoRU::areHitsCloseInEta(const ME0RecHit* h1, const ME0RecHit* h2) const { 
+  // check that hits from different layer gets eta partition number +1 max..
+
+  ME0DetId id1 = h1->me0Id();  
+  const ME0EtaPartition* part1 = theEnsemble.second.find(id1)->second;
+  GlobalPoint gp1 = part1->toGlobal(h1->localPosition());	 
+  int etaP1 = id1.roll();
+
+  ME0DetId id2 = h2->me0Id();  
+  const ME0EtaPartition* part2 = theEnsemble.second.find(id2)->second;
+  GlobalPoint gp2 = part2->toGlobal(h2->localPosition());	 
+  int etaP2 = id2.roll();
+
+  //find z to understand the direction 
+  float h1z = gp1.z(); 
+  float h2z = gp2.z(); 
+  bool good = false;
+  float dR = 9999;
+  if (doCollisions){
+    if ( abs(h1z) > abs(h2z) ) {
+      good = (etaP1==etaP2 || etaP1 == etaP2-1);
+    }else{
+      good = (etaP1==etaP2 || etaP2 == etaP1-1);
+    }	 
+    dR = fabs(gp1.perp()-gp2.perp());
+  }else{
+    good = std::abs(etaP1-etaP2) <= 1;
+    dR = 0;
+  }
+  return (good && dR<dRMax);
+} 
+
+bool ME0SegAlgoRU::areHitsCloseInGlobalPhi(const ME0RecHit* h1, const ME0RecHit* h2) const { 
+
+  ME0DetId id1 = h1->me0Id();  
+  const ME0EtaPartition* part1 = theEnsemble.second.find(id1)->second;
+  GlobalPoint gp1 = part1->toGlobal(h1->localPosition());	 
+
+  ME0DetId id2 = h2->me0Id();  
+  const ME0EtaPartition* part2 = theEnsemble.second.find(id2)->second;
+  GlobalPoint gp2 = part2->toGlobal(h2->localPosition());	 
+
+  float dphi12 = deltaPhi(gp1.barePhi(),gp2.barePhi());
+  return fabs(dphi12) < dPhiMax; 
+} 
+
+bool ME0SegAlgoRU::isHitNearSegment(const ME0RecHit* h) const { 
+
+  // Is hit near segment?  
+  // Requires deltaphi and deltaR within ranges specified in parameter set. 
+  // Note that to make intuitive cuts on delta(phi) one must work in 
+  // phi range (-pi, +pi] not [0, 2pi) 
+
+  ME0DetId besId = (*(proto_segment.begin()))->me0Id();
+  const ME0EtaPartition* l1 = theEnsemble.second.find(besId)->second;
+  GlobalPoint gp1 = l1->toGlobal((*(proto_segment.begin()))->localPosition()); 
+
+  ME0DetId nesId = (*(proto_segment.begin()+1))->me0Id();
+  const ME0EtaPartition* l2 = theEnsemble.second.find(nesId)->second;
+  GlobalPoint gp2 = l2->toGlobal((*(proto_segment.begin()+1))->localPosition()); 
+
+
+  const ME0EtaPartition* l = theEnsemble.second.find(h->me0Id())->second;
+  GlobalPoint hp = l->toGlobal(h->localPosition()); 
+  
+  float hphi = hp.phi();          // in (-pi, +pi] 
+  if (hphi < 0.) 
+    hphi += 2.*M_PI;            // into range [0, 2pi) 
+  float sphi = this->phiAtZ(hp.z());    // in [0, 2*pi) 
+  float phidif = sphi-hphi; 
+  if (phidif < 0.) 
+    phidif += 2.*M_PI;          // into range [0, 2pi) 
+  if (phidif > M_PI) 
+    phidif -= 2.*M_PI;          // into range (-pi, pi] 
+
+  SVector6 r_glob; 
+  r_glob((*(proto_segment.begin()))->me0Id().layer()-1) = gp1.perp(); 
+  r_glob((*(proto_segment.begin()+1))->me0Id().layer()-1) = gp2.perp(); 
+
+  float R =  hp.perp(); 
+  int layer = h->me0Id().layer(); 
+
+  float r_interpolated = this->fit_r_phi(r_glob,layer); 
+  float dr = fabs(r_interpolated - R); 
+  
+  return (fabs(phidif) <  dPhiIntMax && fabs(dr) < dRIntMax);
+} 
+
+float ME0SegAlgoRU::phiAtZ(float z) const { 
+
+  if ( !sfit_ ) return 0.;
+
+  // Returns a phi in [ 0, 2*pi )
+  //  const ME0EtaPartition* l1 = theEnsemble.second.find((*(proto_segment.begin()))->me0Id())->second;
+  const ME0EtaPartition* l1 = theEnsemble.first;
+  GlobalPoint gp = l1->toGlobal(sfit_->intercept());
+  GlobalVector gv = l1->toGlobal(sfit_->localdir());
+
+  float x = gp.x() + (gv.x()/gv.z())*(z - gp.z());
+  float y = gp.y() + (gv.y()/gv.z())*(z - gp.z());
+
+  float phi = atan2(y, x);
+  if (phi < 0.f ) phi += 2. * M_PI;
+
+  return phi ;
+}
+
+bool ME0SegAlgoRU::isSegmentGood(const EnsembleHitContainer& rechitsInChamber) const { 
+
+  // If the chamber has 20 hits or fewer, require at least 3 hits on segment 
+  // If the chamber has >20 hits require at least 4 hits 
+  //@@ THESE VALUES SHOULD BECOME PARAMETERS? 
+  bool ok = false; 
+
+  unsigned int iadd = ( rechitsInChamber.size() > 20)?  1 : 0;   
+
+  if (windowScale > 1.) 
+    iadd = 1; 
+
+  if (proto_segment.size() >= 3+iadd) 
+    ok = true; 
+  return ok; 
+} 
+
+void ME0SegAlgoRU::flagHitsAsUsed(const EnsembleHitContainer& rechitsInChamber,  
+				  BoolContainer& used ) const { 
+
+  // Flag hits on segment as used 
+  EnsembleHitContainerCIt ib = rechitsInChamber.begin(); 
+  EnsembleHitContainerCIt hi, iu; 
+
+  for(hi = proto_segment.begin(); hi != proto_segment.end(); ++hi) { 
+    for(iu = ib; iu != rechitsInChamber.end(); ++iu) { 
+      if(*hi == *iu) 
+	used[iu-ib] = true; 
+    } 
+  } 
+} 
+
+bool ME0SegAlgoRU::addHit(const ME0RecHit* aHit, int layer) { 
+
+  // Return true if hit was added successfully
+  // (and then parameters are updated).
+  // Return false if there is already a hit on the same layer, or insert failed.
+
+  EnsembleHitContainer::const_iterator it;
+  
+  for(it = proto_segment.begin(); it != proto_segment.end(); it++)
+    if (((*it)->me0Id().layer() == layer) && (aHit != (*it)))
+      return false;
+  proto_segment.push_back(aHit);
+  // make a fit
+  this->updateParameters();
+  return true;
+} 
+
+void ME0SegAlgoRU::updateParameters() { 
+  // update the current MuonSegFit one and make the fit
+  // for ME0 we take the me0rechit from the proto_segment we transform into Tracking Rechits 
+  // the local rest frame is the ME0Chamber of layer 1 the refPart
+  MuonSegFit::MuonRecHitContainer muonRecHits;
+  const ME0EtaPartition * refPart = theEnsemble.first;
+  for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
+    const ME0EtaPartition * thePartition   = (theEnsemble.second.find((*rh)->me0Id()))->second;
+    GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
+    const LocalPoint lp = refPart->toLocal(gp);
+    ME0RecHit *newRH = (*rh)->clone();
+    newRH->setPosition(lp);
+    MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
+    muonRecHits.push_back(trkRecHit);
+  }
+  sfit_.reset(new MuonSegFit(muonRecHits));
+  sfit_->fit();
+} 
+
+float ME0SegAlgoRU::fit_r_phi(SVector6 points, int layer) const{ 
+  //find R or Phi on the given layer using the given points for the interpolation 
+  float Sx  = 0; 
+  float Sy  = 0; 
+  float Sxx = 0; 
+  float Sxy = 0; 
+
+  for (int i=1;i<7;i++){ 
+    if (points(i-1)== 0.) continue; 
+    Sy = Sy + (points(i-1)); 
+    Sx = Sx + i; 
+    Sxx = Sxx + (i*i); 
+    Sxy = Sxy + ((i)*points(i-1)); 
+  } 
+  float delta = 2*Sxx - Sx*Sx; 
+  float intercept = (Sxx*Sy - Sx*Sxy)/delta; 
+  float slope = (2*Sxy - Sx*Sy)/delta;                                                                                                                        
+  return (intercept + slope*layer); 
+} 
+
+void ME0SegAlgoRU::baseline(int n_seg_min){ 
+
+  int nhits      = proto_segment.size(); 
+  EnsembleHitContainer::const_iterator iRH_worst; 
+  //initialise vectors for strip position and error within strip
+  SVector6 sp; 
+  SVector6 se;  
+
+  unsigned int init_size = proto_segment.size(); 
+  
+  EnsembleHitContainer buffer; 
+  buffer.clear(); 
+  buffer.reserve(init_size);
+  while (buffer.size()< init_size){ 
+    EnsembleHitContainer::iterator min; 
+    int min_layer = 99; 
+    for(EnsembleHitContainer::iterator k = proto_segment.begin(); k != proto_segment.end(); k++){             
+      const ME0RecHit* iRHk = *k;  
+      ME0DetId idRHk = iRHk->me0Id(); 
+      int kLayer   = idRHk.layer(); 
+      if(kLayer < min_layer){ 
+	min_layer = kLayer; 
+	min = k; 
+      } 
+    } 
+    buffer.push_back(*min); 
+    proto_segment.erase(min);
+  }//while 
+  proto_segment.clear();  
+
+  for (EnsembleHitContainer::const_iterator cand = buffer.begin(); cand != buffer.end(); cand++) { 
+    proto_segment.push_back(*cand); 
+  } 
+  
+  float phifirst = 0;
+  bool first = true;
+  // fitting the phi global position of the rechits relative to the first phi (to avoid xing the -pi, pi transition....
+  for(EnsembleHitContainer::const_iterator iRH = proto_segment.begin(); iRH != proto_segment.end(); iRH++){       
+    const ME0RecHit* iRHp = *iRH;
+    ME0DetId idRH = iRHp->me0Id();
+    int kLayer = idRH.layer();
+    const ME0EtaPartition * thePartition   = (theEnsemble.second).find(idRH)->second;
+    GlobalPoint gp = thePartition->toGlobal(iRHp->localPosition());
+    float pphi = gp.phi();
+    float prad = gp.perp();
+    if (first) sp(kLayer) = 0;
+    else
+      sp(kLayer) =  pphi*prad -phifirst;      
+    se(kLayer) = sqrt(iRHp->localPositionError().xx());
+    if (first){
+      phifirst = pphi*prad;
+      first = false;
+    }
+  }
+
+  float chi2_str; 
+  this->fitX(sp, se, -1, -1, chi2_str); 
+
+  //----------------------------------------------------- 
+  // Optimal point rejection method 
+  //----------------------------------------------------- 
+
+  float minSum = 1000; 
+  int i1b = 0; 
+  int i2b = 0;  
+  int iworst = -1;  
+  int bad_layer = -1; 
+  EnsembleHitContainer::const_iterator rh_to_be_deleted_1; 
+  EnsembleHitContainer::const_iterator rh_to_be_deleted_2; 
+  if ( nhits > n_seg_min && (chi2_str/(nhits-2)) > chi2_str_*chi2D_iadd){ 
+    for (EnsembleHitContainer::const_iterator i1 = proto_segment.begin(); i1 != proto_segment.end();++i1) { 
+      ++i1b; 
+      const ME0RecHit* i1_1 = *i1;  
+      ME0DetId idRH1 = i1_1->me0Id(); 
+      int z1 = idRH1.layer(); 
+      i2b = i1b; 
+      for (EnsembleHitContainer::const_iterator i2 = i1+1; i2 != proto_segment.end(); ++i2) { 
+	++i2b;  
+	const ME0RecHit* i2_1 = *i2; 
+	ME0DetId idRH2 = i2_1->me0Id(); 
+	int z2 = idRH2.layer(); 
+	int irej = 0; 
+
+	for ( EnsembleHitContainer::const_iterator ir = proto_segment.begin(); ir != proto_segment.end(); ++ir) { 
+	  ++irej;  
+
+	  if (ir == i1 || ir == i2) continue;  
+	  float dsum = 0; 
+	  int hit_nr = 0; 
+	  const ME0RecHit* ir_1 = *ir; 
+	  ME0DetId idRH = ir_1->me0Id(); 
+	  int worst_layer = idRH.layer(); 
+	  for (EnsembleHitContainer::const_iterator i = proto_segment.begin(); i != proto_segment.end(); ++i) {  
+	    ++hit_nr;   
+	    const ME0RecHit* i_1 = *i; 
+	    if (i == i1 || i == i2 || i == ir) continue;  
+	    float slope = (sp(z2-1)-sp(z1-1))/(z2-z1); 
+	    float intersept = sp(z1-1) - slope*z1; 
+	    ME0DetId idRH = i_1->me0Id(); 
+	    int z = idRH.layer(); 
+	    float di = fabs(sp(z-1) - intersept - slope*z); 
+	    dsum = dsum + di; 
+	  }//i 
+	  if (dsum < minSum){ 
+	    minSum = dsum;  
+	    bad_layer = worst_layer;		   
+	    iworst = irej;  
+	    rh_to_be_deleted_1 = ir; 
+	  } 
+	}//ir  
+      }//i2 
+    }//i1 
+    this->fitX(sp, se, bad_layer, -1, chi2_str); 
+  }//if chi2prob<1.0e-4 
+
+  //find worst from n-1 hits 
+  int iworst2 = -1; 
+  int bad_layer2 = -1; 
+  if (iworst > -1 && (nhits-1) > n_seg_min && (chi2_str/(nhits-3)) > chi2_str_*chi2D_iadd){ 
+    iworst = -1; 
+    float minSum = 1000; 
+    int i1b = 0; 
+    int i2b = 0;  
+    for (EnsembleHitContainer::const_iterator i1 = proto_segment.begin(); i1 != proto_segment.end();++i1) { 
+      ++i1b;  
+      const ME0RecHit* i1_1 = *i1; 
+      ME0DetId idRH1 = i1_1->me0Id(); 
+      int z1 = idRH1.layer(); 
+      i2b = i1b; 
+      for ( EnsembleHitContainer::const_iterator i2 = i1+1; i2 != proto_segment.end(); ++i2) { 
+	++i2b;  
+	const ME0RecHit* i2_1 = *i2; 
+
+	ME0DetId idRH2 = i2_1->me0Id(); 
+	int z2 = idRH2.layer(); 
+	int irej = 0; 
+
+	for ( EnsembleHitContainer::const_iterator ir = proto_segment.begin(); ir != proto_segment.end(); ++ir) { 
+
+	  ++irej;   
+	  int irej2 = 0; 
+	  if (ir == i1 || ir == i2 ) continue;  
+	  const ME0RecHit* ir_1 = *ir; 
+	  ME0DetId idRH = ir_1->me0Id(); 
+	  int worst_layer = idRH.layer(); 
+	  for (  EnsembleHitContainer::const_iterator ir2 = proto_segment.begin(); ir2 != proto_segment.end(); ++ir2) { 
+
+            ++irej2;   
+	    if (ir2 == i1 || ir2 == i2 || ir2 ==ir ) continue;  
+	    float dsum = 0; 
+	    int hit_nr = 0; 
+	    const ME0RecHit* ir2_1 = *ir2; 
+	    ME0DetId idRH = ir2_1->me0Id(); 
+	    int worst_layer2 = idRH.layer(); 
+	    for (  EnsembleHitContainer::const_iterator i = proto_segment.begin(); i != proto_segment.end(); ++i) {  
+	      ++hit_nr;  
+	      const ME0RecHit* i_1 = *i; 
+	      if (i == i1 || i == i2 || i == ir|| i == ir2 ) continue;  
+	      float slope = (sp(z2-1)-sp(z1-1))/(z2-z1); 
+	      float intersept = sp(z1-1) - slope*z1; 
+	      ME0DetId idRH = i_1->me0Id(); 
+	      int z = idRH.layer(); 
+	      float di = fabs(sp(z-1) - intersept - slope*z); 
+	      dsum = dsum + di; 
+	    }//i 
+	    if (dsum < minSum){ 
+	      minSum = dsum;  
+	      iworst2 = irej2;  
+	      iworst = irej; 
+	      bad_layer = worst_layer; 
+	      bad_layer2 = worst_layer2;  
+	      rh_to_be_deleted_1 = ir; 
+	      rh_to_be_deleted_2 = ir2; 
+	    } 
+	  }//ir2  
+	}//ir  
+      }//i2 
+    }//i1	 
+
+    this->fitX(sp, se, bad_layer ,bad_layer2, chi2_str); 
+  }//if prob(n-1)<e-4 
+
+  //---------------------------------- 
+  //erase bad_hits 
+  //---------------------------------- 
+
+  if( iworst2-1 >= 0 && iworst2 <= int(proto_segment.size())  ) { 
+    proto_segment.erase( rh_to_be_deleted_2); 
+  } 
+
+  if( iworst-1 >= 0 && iworst <= int(proto_segment.size())  ){ 
+    proto_segment.erase(rh_to_be_deleted_1); 
+  } 
+} 
+
+float ME0SegAlgoRU::fitX(SVector6 points, SVector6 errors, int ir, int ir2, float &chi2_str){ 
+
+  float S   = 0; 
+  float Sx  = 0; 
+  float Sy  = 0; 
+  float Sxx = 0; 
+  float Sxy = 0; 
+  float sigma2 = 0; 
+
+  for (int i=1;i<7;i++){ 
+    if (i == ir || i == ir2 || points(i-1) == 0.) continue; 
+    sigma2 = errors(i-1)*errors(i-1); 
+    float i1 = i - 3.5; 
+    S = S + (1/sigma2); 
+    Sy = Sy + (points(i-1)/sigma2); 
+    Sx = Sx + ((i1)/sigma2); 
+    Sxx = Sxx + (i1*i1)/sigma2; 
+    Sxy = Sxy + (((i1)*points(i-1))/sigma2); 
+  } 
+
+  float delta = S*Sxx - Sx*Sx; 
+  float intercept = (Sxx*Sy - Sx*Sxy)/delta; 
+  float slope = (S*Sxy - Sx*Sy)/delta; 
+
+  float chi_str = 0; 
+  chi2_str = 0; 
+
+  // calculate chi2_str 
+  for (int i=1;i<7;i++){ 
+    if (i == ir || i == ir2 || points(i-1) == 0.) continue; 
+    chi_str = (points(i-1) - intercept - slope*(i-3.5))/(errors(i-1)); 
+    chi2_str = chi2_str + chi_str*chi_str;  
+  } 
+
+  return (intercept + slope*0); 
+} 
+
+bool ME0SegAlgoRU::hasHitOnLayer(int layer) const { 
+
+  // Is there is already a hit on this layer? 
+  EnsembleHitContainerCIt it; 
+
+  for(it = proto_segment.begin(); it != proto_segment.end(); it++) 
+    if ((*it)->me0Id().layer() == layer) 
+      return true;  
+
+  return false; 
+} 
+
+bool ME0SegAlgoRU::replaceHit(const ME0RecHit* h, int layer) { 
+
+  // replace a hit from a layer  
+  EnsembleHitContainer::const_iterator it; 
+  for (it = proto_segment.begin(); it != proto_segment.end();) { 
+    if ((*it)->me0Id().layer() == layer) {
+      it = proto_segment.erase(it); 
+    } else {
+      ++it;    
+    }
+  } 
+  
+  return addHit(h, layer);				     
+} 
+
+void ME0SegAlgoRU::compareProtoSegment(const ME0RecHit* h, int layer) { 
+   // Copy the input MuonSegFit                                                                                                                                                      
+  std::unique_ptr<MuonSegFit> oldfit;// =  new MuonSegFit( *sfit_ );                                                                                                                  
+
+  MuonSegFit::MuonRecHitContainer muonRecHits;
+  const ME0EtaPartition * refPart = theEnsemble.first;
+  for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
+    const ME0EtaPartition * thePartition   = (theEnsemble.second.find((*rh)->me0Id()))->second;
+    GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
+    const LocalPoint lp = refPart->toLocal(gp);
+    ME0RecHit *newRH = (*rh)->clone();
+    newRH->setPosition(lp);
+    MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
+    muonRecHits.push_back(trkRecHit);
+  }
+  oldfit.reset(new MuonSegFit( muonRecHits ));
+  oldfit->fit();
+  auto oldproto = proto_segment;
+   // May create a new fit
+  bool ok = this->replaceHit(h, layer);
+  if ( ( sfit_->chi2() >= oldfit->chi2() ) || !ok ) {
+    sfit_ = std::move(oldfit); // reset to the original input fit 
+    proto_segment = oldproto;
+  }
+} 
+
+void ME0SegAlgoRU::increaseProtoSegment(const ME0RecHit* h, int layer, int chi2_factor) { 
+
+  MuonSegFit::MuonRecHitContainer muonRecHits;
+  const ME0EtaPartition * refPart = theEnsemble.first;
+  for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
+    const ME0EtaPartition * thePartition   = (theEnsemble.second.find((*rh)->me0Id()))->second;
+    GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
+    const LocalPoint lp = refPart->toLocal(gp);
+    ME0RecHit *newRH = (*rh)->clone();
+    newRH->setPosition(lp);
+    MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
+    muonRecHits.push_back(trkRecHit);
+  }
+
+  // Creates a new fit
+  std::unique_ptr<MuonSegFit> oldfit;
+  oldfit.reset(new MuonSegFit( muonRecHits ));
+  oldfit->fit();
+  auto oldproto = proto_segment;
+  bool ok = this->addHit(h, layer);
+  //@@ TEST ON ndof<=0 IS JUST TO ACCEPT nhits=2 CASE??
+  if ( !ok || ( (sfit_->ndof() > 0) && (sfit_->chi2()/sfit_->ndof() >= chi2Max)) ) {
+    sfit_ = std::move(oldfit);
+    proto_segment = oldproto;
+  }
+}

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -25,7 +25,7 @@
 
 
 ME0SegAlgoRU::ME0SegAlgoRU(const edm::ParameterSet& ps)
-  : ME0SegmentAlgorithmBase(ps), myName("ME0SegAlgoRU") {
+: ME0SegmentAlgorithmBase(ps), myName("ME0SegAlgoRU") {
 
 	allowWideSegments = ps.getParameter<bool>("allowWideSegments");
 	doCollisions = ps.getParameter<bool>("doCollisions");
@@ -57,283 +57,283 @@ ME0SegAlgoRU::ME0SegAlgoRU(const edm::ParameterSet& ps)
 	displacedParameters.requireBeamConstr = false;
 
 
-  LogDebug("ME0SegAlgoRU") << myName << " has algorithm cuts set to: \n"
-		  << "--------------------------------------------------------------------\n"
-		  << "allowWideSegments   = " <<allowWideSegments              << "\n"
-		  << "doCollisions        = " <<doCollisions                   << "\n"
-		  << "maxChi2Additional   = " <<stdParameters.maxChi2Additional<< "\n"
-		  << "maxChi2Prune        = " <<stdParameters.maxChi2Prune     << "\n"
-		  << "maxChi2GoodSeg      = " <<stdParameters.maxChi2GoodSeg   << "\n"
-		  << "maxPhiSeeds         = " <<stdParameters.maxPhiSeeds      << "\n"
-		  << "maxPhiAdditional    = " <<stdParameters.maxPhiAdditional << "\n"
-		  << "maxETASeeds         = " <<stdParameters.maxETASeeds      << "\n"
-		  << "maxTOFDiff          = " <<stdParameters.maxTOFDiff       << "\n"
-		   << std::endl;
+	LogDebug("ME0SegAlgoRU") << myName << " has algorithm cuts set to: \n"
+			<< "--------------------------------------------------------------------\n"
+			<< "allowWideSegments   = " <<allowWideSegments              << "\n"
+			<< "doCollisions        = " <<doCollisions                   << "\n"
+			<< "maxChi2Additional   = " <<stdParameters.maxChi2Additional<< "\n"
+			<< "maxChi2Prune        = " <<stdParameters.maxChi2Prune     << "\n"
+			<< "maxChi2GoodSeg      = " <<stdParameters.maxChi2GoodSeg   << "\n"
+			<< "maxPhiSeeds         = " <<stdParameters.maxPhiSeeds      << "\n"
+			<< "maxPhiAdditional    = " <<stdParameters.maxPhiAdditional << "\n"
+			<< "maxETASeeds         = " <<stdParameters.maxETASeeds      << "\n"
+			<< "maxTOFDiff          = " <<stdParameters.maxTOFDiff       << "\n"
+			<< std::endl;
 
-  theChamber=0;
+	theChamber=0;
 
 }
 
 std::vector<ME0Segment> ME0SegAlgoRU::run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits){
 
-  #ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
-  ME0DetId chId(chamber->id());
-  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegmentAlgorithm::run] build segments in chamber " << chId << " which contains "<<rechits.size()<<" rechits";
-  for(unsigned int iH = 0; iH < rechits.size(); ++iH){
-	    auto me0id = rechits[iH].rh->me0Id();
-	    auto rhLP  = rechits[iH].lp;
-	    edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Glb y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<rechits[iH].rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]"<<std::endl;
-  }
-  #endif
-
-
-  if (rechits.size() < 3 || rechits.size()>300){
-	  return std::vector<ME0Segment>();
-  }
-
-  theChamber = chamber;
-
-  std::vector<unsigned int> recHits_per_layer(6,0);
-  for(unsigned int iH = 0; iH < rechits.size(); ++iH) {
-	  recHits_per_layer[rechits[iH].layer-1]++;
-  }
-
-  BoolContainer used(rechits.size(),false);
-
-  // We have at least 2 hits. We intend to try all possible pairs of hits to start
-  // segment building. 'All possible' means each hit lies on different layers in the chamber.
-  // after all same size segs are build we get rid of the overcrossed segments using the chi2 criteria
-  // the hits from the segs that are left are marked as used and are not added to segs in future iterations
-  // the hits from 3p segs are marked as used separately in order to try to assamble them in longer segments
-  // in case there is a second pass
-
-  // Choose first hit (as close to IP as possible) h1 and second hit
-  // (as far from IP as possible) h2 To do this we iterate over hits
-  // in the chamber by layer - pick two layers.  Then we
-  // iterate over hits within each of these layers and pick h1 and h2
-  // these.  If they are 'close enough' we build an empty
-  // segment.  Then try adding hits to this segment.
-
-  std::vector<ME0Segment> segments;
-
-  auto doStd = [&] () {
-	  for(unsigned int n_seg_min = 6u; n_seg_min  >= stdParameters.minNumberOfHits; --n_seg_min)
-		  lookForSegments(stdParameters,n_seg_min,rechits,recHits_per_layer, used, segments);
-  };
-  auto doDisplaced = [&] () {
-	  for(unsigned int n_seg_min = 6u; n_seg_min  >= displacedParameters.minNumberOfHits; --n_seg_min)
-		  lookForSegments(displacedParameters,n_seg_min,rechits,recHits_per_layer, used,segments);
-  };
-  auto doWide = [&] () {
-	  for(unsigned int n_seg_min = 6u; n_seg_min >= wideParameters.minNumberOfHits; --n_seg_min)
-		  lookForSegments(wideParameters,n_seg_min,rechits,recHits_per_layer, used,segments);
-  };
-  auto printSegments = [&] {
 #ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
-for(unsigned int iS = 0; iS < segments.size(); ++iS) {
-  const auto& seg = segments[iS];
-  ME0DetId chId(seg.me0DetId());
-  const auto& rechits = seg.specificRecHits();
-  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU] segment in chamber " << chId << " which contains "<<rechits.size()<<" rechits and with specs: \n"<<seg;
-  for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
-      auto me0id = rh->me0Id();
-      edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rh->localPosition().x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rh->localPosition().y()<<" Time = "<<std::showpos<<rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
-    }
-}
+	ME0DetId chId(chamber->id());
+	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegmentAlgorithm::run] build segments in chamber " << chId << " which contains "<<rechits.size()<<" rechits";
+	for(unsigned int iH = 0; iH < rechits.size(); ++iH){
+		auto me0id = rechits[iH].rh->me0Id();
+		auto rhLP  = rechits[iH].lp;
+		edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Glb y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<rechits[iH].rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]"<<std::endl;
+	}
 #endif
-  };
 
 
-  //If we arent doing collisions, do a single iteration
-  if(!doCollisions){
-	  doDisplaced();
-	  printSegments();
-	  return segments;
-  }
+	if (rechits.size() < 3 || rechits.size()>300){
+		return std::vector<ME0Segment>();
+	}
 
-  //Iteration 1: STD processing
-  doStd();
+	theChamber = chamber;
 
-  if(false){
-	  //How the CSC algorithm ~does iterations. for now not considering
-	  //displaced muons will not worry about it  later
-	  //Iteration 2a: If we don't allow wide segments simply do displaced
-	  // Or if we already found a segment simply skip to displaced
-	  if(!allowWideSegments || segments.size()){
-		  doDisplaced();
-		  return segments;
-	  }
-	  doWide();
-	  doDisplaced();
-  }
-  printSegments();
-  return segments;
+	std::vector<unsigned int> recHits_per_layer(6,0);
+	for(unsigned int iH = 0; iH < rechits.size(); ++iH) {
+		recHits_per_layer[rechits[iH].layer-1]++;
+	}
+
+	BoolContainer used(rechits.size(),false);
+
+	// We have at least 2 hits. We intend to try all possible pairs of hits to start
+	// segment building. 'All possible' means each hit lies on different layers in the chamber.
+	// after all same size segs are build we get rid of the overcrossed segments using the chi2 criteria
+	// the hits from the segs that are left are marked as used and are not added to segs in future iterations
+	// the hits from 3p segs are marked as used separately in order to try to assamble them in longer segments
+	// in case there is a second pass
+
+	// Choose first hit (as close to IP as possible) h1 and second hit
+	// (as far from IP as possible) h2 To do this we iterate over hits
+	// in the chamber by layer - pick two layers.  Then we
+	// iterate over hits within each of these layers and pick h1 and h2
+	// these.  If they are 'close enough' we build an empty
+	// segment.  Then try adding hits to this segment.
+
+	std::vector<ME0Segment> segments;
+
+	auto doStd = [&] () {
+		for(unsigned int n_seg_min = 6u; n_seg_min  >= stdParameters.minNumberOfHits; --n_seg_min)
+			lookForSegments(stdParameters,n_seg_min,rechits,recHits_per_layer, used, segments);
+	};
+	auto doDisplaced = [&] () {
+		for(unsigned int n_seg_min = 6u; n_seg_min  >= displacedParameters.minNumberOfHits; --n_seg_min)
+			lookForSegments(displacedParameters,n_seg_min,rechits,recHits_per_layer, used,segments);
+	};
+	auto doWide = [&] () {
+		for(unsigned int n_seg_min = 6u; n_seg_min >= wideParameters.minNumberOfHits; --n_seg_min)
+			lookForSegments(wideParameters,n_seg_min,rechits,recHits_per_layer, used,segments);
+	};
+	auto printSegments = [&] {
+#ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
+		for(unsigned int iS = 0; iS < segments.size(); ++iS) {
+			const auto& seg = segments[iS];
+			ME0DetId chId(seg.me0DetId());
+			const auto& rechits = seg.specificRecHits();
+			edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU] segment in chamber " << chId << " which contains "<<rechits.size()<<" rechits and with specs: \n"<<seg;
+			for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
+				auto me0id = rh->me0Id();
+				edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rh->localPosition().x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rh->localPosition().y()<<" Time = "<<std::showpos<<rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
+			}
+		}
+#endif
+	};
+
+
+	//If we arent doing collisions, do a single iteration
+	if(!doCollisions){
+		doDisplaced();
+		printSegments();
+		return segments;
+	}
+
+	//Iteration 1: STD processing
+	doStd();
+
+	if(false){
+		//How the CSC algorithm ~does iterations. for now not considering
+		//displaced muons will not worry about it  later
+		//Iteration 2a: If we don't allow wide segments simply do displaced
+		// Or if we already found a segment simply skip to displaced
+		if(!allowWideSegments || segments.size()){
+			doDisplaced();
+			return segments;
+		}
+		doWide();
+		doDisplaced();
+	}
+	printSegments();
+	return segments;
 }
 
 void ME0SegAlgoRU::lookForSegments( const SegmentParameters& params, const unsigned int n_seg_min,
 		const HitAndPositionContainer& rechits, const std::vector<unsigned int>& recHits_per_layer,
 		BoolContainer& used, std::vector<ME0Segment>& segments) const  {
-	  auto ib = rechits.begin();
-	  auto ie = rechits.end();
-	  std::vector<std::pair<float,HitAndPositionPtrContainer> > proto_segments;
-    // the first hit is taken from the back
-    for (auto i1 = ib; i1 != ie; ++i1) {
-    	const auto& h1 = *i1;
+	auto ib = rechits.begin();
+	auto ie = rechits.end();
+	std::vector<std::pair<float,HitAndPositionPtrContainer> > proto_segments;
+	// the first hit is taken from the back
+	for (auto i1 = ib; i1 != ie; ++i1) {
+		const auto& h1 = *i1;
 
-    	//skip if rh is used and the layer tat has big rh multiplicity(>25RHs)
-    	if(used[h1.idx]) continue;
-    	if(recHits_per_layer[h1.layer-1]>100) continue;
+		//skip if rh is used and the layer tat has big rh multiplicity(>25RHs)
+		if(used[h1.idx]) continue;
+		if(recHits_per_layer[h1.layer-1]>100) continue;
 
-//    	bool segok = false;
-    	// the second hit from the front
-    	for (auto i2 = ie-1; i2 != i1; --i2) {
-//    		if(segok) break; //Currently turned off
-    		const auto& h2 = *i2;
+		//    	bool segok = false;
+		// the second hit from the front
+		for (auto i2 = ie-1; i2 != i1; --i2) {
+			//    		if(segok) break; //Currently turned off
+			const auto& h2 = *i2;
 
-    		//skip if rh is used and the layer tat has big rh multiplicity(>25RHs)
-        	if(used[h2.idx]) continue;
-        	if(recHits_per_layer[h2.layer-1]>100) continue;
+			//skip if rh is used and the layer tat has big rh multiplicity(>25RHs)
+			if(used[h2.idx]) continue;
+			if(recHits_per_layer[h2.layer-1]>100) continue;
 
-        	//Stop if the distance between layers is not large enough
-        	if((abs(int(h2.layer) - int(h1.layer)) + 1) < int(n_seg_min)) break;
+			//Stop if the distance between layers is not large enough
+			if((abs(int(h2.layer) - int(h1.layer)) + 1) < int(n_seg_min)) break;
 
-        	if(std::fabs(h1.rh->tof()-h2.rh->tof()) > params.maxTOFDiff + 1.0 )continue;
-        	if(!areHitsCloseInEta(params.maxETASeeds, params.requireBeamConstr, h1.gp, h2.gp)) continue;
-        	if(!areHitsCloseInGlobalPhi(params.maxPhiSeeds,abs(int(h2.layer) - int(h1.layer)), h1.gp, h2.gp)) continue;
+			if(std::fabs(h1.rh->tof()-h2.rh->tof()) > params.maxTOFDiff + 1.0 )continue;
+			if(!areHitsCloseInEta(params.maxETASeeds, params.requireBeamConstr, h1.gp, h2.gp)) continue;
+			if(!areHitsCloseInGlobalPhi(params.maxPhiSeeds,abs(int(h2.layer) - int(h1.layer)), h1.gp, h2.gp)) continue;
 
-        	HitAndPositionPtrContainer current_proto_segment;
-        	std::unique_ptr<MuonSegFit> current_fit;
-        	current_fit = addHit(current_proto_segment,h1);
-        	current_fit = addHit(current_proto_segment,h2);
+			HitAndPositionPtrContainer current_proto_segment;
+			std::unique_ptr<MuonSegFit> current_fit;
+			current_fit = addHit(current_proto_segment,h1);
+			current_fit = addHit(current_proto_segment,h2);
 
-        	tryAddingHitsToSegment(params.maxTOFDiff,params.maxETASeeds, params.maxPhiAdditional, params.maxChi2Additional, current_fit,current_proto_segment, used,i1,i2);
+			tryAddingHitsToSegment(params.maxTOFDiff,params.maxETASeeds, params.maxPhiAdditional, params.maxChi2Additional, current_fit,current_proto_segment, used,i1,i2);
 
-        	if(current_proto_segment.size() > n_seg_min)
-        		pruneBadHits(params.maxChi2Prune,current_proto_segment,current_fit,n_seg_min);
+			if(current_proto_segment.size() > n_seg_min)
+				pruneBadHits(params.maxChi2Prune,current_proto_segment,current_fit,n_seg_min);
 
-        	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::lookForSegments] # of hits in segment " << current_proto_segment.size() <<" min # "<< n_seg_min <<" => "<< (current_proto_segment.size() >= n_seg_min) << " chi2/ndof "<<current_fit->chi2()/current_fit->ndof()<<" => "<<(current_fit->chi2()/current_fit->ndof() < params.maxChi2GoodSeg ) <<std::endl;
+			edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::lookForSegments] # of hits in segment " << current_proto_segment.size() <<" min # "<< n_seg_min <<" => "<< (current_proto_segment.size() >= n_seg_min) << " chi2/ndof "<<current_fit->chi2()/current_fit->ndof()<<" => "<<(current_fit->chi2()/current_fit->ndof() < params.maxChi2GoodSeg ) <<std::endl;
 
-        	if(current_proto_segment.size() < n_seg_min) continue;
+			if(current_proto_segment.size() < n_seg_min) continue;
 
-        	const float current_metric = current_fit->chi2()/current_fit->ndof();
-        	if(current_metric > params.maxChi2GoodSeg) continue;
-//        	segok = true;
+			const float current_metric = current_fit->chi2()/current_fit->ndof();
+			if(current_metric > params.maxChi2GoodSeg) continue;
+			//        	segok = true;
 
-        	proto_segments.emplace_back( current_metric, current_proto_segment);
-    	}
+			proto_segments.emplace_back( current_metric, current_proto_segment);
+		}
 
-    }
-    addUniqueSegments(proto_segments,segments,used);
+	}
+	addUniqueSegments(proto_segments,segments,used);
 
 }
 
 void ME0SegAlgoRU::addUniqueSegments(SegmentByMetricContainer& proto_segments, std::vector<ME0Segment>& segments,BoolContainer& used ) const {
-    std::sort(proto_segments.begin(),proto_segments.end(),
-    		[](const std::pair<float,HitAndPositionPtrContainer> & a,
-    		   const std::pair<float,HitAndPositionPtrContainer> & b) { return a.first < b.first;});
+	std::sort(proto_segments.begin(),proto_segments.end(),
+			[](const std::pair<float,HitAndPositionPtrContainer> & a,
+					const std::pair<float,HitAndPositionPtrContainer> & b) { return a.first < b.first;});
 
-    //Now add to the collect based on minChi2 marking the hits as used after
-    std::vector<unsigned int> usedHits;
-    for(unsigned int iS = 0; iS < proto_segments.size(); ++iS){
-    	HitAndPositionPtrContainer currentProtoSegment = proto_segments[iS].second;
+	//Now add to the collect based on minChi2 marking the hits as used after
+	std::vector<unsigned int> usedHits;
+	for(unsigned int iS = 0; iS < proto_segments.size(); ++iS){
+		HitAndPositionPtrContainer currentProtoSegment = proto_segments[iS].second;
 
-    	//check to see if we already used thes hits this round
-    	bool alreadyFilled=false;
-    	for(unsigned int iH = 0; iH < currentProtoSegment.size(); ++iH){
-    		for(unsigned int iOH = 0; iOH < usedHits.size(); ++iOH){
-    			if(usedHits[iOH]!=currentProtoSegment[iH]->idx) continue;
-    			alreadyFilled = true;
-    			break;
-    		}
-    	}
-    	if(alreadyFilled) continue;
-    	for(const auto* h : currentProtoSegment){
-    		usedHits.push_back(h->idx);
-    		used[h->idx] = true;
-    	}
+		//check to see if we already used thes hits this round
+		bool alreadyFilled=false;
+		for(unsigned int iH = 0; iH < currentProtoSegment.size(); ++iH){
+			for(unsigned int iOH = 0; iOH < usedHits.size(); ++iOH){
+				if(usedHits[iOH]!=currentProtoSegment[iH]->idx) continue;
+				alreadyFilled = true;
+				break;
+			}
+		}
+		if(alreadyFilled) continue;
+		for(const auto* h : currentProtoSegment){
+			usedHits.push_back(h->idx);
+			used[h->idx] = true;
+		}
 
-    	std::unique_ptr<MuonSegFit> current_fit = makeFit(currentProtoSegment);
+		std::unique_ptr<MuonSegFit> current_fit = makeFit(currentProtoSegment);
 
-    	// Create an actual ME0Segment - retrieve all info from the fit
-    	// calculate the timing fron rec hits associated to the TrackingRecHits used
-    	// to fit the segment
-    	float averageTime=0.;
-    	for(const auto* h : currentProtoSegment){
-    	  averageTime += h->rh->tof();
-    	}
-    	averageTime /= float(currentProtoSegment.size());
-    	float timeUncrt=0.;
-    	for(const auto* h : currentProtoSegment){
-    	  timeUncrt += pow( h->rh->tof()-averageTime,2);
-    	}
-    	timeUncrt = std::sqrt(timeUncrt/float(currentProtoSegment.size()-1));
+		// Create an actual ME0Segment - retrieve all info from the fit
+		// calculate the timing fron rec hits associated to the TrackingRecHits used
+		// to fit the segment
+		float averageTime=0.;
+		for(const auto* h : currentProtoSegment){
+			averageTime += h->rh->tof();
+		}
+		averageTime /= float(currentProtoSegment.size());
+		float timeUncrt=0.;
+		for(const auto* h : currentProtoSegment){
+			timeUncrt += pow( h->rh->tof()-averageTime,2);
+		}
+		timeUncrt = std::sqrt(timeUncrt/float(currentProtoSegment.size()-1));
 
-    	std::sort(currentProtoSegment.begin(),currentProtoSegment.end(),
-    			[](const HitAndPosition* a, const HitAndPosition *b) {return a->layer < b->layer;}
-    	);
+		std::sort(currentProtoSegment.begin(),currentProtoSegment.end(),
+				[](const HitAndPosition* a, const HitAndPosition *b) {return a->layer < b->layer;}
+		);
 
-    	std::vector<const ME0RecHit*> bareRHs; bareRHs.reserve(currentProtoSegment.size());
-    	for(const auto* rh : currentProtoSegment) bareRHs.push_back(rh->rh);
-    	ME0Segment temp(bareRHs, current_fit->intercept(),
-    			current_fit->localdir(), current_fit->covarianceMatrix(), current_fit->chi2(), averageTime, timeUncrt);
-    	segments.push_back(temp);
+		std::vector<const ME0RecHit*> bareRHs; bareRHs.reserve(currentProtoSegment.size());
+		for(const auto* rh : currentProtoSegment) bareRHs.push_back(rh->rh);
+		ME0Segment temp(bareRHs, current_fit->intercept(),
+				current_fit->localdir(), current_fit->covarianceMatrix(), current_fit->chi2(), averageTime, timeUncrt);
+		segments.push_back(temp);
 
 
-    }
+	}
 }
 
 void ME0SegAlgoRU::tryAddingHitsToSegment(const float maxTOF,  const float maxETA, const float maxPhi,const float maxChi2, std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& proto_segment,
-					  const BoolContainer& used, HitAndPositionContainer::const_iterator i1, HitAndPositionContainer::const_iterator i2) const {
-  // Iterate over the layers with hits in the chamber
-  // Skip the layers containing the segment endpoints
-  // Test each hit on the other layers to see if it is near the segment
-  // If it is, see whether there is already a hit on the segment from the same layer
-  //    - if so, and there are more than 2 hits on the segment, copy the segment,
-  //      replace the old hit with the new hit. If the new segment chi2 is better
-  //      then replace the original segment with the new one (by swap)
-  //    - if not, copy the segment, add the hit. If the new chi2/dof is still satisfactory
-  //      then replace the original segment with the new one (by swap)
+		const BoolContainer& used, HitAndPositionContainer::const_iterator i1, HitAndPositionContainer::const_iterator i2) const {
+	// Iterate over the layers with hits in the chamber
+	// Skip the layers containing the segment endpoints
+	// Test each hit on the other layers to see if it is near the segment
+	// If it is, see whether there is already a hit on the segment from the same layer
+	//    - if so, and there are more than 2 hits on the segment, copy the segment,
+	//      replace the old hit with the new hit. If the new segment chi2 is better
+	//      then replace the original segment with the new one (by swap)
+	//    - if not, copy the segment, add the hit. If the new chi2/dof is still satisfactory
+	//      then replace the original segment with the new one (by swap)
 
-  //Hits are ordered by layer, "i1" is the inner hit and i2 is the outer hit
-  //so possible hits to add must be between these two iterators
-  for(auto iH = i1 + 1; iH != i2; ++iH ){
-	  if(iH->layer == i1->layer) continue;
-	  if(iH->layer == i2->layer) break;
-	  if(used[iH->idx]) continue;
-	  if(!areHitsConsistentInTime(maxTOF,proto_segment,*iH)) continue;
-	  if (!isHitNearSegment(maxETA,maxPhi,current_fit,proto_segment,*iH)) continue;
-	  if(hasHitOnLayer(proto_segment,iH->layer))
-		  compareProtoSegment(current_fit,proto_segment,*iH);
-	  else
-		  increaseProtoSegment(maxChi2, current_fit,proto_segment,*iH);
-  }
+	//Hits are ordered by layer, "i1" is the inner hit and i2 is the outer hit
+	//so possible hits to add must be between these two iterators
+	for(auto iH = i1 + 1; iH != i2; ++iH ){
+		if(iH->layer == i1->layer) continue;
+		if(iH->layer == i2->layer) break;
+		if(used[iH->idx]) continue;
+		if(!areHitsConsistentInTime(maxTOF,proto_segment,*iH)) continue;
+		if (!isHitNearSegment(maxETA,maxPhi,current_fit,proto_segment,*iH)) continue;
+		if(hasHitOnLayer(proto_segment,iH->layer))
+			compareProtoSegment(current_fit,proto_segment,*iH);
+		else
+			increaseProtoSegment(maxChi2, current_fit,proto_segment,*iH);
+	}
 }
 
 bool ME0SegAlgoRU::areHitsCloseInEta(const float maxETA, const bool beamConst, const GlobalPoint& h1, const GlobalPoint& h2) const {
-  float diff = 0;
-  diff = std::fabs(h1.eta() - h1.eta());
-  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInEta] gp1 = "<<h1<<" in eta part = "<<h1.eta() <<" and gp2 = "<<h2<<" in eta part = "<<h2.eta() <<" ==> dEta = "<<diff<<" ==> return "<<(diff < 0.1)<<std::endl;
-  return (diff < std::max(maxETA,float(0.01)) ); //temp for floating point comparision...maxEta is the difference between partitions, so x1.5 to take into account non-circle geom.
+	float diff = 0;
+	diff = std::fabs(h1.eta() - h1.eta());
+	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInEta] gp1 = "<<h1<<" in eta part = "<<h1.eta() <<" and gp2 = "<<h2<<" in eta part = "<<h2.eta() <<" ==> dEta = "<<diff<<" ==> return "<<(diff < 0.1)<<std::endl;
+	return (diff < std::max(maxETA,float(0.01)) ); //temp for floating point comparision...maxEta is the difference between partitions, so x1.5 to take into account non-circle geom.
 }
 
 bool ME0SegAlgoRU::areHitsCloseInGlobalPhi(const float maxPHI, const unsigned int nLayDisp, const GlobalPoint& h1, const GlobalPoint& h2) const {
-  float dphi12 = deltaPhi(h1.barePhi(),h2.barePhi());
-  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInGlobalPhi] gp1 = "<<h1<<" and gp2 = "<<h2<<" ==> dPhi = "<<dphi12<<" ==> return "<<(fabs(dphi12) < std::max(maxPHI,float(0.02)))<<std::endl;
-  return fabs(dphi12) < std::max(maxPHI, float(float(nLayDisp)*0.004));
+	float dphi12 = deltaPhi(h1.barePhi(),h2.barePhi());
+	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInGlobalPhi] gp1 = "<<h1<<" and gp2 = "<<h2<<" ==> dPhi = "<<dphi12<<" ==> return "<<(fabs(dphi12) < std::max(maxPHI,float(0.02)))<<std::endl;
+	return fabs(dphi12) < std::max(maxPHI, float(float(nLayDisp)*0.004));
 }
 
 bool ME0SegAlgoRU::isHitNearSegment(const float maxETA, const float maxPHI,  const std::unique_ptr<MuonSegFit>& fit, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h) const {
 
 	//Get average eta, based on the two seeds...asssumes that we have not started pruning yet!
 	const float avgETA = (proto_segment[1]->gp.eta() + proto_segment[0]->gp.eta())/2.;
-//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::isHitNearSegment] average eta = "<<avgETA<<" additionalHit eta = "<<h.gp.eta() <<" ==> dEta = "<<std::fabs(h.gp.eta() - avgETA) <<" ==> return "<<(std::fabs(h.gp.eta() - avgETA) < std::max(maxETA,float(0.01) ))<<std::endl;
+	//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::isHitNearSegment] average eta = "<<avgETA<<" additionalHit eta = "<<h.gp.eta() <<" ==> dEta = "<<std::fabs(h.gp.eta() - avgETA) <<" ==> return "<<(std::fabs(h.gp.eta() - avgETA) < std::max(maxETA,float(0.01) ))<<std::endl;
 	if(std::fabs(h.gp.eta() - avgETA) > std::max(maxETA,float(0.01) )) return false;
 
 	//Now check the dPhi based on the segment fit
 	GlobalPoint globIntercept = globalAtZ(fit, h.lp.z());
 	float dPhi = deltaPhi(h.gp.barePhi(),globIntercept.phi());
 	//check to see if it is inbetween the two rolls of the outer and inner hits
-//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::isHitNearSegment] projected phi = "<<globIntercept.phi()<<" additionalHit phi = "<<h.gp.barePhi() <<" ==> dPhi = "<<dPhi <<" ==> return "<<(std::fabs(dPhi) <  std::max(maxPHI,float(0.001)))<<std::endl;
+	//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::isHitNearSegment] projected phi = "<<globIntercept.phi()<<" additionalHit phi = "<<h.gp.barePhi() <<" ==> dPhi = "<<dPhi <<" ==> return "<<(std::fabs(dPhi) <  std::max(maxPHI,float(0.001)))<<std::endl;
 	return (std::fabs(dPhi) <  std::max(maxPHI,float(0.001)));
 }
 
@@ -359,18 +359,18 @@ std::unique_ptr<MuonSegFit> ME0SegAlgoRU::addHit( HitAndPositionPtrContainer& pr
 }
 
 std::unique_ptr<MuonSegFit> ME0SegAlgoRU::makeFit(const HitAndPositionPtrContainer& proto_segment) const {
-  // for ME0 we take the me0rechit from the proto_segment we transform into Tracking Rechits
-  // the local rest frame is the ME0Chamber
-  MuonSegFit::MuonRecHitContainer muonRecHits;
-  for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
-    ME0RecHit *newRH = (*rh)->rh->clone();
-    newRH->setPosition((*rh)->lp);
-    MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
-    muonRecHits.push_back(trkRecHit);
-  }
-  std::unique_ptr<MuonSegFit> currentFit(new MuonSegFit(muonRecHits));
-  currentFit->fit();
-  return currentFit;
+	// for ME0 we take the me0rechit from the proto_segment we transform into Tracking Rechits
+	// the local rest frame is the ME0Chamber
+	MuonSegFit::MuonRecHitContainer muonRecHits;
+	for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
+		ME0RecHit *newRH = (*rh)->rh->clone();
+		newRH->setPosition((*rh)->lp);
+		MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
+		muonRecHits.push_back(trkRecHit);
+	}
+	std::unique_ptr<MuonSegFit> currentFit(new MuonSegFit(muonRecHits));
+	currentFit->fit();
+	return currentFit;
 }
 
 void ME0SegAlgoRU::pruneBadHits(const float maxChi2, HitAndPositionPtrContainer& proto_segment,  std::unique_ptr<MuonSegFit>& fit, const unsigned int n_seg_min) const{
@@ -406,8 +406,8 @@ float ME0SegAlgoRU::getHitSegChi2(const std::unique_ptr<MuonSegFit>& fit, const 
 }
 
 bool ME0SegAlgoRU::hasHitOnLayer(const HitAndPositionPtrContainer& proto_segment, const unsigned int layer) const {
-  for(const auto* h : proto_segment) if(h->layer == layer) return true;
-  return false;
+	for(const auto* h : proto_segment) if(h->layer == layer) return true;
+	return false;
 }
 
 void ME0SegAlgoRU::compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const {
@@ -448,7 +448,7 @@ void ME0SegAlgoRU::compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit,
 void ME0SegAlgoRU::increaseProtoSegment(const float maxChi2, std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const {
 	HitAndPositionPtrContainer new_proto_segment = current_proto_segment;
 	auto new_fit = addHit(new_proto_segment,new_hit);
-//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::increaseProtoSegment] new chi2 = "<<new_fit->chi2()<<" new chi2/dof = "<<new_fit->chi2()/new_fit->ndof() <<" ==> add: " << (new_fit->chi2()/new_fit->ndof() < maxChi2 ) <<std::endl;
+	//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::increaseProtoSegment] new chi2 = "<<new_fit->chi2()<<" new chi2/dof = "<<new_fit->chi2()/new_fit->ndof() <<" ==> add: " << (new_fit->chi2()/new_fit->ndof() < maxChi2 ) <<std::endl;
 	if(new_fit->chi2()/new_fit->ndof() < maxChi2 ){
 		current_proto_segment = new_proto_segment;
 		current_fit = std::move(new_fit);

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -130,11 +130,11 @@ std::vector<ME0Segment> ME0SegAlgoRU::run(const ME0Chamber * chamber, const HitA
   };
   auto printSegments = [&] {
 #ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
-std::vector<ME0Segment>::iterator it =segments.begin();
-for(std::vector<ME0Segment>::iterator it =segments.begin(); it != segments.end(); ++it) {
-  ME0DetId chId(it->me0DetId());
-  auto rechits = it->specificRecHits();
-  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU] segment in chamber " << chId << " which contains "<<rechits.size()<<" rechits and with specs: \n"<<*it;
+for(unsigned int iS = 0; iS < segments.size(); ++iS) {
+  const auto& seg = segments[iS];
+  ME0DetId chId(seg.me0DetId());
+  const auto& rechits = seg.specificRecHits();
+  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU] segment in chamber " << chId << " which contains "<<rechits.size()<<" rechits and with specs: \n"<<seg;
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
       auto me0id = rh->me0Id();
       edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rh->localPosition().x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rh->localPosition().y()<<" Time = "<<std::showpos<<rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
@@ -310,15 +310,7 @@ void ME0SegAlgoRU::tryAddingHitsToSegment(const float maxTOF,  const float maxET
 }
 
 bool ME0SegAlgoRU::areHitsCloseInEta(const float maxETA, const bool beamConst, const GlobalPoint& h1, const GlobalPoint& h2) const {
-  // check that hits from different layer gets eta partition number +1 max..
   float diff = 0;
-//  //actually no difference in our case...may want to consider something later
-//  if(beamConst){
-//	  if(std::fabs(h1.z()) > std::fabs(h2.z())) diff =h1.eta() - h2.eta();
-//	  else diff = h2.eta() - h1.eta();
-//  } else {
-//	  diff = std::fabs(h2.eta() - h1.eta());
-//  }
   diff = std::fabs(h1.eta() - h1.eta());
   edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInEta] gp1 = "<<h1<<" in eta part = "<<h1.eta() <<" and gp2 = "<<h2<<" in eta part = "<<h2.eta() <<" ==> dEta = "<<diff<<" ==> return "<<(diff < 0.1)<<std::endl;
   return (diff < std::max(maxETA,float(0.01)) ); //temp for floating point comparision...maxEta is the difference between partitions, so x1.5 to take into account non-circle geom.

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -195,7 +195,7 @@ void ME0SegAlgoRU::lookForSegments( const SegmentParameters& params, const unsig
 			if(recHits_per_layer[h2.layer-1]>100) continue;
 
 			//Stop if the distance between layers is not large enough
-			if((abs(int(h2.layer) - int(h1.layer)) + 1) < int(n_seg_min)) break;
+			if((std::abs(int(h2.layer) - int(h1.layer)) + 1) < int(n_seg_min)) break;
 
 			if(std::fabs(h1.rh->tof()-h2.rh->tof()) > params.maxTOFDiff + 1.0 )continue;
 			if(!areHitsCloseInEta(params.maxETASeeds, params.requireBeamConstr, h1.gp, h2.gp)) continue;
@@ -264,7 +264,7 @@ void ME0SegAlgoRU::addUniqueSegments(SegmentByMetricContainer& proto_segments, s
 		averageTime /= float(currentProtoSegment.size());
 		float timeUncrt=0.;
 		for(const auto* h : currentProtoSegment){
-			timeUncrt += pow( h->rh->tof()-averageTime,2);
+			timeUncrt += (h->rh->tof()-averageTime)*(h->rh->tof()-averageTime);
 		}
 		timeUncrt = std::sqrt(timeUncrt/float(currentProtoSegment.size()-1));
 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -323,7 +323,6 @@ bool ME0SegAlgoRU::areHitsCloseInGlobalPhi(const float maxPHI, const unsigned in
 }
 
 bool ME0SegAlgoRU::isHitNearSegment(const float maxETA, const float maxPHI,  const std::unique_ptr<MuonSegFit>& fit, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h) const {
-
 	//Get average eta, based on the two seeds...asssumes that we have not started pruning yet!
 	const float avgETA = (proto_segment[1]->gp.eta() + proto_segment[0]->gp.eta())/2.;
 	//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::isHitNearSegment] average eta = "<<avgETA<<" additionalHit eta = "<<h.gp.eta() <<" ==> dEta = "<<std::fabs(h.gp.eta() - avgETA) <<" ==> return "<<(std::fabs(h.gp.eta() - avgETA) < std::max(maxETA,float(0.01) ))<<std::endl;
@@ -423,6 +422,7 @@ void ME0SegAlgoRU::compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit,
 			++it;
 		}
 	}
+	if(old_hit == 0) return;
 	auto new_fit = addHit(new_proto_segment,new_hit);
 
 	//If on the same strip but different BX choose the closest

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.cc
@@ -1,413 +1,134 @@
-/** 
- * \file ME0SegAlgRU.cc 
- *  
+/**
+ * \file ME0SegAlgRU.cc
+ *
  *  \author M. Maggi for ME0
- *  \from V.Palichik & N.Voytishin   
- *  \some functions and structure taken from SK algo by M.Sani and SegFit class by T.Cox 
- */ 
-
-#include "ME0SegAlgoRU.h" 
+ *  \from V.Palichik & N.Voytishin
+ *  \some functions and structure taken from SK algo by M.Sani and SegFit class by T.Cox
+ */
+#include "ME0SegAlgoRU.h"
 #include "MuonSegFit.h"
-#include "Geometry/CSCGeometry/interface/CSCLayer.h" 
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h" 
+#include "Geometry/GEMGeometry/interface/ME0Layer.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h" 
-#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <algorithm> 
-#include <cmath> 
-#include <iostream> 
-#include <string> 
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <Math/Functions.h>
+#include <Math/SVector.h>
+#include <Math/SMatrix.h>
+
+
 
 ME0SegAlgoRU::ME0SegAlgoRU(const edm::ParameterSet& ps)
-  : ME0SegmentAlgorithmBase(ps), myName("ME0SegAlgoRU"), sfit_(nullptr) { 
+  : ME0SegmentAlgorithmBase(ps), myName("ME0SegAlgoRU") {
 
-  doCollisions = ps.getParameter<bool>("doCollisions"); 
-  chi2_str_   = ps.getParameter<double>("chi2_str"); 
-  chi2Norm_2D_   = ps.getParameter<double>("chi2Norm_2D_");    
-  dRMax       = ps.getParameter<double>("dRMax"); 
-  dPhiMax        = ps.getParameter<double>("dPhiMax"); 
-  dRIntMax   = ps.getParameter<double>("dRIntMax"); 
-  dPhiIntMax    = ps.getParameter<double>("dPhiIntMax"); 
-  chi2Max        = ps.getParameter<double>("chi2Max"); 
-  wideSeg        = ps.getParameter<double>("wideSeg"); 
-  minLayersApart = ps.getParameter<int>("minLayersApart"); 
+	allowWideSegments = ps.getParameter<bool>("allowWideSegments");
+	doCollisions = ps.getParameter<bool>("doCollisions");
+	stdParameters.maxChi2Additional = ps.getParameter<double>("maxChi2Additional");
+	stdParameters.maxChi2Prune      = ps.getParameter<double>("maxChi2Prune"     );
+	stdParameters.maxChi2GoodSeg    = ps.getParameter<double>("maxChi2GoodSeg"   ) ;
+	stdParameters.maxPhiSeeds       = ps.getParameter<double>("maxPhiSeeds"      ) ;
+	stdParameters.maxPhiAdditional  = ps.getParameter<double>("maxPhiAdditional" );
+	stdParameters.maxETASeeds       = ps.getParameter<double>("maxETASeeds"      );
+	stdParameters.maxTOFDiff        = ps.getParameter<double>("maxTOFDiff"      );
+	stdParameters.minNumberOfHits        = ps.getParameter<unsigned int>("minNumberOfHits"      );
+	stdParameters.requireBeamConstr = true;
 
-  LogDebug("ME0") << myName << " has algorithm cuts set to: \n" 
-		  << "--------------------------------------------------------------------\n" 
-		  << "dRMax     = " << dRMax << '\n' 
-		  << "dPhiMax      = " << dPhiMax << '\n' 
-		  << "dRIntMax = " << dRIntMax << '\n' 
-		  << "dPhiIntMax  = " << dPhiIntMax << '\n' 
-		  << "chi2Max      = " << chi2Max << '\n' 
-		  << "wideSeg      = " << wideSeg << '\n' 
-		  << "minLayersApart = " << minLayersApart << std::endl; 
+	wideParameters = stdParameters;
+	wideParameters.maxChi2Prune     *=2;
+	wideParameters.maxChi2GoodSeg   *=2;
+	wideParameters.maxPhiSeeds      *=2;
+	wideParameters.maxPhiAdditional *=2;
+	wideParameters.minNumberOfHits  +=1;
 
-  //reset the thresholds for non-collision data 
-  if(!doCollisions){ 
-    dRMax = 2.0; 
-    dPhiMax = 2*dPhiMax; 
-    dRIntMax = 2*dRIntMax; 
-    dPhiIntMax = 2*dPhiIntMax; 
-    chi2Norm_2D_ = 5*chi2Norm_2D_; 
-    chi2_str_ = 100; 
-    chi2Max = 2*chi2Max; 
-  } 
-} 
 
-std::vector<ME0Segment> ME0SegAlgoRU::run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits){ 
-  theEnsemble = ensemble;
+	displacedParameters = stdParameters;
+	displacedParameters.maxChi2Additional *= 2;
+	displacedParameters.maxChi2Prune      = 100;
+	displacedParameters.maxChi2GoodSeg    *= 5;
+	displacedParameters.maxPhiSeeds       *=2;
+	displacedParameters.maxPhiAdditional  *=2;
+	displacedParameters.maxETASeeds       *=2;
+	displacedParameters.requireBeamConstr = false;
+
+
+  LogDebug("ME0SegAlgoRU") << myName << " has algorithm cuts set to: \n"
+		  << "--------------------------------------------------------------------\n"
+		  << "allowWideSegments   = " <<allowWideSegments              << "\n"
+		  << "doCollisions        = " <<doCollisions                   << "\n"
+		  << "maxChi2Additional   = " <<stdParameters.maxChi2Additional<< "\n"
+		  << "maxChi2Prune        = " <<stdParameters.maxChi2Prune     << "\n"
+		  << "maxChi2GoodSeg      = " <<stdParameters.maxChi2GoodSeg   << "\n"
+		  << "maxPhiSeeds         = " <<stdParameters.maxPhiSeeds      << "\n"
+		  << "maxPhiAdditional    = " <<stdParameters.maxPhiAdditional << "\n"
+		  << "maxETASeeds         = " <<stdParameters.maxETASeeds      << "\n"
+		  << "maxTOFDiff          = " <<stdParameters.maxTOFDiff       << "\n"
+		   << std::endl;
+
+  theChamber=0;
+
+}
+
+std::vector<ME0Segment> ME0SegAlgoRU::run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits){
+
   #ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
-  ME0DetId chId((ensemble.first)->id());
+  ME0DetId chId(chamber->id());
   edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegmentAlgorithm::run] build segments in chamber " << chId << " which contains "<<rechits.size()<<" rechits";
-  for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
-    auto me0id = (*rh)->me0Id();
-    auto ch    = theEnsemble.first;
-    auto ep    = (theEnsemble.second).find(me0id)->second;
-    auto rhGP  = ep->toGlobal((*rh)->localPosition());
-    auto rhLP  = ch->toLocal(rhGP);
-    edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Glb y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<(*rh)->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
+  for(unsigned int iH = 0; iH < rechits.size(); ++iH){
+	    auto me0id = rechits[iH].rh->me0Id();
+	    auto rhLP  = rechits[iH].lp;
+	    edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Glb y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<rechits[iH].rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]"<<std::endl;
   }
   #endif
-  return this->buildSegments(rechits);  
-} 
 
-std::vector<ME0Segment> ME0SegAlgoRU::buildSegments(const EnsembleHitContainer& urechits) { 
-  EnsembleHitContainer rechits = urechits; 
-  LayerIndex layerIndex(rechits.size()); 
-  // MM hard coded should work for <=6 layer..
-  int recHits_per_layer[6] = {0,0,0,0,0,0}; 
 
-  // MM this should be verified for ME0, noise and PU and high eta are difficult regions...
-  //skip events with high multiplicity of hits 
-  if (rechits.size()>300){ 
-    return std::vector<ME0Segment>(); 
-  } 
-
-  int iadd = 0; 
-  // determine if smaller layer correspong to smaller abs(z) nearest to IP
-  int minlayer = 99;
-  int maxlayer = -1;
-  float zmin = 0;
-  float zmax = 0;
-  for(unsigned int i = 0; i < rechits.size(); i++) {  
-    int layer = rechits[i]->me0Id().layer();
-    recHits_per_layer[layer-1]++;//count rh per chamber 
-    layerIndex[i] = layer;
-    if (layer > maxlayer ) {
-      maxlayer = layer;
-      const ME0EtaPartition * thePartition   = (theEnsemble.second).find(rechits[i]->me0Id())->second;
-      zmax = (thePartition->toGlobal(rechits[i]->localPosition())).z();
-    }
-    if (layer < minlayer ) {
-      minlayer = layer;
-      const ME0EtaPartition * thePartition   = (theEnsemble.second).find(rechits[i]->me0Id())->second;
-      zmin = (thePartition->toGlobal(rechits[i]->localPosition())).z();
-    }
+  if (rechits.size() < 3 || rechits.size()>300){
+	  return std::vector<ME0Segment>();
   }
 
-  if (std::abs(zmin) > std::abs(zmax)){ 
-    reverse(layerIndex.begin(), layerIndex.end()); 
-    reverse(rechits.begin(), rechits.end()); 
-  }     
- 
-  if (rechits.size() < 2) { 
-    return std::vector<ME0Segment>();  
-  } 
+  theChamber = chamber;
 
-  // We have at least 2 hits. We intend to try all possible pairs of hits to start  
-  // segment building. 'All possible' means each hit lies on different layers in the chamber. 
-  // after all same size segs are build we get rid of the overcrossed segments using the chi2 criteria 
-  // the hits from the segs that are left are marked as used and are not added to segs in future iterations 
-  // the hits from 3p segs are marked as used separately in order to try to assamble them in longer segments  
-  // in case there is a second pass    
+  std::vector<unsigned int> recHits_per_layer(6,0);
+  for(unsigned int iH = 0; iH < rechits.size(); ++iH) {
+	  recHits_per_layer[rechits[iH].layer-1]++;
+  }
 
-  // Choose first hit (as close to IP as possible) h1 and second hit 
-  // (as far from IP as possible) h2 To do this we iterate over hits 
-  // in the chamber by layer - pick two layers.  Then we 
-  // iterate over hits within each of these layers and pick h1 and h2 
-  // these.  If they are 'close enough' we build an empty 
-  // segment.  Then try adding hits to this segment. 
+  BoolContainer used(rechits.size(),false);
 
-  // Initialize flags that a given hit has been allocated to a segment 
-  BoolContainer used(rechits.size(), false); 
-  BoolContainer used3p(rechits.size(), false); 
+  // We have at least 2 hits. We intend to try all possible pairs of hits to start
+  // segment building. 'All possible' means each hit lies on different layers in the chamber.
+  // after all same size segs are build we get rid of the overcrossed segments using the chi2 criteria
+  // the hits from the segs that are left are marked as used and are not added to segs in future iterations
+  // the hits from 3p segs are marked as used separately in order to try to assamble them in longer segments
+  // in case there is a second pass
 
-  // This is going to point to fits to hits, and its content will be used to create a ME0Segment
-  sfit_ = 0;
+  // Choose first hit (as close to IP as possible) h1 and second hit
+  // (as far from IP as possible) h2 To do this we iterate over hits
+  // in the chamber by layer - pick two layers.  Then we
+  // iterate over hits within each of these layers and pick h1 and h2
+  // these.  If they are 'close enough' we build an empty
+  // segment.  Then try adding hits to this segment.
 
-  // Define buffer for segments we build  
-  std::vector<ME0Segment> segments; 
+  std::vector<ME0Segment> segments;
 
-  EnsembleHitContainerCIt ib = rechits.begin(); 
-  EnsembleHitContainerCIt ie = rechits.end(); 
-
-  // Possibly allow 3 passes, second widening scale factor for cuts, third for segments from displaced vertices 
-  windowScale = 1.; // scale factor for cuts 
-
-  bool search_disp = false;	   
-  int npass = (wideSeg > 1.)? 3 : 2; 
-
-  for (int ipass = 0; ipass < npass; ++ipass) { 
-    if(windowScale >1.){ 
-      iadd = 1; 
-      strip_iadd = 2; 
-      chi2D_iadd = 2; 
-    } 
-
-    int used_rh = 0;
-    for (EnsembleHitContainerCIt i1 = ib; i1 != ie; ++i1) {
-      if(used[i1-ib])used_rh++;
-    }
-    //change the tresholds if it's time to look for displaced mu segments                                                                                                                                                          
-    if(doCollisions && search_disp && int(rechits.size()-used_rh)>2){//check if there are enough recHits left to build a segment from displaced vertices                                                                     
-      doCollisions = false;
-      windowScale = 1.; // scale factor for cuts   
-      dRMax = 2.*dRMax;
-      dPhiMax = 2*dPhiMax;
-      dRIntMax = 2*dRIntMax;
-      dPhiIntMax = 2*dPhiIntMax;
-      chi2Norm_2D_ = 5*chi2Norm_2D_;
-      //      chi2_str_ = 100;
-      chi2Max = 2*chi2Max;
-    }
-
-    for(unsigned int n_seg_min = 6u; n_seg_min > 2u + iadd; --n_seg_min){ 
-      BoolContainer common_used(rechits.size(),false); 
-      std::array<BoolContainer, 120> common_used_it = {}; 
-      for (unsigned int i = 0; i < common_used_it.size(); i++) { 
-	common_used_it[i] = common_used; 
-      } 
-      EnsembleHitContainer best_proto_segment[120]; 
-      float min_chi[120] = {9999}; 
-      int common_it = 0; 
-      bool first_proto_segment = true; 
-      // the first hit is taken from the back
-      
-      for (EnsembleHitContainerCIt i1 = ib; i1 != ie; ++i1) { 
-	  
-	//skip if rh is used and the layer tat has big rh multiplicity(>25RHs) 
-	if(used[i1-ib] || recHits_per_layer[int(layerIndex[i1-ib])-1]>25 || (n_seg_min == 3 && used3p[i1-ib])) continue; 
-
-	int layer1 = layerIndex[i1-ib];  
-	const ME0RecHit* h1 = *i1; 
-	// the second hit from the front
-	for (EnsembleHitContainerCIt i2 = ie-1; i2 != i1; --i2) { 
-	  bool segok = false; 
-	  if(used[i2-ib] || recHits_per_layer[int(layerIndex[i2-ib])-1]>25 || (n_seg_min == 3 && used3p[i2-ib])) continue; 
-
-	  int layer2 = layerIndex[i2-ib]; 
-	  if((abs(layer2 - layer1) + 1) < int(n_seg_min)) break;//decrease n_seg_min 
-          const ME0RecHit* h2 = *i2; 	
-	    if (this->areHitsCloseInEta(h1, h2) && this->areHitsCloseInGlobalPhi(h1, h2)) { 
-	    proto_segment.clear(); 
-	    if (!this->addHit(h1, layer1))continue; 
-	    if (!this->addHit(h2, layer2))continue; 
-
-	    // Can only add hits if already have a segment
-	    if ( sfit_ ) this->tryAddingHitsToSegment(rechits, used, layerIndex, i1, i2);  
-	    segok = this->isSegmentGood(rechits); 
-	    if (segok) { 
-	      if(proto_segment.size() > n_seg_min){
-		this->baseline(n_seg_min); 
-		this->updateParameters();
-	      }
-	      if(sfit_->chi2()/sfit_->ndof() > chi2Norm_2D_*chi2D_iadd || proto_segment.size() < n_seg_min) {
-		proto_segment.clear(); 
-	      }
-	      
-	      if (!proto_segment.empty()) { 
-		this->updateParameters(); 
-
-	        //add same-size overcrossed protosegments to the collection 
-		if(first_proto_segment){ 
-		  
-		  this->flagHitsAsUsed(rechits, common_used_it[0]); 
-		  min_chi[0] = sfit_->chi2()/sfit_->ndof(); 
-		  best_proto_segment[0] = proto_segment; 
-		  
-		  first_proto_segment = false; 
-		}else{  //for the rest of found proto_segments  
-		  common_it++; 
-		  this->flagHitsAsUsed(rechits, common_used_it[common_it]); 
-
-		  min_chi[common_it] = sfit_->chi2()/sfit_->ndof(); 
-		  best_proto_segment[common_it] = proto_segment; 
-		  EnsembleHitContainerCIt hi, iu, ik; 
-		  int iter = common_it; 
-		  for(iu = ib; iu != ie; ++iu) { 
-		    for(hi = proto_segment.begin(); hi != proto_segment.end(); ++hi) { 
-		      if(*hi == *iu) { 
-			int merge_nr = -1; 
-			for(int k = 0; k < iter+1; k++){ 
-			  if(common_used_it[k][iu-ib] == true){ 
-			    if(merge_nr != -1){ 
-
-			      //merge the k and merge_nr collections of flaged hits into the merge_nr collection and unmark the k collection hits                                   
-			      for(ik = ib; ik != ie; ++ik) { 
-				if(common_used_it[k][ik-ib] == true){ 
-				  common_used_it[merge_nr][ik-ib] = true; 
-				  common_used_it[k][ik-ib] = false; 
-				} 
-			      } 
-			      //change best_protoseg if min_chi_2 is smaller                                                                                                                       
-			      if(min_chi[k] < min_chi[merge_nr]){ 
-				min_chi[merge_nr] = min_chi[k]; 
-				best_proto_segment[merge_nr] = best_proto_segment[k]; 
-				best_proto_segment[k].clear(); 
-				min_chi[k] = 9999; 
-			      } 
-			      common_it--; 
-			    } 
-			    else{ 
-			      merge_nr = k; 
-			    } 
-			  }//if(common_used[k][iu-ib] == true)                                                                                                                                     
-			}//for k                                                                                                                                                                    
-		      }//if                                                                                                                                                                        
-		    }//for proto_seg                                                                                                                                                                 
-		  }//for rec_hits   
-		}//else 
-	      }//proto seg not empty 
-	    }
-	  }  //   h1 & h2 close 
-	  if (segok)  {
-	    //            break; 
-	  }
-	}  //  i2 
-      }  //  i1 
-
-      //add the reconstructed segments 
-      for(int j = 0;j < common_it+1; j++){ 
-	
-	proto_segment = best_proto_segment[j]; 
-	best_proto_segment[j].clear(); 
-	//SKIP empty proto-segments
-        if(proto_segment.size() == 0) continue;
-	this->updateParameters();   
-    
-	// Create an actual ME0Segment - retrieve all info from the fit
-	// calculate the timing fron rec hits associated to the TrackingRecHits used 
-	// to fit the segment 
-	float averageTime=0.;
-	for(EnsembleHitContainer::iterator ir=proto_segment.begin(); ir<proto_segment.end(); ++ir ) {
-	  averageTime += (*ir)->tof();
-	}
-	if(proto_segment.size() != 0)
-	  averageTime=averageTime/(proto_segment.size());
-	float timeUncrt=0.;
-	for(EnsembleHitContainer::iterator ir=proto_segment.begin(); ir<proto_segment.end(); ++ir ) {
-	  timeUncrt += pow( (*ir)->tof()-averageTime,2);
-	}
-	if(proto_segment.size() > 1)
-	  timeUncrt=timeUncrt/(proto_segment.size()-1);
-	timeUncrt = sqrt(timeUncrt);
-	std::sort(proto_segment.begin(),proto_segment.end(),sortByLayer());
-
-	// Set Out from IP
-	// Function was removed from MuonSegFit 
-	// since it depended on chamber INFO
-	// which is different for GEM and ME0
-	// So I implement it here
-	auto ch    = theEnsemble.first;
-	double globalZpos    = ( ch->toGlobal( sfit_->intercept() ) ).z();
-	double globalZdir    = ( ch->toGlobal( sfit_->localdir()  ) ).z();
-	double directionSign = globalZpos * globalZdir;
-	LocalVector localDir = (directionSign * localDir ).unit();
-
-
-	ME0Segment temp(proto_segment, sfit_->intercept(),
-			/*sfit_->localdir(),*/ localDir, sfit_->covarianceMatrix(), sfit_->chi2(), averageTime, timeUncrt);
-	sfit_ = 0;
-	segments.push_back(temp);                         
-	//if the segment has 3 hits flag them as used in a particular way 
-	if(proto_segment.size() == 3){ 
-	  this->flagHitsAsUsed(rechits, used3p); 
-	} 
-	else{ 
-	  this->flagHitsAsUsed(rechits, used);   
-	} 
-	proto_segment.clear(); 
-      }  
-    }//for n_seg_min 
-
-    if(!doCollisions && search_disp){
-
-      //reset params and flags for the next ensemble                                                                                                                           
-      search_disp = false;
-      doCollisions = true;
-      dRMax = dRMax/2.0;
-      dPhiMax = dPhiMax/2;
-      dRIntMax = dRIntMax/2;
-      dPhiIntMax = dPhiIntMax/2;
-      chi2Norm_2D_ = chi2Norm_2D_/5;
-      chi2_str_ = 100;
-      chi2Max = chi2Max/2;
-    }     
-
-    std::vector<ME0Segment>::iterator it =segments.begin(); 
-    bool good_segs = false; 
-    while(it != segments.end()) { 
-      if ((*it).nRecHits() > 3){ 
-	good_segs = true; 
-	break; 
-      } 
-      ++it;	 
-    }     
-
-    if (good_segs) {  // only change window if not enough good segments were found (bool can be changed to int if a >0 number of good segs is required) 
-      search_disp = true;
-      continue;//proceed to search the segs from displaced vertices
-    }
-
-    // Increase cut windows by factor of wideSeg only for collisions 
-    if(!doCollisions && !search_disp) break;     
-    windowScale = wideSeg; 
-  }  //  ipass 
-  /* Specific to CSC not used at the moment for ME0
-  //get rid of enchansed 3p segments 
-  std::vector<ME0Segment>::iterator it =segments.begin(); 
-  while(it != segments.end()) { 
-    if((*it).nRecHits() == 3){ 
-      bool found_common = false; 
-      const std::vector<ME0RecHit>& theseRH = (*it).specificRecHits(); 
-      for (EnsembleHitContainerCIt i1 = ib; i1 != ie; ++i1) { 
-	if(used[i1-ib] && used3p[i1-ib]){ 
-	  const ME0RecHit* sh1 = *i1; 
-
-	  ME0DetId id = sh1->me0Id(); 
-	  int sh1layer = id.layer(); 
-	  int RH_centerid     =  sh1->nStrips()/2; 
-	  int RH_centerStrip =  sh1->channels(RH_centerid); 
-	  int RH_wg = sh1->hitWire();
-	  std::vector<ME0RecHit>::const_iterator sh; 
-	  for(sh = theseRH.begin(); sh != theseRH.end(); ++sh){ 
-	    ME0DetId idRH = sh->me0Id();
-
-	    //find segment hit coord 
-	    int shlayer = idRH.layer(); 
-	    int SegRH_centerid     =  sh->nStrips()/2; 
-	    int SegRH_centerStrip =  sh->channels(SegRH_centerid); 
-	    int SegRH_wg = sh->hitWire(); 
-
-	    if(sh1layer == shlayer && SegRH_centerStrip == RH_centerStrip && SegRH_wg == RH_wg){ 
-	      //remove the enchansed 3p segment 
-	      segments.erase(it,(it+1)); 
-	      found_common = true; 
-	      break; 
-	    } 
-	  }//theserh 
-	} 
-	if(found_common) break;//current seg has already been erased 
-      }//camber hits 
-      if(!found_common)++it;  
-    }//its a 3p seg 
-    else{ 
-      ++it;//go to the next seg 
-    }  
-  }//while 
-  */
-
+  auto doStd = [&] () {
+	  for(unsigned int n_seg_min = 6u; n_seg_min  >= stdParameters.minNumberOfHits; --n_seg_min)
+		  lookForSegments(stdParameters,n_seg_min,rechits,recHits_per_layer, used, segments);
+  };
+  auto doDisplaced = [&] () {
+	  for(unsigned int n_seg_min = 6u; n_seg_min  >= displacedParameters.minNumberOfHits; --n_seg_min)
+		  lookForSegments(displacedParameters,n_seg_min,rechits,recHits_per_layer, used,segments);
+  };
+  auto doWide = [&] () {
+	  for(unsigned int n_seg_min = 6u; n_seg_min >= wideParameters.minNumberOfHits; --n_seg_min)
+		  lookForSegments(wideParameters,n_seg_min,rechits,recHits_per_layer, used,segments);
+  };
+  auto printSegments = [&] {
 #ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
 std::vector<ME0Segment>::iterator it =segments.begin();
 for(std::vector<ME0Segment>::iterator it =segments.begin(); it != segments.end(); ++it) {
@@ -416,571 +137,328 @@ for(std::vector<ME0Segment>::iterator it =segments.begin(); it != segments.end()
   edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU] segment in chamber " << chId << " which contains "<<rechits.size()<<" rechits and with specs: \n"<<*it;
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
       auto me0id = rh->me0Id();
-      auto ch    = theEnsemble.first;
-      auto ep    = (theEnsemble.second).find(me0id)->second;
-      auto rhGP  = ep->toGlobal(rh->localPosition());
-      auto rhLP  = ch->toLocal(rhGP);
-      edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
+      edm::LogVerbatim("ME0SegAlgoRU") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rh->localPosition().x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rh->localPosition().y()<<" Time = "<<std::showpos<<rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
     }
 }
-#endif    
+#endif
+  };
 
-  // Give the segments to the ME0Ensemble 
-  return segments; 
-}//build segments 
 
-void ME0SegAlgoRU::tryAddingHitsToSegment(const EnsembleHitContainer& rechits,  
-					  const BoolContainer& used, const LayerIndex& layerIndex, 
-					  const EnsembleHitContainerCIt i1, const EnsembleHitContainerCIt i2) { 
+  //If we arent doing collisions, do a single iteration
+  if(!doCollisions){
+	  doDisplaced();
+	  printSegments();
+	  return segments;
+  }
 
-  // Iterate over the layers with hits in the chamber 
-  // Skip the layers containing the segment endpoints 
-  // Test each hit on the other layers to see if it is near the segment 
-  // If it is, see whether there is already a hit on the segment from the same layer 
-  //    - if so, and there are more than 2 hits on the segment, copy the segment, 
-  //      replace the old hit with the new hit. If the new segment chi2 is better 
-  //      then replace the original segment with the new one (by swap) 
-  //    - if not, copy the segment, add the hit. If the new chi2/dof is still satisfactory 
-  //      then replace the original segment with the new one (by swap) 
+  //Iteration 1: STD processing
+  doStd();
 
-  EnsembleHitContainerCIt ib = rechits.begin(); 
-  EnsembleHitContainerCIt ie = rechits.end(); 
-  
-  for (EnsembleHitContainerCIt i = ib; i != ie; ++i) { 
-    if(layerIndex[i1-ib]<layerIndex[i2-ib]){ 
-      if (layerIndex[i-ib] <= layerIndex[i1-ib] || layerIndex[i-ib] >= layerIndex[i2-ib] || i  == i1 || i == i2 || used[i-ib]){  
-	if ( i  == i1 || i == i2 || used[i-ib]) 
-	  continue;  
-      } 
-    } 
-    else{ 
-      if (layerIndex[i-ib] >= layerIndex[i1-ib] || layerIndex[i-ib] <= layerIndex[i2-ib] || i  == i1 || i == i2 || used[i-ib]){ 
-	if ( i  == i1 || i == i2 || used[i-ib])                                                                                                              
-	  continue; 
-      }  
-    } 
-    int layer = layerIndex[i-ib]; 
-    const ME0RecHit* h = *i; 
-    if (this->isHitNearSegment(h)) {
+  if(false){
+	  //How the CSC algorithm ~does iterations. for now not considering
+	  //displaced muons will not worry about it  later
+	  //Iteration 2a: If we don't allow wide segments simply do displaced
+	  // Or if we already found a segment simply skip to displaced
+	  if(!allowWideSegments || segments.size()){
+		  doDisplaced();
+		  return segments;
+	  }
+	  doWide();
+	  doDisplaced();
+  }
+  printSegments();
+  return segments;
+}
 
-      // Don't consider alternate hits on layers holding the two starting points 
-      if (this->hasHitOnLayer(layer)) { 
-	if (proto_segment.size() <= 2) continue; 
-	this->compareProtoSegment(h, layer); 
-      }  
-      else{ 
-	this->increaseProtoSegment(h, layer, chi2D_iadd);  
-      }
-      
-    }   // h & seg close 
-  }   // i 
-} 
+void ME0SegAlgoRU::lookForSegments( const SegmentParameters& params, const unsigned int n_seg_min,
+		const HitAndPositionContainer& rechits, const std::vector<unsigned int>& recHits_per_layer,
+		BoolContainer& used, std::vector<ME0Segment>& segments) const  {
+	  auto ib = rechits.begin();
+	  auto ie = rechits.end();
+	  std::vector<std::pair<float,HitAndPositionPtrContainer> > proto_segments;
+    // the first hit is taken from the back
+    for (auto i1 = ib; i1 != ie; ++i1) {
+    	const auto& h1 = *i1;
 
-bool ME0SegAlgoRU::areHitsCloseInEta(const ME0RecHit* h1, const ME0RecHit* h2) const { 
+    	//skip if rh is used and the layer tat has big rh multiplicity(>25RHs)
+    	if(used[h1.idx]) continue;
+    	if(recHits_per_layer[h1.layer-1]>100) continue;
+
+//    	bool segok = false;
+    	// the second hit from the front
+    	for (auto i2 = ie-1; i2 != i1; --i2) {
+//    		if(segok) break; //Currently turned off
+    		const auto& h2 = *i2;
+
+    		//skip if rh is used and the layer tat has big rh multiplicity(>25RHs)
+        	if(used[h2.idx]) continue;
+        	if(recHits_per_layer[h2.layer-1]>100) continue;
+
+        	//Stop if the distance between layers is not large enough
+        	if((abs(int(h2.layer) - int(h1.layer)) + 1) < int(n_seg_min)) break;
+
+        	if(std::fabs(h1.rh->tof()-h2.rh->tof()) > params.maxTOFDiff + 1.0 )continue;
+        	if(!areHitsCloseInEta(params.maxETASeeds, params.requireBeamConstr, h1.gp, h2.gp)) continue;
+        	if(!areHitsCloseInGlobalPhi(params.maxPhiSeeds,abs(int(h2.layer) - int(h1.layer)), h1.gp, h2.gp)) continue;
+
+        	HitAndPositionPtrContainer current_proto_segment;
+        	std::unique_ptr<MuonSegFit> current_fit;
+        	current_fit = addHit(current_proto_segment,h1);
+        	current_fit = addHit(current_proto_segment,h2);
+
+        	tryAddingHitsToSegment(params.maxTOFDiff,params.maxETASeeds, params.maxPhiAdditional, params.maxChi2Additional, current_fit,current_proto_segment, used,i1,i2);
+
+        	if(current_proto_segment.size() > n_seg_min)
+        		pruneBadHits(params.maxChi2Prune,current_proto_segment,current_fit,n_seg_min);
+
+        	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::lookForSegments] # of hits in segment " << current_proto_segment.size() <<" min # "<< n_seg_min <<" => "<< (current_proto_segment.size() >= n_seg_min) << " chi2/ndof "<<current_fit->chi2()/current_fit->ndof()<<" => "<<(current_fit->chi2()/current_fit->ndof() < params.maxChi2GoodSeg ) <<std::endl;
+
+        	if(current_proto_segment.size() < n_seg_min) continue;
+
+        	const float current_metric = current_fit->chi2()/current_fit->ndof();
+        	if(current_metric > params.maxChi2GoodSeg) continue;
+//        	segok = true;
+
+        	proto_segments.emplace_back( current_metric, current_proto_segment);
+    	}
+
+    }
+    addUniqueSegments(proto_segments,segments,used);
+
+}
+
+void ME0SegAlgoRU::addUniqueSegments(SegmentByMetricContainer& proto_segments, std::vector<ME0Segment>& segments,BoolContainer& used ) const {
+    std::sort(proto_segments.begin(),proto_segments.end(),
+    		[](const std::pair<float,HitAndPositionPtrContainer> & a,
+    		   const std::pair<float,HitAndPositionPtrContainer> & b) { return a.first < b.first;});
+
+    //Now add to the collect based on minChi2 marking the hits as used after
+    std::vector<unsigned int> usedHits;
+    for(unsigned int iS = 0; iS < proto_segments.size(); ++iS){
+    	HitAndPositionPtrContainer currentProtoSegment = proto_segments[iS].second;
+
+    	//check to see if we already used thes hits this round
+    	bool alreadyFilled=false;
+    	for(unsigned int iH = 0; iH < currentProtoSegment.size(); ++iH){
+    		for(unsigned int iOH = 0; iOH < usedHits.size(); ++iOH){
+    			if(usedHits[iOH]!=currentProtoSegment[iH]->idx) continue;
+    			alreadyFilled = true;
+    			break;
+    		}
+    	}
+    	if(alreadyFilled) continue;
+    	for(const auto* h : currentProtoSegment){
+    		usedHits.push_back(h->idx);
+    		used[h->idx] = true;
+    	}
+
+    	std::unique_ptr<MuonSegFit> current_fit = makeFit(currentProtoSegment);
+
+    	// Create an actual ME0Segment - retrieve all info from the fit
+    	// calculate the timing fron rec hits associated to the TrackingRecHits used
+    	// to fit the segment
+    	float averageTime=0.;
+    	for(const auto* h : currentProtoSegment){
+    	  averageTime += h->rh->tof();
+    	}
+    	averageTime /= float(currentProtoSegment.size());
+    	float timeUncrt=0.;
+    	for(const auto* h : currentProtoSegment){
+    	  timeUncrt += pow( h->rh->tof()-averageTime,2);
+    	}
+    	timeUncrt = std::sqrt(timeUncrt/float(currentProtoSegment.size()-1));
+
+    	std::sort(currentProtoSegment.begin(),currentProtoSegment.end(),
+    			[](const HitAndPosition* a, const HitAndPosition *b) {return a->layer < b->layer;}
+    	);
+
+    	std::vector<const ME0RecHit*> bareRHs; bareRHs.reserve(currentProtoSegment.size());
+    	for(const auto* rh : currentProtoSegment) bareRHs.push_back(rh->rh);
+    	ME0Segment temp(bareRHs, current_fit->intercept(),
+    			current_fit->localdir(), current_fit->covarianceMatrix(), current_fit->chi2(), averageTime, timeUncrt);
+    	segments.push_back(temp);
+
+
+    }
+}
+
+void ME0SegAlgoRU::tryAddingHitsToSegment(const float maxTOF,  const float maxETA, const float maxPhi,const float maxChi2, std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& proto_segment,
+					  const BoolContainer& used, HitAndPositionContainer::const_iterator i1, HitAndPositionContainer::const_iterator i2) const {
+  // Iterate over the layers with hits in the chamber
+  // Skip the layers containing the segment endpoints
+  // Test each hit on the other layers to see if it is near the segment
+  // If it is, see whether there is already a hit on the segment from the same layer
+  //    - if so, and there are more than 2 hits on the segment, copy the segment,
+  //      replace the old hit with the new hit. If the new segment chi2 is better
+  //      then replace the original segment with the new one (by swap)
+  //    - if not, copy the segment, add the hit. If the new chi2/dof is still satisfactory
+  //      then replace the original segment with the new one (by swap)
+
+  //Hits are ordered by layer, "i1" is the inner hit and i2 is the outer hit
+  //so possible hits to add must be between these two iterators
+  for(auto iH = i1 + 1; iH != i2; ++iH ){
+	  if(iH->layer == i1->layer) continue;
+	  if(iH->layer == i2->layer) break;
+	  if(used[iH->idx]) continue;
+	  if(!areHitsConsistentInTime(maxTOF,proto_segment,*iH)) continue;
+	  if (!isHitNearSegment(maxETA,maxPhi,current_fit,proto_segment,*iH)) continue;
+	  if(hasHitOnLayer(proto_segment,iH->layer))
+		  compareProtoSegment(current_fit,proto_segment,*iH);
+	  else
+		  increaseProtoSegment(maxChi2, current_fit,proto_segment,*iH);
+  }
+}
+
+bool ME0SegAlgoRU::areHitsCloseInEta(const float maxETA, const bool beamConst, const GlobalPoint& h1, const GlobalPoint& h2) const {
   // check that hits from different layer gets eta partition number +1 max..
-
-  ME0DetId id1 = h1->me0Id();  
-  const ME0EtaPartition* part1 = theEnsemble.second.find(id1)->second;
-  GlobalPoint gp1 = part1->toGlobal(h1->localPosition());	 
-  int etaP1 = id1.roll();
-
-  ME0DetId id2 = h2->me0Id();  
-  const ME0EtaPartition* part2 = theEnsemble.second.find(id2)->second;
-  GlobalPoint gp2 = part2->toGlobal(h2->localPosition());	 
-  int etaP2 = id2.roll();
-
-  //find z to understand the direction 
-  float h1z = gp1.z(); 
-  float h2z = gp2.z(); 
-  bool good = false;
-  float dR = 9999;
-  if (doCollisions){
-    if ( abs(h1z) > abs(h2z) ) {
-      good = (etaP1==etaP2 || etaP1 == etaP2-1);
-    }else{
-      good = (etaP1==etaP2 || etaP2 == etaP1-1);
-    }	 
-    dR = fabs(gp1.perp()-gp2.perp());
-  }else{
-    good = std::abs(etaP1-etaP2) <= 1;
-    dR = 0;
-  }
-  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInEta] gp1 = "<<gp1<<" in eta part = "<<etaP1<<" and gp2 = "<<gp2<<" in eta part = "<<etaP2<<" ==> dR = "<<dR<<" ==> return "<<(good && dR<dRMax)<<std::endl;
-  return (good && dR<dRMax);
-} 
-
-bool ME0SegAlgoRU::areHitsCloseInGlobalPhi(const ME0RecHit* h1, const ME0RecHit* h2) const { 
-
-  ME0DetId id1 = h1->me0Id();  
-  const ME0EtaPartition* part1 = theEnsemble.second.find(id1)->second;
-  GlobalPoint gp1 = part1->toGlobal(h1->localPosition());	 
-
-  ME0DetId id2 = h2->me0Id();  
-  const ME0EtaPartition* part2 = theEnsemble.second.find(id2)->second;
-  GlobalPoint gp2 = part2->toGlobal(h2->localPosition());	 
-
-  float dphi12 = deltaPhi(gp1.barePhi(),gp2.barePhi());
-  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInGlobalPhi] gp1 = "<<gp1<<" and gp2 = "<<gp2<<" ==> dPhi = "<<dphi12<<" ==> return "<<(fabs(dphi12) < dPhiMax)<<std::endl;
-  return fabs(dphi12) < dPhiMax; 
-} 
-
-bool ME0SegAlgoRU::isHitNearSegment(const ME0RecHit* h) const { 
-
-  // Is hit near segment?  
-  // Requires deltaphi and deltaR within ranges specified in parameter set. 
-  // Note that to make intuitive cuts on delta(phi) one must work in 
-  // phi range (-pi, +pi] not [0, 2pi) 
-
-  ME0DetId besId = (*(proto_segment.begin()))->me0Id();
-  const ME0EtaPartition* l1 = theEnsemble.second.find(besId)->second;
-  GlobalPoint gp1 = l1->toGlobal((*(proto_segment.begin()))->localPosition()); 
-
-  ME0DetId nesId = (*(proto_segment.begin()+1))->me0Id();
-  const ME0EtaPartition* l2 = theEnsemble.second.find(nesId)->second;
-  GlobalPoint gp2 = l2->toGlobal((*(proto_segment.begin()+1))->localPosition()); 
-
-
-  const ME0EtaPartition* l = theEnsemble.second.find(h->me0Id())->second;
-  GlobalPoint hp = l->toGlobal(h->localPosition()); 
-  
-  float hphi = hp.phi();          // in (-pi, +pi] 
-  if (hphi < 0.) 
-    hphi += 2.*M_PI;            // into range [0, 2pi) 
-  float sphi = this->phiAtZ(hp.z());    // in [0, 2*pi) 
-  float phidif = sphi-hphi; 
-  if (phidif < 0.) 
-    phidif += 2.*M_PI;          // into range [0, 2pi) 
-  if (phidif > M_PI) 
-    phidif -= 2.*M_PI;          // into range (-pi, pi] 
-
-  SVector6 r_glob; 
-  r_glob((*(proto_segment.begin()))->me0Id().layer()-1) = gp1.perp(); 
-  r_glob((*(proto_segment.begin()+1))->me0Id().layer()-1) = gp2.perp(); 
-
-  float R =  hp.perp(); 
-  int layer = h->me0Id().layer(); 
-
-  float r_interpolated = this->fit_r_phi(r_glob,layer); 
-  float dr = fabs(r_interpolated - R); 
-  
-  return (fabs(phidif) <  dPhiIntMax && fabs(dr) < dRIntMax);
-} 
-
-float ME0SegAlgoRU::phiAtZ(float z) const { 
-
-  if ( !sfit_ ) return 0.;
-
-  // Returns a phi in [ 0, 2*pi )
-  //  const ME0EtaPartition* l1 = theEnsemble.second.find((*(proto_segment.begin()))->me0Id())->second;
-  const auto* l1 = theEnsemble.first;
-  GlobalPoint gp = l1->toGlobal(sfit_->intercept());
-  GlobalVector gv = l1->toGlobal(sfit_->localdir());
-
-  float x = gp.x() + (gv.x()/gv.z())*(z - gp.z());
-  float y = gp.y() + (gv.y()/gv.z())*(z - gp.z());
-
-  float phi = atan2(y, x);
-  if (phi < 0.f ) phi += 2. * M_PI;
-
-  return phi ;
+  float diff = 0;
+//  //actually no difference in our case...may want to consider something later
+//  if(beamConst){
+//	  if(std::fabs(h1.z()) > std::fabs(h2.z())) diff =h1.eta() - h2.eta();
+//	  else diff = h2.eta() - h1.eta();
+//  } else {
+//	  diff = std::fabs(h2.eta() - h1.eta());
+//  }
+  diff = std::fabs(h1.eta() - h1.eta());
+  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInEta] gp1 = "<<h1<<" in eta part = "<<h1.eta() <<" and gp2 = "<<h2<<" in eta part = "<<h2.eta() <<" ==> dEta = "<<diff<<" ==> return "<<(diff < 0.1)<<std::endl;
+  return (diff < std::max(maxETA,float(0.01)) ); //temp for floating point comparision...maxEta is the difference between partitions, so x1.5 to take into account non-circle geom.
 }
 
-bool ME0SegAlgoRU::isSegmentGood(const EnsembleHitContainer& rechitsInChamber) const { 
+bool ME0SegAlgoRU::areHitsCloseInGlobalPhi(const float maxPHI, const unsigned int nLayDisp, const GlobalPoint& h1, const GlobalPoint& h2) const {
+  float dphi12 = deltaPhi(h1.barePhi(),h2.barePhi());
+  edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::areHitsCloseInGlobalPhi] gp1 = "<<h1<<" and gp2 = "<<h2<<" ==> dPhi = "<<dphi12<<" ==> return "<<(fabs(dphi12) < std::max(maxPHI,float(0.02)))<<std::endl;
+  return fabs(dphi12) < std::max(maxPHI, float(float(nLayDisp)*0.004));
+}
 
-  // If the chamber has 20 hits or fewer, require at least 3 hits on segment 
-  // If the chamber has >20 hits require at least 4 hits 
-  //@@ THESE VALUES SHOULD BECOME PARAMETERS? 
-  bool ok = false; 
+bool ME0SegAlgoRU::isHitNearSegment(const float maxETA, const float maxPHI,  const std::unique_ptr<MuonSegFit>& fit, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h) const {
 
-  unsigned int iadd = ( rechitsInChamber.size() > 20)?  1 : 0;   
+	//Get average eta, based on the two seeds...asssumes that we have not started pruning yet!
+	const float avgETA = (proto_segment[1]->gp.eta() + proto_segment[0]->gp.eta())/2.;
+//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::isHitNearSegment] average eta = "<<avgETA<<" additionalHit eta = "<<h.gp.eta() <<" ==> dEta = "<<std::fabs(h.gp.eta() - avgETA) <<" ==> return "<<(std::fabs(h.gp.eta() - avgETA) < std::max(maxETA,float(0.01) ))<<std::endl;
+	if(std::fabs(h.gp.eta() - avgETA) > std::max(maxETA,float(0.01) )) return false;
 
-  if (windowScale > 1.) 
-    iadd = 1; 
+	//Now check the dPhi based on the segment fit
+	GlobalPoint globIntercept = globalAtZ(fit, h.lp.z());
+	float dPhi = deltaPhi(h.gp.barePhi(),globIntercept.phi());
+	//check to see if it is inbetween the two rolls of the outer and inner hits
+//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::isHitNearSegment] projected phi = "<<globIntercept.phi()<<" additionalHit phi = "<<h.gp.barePhi() <<" ==> dPhi = "<<dPhi <<" ==> return "<<(std::fabs(dPhi) <  std::max(maxPHI,float(0.001)))<<std::endl;
+	return (std::fabs(dPhi) <  std::max(maxPHI,float(0.001)));
+}
 
-  if (proto_segment.size() >= 3+iadd) 
-    ok = true; 
-  return ok; 
-} 
+bool ME0SegAlgoRU::areHitsConsistentInTime(const float maxTOF, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h)  const {
+	std::vector<float> tofs; tofs.reserve(proto_segment.size() + 1);
+	tofs.push_back(h.rh->tof());
+	for(const auto* ih : proto_segment) tofs.push_back(ih->rh->tof());
+	std::sort(tofs.begin(),tofs.end());
+	if(std::fabs(tofs.front() - tofs.back()) < maxTOF +1.0 ) return true;
+	return false;
+}
 
-void ME0SegAlgoRU::flagHitsAsUsed(const EnsembleHitContainer& rechitsInChamber,  
-				  BoolContainer& used ) const { 
+GlobalPoint ME0SegAlgoRU::globalAtZ(const std::unique_ptr<MuonSegFit>& fit, float z) const {
+	float x = fit->xfit(z);
+	float y = fit->yfit(z);
+	return theChamber->toGlobal(LocalPoint(x,y,z));
+}
 
-  // Flag hits on segment as used 
-  EnsembleHitContainerCIt ib = rechitsInChamber.begin(); 
-  EnsembleHitContainerCIt hi, iu; 
+std::unique_ptr<MuonSegFit> ME0SegAlgoRU::addHit( HitAndPositionPtrContainer& proto_segment, const HitAndPosition& aHit) const {
+	proto_segment.push_back(&aHit);
+	// make a fit
+	return makeFit(proto_segment);
+}
 
-  for(hi = proto_segment.begin(); hi != proto_segment.end(); ++hi) { 
-    for(iu = ib; iu != rechitsInChamber.end(); ++iu) { 
-      if(*hi == *iu) 
-	used[iu-ib] = true; 
-    } 
-  } 
-} 
-
-bool ME0SegAlgoRU::addHit(const ME0RecHit* aHit, int layer) { 
-
-  // Return true if hit was added successfully
-  // (and then parameters are updated).
-  // Return false if there is already a hit on the same layer, or insert failed.
-
-  EnsembleHitContainer::const_iterator it;
-  
-  for(it = proto_segment.begin(); it != proto_segment.end(); it++)
-    if (((*it)->me0Id().layer() == layer) && (aHit != (*it)))
-      return false;
-  proto_segment.push_back(aHit);
-  // make a fit
-  this->updateParameters();
-  return true;
-} 
-
-void ME0SegAlgoRU::updateParameters() { 
-  // update the current MuonSegFit one and make the fit
-  // for ME0 we take the me0rechit from the proto_segment we transform into Tracking Rechits 
-  // the local rest frame is the ME0Chamber of layer 1 the refPart
+std::unique_ptr<MuonSegFit> ME0SegAlgoRU::makeFit(const HitAndPositionPtrContainer& proto_segment) const {
+  // for ME0 we take the me0rechit from the proto_segment we transform into Tracking Rechits
+  // the local rest frame is the ME0Chamber
   MuonSegFit::MuonRecHitContainer muonRecHits;
-  const auto * refPart = theEnsemble.first;
   for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
-    const ME0EtaPartition * thePartition   = (theEnsemble.second.find((*rh)->me0Id()))->second;
-    GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
-    const LocalPoint lp = refPart->toLocal(gp);
-    ME0RecHit *newRH = (*rh)->clone();
-    newRH->setPosition(lp);
+    ME0RecHit *newRH = (*rh)->rh->clone();
+    newRH->setPosition((*rh)->lp);
     MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
     muonRecHits.push_back(trkRecHit);
   }
-  sfit_.reset(new MuonSegFit(muonRecHits));
-  sfit_->fit();
-} 
+  std::unique_ptr<MuonSegFit> currentFit(new MuonSegFit(muonRecHits));
+  currentFit->fit();
+  return currentFit;
+}
 
-float ME0SegAlgoRU::fit_r_phi(SVector6 points, int layer) const{ 
-  //find R or Phi on the given layer using the given points for the interpolation 
-  float Sx  = 0; 
-  float Sy  = 0; 
-  float Sxx = 0; 
-  float Sxy = 0; 
+void ME0SegAlgoRU::pruneBadHits(const float maxChi2, HitAndPositionPtrContainer& proto_segment,  std::unique_ptr<MuonSegFit>& fit, const unsigned int n_seg_min) const{
+	while(proto_segment.size() > n_seg_min && fit->chi2()/fit->ndof()  > maxChi2){
+		float maxDev = -1;
+		HitAndPositionPtrContainer::iterator worstHit;
+		for(auto it = proto_segment.begin(); it != proto_segment.end(); ++it){
+			const float dev = getHitSegChi2(fit,*(*it)->rh);
+			if(dev < maxDev) continue;
+			maxDev = dev;
+			worstHit = it;
+		}
+		edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::pruneBadHits] pruning one hit-> layer: "<< (*worstHit)->layer <<" eta: "<< (*worstHit)->gp.eta() <<" phi: "<<(*worstHit)->gp.phi()<<" old chi2/dof: "<<fit->chi2()/fit->ndof() << std::endl;
+		proto_segment.erase( worstHit);
+		fit = makeFit(proto_segment);
+	}
+}
 
-  for (int i=1;i<7;i++){ 
-    if (points(i-1)== 0.) continue; 
-    Sy = Sy + (points(i-1)); 
-    Sx = Sx + i; 
-    Sxx = Sxx + (i*i); 
-    Sxy = Sxy + ((i)*points(i-1)); 
-  } 
-  float delta = 2*Sxx - Sx*Sx; 
-  float intercept = (Sxx*Sy - Sx*Sxy)/delta; 
-  float slope = (2*Sxy - Sx*Sy)/delta;                                                                                                                        
-  return (intercept + slope*layer); 
-} 
+float ME0SegAlgoRU::getHitSegChi2(const std::unique_ptr<MuonSegFit>& fit, const ME0RecHit& hit) const{
+	const auto lp = hit.localPosition();
+	const auto le = hit.localPositionError();
+	const float du = fit->xdev(lp.x(),lp.z());
+	const float dv = fit->ydev(lp.y(),lp.z());
 
-void ME0SegAlgoRU::baseline(int n_seg_min){ 
+	ROOT::Math::SMatrix<double,2,2,ROOT::Math::MatRepSym<double,2> > IC;
+	IC(0,0) = le.xx();
+	IC(1,0) = le.xy();
+	IC(1,1) = le.yy();
 
-  int nhits      = proto_segment.size(); 
-  EnsembleHitContainer::const_iterator iRH_worst; 
-  //initialise vectors for strip position and error within strip
-  SVector6 sp; 
-  SVector6 se;  
+	// Invert covariance matrix
+	IC.Invert();
+	return du*du*IC(0,0) + 2.*du*dv*IC(0,1) + dv*dv*IC(1,1);
+}
 
-  unsigned int init_size = proto_segment.size(); 
-  
-  EnsembleHitContainer buffer; 
-  buffer.clear(); 
-  buffer.reserve(init_size);
-  while (buffer.size()< init_size){ 
-    EnsembleHitContainer::iterator min; 
-    int min_layer = 99; 
-    for(EnsembleHitContainer::iterator k = proto_segment.begin(); k != proto_segment.end(); k++){             
-      const ME0RecHit* iRHk = *k;  
-      ME0DetId idRHk = iRHk->me0Id(); 
-      int kLayer   = idRHk.layer(); 
-      if(kLayer < min_layer){ 
-	min_layer = kLayer; 
-	min = k; 
-      } 
-    } 
-    buffer.push_back(*min); 
-    proto_segment.erase(min);
-  }//while 
-  proto_segment.clear();  
+bool ME0SegAlgoRU::hasHitOnLayer(const HitAndPositionPtrContainer& proto_segment, const unsigned int layer) const {
+  for(const auto* h : proto_segment) if(h->layer == layer) return true;
+  return false;
+}
 
-  for (EnsembleHitContainer::const_iterator cand = buffer.begin(); cand != buffer.end(); cand++) { 
-    proto_segment.push_back(*cand); 
-  } 
-  
-  float phifirst = 0;
-  bool first = true;
-  // fitting the phi global position of the rechits relative to the first phi (to avoid xing the -pi, pi transition....
-  for(EnsembleHitContainer::const_iterator iRH = proto_segment.begin(); iRH != proto_segment.end(); iRH++){       
-    const ME0RecHit* iRHp = *iRH;
-    ME0DetId idRH = iRHp->me0Id();
-    int kLayer = idRH.layer();
-    const ME0EtaPartition * thePartition   = (theEnsemble.second).find(idRH)->second;
-    GlobalPoint gp = thePartition->toGlobal(iRHp->localPosition());
-    float pphi = gp.phi();
-    float prad = gp.perp();
-    if (first) sp(kLayer) = 0;
-    else
-      sp(kLayer) =  pphi*prad -phifirst;      
-    se(kLayer) = sqrt(iRHp->localPositionError().xx());
-    if (first){
-      phifirst = pphi*prad;
-      first = false;
-    }
-  }
+void ME0SegAlgoRU::compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const {
+	const HitAndPosition * old_hit = 0;
+	HitAndPositionPtrContainer new_proto_segment = current_proto_segment;
 
-  float chi2_str; 
-  this->fitX(sp, se, -1, -1, chi2_str); 
+	HitAndPositionPtrContainer::const_iterator it;
+	for (auto it = new_proto_segment.begin(); it != new_proto_segment.end();) {
+		if ((*it)->layer == new_hit.layer) {
+			old_hit = *it;
+			it = new_proto_segment.erase(it);
+		} else {
+			++it;
+		}
+	}
+	auto new_fit = addHit(new_proto_segment,new_hit);
 
-  //----------------------------------------------------- 
-  // Optimal point rejection method 
-  //----------------------------------------------------- 
+	//If on the same strip but different BX choose the closest
+	bool useNew = false;
+	if(old_hit->lp == new_hit.lp ){
+		float avgtof = 0;
+		for(const auto* h : current_proto_segment)
+			if(old_hit != h) avgtof += h->rh->tof();
+		avgtof /= float(current_proto_segment.size() - 1);
+		if(std::abs(avgtof - new_hit.rh->tof() ) <
+				std::abs(avgtof - old_hit->rh->tof() )
+		) useNew = true;
+	} //otherwise base it on chi2
+	else if(new_fit->chi2() < current_fit->chi2()) useNew = true;
 
-  float minSum = 1000; 
-  int i1b = 0; 
-  int i2b = 0;  
-  int iworst = -1;  
-  int bad_layer = -1; 
-  EnsembleHitContainer::const_iterator rh_to_be_deleted_1; 
-  EnsembleHitContainer::const_iterator rh_to_be_deleted_2; 
-  if ( nhits > n_seg_min && (chi2_str/(nhits-2)) > chi2_str_*chi2D_iadd){ 
-    for (EnsembleHitContainer::const_iterator i1 = proto_segment.begin(); i1 != proto_segment.end();++i1) { 
-      ++i1b; 
-      const ME0RecHit* i1_1 = *i1;  
-      ME0DetId idRH1 = i1_1->me0Id(); 
-      int z1 = idRH1.layer(); 
-      i2b = i1b; 
-      for (EnsembleHitContainer::const_iterator i2 = i1+1; i2 != proto_segment.end(); ++i2) { 
-	++i2b;  
-	const ME0RecHit* i2_1 = *i2; 
-	ME0DetId idRH2 = i2_1->me0Id(); 
-	int z2 = idRH2.layer(); 
-	int irej = 0; 
+	if(useNew){
+		current_proto_segment = new_proto_segment;
+		current_fit = std::move(new_fit);
+	}
 
-	for ( EnsembleHitContainer::const_iterator ir = proto_segment.begin(); ir != proto_segment.end(); ++ir) { 
-	  ++irej;  
+}
 
-	  if (ir == i1 || ir == i2) continue;  
-	  float dsum = 0; 
-	  int hit_nr = 0; 
-	  const ME0RecHit* ir_1 = *ir; 
-	  ME0DetId idRH = ir_1->me0Id(); 
-	  int worst_layer = idRH.layer(); 
-	  for (EnsembleHitContainer::const_iterator i = proto_segment.begin(); i != proto_segment.end(); ++i) {  
-	    ++hit_nr;   
-	    const ME0RecHit* i_1 = *i; 
-	    if (i == i1 || i == i2 || i == ir) continue;  
-	    float slope = (sp(z2-1)-sp(z1-1))/(z2-z1); 
-	    float intersept = sp(z1-1) - slope*z1; 
-	    ME0DetId idRH = i_1->me0Id(); 
-	    int z = idRH.layer(); 
-	    float di = fabs(sp(z-1) - intersept - slope*z); 
-	    dsum = dsum + di; 
-	  }//i 
-	  if (dsum < minSum){ 
-	    minSum = dsum;  
-	    bad_layer = worst_layer;		   
-	    iworst = irej;  
-	    rh_to_be_deleted_1 = ir; 
-	  } 
-	}//ir  
-      }//i2 
-    }//i1 
-    this->fitX(sp, se, bad_layer, -1, chi2_str); 
-  }//if chi2prob<1.0e-4 
-
-  //find worst from n-1 hits 
-  int iworst2 = -1; 
-  int bad_layer2 = -1; 
-  if (iworst > -1 && (nhits-1) > n_seg_min && (chi2_str/(nhits-3)) > chi2_str_*chi2D_iadd){ 
-    iworst = -1; 
-    float minSum = 1000; 
-    int i1b = 0; 
-    int i2b = 0;  
-    for (EnsembleHitContainer::const_iterator i1 = proto_segment.begin(); i1 != proto_segment.end();++i1) { 
-      ++i1b;  
-      const ME0RecHit* i1_1 = *i1; 
-      ME0DetId idRH1 = i1_1->me0Id(); 
-      int z1 = idRH1.layer(); 
-      i2b = i1b; 
-      for ( EnsembleHitContainer::const_iterator i2 = i1+1; i2 != proto_segment.end(); ++i2) { 
-	++i2b;  
-	const ME0RecHit* i2_1 = *i2; 
-
-	ME0DetId idRH2 = i2_1->me0Id(); 
-	int z2 = idRH2.layer(); 
-	int irej = 0; 
-
-	for ( EnsembleHitContainer::const_iterator ir = proto_segment.begin(); ir != proto_segment.end(); ++ir) { 
-
-	  ++irej;   
-	  int irej2 = 0; 
-	  if (ir == i1 || ir == i2 ) continue;  
-	  const ME0RecHit* ir_1 = *ir; 
-	  ME0DetId idRH = ir_1->me0Id(); 
-	  int worst_layer = idRH.layer(); 
-	  for (  EnsembleHitContainer::const_iterator ir2 = proto_segment.begin(); ir2 != proto_segment.end(); ++ir2) { 
-
-            ++irej2;   
-	    if (ir2 == i1 || ir2 == i2 || ir2 ==ir ) continue;  
-	    float dsum = 0; 
-	    int hit_nr = 0; 
-	    const ME0RecHit* ir2_1 = *ir2; 
-	    ME0DetId idRH = ir2_1->me0Id(); 
-	    int worst_layer2 = idRH.layer(); 
-	    for (  EnsembleHitContainer::const_iterator i = proto_segment.begin(); i != proto_segment.end(); ++i) {  
-	      ++hit_nr;  
-	      const ME0RecHit* i_1 = *i; 
-	      if (i == i1 || i == i2 || i == ir|| i == ir2 ) continue;  
-	      float slope = (sp(z2-1)-sp(z1-1))/(z2-z1); 
-	      float intersept = sp(z1-1) - slope*z1; 
-	      ME0DetId idRH = i_1->me0Id(); 
-	      int z = idRH.layer(); 
-	      float di = fabs(sp(z-1) - intersept - slope*z); 
-	      dsum = dsum + di; 
-	    }//i 
-	    if (dsum < minSum){ 
-	      minSum = dsum;  
-	      iworst2 = irej2;  
-	      iworst = irej; 
-	      bad_layer = worst_layer; 
-	      bad_layer2 = worst_layer2;  
-	      rh_to_be_deleted_1 = ir; 
-	      rh_to_be_deleted_2 = ir2; 
-	    } 
-	  }//ir2  
-	}//ir  
-      }//i2 
-    }//i1	 
-
-    this->fitX(sp, se, bad_layer ,bad_layer2, chi2_str); 
-  }//if prob(n-1)<e-4 
-
-  //---------------------------------- 
-  //erase bad_hits 
-  //---------------------------------- 
-
-  if( iworst2-1 >= 0 && iworst2 <= int(proto_segment.size())  ) { 
-    proto_segment.erase( rh_to_be_deleted_2); 
-  } 
-
-  if( iworst-1 >= 0 && iworst <= int(proto_segment.size())  ){ 
-    proto_segment.erase(rh_to_be_deleted_1); 
-  } 
-} 
-
-float ME0SegAlgoRU::fitX(SVector6 points, SVector6 errors, int ir, int ir2, float &chi2_str){ 
-
-  float S   = 0; 
-  float Sx  = 0; 
-  float Sy  = 0; 
-  float Sxx = 0; 
-  float Sxy = 0; 
-  float sigma2 = 0; 
-
-  for (int i=1;i<7;i++){ 
-    if (i == ir || i == ir2 || points(i-1) == 0.) continue; 
-    sigma2 = errors(i-1)*errors(i-1); 
-    float i1 = i - 3.5; 
-    S = S + (1/sigma2); 
-    Sy = Sy + (points(i-1)/sigma2); 
-    Sx = Sx + ((i1)/sigma2); 
-    Sxx = Sxx + (i1*i1)/sigma2; 
-    Sxy = Sxy + (((i1)*points(i-1))/sigma2); 
-  } 
-
-  float delta = S*Sxx - Sx*Sx; 
-  float intercept = (Sxx*Sy - Sx*Sxy)/delta; 
-  float slope = (S*Sxy - Sx*Sy)/delta; 
-
-  float chi_str = 0; 
-  chi2_str = 0; 
-
-  // calculate chi2_str 
-  for (int i=1;i<7;i++){ 
-    if (i == ir || i == ir2 || points(i-1) == 0.) continue; 
-    chi_str = (points(i-1) - intercept - slope*(i-3.5))/(errors(i-1)); 
-    chi2_str = chi2_str + chi_str*chi_str;  
-  } 
-
-  return (intercept + slope*0); 
-} 
-
-bool ME0SegAlgoRU::hasHitOnLayer(int layer) const { 
-
-  // Is there is already a hit on this layer? 
-  EnsembleHitContainerCIt it; 
-
-  for(it = proto_segment.begin(); it != proto_segment.end(); it++) 
-    if ((*it)->me0Id().layer() == layer) 
-      return true;  
-
-  return false; 
-} 
-
-bool ME0SegAlgoRU::replaceHit(const ME0RecHit* h, int layer) { 
-
-  // replace a hit from a layer  
-  EnsembleHitContainer::const_iterator it; 
-  for (it = proto_segment.begin(); it != proto_segment.end();) { 
-    if ((*it)->me0Id().layer() == layer) {
-      it = proto_segment.erase(it); 
-    } else {
-      ++it;    
-    }
-  } 
-  
-  return addHit(h, layer);				     
-} 
-
-void ME0SegAlgoRU::compareProtoSegment(const ME0RecHit* h, int layer) { 
-   // Copy the input MuonSegFit                                                                                                                                                      
-  std::unique_ptr<MuonSegFit> oldfit;// =  new MuonSegFit( *sfit_ );                                                                                                                  
-
-  MuonSegFit::MuonRecHitContainer muonRecHits;
-  const auto * refPart = theEnsemble.first;
-  for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
-    const ME0EtaPartition * thePartition   = (theEnsemble.second.find((*rh)->me0Id()))->second;
-    GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
-    const LocalPoint lp = refPart->toLocal(gp);
-    ME0RecHit *newRH = (*rh)->clone();
-    newRH->setPosition(lp);
-    MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
-    muonRecHits.push_back(trkRecHit);
-  }
-  oldfit.reset(new MuonSegFit( muonRecHits ));
-  oldfit->fit();
-  auto oldproto = proto_segment;
-   // May create a new fit
-  bool ok = this->replaceHit(h, layer);
-  if ( ( sfit_->chi2() >= oldfit->chi2() ) || !ok ) {
-    sfit_ = std::move(oldfit); // reset to the original input fit 
-    proto_segment = oldproto;
-  }
-} 
-
-void ME0SegAlgoRU::increaseProtoSegment(const ME0RecHit* h, int layer, int chi2_factor) { 
-
-  MuonSegFit::MuonRecHitContainer muonRecHits;
-  const auto* refPart = theEnsemble.first;
-  for (auto rh=proto_segment.begin();rh<proto_segment.end(); rh++){
-    const ME0EtaPartition * thePartition   = (theEnsemble.second.find((*rh)->me0Id()))->second;
-    GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
-    const LocalPoint lp = refPart->toLocal(gp);
-    ME0RecHit *newRH = (*rh)->clone();
-    newRH->setPosition(lp);
-    MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
-    muonRecHits.push_back(trkRecHit);
-  }
-
-  // Creates a new fit
-  std::unique_ptr<MuonSegFit> oldfit;
-  oldfit.reset(new MuonSegFit( muonRecHits ));
-  oldfit->fit();
-  auto oldproto = proto_segment;
-  bool ok = this->addHit(h, layer);
-  //@@ TEST ON ndof<=0 IS JUST TO ACCEPT nhits=2 CASE??
-  if ( !ok || ( (sfit_->ndof() > 0) && (sfit_->chi2()/sfit_->ndof() >= chi2Max)) ) {
-    sfit_ = std::move(oldfit);
-    proto_segment = oldproto;
-  }
+void ME0SegAlgoRU::increaseProtoSegment(const float maxChi2, std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const {
+	HitAndPositionPtrContainer new_proto_segment = current_proto_segment;
+	auto new_fit = addHit(new_proto_segment,new_hit);
+//	edm::LogVerbatim("ME0SegAlgoRU") << "[ME0SegAlgoRU::increaseProtoSegment] new chi2 = "<<new_fit->chi2()<<" new chi2/dof = "<<new_fit->chi2()/new_fit->ndof() <<" ==> add: " << (new_fit->chi2()/new_fit->ndof() < maxChi2 ) <<std::endl;
+	if(new_fit->chi2()/new_fit->ndof() < maxChi2 ){
+		current_proto_segment = new_proto_segment;
+		current_fit = std::move(new_fit);
+	}
 }

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
@@ -1,0 +1,160 @@
+#ifndef ME0Segment_ME0SegAlgoRU_h
+#define ME0Segment_ME0SegAlgoRU_h
+
+/**
+ * \class ME0SegAlgoRU
+ * adapted from CSC to ME0 bt Marcello Maggi
+ *
+ * This is the original algorithm for building endcap muon track segments
+ * out of the rechit's in a ME0Chamber
+ * 'RU' = 'RUssia' = Road Usage
+ *
+ * A ME0Segment is a RecSegment4D, and is built from
+ * ME0RecHit2D objects, each of which is a RecHit2DLocalPos. <BR>
+ *
+ * This class is used by the ME0SegmentAlgorithm. <BR>
+ * Alternative algorithms can be used for the segment building
+ * by writing classes like this, and then selecting which one is actually
+ * used via the ME0SegmentBuilder. <BR>
+ *
+ * developed and implemented by Vladimir Palichik <Vladimir.Paltchik@cern.ch>
+ *                          and Nikolay Voytishin <nikolay.voytishin@cern.ch>
+ */
+
+#include <RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithmBase.h>
+#include <DataFormats/GEMRecHit/interface/ME0RecHit.h>
+#include "MuonSegFit.h"
+
+#include <Math/Functions.h>
+#include <Math/SVector.h>
+#include <Math/SMatrix.h>
+
+#include <vector>
+
+class MuonSegFit;
+
+class ME0SegAlgoRU : public ME0SegmentAlgorithmBase {
+
+public:
+
+    // Tim tried using map as basic container of all (space-point) RecHit's in a chamber:
+    // The 'key' is a pseudo-layer number (1-6 but with 1 always closest to IP).
+    // The 'value' is a vector of the RecHit's on that layer.
+    // Using the layer number like this removes the need to sort in global z.
+    // Instead we just have to ensure the layer index is correctly adjusted 
+    // to enforce the requirement that 'layer 1' is closest in the chamber
+    // to the IP.
+    // For ME0 those are 6 different ME0Chamber forming an ME0Ensemble
+
+    /// Typedefs
+  
+  
+    // 4-dim vector                                                                                                                                                                   
+    typedef ROOT::Math::SVector<double,6> SVector6;
+    typedef std::vector<int> LayerIndex;
+    typedef EnsembleHitContainer::const_iterator EnsembleHitContainerCIt;
+
+    // We need to be able to flag a hit as 'used' and so need a container of bool's. 
+    typedef std::vector<bool> BoolContainer;
+    
+    /// Constructor
+    explicit ME0SegAlgoRU(const edm::ParameterSet& ps);
+    /// Destructor
+    virtual ~ME0SegAlgoRU() {};
+
+    /**
+     * Build track segments in this chamber (this is where the actual
+     * segment-building algorithm hides.)
+     */
+    std::vector<ME0Segment> buildSegments(const EnsembleHitContainer& rechits);
+
+    //    std::vector<ME0Segment> assambleRechitsInSegments(const EnsembleHitContainer& rechits, int iadd, BoolContainer& used, BoolContainer& used3p, int *recHits_per_layer, const LayerIndex& layerIndex, std::vector<ME0Segment> segments);
+
+    /**
+     * Here we must implement the algorithm
+     */
+    std::vector<ME0Segment> run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits); 
+
+private:
+
+    /// Utility functions 
+    // Could be static at the moment, but in principle one
+    // might like ME0Segmentizer-specific behaviour?
+    bool areHitsCloseInEta(const ME0RecHit* h1, const ME0RecHit* h2) const;
+    bool areHitsCloseInGlobalPhi(const ME0RecHit* h1, const ME0RecHit* h2) const;
+    bool isHitNearSegment(const ME0RecHit* h) const;
+
+    /**
+     * Try adding non-used hits to segment
+     */
+    void tryAddingHitsToSegment(const EnsembleHitContainer& rechitsInChamber,
+	const BoolContainer& used, const LayerIndex& layerIndex,
+        const EnsembleHitContainerCIt i1, const EnsembleHitContainerCIt i2);
+
+    /**
+     * Return true if segment is 'good'.
+     * In this algorithm, 'good' means has sufficient hits
+     */
+    bool isSegmentGood(const EnsembleHitContainer& rechitsInChamber) const;
+
+    /**
+     * Flag hits on segment as used
+     */
+    void flagHitsAsUsed(const EnsembleHitContainer& rechitsInChamber, BoolContainer& used) const;
+	
+    /// Utility functions 	
+    bool addHit(const ME0RecHit* hit, int layer);
+    void updateParameters(void);
+    float fit_r_phi(SVector6 points, int layer) const;
+    float fitX(SVector6 points, SVector6 errors, int ir, int ir2, float &chi2_str);
+    void baseline(int n_seg_min);//function for arasing bad hits in case of bad chi2/NDOF 
+   /**
+     * Always enforce direction of segment to point from IP outwards
+     * (Incorrect for particles not coming from IP, of course.)
+     */
+    float phiAtZ(float z) const;
+    bool hasHitOnLayer(int layer) const;
+    bool replaceHit(const ME0RecHit* h, int layer);
+    void compareProtoSegment(const ME0RecHit* h, int layer);
+    void increaseProtoSegment(const ME0RecHit* h, int layer, int chi2_factor);
+
+		
+    // Member variables
+    // ================
+
+    ME0Ensemble theEnsemble;
+    EnsembleHitContainer proto_segment;
+    const std::string myName; 
+		
+    double theChi2;
+    LocalPoint theOrigin;
+    LocalVector theDirection;
+    float uz, vz;
+    float windowScale;
+    int chi2D_iadd=1;
+    int strip_iadd=1;	
+    bool doCollisions;
+    float dRMax ;
+    float dPhiMax;
+    float dRIntMax;
+    float dPhiIntMax;
+    float chi2Max;
+    float chi2_str_;
+    float chi2Norm_2D_; 
+    float wideSeg;
+    int minLayersApart;
+    bool debugInfo;
+
+    std::unique_ptr<MuonSegFit> sfit_;
+};
+
+// functor to sort rechits in the segment
+struct  sortByLayer{
+  sortByLayer(){}
+  bool operator()(const ME0RecHit* a, const ME0RecHit* b) const{
+    int layer1 = a->me0Id().layer();
+    int layer2 = b->me0Id().layer();
+    return  layer1 < layer2;
+  }
+};
+#endif

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
@@ -25,37 +25,29 @@
 #include <DataFormats/GEMRecHit/interface/ME0RecHit.h>
 #include "MuonSegFit.h"
 
-#include <Math/Functions.h>
-#include <Math/SVector.h>
-#include <Math/SMatrix.h>
 
 #include <vector>
 
 class MuonSegFit;
-
 class ME0SegAlgoRU : public ME0SegmentAlgorithmBase {
 
 public:
+	struct SegmentParameters {
+		float maxETASeeds       ;
+		float maxPhiSeeds       ;
+		float maxPhiAdditional  ;
+		float maxChi2Additional ;
+		float maxChi2Prune      ;
+		float maxChi2GoodSeg    ;
+		float maxTOFDiff        ;
+		unsigned int minNumberOfHits;
+		bool  requireBeamConstr  ;
 
-    // Tim tried using map as basic container of all (space-point) RecHit's in a chamber:
-    // The 'key' is a pseudo-layer number (1-6 but with 1 always closest to IP).
-    // The 'value' is a vector of the RecHit's on that layer.
-    // Using the layer number like this removes the need to sort in global z.
-    // Instead we just have to ensure the layer index is correctly adjusted 
-    // to enforce the requirement that 'layer 1' is closest in the chamber
-    // to the IP.
-    // For ME0 those are 6 different ME0Chamber forming an ME0Ensemble
-
-    /// Typedefs
-  
-  
-    // 4-dim vector                                                                                                                                                                   
-    typedef ROOT::Math::SVector<double,6> SVector6;
-    typedef std::vector<int> LayerIndex;
-    typedef EnsembleHitContainer::const_iterator EnsembleHitContainerCIt;
+	};
 
     // We need to be able to flag a hit as 'used' and so need a container of bool's. 
     typedef std::vector<bool> BoolContainer;
+	typedef std::vector<std::pair<float,HitAndPositionPtrContainer> > SegmentByMetricContainer;
     
     /// Constructor
     explicit ME0SegAlgoRU(const edm::ParameterSet& ps);
@@ -63,98 +55,58 @@ public:
     virtual ~ME0SegAlgoRU() {};
 
     /**
-     * Build track segments in this chamber (this is where the actual
-     * segment-building algorithm hides.)
-     */
-    std::vector<ME0Segment> buildSegments(const EnsembleHitContainer& rechits);
-
-    //    std::vector<ME0Segment> assambleRechitsInSegments(const EnsembleHitContainer& rechits, int iadd, BoolContainer& used, BoolContainer& used3p, int *recHits_per_layer, const LayerIndex& layerIndex, std::vector<ME0Segment> segments);
-
-    /**
      * Here we must implement the algorithm
      */
-    std::vector<ME0Segment> run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits); 
+    std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits);
 
 private:
 
-    /// Utility functions 
-    // Could be static at the moment, but in principle one
-    // might like ME0Segmentizer-specific behaviour?
-    bool areHitsCloseInEta(const ME0RecHit* h1, const ME0RecHit* h2) const;
-    bool areHitsCloseInGlobalPhi(const ME0RecHit* h1, const ME0RecHit* h2) const;
-    bool isHitNearSegment(const ME0RecHit* h) const;
+    //Look for segments that have at least "n_seg_min" consituents and following the associated paramters
+    void lookForSegments(const SegmentParameters& params, const unsigned int n_seg_min, const HitAndPositionContainer& rechits, const std::vector<unsigned int>& recHits_per_layer, BoolContainer& used, std::vector<ME0Segment>& segments) const;
+    //Look for any hits between the two seed hits consistent with a segment
+    void tryAddingHitsToSegment( const float maxTOF,const float maxETA,  const float maxPhi, const float maxChi2, std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& proto_segment,
+    					  const BoolContainer& used, HitAndPositionContainer::const_iterator i1, HitAndPositionContainer::const_iterator i2) const;
+    //Remove extra hits until the segment passes "maxChi2"
+    void pruneBadHits(const float maxChi2, HitAndPositionPtrContainer& proto_segment,  std::unique_ptr<MuonSegFit>& fit, const unsigned int n_seg_min) const;
+    //Remove any overlapping segments by which has the lowset chi2
+    void addUniqueSegments(SegmentByMetricContainer& proto_segments, std::vector<ME0Segment>& segments, BoolContainer& used) const;
 
-    /**
-     * Try adding non-used hits to segment
-     */
-    void tryAddingHitsToSegment(const EnsembleHitContainer& rechitsInChamber,
-	const BoolContainer& used, const LayerIndex& layerIndex,
-        const EnsembleHitContainerCIt i1, const EnsembleHitContainerCIt i2);
+    //Are the two seed hits consistent spatially?
+    bool areHitsCloseInEta(const float maxETA, const bool beamConst,  const GlobalPoint& h1, const GlobalPoint& h2) const;
+    bool areHitsCloseInGlobalPhi(const float maxPHI, const unsigned int nLayDisp, const GlobalPoint& h1, const GlobalPoint& h2) const;
 
-    /**
-     * Return true if segment is 'good'.
-     * In this algorithm, 'good' means has sufficient hits
-     */
-    bool isSegmentGood(const EnsembleHitContainer& rechitsInChamber) const;
+    //Add a hit to a segment
+    std::unique_ptr<MuonSegFit> addHit(HitAndPositionPtrContainer& proto_segment, const HitAndPosition& aHit) const;
+    //Does the segment have any hits on this layer?
+    bool hasHitOnLayer(const HitAndPositionPtrContainer& proto_segment, const unsigned int layer) const;
+    //Produce a new fit
+    std::unique_ptr<MuonSegFit> makeFit(const HitAndPositionPtrContainer& proto_segment) const;
 
-    /**
-     * Flag hits on segment as used
-     */
-    void flagHitsAsUsed(const EnsembleHitContainer& rechitsInChamber, BoolContainer& used) const;
-	
-    /// Utility functions 	
-    bool addHit(const ME0RecHit* hit, int layer);
-    void updateParameters(void);
-    float fit_r_phi(SVector6 points, int layer) const;
-    float fitX(SVector6 points, SVector6 errors, int ir, int ir2, float &chi2_str);
-    void baseline(int n_seg_min);//function for arasing bad hits in case of bad chi2/NDOF 
-   /**
-     * Always enforce direction of segment to point from IP outwards
-     * (Incorrect for particles not coming from IP, of course.)
-     */
-    float phiAtZ(float z) const;
-    bool hasHitOnLayer(int layer) const;
-    bool replaceHit(const ME0RecHit* h, int layer);
-    void compareProtoSegment(const ME0RecHit* h, int layer);
-    void increaseProtoSegment(const ME0RecHit* h, int layer, int chi2_factor);
+    //Is this hit consistent in time with the other hits?
+    bool areHitsConsistentInTime(const float maxTOF, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h)  const;
+    //Is this new hit btw the seeds near the segment fit?
+    bool isHitNearSegment(const float maxETA, const float maxPHI, const std::unique_ptr<MuonSegFit>& fit, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h)  const;
+    //Return a chi2 for a hit and a predicted segment extrapolation
+    float getHitSegChi2(const std::unique_ptr<MuonSegFit>& fit, const ME0RecHit& hit) const;
+    //Global point of a segment extrapolated to a Z value
+    GlobalPoint globalAtZ(const std::unique_ptr<MuonSegFit>& fit, float z) const;
 
-		
-    // Member variables
-    // ================
+    //Try adding a hit instead of another and return new or old, depending on which has the smallest chi2
+    void compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const;
+    //Try adding this hit to the segment, dont if the new chi2 is too big
+    void increaseProtoSegment(const float maxChi2,  std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const;
 
-    ME0Ensemble theEnsemble;
-    EnsembleHitContainer proto_segment;
-    const std::string myName; 
-		
-    double theChi2;
-    LocalPoint theOrigin;
-    LocalVector theDirection;
-    float uz, vz;
-    float windowScale;
-    int chi2D_iadd=1;
-    int strip_iadd=1;	
-    bool doCollisions;
-    float dRMax ;
-    float dPhiMax;
-    float dRIntMax;
-    float dPhiIntMax;
-    float chi2Max;
-    float chi2_str_;
-    float chi2Norm_2D_; 
-    float wideSeg;
-    int minLayersApart;
-    bool debugInfo;
 
-    std::unique_ptr<MuonSegFit> sfit_;
+    const std::string myName;
+	bool doCollisions;
+    bool allowWideSegments;
+
+    SegmentParameters stdParameters;
+    SegmentParameters displacedParameters;
+    SegmentParameters wideParameters;
+
+    //Objects used to produce the segments
+    const ME0Chamber *theChamber;
 };
 
-// functor to sort rechits in the segment
-struct  sortByLayer{
-  sortByLayer(){}
-  bool operator()(const ME0RecHit* a, const ME0RecHit* b) const{
-    int layer1 = a->me0Id().layer();
-    int layer2 = b->me0Id().layer();
-    return  layer1 < layer2;
-  }
-};
 #endif

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h
@@ -45,68 +45,68 @@ public:
 
 	};
 
-    // We need to be able to flag a hit as 'used' and so need a container of bool's. 
-    typedef std::vector<bool> BoolContainer;
+	// We need to be able to flag a hit as 'used' and so need a container of bool's.
+	typedef std::vector<bool> BoolContainer;
 	typedef std::vector<std::pair<float,HitAndPositionPtrContainer> > SegmentByMetricContainer;
-    
-    /// Constructor
-    explicit ME0SegAlgoRU(const edm::ParameterSet& ps);
-    /// Destructor
-    virtual ~ME0SegAlgoRU() {};
 
-    /**
-     * Here we must implement the algorithm
-     */
-    std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits);
+	/// Constructor
+	explicit ME0SegAlgoRU(const edm::ParameterSet& ps);
+	/// Destructor
+	virtual ~ME0SegAlgoRU() {};
+
+	/**
+	 * Here we must implement the algorithm
+	 */
+	std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits);
 
 private:
 
-    //Look for segments that have at least "n_seg_min" consituents and following the associated paramters
-    void lookForSegments(const SegmentParameters& params, const unsigned int n_seg_min, const HitAndPositionContainer& rechits, const std::vector<unsigned int>& recHits_per_layer, BoolContainer& used, std::vector<ME0Segment>& segments) const;
-    //Look for any hits between the two seed hits consistent with a segment
-    void tryAddingHitsToSegment( const float maxTOF,const float maxETA,  const float maxPhi, const float maxChi2, std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& proto_segment,
-    					  const BoolContainer& used, HitAndPositionContainer::const_iterator i1, HitAndPositionContainer::const_iterator i2) const;
-    //Remove extra hits until the segment passes "maxChi2"
-    void pruneBadHits(const float maxChi2, HitAndPositionPtrContainer& proto_segment,  std::unique_ptr<MuonSegFit>& fit, const unsigned int n_seg_min) const;
-    //Remove any overlapping segments by which has the lowset chi2
-    void addUniqueSegments(SegmentByMetricContainer& proto_segments, std::vector<ME0Segment>& segments, BoolContainer& used) const;
+	//Look for segments that have at least "n_seg_min" consituents and following the associated paramters
+	void lookForSegments(const SegmentParameters& params, const unsigned int n_seg_min, const HitAndPositionContainer& rechits, const std::vector<unsigned int>& recHits_per_layer, BoolContainer& used, std::vector<ME0Segment>& segments) const;
+	//Look for any hits between the two seed hits consistent with a segment
+	void tryAddingHitsToSegment( const float maxTOF,const float maxETA,  const float maxPhi, const float maxChi2, std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& proto_segment,
+			const BoolContainer& used, HitAndPositionContainer::const_iterator i1, HitAndPositionContainer::const_iterator i2) const;
+	//Remove extra hits until the segment passes "maxChi2"
+	void pruneBadHits(const float maxChi2, HitAndPositionPtrContainer& proto_segment,  std::unique_ptr<MuonSegFit>& fit, const unsigned int n_seg_min) const;
+	//Remove any overlapping segments by which has the lowset chi2
+	void addUniqueSegments(SegmentByMetricContainer& proto_segments, std::vector<ME0Segment>& segments, BoolContainer& used) const;
 
-    //Are the two seed hits consistent spatially?
-    bool areHitsCloseInEta(const float maxETA, const bool beamConst,  const GlobalPoint& h1, const GlobalPoint& h2) const;
-    bool areHitsCloseInGlobalPhi(const float maxPHI, const unsigned int nLayDisp, const GlobalPoint& h1, const GlobalPoint& h2) const;
+	//Are the two seed hits consistent spatially?
+	bool areHitsCloseInEta(const float maxETA, const bool beamConst,  const GlobalPoint& h1, const GlobalPoint& h2) const;
+	bool areHitsCloseInGlobalPhi(const float maxPHI, const unsigned int nLayDisp, const GlobalPoint& h1, const GlobalPoint& h2) const;
 
-    //Add a hit to a segment
-    std::unique_ptr<MuonSegFit> addHit(HitAndPositionPtrContainer& proto_segment, const HitAndPosition& aHit) const;
-    //Does the segment have any hits on this layer?
-    bool hasHitOnLayer(const HitAndPositionPtrContainer& proto_segment, const unsigned int layer) const;
-    //Produce a new fit
-    std::unique_ptr<MuonSegFit> makeFit(const HitAndPositionPtrContainer& proto_segment) const;
+	//Add a hit to a segment
+	std::unique_ptr<MuonSegFit> addHit(HitAndPositionPtrContainer& proto_segment, const HitAndPosition& aHit) const;
+	//Does the segment have any hits on this layer?
+	bool hasHitOnLayer(const HitAndPositionPtrContainer& proto_segment, const unsigned int layer) const;
+	//Produce a new fit
+	std::unique_ptr<MuonSegFit> makeFit(const HitAndPositionPtrContainer& proto_segment) const;
 
-    //Is this hit consistent in time with the other hits?
-    bool areHitsConsistentInTime(const float maxTOF, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h)  const;
-    //Is this new hit btw the seeds near the segment fit?
-    bool isHitNearSegment(const float maxETA, const float maxPHI, const std::unique_ptr<MuonSegFit>& fit, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h)  const;
-    //Return a chi2 for a hit and a predicted segment extrapolation
-    float getHitSegChi2(const std::unique_ptr<MuonSegFit>& fit, const ME0RecHit& hit) const;
-    //Global point of a segment extrapolated to a Z value
-    GlobalPoint globalAtZ(const std::unique_ptr<MuonSegFit>& fit, float z) const;
+	//Is this hit consistent in time with the other hits?
+	bool areHitsConsistentInTime(const float maxTOF, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h)  const;
+	//Is this new hit btw the seeds near the segment fit?
+	bool isHitNearSegment(const float maxETA, const float maxPHI, const std::unique_ptr<MuonSegFit>& fit, const HitAndPositionPtrContainer& proto_segment, const HitAndPosition& h)  const;
+	//Return a chi2 for a hit and a predicted segment extrapolation
+	float getHitSegChi2(const std::unique_ptr<MuonSegFit>& fit, const ME0RecHit& hit) const;
+	//Global point of a segment extrapolated to a Z value
+	GlobalPoint globalAtZ(const std::unique_ptr<MuonSegFit>& fit, float z) const;
 
-    //Try adding a hit instead of another and return new or old, depending on which has the smallest chi2
-    void compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const;
-    //Try adding this hit to the segment, dont if the new chi2 is too big
-    void increaseProtoSegment(const float maxChi2,  std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const;
+	//Try adding a hit instead of another and return new or old, depending on which has the smallest chi2
+	void compareProtoSegment(std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const;
+	//Try adding this hit to the segment, dont if the new chi2 is too big
+	void increaseProtoSegment(const float maxChi2,  std::unique_ptr<MuonSegFit>& current_fit, HitAndPositionPtrContainer& current_proto_segment, const HitAndPosition& new_hit) const;
 
 
-    const std::string myName;
+	const std::string myName;
 	bool doCollisions;
-    bool allowWideSegments;
+	bool allowWideSegments;
 
-    SegmentParameters stdParameters;
-    SegmentParameters displacedParameters;
-    SegmentParameters wideParameters;
+	SegmentParameters stdParameters;
+	SegmentParameters displacedParameters;
+	SegmentParameters wideParameters;
 
-    //Objects used to produce the segments
-    const ME0Chamber *theChamber;
+	//Objects used to produce the segments
+	const ME0Chamber *theChamber;
 };
 
 #endif

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
@@ -302,13 +302,13 @@ void ME0SegmentAlgorithm::buildSegments(const ME0Ensemble& ensemble, const Ensem
   proto_segment.clear();
   
   // select hits from the ensemble and sort it 
-  const ME0Chamber * chamber   = ensemble.first;
+  const ME0EtaPartition * refPart   = ensemble.first;
   for (auto rh=rechits.begin(); rh!=rechits.end();rh++){
     proto_segment.push_back(*rh);
-    // for segFit - using local point in chamber frame
+    // for segFit - using local point in first partition frame
     const ME0EtaPartition * thePartition   = (ensemble.second.find((*rh)->me0Id()))->second;
     GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
-    const LocalPoint lp = chamber->toLocal(gp);    
+    const LocalPoint lp = refPart->toLocal(gp);    
     ME0RecHit *newRH = (*rh)->clone();
     newRH->setPosition(lp);
 
@@ -342,6 +342,7 @@ void ME0SegmentAlgorithm::buildSegments(const ME0Ensemble& ensemble, const Ensem
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
     timeUncrt += pow((*rh)->tof()-averageTime,2);
   }
+
   if(rechits.size() > 1) timeUncrt=timeUncrt/(rechits.size()-1);
   timeUncrt = sqrt(timeUncrt);
 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
@@ -1,10 +1,10 @@
 /**
  * \file ME0SegmentAlgorithm.cc
  *  based on CSCSegAlgoST.cc
- * 
+ *
  *  \authors: Marcello Maggi, Jason Lee
  */
- 
+
 #include "ME0SegmentAlgorithm.h"
 #include "MuonSegFit.h"
 
@@ -48,15 +48,15 @@ ME0SegmentAlgorithm::~ME0SegmentAlgorithm() {
 }
 
 
-std::vector<ME0Segment> ME0SegmentAlgorithm::run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits) {
+std::vector<ME0Segment> ME0SegmentAlgorithm::run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits) {
 
   #ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
-  ME0DetId chId((ensemble.first)->id());  
+  ME0DetId chId((ensemble.first)->id());
   edm::LogVerbatim("ME0SegAlgoMM") << "[ME0SegmentAlgorithm::run] build segments in chamber " << chId << " which contains "<<rechits.size()<<" rechits";
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
-    auto me0id = (*rh)->me0Id();
-    auto rhLP = (*rh)->localPosition();
-    edm::LogVerbatim("ME0SegmentAlgorithm") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<(*rh)->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
+    auto me0id = (*rh)->rh->me0Id();
+    auto rhLP = (*rh)->lp;
+    edm::LogVerbatim("ME0SegmentAlgorithm") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<(*rh)->rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
   }
   #endif
 
@@ -64,13 +64,13 @@ std::vector<ME0Segment> ME0SegmentAlgorithm::run(const ME0Ensemble& ensemble, co
   std::vector<ME0Segment>          segments_temp;
   std::vector<ME0Segment>          segments;
   ProtoSegments rechits_clusters; // this is a collection of groups of rechits
-  
+
   if(preClustering) {
     // run a pre-clusterer on the given rechits to split obviously separated segment seeds:
     if(preClustering_useChaining){
       // it uses X,Y,Z information; there are no configurable parameters used;
       // the X, Y, Z "cuts" are just (much) wider than reasonable high pt segments
-      rechits_clusters = this->chainHits(ensemble, rechits );
+      rechits_clusters = this->chainHits(chamber, rechits );
     }
     else{
       // it uses X,Y information + configurable parameters
@@ -81,22 +81,24 @@ std::vector<ME0Segment> ME0SegmentAlgorithm::run(const ME0Ensemble& ensemble, co
       // clear the buffer for the subset of segments:
       segments_temp.clear();
       // build the subset of segments:
-      this->buildSegments(ensemble, (*sub_rechits), segments_temp );
+      this->buildSegments((*sub_rechits), segments_temp );
       // add the found subset of segments to the collection of all segments in this chamber:
       segments.insert( segments.end(), segments_temp.begin(), segments_temp.end() );
     }
     return segments;
   }
   else {
-    this->buildSegments(ensemble, rechits, segments);
+	  HitAndPositionPtrContainer ptrRH; ptrRH.reserve(rechits.size());
+	  for(const auto& rh : rechits) ptrRH.push_back(&rh);
+    this->buildSegments(ptrRH, segments);
     return segments;
   }
 }
 
 
 // ********************************************************************;
-ME0SegmentAlgorithm::ProtoSegments 
-ME0SegmentAlgorithm::clusterHits(const EnsembleHitContainer& rechits) {
+ME0SegmentAlgorithm::ProtoSegments
+ME0SegmentAlgorithm::clusterHits(const HitAndPositionContainer& rechits) {
 
   ProtoSegments rechits_clusters; // this is a collection of groups of rechits
 
@@ -114,33 +116,33 @@ ME0SegmentAlgorithm::clusterHits(const EnsembleHitContainer& rechits) {
   std::vector<float> seed_maxY; seed_maxY.reserve(rechits.size());
 
   // split rechits into subvectors and return vector of vectors:
-  // Loop over rechits 
+  // Loop over rechits
   // Create one seed per hit
   for(unsigned int i = 0; i < rechits.size(); ++i) {
-    seeds.push_back(EnsembleHitContainer(1,rechits[i]));
+    seeds.push_back(HitAndPositionPtrContainer(1,&rechits[i]));
 
     // First added hit in seed defines the mean to which the next hit is compared
     // for this seed.
 
-    running_meanX.push_back( rechits[i]->localPosition().x() );
-    running_meanY.push_back( rechits[i]->localPosition().y() );
-	
+    running_meanX.push_back( rechits[i].lp.x() );
+    running_meanY.push_back( rechits[i].lp.y() );
+
     // set min/max X and Y for box containing the hits in the precluster:
-    seed_minX.push_back( rechits[i]->localPosition().x() );
-    seed_maxX.push_back( rechits[i]->localPosition().x() );
-    seed_minY.push_back( rechits[i]->localPosition().y() );
-    seed_maxY.push_back( rechits[i]->localPosition().y() );
+    seed_minX.push_back( rechits[i].lp.x() );
+    seed_maxX.push_back( rechits[i].lp.x() );
+    seed_minY.push_back( rechits[i].lp.y() );
+    seed_maxY.push_back( rechits[i].lp.y() );
   }
-    
+
   // merge clusters that are too close
   // measure distance between final "running mean"
   for(size_t NNN = 0; NNN < seeds.size(); ++NNN) {
     for(size_t MMM = NNN+1; MMM < seeds.size(); ++MMM) {
       if(running_meanX[MMM] == running_max || running_meanX[NNN] == running_max ) {
 	LogDebug("ME0SegmentAlgorithm") << "[ME0SegmentAlgorithm::clusterHits]: ALARM! Skipping used seeds, this should not happen - inform developers!";
-	continue; //skip seeds that have been used 
+	continue; //skip seeds that have been used
       }
-	  
+
       // calculate cut criteria for simple running mean distance cut:
       //dXclus = fabs(running_meanX[NNN] - running_meanX[MMM]);
       //dYclus = fabs(running_meanY[NNN] - running_meanY[MMM]);
@@ -149,12 +151,12 @@ ME0SegmentAlgorithm::clusterHits(const EnsembleHitContainer& rechits) {
       else                                           dXclus_box = seed_minX[MMM] - seed_maxX[NNN];
       if ( running_meanY[NNN] > running_meanY[MMM] ) dYclus_box = seed_minY[NNN] - seed_maxY[MMM];
       else                                           dYclus_box = seed_minY[MMM] - seed_maxY[NNN];
-	  
-	  
+
+
       if( dXclus_box < dXclusBoxMax && dYclus_box < dYclusBoxMax ) {
 	// merge clusters!
 	// merge by adding seed NNN to seed MMM and erasing seed NNN
-	    
+
 	// calculate running mean for the merged seed:
 	if(seeds[NNN].size()+seeds[MMM].size() != 0) {
 	  running_meanX[MMM] = (running_meanX[NNN]*seeds[NNN].size() + running_meanX[MMM]*seeds[MMM].size()) / (seeds[NNN].size()+seeds[MMM].size());
@@ -166,14 +168,14 @@ ME0SegmentAlgorithm::clusterHits(const EnsembleHitContainer& rechits) {
 	if ( seed_maxX[NNN] >  seed_maxX[MMM] ) seed_maxX[MMM] = seed_maxX[NNN];
 	if ( seed_minY[NNN] <  seed_minY[MMM] ) seed_minY[MMM] = seed_minY[NNN];
 	if ( seed_maxY[NNN] >  seed_maxY[MMM] ) seed_maxY[MMM] = seed_maxY[NNN];
-	    
+
 	// add seed NNN to MMM (lower to larger number)
 	seeds[MMM].insert(seeds[MMM].end(),seeds[NNN].begin(),seeds[NNN].end());
-	    
+
 	// mark seed NNN as used (at the moment just set running mean to 999999.)
 	running_meanX[NNN] = running_max;
 	running_meanY[NNN] = running_max;
-	// we have merged a seed (NNN) to the highter seed (MMM) - need to contimue to 
+	// we have merged a seed (NNN) to the highter seed (MMM) - need to contimue to
 	// next seed (NNN+1)
 	break;
       }
@@ -181,33 +183,33 @@ ME0SegmentAlgorithm::clusterHits(const EnsembleHitContainer& rechits) {
   }
 
   // hand over the final seeds to the output
-  // would be more elegant if we could do the above step with 
-  // erasing the merged ones, rather than the 
+  // would be more elegant if we could do the above step with
+  // erasing the merged ones, rather than the
   for(size_t NNN = 0; NNN < seeds.size(); ++NNN) {
     if(running_meanX[NNN] == running_max) continue; //skip seeds that have been marked as used up in merging
     rechits_clusters.push_back(seeds[NNN]);
   }
 
-  return rechits_clusters; 
+  return rechits_clusters;
 }
 
 
-ME0SegmentAlgorithm::ProtoSegments 
-ME0SegmentAlgorithm::chainHits(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits) {
+ME0SegmentAlgorithm::ProtoSegments
+ME0SegmentAlgorithm::chainHits(const ME0Chamber * chamber, const HitAndPositionContainer& rechits) {
 
-  ProtoSegments rechits_chains; 
+  ProtoSegments rechits_chains;
   ProtoSegments seeds;
   seeds.reserve(rechits.size());
   std::vector<bool> usedCluster(rechits.size(),false);
-  
+
   // split rechits into subvectors and return vector of vectors:
   // Loop over rechits
   // Create one seed per hit
   for ( unsigned int i=0; i<rechits.size(); ++i){
-    if(std::abs(rechits[i]->tof()) > dTimeChainBoxMax) continue;
-    seeds.push_back(EnsembleHitContainer(1,rechits[i]));
+    if(std::abs(rechits[i].rh->tof()) > dTimeChainBoxMax) continue;
+    seeds.push_back(HitAndPositionPtrContainer(1,&rechits[i]));
   }
-  
+
   // merge chains that are too close ("touch" each other)
   for(size_t NNN = 0; NNN < seeds.size(); ++NNN) {
     for(size_t MMM = NNN+1; MMM < seeds.size(); ++MMM) {
@@ -218,14 +220,14 @@ ME0SegmentAlgorithm::chainHits(const ME0Ensemble& ensemble, const EnsembleHitCon
       // try not to "cluster" the hits but to "chain" them;
       // it does the clustering but also does a better job
       // for inclined tracks (not clustering them together;
-      // crossed tracks would be still clustered together) 
-      // 22.12.09: In fact it is not much more different 
+      // crossed tracks would be still clustered together)
+      // 22.12.09: In fact it is not much more different
       // than the "clustering", we just introduce another
-      // variable in the game - Z. And it makes sense 
+      // variable in the game - Z. And it makes sense
       // to re-introduce Y (or actually wire group mumber)
       // in a similar way as for the strip number - see
       // the code below.
-      bool goodToMerge  = isGoodToMerge(ensemble, seeds[NNN], seeds[MMM]);
+      bool goodToMerge  = isGoodToMerge(chamber, seeds[NNN], seeds[MMM]);
       if(goodToMerge){
         // merge chains!
         // merge by adding seed NNN to seed MMM and erasing seed NNN
@@ -257,28 +259,28 @@ ME0SegmentAlgorithm::chainHits(const ME0Ensemble& ensemble, const EnsembleHitCon
   return rechits_chains;
 }
 
-bool ME0SegmentAlgorithm::isGoodToMerge(const ME0Ensemble& ensemble, const EnsembleHitContainer& newChain, const EnsembleHitContainer& oldChain) {
+bool ME0SegmentAlgorithm::isGoodToMerge(const ME0Chamber * chamber, const HitAndPositionPtrContainer& newChain, const HitAndPositionPtrContainer& oldChain) {
   for(size_t iRH_new = 0;iRH_new<newChain.size();++iRH_new){
-    GlobalPoint pos_new = ensemble.first->toGlobal(newChain[iRH_new]->localPosition());
-          
+    GlobalPoint pos_new = newChain[iRH_new]->gp;
+
     for(size_t iRH_old = 0;iRH_old<oldChain.size();++iRH_old){
-      GlobalPoint pos_old = ensemble.first->toGlobal(oldChain[iRH_old]->localPosition());
+      GlobalPoint pos_old = oldChain[iRH_old]->gp;
       // to be chained, two hits need to be in neighbouring layers...
       // or better allow few missing layers (upto 3 to avoid inefficiencies);
       // however we'll not make an angle correction because it
-      // worsen the situation in some of the "regular" cases 
+      // worsen the situation in some of the "regular" cases
       // (not making the correction means that the conditions for
       // forming a cluster are different if we have missing layers -
-      // this could affect events at the boundaries ) 
+      // this could affect events at the boundaries )
 
       // to be chained, two hits need also to be "close" in phi and eta
       if (std::abs(reco::deltaPhi( float(pos_new.phi()), float(pos_old.phi()) )) >= dPhiChainBoxMax) continue;
       if (std::abs(pos_new.eta()-pos_old.eta()) >= dEtaChainBoxMax) continue;
       // and the difference in layer index should be < (nlayers-1)
-      if (std::abs(newChain[iRH_new]->me0Id().layer() - oldChain[iRH_old]->me0Id().layer()) >= (ensemble.first->id().nlayers()-1)) continue;
-      // and they should have a time difference compatible with the hypothesis 
+      if (std::abs(newChain[iRH_new]->layer - oldChain[iRH_old]->layer) >= (chamber->id().nlayers()-1)) continue;
+      // and they should have a time difference compatible with the hypothesis
       // that the rechits originate from the same particle, but were detected in different layers
-      if (std::abs(newChain[iRH_new]->tof() - oldChain[iRH_old]->tof()) >= dTimeChainBoxMax) continue;
+      if (std::abs(newChain[iRH_new]->rh->tof() - oldChain[iRH_old]->rh->tof()) >= dTimeChainBoxMax) continue;
 
       return true;
     }
@@ -286,31 +288,27 @@ bool ME0SegmentAlgorithm::isGoodToMerge(const ME0Ensemble& ensemble, const Ensem
   return false;
 }
 
-void ME0SegmentAlgorithm::buildSegments(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits, std::vector<ME0Segment>& me0segs) {
+void ME0SegmentAlgorithm::buildSegments(const HitAndPositionPtrContainer& rechits, std::vector<ME0Segment>& me0segs) {
   if (rechits.size() < minHitsPerSegment) return;
-  
-#ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode 
+
+#ifdef EDM_ML_DEBUG // have lines below only compiled when in debug mode
   edm::LogVerbatim("ME0SegmentAlgorithm") << "[ME0SegmentAlgorithm::buildSegments] will now try to fit a ME0Segment from collection of "<<rechits.size()<<" ME0 RecHits";
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
-    auto me0id = (*rh)->me0Id();
-    auto rhLP = (*rh)->localPosition();
-    edm::LogVerbatim("ME0SegmentAlgorithm") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<(*rh)->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
+    auto me0id = (*rh)->rh->me0Id();
+    auto rhLP = (*rh)->lp;
+    edm::LogVerbatim("ME0SegmentAlgorithm") << "[RecHit :: Loc x = "<<std::showpos<<std::setw(9)<<rhLP.x()<<" Loc y = "<<std::showpos<<std::setw(9)<<rhLP.y()<<" Time = "<<std::showpos<<(*rh)->rh->tof()<<" -- "<<me0id.rawId()<<" = "<<me0id<<" ]";
   }
 #endif
 
   MuonSegFit::MuonRecHitContainer muonRecHits;
-  proto_segment.clear();
-  
-  // select hits from the ensemble and sort it 
-  const ME0EtaPartition * refPart   = ensemble.first;
+  std::vector<const ME0RecHit*> bareRHs;
+
+  // select hits from the ensemble and sort it
   for (auto rh=rechits.begin(); rh!=rechits.end();rh++){
-    proto_segment.push_back(*rh);
-    // for segFit - using local point in first partition frame
-    const ME0EtaPartition * thePartition   = (ensemble.second.find((*rh)->me0Id()))->second;
-    GlobalPoint gp = thePartition->toGlobal((*rh)->localPosition());
-    const LocalPoint lp = refPart->toLocal(gp);    
-    ME0RecHit *newRH = (*rh)->clone();
-    newRH->setPosition(lp);
+	  bareRHs.push_back((*rh)->rh );
+    // for segFit - using local point in chamber frame
+    ME0RecHit *newRH = (*rh)->rh->clone();
+    newRH->setPosition((*rh)->lp);
 
     MuonSegFit::MuonRecHitPtr trkRecHit(newRH);
     muonRecHits.push_back(trkRecHit);
@@ -321,26 +319,26 @@ void ME0SegmentAlgorithm::buildSegments(const ME0Ensemble& ensemble, const Ensem
   bool goodfit = sfit_->fit();
   edm::LogVerbatim("ME0SegmentAlgorithm") << "[ME0SegmentAlgorithm::buildSegments] ME0Segment fit done";
 
-  // quit function if fit was not OK  
+  // quit function if fit was not OK
   if(!goodfit){
     for (auto rh:muonRecHits) rh.reset();
     return;
   }
-  
+
   // obtain all information necessary to make the segment:
   LocalPoint protoIntercept      = sfit_->intercept();
   LocalVector protoDirection     = sfit_->localdir();
-  AlgebraicSymMatrix protoErrors = sfit_->covarianceMatrix(); 
+  AlgebraicSymMatrix protoErrors = sfit_->covarianceMatrix();
   double protoChi2               = sfit_->chi2();
   // Calculate the central value and uncertainty of the segment time
   float averageTime=0.;
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
-    averageTime += (*rh)->tof();                                          
+    averageTime += (*rh)->rh->tof();
   }
   if(rechits.size() != 0) averageTime=averageTime/(rechits.size());
   float timeUncrt=0.;
   for (auto rh=rechits.begin(); rh!=rechits.end(); ++rh){
-    timeUncrt += pow((*rh)->tof()-averageTime,2);
+    timeUncrt += pow((*rh)->rh->tof()-averageTime,2);
   }
 
   if(rechits.size() > 1) timeUncrt=timeUncrt/(rechits.size()-1);
@@ -348,11 +346,11 @@ void ME0SegmentAlgorithm::buildSegments(const ME0Ensemble& ensemble, const Ensem
 
   // save all information inside GEMCSCSegment
   edm::LogVerbatim("ME0SegmentAlgorithm") << "[ME0SegmentAlgorithm::buildSegments] will now try to make ME0Segment from collection of "<<rechits.size()<<" ME0 RecHits";
-  ME0Segment tmp(proto_segment, protoIntercept, protoDirection, protoErrors, protoChi2, averageTime, timeUncrt);
+  ME0Segment tmp(bareRHs, protoIntercept, protoDirection, protoErrors, protoChi2, averageTime, timeUncrt);
 
   edm::LogVerbatim("ME0SegmentAlgorithm") << "[ME0SegmentAlgorithm::buildSegments] ME0Segment made";
   edm::LogVerbatim("ME0SegmentAlgorithm") << "[ME0SegmentAlgorithm::buildSegments] "<<tmp;
-  
+
   for (auto rh:muonRecHits) rh.reset();
   me0segs.push_back(tmp);
   return;

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.cc
@@ -277,7 +277,7 @@ bool ME0SegmentAlgorithm::isGoodToMerge(const ME0Chamber * chamber, const HitAnd
       if (std::abs(reco::deltaPhi( float(pos_new.phi()), float(pos_old.phi()) )) >= dPhiChainBoxMax) continue;
       if (std::abs(pos_new.eta()-pos_old.eta()) >= dEtaChainBoxMax) continue;
       // and the difference in layer index should be < (nlayers-1)
-      if (std::abs(newChain[iRH_new]->layer - oldChain[iRH_old]->layer) >= (chamber->id().nlayers()-1)) continue;
+      if (std::abs(int(newChain[iRH_new]->layer) - int(oldChain[iRH_old]->layer)) >= (chamber->id().nlayers()-1)) continue;
       // and they should have a time difference compatible with the hypothesis
       // that the rechits originate from the same particle, but were detected in different layers
       if (std::abs(newChain[iRH_new]->rh->tof() - oldChain[iRH_old]->rh->tof()) >= dTimeChainBoxMax) continue;

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.h
@@ -27,8 +27,7 @@ class ME0SegmentAlgorithm : public ME0SegmentAlgorithmBase {
 public:
 
   /// Typedefs
-  typedef std::vector<const ME0RecHit*> EnsembleHitContainer;
-  typedef std::vector<EnsembleHitContainer> ProtoSegments;
+  typedef std::vector<HitAndPositionPtrContainer> ProtoSegments;
 
   /// Constructor
   explicit ME0SegmentAlgorithm(const edm::ParameterSet& ps);
@@ -38,21 +37,21 @@ public:
   /**
    * Build segments for all desired groups of hits
    */
-  std::vector<ME0Segment> run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits); 
+  std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits);
 
 private:
   /// Utility functions 
 
   //  Build groups of rechits that are separated in x and y to save time on the segment finding
-  ProtoSegments clusterHits(const EnsembleHitContainer& rechits);
+  ProtoSegments clusterHits(const HitAndPositionContainer& rechits);
 
   // Build groups of rechits that are separated in strip numbers and Z to save time on the segment finding
-  ProtoSegments chainHits(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits);
+  ProtoSegments chainHits(const ME0Chamber * chamber, const HitAndPositionContainer& rechits);
 
-  bool isGoodToMerge(const ME0Ensemble& ensemble, const EnsembleHitContainer& newChain, const EnsembleHitContainer& oldChain);
+  bool isGoodToMerge(const ME0Chamber * chamber, const HitAndPositionPtrContainer& newChain, const HitAndPositionPtrContainer& oldChain);
 
   // Build track segments in this chamber (this is where the actual segment-building algorithm hides.)
-  void buildSegments(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits, std::vector<ME0Segment>& me0segs);
+  void buildSegments(const HitAndPositionPtrContainer& rechits, std::vector<ME0Segment>& me0segs);
 
   // Member variables
   const std::string myName; 
@@ -69,8 +68,6 @@ private:
   double  dTimeChainBoxMax;
   int     maxRecHitsInCluster;
   
-  EnsembleHitContainer proto_segment;
-
   static constexpr float running_max=std::numeric_limits<float>::max();
   std::unique_ptr<MuonSegFit> sfit_;
 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithmBase.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithmBase.h
@@ -15,14 +15,17 @@
 #include "DataFormats/GEMRecHit/interface/ME0RecHitCollection.h"
 #include "DataFormats/GEMRecHit/interface/ME0Segment.h"
 #include "Geometry/GEMGeometry/interface/ME0EtaPartition.h"
-#include "Geometry/GEMGeometry/interface/ME0Chamber.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include <map>
 #include <vector>
 
 class ME0SegmentAlgorithmBase {
 public:
-  typedef std::pair<const ME0Chamber*, std::map<uint32_t, const ME0EtaPartition*> >ME0Ensemble; 
+
+  /// Typedefs
+  typedef std::vector<const ME0RecHit*> EnsembleHitContainer;
+  typedef std::vector<EnsembleHitContainer> ProtoSegments;
+  typedef std::pair<const ME0EtaPartition*, std::map<uint32_t, const ME0EtaPartition*> >ME0Ensemble;
 
     /// Constructor
     explicit ME0SegmentAlgorithmBase(const edm::ParameterSet&) {};
@@ -31,9 +34,8 @@ public:
 
     /** Run the algorithm = build the segments in this chamber
     */
-    virtual std::vector<ME0Segment> run(const ME0Ensemble& ensemble, const std::vector<const ME0RecHit*>& rechits) = 0;  
+    virtual std::vector<ME0Segment> run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits) = 0;  
 
     private:
 };
-
 #endif

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithmBase.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithmBase.h
@@ -3,7 +3,7 @@
 
 /** \class ME0SegmentAlgo derived from CSC
  * An abstract base class for algorithmic classes used to
- * build segments in one ensemble of ME0 detector 
+ * build segments in one ensemble of ME0 detector
  *
  * Implementation notes: <BR>
  * For example, ME0SegmAlgoMM inherits from this class,
@@ -15,6 +15,7 @@
 #include "DataFormats/GEMRecHit/interface/ME0RecHitCollection.h"
 #include "DataFormats/GEMRecHit/interface/ME0Segment.h"
 #include "Geometry/GEMGeometry/interface/ME0EtaPartition.h"
+#include "Geometry/GEMGeometry/interface/ME0Chamber.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include <map>
 #include <vector>
@@ -22,10 +23,18 @@
 class ME0SegmentAlgorithmBase {
 public:
 
-  /// Typedefs
-  typedef std::vector<const ME0RecHit*> EnsembleHitContainer;
-  typedef std::vector<EnsembleHitContainer> ProtoSegments;
-  typedef std::pair<const ME0EtaPartition*, std::map<uint32_t, const ME0EtaPartition*> >ME0Ensemble;
+	struct HitAndPosition {
+		HitAndPosition (const ME0RecHit * rh, const LocalPoint& lp, const GlobalPoint& gp, unsigned int idx ) :
+			rh(rh),lp(lp),gp(gp), layer(rh->me0Id().layer()), idx(idx){}
+		const ME0RecHit * rh;
+		LocalPoint lp;
+		GlobalPoint gp;
+		unsigned int layer;
+		unsigned int idx;
+	};
+
+	typedef std::vector<HitAndPosition> HitAndPositionContainer;
+	typedef std::vector<const HitAndPosition*> HitAndPositionPtrContainer;
 
     /// Constructor
     explicit ME0SegmentAlgorithmBase(const edm::ParameterSet&) {};
@@ -34,7 +43,7 @@ public:
 
     /** Run the algorithm = build the segments in this chamber
     */
-    virtual std::vector<ME0Segment> run(const ME0Ensemble& ensemble, const EnsembleHitContainer& rechits) = 0;  
+    virtual std::vector<ME0Segment> run(const ME0Chamber * chamber, const HitAndPositionContainer& rechits ) = 0;
 
     private:
 };

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
@@ -3,7 +3,7 @@
 #include "DataFormats/GEMRecHit/interface/ME0RecHit.h"
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 #include "Geometry/GEMGeometry/interface/ME0EtaPartition.h"
-#include "Geometry/GEMGeometry/interface/ME0Chamber.h"
+//#include "Geometry/GEMGeometry/interface/ME0Chamber.h"
 #include "RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithmBase.h"
 #include "RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilderPluginFactory.h"
 	 
@@ -12,17 +12,18 @@
 
 ME0SegmentBuilder::ME0SegmentBuilder(const edm::ParameterSet& ps) : geom_(0) {
   
-  // Algo name
-  std::string algoName = ps.getParameter<std::string>("algo_name");
-  
+  // Algo type (indexed)
+  int chosenAlgo = ps.getParameter<int>("algo_type") - 1;
+  // Find appropriate ParameterSets for each algo type
+
+  std::vector<edm::ParameterSet> algoPSets = ps.getParameter<std::vector<edm::ParameterSet> >("algo_psets");  
+
+  edm::ParameterSet segAlgoPSet = algoPSets[chosenAlgo].getParameter<edm::ParameterSet>("algo_pset");
+  std::string algoName = algoPSets[chosenAlgo].getParameter<std::string>("algo_name");
   LogDebug("ME0SegmentBuilder")<< "ME0SegmentBuilder algorithm name: " << algoName;
-  
-  // SegAlgo parameter set
-  edm::ParameterSet segAlgoPSet = ps.getParameter<edm::ParameterSet>("algo_pset");
-  
-  // Ask factory to build this algorithm, giving it appropriate ParameterSet  
+
+  // Ask factory to build this algorithm, giving it appropriate ParameterSet
   algo = std::unique_ptr<ME0SegmentAlgorithmBase>(ME0SegmentBuilderPluginFactory::get()->create(algoName, segAlgoPSet));
-  
 }
 
 ME0SegmentBuilder::~ME0SegmentBuilder() {}
@@ -46,23 +47,31 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
     // if one wants to recover segments that are at the border of a roll]
     ME0DetId id(it2->me0Id().region(),1,it2->me0Id().chamber(),it2->me0Id().roll());
     // save current ME0RecHit in vector associated to the reference id
-    ensembleRH[id.rawId()].push_back(it2->clone());    
+    ensembleRH[id.rawId()].push_back(it2->clone());
+    // cover the case in which a muon passes through etapartition N for layers 1 .. X
+    // and through eta partition N-1 for layers X+1 .. NLAYERS
+    // therefore check whether Layer > 1 and EtaPart < MAX
+    // and put the rechit also in the ensembleRH for the EtaPart+1
+    if(it2->me0Id().layer()>1 && it2->me0Id().roll()<ME0DetId::maxRollId) {
+      ME0DetId id2(it2->me0Id().region(),1,it2->me0Id().chamber(),it2->me0Id().roll()+1);
+      ensembleRH[id2.rawId()].push_back(it2->clone());
+    }
   }
 
-  std::map<uint32_t, std::vector<ME0Segment> > ensembleSeg;  // collect here all segments from the same chamber
+  std::map<uint32_t, std::vector<ME0Segment> > ensembleSeg;  // collect here all segments from each reference first layer roll
 
   for(auto enIt=ensembleRH.begin(); enIt != ensembleRH.end(); ++enIt) {
     
     std::vector<const ME0RecHit*> me0RecHits;
     std::map<uint32_t,const ME0EtaPartition* > ens;
     
-    // all detIds have been assigned to the to chamber
-    const ME0Chamber* chamber = geom_->chamber(enIt->first);    
+    // all detIds have been assigned to the reference detId of layer 1
+    const ME0EtaPartition* firstlayer  = geom_->etaPartition(enIt->first);
     for(auto rechit = enIt->second.begin(); rechit != enIt->second.end(); ++rechit) {
       me0RecHits.push_back(*rechit);
       ens[(*rechit)->me0Id()]=geom_->etaPartition((*rechit)->me0Id());
     }    
-    ME0SegmentAlgorithmBase::ME0Ensemble ensemble(std::pair<const ME0Chamber*, std::map<uint32_t,const ME0EtaPartition*> >(chamber,ens));
+    ME0SegmentAlgorithmBase::ME0Ensemble ensemble(std::pair<const ME0EtaPartition*, std::map<uint32_t,const ME0EtaPartition*> >(firstlayer,ens));
     
     ME0DetId mid(enIt->first);
     #ifdef EDM_ML_DEBUG
@@ -81,13 +90,15 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
 
     // Add the segments to the chamber segment collection
     // segment is defined from first partition of first layer    
-    ME0DetId midch = mid.chamberId();
-    ensembleSeg[midch.rawId()].insert(ensembleSeg[midch.rawId()].end(), segv.begin(), segv.end());
+    //    ME0DetId midch = mid.chamberId();
+    std::cout <<" Inserting Segment in "<<mid<<std::endl;
+    ensembleSeg[mid.rawId()].insert(ensembleSeg[mid.rawId()].end(), segv.begin(), segv.end());
   }
 
   for(auto segIt=ensembleSeg.begin(); segIt != ensembleSeg.end(); ++segIt) {
     // Add the segments to master collection
     ME0DetId midch(segIt->first);
+    std::cout <<" Writing Segment in "<<midch<<std::endl;
     oc.put(midch, segIt->second.begin(), segIt->second.end());
   }
 }

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
@@ -3,20 +3,20 @@
 #include "DataFormats/GEMRecHit/interface/ME0RecHit.h"
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 #include "Geometry/GEMGeometry/interface/ME0EtaPartition.h"
-//#include "Geometry/GEMGeometry/interface/ME0Chamber.h"
+#include "Geometry/GEMGeometry/interface/ME0Chamber.h"
 #include "RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithmBase.h"
 #include "RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilderPluginFactory.h"
-	 
+
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ME0SegmentBuilder::ME0SegmentBuilder(const edm::ParameterSet& ps) : geom_(0) {
-  
+
   // Algo type (indexed)
   int chosenAlgo = ps.getParameter<int>("algo_type") - 1;
   // Find appropriate ParameterSets for each algo type
 
-  std::vector<edm::ParameterSet> algoPSets = ps.getParameter<std::vector<edm::ParameterSet> >("algo_psets");  
+  std::vector<edm::ParameterSet> algoPSets = ps.getParameter<std::vector<edm::ParameterSet> >("algo_psets");
 
   edm::ParameterSet segAlgoPSet = algoPSets[chosenAlgo].getParameter<edm::ParameterSet>("algo_pset");
   std::string algoName = algoPSets[chosenAlgo].getParameter<std::string>("algo_name");
@@ -29,77 +29,52 @@ ME0SegmentBuilder::ME0SegmentBuilder(const edm::ParameterSet& ps) : geom_(0) {
 ME0SegmentBuilder::~ME0SegmentBuilder() {}
 
 void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentCollection& oc) {
-  	
+
   LogDebug("ME0SegmentBuilder")<< "Total number of rechits in this event: " << recHits->size();
-  
-  // Let's define the ensemble of ME0 devices having the same region, chambers number (phi), and eta partition
-  // and layer run from 1 to number of layer. This is not the definition of one chamber... and indeed segments
-  // could in principle run in different way... The concept of the DetLayer would be more appropriate...
 
-  std::map<uint32_t, std::vector<ME0RecHit*> > ensembleRH;
-    
-  // Loop on the ME0 rechit and select the different ME0 Ensemble
-  for(ME0RecHitCollection::const_iterator it2 = recHits->begin(); it2 != recHits->end(); ++it2) {
-    // ME0 Ensemble is defined by assigning all the ME0DetIds of the same "superchamber" 
-    // (i.e. region same, chamber same) to the DetId of the first layer
-    // At this point there is only one roll, so nothing to be worried about ...
-    // [At a later stage one will have to mask also the rolls 
-    // if one wants to recover segments that are at the border of a roll]
-    ME0DetId id(it2->me0Id().region(),1,it2->me0Id().chamber(),it2->me0Id().roll());
-    // save current ME0RecHit in vector associated to the reference id
-    ensembleRH[id.rawId()].push_back(it2->clone());
-    // cover the case in which a muon passes through etapartition N for layers 1 .. X
-    // and through eta partition N-1 for layers X+1 .. NLAYERS
-    // therefore check whether Layer > 1 and EtaPart < MAX
-    // and put the rechit also in the ensembleRH for the EtaPart+1
-    if(it2->me0Id().layer()>1 && it2->me0Id().roll()<ME0DetId::maxRollId) {
-      ME0DetId id2(it2->me0Id().region(),1,it2->me0Id().chamber(),it2->me0Id().roll()+1);
-      ensembleRH[id2.rawId()].push_back(it2->clone());
-    }
-  }
 
-  std::map<uint32_t, std::vector<ME0Segment> > ensembleSeg;  // collect here all segments from each reference first layer roll
+  std::map<ME0DetId, bool> foundChambers;
+  for(ME0RecHitCollection::const_iterator it = recHits->begin(); it != recHits->end(); it++) {
+	  const auto chId = it->me0Id().chamberId();
+	  auto chIt = foundChambers.find(chId);
+	  if(chIt !=  foundChambers.end()) continue;
+	  foundChambers[chId] = true;
+      ME0SegmentAlgorithmBase::HitAndPositionContainer hitAndPositions;
+      const ME0Chamber* chamber = geom_->chamber(chId);
+	  for(ME0RecHitCollection::const_iterator it2 = it; it2 != recHits->end(); it2++) {
+		  if(it2->me0Id().chamberId() != chId) continue;
 
-  for(auto enIt=ensembleRH.begin(); enIt != ensembleRH.end(); ++enIt) {
-    
-    std::vector<const ME0RecHit*> me0RecHits;
-    std::map<uint32_t,const ME0EtaPartition* > ens;
-    
-    // all detIds have been assigned to the reference detId of layer 1
-    const ME0EtaPartition* firstlayer  = geom_->etaPartition(enIt->first);
-    for(auto rechit = enIt->second.begin(); rechit != enIt->second.end(); ++rechit) {
-      me0RecHits.push_back(*rechit);
-      ens[(*rechit)->me0Id()]=geom_->etaPartition((*rechit)->me0Id());
-    }    
-    ME0SegmentAlgorithmBase::ME0Ensemble ensemble(std::pair<const ME0EtaPartition*, std::map<uint32_t,const ME0EtaPartition*> >(firstlayer,ens));
-    
-    ME0DetId mid(enIt->first);
-    #ifdef EDM_ML_DEBUG
-    LogDebug("ME0SegmentBuilder") << "found " << me0RecHits.size() << " rechits in etapart " << mid;
-    #endif
-    
-    // given the chamber select the appropriate algo... and run it
-    std::vector<ME0Segment> segv = algo->run(ensemble, me0RecHits);
-    
-    #ifdef EDM_ML_DEBUG
-    LogDebug("ME0SegmentBuilder") << "found " << segv.size() << " segments in etapart " << mid;
-    #endif
-    
-    // Add the segments to master collection
-    // oc.put(mid, segv.begin(), segv.end());
+          const auto*  part = geom_->etaPartition(it2->me0Id());
+          GlobalPoint glb = part->toGlobal(it2->localPosition());
+          LocalPoint nLoc = chamber->toLocal(glb);
+          hitAndPositions.emplace_back(&(*it2),nLoc,glb,hitAndPositions.size());
+	  }
 
-    // Add the segments to the chamber segment collection
-    // segment is defined from first partition of first layer    
-    //    ME0DetId midch = mid.chamberId();
-    std::cout <<" Inserting Segment in "<<mid<<std::endl;
-    ensembleSeg[mid.rawId()].insert(ensembleSeg[mid.rawId()].end(), segv.begin(), segv.end());
-  }
+      LogDebug("ME0Segment|ME0") << "found " << hitAndPositions.size() << " rechits in chamber " << *chIt;
+      //sort by layer
+        auto getLayer =[&](int iL) ->const ME0Layer* { //function is broken in the geo currently
+      	  for (auto layer : chamber->layers()){
+      		  if (layer->id().layer()==iL)
+      			  return layer;
+      	  }
+      	  return 0;
+        };
+        float z1 = getLayer(1)->position().z();
+        float z6 = getLayer(6)->position().z();
+        if(z1 < z6)
+        	std::sort(hitAndPositions.begin(), hitAndPositions.end(), [](const ME0SegmentAlgorithmBase::HitAndPosition& h1,const ME0SegmentAlgorithmBase::HitAndPosition& h2 ) {return h1.layer < h2.layer;});
+        else
+        	std::sort(hitAndPositions.begin(), hitAndPositions.end(), [](const ME0SegmentAlgorithmBase::HitAndPosition& h1,const ME0SegmentAlgorithmBase::HitAndPosition& h2 ) {return h1.layer < h2.layer;} );
 
-  for(auto segIt=ensembleSeg.begin(); segIt != ensembleSeg.end(); ++segIt) {
-    // Add the segments to master collection
-    ME0DetId midch(segIt->first);
-    std::cout <<" Writing Segment in "<<midch<<std::endl;
-    oc.put(midch, segIt->second.begin(), segIt->second.end());
+      // given the chamber select the appropriate algo... and run it
+      std::vector<ME0Segment> segv = algo->run(chamber, hitAndPositions);
+
+      LogDebug("ME0Segment|ME0") << "found " << segv.size() << " segments in chamber " << *chIt;
+
+      // Add the segments to master collection
+      if(segv.size())
+      oc.put(chId, segv.begin(), segv.end());
+
   }
 }
 

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.cc
@@ -64,7 +64,7 @@ void ME0SegmentBuilder::build(const ME0RecHitCollection* recHits, ME0SegmentColl
         if(z1 < z6)
         	std::sort(hitAndPositions.begin(), hitAndPositions.end(), [](const ME0SegmentAlgorithmBase::HitAndPosition& h1,const ME0SegmentAlgorithmBase::HitAndPosition& h2 ) {return h1.layer < h2.layer;});
         else
-        	std::sort(hitAndPositions.begin(), hitAndPositions.end(), [](const ME0SegmentAlgorithmBase::HitAndPosition& h1,const ME0SegmentAlgorithmBase::HitAndPosition& h2 ) {return h1.layer < h2.layer;} );
+        	std::sort(hitAndPositions.begin(), hitAndPositions.end(), [](const ME0SegmentAlgorithmBase::HitAndPosition& h1,const ME0SegmentAlgorithmBase::HitAndPosition& h2 ) {return h1.layer > h2.layer;} );
 
       // given the chamber select the appropriate algo... and run it
       std::vector<ME0Segment> segv = algo->run(chamber, hitAndPositions);

--- a/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.h
+++ b/RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilder.h
@@ -33,7 +33,7 @@ class ME0SegmentBuilder {
   /// Destructor
   ~ME0SegmentBuilder();
 
-  /** Find rechits in each ensemble of 6 ME0 layers, build ME0Segment's ,
+  /** Find rechits in each ensemble of all ME0 layers, build ME0Segment's ,
    *  and fill into output collection.
    */
   void build(const ME0RecHitCollection* rechits, ME0SegmentCollection& oc);

--- a/RecoLocalMuon/GEMSegment/plugins/SealModule.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/SealModule.cc
@@ -3,8 +3,11 @@
 
 #include "RecoLocalMuon/GEMSegment/plugins/ME0SegmentBuilderPluginFactory.h"
 #include "RecoLocalMuon/GEMSegment/plugins/ME0SegmentAlgorithm.h"
+#include "RecoLocalMuon/GEMSegment/plugins/ME0SegAlgoRU.h"
 #include "RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilderPluginFactory.h"
 #include "RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.h"
 
 DEFINE_EDM_PLUGIN(GEMSegmentBuilderPluginFactory, GEMSegmentAlgorithm, "GEMSegmentAlgorithm");
 DEFINE_EDM_PLUGIN(ME0SegmentBuilderPluginFactory, ME0SegmentAlgorithm, "ME0SegmentAlgorithm");
+DEFINE_EDM_PLUGIN(ME0SegmentBuilderPluginFactory, ME0SegAlgoRU, "ME0SegAlgoRU");
+

--- a/RecoLocalMuon/GEMSegment/python/ME0SegmentsAlgorithm_cfi.py
+++ b/RecoLocalMuon/GEMSegment/python/ME0SegmentsAlgorithm_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+ME0SegmentAlgorithm = cms.PSet(
+    algo_name = cms.string("ME0SegmentAlgorithm"),                             
+    algo_pset = cms.PSet(
+        ME0Debug = cms.untracked.bool(True),
+        minHitsPerSegment = cms.uint32(3),
+        preClustering = cms.bool(True),
+        dXclusBoxMax = cms.double(1.),
+        dYclusBoxMax = cms.double(5.),
+        preClusteringUseChaining = cms.bool(True),
+        dPhiChainBoxMax = cms.double(.02),
+        dEtaChainBoxMax = cms.double(.05),
+        dTimeChainBoxMax = cms.double(1.50), # 1ns, +/- time to fly through 30cm thick ME0
+        maxRecHitsInCluster = cms.int32(6)
+    )
+)

--- a/RecoLocalMuon/GEMSegment/python/ME0SegmentsAlgorithm_cfi.py
+++ b/RecoLocalMuon/GEMSegment/python/ME0SegmentsAlgorithm_cfi.py
@@ -11,7 +11,7 @@ ME0SegmentAlgorithm = cms.PSet(
         preClusteringUseChaining = cms.bool(True),
         dPhiChainBoxMax = cms.double(.02),
         dEtaChainBoxMax = cms.double(.05),
-        dTimeChainBoxMax = cms.double(1.50), # 1ns, +/- time to fly through 30cm thick ME0
+        dTimeChainBoxMax = cms.double(15.0), # 1ns, +/- time to fly through 30cm thick ME0
         maxRecHitsInCluster = cms.int32(6)
     )
 )

--- a/RecoLocalMuon/GEMSegment/python/ME0SegmentsRU_cfi.py
+++ b/RecoLocalMuon/GEMSegment/python/ME0SegmentsRU_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+RU_ME0 = cms.PSet(
+    doCollisions = cms.bool(True),
+    chi2Norm_2D_ = cms.double(100),
+    chi2_str = cms.double(100.0),
+    chi2Max = cms.double(100.0),
+    dPhiIntMax = cms.double(0.1),
+    dPhiMax = cms.double(0.1),
+    wideSeg = cms.double(3.0),
+    minLayersApart = cms.int32(1),
+    dRIntMax = cms.double(10.0),
+    dRMax = cms.double(10.0)
+)
+
+ME0SegAlgoRU = cms.PSet(
+    algo_name = cms.string('ME0SegAlgoRU'),
+    algo_pset = cms.PSet(cms.PSet(RU_ME0))
+)
+

--- a/RecoLocalMuon/GEMSegment/python/ME0SegmentsRU_cfi.py
+++ b/RecoLocalMuon/GEMSegment/python/ME0SegmentsRU_cfi.py
@@ -1,16 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 RU_ME0 = cms.PSet(
+    allowWideSegments = cms.bool(True),
     doCollisions = cms.bool(True),
-    chi2Norm_2D_ = cms.double(100),
-    chi2_str = cms.double(100.0),
-    chi2Max = cms.double(100.0),
-    dPhiIntMax = cms.double(0.1),
-    dPhiMax = cms.double(0.1),
-    wideSeg = cms.double(3.0),
-    minLayersApart = cms.int32(1),
-    dRIntMax = cms.double(10.0),
-    dRMax = cms.double(10.0)
+    maxChi2Additional = cms.double(100.0),
+    maxChi2Prune = cms.double(50),
+    maxChi2GoodSeg = cms.double(50),
+    maxPhiSeeds = cms.double(0.000547), #Assuming 768 strips
+    maxPhiAdditional = cms.double(0.000547), #Assuming 768 strips
+    maxETASeeds = cms.double(0.08), #Assuming 8 eta partitions
+    maxTOFDiff = cms.double(25),
+    minNumberOfHits = cms.uint32(4),
 )
 
 ME0SegAlgoRU = cms.PSet(

--- a/RecoLocalMuon/GEMSegment/python/me0Segments_cfi.py
+++ b/RecoLocalMuon/GEMSegment/python/me0Segments_cfi.py
@@ -1,18 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoLocalMuon.GEMSegment.ME0SegmentsAlgorithm_cfi import *
+from RecoLocalMuon.GEMSegment.ME0SegmentsRU_cfi import *
+
 me0Segments = cms.EDProducer("ME0SegmentProducer",
+    # Define input
     me0RecHitLabel = cms.InputTag("me0RecHits"),
-    algo_name = cms.string("ME0SegmentAlgorithm"),                             
-    algo_pset = cms.PSet(
-        ME0Debug = cms.untracked.bool(True),
-        minHitsPerSegment = cms.uint32(3),
-        preClustering = cms.bool(True),
-        dXclusBoxMax = cms.double(1.),
-        dYclusBoxMax = cms.double(5.),
-        preClusteringUseChaining = cms.bool(True),
-        dPhiChainBoxMax = cms.double(.02),
-        dEtaChainBoxMax = cms.double(.15),
-        dTimeChainBoxMax = cms.double(15.0), # 1ns, +/- time to fly through 30cm thick ME0
-        maxRecHitsInCluster = cms.int32(6)
-    )
+    # Choice of the building algo: 1 Average, 2 RU, ...
+    algo_type = cms.int32(2),
+    # std::vector<edm::ParameterSet>
+    algo_psets = cms.VPSet(
+        cms.PSet(
+            ME0SegmentAlgorithm
+        ), 
+        cms.PSet(
+            ME0SegAlgoRU
+        )
+
+     )
 )
+

--- a/RecoLocalMuon/GEMSegment/test/TestME0SegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMSegment/test/TestME0SegmentAnalyzer.cc
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <iomanip>
 
-
 // root include files
 #include "TFile.h"
 #include "TH1F.h"
@@ -37,11 +36,17 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
- 
+#include <DataFormats/GEMRecHit/interface/ME0RecHitCollection.h>
+#include "DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 #include <Geometry/GEMGeometry/interface/ME0EtaPartition.h>
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include <DataFormats/MuonDetId/interface/ME0DetId.h>
+#include "DataFormats/Math/interface/deltaPhi.h"
+
 //
 // class declaration
 //
@@ -60,10 +65,28 @@ class TestME0SegmentAnalyzer : public edm::EDAnalyzer {
   edm::ESHandle<ME0Geometry> me0Geom;
 
   edm::EDGetTokenT<ME0SegmentCollection> ME0Segment_Token;
+  edm::EDGetTokenT<ME0RecHitCollection> ME0RecHit_Token;
+  edm::EDGetTokenT<ME0DigiPreRecoCollection> ME0Digi_Token;
+  //  edm::EDGetTokenT<ME0DigiPreRecoCollection> ME0Digi_Token;
 
   std::string rootFileName;
+
   std::unique_ptr<TFile> outputfile;
+
+  std::unique_ptr<TH1F> ME0_recdR;
+  std::unique_ptr<TH1F> ME0_recdPhi;
+  std::unique_ptr<TH1F> ME0_segdR;
+  std::unique_ptr<TH1F> ME0_segdPhi;
+
   std::unique_ptr<TH1F> ME0_fitchi2;
+  std::unique_ptr<TH1F> ME0_rhmult;
+  std::unique_ptr<TH1F> ME0_rhmultb;
+  std::unique_ptr<TH1F> ME0_sgmult;
+  std::unique_ptr<TH1F> ME0_shtime;
+  std::unique_ptr<TH1F> ME0_rhtime;
+  std::unique_ptr<TH1F> ME0_sgtime;
+  std::unique_ptr<TH1F> ME0_sgterr;
+
   std::unique_ptr<TH1F> ME0_Residuals_x;
   std::unique_ptr<TH1F> ME0_Residuals_l1_x;
   std::unique_ptr<TH1F> ME0_Residuals_l2_x;
@@ -103,12 +126,24 @@ TestME0SegmentAnalyzer::TestME0SegmentAnalyzer(const edm::ParameterSet& iConfig)
 
 {
    //now do what ever initialization is needed
-  ME0Segment_Token = consumes<ME0SegmentCollection>(edm::InputTag("me0Segments"));
-
+  ME0Segment_Token = consumes<ME0SegmentCollection>(edm::InputTag("me0Segments","","ME0RERECO"));
+  ME0RecHit_Token  = consumes<ME0RecHitCollection>(edm::InputTag("me0RecHits"));
+  ME0Digi_Token  = consumes<ME0DigiPreRecoCollection>(edm::InputTag("simMuonME0Digis"));
+  //  ME0SimHit_Token = 
   rootFileName  = iConfig.getUntrackedParameter<std::string>("RootFileName");
   outputfile.reset(TFile::Open(rootFileName.c_str(), "RECREATE"));
 
-  ME0_fitchi2 = std::unique_ptr<TH1F>(new TH1F("chi2Vsndf","chi2Vsndf",50,0.,5.)); 
+  ME0_recdR   = std::unique_ptr<TH1F>(new TH1F("rechitdR","rechidR",50,-10.,10.)); 
+  ME0_recdPhi = std::unique_ptr<TH1F>(new TH1F("rechitdphi","rechidphi",50,-0.005,0.005)); 
+  ME0_segdR   = std::unique_ptr<TH1F>(new TH1F("segmentdR","segmentdR",50,-10.,10.)); 
+  ME0_segdPhi = std::unique_ptr<TH1F>(new TH1F("segmentdphi","segmentdphi",50,-0.1,0.1)); 
+  ME0_fitchi2 = std::unique_ptr<TH1F>(new TH1F("chi2Vsndf","chi2Vsndf",50,0.,100.));
+  ME0_rhmult  = std::unique_ptr<TH1F>(new TH1F("rhmulti","rhmulti",11,-0.5,10.5)); 
+  ME0_rhmultb = std::unique_ptr<TH1F>(new TH1F("rhmultib","rhmultib",11,-0.5,10.5)); 
+  ME0_sgmult  = std::unique_ptr<TH1F>(new TH1F("sgmult","sgmult",11,-0.5,10.5));  
+  ME0_rhtime  = std::unique_ptr<TH1F>(new TH1F("rhtime","rhtime",100,-125.,125.));  
+  ME0_sgtime  = std::unique_ptr<TH1F>(new TH1F("sgtime","sgtime",100,-125.,125.));  
+  ME0_sgterr  = std::unique_ptr<TH1F>(new TH1F("sgterr","sgterr",100,0.,10.));  
   ME0_Residuals_x    = std::unique_ptr<TH1F>(new TH1F("xME0Res","xME0Res",100,-0.5,0.5));
   ME0_Residuals_l1_x = std::unique_ptr<TH1F>(new TH1F("xME0Res_l1","xME0Res_l1",100,-0.5,0.5));
   ME0_Residuals_l2_x = std::unique_ptr<TH1F>(new TH1F("xME0Res_l2","xME0Res_l2",100,-0.5,0.5));
@@ -142,7 +177,17 @@ TestME0SegmentAnalyzer::TestME0SegmentAnalyzer(const edm::ParameterSet& iConfig)
 
 TestME0SegmentAnalyzer::~TestME0SegmentAnalyzer()
 {
+  ME0_recdR->Write();
+  ME0_recdPhi->Write();
+  ME0_segdR->Write();
+  ME0_segdPhi->Write();
   ME0_fitchi2->Write();
+  ME0_rhmult->Write();
+  ME0_rhmultb->Write();
+  ME0_sgmult->Write();
+  ME0_rhtime->Write();
+  ME0_sgtime->Write();
+  ME0_sgterr->Write();
   ME0_Residuals_x->Write();
   ME0_Residuals_l1_x->Write();
   ME0_Residuals_l2_x->Write();
@@ -190,38 +235,97 @@ TestME0SegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
   // ================
   edm::Handle<ME0SegmentCollection> me0Segment;
   iEvent.getByToken(ME0Segment_Token, me0Segment);
+  edm::Handle<ME0RecHitCollection> me0RecHit;
+  iEvent.getByToken(ME0RecHit_Token, me0RecHit);
+  edm::Handle<ME0DigiPreRecoCollection> me0Digi;
+  iEvent.getByToken(ME0Digi_Token, me0Digi);
+  
+  //  std::cout <<"Numner of digi "<<me0Digi->size()<<std::endl;
+  ME0DigiPreRecoCollection::DigiRangeIterator me0dgIt;
+  for (me0dgIt = me0Digi->begin(); me0dgIt != me0Digi->end();
+       ++me0dgIt){
+    const ME0DetId me0Id = (*me0dgIt).first;
+    const ME0DigiPreRecoCollection::Range& digiRange = (*me0dgIt).second;
+    std::cout <<" Original DIGI DET ID "<<me0Id<< " # digis = "<<(digiRange.second-digiRange.first+1)<<std::endl;
 
+    // Get the iterators over the digis associated with this LayerId                                                                                         
+    for (ME0DigiPreRecoCollection::const_iterator digi = digiRange.first;
+	 digi != digiRange.second;digi++) {
+      std::cout <<"x= "<<digi->x()<< " , y= "<<digi->y()<<" timing "<<digi->tof()<<std::endl;
+    }
+  }
+
+  std::cout <<"Number of rec hit "<<me0RecHit->size()<<std::endl;
+  float rlmax = 0.;
+  float rlmin = 999999.;
+  float plmin = 999999.;
+  float plmax = 999999.;
+  int lmin = 100;
+  int lmax = 0;
+  for (auto recHit = me0RecHit->begin(); recHit != me0RecHit->end(); recHit++) {
+    ME0DetId id = recHit->me0Id();
+    auto roll = me0Geom->etaPartition(id);
+    std::cout <<"   Original ME0DetID "<<id<<" Timing "<<recHit->tof()<<std::endl;    
+    int layer = id.layer();
+    if (layer < lmin){
+      lmin = layer;
+      rlmin = (roll->toGlobal(recHit->localPosition())).perp();
+      plmin = (roll->toGlobal(recHit->localPosition())).barePhi();
+    }
+    if (layer > lmax){
+      lmax = layer;
+      rlmax = (roll->toGlobal(recHit->localPosition())).perp();
+      plmax = (roll->toGlobal(recHit->localPosition())).barePhi();
+    }
+  }
+  std::cout <<" Radius  max min  and delta "<<rlmax<<"  "<<rlmin <<" " <<rlmax-rlmin<<std::endl;
+  std::cout <<" Phi     max min  and delta "<<plmax<<"  "<<plmin <<" " <<plmax-plmin<<std::endl;
+  ME0_recdR->Fill(rlmax-rlmin);
+  ME0_recdPhi->Fill(fabs(deltaPhi(plmax,plmin)));
+  
   std::cout <<"Number of Segments "<<me0Segment->size()<<std::endl;
+  ME0_sgmult->Fill(me0Segment->size());
+  float hmax = 0;
   for (auto me0s = me0Segment->begin(); me0s != me0Segment->end(); me0s++) {
-    // The ME0 Ensemble DetId refers to layer = 1   
+    // The ME0 Ensemble DetId refers to layer = 1   and roll = 1
     ME0DetId id = me0s->me0DetId();
+ 
+    ME0_sgtime->Fill(me0s->time());
+    ME0_sgterr->Fill(me0s->timeErr());
     std::cout <<"   Original ME0DetID "<<id<<std::endl;
     auto roll = me0Geom->etaPartition(id); 
     std::cout <<"   Global Segment Position "<<  roll->toGlobal(me0s->localPosition())<<std::endl;
     auto segLP = me0s->localPosition();
     auto segLD = me0s->localDirection();
-    std::cout <<"   Global Direction theta = "<<segLD.theta()<<" phi="<<segLD.phi()<<std::endl;
+    std::cout <<"   Local Direction theta = "<<segLD.theta()<<" phi="<<segLD.phi()<<std::endl;
     ME0_fitchi2->Fill(me0s->chi2()*1.0/me0s->degreesOfFreedom());
-    std::cout <<"   Chi2 = "<<me0s->chi2()<<" ndof = "<<me0s->degreesOfFreedom()<<" ==> chi2/ndof = "<<me0s->chi2()*1.0/me0s->degreesOfFreedom()<<std::endl;
+    std::cout <<"   Chi2 = "<<me0s->chi2()<<" ndof = "<<me0s->degreesOfFreedom()<<" ==> chi2/ndof = "<<me0s->chi2()*1.0/me0s->degreesOfFreedom()
+	      <<" Timing "<<me0s->time()<<" +- "<<me0s->timeErr()
+	      <<std::endl;
 
     auto me0rhs = me0s->specificRecHits();
     std::cout <<"   ME0 Ensemble Det Id "<<id<<"  Number of RecHits "<<me0rhs.size()<<std::endl;
+    ME0_rhmult->Fill(me0rhs.size());
+    if (me0rhs.size()>hmax) hmax = me0rhs.size();
     //loop on rechits.... take layer local position -> global -> ensemble local position same frame as segment
     for (auto rh = me0rhs.begin(); rh!= me0rhs.end(); rh++){
       auto me0id = rh->me0Id();
+      ME0_rhtime->Fill(rh->tof());
       auto rhr = me0Geom->etaPartition(me0id);
       auto rhLP = rh->localPosition();
       auto erhLEP = rh->localPositionError();
       auto rhGP = rhr->toGlobal(rhLP); 
       auto rhLPSegm = roll->toLocal(rhGP);
-      float xe  = segLP.x()+segLD.x()*rhLPSegm.z()/segLD.z();
-      float ye  = segLP.y()+segLD.y()*rhLPSegm.z()/segLD.z();
+      float xe  = segLP.x()+segLD.x()*(rhLPSegm.z()-segLP.z())/segLD.z();
+      float ye  = segLP.y()+segLD.y()*(rhLPSegm.z()-segLP.z())/segLD.z();
       float ze = rhLPSegm.z();
       LocalPoint extrPoint(xe,ye,ze); // in segment rest frame
       auto extSegm = rhr->toLocal(roll->toGlobal(extrPoint)); // in layer restframe
       std::cout <<"      ME0 Layer Id "<<rh->me0Id()<<"  error on the local point "<<  erhLEP
-		<<"\n-> Ensemble Rest Frame  RH local  position "<<rhLPSegm<<"  Segment extrapolation "<<extrPoint
+                <<"\n-> Ensemble Rest Frame  RH local  position "<<rhLPSegm<<"  Segment extrapolation "<<extrPoint
 		<<"\n-> Layer Rest Frame  RH local  position "<<rhLP<<"  Segment extrapolation "<<extSegm
+                <<"\n-> Global Position rechit " << rhGP <<" Segm Extrapolation "<<roll->toGlobal(extrPoint)
+		<<"\n-> Timing "<<rh->tof()
 		<<std::endl;
       ME0_Residuals_x->Fill(rhLP.x()-extSegm.x());
       ME0_Residuals_y->Fill(rhLP.y()-extSegm.y());
@@ -271,6 +375,7 @@ TestME0SegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
     std::cout<<"\n"<<std::endl;
   }
   std::cout<<"\n"<<std::endl;
+  ME0_rhmultb->Fill(hmax);
 }
 
 //define this as a plug-in

--- a/RecoLocalMuon/GEMSegment/test/TestME0SegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMSegment/test/TestME0SegmentAnalyzer.cc
@@ -67,7 +67,6 @@ class TestME0SegmentAnalyzer : public edm::EDAnalyzer {
   edm::EDGetTokenT<ME0SegmentCollection> ME0Segment_Token;
   edm::EDGetTokenT<ME0RecHitCollection> ME0RecHit_Token;
   edm::EDGetTokenT<ME0DigiPreRecoCollection> ME0Digi_Token;
-  //  edm::EDGetTokenT<ME0DigiPreRecoCollection> ME0Digi_Token;
 
   std::string rootFileName;
 

--- a/RecoLocalMuon/GEMSegment/test/testme0segementanalyzer_cfg.py
+++ b/RecoLocalMuon/GEMSegment/test/testme0segementanalyzer_cfg.py
@@ -2,8 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TestME0Segment")
 process.load("FWCore.MessageService.MessageLogger_cfi")
-
-process.load('Configuration.Geometry.GeometryExtended2015MuonGEMDevReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023D6Reco_cff')
 # process.load('Configuration.Geometry.GeometryExtended2023HGCalMuonReco_cff')
 # process.load("Geometry.GEMGeometry.me0Geometry_cfi")
 # process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
@@ -12,13 +11,12 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        # 'file:./out_rec_me0.test2.root'
-        'file:out_local_reco_me0segment.root'
+        'file:/afs/cern.ch/work/m/mmaggi/ME0/SEGMENTS/CMSSW_9_0_0_pre1/src/McProd/nick_me0segment.root'
     )
 )
 
 process.me0s = cms.EDAnalyzer('TestME0SegmentAnalyzer',
-                              RootFileName = cms.untracked.string("TestME0SegmentHistograms.root"),
+                              RootFileName = cms.untracked.string("TestME0NickSegmentHistogramsRU.root"),
 
 )
 


### PR DESCRIPTION
Translated CSC RU algorithm (https://indico.cern.ch/event/578871/contributions/2345178/attachments/1358089/2053858/16_10_19-Voytishin_Palichik-CSCSegBuilderCSCWeekly.pdf) for use in ME0. It is not a direct port as some of the assumptions made for the CSC do not apply to ME0. It is now set as the default. Also updated standard segment algorithm to use the chamber as the coordinate reference frame. 

Right now the default cfg parameters are for a 10 eta partition geometry and 768 strips...this will change once the geometry is finalized.
Automatically ported from CMSSW_9_0_X #17677 (original by @nickmccoll).
Please wait for a new IB (12 to 24H) before requesting to test this PR.