### PR TITLE
Pixel Template reconstruction for Phase 1

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml
@@ -2,7 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
  <ConstantsSection  label="trackerParameters.xml" eval="true">
   <Vector name="vPars" type="numeric" nEntries="6">
-    80, 52, 0, 0, 2, 8
+    80, 52, 1, 2, 2, 8
   </Vector>
   <Vector name="Subdetector1" type="numeric" nEntries="6">
     20, 12, 2, 0xF, 0xFF, 0x3FF

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -91,7 +91,7 @@ TrackerGeomBuilderFromGeometricDet::build( const GeometricDet* gd, const PTracke
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelPhase1Barrel) 
       buildPixel(dets[i],tracker,GeomDetEnumerators::SubDetector::P1PXB,
-		 true,
+		 false,
 		 BIG_PIX_PER_ROC_X,
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelEndCap)
@@ -101,7 +101,7 @@ TrackerGeomBuilderFromGeometricDet::build( const GeometricDet* gd, const PTracke
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelPhase1EndCap)
       buildPixel(dets[i],tracker,GeomDetEnumerators::SubDetector::P1PXEC,
-		 true,
+		 false,
 		 BIG_PIX_PER_ROC_X,
 		 BIG_PIX_PER_ROC_Y); 
     if(gdsubdetmap[i] == GeometricDet::PixelPhase2EndCap)

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -74,6 +74,7 @@ class PixelCPEBase : public PixelClusterParameterEstimator
     //float theSign; //Not used, AH
 
     float bz; // local Bz
+    float bx; // local Bx
     LocalVector driftDirection;
     float widthLAFractionX;    // Width-LA to Offset-LA in X
     float widthLAFractionY;    // same in Y

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h
@@ -1,10 +1,11 @@
 //
-//  SiPixelGenError.h (v1.00)
+//  SiPixelGenError.h (v2.00)
 //
 //  Object to contain Lorentz drift and error information for the Generic Algorithm
 //
 // Created by Morris Swartz on 1/10/2014.
 //
+// Update for Phase 1 FPix, M.S. 1/15/17
 //
  
 // Build the template storage structure from several pieces 
@@ -115,7 +116,7 @@ class SiPixelGenError {
   
 	
 // Interpolate input beta angle to estimate the average charge. return qbin flag for input cluster charge, and estimate y/x errors and biases for the Generic Algorithm.
-  int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
+  int qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax,
             float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
   // Overloaded method to provide only the LA parameters
   int qbin(int id);

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.h (v9.00)
+//  SiPixelTemplate.h (v10.00)
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -69,6 +69,9 @@
 //  V8.33 - Fix small type conversion warnings
 //  V8.40 - Incorporate V.I. optimizations
 //  V9.00 - Expand header to include multi and single dcol thresholds, LA biases, and (variable) Qbin definitions
+//  V9.01 - Protect against negative error squared
+//  V10.00 - Update to work with Phase 1 FPix.  Fix some code problems introduced by other maintainers.
+
 
 // Created by Morris Swartz on 10/27/06.
 //
@@ -243,9 +246,11 @@ class SiPixelTemplate {
   static bool pushfile(const SiPixelTemplateDBObject& dbobject, std::vector< SiPixelTemplateStore > & thePixelTemp_);     // load the private store with info from db
 #endif
   
-  // initialize the rest;
+// initialize the rest;
   static void postInit(std::vector< SiPixelTemplateStore > & thePixelTemp_);
-
+   
+// Interpolate input alpha and beta angles to produce a working template for each individual hit.
+   bool interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx);
 	
 // Interpolate input alpha and beta angles to produce a working template for each individual hit. 
   bool interpolate(int id, float cotalpha, float cotbeta, float locBz);
@@ -285,21 +290,7 @@ class SiPixelTemplate {
   
 // Interpolate qfl correction in x. 
   float xflcorr(int binq, float qflx);
-  
-// Interpolate input beta angle to estimate the average charge. return qbin flag for input cluster charge, and estimate y/x errors and biases for the Generic Algorithm. 
-//  int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
-//           float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2, float& lorywidth, float& lorxwidth);
-	
-// Overload for backward compatibility. 
-  int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
-	   float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
-	
-// Overload to use for cluster splitting 
-	int qbin(int id, float cotalpha, float cotbeta, float qclus);
-	
-// Overload to keep legacy interface 
-  int qbin(int id, float cotbeta, float qclus);
-	
+  	
 // Method to return template errors for fastsim
   void temperrors(int id, float cotalpha, float cotbeta, int qBin, float& sigmay, float& sigmax, float& sy1, float& sy2, float& sx1, float& sx2);
 	

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -290,7 +290,19 @@ class SiPixelTemplate {
   
 // Interpolate qfl correction in x. 
   float xflcorr(int binq, float qflx);
-  	
+  
+  int qbin(int id, float cotalpha, float cotbeta, float locBz, float locBx, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
+	   float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
+	     
+  int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
+	   float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
+	
+// Overload to use for cluster splitting 
+	int qbin(int id, float cotalpha, float cotbeta, float qclus);
+	
+// Overload to keep legacy interface 
+  int qbin(int id, float cotbeta, float qclus);
+	  	
 // Method to return template errors for fastsim
   void temperrors(int id, float cotalpha, float cotbeta, int qBin, float& sigmay, float& sigmax, float& sy1, float& sy2, float& sx1, float& sx2);
 	

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplateReco.cc (Version 8.25)
+//  SiPixelTemplateReco.cc (Version 10.00)
 //
 //  Add goodness-of-fit to algorithm, include single pixel clusters in chi2 calculation
 //  Try "decapitation" of large single pixels
@@ -40,6 +40,9 @@
 //  V8.11 - Change probQ to upper tail probability always (rather than two-sided tail probability)
 //  V8.20 - Use template cytemp/cxtemp methods to center the data cluster in the right place when the template becomes asymmetric after irradiation
 //  V8.25 - Incorporate VIs speed improvements
+//  V8.26 - Fix centering problem for small signals
+//  V9.00 - Set QProb = Q/Q_avg when calcultion is turned off, use fbin definitions of Qbin
+//  V10.00 - Use new template object to reco Phase 1 FPix hits
 //
 //
 //
@@ -50,11 +53,11 @@
 #ifndef SiPixelTemplateReco_h
 #define SiPixelTemplateReco_h 1
 
-#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateDefs.h"
-
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateDefs.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h"
 #else
+#include "SiPixelTemplateDefs.h"
 #include "SiPixelTemplate.h"
 #endif
 
@@ -74,13 +77,13 @@ namespace SiPixelTemplateReco {
       int mrow, mcol;
      };
 
-	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, ClusMatrix & cluster, 
+	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
 				SiPixelTemplate& templ, 
 				float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed, bool deadpix, 
                                 std::vector<std::pair<int, int> >& zeropix,
-				float& probQ);
+				float& probQ, int& nypix, int& nxpix);
 
-	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, ClusMatrix & cluster,
+	int PixelTempReco2D(int id, float cotalpha, float cotbeta, float locBz, float locBx, ClusMatrix & cluster,
 				SiPixelTemplate& templ, 
 				float& yrec, float& sigmay, float& proby, float& xrec, float& sigmax, float& probx, int& qbin, int speed,
 				float& probQ);

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -205,6 +205,7 @@ void PixelCPEBase::fillDetParams()
 
     LocalVector Bfield = p.theDet->surface().toLocal(magfield_->inTesla(p.theDet->surface().position()));
     p.bz = Bfield.z();
+    p.bx = Bfield.x();
 
 
     // Compute the Lorentz shifts for this detector element

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -179,6 +179,7 @@ PixelCPEGeneric::localPosition(DetParam const & theDetParam, ClusterParam & theC
 
       float qclus = theClusterParam.theCluster->charge();     
       float locBz = theDetParam.bz;
+      float locBx = theDetParam.bx;
       //cout << "PixelCPEGeneric::localPosition(...) : locBz = " << locBz << endl;
       
       theClusterParam.pixmx  = -999.9; // max pixel charge for truncation of 2-D cluster
@@ -202,7 +203,7 @@ PixelCPEGeneric::localPosition(DetParam const & theDetParam, ClusterParam & theC
       //int gtemplID0 = genErrorDBObject_->getGenErrorID(theDetParam.theDet->geographicalId().rawId());
       //if(gtemplID0!=gtemplID_) cout<<" different id "<< gtemplID_<<" "<<gtemplID0<<endl;
 
-      theClusterParam.qBin_ = gtempl.qbin( gtemplID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, qclus,  
+      theClusterParam.qBin_ = gtempl.qbin( gtemplID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, locBx, qclus,  
 					   theClusterParam.pixmx, theClusterParam.sigmay, theClusterParam.deltay, 
 					   theClusterParam.sigmax, theClusterParam.deltax, theClusterParam.sy1, 
 					   theClusterParam.dy1, theClusterParam.sy2, theClusterParam.dy2, theClusterParam.sx1, 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -234,10 +234,11 @@ PixelCPETemplateReco::localPosition(DetParam const & theDetParam, ClusterParam &
 
  
   float locBz = theDetParam.bz;
+  float locBx = theDetParam.bx;
     
   theClusterParam.ierr =
     PixelTempReco2D( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
-		     locBz, 
+		     locBz, locBx,
 		     clusterPayload,
 		     templ,
 		     theClusterParam.templYrec_, theClusterParam.templSigmaY_, theClusterParam.templProbY_,

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -1,5 +1,5 @@
 //
-//  SiPixelTemplate.cc  Version 9.00 
+//  SiPixelTemplate.cc  Version 10.00 
 //
 //  Add goodness-of-fit info and spare entries to templates, version number in template header, more error checking
 //  Add correction for (Q_F-Q_L)/(Q_F+Q_L) bias
@@ -71,7 +71,10 @@
 //  V8.33 - Fix small type conversion warnings
 //  V8.40 - Incorporate V.I. optimizations
 //  V9.00 - Expand header to include multi and single dcol thresholds, LA biases, and (variable) Qbin definitions
-// Due to a bug I have to fix fbin to 1.5,1.0,0.85. Delete version testing. d.k. 5/14
+//  V9.01 - Protect against negative error squared
+//  V10.00 - Update to work with Phase 1 FPix.  Fix some code problems introduced by other maintainers.
+
+
 //  Created by Morris Swartz on 10/27/06.
 //
 //
@@ -110,10 +113,6 @@ using namespace edm;
 #define LOGINFO(x) std::cout << x << ": "
 #define ENDL std::endl
 #endif
-
-namespace {
-  const float fbin0=1.50f, fbin1=1.00f, fbin2=0.85f;
-}
 
 //**************************************************************** 
 //! This routine initializes the global template structures from 
@@ -191,9 +190,9 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector< SiPixelTemplateStore > 
 	    theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
 	    theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
 	    theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-	    theCurrentTemp.head.fbin[0] = fbin0;
-	    theCurrentTemp.head.fbin[1] = fbin1;
-	    theCurrentTemp.head.fbin[2] = fbin2;
+	    theCurrentTemp.head.fbin[0] = 1.5f;
+	    theCurrentTemp.head.fbin[1] = 1.00f;
+	    theCurrentTemp.head.fbin[2] = 0.85f;
 	  }
 		
 	  LOGINFO("SiPixelTemplate") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version " << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield 
@@ -594,9 +593,9 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 	    theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
 	    theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth/2.f;
 	    theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth/2.f;
-	    theCurrentTemp.head.fbin[0] = fbin0;
-	    theCurrentTemp.head.fbin[1] = fbin1;
-	    theCurrentTemp.head.fbin[2] = fbin2;
+	    theCurrentTemp.head.fbin[0] = 1.50f;
+	    theCurrentTemp.head.fbin[1] = 1.00f;
+	    theCurrentTemp.head.fbin[2] = 0.85f;
 	    //std::cout<<" set fbin  "<< theCurrentTemp.head.fbin[0]<<" "<<theCurrentTemp.head.fbin[1]<<" "
 	    //	     <<theCurrentTemp.head.fbin[2]<<std::endl;
 	  }
@@ -976,16 +975,20 @@ void SiPixelTemplate::postInit(std::vector< SiPixelTemplateStore > & thePixelTem
 //! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
 //! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
 //! \param locBz - (input) the sign of this quantity is used to determine whether to flip cot(beta)<0 quantities from cot(beta)>0 (FPix only)
-//!                    for FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
+//!                    for Phase 0 FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
+//!                    for Phase 1 FPix IP-related tracks, see next comment
+//! \param locBx - (input) the sign of this quantity is used to determine whether to flip cot(alpha/beta)<0 quantities from cot(alpha/beta)>0 (FPix only)
+//!                    for Phase 1 FPix IP-related tracks, locBx/locBz > 0 for cot(alpha) > 0 and locBx/locBz < 0 for cot(alpha) < 0
+//!                    for Phase 1 FPix IP-related tracks, locBx > 0 for cot(beta) > 0 and locBx < 0 for cot(beta) < 0
 // ************************************************************************************************************ 
-bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz){
+bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz, float locBx){
     // Interpolate for a new set of track angles 
     
     // Local variables 
   int i, j;
   int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, imidy, imaxx;
-  float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cotb, cotalpha0, cotbeta0;
-  bool flip_y;
+  float yratio, yxratio, xxratio, sxmax, qcorrect, qxtempcor, symax, chi2xavgone, chi2xminone, cota, cotb, cotalpha0, cotbeta0;
+  bool flip_x, flip_y;
   //	std::vector <float> xrms(4), xgsig(4), xrmsc2m(4);
   float chi2xavg[4], chi2xmin[4], chi2xavgc2m[4], chi2xminc2m[4];
 
@@ -1050,19 +1053,43 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 	cotalpha0 =  thePixelTemp_[index_id_].enty[0].cotalpha;
 	qcorrect=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta*cotbeta+cotalpha0*cotalpha0));
 	
-// for some cosmics, the ususal gymnastics are incorrect   
-	if(thePixelTemp_[index_id_].head.Dtype == 0) {
-		cotb = abs_cotb_;
-		flip_y = false;
-		if(cotbeta < 0.f) {flip_y = true;}
-	} else {
-	    if(locBz < 0.f) {
-			cotb = cotbeta;
-			flip_y = false;
-		} else {
-			cotb = -cotbeta;
-			flip_y = true;
-		}	
+// for some cosmics, the ususal gymnastics are incorrect  
+    cota = cotalpha; 
+    cotb = abs_cotb_;
+    flip_x = false;
+	flip_y = false;
+	switch(thePixelTemp_[index_id_].head.Dtype) {
+	   case 0:
+		  if(cotbeta < 0.f) {flip_y = true;}
+		  break;
+	   case 1:
+	      if(locBz < 0.f) {
+			  cotb = cotbeta;
+		  } else {
+			  cotb = -cotbeta;
+			  flip_y = true;
+		  }	
+		  break;
+	   case 2:
+	   case 3:
+	   case 4:
+	      if(locBx*locBz < 0.f) {
+	         cota = -cotalpha;
+	         flip_x = true;
+	      }
+	      if(locBx > 0.f) {
+	         cotb = cotbeta;
+	      } else {
+	         cotb = -cotbeta;
+	         flip_y = true;
+	      }
+	      break;
+	   default:
+#ifndef SI_PIXEL_TEMPLATE_STANDALONE
+		  throw cms::Exception("DataCorrupt") << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+#else
+	      std::cout << "SiPixelTemplate::illegal subdetector ID = " << thePixelTemp_[index_id_].head.Dtype << std::endl;
+#endif
 	}
 		
 	Ny = thePixelTemp_[index_id_].head.NTy;
@@ -1147,10 +1174,16 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 	            yparl_[i][j] = thePixelTemp_[index_id_].enty[ilow].ypar[i][j];
 	            yparh_[i][j] = thePixelTemp_[index_id_].enty[ihigh].ypar[i][j];
 			}
-			xparly0_[i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
-			xparhy0_[i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
-		}
+			if(flip_x) {
+			   xparly0_[1-i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
+			   xparhy0_[1-i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
+			} else {
+			   xparly0_[i][j] = thePixelTemp_[index_id_].enty[ilow].xpar[i][j];
+			   xparhy0_[i][j] = thePixelTemp_[index_id_].enty[ihigh].xpar[i][j];
+			}
+		}		
 	}
+
 	for(i=0; i<4; ++i) {
 		yavg_[i]=(1.f - yratio)*thePixelTemp_[index_id_].enty[ilow].yavg[i] + yratio*thePixelTemp_[index_id_].enty[ihigh].yavg[i];
 		if(flip_y) {yavg_[i] = -yavg_[i];}
@@ -1243,7 +1276,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 	ilow = 0;
 	xxratio = 0.f;
 
-	if(cotalpha >= thePixelTemp_[index_id_].entx[0][Nxx-1].cotalpha) {
+	if(cota >= thePixelTemp_[index_id_].entx[0][Nxx-1].cotalpha) {
 	
 		ilow = Nxx-2;
 		xxratio = 1.f;
@@ -1251,14 +1284,14 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 		
 	} else {
 	   
-		if(cotalpha >= thePixelTemp_[index_id_].entx[0][0].cotalpha) {
+		if(cota >= thePixelTemp_[index_id_].entx[0][0].cotalpha) {
 
 			for (i=0; i<Nxx-1; ++i) { 
     
-			   if( thePixelTemp_[index_id_].entx[0][i].cotalpha <= cotalpha && cotalpha < thePixelTemp_[index_id_].entx[0][i+1].cotalpha) {
+			   if( thePixelTemp_[index_id_].entx[0][i].cotalpha <= cota && cota < thePixelTemp_[index_id_].entx[0][i+1].cotalpha) {
 		  
 				  ilow = i;
-				  xxratio = (cotalpha - thePixelTemp_[index_id_].entx[0][i].cotalpha)/(thePixelTemp_[index_id_].entx[0][i+1].cotalpha - thePixelTemp_[index_id_].entx[0][i].cotalpha);
+				  xxratio = (cota - thePixelTemp_[index_id_].entx[0][i].cotalpha)/(thePixelTemp_[index_id_].entx[0][i+1].cotalpha - thePixelTemp_[index_id_].entx[0][i].cotalpha);
 				  break;
 			}
 		  }
@@ -1280,15 +1313,25 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 	symax_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].symax + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].symax;
 	if(thePixelTemp_[index_id_].entx[imaxx][imidy].symax != 0.f) {symax_=symax_/thePixelTemp_[index_id_].entx[imaxx][imidy].symax*symax;}
 	dxone_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].dxone + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].dxone;
+	if(flip_x) {dxone_ = -dxone_;}
 	sxone_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].sxone + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].sxone;
 	dxtwo_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].dxtwo + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].dxtwo;
+	if(flip_x) {dxtwo_ = -dxtwo_;}
 	sxtwo_ = (1.f - xxratio)*thePixelTemp_[index_id_].entx[0][ilow].sxtwo + xxratio*thePixelTemp_[index_id_].entx[0][ihigh].sxtwo;
 	clslenx_ = fminf(thePixelTemp_[index_id_].entx[0][ilow].clslenx, thePixelTemp_[index_id_].entx[0][ihigh].clslenx);
+
 	for(i=0; i<2 ; ++i) {
 		for(j=0; j<5 ; ++j) {
-	         xpar0_[i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
-	         xparl_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
-	         xparh_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
+// Charge loss switches sides when cot(alpha) changes sign
+            if(flip_x) {
+	            xpar0_[1-i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
+	            xparl_[1-i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
+	            xparh_[1-i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
+	         } else {
+	         	xpar0_[i][j] = thePixelTemp_[index_id_].entx[imaxx][imidy].xpar[i][j];
+	            xparl_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ilow].xpar[i][j];
+	            xparh_[i][j] = thePixelTemp_[index_id_].entx[imaxx][ihigh].xpar[i][j];
+	        } 
 		}
 	}
 	   		  
@@ -1305,6 +1348,7 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 	for(i=0; i<4; ++i) {
 		xavg_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xavg[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xavg[i])
 				+yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xavg[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavg[i]);
+		if(flip_x) {xavg_[i] = -xavg_[i];}
 		  
 		xrms_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xrms[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xrms[i])
 				+yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xrms[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrms[i]);
@@ -1317,7 +1361,8 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 				  
 		xavgc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xavgc2m[i])
 				+yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xavgc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xavgc2m[i]);
-		  
+		if(flip_x) {xavgc2m_[i] = -xavgc2m_[i];}
+				  
 		xrmsc2m_[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iylow][ilow].xrmsc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iylow][ihigh].xrmsc2m[i])
 				+yxratio*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xrmsc2m[i] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xrmsc2m[i]);
 		  
@@ -1352,8 +1397,16 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 	         xflparlh_[i][j] = thePixelTemp_[index_id_].entx[iylow][ihigh].xflpar[i][j];
 	         xflparhl_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ilow].xflpar[i][j];
 	         xflparhh_[i][j] = thePixelTemp_[index_id_].entx[iyhigh][ihigh].xflpar[i][j];
+// Since Q_fl is odd under cotalpha, it flips qutomatically, change only even terms
+	         if(flip_x && (j == 0 || j == 2 || j == 4)) {
+			    xflparll_[i][j] = -xflparll_[i][j];
+			    xflparlh_[i][j] = -xflparlh_[i][j];
+			    xflparhl_[i][j] = -xflparhl_[i][j];
+			    xflparhh_[i][j] = -xflparhh_[i][j];
+			}
 		}
 	}
+
 	   
 // Do the spares next
 
@@ -1383,7 +1436,11 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 //  Take next largest x-slice for the x-template (it reduces bias in the forward direction after irradiation)
 //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[imaxx][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[imaxx][ihigh].xtemp[i][j];
 //		   xtemp_[i][j+2]=(1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j];
-         xtemp_[i][j+2]=qxtempcor*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
+          if(flip_x) {
+             xtemp_[8-i][BXM3-j]=qxtempcor*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
+          } else {
+             xtemp_[i][j+2]=qxtempcor*((1.f - xxratio)*thePixelTemp_[index_id_].entx[iyhigh][ilow].xtemp[i][j] + xxratio*thePixelTemp_[index_id_].entx[iyhigh][ihigh].xtemp[i][j]);
+          }
 		}
 	}
 	
@@ -1391,7 +1448,8 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 	lorxwidth_ = thePixelTemp_[index_id_].head.lorxwidth;
    lorybias_ = thePixelTemp_[index_id_].head.lorybias;
    lorxbias_ = thePixelTemp_[index_id_].head.lorxbias;
-   if(locBz > 0.f) {lorywidth_ = -lorywidth_; lorybias_ = -lorybias_;}
+   if(flip_x) {lorxwidth_ = -lorxwidth_; lorxbias_ = -lorxbias_;}
+   if(flip_y) {lorywidth_ = -lorywidth_; lorybias_ = -lorybias_;}
 	
 	
   }
@@ -1408,19 +1466,39 @@ bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float l
 //! \param id - (input) index of the template to use
 //! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
 //! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
+//! Use this for Phase 1, IP related hits
 // ************************************************************************************************************ 
 bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta)
 {
     // Interpolate for a new set of track angles 
     
     // Local variables 
-    float locBz;
-    locBz = -1.f;
-    if(cotbeta < 0.f) {locBz = -locBz;}
-    return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz);
+    float locBx, locBz;
+    locBx = 1.f;
+    if(cotbeta < 0.f) {locBx = -1.f;}
+    locBz = locBx;
+    if(cotalpha < 0.f) {locBz = -locBx;}
+    return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
 }
 
 
+
+// ************************************************************************************************************ 
+//! Interpolate input alpha and beta angles to produce a working template for each individual hit. 
+//! \param id - (input) index of the template to use
+//! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
+//! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
+//! Use this for Phase 0, IP related hits
+// ************************************************************************************************************ 
+bool SiPixelTemplate::interpolate(int id, float cotalpha, float cotbeta, float locBz)
+{
+    // Interpolate for a new set of track angles 
+    
+    // Local variables 
+    float locBx;
+    locBx = 1.f;
+    return SiPixelTemplate::interpolate(id, cotalpha, cotbeta, locBz, locBx);
+}
 
 
 // ************************************************************************************************************ 
@@ -2237,331 +2315,6 @@ void SiPixelTemplate::xtemp3d(int i, int j, std::vector<float>& xtemplate)
 	return;
 	
 } // End xtemp3d
-
-
-// ************************************************************************************************************ 
-//! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge 
-//! of the cluster [0: 1.5<Q/Qavg, 1: 1<Q/Qavg<1.5, 2: 0.85<Q/Qavg<1, 3: 0.95Qmin<Q<0.85Qavg, 4: Q<0.95Qmin].
-//! \param id - (input) index of the template to use
-//! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
-//! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
-//! \param locBz - (input) the sign of this quantity is used to determine whether to flip cot(beta)<0 quantities from cot(beta)>0 (FPix only)
-//!                    for FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
-//! \param qclus - (input) the cluster charge in electrons 
-//! \param pixmax - (output) the maximum pixel charge in electrons (truncation value)
-//! \param sigmay - (output) the estimated y-error for CPEGeneric in microns
-//! \param deltay - (output) the estimated y-bias for CPEGeneric in microns
-//! \param sigmax - (output) the estimated x-error for CPEGeneric in microns
-//! \param deltax - (output) the estimated x-bias for CPEGeneric in microns
-//! \param sy1 - (output) the estimated y-error for 1 single-pixel clusters in microns
-//! \param dy1 - (output) the estimated y-bias for 1 single-pixel clusters in microns
-//! \param sy2 - (output) the estimated y-error for 1 double-pixel clusters in microns
-//! \param dy2 - (output) the estimated y-bias for 1 double-pixel clusters in microns
-//! \param sx1 - (output) the estimated x-error for 1 single-pixel clusters in microns
-//! \param dx1 - (output) the estimated x-bias for 1 single-pixel clusters in microns
-//! \param sx2 - (output) the estimated x-error for 1 double-pixel clusters in microns
-//! \param dx2 - (output) the estimated x-bias for 1 double-pixel clusters in microns
-//! \param lorywidth - (output) the estimated y Lorentz width
-//! \param lorxwidth - (output) the estimated x Lorentz width
-// ************************************************************************************************************ 
-int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, 
-    float& sigmay, float& deltay, float& sigmax, float& deltax,float& sy1, float& dy1, float& sy2, 
-    float& dy2, float& sx1, float& dx1, float& sx2, float& dx2) // float& lorywidth, float& lorxwidth)		 
-{
-    // Interpolate for a new set of track angles 
-    
-
-// Find the index corresponding to id
-
-   int index = -1;
-    for( int i=0; i<(int)thePixelTemp_.size(); ++i) {      
-      if(id == thePixelTemp_[i].head.ID) {
-	index = i;
-	break;
-      }
-    }
-	 
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-    if(index < 0 || index >= (int)thePixelTemp_.size()) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin can't find needed template ID = " << id << std::endl;
-    }
-#else
-    assert(index >= 0 && index < (int)thePixelTemp_.size());
-#endif
-	 
-    //	
-
-
-    auto const & templ = thePixelTemp_[index];	
-    
-    // Interpolate the absolute value of cot(beta)     
-    
-    auto acotb = std::abs(cotbeta);
-    
-    //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)	
-	
-    auto cotalpha0 =  thePixelTemp_[index].enty[0].cotalpha;
-    auto qcorrect=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta*cotbeta+cotalpha0*cotalpha0));
-    
-    // for some cosmics, the ususal gymnastics are incorrect   
-    
-    float cotb; bool flip_y;
-    if(thePixelTemp_[index].head.Dtype == 0) {
-      cotb = acotb;
-      flip_y = false;
-      if(cotbeta < 0.f) {flip_y = true;}
-    } else {
-      if(locBz < 0.f) {
-	cotb = cotbeta;
-	flip_y = false;
-      } else {
-	cotb = -cotbeta;
-	flip_y = true;
-      }	
-    }
-    
-    // Copy the charge scaling factor to the private variable     
-    
-    auto qscale = thePixelTemp_[index].head.qscale;
-
-
-     /*
-    lorywidth = thePixelTemp_[index].head.lorywidth;
-    if(locBz > 0.f) {lorywidth = -lorywidth;}
-    lorxwidth = thePixelTemp_[index].head.lorxwidth;
-    */
-
-    
-    auto Ny = thePixelTemp_[index].head.NTy;
-    auto Nyx = thePixelTemp_[index].head.NTyx;
-    auto Nxx = thePixelTemp_[index].head.NTxx;
-    
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-    if(Ny < 2 || Nyx < 1 || Nxx < 2) {
-      throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx << std::endl;
-    }
-#else
-    assert(Ny > 1 && Nyx > 0 && Nxx > 1);
-#endif
-    
-    // next, loop over all y-angle entries   
-    
-    auto ilow = 0;
-    auto ihigh = 0;
-    auto yratio = 0.f;
-      
-    {
-      auto j = std::lower_bound(templ.cotbetaY,templ.cotbetaY+Ny,cotb);
-      if (j==templ.cotbetaY+Ny) { --j;  yratio = 1.f; }
-      else if (j==templ.cotbetaY) { ++j; yratio = 0.f;}
-      else { yratio = (cotb - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
-      
-      ihigh = j-templ.cotbetaY;
-      ilow = ihigh-1;
-    }
-
-
-
-    // Interpolate/store all y-related quantities (flip displacements when flip_y)
-    
-    dy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dyone + yratio*thePixelTemp_[index].enty[ihigh].dyone;
-    if(flip_y) {dy1 = -dy1;}
-    sy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].syone + yratio*thePixelTemp_[index].enty[ihigh].syone;
-    dy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dytwo + yratio*thePixelTemp_[index].enty[ihigh].dytwo;
-    if(flip_y) {dy2 = -dy2;}
-    sy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].sytwo + yratio*thePixelTemp_[index].enty[ihigh].sytwo;
- 
-    auto qavg = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qavg + yratio*thePixelTemp_[index].enty[ihigh].qavg;
-    qavg *= qcorrect;
-    auto qmin = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin + yratio*thePixelTemp_[index].enty[ihigh].qmin;
-    qmin *= qcorrect;
-    auto qmin2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin2 + yratio*thePixelTemp_[index].enty[ihigh].qmin2;
-    qmin2 *= qcorrect;
-
-
-#ifndef SI_PIXEL_TEMPLATE_STANDALONE
-    if(qavg <= 0.f || qmin <= 0.f) {
-      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin, qavg or qmin <= 0," 
-					  << " Probably someone called the generic pixel reconstruction with an illegal trajectory state" << std::endl;
-    }
-#else
-    assert(qavg > 0.f && qmin > 0.f);
-#endif
-    
-    //  Scale the input charge to account for differences between pixelav and CMSSW simulation or data	
-    
-    auto qtotal = qscale*qclus;
-    
-    // uncertainty and final corrections depend upon total charge bin 	       
-    auto fq = qtotal/qavg;
-    int  binq;
-    // since fbin is undefined I define it here d.k. 6/14
-    fbin_[0]=fbin0; fbin_[1]=fbin1; fbin_[2]=fbin2; 
-
-    if(fq > fbin_[0]) {
-      binq=0;
-      //std::cout<<" fq "<<fq<<" "<<qtotal<<" "<<qavg<<" "<<qclus<<" "<<qscale<<" "
-      //       <<fbin_[0]<<" "<<fbin_[1]<<" "<<fbin_[2]<<std::endl;
-    } else {
-      if(fq > fbin_[1]) {
-	binq=1;
-      } else {
-	if(fq > fbin_[2]) {
-	  binq=2;
-	} else {
-	  binq=3;
-	}
-      }
-    }
-
-    auto yavggen =(1.f - yratio)*thePixelTemp_[index].enty[ilow].yavggen[binq] + yratio*thePixelTemp_[index].enty[ihigh].yavggen[binq];
-    if(flip_y) {yavggen = -yavggen;}
-    auto yrmsgen =(1.f - yratio)*thePixelTemp_[index].enty[ilow].yrmsgen[binq] + yratio*thePixelTemp_[index].enty[ihigh].yrmsgen[binq];
-    
-    
-// next, loop over all x-angle entries, first, find relevant y-slices   
-    
-    auto iylow = 0;
-    auto iyhigh = 0;
-    auto yxratio = 0.f;
-       
-
-    {
-      auto j = std::lower_bound(templ.cotbetaX,templ.cotbetaX+Nyx,acotb);
-      if (j==templ.cotbetaX+Nyx) { --j;  yxratio = 1.f; }
-      else if (j==templ.cotbetaX) { ++j; yxratio = 0.f;}
-      else { yxratio = (acotb - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
-      
-      iyhigh = j-templ.cotbetaX;
-      iylow = iyhigh -1;
-    }
-
-
-
-    ilow = ihigh = 0;
-    auto xxratio = 0.f;  
-
-    {
-      auto j = std::lower_bound(templ.cotalphaX,templ.cotalphaX+Nxx,cotalpha);
-      if (j==templ.cotalphaX+Nxx) { --j;  xxratio = 1.f; }
-      else if (j==templ.cotalphaX) { ++j; xxratio = 0.f;}
-      else { xxratio = (cotalpha - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
-
-      ihigh = j-templ.cotalphaX;
-      ilow = ihigh-1; 
-    }
-    
-
-
-    dx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxone + xxratio*thePixelTemp_[index].entx[0][ihigh].dxone;
-    sx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxone + xxratio*thePixelTemp_[index].entx[0][ihigh].sxone;
-    dx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].dxtwo;
-    sx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].sxtwo;
-    
-    // pixmax is the maximum allowed pixel charge (used for truncation)
-    
-    pixmx=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iylow][ihigh].pixmax)
-      +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].pixmax);
-    
-    auto xavggen = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xavggen[binq] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xavggen[binq])
-      +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xavggen[binq] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xavggen[binq]);
-    
-    auto xrmsgen = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xrmsgen[binq] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xrmsgen[binq])
-      +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xrmsgen[binq] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xrmsgen[binq]);		  
-    
-		
-    
-    //  Take the errors and bias from the correct charge bin
-	
-    sigmay = yrmsgen; deltay = yavggen;
-    
-    sigmax = xrmsgen; deltax = xavggen;
-    
-    // If the charge is too small (then flag it)
-    
-    if(qtotal < 0.95f*qmin) {binq = 5;} else {if(qtotal < 0.95f*qmin2) {binq = 4;}}
-    
-    return binq;
-    
-} // qbin
-
-// ************************************************************************************************************ 
-//! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge 
-//! of the cluster [0: 1.5<Q/Qavg, 1: 1<Q/Qavg<1.5, 2: 0.85<Q/Qavg<1, 3: 0.95Qmin<Q<0.85Qavg, 4: Q<0.95Qmin].
-//! \param id - (input) index of the template to use
-//! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
-//! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
-//! \param locBz - (input) the sign of this quantity is used to determine whether to flip cot(beta)<0 quantities from cot(beta)>0 (FPix only)
-//!                    for FPix IP-related tracks, locBz < 0 for cot(beta) > 0 and locBz > 0 for cot(beta) < 0
-//! \param qclus - (input) the cluster charge in electrons 
-//! \param pixmax - (output) the maximum pixel charge in electrons (truncation value)
-//! \param sigmay - (output) the estimated y-error for CPEGeneric in microns
-//! \param deltay - (output) the estimated y-bias for CPEGeneric in microns
-//! \param sigmax - (output) the estimated x-error for CPEGeneric in microns
-//! \param deltax - (output) the estimated x-bias for CPEGeneric in microns
-//! \param sy1 - (output) the estimated y-error for 1 single-pixel clusters in microns
-//! \param dy1 - (output) the estimated y-bias for 1 single-pixel clusters in microns
-//! \param sy2 - (output) the estimated y-error for 1 double-pixel clusters in microns
-//! \param dy2 - (output) the estimated y-bias for 1 double-pixel clusters in microns
-//! \param sx1 - (output) the estimated x-error for 1 single-pixel clusters in microns
-//! \param dx1 - (output) the estimated x-bias for 1 single-pixel clusters in microns
-//! \param sx2 - (output) the estimated x-error for 1 double-pixel clusters in microns
-//! \param dx2 - (output) the estimated x-bias for 1 double-pixel clusters in microns
-// ************************************************************************************************************ 
-/*
-int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
-                          float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2)
-
-{
-	float lorywidth, lorxwidth;
-	return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, qclus, pixmx, sigmay, deltay, sigmax, deltax, 
-								 sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, lorywidth, lorxwidth);
-	
-} // qbin
-*/
-
-// ************************************************************************************************************ 
-//! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge 
-//! of the cluster [0: 1.5<Q/Qavg, 1: 1<Q/Qavg<1.5, 2: 0.85<Q/Qavg<1, 3: 0.95Qmin<Q<0.85Qavg, 4: Q<0.95Qmin].
-//! \param id - (input) index of the template to use
-//! \param cotalpha - (input) the cotangent of the alpha track angle (see CMS IN 2004/014)
-//! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
-//! \param qclus - (input) the cluster charge in electrons 
-// ************************************************************************************************************ 
-int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float qclus)
-{
-	// Interpolate for a new set of track angles 
-	
-	// Local variables 
-	float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz; //  lorywidth, lorxwidth;
-	locBz = -1.f;
-	if(cotbeta < 0.f) {locBz = -locBz;}
-	return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, qclus, pixmx, sigmay, deltay, sigmax, deltax, 
-										  sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
-	
-} // qbin
-
-// ************************************************************************************************************ 
-//! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge 
-//! of the cluster [0: 1.5<Q/Qavg, 1: 1<Q/Qavg<1.5, 2: 0.85<Q/Qavg<1, 3: 0.95Qmin<Q<0.85Qavg, 4: Q<0.95Qmin].
-//! \param id - (input) index of the template to use
-//! \param cotbeta - (input) the cotangent of the beta track angle (see CMS IN 2004/014)
-//! \param qclus - (input) the cluster charge in electrons 
-// ************************************************************************************************************ 
-int SiPixelTemplate::qbin(int id, float cotbeta, float qclus)
-{
-// Interpolate for a new set of track angles 
-				
-// Local variables 
-	float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz; //, lorywidth, lorxwidth;
-	const float cotalpha = 0.f;
-	locBz = -1.f;
-	if(cotbeta < 0.f) {locBz = -locBz;}
-	return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, qclus, pixmx, sigmay, deltay, sigmax, deltax, 
-								sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
-				
-} // qbin
-				
 
 
 // ************************************************************************************************************ 


### PR DESCRIPTION
Template reconstruction for Phase 1, including proper treatment of the Phase 1 local coordinate systems (which violate the Run 1 convention, thereby necessitating changes to template reco).  This includes the new gen error object as well.  Requires new template payload for MC and data.
Automatically ported from CMSSW_9_0_X #17502 (original by @pmaksim1).
Please wait for a new IB (12 to 24H) before requesting to test this PR.