### PR TITLE
90x TTrackAssociator in L1TrackTrigger Sequence and in FEVT Eventcontent.

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -839,7 +839,9 @@ for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
     phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + [
         'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
         'keep *_TTClustersFromPhase2TrackerDigis_*_*',
-        'keep *_TTStubsFromPhase2TrackerDigis_*_*'
+        'keep *_TTStubsFromPhase2TrackerDigis_*_*',
+        'keep *_TTClusterAssociatorFromPixelDigis_*_*',
+        'keep *_TTStubAssociatorFromPixelDigis_*_*'
     ])
 
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import RecoLocalFastTimeFEVT, RecoLocalFastTimeRECO, RecoLocalFastTimeAOD

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.TrackTrigger.TrackTrigger_cff import *
-##from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
+from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 
 #L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
-L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs)
+L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs)
+
+TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)
+TTClusterAssociatorFromPixelDigis.digiSimLinks          = cms.InputTag( "simSiPixelDigis","Tracker" )

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.cc
@@ -31,8 +31,7 @@ TrackerParametersESModule::fillDescriptions( edm::ConfigurationDescriptions & de
 TrackerParametersESModule::ReturnType
 TrackerParametersESModule::produce( const PTrackerParametersRcd& iRecord )
 {
-  //edm::LogInfo("TrackerParametersESModule")
-  std::cout <<  "TrackerParametersESModule::produce(const PTrackerParametersRcd& iRecord)" << std::endl;
+  edm::LogInfo("TrackerParametersESModule") <<  "TrackerParametersESModule::produce(const PTrackerParametersRcd& iRecord)" << std::endl;
   edm::ESTransientHandle<DDCompactView> cpv;
   iRecord.getRecord<IdealGeometryRecord>().get( cpv );
     


### PR DESCRIPTION
This is useful for L1T MC production....don't want to calculated TriggerTrack Stubs, Clusters, and Associator.

Details of the PR:
 * Add TrackTriggerAssociatorClustersStubs to the L1TrackTrigger sequence, and configure Associator and StubAlgorithm as per experts recipe 
* Add keep Associator digis in FEVT* event content. 
* Turn cout to LogInfo for TrackerParametersESModule.
Automatically ported from CMSSW_9_0_X #17665 (original by @rekovic).
Please wait for a new IB (12 to 24H) before requesting to test this PR.