### PR TITLE
nbOfDaughters_electrons_correction_Histos_90X_V2

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -235,11 +235,9 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
 
     pat::Electron gsfElectron ;
 
-//    for(std::vector<pat::Electron>::const_iterator el1=electrons->begin(); el1!=electrons->end(); el1++) {
     pat::ElectronCollection::const_iterator el1 ;
     pat::ElectronCollection::const_iterator el2 ;
     for(el1=electrons->begin(); el1!=electrons->end(); el1++) {
-//        for (std::vector<pat::Electron>::const_iterator el2=el1+1 ; el2!=electrons->end() ; el2++ )
         for (el2=el1+1 ; el2!=electrons->end() ; el2++ )
         {
             math::XYZTLorentzVector p12 = el1->p4()+el2->p4();
@@ -265,11 +263,18 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
     //===============================================
 
     for(size_t i=0; i<genParticles->size(); i++) {  
-        // number of mc particles
+/*                // DEBUG LINES - KEEP IT !
+        std::cout << "\nevt ID = " << iEvent.id() ; 
+        std::cout << ",  mcIter position : " << i << std::endl; 
+        std::cout << "pdgID : " << (*genParticles)[i].pdgId() << ", Pt : " << (*genParticles)[i].pt() ; 
+        std::cout << ", eta : " << (*genParticles)[i].eta() << ", phi : " << (*genParticles)[i].phi() << std::endl; 
+                // DEBUG LINES - KEEP IT !  */ 
+
+                // number of mc particles
         mcNum++ ;
 
         // counts photons
-        if ( (*genParticles)[i].pdgId() == 22 )
+        if ( (*genParticles)[i].pdgId() == 22 )       
             { gamNum++ ; }
 
         // select requested mother matching gen particle
@@ -277,12 +282,37 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
         const Candidate * mother = (*genParticles)[i].mother(0) ;
         matchingMotherID = false ;
         for ( unsigned int ii=0 ; ii<matchingMotherIDs_.size() ; ii++ ) {
-            if ( (mother == 0) || ((mother != 0) &&  mother->pdgId() == matchingMotherIDs_[ii]) )
-                { matchingMotherID = true ; 
-//			std::cout << "matchingMotherID :" << matchingMotherIDs_[ii] << std::endl ;
+
+/*                // DEBUG LINES - KEEP IT !
+                std::cout << "Matching : matchingMotherID[" << ii << "] : "<< matchingMotherIDs_[ii]  << ", evt ID = " << iEvent.id() << ", mother : "  << mother ; 
+                if (mother != 0) { 
+			        std::cout << "mother : " << mother << ", mother pdgID : " << mother->pdgId() << std::endl ; 
+                    std::cout << "mother pdgID : " << mother->pdgId() << ", Pt : " << mother->pt() << ", eta : " << mother->eta() << ", phi : " << mother->phi() << std::endl; 
+                }
+                else { 
+                    std::cout << std::endl; 
+                } 
+                // DEBUG LINES - KEEP IT !  */ 
+
+            if ( mother == 0 ) {
+                matchingMotherID = true ; 
             }
-        }
-        if (!matchingMotherID) continue ;
+            else if ( mother->pdgId() == matchingMotherIDs_[ii] ) { 
+                if ( mother->numberOfDaughters() <= 2 ) {
+                    matchingMotherID = true ;
+                    //std::cout << "evt ID = " << iEvent.id() ;                                                                               // debug lines
+                    //std::cout << " - nb of Daughters : " << mother->numberOfDaughters() << " - pdgId() : " << mother->pdgId() << std::endl; // debug lines
+                }
+            } // end of mother if test
+
+/*                // DEBUG LINES - KEEP IT !
+            if (mother != 0) { 
+                std::cout << "mother : " << mother << ", mother pdgID : " << mother->pdgId() << std::endl ; 
+                std::cout << "mother pdgID : " << mother->pdgId() << ", Pt : " << mother->pt() << ", eta : " << mother->eta() << ", phi : " << mother->phi() << std::endl; 
+            } 
+                // DEBUG LINES - KEEP IT !  */ 
+        } // end of for loop
+    if (!matchingMotherID) {continue ;}
 
         // electron preselection
         if ((*genParticles)[i].pt()> maxPt_ || std::abs((*genParticles)[i].eta())> maxAbsEta_)
@@ -318,6 +348,10 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
                         relisoNeutralHadronPt_recomp = sumNeutralHadronPt_recomp/pt_;
                         relisoPhotonPt_recomp = sumPhotonPt_recomp/pt_; /**/
                         okGsfFound = true;
+                        
+                // DEBUG LINES - KEEP IT !
+                        std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
+                // DEBUG LINES - KEEP IT !  /**/ 
                     }
                 }
             }
@@ -408,6 +442,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
 
     } // fin boucle size_t i
 
-//    std::cout << ("fin analyze\n");
+    //std::cout << ("fin analyze\n"); //
 }
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -1209,24 +1209,57 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
   for
    ( mcIter=genParticles->begin() ; mcIter!=genParticles->end() ; mcIter++ )
    {
+/*                // DEBUG LINES - KEEP IT !
+    std::cout << "\nevt ID = " << iEvent.id() ; 
+    std::cout << ",  mcIter position : " << mcIter - genParticles->begin() << std::endl ; 
+    std::cout << "pdgID : " << mcIter->pdgId() << ", Pt : " << mcIter->pt() << ", eta : " << mcIter->eta() << ", phi : " << mcIter->phi() << std::endl; 
+                // DEBUG LINES - KEEP IT !  */ 
+
     // select requested matching gen particle
     matchingID=false;
-    for ( unsigned int i=0 ; i<matchingIDs_.size() ; i++ )
-     {
-      if ( mcIter->pdgId() == matchingIDs_[i] )
-       { matchingID=true ; }
+    for ( unsigned int i=0 ; i<matchingIDs_.size() ; i++ ) {
+
+        if ( mcIter->pdgId() == matchingIDs_[i] )
+           { matchingID=true ; 
+/*                // DEBUG LINES - KEEP IT !
+			std::cout << "\nMatching mis-reco : matchingIDs_.size() = " << matchingIDs_.size() << ", evt ID = " << iEvent.id() ; 
+            std::cout << ", mcIter pdgID : " << mcIter->pdgId() << ", matchingID : " << matchingID << std::endl ; 
+                // DEBUG LINES - KEEP IT !  */ 
+       }
      }
-    if (matchingID)
-     {
+    if (matchingID) {
       // select requested mother matching gen particle
       // always include single particle with no mother
       const Candidate * mother = mcIter->mother() ;
       matchingMotherID = false ;
       for ( unsigned int i=0 ; i<matchingMotherIDs_.size() ; i++ )
        {
-        if ((mother == 0) || ((mother != 0) &&  mother->pdgId() == matchingMotherIDs_[i]) )
-         { matchingMotherID = true ; }
-       }
+/*                // DEBUG LINES - KEEP IT !
+                std::cout << "Matching : matchingMotherID[" << ii << "] : "<< matchingMotherIDs_[ii]  << ", evt ID = " << iEvent.id() << ", mother : "  << mother ; 
+                if (mother != 0) { 
+			        std::cout << "mother : " << mother << ", mother pdgID : " << mother->pdgId() << std::endl ; 
+                    std::cout << "mother pdgID : " << mother->pdgId() << ", Pt : " << mother->pt() << ", eta : " << mother->eta() << ", phi : " << mother->phi() << std::endl; 
+                }
+                else { 
+                    std::cout << std::endl; 
+                } 
+                // DEBUG LINES - KEEP IT !  */ 
+                
+        if ( mother == 0 ) {
+            matchingMotherID = true ; 
+        }
+        else if ( mother->pdgId() == matchingMotherIDs_[i] ) { 
+            if ( mother->numberOfDaughters() <= 2 ) {
+                matchingMotherID = true ;
+/*                // DEBUG LINES - KEEP IT !
+			    std::cout << "Matching mis-reco : matchingMotherID[" << i << "] : " << matchingMotherIDs_[i] << ", evt ID = " << iEvent.id() << ", mother : " << mother ; // debug lines
+                std::cout << "evt ID = " << iEvent.id() ;                                                                                                                 // debug lines
+                std::cout << " - nb of Daughters : " << mother->numberOfDaughters() << " - pdgId() : " << mother->pdgId() << std::endl;                                   // debug lines
+                // DEBUG LINES - KEEP IT !  */ 
+            }
+        } // end of mother if test
+
+         }
       if (matchingMotherID)
        {
         if ( mcIter->pt()>maxPt_ || std::abs(mcIter->eta())>maxAbsEta_ )
@@ -1249,7 +1282,6 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
           double dphi = gsfIter->phi()-mcIter->phi() ;
           if (std::abs(dphi)>CLHEP::pi)
            { dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi ; }
-//          double deltaR = sqrt(pow((gsfIter->eta()-mcIter->eta()),2) + pow(dphi,2)) ;
           double deltaR2 = (gsfIter->eta()-mcIter->eta()) * (gsfIter->eta()-mcIter->eta()) + dphi * dphi ;
           if ( deltaR2 < deltaR2_ )
            {
@@ -1272,15 +1304,14 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
          } // loop over rec ele to look for the best one
 
         // analysis when the mc track is found
-        if (okGsfFound)
-         {
+        if (okGsfFound) {
           // generated distributions for matched electrons
           h1_mc_Pt_matched_qmisid->Fill( mcIter->pt() ) ;
           h1_mc_Phi_matched_qmisid->Fill( mcIter->phi() ) ;
           h1_mc_AbsEta_matched_qmisid->Fill( std::abs(mcIter->eta()) ) ;
           h1_mc_Eta_matched_qmisid->Fill( mcIter->eta() ) ;
           h1_mc_Z_matched_qmisid->Fill( mcIter->vz() ) ;
-         }
+        }
        }
      }
    }
@@ -1314,7 +1345,17 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     for ( unsigned int i=0 ; i<matchingMotherIDs_.size() ; i++ )
      {
       if ( (mother == 0) || ((mother != 0) &&  mother->pdgId() == matchingMotherIDs_[i]) )
-       { matchingMotherID = true ; }
+       { matchingMotherID = true ; 
+/*                // DEBUG LINES - KEEP IT !
+			std::cout << "Matching mc-reco : matchingMotherID[" << i << "] : " << matchingMotherIDs_[i] << ", evt ID = " << iEvent.id() << ", mother : " << mother ; 
+            if (mother != 0) {
+                std::cout << ", mother pdgID : " << mother->pdgId() << std::endl ; 
+            }
+            else {
+                std::cout << std::endl ; 
+            }
+                // DEBUG LINES - KEEP IT !  */ 
+        }
      }
     if (!matchingMotherID) continue ;
 
@@ -1350,7 +1391,6 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
       double dphi = gsfIter->phi()-mcIter->phi() ;
       if (std::abs(dphi)>CLHEP::pi)
        { dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi ; }
-//      double deltaR = sqrt(pow((gsfIter->eta()-mcIter->eta()),2) + pow(dphi,2));
       double deltaR2 = (gsfIter->eta()-mcIter->eta()) * (gsfIter->eta()-mcIter->eta()) + dphi * dphi;
       if ( deltaR2 < deltaR2_ )
        {
@@ -1364,6 +1404,8 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
             bestGsfElectron=*gsfIter;
             bestGsfElectronRef=reco::GsfElectronRef(gsfElectrons,iElectron);
             okGsfFound = true;
+            
+            //std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl; // debug lines
            }
          }
        }

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
@@ -35,8 +35,8 @@ process.electronMcSignalPostValidatorPt1000.InputFolderName = cms.string("Egamma
 process.electronMcSignalPostValidatorPt1000.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorPt1000")
 
 from Configuration.AlCa.autoCond import autoCond
-#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+#process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 
 process.dqmSaver.workflow = '/electronHistos/' + t1[1] + '/RECO3'

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
@@ -19,10 +19,27 @@ dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 # OLD WAY
 
 print "reading files ..."
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
-process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
+max_number = -1 # number of events
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(max_number))
+process.source = cms.Source ("PoolSource",
+#eventsToProcess = cms.untracked.VEventRange('1:2682-1:2682'), 
+#eventsToProcess = cms.untracked.VEventRange('1:8259-1:8259'), 
+fileNames = cms.untracked.vstring([
+#        'file:PAT_249120E2-D1EC-E611-83C2-0CC47A7C347A.root',
+#        'file:PAT_76F9AD07-D3EC-E611-AA87-0CC47A745250.root',
+#        'file:PAT_FA0E1D02-D5EC-E611-B8CA-0025905A6080.root',
+#        'file:PAT_EE728E01-D5EC-E611-9DC5-0025905A6126.root',
+    ]),
+secondaryFileNames = cms.untracked.vstring() )
 process.source.fileNames.extend(dd.search())
 print "done"
+
+#process.printTree = cms.EDAnalyzer("ParticleListDrawer",
+#  maxEventsToPrint = cms.untracked.int32(1),
+#  printVertex = cms.untracked.bool(False),
+#  printOnlyHardInteraction = cms.untracked.bool(False), # Print only status=3 particles. This will not work for Pythia8, which does not have any such particles.
+#  src = cms.InputTag("prunedGenParticles")
+#)
 
 # NEW WAY
 #print "reading files ..."
@@ -61,6 +78,7 @@ process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")
 process.load("Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi")
 process.load("Validation.RecoEgamma.ElectronIsolation_cfi")
+#process.load("PhysicsTools.PatAlgos.slimming.prunedGenParticles_cfi")
 
 # load DQM
 process.load("DQMServices.Core.DQM_cfg")
@@ -74,9 +92,10 @@ fileName = cms.untracked.string(os.environ['TEST_HISTOS_FILE'].replace(".root", 
 process.electronMcSignalValidatorMiniAOD.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
 process.electronMcSignalValidatorMiniAOD.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
 
-process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
+#process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
+#process.p = cms.Path(process.prunedGenParticles * process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.printTree)
+process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) # * process.printTree
 #process.p = cms.Path(process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
-#process.p = cms.Path(process.ElectronIsolation)
 
 process.outpath = cms.EndPath(
 process.EDM,

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py
@@ -29,8 +29,8 @@ process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
-#process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
+process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
+#process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -11,9 +11,21 @@ process.load("DQMServices.Components.DQMStoreStats_cfi")
 from DQMServices.Components.DQMStoreStats_cfi import *
 dqmStoreStats.runOnEndJob = cms.untracked.bool(True)
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+#max_skipped = 165
+max_number = -1 # number of events
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(max_number))
+#process.source = cms.Source ("PoolSource",skipEvents = cms.untracked.uint32(max_skipped), fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
 process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
+#process.source = cms.Source ("PoolSource",eventsToProcess = cms.untracked.VEventRange('1:8259-1:8259'), fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
+#process.source = cms.Source ("PoolSource",eventsToProcess = cms.untracked.VEventRange('1:2682-1:2682'), fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
 process.source.fileNames.extend(dd.search())
+
+#process.printTree = cms.EDAnalyzer("ParticleListDrawer",
+#  maxEventsToPrint = cms.untracked.int32(1),
+#  printVertex = cms.untracked.bool(False),
+#  printOnlyHardInteraction = cms.untracked.bool(False), # Print only status=3 particles. This will not work for Pythia8, which does not have any such particles.
+#  src = cms.InputTag("genParticles")
+#)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
@@ -31,6 +43,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 #process.GlobalTag.globaltag = '76X_mcRun2_asymptotic_Queue'
+#process.GlobalTag.globaltag = '90X_upgrade2017_realistic_v6_B5'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
 
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
@@ -52,6 +65,7 @@ process.electronMcSignalValidator.OutputFolderName = cms.string("EgammaV/Electro
 
 #process.p = cms.Path(process.electronIsoFromDeps * process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
 process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter * process.dqmStoreStats)
+#process.p = cms.Path(process.electronMcSignalValidator * process.MEtoEDMConverter * process.printTree)
 
 process.outpath = cms.EndPath(
 process.EDM,

--- a/Validation/RecoEgamma/test/OvalFile
+++ b/Validation/RecoEgamma/test/OvalFile
@@ -1,19 +1,19 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_1_0_pre12_std2">
-<var name="TEST_REF" value="8_1_0_pre12_std2">
+<var name="TEST_NEW" value="9_0_0_pre4_2017_miniAOD_DQM_dev">
+<var name="TEST_REF" value="9_0_0_pre4_2017_DQM_dev">
 
-<var name="TAG_STARTUP" value="81X_mcRun2_asymptotic_v8">
+<var name="TAG_STARTUP" value="90X_upgrade2017_realistic_v6">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="81X_mcRun2_asymptotic_v8-v1">
+<var name="DD_COND_REF" value="90X_upgrade2017_realistic_v6-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 <!--var name="DD_RELEASE" value="CMSSW_8_0_0_pre2"-->
 
 <var name="STORE_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_NEW}">
 <var name="STORE_REF" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Store/${TEST_REF}">
- 
+
 <var name="WEB_DIR" value="/afs/cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev">
 
 <!--var name="WEB_DIR" value="/afs/cern.ch/user/c/chamont/www/validation"-->
@@ -92,956 +92,113 @@ FullSim
 
   This set of targets is currently used for the validation of electrons.
 
-  Used if DD_SOURCE=das
-  <!--var name="DD_TIER" value="*RECO*"-->
-
   Used if DD_source=/eos/...
-  <var name="DD_TIER" value="GEN-SIM-RECO">
+  <!--var name="DD_TIER" value="GEN-SIM-RECO"-->
+  <var name="DD_TIER" value="MINIAODSIM">
   
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
-  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
-  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidation_gedGsfElectrons_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
+  <var name="VAL_HISTOS" value="ElectronMcSignalHistosMiniAOD.txt">
+  <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorMiniAOD">
+  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorMiniAOD">
+  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationMiniAOD_cfg">
+  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationMiniAOD_cfg">
       
   <environment name="ValFullStdStatsStartup">
   
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
     <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
     
-    <!--var name="DD_COND" value="STARTUP"-->
-    <environment name="ValFullPt10Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullPt35Startup_UP15">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-            
-    </environment>
-
-    <environment name="ValFullPt1000Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_cfg.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullTTbarStartup_13">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullZEEStartup_13">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullQcdPt80Pt120Startup_13">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullPt10Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
-    </environment>
-
-    <environment name="ValFullPt35Startup_UP15_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      
-    </environment>
-    
-    <environment name="ValFullPt1000Startup_UP15_gedGsfE">
-    
-      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
-      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
-    </environment>
-
     <environment name="ValFullTTbarStartup_13_gedGsfE">
-  
       <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <target name="dqm" cmd="electronDataDiscovery.py castor">
       <target name="wget" cmd="electronWget.py castor">
-      
       <target name="dd" cmd="electronDataDiscovery.py">
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
       <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
     </environment>
   
-    <environment name="ValFullZEEStartup_13_gedGsfE">
-    
+    <environment name="ValFullZEEStartup_13_gedGsfE">    
       <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
+      <target name="wget" cmd="electronWget.py castor">      
       <target name="dd" cmd="electronDataDiscovery.py">
       <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
     </environment>
-
-    <environment name="ValFullQcdPt80Pt120Startup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
+  
+    <environment name="ValFullPt10Startup_UP15_gedGsfE">    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
+      <target name="wget" cmd="electronWget.py castor">      
       <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
       <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-
-    </environment>  
-  
-  </environment>
-
-  <environment name="ValFullGsfvsGsf">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
-    <environment name="ValGsfvsGsfFullPt10Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullPt35Startup_UP15">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-            
-    </environment>
-
-    <environment name="ValGsfvsGsfFullPt1000Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullTTbarStartup_13">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullZEEStartup_13">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullZEEStartup_13.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullQcdPt80Pt120Startup_13">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
-      
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-  </environment>
-  
-  <environment name="ValFullgedvsGsf">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
-
-    <environment name="ValgedvsGsfFullPt10Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsGsfFullPt35Startup_UP15_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-      
-    </environment>
-    
-    <environment name="ValgedvsGsfFullPt1000Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsGsfFullTTbarStartup_13_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
     </environment>
   
-    <environment name="ValgedvsGsfFullZEEStartup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-  
+    <environment name="ValFullPt10Startup_gedGsfE">    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
     </environment>
-
-    <environment name="ValgedvsGsfFullQcdPt80Pt120Startup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
-
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>  
-  
-  </environment>
   
   <environment name="ValFullgedvsged">
   
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
+    <var name="TEST_GLOBAL_AUTOCOND" value="startup">       
     <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
 
-    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsgedFullPt35Startup_UP15_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-      
-    </environment>
-    
-    <environment name="ValgedvsgedFullPt1000Startup_UP15_gedGsfE">
-    
-      <var name="VAL_HISTOS" value="ElectronMcSignalHistosPt1000.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
-      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">
-  
+    <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">  
       <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
-
       <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
     </environment>
   
-    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">
-    
+    <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">  
       <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
       <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
-
       <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-  
     </environment>
 
-    <environment name="ValgedvsgedFullQcdPt80Pt120Startup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
-
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
+    <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
       <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>  
-  
-  </environment>
-
-  <environment name="ValPileUpStartup">
-    
-    <var name="TAG_STARTUP" value="PU_${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="ValPileUpTTbarStartup">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
-      </environment>
-
-    <environment name="ValPileUpZEEStartup">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} /${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
     </environment>
 
-      <environment name="ValPileUpTTbarStartup_gedGsfE">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-	
-	    <var name="BLUE_FILE" value="electronHistos.ValPileUpTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValPileUpTTbarStartup_gedGsfE.root">
- 
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-      </environment>
-
-    <environment name="ValPileUpZEEStartup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-     
-      <var name="BLUE_FILE" value="electronHistos.ValPileUpZEEStartup.root">
-      <var name="RED_FILE" value="electronHistos.ValPileUpZEEStartup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-  
-  </environment>
-    
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-FastSim
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="FastSim">
-
-  <var name="DD_TIER" value="GEN-SIM-DIGI-RECO">
-
-  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
- 
-  <environment name="ValFast">
-
-    <environment name="ValFastStartup">
-
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="/${TEST_GLOBAL_TAG}_FastSim-${DATA_VERSION}">
-      
-      <environment name="ValFastTTbarStartup">
-      
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SAMPLE" value="RelValTTbar">
-	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
-	
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-        
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-        
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        
-      </environment>
-    
-      <environment name="ValFastZEEStartup">
-      
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SAMPLE" value="RelValZEE">
-	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
-	
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-        
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-        
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        
-      </environment>
-    
-    </environment>
-    
-  </environment>
-  
-  <environment name="ValFastVsFast">
-  
-    <environment name="ValFastVsFastStartup">
-    
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}*FastSim*-${DATA_VERSION}">
-
-      <environment name="ValFastVsFastTTbarStartup">
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
-      </environment>
-      
-      <environment name="ValFastVsFastZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
-      </environment>
-        
-    </environment>
-    
-  </environment>
-  
-  <environment name="ValFastVsFull">
-  
-    <environment name="ValFastVsFullStartup">
-    
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="ValFastVsFullTTbarStartup">
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastTTbarStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
-      </environment>
-      
-      <environment name="ValFastVsFullZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastZEEStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
-      </environment>
-      
-    </environment>
-        
-  </environment>
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to redo the electrons
-with the local modified code.
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Redo">
-
-  <environment name="SeedsRemaker">
-
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-    <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      
-    <environment name="SeedsRemakerStep1">
-
-      <var name="DD_TIER" value="*RAW*">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-FIRST-RECO.root">
-
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 -s RAW2DIGI,L1Reco,RECO,VALIDATION,DQM --conditions auto:startup --datatier GEN-SIM-RECO,DQM --eventcontent RECOSIM,DQM --filein=Dummy-STARTUP-RAW.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.storeseed --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="reco" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      
-    </environment>
-  
-    <environment name="SeedsRemakerStep2">
-    
-      <var name="DD_TIER" value="*FIRST-RECO*">
-      <var name="DD_SOURCE" value="electronInputDataFiles.txt">
-      <var name="DD_COND" value="STARTUP">
-      <file name="electronInputDataFiles.txt">
-      file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-FIRST-RECO.root
-      </file>
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 --process reRECO --filtername RECOfromRECO -s RECO:reconstruction_fromRECO_noTrackingTest --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-STARTUP-RECO.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.reseed+regenseed+reconv --python_filename=SeedsRemaker_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun SeedsRemaker_cfg.py">
-      
-    </environment>
-
-  </environment>
-  
-  <environment name="RedoFromTrackSeeds">
-
-    <var name="VAL_CONFIGURATION" value="ElectronRedoFromTrackSeeds_cfg">
-    
-    <environment name="RedoFromTrackSeedsPt35">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsQcdPt80Pt120">
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsPt10">
+    <environment name="ValgedvsgedFullPt10Startup_gedGsfE">  
       <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
     </environment>
-  
+
   </environment>
-
-  <environment name="RedoFromCore">
-
-    <environment name="RedoFromCoreStartup">
-  
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="RedoFromCoreZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <executable name="electronDataDiscovery.py">
-        <executable name="cmsRun" args="ElectronRedoFromCore_cfg.py">
-      </environment>
-    
-    </environment>
-        
+ 
   </environment>
-
-  <environment name="RedoFromRaw">
-
-    <var name="DD_TIER" value="*RAW*">
-
-    <!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
-    <file name="electronInputDataFiles.txt">
-    ${TEST_AFS_DIR}/RelValSingleElectronPt10-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValSingleElectronPt35-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValTTbar-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-STARTUP-RAW.root
-    ${TEST_AFS_DIR}/RelValQCD_Pt_80_120-IDEAL-RAW.root
-    </file>
-
-    <environment name="RedoFromRawStartup">
-
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-      <!--var name="DD_COND" value="STARTUP"-->
-
-      <target name="cfg" cmd="cmsDriver.py reco -s RAW2DIGI,RECO -n -1 --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-RAW.root --fileout=Dummy-STARTUP-RECO.root --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-
-      <environment name="RedoFromRawPt35Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
     
-      <environment name="RedoFromRawQcdPt80Pt120Startup">
-        <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-      <environment name="RedoFromRawPt10Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-  
-      <environment name="RedoFromRawZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-    </environment>
-    
-  </environment>
-  
 </environment>
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to test cmsDriver.py steps
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Validation">
-
-  <target name="step1" cmd="cmsDriver.py SingleElectronPt35_pythia8_cfi.py -s GEN,SIM,DIGI,L1,DIGI2RAW,HLT:GRun -n 10 --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RAW.root">
-  <target name="step2" cmd="cmsDriver.py step2 -s RAW2DIGI,RECO,VALIDATION,DQM -n 10 --filein file:SingleElectronPt35-10-IDEAL-RAW.root --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RECO.root">
-  <target name="step3" cmd="cmsDriver.py step3 -s HARVESTING:validationHarvesting+dqmHarvesting --harvesting AtRunEnd --conditions auto:mc --filein file:SingleElectronPt35-10-IDEAL-RECO.root --mc">
-
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Process uncleaned superclusters
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Uncleaned">
-
-  <var name="DD_TIER" value="*RAW*">
-  <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-  <var name="TEST_HISTOS_FILE" value="${DD_SAMPLE}-IDEAL-UNCLEANED-RECO.root">
-  
-  <target name="dd" cmd="electronDataDiscovery.py">
-  <target name="py" cmd="python ElectronFromUncleanedOnly_cfg.py">
-  <target name="reco" cmd="cmsRun ElectronFromUncleanedOnly_cfg.py">
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Photons
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Photons">
-
-  Those few photons datasets are checked so to compare
-  size and performance with electrons.
-
-  <var name="DD_TIER_SECONDARY" value="*RAW*">
-  <!--var name="DD_RELEASE" value="LOCAL"-->
-  <!--var name="DD_COND" value=""-->
-
-  <environment name="PhotonPt35">
-    <var name="DD_SAMPLE" value="RelValSingleGammaPt35">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
-  </environment>
-  
-  <environment name="PhotonQcdPt80-120">
-    <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
-  </environment>
-  
-</environment>

--- a/Validation/RecoEgamma/test/OvalFile.GED
+++ b/Validation/RecoEgamma/test/OvalFile.GED
@@ -1,12 +1,12 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_1_0_pre9_std">
-<var name="TEST_REF" value="8_1_0_pre5_std">
+<var name="TEST_NEW" value="9_0_0_pre4_2017_DQM_dev">
+<var name="TEST_REF" value="9_0_0_pre4_DQM_dev">
 
-<var name="TAG_STARTUP" value="81X_mcRun2_asymptotic_v2">
+<var name="TAG_STARTUP" value="90X_upgrade2017_realistic_v6">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="80X_mcRun2_asymptotic_v13-v1">
+<var name="DD_COND_REF" value="90X_mcRun2_asymptotic_v1-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 <!--var name="DD_RELEASE" value="CMSSW_8_0_0_pre2"-->
@@ -69,6 +69,7 @@ some RelVal reco files which have been regenerated locally.
 <file name="electronInputDataFiles.txt">
 file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-RECO.root
 file:${TEST_AFS_DIR}/RelValSingleElectronPt35-STARTUP-RECO.root
+file:${TEST_AFS_DIR}/RelValSingleElectronPt1000-STARTUP-RECO.root
 file:${TEST_AFS_DIR}/RelValTTbar-STARTUP-RECO.root
 file:${TEST_AFS_DIR}/RelValZEE-STARTUP-RECO.root
 file:${TEST_AFS_DIR}/RelValQCD_Pt_80_120-STARTUP-RECO.root
@@ -112,124 +113,9 @@ FullSim
        
     <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
     
-    <!--var name="DD_COND" value="STARTUP"-->
-    <environment name="ValFullPt10Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullPt35Startup_UP15">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-            
-    </environment>
-
-    <environment name="ValFullPt1000Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ElectronMcSignalPt1000Validation_cfg.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullTTbarStartup_13">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullZEEStartup_13">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
-    <environment name="ValFullQcdPt80Pt120Startup_13">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-  
-    </environment>
-
     <environment name="ValFullPt10Startup_UP15_gedGsfE">
     
       <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <target name="dqm" cmd="electronDataDiscovery.py castor">
@@ -247,7 +133,6 @@ FullSim
     <environment name="ValFullPt35Startup_UP15_gedGsfE">
   
       <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <target name="dqm" cmd="electronDataDiscovery.py castor">
@@ -269,7 +154,61 @@ FullSim
       <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
       <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
       <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+
+    </environment>
+
+    <environment name="ValFullPt10Startup_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+
+    </environment>
+
+    <environment name="ValFullPt35Startup_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">
+      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
+      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      
+    </environment>
+    
+    <environment name="ValFullPt1000Startup_gedGsfE">
+    
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000">
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <target name="dqm" cmd="electronDataDiscovery.py castor">
@@ -287,7 +226,6 @@ FullSim
     <environment name="ValFullTTbarStartup_13_gedGsfE">
   
       <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <target name="dqm" cmd="electronDataDiscovery.py castor">
@@ -305,7 +243,6 @@ FullSim
     <environment name="ValFullZEEStartup_13_gedGsfE">
     
       <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <target name="dqm" cmd="electronDataDiscovery.py castor">
@@ -323,7 +260,6 @@ FullSim
     <environment name="ValFullQcdPt80Pt120Startup_13_gedGsfE">
     
       <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
@@ -345,183 +281,6 @@ FullSim
     </environment>  
   
   </environment>
-
-  <environment name="ValFullGsfvsGsf">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
-    <environment name="ValGsfvsGsfFullPt10Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullPt35Startup_UP15">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-            
-    </environment>
-
-    <environment name="ValGsfvsGsfFullPt1000Startup_UP15">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullTTbarStartup_13">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullZEEStartup_13">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullZEEStartup_13.root">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-    <environment name="ValGsfvsGsfFullQcdPt80Pt120Startup_13">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      <var name="TEST_HISTOS_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
-      
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/FullGsfvsGsf_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-  </environment>
-  
-  <environment name="ValFullgedvsGsf">
-  
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-       
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
-    
-    <!--var name="DD_COND" value="STARTUP"-->
-
-    <environment name="ValgedvsGsfFullPt10Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsGsfFullPt35Startup_UP15_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-      
-    </environment>
-    
-    <environment name="ValgedvsGsfFullPt1000Startup_UP15_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_UP15.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-
-    <environment name="ValgedvsGsfFullTTbarStartup_13_gedGsfE">
-  
-      <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullTTbarStartup_13.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-  
-    <environment name="ValgedvsGsfFullZEEStartup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullZEEStartup_13.root">
-
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-  
-    </environment>
-
-    <environment name="ValgedvsGsfFullQcdPt80Pt120Startup_13_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
-      <var name="RED_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13.root">
-
-      <var name="VAL_HISTOS" value="ElectronMcFakeHistos.txt">
-      <var name="VAL_ANALYZER" value="ElectronMcFakeValidator">
-      <var name="VAL_POST_ANALYZER" value="ElectronMcFakePostValidator">
-      <var name="VAL_CONFIGURATION" value="ElectronMcFakeValidation_gedGsfElectrons_cfg">
-      <var name="VAL_POST_CONFIGURATION" value="ElectronMcFakePostValidation_cfg">
-      
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGed/FullgedvsGsf_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>  
-  
-  </environment>
   
   <environment name="ValFullgedvsged">
   
@@ -530,12 +289,9 @@ FullSim
        
     <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">    
     
-    <!--var name="DD_COND" value="STARTUP"-->
-
     <environment name="ValgedvsgedFullPt10Startup_UP15_gedGsfE">
     
       <var name="DD_SAMPLE" value="RelValSingleElectronPt10_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
@@ -548,7 +304,6 @@ FullSim
     <environment name="ValgedvsgedFullPt35Startup_UP15_gedGsfE">
   
       <var name="DD_SAMPLE" value="RelValSingleElectronPt35_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_UP15_gedGsfE.root">
@@ -566,7 +321,6 @@ FullSim
       <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
       <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
       <var name="DD_SAMPLE" value="RelValSingleElectronPt1000_UP15">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_UP15_gedGsfE.root">
@@ -576,10 +330,50 @@ FullSim
 
     </environment>
 
+    <environment name="ValgedvsgedFullPt10Startup_gedGsfE">
+    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
+    <environment name="ValgedvsgedFullPt35Startup_gedGsfE">
+  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt35Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt35Startup_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+      
+    </environment>
+    
+    <environment name="ValgedvsgedFullPt1000Startup_gedGsfE">
+    
+      <var name="VAL_HISTOS" value="ElectronMcSignalHistosPt1000.txt">
+      <var name="VAL_ANALYZER" value="ElectronMcSignalValidatorPt1000">
+      <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidatorPt1000">
+      <var name="VAL_CONFIGURATION_gedGsfE" value="ElectronMcSignalValidationPt1000_gedGsfElectrons_cfg">
+      <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidationPt1000_cfg">
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt1000">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
+      
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt1000Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt1000Startup_gedGsfE.root">
+
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+
+    </environment>
+
     <environment name="ValgedvsgedFullTTbarStartup_13_gedGsfE">
   
       <var name="DD_SAMPLE" value="RelValTTbar_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup_13_gedGsfE.root">
@@ -592,7 +386,6 @@ FullSim
     <environment name="ValgedvsgedFullZEEStartup_13_gedGsfE">
     
       <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup_13_gedGsfE.root">
@@ -605,7 +398,6 @@ FullSim
     <environment name="ValgedvsgedFullQcdPt80Pt120Startup_13_gedGsfE">
     
       <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
       
       <var name="BLUE_FILE" value="electronHistos.ValFullQcdPt80Pt120Startup_13_gedGsfE.root">
@@ -622,426 +414,8 @@ FullSim
     </environment>  
   
   </environment>
-
-  <environment name="ValPileUpStartup">
-    
-    <var name="TAG_STARTUP" value="PU_${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="ValPileUpTTbarStartup">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
-      </environment>
-
-    <environment name="ValPileUpZEEStartup">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-      
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} /${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/PileUp_${DD_SAMPLE}_Startup'>
-  
-    </environment>
-
-      <environment name="ValPileUpTTbarStartup_gedGsfE">
-        
-        <var name="DD_SAMPLE" value="RelValTTbar_13">
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-	
-	    <var name="BLUE_FILE" value="electronHistos.ValPileUpTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValPileUpTTbarStartup_gedGsfE.root">
- 
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-      
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-	    <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_NEW} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-      </environment>
-
-    <environment name="ValPileUpZEEStartup_gedGsfE">
-    
-      <var name="DD_SAMPLE" value="RelValZEE_13">
-      <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">
-     
-      <var name="BLUE_FILE" value="electronHistos.ValPileUpZEEStartup.root">
-      <var name="RED_FILE" value="electronHistos.ValPileUpZEEStartup_gedGsfE.root">
-
-      <target name="dqm" cmd="electronDataDiscovery.py castor">
-      <target name="wget" cmd="electronWget.py castor">
-      
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
-      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-      
-      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "${TEST_NEW} / gedGsfElectrons / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / GsfElectrons / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GfsVsGedGsf/PileUp_${DD_SAMPLE}_gedGsfE_Startup'>
-
-    </environment>
-  
-  </environment>
     
 </environment>
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-FastSim
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-<environment name="FastSim">
-
-  <var name="DD_TIER" value="GEN-SIM-DIGI-RECO">
-
-  <var name="VAL_ANALYZER" value="ElectronMcSignalValidator">
-  <var name="VAL_POST_ANALYZER" value="ElectronMcSignalPostValidator">
-  <var name="VAL_CONFIGURATION" value="ElectronMcSignalValidation_cfg">
-  <var name="VAL_POST_CONFIGURATION" value="ElectronMcSignalPostValidation_cfg">
-  <var name="VAL_HISTOS" value="ElectronMcSignalHistos.txt">
- 
-  <environment name="ValFast">
-
-    <environment name="ValFastStartup">
-
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="/${TEST_GLOBAL_TAG}_FastSim-${DATA_VERSION}">
-      
-      <environment name="ValFastTTbarStartup">
-      
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SAMPLE" value="RelValTTbar">
-	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
-	
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-        
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-        
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        
-      </environment>
-    
-      <environment name="ValFastZEEStartup">
-      
-        <!--var name="DD_SOURCE" value="/castor/cern.ch/cms/store/unmerged/dqm/${DD_SAMPLE}-${DD_RELEASE}-${DD_COND}-DQM-DQMHarvest-OfflineDQM"-->
-        <var name="DD_SAMPLE" value="RelValZEE">
-	<var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}">
-	
-        <target name="dqm" cmd="electronDataDiscovery.py castor">
-        <target name="wget" cmd="electronWget.py castor">
-        
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-        <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">
-        
-        <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
-        
-      </environment>
-    
-    </environment>
-    
-  </environment>
-  
-  <environment name="ValFastVsFast">
-  
-    <environment name="ValFastVsFastStartup">
-    
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}*FastSim*-${DATA_VERSION}">
-
-      <environment name="ValFastVsFastTTbarStartup">
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastTTbarStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
-      </environment>
-      
-      <environment name="ValFastVsFastZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="electronHistos.ValFastZEEStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${TEST_NEW} -b ${TEST_REF} -t "${TEST_NEW} / ${DD_SAMPLE} / ${DD_COND} vs ${TEST_REF} / ${DD_SAMPLE} / ${DD_COND_REF}" ${STORE_DIR}/${TEST_HISTOS_FILE} ${STORE_REF}/${TEST_HISTOS_FILE} ${WEB_DIR}/${TEST_NEW}/vs${TEST_REF}/Fast_${DD_SAMPLE}_Startup'>
-      </environment>
-        
-    </environment>
-    
-  </environment>
-  
-  <environment name="ValFastVsFull">
-  
-    <environment name="ValFastVsFullStartup">
-    
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="ValFastVsFullTTbarStartup">
-        <var name="DD_SAMPLE" value="RelValTTbar">
-        <var name="BLUE_FILE" value="electronHistos.ValFullTTbarStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastTTbarStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
-      </environment>
-      
-      <environment name="ValFastVsFullZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="BLUE_FILE" value="electronHistos.ValFullZEEStartup.root">
-        <var name="RED_FILE" value="electronHistos.ValFastZEEStartup.root">
-        <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r FastSim -b FullSim -t "Fast vs Full / ${DD_SAMPLE} / ${DD_COND}" ${STORE_DIR}/${RED_FILE} ${STORE_DIR}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/FastVsFull/${DD_SAMPLE}_Startup'>
-      </environment>
-      
-    </environment>
-        
-  </environment>
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to redo the electrons
-with the local modified code.
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Redo">
-
-  <environment name="SeedsRemaker">
-
-    <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-    <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-    <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-    <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      
-    <environment name="SeedsRemakerStep1">
-
-      <var name="DD_TIER" value="*RAW*">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-FIRST-RECO.root">
-
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 -s RAW2DIGI,L1Reco,RECO,VALIDATION,DQM --conditions auto:startup --datatier GEN-SIM-RECO,DQM --eventcontent RECOSIM,DQM --filein=Dummy-STARTUP-RAW.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.storeseed --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="reco" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      
-    </environment>
-  
-    <environment name="SeedsRemakerStep2">
-    
-      <var name="DD_TIER" value="*FIRST-RECO*">
-      <var name="DD_SOURCE" value="electronInputDataFiles.txt">
-      <var name="DD_COND" value="STARTUP">
-      <file name="electronInputDataFiles.txt">
-      file:${TEST_AFS_DIR}/RelValSingleElectronPt10-STARTUP-FIRST-RECO.root
-      </file>
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      
-      <target name="cfg" cmd="cmsDriver.py step3 -n -1 --process reRECO --filtername RECOfromRECO -s RECO:reconstruction_fromRECO_noTrackingTest --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-STARTUP-RECO.root --fileout=Dummy-STARTUP-RECO.root --customise reseed.reseed+regenseed+reconv --python_filename=SeedsRemaker_driver_cfg.py --no_exec">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun SeedsRemaker_cfg.py">
-      
-    </environment>
-
-  </environment>
-  
-  <environment name="RedoFromTrackSeeds">
-
-    <var name="VAL_CONFIGURATION" value="ElectronRedoFromTrackSeeds_cfg">
-    
-    <environment name="RedoFromTrackSeedsPt35">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsQcdPt80Pt120">
-      <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-    <environment name="RedoFromTrackSeedsPt10">
-      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-      <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-      <target name="dd" cmd="electronDataDiscovery.py">
-      <target name="redo" cmd="cmsRun ${VAL_CONFIGURATION}.py">
-    </environment>
-  
-  </environment>
-
-  <environment name="RedoFromCore">
-
-    <environment name="RedoFromCoreStartup">
-  
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-
-      <environment name="RedoFromCoreZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <executable name="electronDataDiscovery.py">
-        <executable name="cmsRun" args="ElectronRedoFromCore_cfg.py">
-      </environment>
-    
-    </environment>
-        
-  </environment>
-
-  <environment name="RedoFromRaw">
-
-    <var name="DD_TIER" value="*RAW*">
-
-    <!--var name="DD_SOURCE" value="electronInputDataFiles.txt"-->
-    <file name="electronInputDataFiles.txt">
-    ${TEST_AFS_DIR}/RelValSingleElectronPt10-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValSingleElectronPt35-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValTTbar-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-IDEAL-RAW.root
-    ${TEST_AFS_DIR}/RelValZEE-STARTUP-RAW.root
-    ${TEST_AFS_DIR}/RelValQCD_Pt_80_120-IDEAL-RAW.root
-    </file>
-
-    <environment name="RedoFromRawStartup">
-
-      <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
-      <var name="TEST_GLOBAL_AUTOCOND" value="startup">
-      <var name="DD_COND" value="-${TEST_GLOBAL_TAG}-${DATA_VERSION}">
-      <!--var name="DD_COND" value="STARTUP"-->
-
-      <target name="cfg" cmd="cmsDriver.py reco -s RAW2DIGI,RECO -n -1 --conditions auto:startup --datatier GEN-SIM-RECO --eventcontent RECOSIM --filein=Dummy-RAW.root --fileout=Dummy-STARTUP-RECO.root --python_filename=ElectronRedoFromRawStartup_driver_cfg.py --no_exec">
-
-      <environment name="RedoFromRawPt35Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-      <environment name="RedoFromRawQcdPt80Pt120Startup">
-        <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-      <environment name="RedoFromRawPt10Startup">
-        <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-  
-      <environment name="RedoFromRawZEEStartup">
-        <var name="DD_SAMPLE" value="RelValZEE">
-        <var name="TEST_HISTOS_FILE" value="${TEST_AFS_DIR}/${DD_SAMPLE}-STARTUP-RECO.root">
-        <target name="dd" cmd="electronDataDiscovery.py">
-        <target name="redo" cmd="cmsRun ElectronRedoFromRawStartup_cfg.py">
-      </environment>
-    
-    </environment>
-    
-  </environment>
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-This set of targets is made to test cmsDriver.py steps
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Validation">
-
-  <target name="step1" cmd="cmsDriver.py SingleElectronPt35_pythia8_cfi.py -s GEN,SIM,DIGI,L1,DIGI2RAW,HLT:GRun -n 10 --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RAW.root">
-  <target name="step2" cmd="cmsDriver.py step2 -s RAW2DIGI,RECO,VALIDATION,DQM -n 10 --filein file:SingleElectronPt35-10-IDEAL-RAW.root --eventcontent FEVTDEBUGHLT --conditions auto:mc --mc --fileout SingleElectronPt35-10-IDEAL-RECO.root">
-  <target name="step3" cmd="cmsDriver.py step3 -s HARVESTING:validationHarvesting+dqmHarvesting --harvesting AtRunEnd --conditions auto:mc --filein file:SingleElectronPt35-10-IDEAL-RECO.root --mc">
-
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Process uncleaned superclusters
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Uncleaned">
-
-  <var name="DD_TIER" value="*RAW*">
-  <var name="DD_SAMPLE" value="RelValSingleElectronPt35">
-  <var name="TEST_HISTOS_FILE" value="${DD_SAMPLE}-IDEAL-UNCLEANED-RECO.root">
-  
-  <target name="dd" cmd="electronDataDiscovery.py">
-  <target name="py" cmd="python ElectronFromUncleanedOnly_cfg.py">
-  <target name="reco" cmd="cmsRun ElectronFromUncleanedOnly_cfg.py">
-  
-</environment>
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-================================================================================
-Photons
-================================================================================
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-<environment name="Photons">
-
-  Those few photons datasets are checked so to compare
-  size and performance with electrons.
-
-  <var name="DD_TIER_SECONDARY" value="*RAW*">
-  <!--var name="DD_RELEASE" value="LOCAL"-->
-  <!--var name="DD_COND" value=""-->
-
-  <environment name="PhotonPt35">
-    <var name="DD_SAMPLE" value="RelValSingleGammaPt35">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
-  </environment>
-  
-  <environment name="PhotonQcdPt80-120">
-    <var name="DD_SAMPLE" value="RelValQCD_Pt_80_120">
-    <executable name="electronDataDiscovery.py">
-    <executable name="cmsRun" args="PhotonValidation_cfg.py">
-  </environment>
-  
-</environment>

--- a/Validation/RecoEgamma/test/OvalFile.miniAOD
+++ b/Validation/RecoEgamma/test/OvalFile.miniAOD
@@ -1,12 +1,12 @@
 <var name="TEST_COMMENT" value="">
-<var name="TEST_NEW" value="8_1_0_pre9_miniAOD_std">
-<var name="TEST_REF" value="8_1_0_pre9_std">
+<var name="TEST_NEW" value="9_0_0_pre4_2017_miniAOD_DQM_dev">
+<var name="TEST_REF" value="9_0_0_pre4_2017_DQM_dev">
 
-<var name="TAG_STARTUP" value="81X_mcRun2_asymptotic_v2">
+<var name="TAG_STARTUP" value="90X_upgrade2017_realistic_v6">
 <var name="DATA_VERSION" value="v1">
 
 TAG for the REFERENCE DATA, USED ONLY FOR INFORMATION ON WEB PAGE
-<var name="DD_COND_REF" value="81X_mcRun2_asymptotic_v2-v1">
+<var name="DD_COND_REF" value="90X_upgrade2017_realistic_v6-v1">
 
 <var name="DD_RELEASE" value="${CMSSW_VERSION}">
 <!--var name="DD_RELEASE" value="CMSSW_8_0_0_pre2"-->
@@ -145,6 +145,18 @@ FullSim
       <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
     </environment>
   
+    <environment name="ValFullPt10Startup_gedGsfE">    
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">      
+      <target name="dqm" cmd="electronDataDiscovery.py castor">
+      <target name="wget" cmd="electronWget.py castor">      
+      <target name="dd" cmd="electronDataDiscovery.py">
+      <target name="analyze" cmd="cmsRun ${VAL_CONFIGURATION_gedGsfE}.py">
+      <target name="finalize" cmd="cmsRun ${VAL_POST_CONFIGURATION}.py">      
+      <target name="store" cmd='electronStore.py -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>
+      <target name="force" cmd='electronStore.py -f -r ${TEST_NEW} -m "${TEST_COMMENT}" -a ${VAL_ANALYZER}/${VAL_POST_ANALYZER} -c ${VAL_CONFIGURATION_gedGsfE}/${VAL_POST_CONFIGURATION} ${TEST_HISTOS_FILE} ${TEST_OUTPUT_LOGS} ${STORE_DIR}'>  
+    </environment>
+  
   <environment name="ValFullgedvsged">
   
     <var name="TEST_GLOBAL_TAG" value="${TAG_STARTUP}">
@@ -172,6 +184,14 @@ FullSim
       <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
       <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
       <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_UP15_gedGsfE.root">
+      <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
+    </environment>
+
+    <environment name="ValgedvsgedFullPt10Startup_gedGsfE">  
+      <var name="DD_SAMPLE" value="RelValSingleElectronPt10">
+      <var name="DD_SOURCE" value="/eos/cms/store/relval/${DD_RELEASE}/${DD_SAMPLE}/${DD_TIER}/${DD_COND}">     
+      <var name="BLUE_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
+      <var name="RED_FILE" value="electronHistos.ValFullPt10Startup_gedGsfE.root">
       <target name="publish" cmd='electronCompare.py -c ${VAL_HISTOS} -r ${RED_FILE} -b ${BLUE_FILE} -t "gedGsfElectrons ${DD_SAMPLE}<br><b><font color='red'>${TEST_NEW}</font></b> : ${DD_COND}<br><b><font color='blue'>${TEST_REF}</font></b> : ${DD_COND_REF}" ${STORE_DIR}/${RED_FILE} ${STORE_REF}/${BLUE_FILE} ${WEB_DIR}/${TEST_NEW}/GedvsGed_${TEST_REF}/Fullgedvsged_${DD_SAMPLE}_gedGsfE_Startup'>
     </environment>
 

--- a/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
+++ b/Validation/RecoEgamma/test/relval_gedGsfE.tcsh
@@ -109,9 +109,12 @@ then
 else
     echo "FULL"
 #    list="Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
-#	list="Pt1000Startup_UP15 TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
+#    list="Pt10Startup_UP15 Pt1000Startup_UP15 Pt35Startup_UP15 "
+#    list="Pt10Startup Pt1000Startup Pt35Startup TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
+#	list="TTbarStartup_13 ZEEStartup_13 QcdPt80Pt120Startup_13"
+	list="TTbarStartup_13 ZEEStartup_13 Pt10Startup"
 #	list="Pt1000Startup_UP15 "
-	list="TTbarStartup_13 ZEEStartup_13  QcdPt80Pt120Startup_13 "
+#	list="TTbarStartup_13 "
     for element in $list    
     do   
         echo "element =" $element   


### PR DESCRIPTION
It is a modification of the validation code (ElectronMcMiniAODSignalValidator.cc & ElectronMcSignalValidator.cc) in order to avoid nbOfDaughters >2 (i.e. 3 or 4). This lead to difference in the entries for miniAOD if nbOfDaughters is >2.

in addition, a few files were cleaned to take into account the SingleElectronPtxx with SingleElectronPtxx_UP15 with xx = 10, 35, 1000.

@beaudett @fcouderc 
Automatically ported from CMSSW_9_0_X #17672 (original by @archiron).
Please wait for a new IB (12 to 24H) before requesting to test this PR.