### PR TITLE
CTPPS: miniAOD (second resubmission)

### DIFF
--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Authors:
+*   Jan Kašpar (jan.kaspar@gmail.com)
+*
+****************************************************************************/
+
+#ifndef DataFormats_CTPPSReco_CTPPSLocalTrackLite
+#define DataFormats_CTPPSReco_CTPPSLocalTrackLite
+
+/**
+ *\brief Local (=single RP) track with essential information only.
+ **/
+struct CTPPSLocalTrackLite
+{
+  public:
+    CTPPSLocalTrackLite(uint32_t pid=0, float px=0., float pxu=-1., float py=0., float pyu=-1., float pt=0., float ptu=-1.)
+      : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), time(pt), time_unc(ptu)
+    {
+    }
+
+    uint32_t getRPId() const
+    {
+      return rpId;
+    }
+
+    float getX() const
+    {
+      return x;
+    }
+
+    float getXUnc() const
+    {
+      return x_unc;
+    }
+
+    float getY() const
+    {
+      return y;
+    }
+
+    float getYUnc() const
+    {
+      return y_unc;
+    }
+
+    float getTime() const
+    {
+      return time;
+    }
+
+    float getTimeUnc() const
+    {
+      return time_unc;
+    }
+
+  protected:
+    /// RP id
+    uint32_t rpId;
+
+    /// horizontal hit position and uncertainty, mm
+    float x, x_unc;
+
+    /// vertical hit position and uncertainty, mm
+    float y, y_unc;
+
+    /// time information and uncertainty
+    float time, time_unc;
+};
+
+#endif

--- a/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
+++ b/DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h
@@ -12,44 +12,55 @@
 /**
  *\brief Local (=single RP) track with essential information only.
  **/
-struct CTPPSLocalTrackLite
+class CTPPSLocalTrackLite
 {
   public:
-    CTPPSLocalTrackLite(uint32_t pid=0, float px=0., float pxu=-1., float py=0., float pyu=-1., float pt=0., float ptu=-1.)
+    CTPPSLocalTrackLite() : rpId(0), x(0.), x_unc(-1.), y(0.), y_unc(-1.), time(0.), time_unc(-1.)
+    {
+    }
+
+    CTPPSLocalTrackLite(uint32_t pid, float px, float pxu, float py, float pyu, float pt=0., float ptu=-1.)
       : rpId(pid), x(px), x_unc(pxu), y(py), y_unc(pyu), time(pt), time_unc(ptu)
     {
     }
 
+    /// returns the RP id
     uint32_t getRPId() const
     {
       return rpId;
     }
 
+    /// returns the horizontal track position
     float getX() const
     {
       return x;
     }
 
+    /// returns the horizontal track position uncertainty
     float getXUnc() const
     {
       return x_unc;
     }
 
+    /// returns the vertical track position
     float getY() const
     {
       return y;
     }
 
+    /// returns the vertical track position uncertainty
     float getYUnc() const
     {
       return y_unc;
     }
 
+    /// returns the track time
     float getTime() const
     {
       return time;
     }
 
+    /// returns the track time uncertainty
     float getTimeUnc() const
     {
       return time_unc;

--- a/DataFormats/CTPPSReco/src/classes.h
+++ b/DataFormats/CTPPSReco/src/classes.h
@@ -11,6 +11,8 @@
 
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h"
 
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+
 #include <vector>
 
 namespace DataFormats_CTPPSReco {
@@ -56,5 +58,11 @@ namespace DataFormats_CTPPSReco {
     edm::DetSetVector<CTPPSDiamondRecHit> dsv_ctd_rh;
     edm::Wrapper< edm::DetSetVector<CTPPSDiamondRecHit> > wrp_dsv_ctd_rh;
 
+    //--- common objects
+
+    CTPPSLocalTrackLite cltl;
+    std::vector<CTPPSLocalTrackLite> v_cltl;
+    edm::Wrapper<CTPPSLocalTrackLite> w_cltl;
+    edm::Wrapper<std::vector<CTPPSLocalTrackLite>> w_v_cltl;
   };
 }

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -56,4 +56,12 @@
   <class name="edm::DetSetVector<CTPPSDiamondRecHit>"/>
   <class name="edm::Wrapper< edm::DetSetVector<CTPPSDiamondRecHit> >"/>
 
+<!-- common objects -->
+
+  <class name="CTPPSLocalTrackLite"  ClassVersion="2">
+    <version ClassVersion="2" checksum="3838813906"/>
+  </class>
+  <class name="std::vector<CTPPSLocalTrackLite>"/>
+  <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>
+  <class name="edm::Wrapper<std::vector<CTPPSLocalTrackLite>>"/>
 </lcgdict>

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -58,8 +58,8 @@
 
 <!-- common objects -->
 
-  <class name="CTPPSLocalTrackLite"  ClassVersion="2">
-    <version ClassVersion="2" checksum="3838813906"/>
+  <class name="CTPPSLocalTrackLite" ClassVersion="3">
+    <version ClassVersion="3" checksum="3838813906"/>
   </class>
   <class name="std::vector<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -65,6 +65,8 @@ MicroEventContent = cms.PSet(
         'keep recoBeamHaloSummary_BeamHaloSummary_*_*',
         # Lumi
         'keep LumiScalerss_scalersRawToDigi_*_*',
+        # CTPPS
+        'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
     )
 )
 MicroEventContentMC = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -359,6 +359,7 @@ def miniAOD_customizeOutput(out):
 def miniAOD_customizeData(process):
     from PhysicsTools.PatAlgos.tools.coreTools import runOnData
     runOnData( process, outputModules = [] )
+    process.load("RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi")
 
 def miniAOD_customizeAllData(process):
     miniAOD_customizeCommon(process)

--- a/RecoCTPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
+++ b/RecoCTPPS/Configuration/python/RecoCTPPS_EventContent_cff.py
@@ -19,6 +19,9 @@ RecoCTPPSFEVT = cms.PSet(
     'keep CTPPSDiamondDigiedmDetSetVector_ctppsDiamondRawToDigi_*_*',
     'keep TotemVFATStatusedmDetSetVector_ctppsDiamondRawToDigi_*_*',
     'keep CTPPSDiamondRecHitedmDetSetVector_ctppsDiamondRecHits_*_*',
+
+    # CTPPS common
+    'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
   )
 )
 
@@ -42,6 +45,9 @@ RecoCTPPSRECO = cms.PSet(
     'keep CTPPSDiamondDigiedmDetSetVector_ctppsDiamondRawToDigi_*_*',
     'keep TotemVFATStatusedmDetSetVector_ctppsDiamondRawToDigi_*_*',
     'keep CTPPSDiamondRecHitedmDetSetVector_ctppsDiamondRecHits_*_*',
+
+    # CTPPS common
+    'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
   )
 )
 
@@ -65,5 +71,8 @@ RecoCTPPSAOD = cms.PSet(
     'keep CTPPSDiamondDigiedmDetSetVector_ctppsDiamondRawToDigi_*_*',
     'keep TotemVFATStatusedmDetSetVector_ctppsDiamondRawToDigi_*_*',
     'keep CTPPSDiamondRecHitedmDetSetVector_ctppsDiamondRecHits_*_*',
+
+    # CTPPS common
+    'keep CTPPSLocalTrackLites_ctppsLocalTrackLiteProducer_*_*'
   )
 )

--- a/RecoCTPPS/Configuration/test/raw_data_test.py
+++ b/RecoCTPPS/Configuration/test/raw_data_test.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("CTPPSReconstructionChainTest")
+process = cms.Process("CTPPSReconstructionChainTest", eras.ctpps_2016)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",
@@ -16,6 +17,7 @@ process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
     # run 274199, fill 4961, 29 May 2016 (before TS1)
     '/store/data/Run2016B/DoubleEG/RAW/v2/000/274/199/00000/04985451-9B26-E611-BEB9-02163E013859.root',
+    #'root://eostotem.cern.ch//eos/totem/user/j/jkaspar/04C8034A-9626-E611-9B6E-02163E011F93.root'
 
     # run 283877, fill 5442, 23 Oct 2016 (after TS2)
     '/store/data/Run2016H/HLTPhysics/RAW/v1/000/283/877/00000/F28F8896-999B-E611-93D8-02163E013706.root'

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -1,0 +1,81 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Authors:
+*   Jan Kašpar (jan.kaspar@gmail.com)
+*
+****************************************************************************/
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+
+//----------------------------------------------------------------------------------------------------
+
+/**
+ * \brief Distills the essential track data from all RPs.
+ **/
+class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<>
+{
+  public:
+    explicit CTPPSLocalTrackLiteProducer(const edm::ParameterSet& conf);
+  
+    virtual ~CTPPSLocalTrackLiteProducer() {}
+  
+    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  
+  private:
+    edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> siStripTrackToken;
+};
+
+//----------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------
+
+using namespace std;
+using namespace edm;
+
+//----------------------------------------------------------------------------------------------------
+
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(edm::ParameterSet const& conf)
+{
+  siStripTrackToken = consumes<DetSetVector<TotemRPLocalTrack>>(conf.getParameter<edm::InputTag>("tagSiStripTrack"));
+
+  produces<vector<CTPPSLocalTrackLite>>();
+}
+
+//----------------------------------------------------------------------------------------------------
+ 
+void CTPPSLocalTrackLiteProducer::produce(edm::Event& e, const edm::EventSetup& es)
+{
+  // get input from Si strips
+  edm::Handle< DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
+  e.getByToken(siStripTrackToken, inputSiStripTracks);
+
+  // prepare output
+  vector<CTPPSLocalTrackLite> output;
+  
+  // process tracks from Si strips
+  for (const auto rpv : *inputSiStripTracks)
+  {
+    const uint32_t rpId = rpv.detId();
+
+    for (const auto t : rpv)
+    {
+      if (t.isValid())
+        output.push_back(CTPPSLocalTrackLite(rpId, t.getX0(), t.getX0Sigma(), t.getY0(), t.getY0Sigma()));
+    }
+  }
+
+  // save output to event
+  e.put(make_unique<vector<CTPPSLocalTrackLite>>(output));
+}
+
+//----------------------------------------------------------------------------------------------------
+
+DEFINE_FWK_MODULE(CTPPSLocalTrackLiteProducer);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -32,6 +32,10 @@ class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<>
   
   private:
     edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> siStripTrackToken;
+
+    /// if true, this module will do nothing
+    /// needed for consistency with CTPPS-less workflows
+    bool doNothing;
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -42,8 +46,12 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(edm::ParameterSet const& conf)
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(edm::ParameterSet const& conf) :
+  doNothing(conf.getParameter<bool>("doNothing"))
 {
+  if (doNothing)
+    return;
+
   siStripTrackToken = consumes<DetSetVector<TotemRPLocalTrack>>(conf.getParameter<edm::InputTag>("tagSiStripTrack"));
 
   produces<vector<CTPPSLocalTrackLite>>();
@@ -53,6 +61,9 @@ CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(edm::ParameterSet const
  
 void CTPPSLocalTrackLiteProducer::produce(edm::Event& e, const edm::EventSetup& es)
 {
+  if (doNothing)
+    return;
+
   // get input from Si strips
   edm::Handle< DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
   e.getByToken(siStripTrackToken, inputSiStripTracks);

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPLocalTrackFitter.cc
@@ -92,10 +92,10 @@ void TotemRPLocalTrackFitter::produce(edm::Event& e, const edm::EventSetup& setu
 
   // run fit for each RP
   DetSetVector<TotemRPLocalTrack> output;
-  
+
   for (const auto &rpv : *input)
   {
-    unsigned int rpDecId =  rpv.detId();
+    CTPPSDetId rpId(rpv.detId());
 
     // is U-V association unique?
     unsigned int n_U=0, n_V=0;
@@ -132,7 +132,7 @@ void TotemRPLocalTrackFitter::produce(edm::Event& e, const edm::EventSetup& setu
     {
       if (verbosity_)
         LogVerbatim("TotemRPLocalTrackFitter")
-          << ">> TotemRPLocalTrackFitter::produce > Impossible to combine U and V patterns in RP " << rpDecId
+          << ">> TotemRPLocalTrackFitter::produce > Impossible to combine U and V patterns in RP " << rpId
           << " (n_U=" << n_U << ", n_V=" << n_V << ").";
 
       continue;
@@ -159,17 +159,12 @@ void TotemRPLocalTrackFitter::produce(edm::Event& e, const edm::EventSetup& setu
     }
 
     // run fit
-    const unsigned int armIdx = rpDecId / 100;
-    const unsigned int stIdx = (rpDecId / 10) % 10;
-    const unsigned int rpIdx = rpDecId % 10;
-    TotemRPDetId rpId(armIdx, stIdx, rpIdx);
-
     double z0 = geometry->GetRPGlobalTranslation(rpId).z();
 
     TotemRPLocalTrack track;
     fitter_.fitTrack(hits, z0, *geometry, track);
     
-    DetSet<TotemRPLocalTrack> &ds = output.find_or_insert(rpDecId);
+    DetSet<TotemRPLocalTrack> &ds = output.find_or_insert(rpId);
     ds.push_back(track);
 
     if (verbosity_ > 5)
@@ -179,7 +174,7 @@ void TotemRPLocalTrackFitter::produce(edm::Event& e, const edm::EventSetup& setu
         n_hits += hds.size();
 
       LogVerbatim("TotemRPLocalTrackFitter")
-        << "    track in RP " << rpDecId << ": valid = " << track.isValid() << ", hits = " << n_hits;
+        << "    track in RP " << rpId << ": valid = " << track.isValid() << ", hits = " << n_hits;
     }
   }
 

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
@@ -214,8 +214,7 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
   // track recognition pot by pot
   for (auto it : rpData)
   {
-    TotemRPDetId rpId(it.first);
-    unsigned int rpDecId = rpId.getRPDecimalId();
+    CTPPSDetId rpId(it.first);
     RPData &data = it.second;
 
     // merge default and exceptional settings (if available)
@@ -224,7 +223,7 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
     double threshold_U = threshold;
     double threshold_V = threshold;
     
-    auto setIt = exceptionalSettings.find(rpDecId);
+    auto setIt = exceptionalSettings.find(rpId);
     if (setIt != exceptionalSettings.end())
     {
       minPlanesPerProjectionToFit_U = setIt->second.minPlanesPerProjectionToFit_U;
@@ -239,7 +238,7 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
     if (verbosity > 5)
     {
       LogVerbatim("TotemRPUVPatternFinder")
-        << "\tRP " << rpDecId
+        << "\tRP " << rpId
         << "\n\t\tall planes: u = " << uColl.size() << ", v = " << vColl.size();
     }
 
@@ -261,7 +260,7 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
       continue;
 
     // prepare data containers
-    DetSet<TotemRPUVPattern> &patterns = patternsVector.find_or_insert(rpDecId);
+    DetSet<TotemRPUVPattern> &patterns = patternsVector.find_or_insert(rpId);
 
     // "typical" z0 for the RP
     double z0 = geometry->GetRPDevice(rpId)->translation().z();

--- a/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
+++ b/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+ctppsLocalTrackLiteProducer = cms.EDProducer("CTPPSLocalTrackLiteProducer",
+    tagSiStripTrack = cms.InputTag("totemRPLocalTrackFitter")
+)

--- a/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
+++ b/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
@@ -1,5 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 ctppsLocalTrackLiteProducer = cms.EDProducer("CTPPSLocalTrackLiteProducer",
-    tagSiStripTrack = cms.InputTag("totemRPLocalTrackFitter")
+  tagSiStripTrack = cms.InputTag("totemRPLocalTrackFitter"),
+
+  # disable the module by default
+  doNothing = cms.bool(True)
 )
+
+# enable the module for CTPPS era(s)
+from Configuration.StandardSequences.Eras import eras
+eras.ctpps_2016.toModify(ctppsLocalTrackLiteProducer, doNothing=cms.bool(False))

--- a/RecoCTPPS/TotemRPLocal/python/totemRPLocalReconstruction_cff.py
+++ b/RecoCTPPS/TotemRPLocal/python/totemRPLocalReconstruction_cff.py
@@ -15,9 +15,14 @@ from RecoCTPPS.TotemRPLocal.totemRPUVPatternFinder_cfi import *
 # local track fitting
 from RecoCTPPS.TotemRPLocal.totemRPLocalTrackFitter_cfi import *
 
+# lite local-track collection from all RPs
+from RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi import *
+
 totemRPLocalReconstruction = cms.Sequence(
     totemRPClusterProducer *
     totemRPRecHitProducer *
     totemRPUVPatternFinder *
-    totemRPLocalTrackFitter
+    totemRPLocalTrackFitter *
+
+    ctppsLocalTrackLiteProducer
 )

--- a/RecoCTPPS/TotemRPLocal/python/totemRPUVPatternFinder_cfi.py
+++ b/RecoCTPPS/TotemRPLocal/python/totemRPUVPatternFinder_cfi.py
@@ -38,7 +38,7 @@ totemRPUVPatternFinder = cms.EDProducer("TotemRPUVPatternFinder",
     # if a RP or projection needs adjustment of the above settings, you can use the following format
 	#	exceptionalSettings = cms.VPSet(
 	#	    cms.PSet(
-	#	        rpId = cms.uint32(20),
+	#	        rpId = cms.uint32(1998061568), # RP id according to CTPPSDetId
 	#	        minPlanesPerProjectionToFit_U = cms.uint32(2),
 	#	        minPlanesPerProjectionToFit_V = cms.uint32(3),
 	#	        threshold_U = cms.double(1.99),


### PR DESCRIPTION
This is a continuation of #17424 after it has been reverted (#17630). It contains:
 * the same commits as #17424 
 * plus a mechanism to inhibit `CTPPSLocalTrackLiteProducer` if era `ctpps_2016` is not selected, as suggested in https://github.com/cms-sw/cmssw/pull/17424#issuecomment-282569060 .

`runTheMatrix -l limited` gave
 * `14 14 13 11 6 0 0 0 tests passed, 2 0 0 0 0 0 0 0 failed`
 * the two failures were `DAS_ERROR` in workflows 4.22 and 1001.0


Automatically ported from CMSSW_9_0_X #17650 (original by @CTPPS).
Please wait for a new IB (12 to 24H) before requesting to test this PR.