### PR TITLE
Make MonitorElement to emit LogWarning instead of writing to std::cout

### DIFF
--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -934,7 +934,7 @@ MonitorElement::setBinLabel(int bin, const std::string &label, int axis /* = 1 *
 #if WITHOUT_CMS_FRAMEWORK
     std::cout
 #else
-    edm::LogInfo("MonitorElement")
+    edm::LogWarning("MonitorElement")
 #endif
       << "*** MonitorElement: WARNING:"
       <<"setBinLabel: attempting to set label of non-existent bin number for ME: "<< getFullname() << " \n";

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -12,6 +12,10 @@
 #include <cfloat>
 #include <inttypes.h>
 
+#if !WITHOUT_CMS_FRAMEWORK
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#endif
+
 static TH1 *
 checkRootObject(const std::string &name, TObject *tobj, const char *func, int reqdim)
 {
@@ -927,9 +931,13 @@ MonitorElement::setBinLabel(int bin, const std::string &label, int axis /* = 1 *
   }
   else
   {
-    //  edm::LogWarning ("MonitorElement")
-    std::cout << "*** MonitorElement: WARNING:"
-              <<"setBinLabel: attempting to set label of non-existent bin number for ME: "<< getFullname() << " \n";
+#if WITHOUT_CMS_FRAMEWORK
+    std::cout
+#else
+    edm::LogInfo("MonitorElement")
+#endif
+      << "*** MonitorElement: WARNING:"
+      <<"setBinLabel: attempting to set label of non-existent bin number for ME: "<< getFullname() << " \n";
   }
 }
 


### PR DESCRIPTION

Automatically ported from CMSSW_9_0_X #17575 (original by @dmitrijus).
Please wait for a new IB (12 to 24H) before requesting to test this PR.