### PR TITLE
Fix numerical precision issue in 2D vertexing and wrong normalization.

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
@@ -113,7 +113,7 @@ double DAClusterizerInZT::update( double beta,
         double zratio = k->pk*k->ei/Zi;
         
 	k->se += tks[i].pi*zratio/k->pk;
-	double w = tks[i].pi * zratio /( tks[i].dz2 * tks[i].dt2 );        
+	double w = tks[i].pi * zratio /( tks[i].dz2 + tks[i].dt2 );        
         
 	k->sw  += w;
 	k->swz += w * tks[i].z;
@@ -257,7 +257,7 @@ double DAClusterizerInZT::beta0( double betamax,
     double sumwt=0.;
     double sumw=0.;
     for(unsigned int i=0; i<nt; i++){
-      double w = tks[i].pi/(tks[i].dz2 * tks[i].dt2);
+      double w = tks[i].pi/(tks[i].dz2 + tks[i].dt2);
       sumwz += w*tks[i].z;
       sumwt += w*tks[i].t;
       sumw  += w;
@@ -270,7 +270,7 @@ double DAClusterizerInZT::beta0( double betamax,
     for(unsigned int i=0; i<nt; i++){
       double dx = tks[i].z-(k->z);
       double dt = tks[i].t-(k->t);
-      double w  = tks[i].pi/(tks[i].dz2 * tks[i].dt2);
+      double w  = tks[i].pi/(tks[i].dz2 + tks[i].dt2);
       a += w*(sqr(dx)/tks[i].dz2 + sqr(dt)/tks[i].dt2);
       b += w;
     }
@@ -315,7 +315,7 @@ bool DAClusterizerInZT::split( double beta,
       if(tks[i].zi>0){
 	//sumpi+=tks[i].pi;
 	double p=y[ik].pk * exp(-beta*e_ik(tks[i],y[ik])) / tks[i].zi*tks[i].pi;
-	double w=p/(tks[i].dz2 * tks[i].dt2);
+	double w=p/(tks[i].dz2 + tks[i].dt2);
 	if(tks[i].z < y[ik].z){
 	  p1+=p; z1+=w*tks[i].z; t1+=w*tks[i].t; w1+=w;
 	}else{

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT.cc
@@ -110,8 +110,11 @@ double DAClusterizerInZT::update( double beta,
     if (tks[i].zi>0){
       // accumulate weighted z and weights for vertex update
       for(vector<vertex_t>::iterator k=y.begin(); k!=y.end(); k++){
-	k->se += tks[i].pi* k->ei / Zi;
-	double w = k->pk * tks[i].pi * k->ei /( Zi * ( tks[i].dz2 * tks[i].dt2 ) );
+        double zratio = k->pk*k->ei/Zi;
+        
+	k->se += tks[i].pi*zratio/k->pk;
+	double w = tks[i].pi * zratio /( tks[i].dz2 * tks[i].dt2 );        
+        
 	k->sw  += w;
 	k->swz += w * tks[i].z;
         k->swt += w * tks[i].t;


### PR DESCRIPTION
Wrong normalization was used every where and shouldn't affect the minimum on average of the set of vertices found. Per-event vertex multiplicities can change.

The numerical fix addresses cases where the partition function was becoming arbitrarily small when the track fake rate was large, reorganization of the floating point math mitigates this case.
Automatically ported from CMSSW_9_0_X #17610 (original by @lgray).
Please wait for a new IB (12 to 24H) before requesting to test this PR.