### PR TITLE
Pfmuon fix 90x

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -142,7 +142,6 @@ importToBlock( const edm::Event& e,
     if( !mask[idx] ) continue; 
     muonref = reco::MuonRef();
     pftrackref = reco::PFRecTrackRef(tracks,idx);    
-    if( vetoed.count(pftrackref->trackRef().key()) ) continue;
     // Get the eventual muon associated to this track
     const int muId = muAssocToTrack( pftrackref->trackRef(), muons );
     bool thisIsAPotentialMuon = false;
@@ -161,7 +160,9 @@ importToBlock( const edm::Event& e,
       if ( useTiming_ ) {
         trkElem->setTime( (*timeH)[pftrackref->trackRef()], (*timeErrH)[pftrackref->trackRef()] );
       }
-      elems.emplace_back(trkElem);
+      if( vetoed.count(pftrackref->trackRef().key()) == 0 || muonref.isNonnull()){
+	elems.emplace_back(trkElem);
+      }
     }
   }
   elems.shrink_to_fit();

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -143,18 +143,18 @@ def _findIndicesByModule(name):
             ret.append(i)
    return ret
 
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-# kill tracks in the HGCal
-_insertGeneralTracksImporter = {}
-for idx in _findIndicesByModule('GeneralTracksImporter'):
-    _insertGeneralTracksImporter[idx] = dict(
-        importerName = cms.string('GeneralTracksImporterWithVeto'),
-        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
-    )
-phase2_hgcal.toModify(
-    particleFlowBlock,
-    elementImporters = _insertGeneralTracksImporter
-)
+#from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+## kill tracks in the HGCal
+#_insertGeneralTracksImporter = {}
+#for idx in _findIndicesByModule('GeneralTracksImporter'):
+#    _insertGeneralTracksImporter[idx] = dict(
+#        importerName = cms.string('GeneralTracksImporterWithVeto'),
+#        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
+#    )
+#phase2_hgcal.toModify(
+#    particleFlowBlock,
+#    elementImporters = _insertGeneralTracksImporter
+#)
 ### for later
 #_phase2_hgcal_Linkers.append( 
 #    cms.PSet( linkerName = cms.string("SCAndHGCalLinker"),

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -143,18 +143,18 @@ def _findIndicesByModule(name):
             ret.append(i)
    return ret
 
-#from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-## kill tracks in the HGCal
-#_insertGeneralTracksImporter = {}
-#for idx in _findIndicesByModule('GeneralTracksImporter'):
-#    _insertGeneralTracksImporter[idx] = dict(
-#        importerName = cms.string('GeneralTracksImporterWithVeto'),
-#        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
-#    )
-#phase2_hgcal.toModify(
-#    particleFlowBlock,
-#    elementImporters = _insertGeneralTracksImporter
-#)
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+# kill tracks in the HGCal
+_insertGeneralTracksImporter = {}
+for idx in _findIndicesByModule('GeneralTracksImporter'):
+    _insertGeneralTracksImporter[idx] = dict(
+        importerName = cms.string('GeneralTracksImporterWithVeto'),
+        veto = cms.InputTag('hgcalTrackCollection:TracksInHGCal')
+    )
+phase2_hgcal.toModify(
+    particleFlowBlock,
+    elementImporters = _insertGeneralTracksImporter
+)
 ### for later
 #_phase2_hgcal_Linkers.append( 
 #    cms.PSet( linkerName = cms.string("SCAndHGCalLinker"),

--- a/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/simPFProducer_cfi.py
@@ -8,6 +8,7 @@ simPFProducer = cms.EDProducer(
     pfRecTrackSrc = cms.InputTag("hgcalTrackCollection:TracksInHGCal"),
     trackSrc = cms.InputTag('generalTracks'),
     gsfTrackSrc = cms.InputTag('electronGsfTracks'),
+    muonSrc = cms.InputTag("muons1stStep"),
     trackingParticleSrc = cms.InputTag('mix:MergedTrackTruth'),
     simClusterTruthSrc = cms.InputTag('mix:MergedCaloTruth'),
     caloParticlesSrc = cms.InputTag('mix:MergedCaloTruth'),

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -30,7 +30,6 @@
 
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
-#include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"  //PFMuons
 
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
@@ -82,7 +81,6 @@ private:
   // tracking particle associators by order of preference
   const std::vector<edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> > associators_;
 
-  std::unique_ptr<PFMuonAlgo> pfmu_;
 };
 
 DEFINE_FWK_MODULE(SimPFProducer);
@@ -119,8 +117,6 @@ SimPFProducer::SimPFProducer(const edm::ParameterSet& conf) :
   produces<reco::PFBlockCollection>();
   produces<reco::SuperClusterCollection>("perfect");
   produces<reco::PFCandidateCollection>();
-  pfmu_ = std::unique_ptr<PFMuonAlgo>(new PFMuonAlgo());
-  pfmu_->setParameters(conf);
 }
 
 void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {  
@@ -150,7 +146,7 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
   edm::Handle<reco::MuonCollection> muons;
   evt.getByToken(muons_,muons);
   std::unordered_set<unsigned> MuonTrackToGeneralTrack;
-  for (auto mu : *muons.product()){
+  for (auto const& mu : *muons.product()){
     reco::TrackRef muTrkRef = mu.track();
     if (muTrkRef.isNonnull())
       MuonTrackToGeneralTrack.insert(muTrkRef.key());

--- a/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc
@@ -273,11 +273,6 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
     const auto& matches = assoc_tps->val;
     
     const auto absPdgId = std::abs(matches[0].first->pdgId());
-
-    // remove tracks already used by muons
-    std::cout <<"simpfproducer trackUsed "<< MuonTrackToGeneralTrack.count(itk) << std::endl;	     
-    if( MuonTrackToGeneralTrack.count(itk) || absPdgId == 13) continue;   
-    
     const auto charge = tkRef->charge();
     const auto three_mom = tkRef->momentum();
     constexpr double mpion2 = 0.13957*0.13957;
@@ -339,7 +334,9 @@ void SimPFProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetu
       }
     }
     usedTrack[tkRef.key()] = true;    
-
+    // remove tracks already used by muons
+    if( MuonTrackToGeneralTrack.count(itk) || absPdgId == 13)
+      candidates->pop_back();
   }
 
   // now loop over the non-collected clusters in blocks 


### PR DESCRIPTION
low tight and loose muon ID efficiency due to low pfmuon efficiency due to GeneralTracksImporterWithVeto killing pftracks
This issue was noticed in #16797 
pfmuon temp fix - hgcal will fix later 

fix rotation in me0geometry - in me0 even and odd chambers are not inverted

@calabria @lgray @pietverwilligen @kpedro88 
Automatically ported from CMSSW_9_0_X #17648 (original by @jshlee).
Please wait for a new IB (12 to 24H) before requesting to test this PR.