### PR TITLE
Update to input collection tokens in PATJetProducer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -54,8 +54,10 @@ PATJetProducer::PATJetProducer(const edm::ParameterSet& iConfig)  :
   getJetMCFlavour_ = iConfig.getParameter<bool>( "getJetMCFlavour" );
   useLegacyJetMCFlavour_ = iConfig.getParameter<bool>( "useLegacyJetMCFlavour" );
   addJetFlavourInfo_ = ( useLegacyJetMCFlavour_ ? false : iConfig.getParameter<bool>( "addJetFlavourInfo" ) );
-  jetPartonMapToken_ = mayConsume<reco::JetFlavourMatchingCollection>(iConfig.getParameter<edm::InputTag>( "JetPartonMapSource" ));
-  jetFlavourInfoToken_ = mayConsume<reco::JetFlavourInfoMatchingCollection>(iConfig.getParameter<edm::InputTag>( "JetFlavourInfoSource" ));
+  if (getJetMCFlavour_ && useLegacyJetMCFlavour_)
+    jetPartonMapToken_ = consumes<reco::JetFlavourMatchingCollection>(iConfig.getParameter<edm::InputTag>( "JetPartonMapSource" ));
+  else if (getJetMCFlavour_ && !useLegacyJetMCFlavour_)
+    jetFlavourInfoToken_ = consumes<reco::JetFlavourInfoMatchingCollection>(iConfig.getParameter<edm::InputTag>( "JetFlavourInfoSource" ));
   addGenPartonMatch_ = iConfig.getParameter<bool>( "addGenPartonMatch" );
   embedGenPartonMatch_ = iConfig.getParameter<bool>( "embedGenPartonMatch" );
   genPartonToken_ = mayConsume<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genPartonMatch" ));


### PR DESCRIPTION
This PR updates the way jet flavor input tokens are assigned in the PATJetProducer in response to the problem reported in https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3726.html

No changes are expected in any of the produced output files. The expected change is that in PAT and MiniAOD workflows legacy flavor modules should no longer be executed.
Automatically ported from CMSSW_9_0_X #17651 (original by @cms-btv-pog).
Please wait for a new IB (12 to 24H) before requesting to test this PR.