### PR TITLE
[90X] Allow multi-IOV input for Millepede alignment framework

### DIFF
--- a/Alignment/CommonAlignment/BuildFile.xml
+++ b/Alignment/CommonAlignment/BuildFile.xml
@@ -1,6 +1,7 @@
 <export>
   <lib   name="1"/>
 </export>
+<use   name="CondCore/CondDB"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/TrackingRecHit"/>

--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -3,6 +3,7 @@
 
 #include "Alignment/CommonAlignment/interface/AlignableSurface.h"
 #include "Alignment/CommonAlignment/interface/StructureType.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 class AlignmentErrorsExtended;
@@ -18,9 +19,6 @@ class SurfaceDeformation;
  * Any Alignable object can be moved and rotated.
  * Also an alignment uncertainty can be set.
  *
- *  $Date: 2011/09/19 11:42:35 $
- *  $Revision: 1.36 $
- *  (last update by $Author: mussgill $)
  */
 
 class AlignmentParameters;
@@ -39,6 +37,8 @@ public:
   typedef align::Alignables   Alignables;
   typedef align::StructureType StructureType;
 
+  enum class CompConstraintType { NONE, POSITION, POSITION_Z };
+
   /// Constructor from id and surface, setting also geomDetId
   /// (AlignableNavigator relies on the fact that only AlignableDet/DetUnit have geomDetId!)
   Alignable( align::ID, const AlignableSurface& );
@@ -49,6 +49,10 @@ public:
 
   /// Destructor
   virtual ~Alignable();
+
+  /// Updater using id and surface.
+  /// The given id has to match the current id.
+  virtual void update(align::ID, const AlignableSurface&);
 
   /// Set the AlignmentParameters
   void setAlignmentParameters( AlignmentParameters* dap );
@@ -184,6 +188,9 @@ public:
   /// Return the ID of Alignable, i.e. DetId of 'first' component GeomDet(Unit). 
   align::ID id() const { return theId; } 
 
+  /// Return the alignable type of contraints wrt. its components
+  virtual CompConstraintType compConstraintType() const { return compConstraintType_; }
+
   /// Recursive printout of alignable information
   virtual void dump() const = 0;
 
@@ -216,8 +223,7 @@ protected:
 
   void addDisplacement( const GlobalVector& displacement );
   void addRotation( const RotationType& rotation );
-
-protected:
+  virtual void updateMother(const GlobalVector& shift);
 
   DetId theDetId; // used to check if Alignable is associated to a GeomDet 
                   // ugly way to keep AlignableNavigator happy for now 
@@ -233,10 +239,13 @@ protected:
   GlobalVector theCachedDisplacement;
   RotationType theCachedRotation;
 
+  CompConstraintType compConstraintType_{CompConstraintType::NONE};
+
   Alignables theDeepComponents; // list of lowest daughters
                                 // contain itself if Alignable is a unit
 
 private:
+
   /// private default ctr. to enforce usage of the specialised ones
   Alignable() {};
 

--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -210,8 +210,16 @@ public:
   /// cache the current position, rotation and other parameters (e.g. surface deformations), also for possible components
   virtual void cacheTransformation();
 
+  /// cache for the given run the current position, rotation and other
+  /// parameters (e.g. surface deformations), also for possible components
+  virtual void cacheTransformation(const align::RunNumber&);
+
   /// restore the previously cached transformation, also for possible components
   virtual void restoreCachedTransformation();
+
+  /// restore for the given run the previously cached transformation, also for
+  /// possible components
+  virtual void restoreCachedTransformation(const align::RunNumber&);
 
   /// Return survey info
   const SurveyDet* survey() const { return theSurvey; }
@@ -220,6 +228,8 @@ public:
   void setSurvey( const SurveyDet* );
 
 protected:
+  template<class T>
+  using Cache = std::map<align::RunNumber, T>;
 
   void addDisplacement( const GlobalVector& displacement );
   void addRotation( const RotationType& rotation );
@@ -243,6 +253,10 @@ protected:
 
   Alignables theDeepComponents; // list of lowest daughters
                                 // contain itself if Alignable is a unit
+
+  Cache<AlignableSurface> surfacesCache_;
+  Cache<GlobalVector> displacementsCache_;
+  Cache<RotationType> rotationsCache_;
 
 private:
 

--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -52,7 +52,7 @@ public:
 
   /// Updater using id and surface.
   /// The given id has to match the current id.
-  virtual void update(align::ID, const AlignableSurface&);
+  void update(align::ID, const AlignableSurface&);
 
   /// Set the AlignmentParameters
   void setAlignmentParameters( AlignmentParameters* dap );

--- a/Alignment/CommonAlignment/interface/AlignableBeamSpot.h
+++ b/Alignment/CommonAlignment/interface/AlignableBeamSpot.h
@@ -87,6 +87,9 @@ public:
   void initialize(double x, double y, double z,
 		  double dxdz, double dydz);
 
+  /// reset beam spot to the uninitialized state
+  void reset();
+
   /// returns the DetId corresponding to the alignable beam spot. Also used
   /// by BeamSpotGeomDet and BeamSpotTransientTrackingRecHit
   static const DetId detId() { return DetId((DetId::Tracker<<DetId::kDetOffset)+0x1ffffff); }

--- a/Alignment/CommonAlignment/interface/AlignableComposite.h
+++ b/Alignment/CommonAlignment/interface/AlignableComposite.h
@@ -36,6 +36,12 @@ public:
   /// deleting its components
   virtual ~AlignableComposite();
 
+  /// Updater for a composite with given rotation.
+  /// The given id and structure type have to match the current ones.
+  virtual void update(align::ID id,
+                      StructureType aType,
+                      const RotationType& rot = RotationType());
+
   /// Add a component and set its mother to this alignable.
   /// (Note: The component will be adopted, e.g. later deleted.)
   /// Also find average position of this composite from its modules' positions.
@@ -100,6 +106,13 @@ public:
 protected:
   /// Constructor from GeomDet, only for use in AlignableDet
   explicit AlignableComposite( const GeomDet* geomDet );
+
+  /// Updater from GeomDet, only for use in AlignableDet
+  /// The given GeomDetUnit id has to match the current id.
+  virtual void update(const GeomDet* geomDet);
+
+  // avoid implicit cast of not explicitely defined version to the defined ones
+  template<class T> void update(T) = delete;
 
   void setSurface( const AlignableSurface& s) { theSurface = s; }
   

--- a/Alignment/CommonAlignment/interface/AlignableComposite.h
+++ b/Alignment/CommonAlignment/interface/AlignableComposite.h
@@ -38,9 +38,9 @@ public:
 
   /// Updater for a composite with given rotation.
   /// The given id and structure type have to match the current ones.
-  virtual void update(align::ID id,
-                      StructureType aType,
-                      const RotationType& rot = RotationType());
+  void update(align::ID,
+              StructureType aType,
+              const RotationType& rot = RotationType());
 
   /// Add a component and set its mother to this alignable.
   /// (Note: The component will be adopted, e.g. later deleted.)
@@ -109,7 +109,7 @@ protected:
 
   /// Updater from GeomDet, only for use in AlignableDet
   /// The given GeomDetUnit id has to match the current id.
-  virtual void update(const GeomDet* geomDet);
+  void update(const GeomDet* geomDet);
 
   // avoid implicit cast of not explicitely defined version to the defined ones
   template<class T> void update(T) = delete;

--- a/Alignment/CommonAlignment/interface/AlignableCompositeBuilder.h
+++ b/Alignment/CommonAlignment/interface/AlignableCompositeBuilder.h
@@ -39,7 +39,7 @@ class AlignableCompositeBuilder {
     /// - TPBHalfBarrel (with TPBLayer as children)
     /// - TPBBarrel     (with TPBHalfBarrel as children)
     /// Returns the number of composite Alignables which were built.
-    unsigned int buildAll(AlignableMap&);
+    unsigned int buildAll(AlignableMap&, bool update = false);
 
     /// Return tracker alignable object ID provider derived from the tracker's geometry
     const AlignableObjectId& objectIdProvider() const { return alignableObjectId_; }
@@ -49,7 +49,7 @@ class AlignableCompositeBuilder {
 
     /// Builds the components for a given level in the hierarchy.
     unsigned int buildLevel(unsigned int parentLevel, AlignableMap&,
-                            std::ostringstream&);
+                            std::ostringstream&, bool update = false);
 
     /// Calculates the theoretical max. number of components for a given level
     /// in the hierarchy.

--- a/Alignment/CommonAlignment/interface/AlignableDet.h
+++ b/Alignment/CommonAlignment/interface/AlignableDet.h
@@ -17,6 +17,10 @@ public:
   /// Destructor
   virtual ~AlignableDet();
 
+  /// Updater from GeomDet
+  /// The given GeomDet id has to match the current id.
+  virtual void update(const GeomDet* geomDet, bool updateComponents = true);
+
   /// Set the AlignmentPositionError and, if (propagateDown), to all components
   virtual void setAlignmentPositionError(const AlignmentPositionError &ape, bool propagateDown);
 

--- a/Alignment/CommonAlignment/interface/AlignableDet.h
+++ b/Alignment/CommonAlignment/interface/AlignableDet.h
@@ -19,7 +19,7 @@ public:
 
   /// Updater from GeomDet
   /// The given GeomDet id has to match the current id.
-  virtual void update(const GeomDet* geomDet, bool updateComponents = true);
+  void update(const GeomDet* geomDet, bool updateComponents = true);
 
   /// Set the AlignmentPositionError and, if (propagateDown), to all components
   virtual void setAlignmentPositionError(const AlignmentPositionError &ape, bool propagateDown);

--- a/Alignment/CommonAlignment/interface/AlignableDetUnit.h
+++ b/Alignment/CommonAlignment/interface/AlignableDetUnit.h
@@ -21,6 +21,10 @@ public:
   /// Destructor
   virtual ~AlignableDetUnit();
 
+  /// Updater from GeomDetUnit
+  /// The given GeomDetUnit id has to match the current id.
+  virtual void update(const GeomDetUnit* geomDetUnit);
+
   /// No components here => exception!
   virtual void addComponent( Alignable* );
 

--- a/Alignment/CommonAlignment/interface/AlignableDetUnit.h
+++ b/Alignment/CommonAlignment/interface/AlignableDetUnit.h
@@ -80,8 +80,14 @@ public:
   /// cache the current position, rotation and other parameters (e.g. surface deformations)
   virtual void cacheTransformation();
 
+  /// cache for the given run the current position, rotation and other parameters (e.g. surface deformations)
+  virtual void cacheTransformation(const align::RunNumber&);
+
   /// restore the previously cached transformation
   virtual void restoreCachedTransformation();
+
+  /// restore for the given run the previously cached transformation
+  virtual void restoreCachedTransformation(const align::RunNumber&);
 
   /// alignment position error - for checking only, otherwise use alignmentErrors() above!  
   const AlignmentPositionError* alignmentPositionError() const { return theAlignmentPositionError;}
@@ -91,6 +97,7 @@ private:
   AlignmentPositionError* theAlignmentPositionError;
   SurfaceDeformation* theSurfaceDeformation;
   SurfaceDeformation* theCachedSurfaceDeformation;
+  Cache<SurfaceDeformation*> surfaceDeformationsCache_;
 };
 
 #endif 

--- a/Alignment/CommonAlignment/interface/AlignableDetUnit.h
+++ b/Alignment/CommonAlignment/interface/AlignableDetUnit.h
@@ -23,7 +23,7 @@ public:
 
   /// Updater from GeomDetUnit
   /// The given GeomDetUnit id has to match the current id.
-  virtual void update(const GeomDetUnit* geomDetUnit);
+  void update(const GeomDetUnit* geomDetUnit);
 
   /// No components here => exception!
   virtual void addComponent( Alignable* );

--- a/Alignment/CommonAlignment/interface/AlignableExtras.h
+++ b/Alignment/CommonAlignment/interface/AlignableExtras.h
@@ -47,6 +47,9 @@ class AlignableExtras
   void initializeBeamSpot(double x, double y, double z,
 			  double dxdz, double dydz);
 
+  /// Initialize the alignable beam spot with the given parameters
+  void resetBeamSpot();
+
  private:
   
   AlignableMap alignableLists_; //< kind of map of lists of alignables

--- a/Alignment/CommonAlignment/interface/Utilities.h
+++ b/Alignment/CommonAlignment/interface/Utilities.h
@@ -13,8 +13,9 @@
 #include <map>
 #include <memory>
 
+#include "CondCore/CondDB/interface/Time.h"
 #include "CondFormats/Alignment/interface/Definitions.h"
-#include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class Alignable;
 class AlignmentParameters;
@@ -32,6 +33,10 @@ namespace align
   typedef std::vector<std::unique_ptr<AlignmentLevel> > AlignmentLevels;
 
   typedef std::map<std::pair<Alignable*, Alignable*>, AlgebraicMatrix> Correlations;
+
+  using RunNumber = cond::RealTimeType<cond::runnumber>::type;
+  using RunRange = std::pair<RunNumber, RunNumber>;
+  using RunRanges = std::vector<RunRange>;
 
   /// Convert rotation matrix to angles about x-, y-, z-axes (frame rotation).
   EulerAngles toAngles(
@@ -70,6 +75,12 @@ namespace align
   void rectify(
 	       RotationType&
 	       );
+
+
+  RunRanges makeNonOverlappingRunRanges(const edm::VParameterSet& runRanges,
+                                        const RunNumber& defaultRun);
+  RunRanges makeUniqueRunRanges(const edm::VParameterSet& runRanges,
+                                const RunNumber& defaultRun);
 }
 
 #endif

--- a/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
+++ b/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
@@ -152,6 +152,7 @@ AlignmentErrorsExtended* AlignableBeamSpot::alignmentErrors( void ) const
   return m_alignmentErrors;
 }
 
+//______________________________________________________________________________
 void AlignableBeamSpot::initialize(double x, double y, double z,
 				   double dxdz, double dydz)
 {
@@ -176,4 +177,13 @@ void AlignableBeamSpot::initialize(double x, double y, double z,
   this->dump();
   
   theInitializedFlag = true;
+}
+
+//______________________________________________________________________________
+void AlignableBeamSpot::reset()
+{
+  Alignable::update(this->id(), AlignableSurface());
+  delete theAlignmentPositionError;
+  theAlignmentPositionError = nullptr;
+  theInitializedFlag = false;
 }

--- a/Alignment/CommonAlignment/src/AlignableComposite.cc
+++ b/Alignment/CommonAlignment/src/AlignableComposite.cc
@@ -15,21 +15,52 @@ AlignableComposite::AlignableComposite( const GeomDet* geomDet ) :
   Alignable( geomDet->geographicalId().rawId(), geomDet->surface() ),
   theStructureType(align::AlignableDet)
 {
+  compConstraintType_ = Alignable::CompConstraintType::POSITION;
 }
 
+//__________________________________________________________________________________________________
 AlignableComposite::AlignableComposite(align::ID id,
 				       StructureType type,
 				       const RotationType& rot):
   Alignable(id, rot),
   theStructureType(type)
 {
+  compConstraintType_ = Alignable::CompConstraintType::POSITION;
 }
 
+//__________________________________________________________________________________________________
 AlignableComposite::~AlignableComposite()
 {
   for (unsigned int i = 0; i < theComponents.size(); ++i) delete theComponents[i];
 }
 
+//__________________________________________________________________________________________________
+void AlignableComposite::update(const GeomDet* geomDet)
+{
+  if (!geomDet) {
+    throw cms::Exception("Alignment")
+      << "@SUB=AlignableComposite::update\n"
+      << "Trying to update with GeomDet* pointing to 'nullptr'.";
+  }
+
+  Alignable::update(geomDet->geographicalId().rawId(), geomDet->surface());
+}
+
+//__________________________________________________________________________________________________
+void AlignableComposite::update(align::ID id,
+                                StructureType type,
+                                const RotationType& rot)
+{
+  if (theStructureType != type) {
+    throw cms::Exception("Alignment")
+      << "@SUB=AlignableComposite::update\n"
+      << "Current alignable type does not match type of the update.";
+  }
+  // composite's position is already updated by components, i.e. it needs to be kept
+  Alignable::update(id, AlignableSurface{this->globalPosition(), rot});
+}
+
+//__________________________________________________________________________________________________
 void AlignableComposite::addComponent(Alignable* ali)
 {
   const Alignables& newComps = ali->deepComponents();

--- a/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
+++ b/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
@@ -40,7 +40,7 @@ void AlignableCompositeBuilder
 
 //_____________________________________________________________________________
 unsigned int AlignableCompositeBuilder
-::buildAll(AlignableMap& alignableMap)
+::buildAll(AlignableMap& alignableMap, bool update)
 {
   auto highestLevel = alignmentLevels_.back()->levelType;
 
@@ -50,7 +50,7 @@ unsigned int AlignableCompositeBuilder
 
   unsigned int numCompositeAlignables = 0;
   for (unsigned int level = 1; level < alignmentLevels_.size(); ++level) {
-    numCompositeAlignables += buildLevel(level, alignableMap, ss);
+    numCompositeAlignables += buildLevel(level, alignableMap, ss, update);
   }
 
   ss << "built " << numCompositeAlignables << " CompositeAlignables for "
@@ -71,7 +71,8 @@ unsigned int AlignableCompositeBuilder
 unsigned int AlignableCompositeBuilder
 ::buildLevel(unsigned int parentLevel,
              AlignableMap& alignableMap,
-             std::ostringstream& ss)
+             std::ostringstream& ss,
+             bool update)
 {
   unsigned int childLevel    = parentLevel - 1;
   unsigned int maxNumParents = maxNumComponents(parentLevel);
@@ -81,7 +82,7 @@ unsigned int AlignableCompositeBuilder
 
   auto& children = alignableMap.find(alignableObjectId_.idToString(childType));
   auto& parents  = alignableMap.get (alignableObjectId_.idToString(parentType));
-  parents.reserve(maxNumParents);
+  if (!update) parents.reserve(maxNumParents);
 
   // This vector is used indicate if a parent already exists. It is initialized
   // with 'naked' Alignables-pointers; if the pointer is not naked (!= nullptr)
@@ -95,7 +96,12 @@ unsigned int AlignableCompositeBuilder
     auto& parent = tmpParents[index];
 
     // if parent was not built yet ...
-    if (!parent) {
+    if (!parent && !update) {
+      if (update) {
+	throw cms::Exception("LogicError")
+	  << "@SUB=AlignableCompositeBuilder::buildLevel\n"
+	  << "trying to update a non-existing AlignableComposite";
+      }
       // ... build new composite Alignable with ID of child (obviously its the
       // first child of the Alignable)
       if (alignmentLevels_[parentLevel]->isFlat) {
@@ -106,10 +112,24 @@ unsigned int AlignableCompositeBuilder
                                         align::RotationType());
       }
       parents.push_back(parent);
+    } else if (update) {
+      if (alignmentLevels_[parentLevel]->isFlat) {
+        // needed to update rotation of flat composites
+	auto mother = dynamic_cast<AlignableComposite*>(child->mother());
+	if (!mother) {
+	  throw cms::Exception("LogicError")
+	    << "@SUB=AlignableCompositeBuilder::buildLevel\n"
+	    << "trying to update a flat composite that is not of type "
+	    << "AlignableComposite";
+	}
+	if (mother->id() == child->id()) {
+	  mother->update(child->id(), parentType, child->globalRotation());
+	}
+      }
     }
 
-    // in all cases add the child to the parent Alignable
-    parent->addComponent(child);
+    // in all cases (except updates) add the child to the parent Alignable
+    if (!update) parent->addComponent(child);
   }
 
   ss << "   built " << parents.size() << " "

--- a/Alignment/CommonAlignment/src/AlignableDet.cc
+++ b/Alignment/CommonAlignment/src/AlignableDet.cc
@@ -17,6 +17,10 @@ AlignableDet::AlignableDet( const GeomDet* geomDet, bool addComponents ) :
   AlignableComposite( geomDet ), 
   theAlignmentPositionError(0)
 {
+  // ensure that the surface is not constrained to the average position of the
+  // components:
+  compConstraintType_ = Alignable::CompConstraintType::NONE;
+
   if (geomDet->alignmentPositionError()) {
     // false: do not propagate APE to (anyway not yet existing) daughters
     this->setAlignmentPositionError(*(geomDet->alignmentPositionError()), false); 
@@ -52,6 +56,62 @@ AlignableDet::~AlignableDet()
 
   delete theAlignmentPositionError;
 
+}
+
+
+//______________________________________________________________________________
+void AlignableDet::update(const GeomDet* geomDet, bool updateComponents)
+{
+  AlignableComposite::update(geomDet);
+
+  if (geomDet->alignmentPositionError()) {
+    // false: do not propagate APE to daughters (done by their update functions)
+    this->setAlignmentPositionError(*(geomDet->alignmentPositionError()), false);
+  }
+
+  if (updateComponents) {
+    if (geomDet->components().size() == 0 ) { // Is a DetUnit
+      throw cms::Exception("BadHierarchy")
+	<< "[AlignableDet] GeomDet with DetId "
+	<< geomDet->geographicalId().rawId()
+	<< " has no components, use AlignableDetUnit.\n";
+    } else { // Push back all components
+      const auto& geomDets = geomDet->components();
+      for (const auto& idet: geomDets) {
+        auto unit = dynamic_cast<const GeomDetUnit*>(idet);
+        if (!unit) {
+          throw cms::Exception("BadHierarchy")
+            << "[AlignableDet] component not GeomDetUnit, call with "
+	    << "updateComponents==false and build hierarchy yourself.\n";
+	  // -> e.g. AlignableDTChamber
+        }
+
+	const auto components = this->components();
+	auto comp =
+	  std::find_if(components.begin(), components.end(),
+		       [&unit](const auto& c) {
+			 return c->id() == unit->geographicalId().rawId(); });
+
+	if (comp != components.end()) {
+	  auto aliDetUnit = dynamic_cast<AlignableDetUnit*>(*comp);
+	  if (aliDetUnit) {
+	    aliDetUnit->update(unit);
+	  } else {
+	    throw cms::Exception("LogicError")
+	      << "[AlignableDet::update] cast to 'AlignableDetUnit*' failed "
+	      << "while it should not\n";
+	  }
+	} else {
+          throw cms::Exception("GeometryMismatch")
+	    << "[AlignableDet::update] GeomDet with DetId "
+	    << unit->geographicalId().rawId()
+            << " not found in current geometry.\n";
+	}
+      }
+    }
+    // Ensure that the surface is not screwed up by update of components, it must stay the GeomDet's one:
+    theSurface = AlignableSurface(geomDet->surface());
+  } // end updateComponents
 }
 
 

--- a/Alignment/CommonAlignment/src/AlignableDetUnit.cc
+++ b/Alignment/CommonAlignment/src/AlignableDetUnit.cc
@@ -178,13 +178,22 @@ void AlignableDetUnit::addSurfaceDeformation(const SurfaceDeformation *deformati
 //__________________________________________________________________________________________________
 void AlignableDetUnit::dump() const
 {
+  std::ostringstream parameters;
+  if (theSurfaceDeformation) {
+    parameters << "    surface deformation parameters:";
+    for (const auto& param: theSurfaceDeformation->parameters()) {
+      parameters << " " << param;
+    }
+  } else {
+    parameters << "    no surface deformation parameters";
+  }
 
   edm::LogInfo("AlignableDump") 
     << " AlignableDetUnit has position = " << this->globalPosition() 
     << ", orientation:" << std::endl << this->globalRotation() << std::endl
     << " total displacement and rotation: " << this->displacement() << std::endl
-    << this->rotation();
-
+    << this->rotation() << "\n"
+    << parameters.str();
 }
 
 

--- a/Alignment/CommonAlignment/src/AlignableDetUnit.cc
+++ b/Alignment/CommonAlignment/src/AlignableDetUnit.cc
@@ -41,6 +41,28 @@ AlignableDetUnit::~AlignableDetUnit()
 }
 
 //__________________________________________________________________________________________________
+void AlignableDetUnit::update(const GeomDetUnit *geomDetUnit)
+{
+  if (!geomDetUnit) {
+    throw cms::Exception("Alignment")
+      << "@SUB=AlignableDetUnit::update\n"
+      << "Trying to update with GeomDetUnit* pointing to 'nullptr'.";
+  }
+
+  Alignable::update(geomDetUnit->geographicalId().rawId(), geomDetUnit->surface());
+
+  if (geomDetUnit->alignmentPositionError()) { // take over APE from geometry
+    // 2nd argument w/o effect:
+    this->setAlignmentPositionError(*(geomDetUnit->alignmentPositionError()), false);
+  }
+
+  if (geomDetUnit->surfaceDeformation()) { // take over surface modification
+    // 2nd argument w/o effect:
+    this->setSurfaceDeformation(geomDetUnit->surfaceDeformation(), false);
+  }
+}
+
+//__________________________________________________________________________________________________
 void AlignableDetUnit::addComponent( Alignable* /*unused*/)
 {
   throw cms::Exception("LogicError") 

--- a/Alignment/CommonAlignment/src/AlignableExtras.cc
+++ b/Alignment/CommonAlignment/src/AlignableExtras.cc
@@ -86,6 +86,7 @@ AlignmentErrorsExtended* AlignableExtras::alignmentErrors( void ) const
   return m_alignmentErrors;
 }
 
+//______________________________________________________________________________
 void AlignableExtras::initializeBeamSpot(double x, double y, double z,
 					 double dxdz, double dydz)
 {
@@ -96,5 +97,19 @@ void AlignableExtras::initializeBeamSpot(double x, double y, double z,
   } else {
     edm::LogError("AlignableExtras") 
       << " AlignableBeamSpot not available. Cannot initialize!" << std::endl;
+  }
+}
+
+//______________________________________________________________________________
+void AlignableExtras::resetBeamSpot()
+{
+  align::Alignables& alis = beamSpot();
+  AlignableBeamSpot * aliBS = dynamic_cast<AlignableBeamSpot*>(alis.back());
+  if (aliBS) {
+    aliBS->reset();
+  } else {
+    edm::LogWarning("AlignableExtras")
+      << "@SUB=AlignableExtras::resetBeamSpot"
+      << "AlignableBeamSpot not available. Cannot reset!" << std::endl;
   }
 }

--- a/Alignment/CommonAlignment/src/Utilities.cc
+++ b/Alignment/CommonAlignment/src/Utilities.cc
@@ -4,8 +4,6 @@
 #include "FWCore/Utilities/interface/Parse.h"
 
 #include "Alignment/CommonAlignment/interface/Utilities.h"
-#include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
-#include "Alignment/MuonAlignment/interface/AlignableMuon.h"
 
 
 align::EulerAngles align::toAngles(const RotationType& rot)

--- a/Alignment/CommonAlignment/src/Utilities.cc
+++ b/Alignment/CommonAlignment/src/Utilities.cc
@@ -1,6 +1,7 @@
 // #include "Math/GenVector/Rotation3D.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Parse.h"
 
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
@@ -212,4 +213,63 @@ void align::rectify(RotationType& rot)
 //   rot = RotationType(elems);
 
   rot = toMatrix( toAngles(rot) ); // fast rectification but less precise
+}
+
+
+align::RunRanges
+align::makeNonOverlappingRunRanges(const edm::VParameterSet& runRanges,
+                                   const RunNumber& defaultRun)
+{
+  const auto beginValue = cond::timeTypeSpecs[cond::runnumber].beginValue;
+  const auto endValue = cond::timeTypeSpecs[cond::runnumber].endValue;
+  RunRanges uniqueRunRanges;
+  if (!runRanges.empty()) {
+    std::map<RunNumber,RunNumber> uniqueFirstRunNumbers;
+    for (const auto& ipset: runRanges) {
+      const auto RunRangeStrings =
+        ipset.getParameter<std::vector<std::string> >("RunRanges");
+      for (const auto& irange: RunRangeStrings) {
+        if (irange.find(':')==std::string::npos) {
+          long int temp{strtol(irange.c_str(), 0, 0)};
+          auto first = (temp != -1) ? temp : beginValue;
+          uniqueFirstRunNumbers[first] = first;
+        } else {
+          edm::LogWarning("BadConfig")
+            << "@SUB=align::makeNonOverlappingRunRanges"
+            << "Config file contains old format for 'RunRangeSelection'. Only "
+            << "the start run number is used internally. The number of the last"
+            << " run is ignored and can besafely removed from the config file.";
+          auto tokens = edm::tokenize(irange, ":");
+          long int temp{strtol(tokens[0].c_str(), 0, 0)};
+          auto first = (temp != -1) ? temp : beginValue;
+          uniqueFirstRunNumbers[first] = first;
+        }
+      }
+    }
+
+    for (const auto& iFirst: uniqueFirstRunNumbers) {
+      uniqueRunRanges.push_back(std::make_pair(iFirst.first, endValue));
+    }
+    for (unsigned int i = 0;i<uniqueRunRanges.size()-1;++i) {
+      uniqueRunRanges[i].second = uniqueRunRanges[i+1].first - 1;
+    }
+  } else {
+    uniqueRunRanges.push_back(std::make_pair(defaultRun, endValue));
+  }
+
+  return uniqueRunRanges;
+}
+
+
+align::RunRanges
+align::makeUniqueRunRanges(const edm::VParameterSet& runRanges,
+                           const RunNumber& defaultRun) {
+  auto uniqueRunRanges =
+    align::makeNonOverlappingRunRanges(runRanges, defaultRun);
+  if (uniqueRunRanges.empty()) { // create dummy IOV
+    const RunRange runRange(defaultRun,
+			    cond::timeTypeSpecs[cond::runnumber].endValue);
+    uniqueRunRanges.push_back(runRange);
+  }
+  return uniqueRunRanges;
 }

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -33,7 +33,7 @@ class Trajectory;
 // class TsosVectorCollection;
 // class TkFittedLasBeamCollection;
 // class AliClusterValueMap;
-#include "CondCore/CondDB/interface/Time.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/LaserAlignment/interface/TsosVectorCollection.h"
 #include "DataFormats/Alignment/interface/TkFittedLasBeamCollectionFwd.h"
 #include "DataFormats/Alignment/interface/AliClusterValueMapFwd.h"
@@ -48,10 +48,6 @@ typedef std::vector< ConstTrajTrackPair >                ConstTrajTrackPairs;
 
 typedef std::vector<IntegratedCalibrationBase*> Calibrations;
 
-typedef cond::RealTimeType<cond::runnumber>::type RunNumber;
-typedef std::pair<RunNumber,RunNumber>            RunRange;
-typedef std::vector<RunRange>                     RunRanges;
-
 
 
 class AlignmentAlgorithmBase
@@ -65,8 +61,8 @@ public:
   // in other files.
   typedef std::pair<const Trajectory*, const reco::Track*> ConstTrajTrackPair; 
   typedef std::vector< ConstTrajTrackPair >  ConstTrajTrackPairCollection;
-  typedef cond::RealTimeType<cond::runnumber>::type RunNumber;
-  typedef std::pair<RunNumber,RunNumber> RunRange;
+  using RunNumber = align::RunNumber;
+  using RunRange = align::RunRange;
 
   /// define event information passed to algorithms
   class EventInfo {

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -145,7 +145,7 @@ public:
   virtual void run( const edm::EventSetup &setup, const EventInfo &eventInfo) = 0;
 
   /// called at begin of run
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup &setup) {};
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&, bool changed) {};
 
   /// called at end of run - order of arguments like in EDProducer etc.
   virtual void endRun(const EndRunInfo &runInfo, const edm::EventSetup &setup) {};

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
@@ -86,8 +86,14 @@ public:
   /// cache the current position, rotation and other parameters
   void cacheTransformations(void);
 
+  /// cache for the given run the current position, rotation and other parameters
+  void cacheTransformations(const align::RunNumber&);
+
   /// restore the previously cached position, rotation and other parameters
   void restoreCachedTransformations(void);
+
+  /// restore for the given run the previously cached position, rotation and other parameters
+  void restoreCachedTransformations(const align::RunNumber&);
 
   /// acquire shifts/rotations from alignables of the store and copy into 
   ///  alignment parameters (local frame) 

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
@@ -352,12 +352,27 @@ void AlignmentParameterStore::cacheTransformations(void)
 
 
 //__________________________________________________________________________________________________
+void AlignmentParameterStore::cacheTransformations(const align::RunNumber& run)
+{
+  for (const auto& iali: theAlignables) iali->cacheTransformation(run);
+}
+
+
+//__________________________________________________________________________________________________
 void AlignmentParameterStore::restoreCachedTransformations(void)
 {
   align::Alignables::const_iterator iali;
   for ( iali = theAlignables.begin(); iali != theAlignables.end(); ++iali) 
     (*iali)->restoreCachedTransformation();
 }
+
+
+//__________________________________________________________________________________________________
+void AlignmentParameterStore::restoreCachedTransformations(const align::RunNumber& run)
+{
+  for (const auto& iali: theAlignables) iali->restoreCachedTransformation(run);
+}
+
 
 //__________________________________________________________________________________________________
 void AlignmentParameterStore::acquireRelativeParameters(void)
@@ -686,6 +701,8 @@ bool AlignmentParameterStore
 
     const ParametersToParametersDerivatives p2pDerivs(**iComp, *ali);
     if (!p2pDerivs.isOK()) {
+      // std::cerr << (*iComp)->alignmentParameters()->type() << " "
+      // 		<< ali->alignmentParameters()->type() << std::endl;
       throw cms::Exception("BadConfig")
 	<< "AlignmentParameterStore::hierarchyConstraints"
 	<< " Bad match of types of AlignmentParameters classes.\n";

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
@@ -393,6 +393,12 @@ AlignmentProducer::duringLoop( const edm::Event& event,
 // ----------------------------------------------------------------------------
 void AlignmentProducer::beginRun(const edm::Run &run, const edm::EventSetup &setup)
 {
+  if (setupChanged(setup)) {
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::beginRun"
+                              << "EventSetup-Record changed.";
+    initAlignmentAlgorithm(setup);
+  }
+
   theAlignmentAlgo->beginRun(run, setup);
 }
 
@@ -449,6 +455,61 @@ AlignmentProducer::createAlignmentAlgorithm(const edm::ParameterSet& config)
     throw cms::Exception("BadConfig")
       << "Couldn't find the called alignment algorithm: " << algoName;
   }
+}
+
+
+//------------------------------------------------------------------------------
+bool
+AlignmentProducer::setupChanged(const edm::EventSetup& setup)
+{
+  bool changed{false};
+
+  if (watchIdealGeometryRcd.check(setup)) {
+    changed = true;
+  }
+
+  if (watchGlobalPositionRcd.check(setup)) {
+    changed = true;
+  }
+
+  if (doTracker_) {
+    if (watchTrackerAlRcd.check(setup)) {
+        changed = true;
+    }
+
+    if (watchTrackerAlErrorExtRcd.check(setup)) {
+      changed = true;
+    }
+
+    if (watchTrackerSurDeRcd.check(setup)) {
+      changed = true;
+    }
+  }
+
+  if (doMuon_) {
+    if (watchDTAlRcd.check(setup)) {
+      changed = true;
+    }
+
+    if (watchDTAlErrExtRcd.check(setup)) {
+      changed = true;
+    }
+
+    if (watchCSCAlRcd.check(setup)) {
+      changed = true;
+    }
+
+    if (watchCSCAlErrExtRcd.check(setup)) {
+      changed = true;
+    }
+  }
+
+  /* TODO: ExtraAlignables: Which record(s) to check?
+   *
+  if (useExtras_) {}
+  */
+
+  return changed;
 }
 
 

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -117,7 +117,7 @@ class AlignmentProducer : public edm::ESProducerLooper
 
   /// Creates Geometry and Alignables of the Tracker and initializes the
   /// AlignmentAlgorithm @theAlignmentAlgo
-  void initAlignmentAlgorithm(const edm::EventSetup&);
+  void initAlignmentAlgorithm(const edm::EventSetup&, bool update = false);
 
   /// Applies Alignments from Database (GlobalPositionRcd) to Geometry
   /// @theTracker
@@ -125,7 +125,7 @@ class AlignmentProducer : public edm::ESProducerLooper
 
   /// Creates Alignables @theAlignableTracker from the previously loaded
   /// Geometry @theTracker
-  void createAlignables(const TrackerTopology*);
+  void createAlignables(const TrackerTopology*, bool update = false);
 
   /// Creates the @theAlignmentParameterStore, which manages all Alignables
   void buildParameterStore();

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -108,12 +108,37 @@ class AlignmentProducer : public edm::ESProducerLooper
 
   // private member functions
 
+  /// Creates the choosen alignment algorithm (specified in config-file)
+  void createAlignmentAlgorithm(const edm::ParameterSet&);
+
+  /// Creates Geometry and Alignables of the Tracker and initializes the
+  /// AlignmentAlgorithm @theAlignmentAlgo
+  void initAlignmentAlgorithm(const edm::EventSetup&);
+
+  /// Applies Alignments from Database (GlobalPositionRcd) to Geometry
+  /// @theTracker
+  void applyAlignmentsToDB(const edm::EventSetup&);
+
+  /// Creates Alignables @theAlignableTracker from the previously loaded
+  /// Geometry @theTracker
+  void createAlignables(const TrackerTopology*);
+
+  /// Creates the @theAlignmentParameterStore, which manages all Alignables
+  void buildParameterStore();
+
+  /// Applies misalignment scenario to @theAlignableTracker
+  void applyMisalignment();
+
   /// Apply random shifts and rotations to selected alignables, according to configuration
-  void simpleMisalignment_(const Alignables &alivec, const std::string &selection,
+  void simpleMisalignment(const Alignables &alivec, const std::string &selection,
                           float shift, float rot, bool local);
 
   /// Create tracker and muon geometries
-  void createGeometries_( const edm::EventSetup& );
+  void createGeometries(const edm::EventSetup&, const TrackerTopology*);
+
+  /// Applies Alignments, AlignmentErrors and SurfaceDeformations to
+  /// @theTracker
+  void applyAlignmentsToGeometry();
 
   /// Apply DB constants belonging to (Err)Rcd to geometry,
   /// taking into account 'globalPosition' correction.

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -213,6 +213,7 @@ class AlignmentProducer : public edm::ESProducerLooper
   const bool saveToDB_, saveApeToDB_,saveDeformationsToDB_;
   const bool doTracker_,doMuon_,useExtras_;
   const bool useSurvey_; // true to read survey info from DB
+  const bool enableAlignableUpdates_;
 
   // event input tags
   const edm::InputTag tjTkAssociationMapTag_; // map with tracks/trajectories

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -25,6 +25,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 // Alignment
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 #include "Alignment/CommonAlignmentMonitor/interface/AlignmentMonitorBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h" 
@@ -57,13 +58,13 @@ class AlignmentProducer : public edm::ESProducerLooper
 {
 
  public:
-  typedef std::vector<Alignable*> Alignables;
+  using Alignables = align::Alignables;
   typedef std::pair<const Trajectory*, const reco::Track*> ConstTrajTrackPair; 
   typedef std::vector<ConstTrajTrackPair>  ConstTrajTrackPairCollection;
 
-  typedef AlignmentAlgorithmBase::RunNumber            RunNumber;
-  typedef AlignmentAlgorithmBase::RunRange             RunRange;
-  typedef std::vector<RunRange>                        RunRanges;
+  using RunNumber = align::RunNumber;
+  using RunRange = align::RunRange;
+  using RunRanges = align::RunRanges;
 
   /// Constructor
   AlignmentProducer( const edm::ParameterSet& iConfig );
@@ -175,8 +176,6 @@ class AlignmentProducer : public edm::ESProducerLooper
   /// read in survey records
   void readInSurveyRcds( const edm::EventSetup& );
 
-  RunRanges makeNonOverlappingRunRanges(const edm::VParameterSet& RunRangeSelectionVPSet);
-  RunRanges makeUniqueRunRanges(const edm::ParameterSet& cfg);
 
   // private data members
 

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -111,6 +111,9 @@ class AlignmentProducer : public edm::ESProducerLooper
   /// Creates the choosen alignment algorithm (specified in config-file)
   void createAlignmentAlgorithm(const edm::ParameterSet&);
 
+  /// Checks if one of the EventSetup-Records has changed
+  bool setupChanged(const edm::EventSetup&);
+
   /// Creates Geometry and Alignables of the Tracker and initializes the
   /// AlignmentAlgorithm @theAlignmentAlgo
   void initAlignmentAlgorithm(const edm::EventSetup&);
@@ -219,6 +222,19 @@ class AlignmentProducer : public edm::ESProducerLooper
   const edm::InputTag clusterValueMapTag_;              // ValueMap containing associtaion cluster - flag
 
   // ESWatcher
+
+  edm::ESWatcher<IdealGeometryRecord> watchIdealGeometryRcd;
+  edm::ESWatcher<GlobalPositionRcd> watchGlobalPositionRcd;
+
+  edm::ESWatcher<TrackerAlignmentRcd> watchTrackerAlRcd;
+  edm::ESWatcher<TrackerAlignmentErrorExtendedRcd> watchTrackerAlErrorExtRcd;
+  edm::ESWatcher<TrackerSurfaceDeformationRcd> watchTrackerSurDeRcd;
+
+  edm::ESWatcher<DTAlignmentRcd> watchDTAlRcd;
+  edm::ESWatcher<DTAlignmentErrorExtendedRcd> watchDTAlErrExtRcd;
+  edm::ESWatcher<CSCAlignmentRcd> watchCSCAlRcd;
+  edm::ESWatcher<CSCAlignmentErrorExtendedRcd> watchCSCAlErrExtRcd;
+
   edm::ESWatcher<TrackerSurveyRcd> watchTkSurveyRcd_;
   edm::ESWatcher<TrackerSurveyErrorExtendedRcd> watchTkSurveyErrRcd_;
   edm::ESWatcher<DTSurveyRcd> watchDTSurveyRcd_;

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
@@ -175,13 +175,14 @@ void PCLTrackerAlProducer
 void PCLTrackerAlProducer
 ::beginRun(const edm::Run& run, const edm::EventSetup& setup)
 {
-  if (setupChanged(setup)) {
+  const bool changed{setupChanged(setup)};
+  if (changed) {
     edm::LogInfo("Alignment") << "@SUB=PCLTrackerAlProducer::beginRun"
                               << "EventSetup-Record changed.";
     initAlignmentAlgorithm(setup);
   }
 
-  theAlignmentAlgo->beginRun(run, setup);
+  theAlignmentAlgo->beginRun(run, setup, changed);
 
   if (setupChanged(setup)) {
     initAlignmentAlgorithm(setup);

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
@@ -81,6 +81,7 @@ PCLTrackerAlProducer
   doMuon_                  (config.getUntrackedParameter<bool>("doMuon") ),
   useExtras_               (config.getUntrackedParameter<bool>("useExtras")),
   useSurvey_               (config.getParameter<bool>         ("useSurvey")),
+  enableAlignableUpdates_  (config.getParameter<bool>         ("enableAlignableUpdates")),
 
   /* Event input tags */
   tjTkAssociationMapTag_   (config.getParameter<edm::InputTag>("tjTkAssociationMapTag")),
@@ -320,8 +321,11 @@ void PCLTrackerAlProducer
   edm::ParameterSet algoConfig    = config.getParameter<edm::ParameterSet>("algoConfig");
   edm::VParameterSet iovSelection = config.getParameter<edm::VParameterSet>("RunRangeSelection");
   algoConfig.addUntrackedParameter<edm::VParameterSet>("RunRangeSelection", iovSelection);
-  // provide required parameter while keeping current functionality for PCL:
+
+  // provide required parameters while keeping current functionality for PCL:
   algoConfig.addUntrackedParameter<align::RunNumber>("firstIOV", 1);
+  algoConfig.addUntrackedParameter<bool>("enableAlignableUpdates",
+                                         enableAlignableUpdates_);
 
   std::string algoName = algoConfig.getParameter<std::string>("algoName");
   theAlignmentAlgo = AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig);

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.cc
@@ -20,7 +20,6 @@
 #include "FWCore/Framework/interface/Run.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/Parse.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h" 
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
@@ -321,7 +320,7 @@ void PCLTrackerAlProducer
   edm::VParameterSet iovSelection = config.getParameter<edm::VParameterSet>("RunRangeSelection");
   algoConfig.addUntrackedParameter<edm::VParameterSet>("RunRangeSelection", iovSelection);
   // provide required parameter while keeping current functionality for PCL:
-  algoConfig.addUntrackedParameter<RunNumber>("firstIOV", 1);
+  algoConfig.addUntrackedParameter<align::RunNumber>("firstIOV", 1);
 
   std::string algoName = algoConfig.getParameter<std::string>("algoName");
   theAlignmentAlgo = AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig);
@@ -1005,15 +1004,10 @@ void PCLTrackerAlProducer
                                << "do not dare to store to DB.";
   } else {
     // Expand run ranges and make them unique
-    edm::VParameterSet runRangeSelectionVPSet(theParameterSet.getParameter<edm::VParameterSet>("RunRangeSelection"));
-    RunRanges uniqueRunRanges(makeNonOverlappingRunRanges(runRangeSelectionVPSet));
-
-    // create dummy IOV
-    if (uniqueRunRanges.empty()) {
-      const RunRange runRange(cond::timeTypeSpecs[cond::runnumber].beginValue,
-                              cond::timeTypeSpecs[cond::runnumber].endValue);
-      uniqueRunRanges.push_back(runRange);
-    }
+    const auto runRangeSelectionVPSet =
+      theParameterSet.getParameter<edm::VParameterSet>("RunRangeSelection");
+    align::RunRanges uniqueRunRanges
+      (align::makeUniqueRunRanges(runRangeSelectionVPSet, theFirstRun));
 
     std::vector<AlgebraicVector> beamSpotParameters;
 
@@ -1055,72 +1049,6 @@ void PCLTrackerAlProducer
                                 << bsOutput.str();
     }
   }
-}
-
-//_____________________________________________________________________________
-RunRanges PCLTrackerAlProducer
-::makeNonOverlappingRunRanges(const edm::VParameterSet& RunRangeSelectionVPSet)
-{
-  static bool oldRunRangeSelectionWarning = false;
-
-  const RunNumber beginValue = cond::timeTypeSpecs[cond::runnumber].beginValue;
-  const RunNumber endValue   = cond::timeTypeSpecs[cond::runnumber].endValue;
-
-  RunRanges uniqueRunRanges;
-  if (!RunRangeSelectionVPSet.empty()) {
-
-    std::map<RunNumber,RunNumber> uniqueFirstRunNumbers;
-
-    for (auto ipset  = RunRangeSelectionVPSet.begin();
-              ipset != RunRangeSelectionVPSet.end();
-            ++ipset) {
-      const std::vector<std::string> RunRangeStrings = (*ipset).getParameter<std::vector<std::string> >("RunRanges");
-
-      for (auto irange  = RunRangeStrings.begin();
-                irange != RunRangeStrings.end();
-              ++irange) {
-
-        if ((*irange).find(':') == std::string::npos) {
-
-          RunNumber first = beginValue;
-          long int temp = strtol((*irange).c_str(), 0, 0);
-          if (temp!=-1) first = temp;
-          uniqueFirstRunNumbers[first] = first;
-
-        } else {
-          if (!oldRunRangeSelectionWarning) {
-            edm::LogWarning("BadConfig") << "@SUB=PCLTrackerAlProducer::makeNonOverlappingRunRanges"
-                         << "Config file contains old format for 'RunRangeSelection'. Only the start run\n"
-                         << "number is used internally. The number of the last run is ignored and can be\n"
-                         << "safely removed from the config file.\n";
-            oldRunRangeSelectionWarning = true;
-          }
-
-          std::vector<std::string> tokens = edm::tokenize(*irange, ":");
-          long int temp;
-          RunNumber first = beginValue;
-          temp = strtol(tokens[0].c_str(), 0, 0);
-          if (temp!=-1) first = temp;
-          uniqueFirstRunNumbers[first] = first;
-        }
-      }
-    }
-
-    for (auto iFirst  = uniqueFirstRunNumbers.begin();
-              iFirst != uniqueFirstRunNumbers.end();
-            ++iFirst) {
-      uniqueRunRanges.push_back(std::pair<RunNumber,RunNumber>((*iFirst).first, endValue));
-    }
-
-    for (size_t i = 0; i < uniqueRunRanges.size()-1; ++i) {
-      uniqueRunRanges[i].second = uniqueRunRanges[i+1].first - 1;
-    }
-
-  } else {
-    uniqueRunRanges.push_back(std::pair<RunNumber,RunNumber>(theFirstRun, endValue));
-  }
-
-  return uniqueRunRanges;
 }
 
 //_____________________________________________________________________________

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
@@ -44,6 +44,7 @@
 
 #include "Alignment/CommonAlignment/interface/Alignable.h"
 #include "Alignment/CommonAlignment/interface/AlignableExtras.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
 
@@ -189,9 +190,6 @@ class PCLTrackerAlProducer : public edm::EDAnalyzer {
 
     /// Writes Alignments (i.e. Records) to database-file
     void storeAlignmentsToDB();
-
-    /// Makes unique RunRanges (specified in config-file)
-    RunRanges makeNonOverlappingRunRanges(const edm::VParameterSet&);
 
     /// Writes Alignments and AlignmentErrors for all sub detectors and the
     /// given run number

--- a/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/PCLTrackerAlProducer.h
@@ -245,6 +245,7 @@ class PCLTrackerAlProducer : public edm::EDAnalyzer {
     const bool   saveToDB_, saveApeToDB_, saveDeformationsToDB_;
     const bool   doTracker_, doMuon_, useExtras_;
     const bool   useSurvey_;
+    const bool   enableAlignableUpdates_;
 
     /// Map with tracks/trajectories
     const edm::InputTag tjTkAssociationMapTag_;

--- a/Alignment/CommonAlignmentProducer/python/AlignmentProducer_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlignmentProducer_cff.py
@@ -70,7 +70,10 @@ looper = cms.Looper("AlignmentProducer",
 
 
                     # Save alignment to DB: true requires configuration of PoolDBOutputService
-                    saveToDB = cms.bool(False),            # save alignment?
-                    saveApeToDB = cms.bool(False),         # save APE?
-                    saveDeformationsToDB = cms.bool(False) # save surface deformations (bows, etc.)?
+                    saveToDB = cms.bool(False),             # save alignment?
+                    saveApeToDB = cms.bool(False),          # save APE?
+                    saveDeformationsToDB = cms.bool(False), # save surface deformations (bows, etc.)?
+
+                    # update alignables if triggered by corresponding input IOV boundary
+                    enableAlignableUpdates = cms.bool(False),
                     )

--- a/Alignment/CommonAlignmentProducer/python/TrackerAlignmentProducerForPCL_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/TrackerAlignmentProducerForPCL_cff.py
@@ -74,7 +74,10 @@ AlignmentProducer = cms.EDAnalyzer("PCLTrackerAlProducer",
                     #trackerGeometryConstants = cms.PSet(trackerGeometryConstants_cfi.trackerGeometryConstants),
 
                     # Save alignment to DB: true requires configuration of PoolDBOutputService
-                    saveToDB = cms.bool(False),            # save alignment?
-                    saveApeToDB = cms.bool(False),         # save APE?
+                    saveToDB = cms.bool(False),             # save alignment?
+                    saveApeToDB = cms.bool(False),          # save APE?
                     saveDeformationsToDB = cms.bool(False), # save surface deformations (bows, etc.)?
+
+                    # update alignables if triggered by corresponding input IOV boundary
+                    enableAlignableUpdates = cms.bool(False),
                     )

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h
@@ -15,6 +15,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
+#include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
@@ -34,9 +35,9 @@ class PedeLabelerBase
 {
  public:
 
-  typedef AlignmentAlgorithmBase::RunNumber  RunNumber;
-  typedef AlignmentAlgorithmBase::RunRange   RunRange;
-  typedef std::vector<RunRange>              RunRanges;
+  using RunNumber = align::RunNumber;
+  using RunRange = align::RunRange;
+  using RunRanges = align::RunRanges;
 
   class TopLevelAlignables
   {

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -103,6 +103,7 @@ MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet
   theGblDoubleBinary(cfg.getParameter<bool>("doubleBinary")),
   runAtPCL_(cfg.getParameter<bool>("runAtPCL")),
   ignoreHitsWithoutGlobalDerivatives_(cfg.getParameter<bool>("ignoreHitsWithoutGlobalDerivatives")),
+  skipGlobalPositionRcdCheck_(cfg.getParameter<bool>("skipGlobalPositionRcdCheck")),
   uniqueRunRanges_
   (align::makeUniqueRunRanges(cfg.getUntrackedParameter<edm::VParameterSet>("RunRangeSelection"),
                               cond::timeTypeSpecs[cond::runnumber].beginValue))
@@ -650,8 +651,13 @@ void MillePedeAlignmentAlgorithm::beginRun(const edm::Run& run,
         message
           << " - GlobalPositionRecord '" << globalPosRcd.key().name()
           << "' (since "
-          << globalPosRcd.validityInterval().first().eventID().run() << ")\n";
-	throwException = true;
+          << globalPosRcd.validityInterval().first().eventID().run() << ")";
+        if (skipGlobalPositionRcdCheck_) {
+          message << " --> ignored\n";
+        } else {
+          message << "\n";
+          throwException = true;
+        }
       }
       if (alignmentRcd.validityInterval().first().eventID().run() > firstRun) {
         message

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -587,7 +587,8 @@ MillePedeAlignmentAlgorithm::addHitCount(const std::vector<AlignmentParameters*>
 
 
 void MillePedeAlignmentAlgorithm::beginRun(const edm::Run& run,
-                                           const edm::EventSetup& setup) {
+                                           const edm::EventSetup& setup,
+                                           bool changed) {
   if (run.run() < firstIOV_ && !ignoreFirstIOVCheck_) {
     throw cms::Exception("Alignment")
       << "@SUB=MillePedeAlignmentAlgorithm::beginRun\n"

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -260,7 +260,7 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   unsigned int              theMinNumHits;
   double                    theMaximalCor2D; /// maximal correlation allowed for 2D hit in TID/TEC.
                                              /// If larger, the 2D measurement gets diagonalized!!!
-  const AlignmentAlgorithmBase::RunNumber firstIOV_;
+  const align::RunNumber firstIOV_;
   const bool ignoreFirstIOVCheck_;
   int                       theLastWrittenIov; // keeping track for output trees...
   std::vector<float>        theFloatBufferX;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -275,6 +275,8 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
 
   const bool                runAtPCL_;
   const bool                ignoreHitsWithoutGlobalDerivatives_;
+  const bool                skipGlobalPositionRcdCheck_;
+
   const align::RunRanges uniqueRunRanges_;
   std::vector<align::RunNumber> cachedRuns_;
 };

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -235,6 +235,9 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   /// add measurement data from PXB survey
   void addPxbSurvey(const edm::ParameterSet &pxbSurveyCfg);
 
+  //
+  bool areIOVsSpecified() const;
+
   //--------------------------------------------------------
   // Data members
   //--------------------------------------------------------
@@ -278,6 +281,7 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   const bool                skipGlobalPositionRcdCheck_;
 
   const align::RunRanges uniqueRunRanges_;
+  const bool enforceSingleIOVInput_;
   std::vector<align::RunNumber> cachedRuns_;
 };
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -275,6 +275,8 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
 
   const bool                runAtPCL_;
   const bool                ignoreHitsWithoutGlobalDerivatives_;
+  const align::RunRanges uniqueRunRanges_;
+  std::vector<align::RunNumber> cachedRuns_;
 };
 
 DEFINE_EDM_PLUGIN(AlignmentAlgorithmPluginFactory,

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -283,6 +283,7 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   const align::RunRanges uniqueRunRanges_;
   const bool enforceSingleIOVInput_;
   std::vector<align::RunNumber> cachedRuns_;
+  align::RunNumber lastProcessedRun_;
 };
 
 DEFINE_EDM_PLUGIN(AlignmentAlgorithmPluginFactory,

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -267,6 +267,7 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
                                              /// If larger, the 2D measurement gets diagonalized!!!
   const align::RunNumber firstIOV_;
   const bool ignoreFirstIOVCheck_;
+  const bool enableAlignableUpdates_;
   int                       theLastWrittenIov; // keeping track for output trees...
   std::vector<float>        theFloatBufferX;
   std::vector<float>        theFloatBufferY;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -87,7 +87,9 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   virtual void run(const edm::EventSetup &setup, const EventInfo &eventInfo) override;
 
   /// called at begin of run
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup) override;
+  virtual void beginRun(const edm::Run& run,
+                        const edm::EventSetup& setup,
+                        bool changed) override;
 
   // TODO: This method does NOT match endRun() in base class! Nobody is
   //       calling this?

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
@@ -28,6 +28,10 @@ MillePedeAlignmentAlgorithm = cms.PSet(
                                                           #   hit are set to '0', the hit is ignored
                                                           # - has only an effect with non-GBL
                                                           #   material-effects description
+    skipGlobalPositionRcdCheck = cms.bool(False), # since the change of the GlobalPositionRcd is
+                                                  # mostly driven by changes of the muon system
+                                                  # it is often safe to ignore this change for
+                                                  # tracker alignment
 
     # PSet that allows to configure the pede labeler, i.e. select the actual
     # labeler plugin to use and parameters for the selected plugin

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
@@ -15,6 +15,9 @@ def setConfiguration(process, collection, mode, monitorFile, binaryFile,
     # What tracks are used to construct the reference trajectories?
     process.AlignmentProducer.tjTkAssociationMapTag = "FinalTrackRefitter"
 
+    # enable proper handling of multi-IOV input
+    process.AlignmentProducer.enableAlignableUpdates = True
+
     # Configure the algorithm
     process.AlignmentProducer.algoConfig = cms.PSet(
         process.MillePedeAlignmentAlgorithm)

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
@@ -20,6 +20,7 @@ def setConfiguration(process, collection, mode, monitorFile, binaryFile,
         process.MillePedeAlignmentAlgorithm)
     process.AlignmentProducer.algoConfig.mode              = mode
     process.AlignmentProducer.algoConfig.mergeBinaryFiles  = cms.vstring()
+    process.AlignmentProducer.algoConfig.skipGlobalPositionRcdCheck = True
 
     # default pede options:
     process.AlignmentProducer.algoConfig.pedeSteerer.method = "sparseMINRES-QLP 3  0.8"

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/PedeSetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/PedeSetup.py
@@ -60,12 +60,12 @@ def setup(process, binary_files, tree_files, run_start_geometry):
     # --------------------------------------------------------------------------
     if (hasattr(process.AlignmentProducer, "RunRangeSelection") and
         len(process.AlignmentProducer.RunRangeSelection) > 0):
-        if len(process.AlignmentProducer.RunRangeSelection) == 1:
-            iovs = process.AlignmentProducer.RunRangeSelection[0].RunRanges
-            number_of_events = int(iovs[-1]) - int(iovs[0]) + 1
-        else:
-            print "Unsupported config: More than one IOV definition found."
-            sys.exit(1)
+        iovs = set([int(iov)
+                    for sel in process.AlignmentProducer.RunRangeSelection
+                    for iov in sel.RunRanges
+                    ])
+        iovs = sorted(iovs)
+        number_of_events = iovs[-1] - iovs[0] + 1
     else:
         number_of_events = 1
 

--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/PedeSetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/PedeSetup.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import Alignment.MillePedeAlignmentAlgorithm.mpslib.tools as mps_tools
 
 
 def setup(process, binary_files, tree_files, run_start_geometry):
@@ -58,16 +59,8 @@ def setup(process, binary_files, tree_files, run_start_geometry):
 
     # Set a new source and path.
     # --------------------------------------------------------------------------
-    if (hasattr(process.AlignmentProducer, "RunRangeSelection") and
-        len(process.AlignmentProducer.RunRangeSelection) > 0):
-        iovs = set([int(iov)
-                    for sel in process.AlignmentProducer.RunRangeSelection
-                    for iov in sel.RunRanges
-                    ])
-        iovs = sorted(iovs)
-        number_of_events = iovs[-1] - iovs[0] + 1
-    else:
-        number_of_events = 1
+    iovs = mps_tools.make_unique_runranges(process.AlignmentProducer)
+    number_of_events = iovs[-1] - iovs[0] + 1
 
     process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(number_of_events))

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
@@ -6,65 +6,46 @@ import subprocess
 import CondCore.Utilities.conddblib as conddb
 
 
-def create_single_iov_db(global_tag, run_number, output_db):
+def create_single_iov_db(inputs, run_number, output_db):
     """Create an sqlite file with single-IOV tags for alignment payloads.
 
     Arguments:
-    - `global_tag`: global tag from which to extract the payloads
+    - `inputs`: dictionary with input needed for payload extraction
     - `run_number`: run for which the IOVs are selected
     - `output_db`: name of the output sqlite file
     """
 
-    # setting up the DB session
-    con = conddb.connect(url = conddb.make_url())
-    session = con.session()
-    GlobalTagMap = session.get_dbtype(conddb.GlobalTagMap)
-    IOV = session.get_dbtype(conddb.IOV)
-
-    # query tag names for records of interest contained in `global_tag`
-    tags = session.query(GlobalTagMap.record, GlobalTagMap.tag_name).\
-           filter(GlobalTagMap.global_tag_name == global_tag,
-                  sqlalchemy.or_(
-                      GlobalTagMap.record == "TrackerAlignmentRcd",
-                      GlobalTagMap.record == "TrackerSurfaceDeformationRcd",
-                      GlobalTagMap.record == "TrackerAlignmentErrorExtendedRcd")
-           ).all()
-    tags = {item[0]: {"name": item[1]} for item in tags}
-
-    # query IOVs for each tag and find the IOV containing `run_number`
-    for record,tag in tags.iteritems():
-        iovs = session.query(IOV.since).filter(IOV.tag_name == tag["name"]).all()
+    # find the IOV containing `run_number`
+    for record,tag in inputs.iteritems():
         run_is_covered = False
-        for iov in reversed(iovs):
-            if iov[0] <= run_number:
-                tag["since"] = str(iov[0])
+        for iov in reversed(tag["iovs"]):
+            if iov <= run_number:
+                tag["since"] = str(iov)
                 run_is_covered = True
                 break
         if not run_is_covered:
             msg = ("Run number {0:d} is not covered in '{1:s}' ({2:s}) from"
-                   " '{3:s}'.".format(run_number, tag["name"], record,
+                   " '{3:s}'.".format(run_number, tag["tag"], record,
                                       global_tag))
             print msg
             print "Aborting..."
             sys.exit(1)
 
-    # closing the DB session
-    session.close()
-
     result = {}
     if os.path.exists(output_db): os.remove(output_db)
-    for record,tag in tags.iteritems():
+    for record,tag in inputs.iteritems():
         result[record] = {"connect": "sqlite_file:"+output_db,
-                          "tag": "_".join([tag["name"], tag["since"]])}
+                          "tag": "_".join([tag["tag"], tag["since"]])}
         cmd = ("conddb_import",
                "-f", "frontier://PromptProd/cms_conditions",
                "-c", result[record]["connect"],
-               "-i", tag["name"],
+               "-i", tag["tag"],
                "-t", result[record]["tag"],
                "-b", str(run_number),
                "-e", str(run_number))
         run_checked(cmd)
-    run_checked(["sqlite3", output_db, "update iov set since=1"])
+    if len(inputs) > 0:
+        run_checked(["sqlite3", output_db, "update iov set since=1"])
 
     return result
 
@@ -99,5 +80,78 @@ def get_process_object(cfg):
         importlib.import_module(os.path.splitext(os.path.basename(cfg))[0])
     sys.stdout = cache_stdout
     sys.path.pop()                        # clean up python path again
+    try:
+        os.remove(cfg+"c")                # try to remove temporary .pyc file
+    except OSError as e:
+        if e.args == (2, "No such file or directory"): pass
+        else: raise
 
     return __configuration.process
+
+
+def make_unique_runranges(ali_producer):
+    """Derive unique run ranges from AlignmentProducer PSet.
+
+    Arguments:
+    - `ali_producer`: cms.PSet containing AlignmentProducer configuration
+    """
+
+    if (hasattr(ali_producer, "RunRangeSelection") and
+        len(ali_producer.RunRangeSelection) > 0):
+        iovs = set([int(iov)
+                    for sel in ali_producer.RunRangeSelection
+                    for iov in sel.RunRanges])
+        if len(iovs) == 0: return [1] # single IOV starting from run 1
+        return sorted(iovs)
+    else:
+        return [1]                    # single IOV starting from run 1
+
+
+def get_tags(global_tag, records):
+    """Get tags for `records` contained in `global_tag`.
+
+    Arguments:
+    - `global_tag`: global tag of interest
+    - `records`: database records of interest
+    """
+
+    if len(records) == 0: return {} # avoid useless DB query
+
+    # setting up the DB session
+    con = conddb.connect(url = conddb.make_url())
+    session = con.session()
+    GlobalTagMap = session.get_dbtype(conddb.GlobalTagMap)
+
+    # query tag names for records of interest contained in `global_tag`
+    tags = session.query(GlobalTagMap.record, GlobalTagMap.tag_name).\
+           filter(GlobalTagMap.global_tag_name == global_tag,
+                  GlobalTagMap.record.in_(records)).all()
+
+    # closing the DB session
+    session.close()
+
+    return {item[0]: {"tag": item[1], "connect": "pro"} for item in tags}
+
+
+def get_iovs(db, tag):
+    """Retrieve the list of IOVs from `db` for `tag`.
+
+    Arguments:
+    - `db`: database connection string
+    - `tag`: tag of database record
+    """
+
+    db = db.replace("sqlite_file:", "").replace("sqlite:", "")
+
+    con = conddb.connect(url = conddb.make_url(db))
+    session = con.session()
+    IOV = session.get_dbtype(conddb.IOV)
+
+    iovs = set(session.query(IOV.since).filter(IOV.tag_name == tag).all())
+    if len(iovs) == 0:
+        print "No IOVs found for tag '"+tag+"' in database '"+db+"'."
+        sys.exit(1)
+
+    session.close()
+
+    return sorted([int(item[0]) for item in iovs])

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpslib/tools.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import importlib
 import sqlalchemy
 import subprocess
 import CondCore.Utilities.conddblib as conddb
@@ -82,3 +83,21 @@ def run_checked(cmd):
         print "Problem in running the following command:"
         print " ".join(e.cmd)
         sys.exit(1)
+
+
+def get_process_object(cfg):
+    """Returns cms.Process object defined in `cfg`.
+
+    Arguments:
+    - `cfg`: path to CMSSW config file
+    """
+
+    sys.path.append(os.path.dirname(cfg)) # add location to python path
+    cache_stdout = sys.stdout
+    sys.stdout = open(os.devnull, "w")    # suppress unwanted output
+    __configuration = \
+        importlib.import_module(os.path.splitext(os.path.basename(cfg))[0])
+    sys.stdout = cache_stdout
+    sys.path.pop()                        # clean up python path again
+
+    return __configuration.process

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
@@ -99,6 +99,18 @@ def create_input_db(cfg, run_number):
         print "'FirstRunForStartGeometry' must be positive, but is", run_number
         sys.exit(1)
 
+    # return if IOVs are defined; if not continue to create single IOV input
+    if len(__configuration.process.AlignmentProducer.RunRangeSelection) > 0:
+        iovs_are_defined = False
+        for pset in __configuration.process.AlignmentProducer.RunRangeSelection:
+            if len(pset.RunRanges) > 0:
+                iovs_are_defined = True
+                break
+        if iovs_are_defined:
+            os.remove(cfg+"c")
+            return ""
+
+
     global_tag = __configuration.process.GlobalTag.globaltag.value()
     input_db_name = os.path.abspath("alignment_input.db")
     tags = mps_tools.create_single_iov_db(global_tag, run_number, input_db_name)
@@ -119,6 +131,8 @@ def create_input_db(cfg, run_number):
 
     os.remove(cfg+"c")
     return result
+
+
 
 # ------------------------------------------------------------------------------
 # set up argument parser and config parser
@@ -274,6 +288,9 @@ if args.weight:
     tmpFile = re.sub('setupCollection\s*\=\s*[\"\'](.*?)[\"\']',
                      'setupCollection = \"'+collection+'\"',
                      tmpFile)
+    tmpFile = re.sub(re.compile("setupRunStartGeometry\s*\=\s*.*$", re.M),
+                     "setupRunStartGeometry = "+first_run,
+                     tmpFile)
 
     thisCfgTemplate = "tmp.py"
     with open(thisCfgTemplate, "w") as f: f.write(tmpFile)
@@ -322,6 +339,7 @@ if args.weight:
 
     # remove temporary file
     os.system("rm "+thisCfgTemplate)
+
     if overrideGT.strip() != "":
         print "="*60
         msg = ("Overriding global tag with single-IOV tags extracted from '{}' "
@@ -438,6 +456,9 @@ for section in config.sections():
         tmpFile = re.sub('setupGlobaltag\s*\=\s*[\"\'](.*?)[\"\']',
                          'setupGlobaltag = \"'+datasetOptions['globaltag']+'\"',
                          tmpFile)
+        tmpFile = re.sub(re.compile("setupRunStartGeometry\s*\=\s*.*$", re.M),
+                         "setupRunStartGeometry = "+
+                         generalOptions["FirstRunForStartGeometry"], tmpFile)
         tmpFile = re.sub('setupCollection\s*\=\s*[\"\'](.*?)[\"\']',
                          'setupCollection = \"'+datasetOptions['collection']+'\"',
                          tmpFile)

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_alisetup.py
@@ -75,18 +75,16 @@ def get_weight_configs(config):
     return configs
 
 
-def create_input_db(cfg, run_number):
+def create_input_db(cms_process, run_number):
     """
     Create sqlite file with single-IOV tags and use it to override the GT. If
     the GT is already customized by the user, the customization has higher
     priority. Returns a snippet to be appended to the configuration file
 
     Arguments:
-    - `cfg`: path to python configuration
+    - `cms_process`: cms.Process object
     - `run_number`: run from which to extract the alignment payloads
     """
-
-    cms_process = mps_tools.get_process_object(cfg)
 
     run_number = int(run_number)
     if not run_number > 0:
@@ -288,7 +286,10 @@ if args.weight:
 
     thisCfgTemplate = "tmp.py"
     with open(thisCfgTemplate, "w") as f: f.write(tmpFile)
-    overrideGT = create_input_db(thisCfgTemplate, first_run)
+
+    cms_process = mps_tools.get_process_object(thisCfgTemplate)
+
+    overrideGT = create_input_db(cms_process, first_run)
     with open(thisCfgTemplate, "a") as f: f.write(overrideGT)
 
     for setting in pedesettings:
@@ -484,7 +485,8 @@ for section in config.sections():
             append = ''
             firstDataset = False
             configTemplate = tmpFile
-            overrideGT = create_input_db(thisCfgTemplate,
+            cms_process = mps_tools.get_process_object(thisCfgTemplate)
+            overrideGT = create_input_db(cms_process,
                                          generalOptions["FirstRunForStartGeometry"])
 
         with open(thisCfgTemplate, "a") as f: f.write(overrideGT)

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_parse_pedechi2hist.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_parse_pedechi2hist.py
@@ -20,6 +20,7 @@ import sys
 import re
 import argparse
 
+import Alignment.MillePedeAlignmentAlgorithm.mpslib.tools as mps_tools
 import Alignment.MillePedeAlignmentAlgorithm.mpslib.Mpslibclass as mpslib
 
 
@@ -96,14 +97,9 @@ def get_used_binaries(cfg, no_binary_check):
     - `no_binary_check`: if 'True' a check for file existence is skipped
     """
 
-    sys.path.append(os.path.dirname(cfg))
+    cms_process = mps_tools.get_process_object(cfg)
 
-    cache_stdout = sys.stdout
-    sys.stdout = open(os.devnull, "w") # suppress unwanted output
-    __cfg = importlib.import_module(os.path.splitext(os.path.basename(cfg))[0])
-    sys.stdout = cache_stdout
-
-    binaries = __cfg.process.AlignmentProducer.algoConfig.mergeBinaryFiles
+    binaries = cms_process.AlignmentProducer.algoConfig.mergeBinaryFiles
     if no_binary_check:
         used_binaries = binaries
     else:
@@ -113,7 +109,6 @@ def get_used_binaries(cfg, no_binary_check):
 
     used_binaries = [int(re.sub(r"milleBinary(\d+)\.dat", r"\1", b))
                      for b in used_binaries]
-    del sys.path[-1]            # remove the temporary search path extension
 
     return used_binaries
 

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_prepare_input_db.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_prepare_input_db.py
@@ -28,9 +28,13 @@ def main(argv = None):
                         help="name of the output file (default: '%(default)s')")
     args = parser.parse_args(argv)
 
-    mps_tools.create_single_iov_db(args.global_tag,
-                                   args.run_number,
-                                   args.output_db)
+    inputs = mps_tools.get_tags(args.global_tag,
+                                ["TrackerAlignmentRcd",
+                                 "TrackerSurfaceDeformationRcd",
+                                 "TrackerAlignmentErrorExtendedRcd"])
+    for inp in inputs.itervalues():
+        inp["iovs"] = mps_tools.get_iovs(inp["connect"], inp["tag"])
+    mps_tools.create_single_iov_db(inputs, args.run_number, args.output_db)
 
 
 ################################################################################

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/universalConfigTemplate.py
@@ -47,6 +47,7 @@ setupCosmicsDecoMode  = False
 setupCosmicsZeroTesla = False
 setupPrimaryWidth     = -1.0
 setupJson             = "placeholder_json"
+setupRunStartGeometry = -1
 
 ################################################################################
 # Variables edited by MPS (mps_setup and mps_merge). Be careful.
@@ -166,4 +167,5 @@ else:
     import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.PedeSetup as pede
     pede.setup(process,
                binary_files = merge_binary_files,
-               tree_files = merge_tree_files)
+               tree_files = merge_tree_files,
+               run_start_geometry = setupRunStartGeometry)

--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="testPrepareInputDb" command="mps_prepare_input_db.py -g 90X_dataRun2_Queue -r 1 -o /tmp/test_input.db"/>

--- a/Alignment/MuonAlignment/interface/AlignableCSCChamber.h
+++ b/Alignment/MuonAlignment/interface/AlignableCSCChamber.h
@@ -28,6 +28,9 @@ class AlignableCSCChamber: public AlignableDet {
 
   /// Constructor
   AlignableCSCChamber(const GeomDet *geomDet);
+
+  /// Updater
+  virtual void update(const GeomDet* geomDet);
 };
 
 #endif  // ALIGNABLE_CSC_CHAMBER_H

--- a/Alignment/MuonAlignment/interface/AlignableCSCChamber.h
+++ b/Alignment/MuonAlignment/interface/AlignableCSCChamber.h
@@ -30,7 +30,7 @@ class AlignableCSCChamber: public AlignableDet {
   AlignableCSCChamber(const GeomDet *geomDet);
 
   /// Updater
-  virtual void update(const GeomDet* geomDet);
+  void update(const GeomDet* geomDet);
 };
 
 #endif  // ALIGNABLE_CSC_CHAMBER_H

--- a/Alignment/MuonAlignment/interface/AlignableMuon.h
+++ b/Alignment/MuonAlignment/interface/AlignableMuon.h
@@ -47,7 +47,7 @@ public:
   
   /// Updater using DTGeometry and CSCGeometry.
   /// The given geometries have to match the current ones.
-  virtual void update(const DTGeometry* , const CSCGeometry*);
+  void update(const DTGeometry* , const CSCGeometry*);
 
   /// Return all components
   virtual align::Alignables components() const { return theMuonComponents; }

--- a/Alignment/MuonAlignment/interface/AlignableMuon.h
+++ b/Alignment/MuonAlignment/interface/AlignableMuon.h
@@ -45,6 +45,9 @@ public:
   /// Destructor
   ~AlignableMuon();
   
+  /// Updater using DTGeometry and CSCGeometry.
+  /// The given geometries have to match the current ones.
+  virtual void update(const DTGeometry* , const CSCGeometry*);
 
   /// Return all components
   virtual align::Alignables components() const { return theMuonComponents; }
@@ -52,7 +55,7 @@ public:
   /// Alignable tracker has no mother
   virtual Alignable* mother() { return 0; }
 
-  // Methods to return specific of components
+  /// Methods to return specific of components
   align::Alignables DTLayers();
   align::Alignables DTSuperLayers();
   align::Alignables DTChambers();
@@ -65,16 +68,16 @@ public:
   align::Alignables CSCRings();
   align::Alignables CSCEndcaps();
 
-  // Get DT alignments sorted by DetId
+  /// Get DT alignments sorted by DetId
   Alignments* dtAlignments();
 
-  // Get DT alignment errors sorted by DetId
+  /// Get DT alignment errors sorted by DetId
   AlignmentErrorsExtended* dtAlignmentErrorsExtended();
 
-  // Get CSC alignments sorted by DetId
+  /// Get CSC alignments sorted by DetId
   Alignments* cscAlignments();
 
-  // Get CSC alignment errors sorted by DetId
+  /// Get CSC alignment errors sorted by DetId
   AlignmentErrorsExtended* cscAlignmentErrorsExtended();
 
 
@@ -83,30 +86,30 @@ public:
 
 private:
   
-  // Get the position (centered at 0 by default)
+  /// Get the position (centered at 0 by default)
   PositionType computePosition(); 
 
-  // Get the global orientation (no rotation by default)
+  /// Get the global orientation (no rotation by default)
   RotationType computeOrientation();
 
-  // Get the Surface
+  /// Get the Surface
   AlignableSurface computeSurface();
 
-  // Get alignments sorted by DetId
+  /// Get alignments sorted by DetId
   Alignments* alignments() const;
 
-  // Get alignment errors sorted by DetId
+  /// Get alignment errors sorted by DetId
   AlignmentErrorsExtended* alignmentErrors() const;
 
 
 
-   // Sub-structure builders 
+  // Sub-structure builders
 
-   // Build muon barrel
-  void buildDTBarrel( const DTGeometry*  );
+  /// Build muon barrel
+  void buildDTBarrel(const DTGeometry*, bool update = false);
 
-  // Build muon end caps
-  void buildCSCEndcap( const CSCGeometry*  );
+  /// Build muon end caps
+  void buildCSCEndcap(const CSCGeometry*, bool update = false);
 
   /// Set mothers recursively
   void recursiveSetMothers( Alignable* alignable );
@@ -114,8 +117,7 @@ private:
   /// alignable object ID provider
   const AlignableObjectId alignableObjectId_;
 
-  // Containers of separate components
-
+  /// Containers of separate components
   std::vector<AlignableDTChamber*>   theDTChambers;
   std::vector<AlignableDTStation*>   theDTStations;
   std::vector<AlignableDTWheel*>     theDTWheels;

--- a/Alignment/MuonAlignment/src/AlignableCSCChamber.cc
+++ b/Alignment/MuonAlignment/src/AlignableCSCChamber.cc
@@ -7,11 +7,22 @@
  
 #include "Alignment/MuonAlignment/interface/AlignableCSCChamber.h"
 
-AlignableCSCChamber::AlignableCSCChamber(const GeomDet *geomDet): AlignableDet(geomDet)
+AlignableCSCChamber::AlignableCSCChamber(const GeomDet* geomDet) :
+  AlignableDet(geomDet)
 {
-   theStructureType = align::AlignableCSCChamber;
-   // DO NOT let the chamber position become an average of the layers
-   this->theSurface = geomDet->surface();
+  theStructureType = align::AlignableCSCChamber;
+  // DO NOT let the chamber position become an average of the layers
+  // FIXME: is this redundant?
+  theSurface = geomDet->surface();
+  compConstraintType_ = Alignable::CompConstraintType::NONE;
+}
+
+void AlignableCSCChamber::update(const GeomDet* geomDet)
+{
+  AlignableDet::update(geomDet);
+  // DO NOT let the chamber position become an average of the layers
+  // FIXME: is this redundant?
+  theSurface = geomDet->surface();
 }
 
 /// Printout the DetUnits in the CSC chamber

--- a/Alignment/MuonAlignment/src/AlignableCSCEndcap.cc
+++ b/Alignment/MuonAlignment/src/AlignableCSCEndcap.cc
@@ -21,7 +21,7 @@ AlignableCSCEndcap::AlignableCSCEndcap( const std::vector<AlignableCSCStation*>&
   theCSCStations.insert( theCSCStations.end(), cscStations.begin(), cscStations.end() );
 
   setSurface( computeSurface() );
-   
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
       
 

--- a/Alignment/MuonAlignment/src/AlignableCSCRing.cc
+++ b/Alignment/MuonAlignment/src/AlignableCSCRing.cc
@@ -19,7 +19,7 @@ AlignableCSCRing::AlignableCSCRing( const std::vector<AlignableCSCChamber*>& csc
   theCSCChambers.insert( theCSCChambers.end(), cscChambers.begin(), cscChambers.end() );
 
   setSurface( computeSurface() );
-   
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
       
 

--- a/Alignment/MuonAlignment/src/AlignableCSCStation.cc
+++ b/Alignment/MuonAlignment/src/AlignableCSCStation.cc
@@ -19,7 +19,7 @@ AlignableCSCStation::AlignableCSCStation( const std::vector<AlignableCSCRing*>& 
   theCSCRings.insert( theCSCRings.end(), cscRings.begin(), cscRings.end() );
 
   setSurface( computeSurface() );
-   
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
       
 

--- a/Alignment/MuonAlignment/src/AlignableDTBarrel.cc
+++ b/Alignment/MuonAlignment/src/AlignableDTBarrel.cc
@@ -21,7 +21,7 @@ AlignableDTBarrel::AlignableDTBarrel( const std::vector<AlignableDTWheel*>& dtWh
   theDTWheels.insert( theDTWheels.end(), dtWheels.begin(), dtWheels.end() );
 
   setSurface( computeSurface() );
-   
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
       
 

--- a/Alignment/MuonAlignment/src/AlignableDTStation.cc
+++ b/Alignment/MuonAlignment/src/AlignableDTStation.cc
@@ -19,7 +19,7 @@ AlignableDTStation::AlignableDTStation( const std::vector<AlignableDTChamber*>& 
   theDTChambers.insert( theDTChambers.end(), dtChambers.begin(), dtChambers.end() );
 
   setSurface( computeSurface() );
-   
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
       
 

--- a/Alignment/MuonAlignment/src/AlignableDTWheel.cc
+++ b/Alignment/MuonAlignment/src/AlignableDTWheel.cc
@@ -19,7 +19,7 @@ AlignableDTWheel::AlignableDTWheel( const std::vector<AlignableDTStation*>& dtSt
   theDTStations.insert( theDTStations.end(), dtStations.begin(), dtStations.end() );
 
   setSurface( computeSurface() );
-   
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
 }
       
 

--- a/Alignment/TrackerAlignment/interface/AlignableTracker.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTracker.h
@@ -34,7 +34,7 @@ public:
 
   /// Updater using TrackerGeometry and TrackerTopology.
   /// The given geometry and topology have to match the current ones.
-  virtual void update(const TrackerGeometry*, const TrackerTopology*);
+  void update(const TrackerGeometry*, const TrackerTopology*);
 
   /// Return TOB half barrels
   Alignables& outerHalfBarrels() {

--- a/Alignment/TrackerAlignment/interface/AlignableTracker.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTracker.h
@@ -29,8 +29,12 @@ public:
   /// Return alignables of subdet and hierarchy level determined by name
   /// as defined in tracker part of Alignment/CommonAlignment/StructureType.h
   Alignables& subStructures(const std::string &subStructName) {
-    return alignableMap.find(subStructName);
+    return alignableMap_.find(subStructName);
   }
+
+  /// Updater using TrackerGeometry and TrackerTopology.
+  /// The given geometry and topology have to match the current ones.
+  virtual void update(const TrackerGeometry*, const TrackerTopology*);
 
   /// Return TOB half barrels
   Alignables& outerHalfBarrels() {
@@ -167,7 +171,7 @@ private:
   const TrackerTopology* tTopo_;
   align::TrackerNameSpace trackerNameSpace_;
   AlignableObjectId alignableObjectId_;
-  AlignableMap alignableMap;
+  AlignableMap alignableMap_;
 
 };
 

--- a/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
@@ -25,7 +25,7 @@ class AlignableTrackerBuilder {
 
     /// Builds all Alignables (units and composites) of the tracker, based on
     /// the given TrackerGeometry.
-    void buildAlignables(AlignableTracker*);
+    void buildAlignables(AlignableTracker*, bool update = false);
 
     /// Return tracker name space derived from the tracker's topology
     const align::TrackerNameSpace& trackerNameSpace() const {
@@ -39,22 +39,25 @@ class AlignableTrackerBuilder {
   private: //==================================================================
 
     /// Builds Alignables on module-level for each part of the tracker.
-    void buildAlignableDetUnits();
+    void buildAlignableDetUnits(bool update = false);
     /// Decides whether a GeomDet is from Pixel- or Strip-Detector and calls
     /// the according method to build the Alignable.
     void convertGeomDetsToAlignables(const TrackingGeometry::DetContainer&,
-                                     const std::string& moduleName);
+                                     const std::string& moduleName,
+                                     bool update = false);
     /// Converts GeomDetUnits of PXB and PXE to AlignableDetUnits.
     void buildPixelDetectorAlignable(const GeomDet*, int subdetId,
-                                     Alignables& aliDets, Alignables& aliDetUnits);
+                                     Alignables& aliDets, Alignables& aliDetUnits,
+                                     bool update = false);
     /// Converts GeomDets of TIB, TID, TOB and TEC either to AlignableDetUnits
     /// or AlignableSiStripDet, depending on the module-type (2D or 1D).
     void buildStripDetectorAlignable(const GeomDet*, int subdetId,
-                                     Alignables& aliDets, Alignables& aliDetUnits);
+                                     Alignables& aliDets, Alignables& aliDetUnits,
+                                     bool update = false);
 
     /// Builds all composite Alignables for the tracker. The hierarchy and
     /// numbers of components are determined in TrackerAlignmentLevelBuilder.
-    void buildAlignableComposites();
+    void buildAlignableComposites(bool update = false);
     /// Builds the PixelDetector by hand.
     void buildPixelDetector(AlignableTracker*);
     /// Builds the StripDetector by hand.
@@ -63,8 +66,8 @@ class AlignableTrackerBuilder {
   //========================== PRIVATE DATA ===================================
   //===========================================================================
 
-    const TrackerGeometry* trackerGeometry;
-    const TrackerTopology* trackerTopology;
+    const TrackerGeometry* trackerGeometry_;
+    const TrackerTopology* trackerTopology_;
     const AlignableObjectId alignableObjectId_;
 
     AlignableMap* alignableMap;

--- a/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
@@ -70,7 +70,7 @@ class AlignableTrackerBuilder {
     const TrackerTopology* trackerTopology_;
     const AlignableObjectId alignableObjectId_;
 
-    AlignableMap* alignableMap;
+    AlignableMap* alignableMap_;
 
     TrackerAlignmentLevelBuilder trackerAlignmentLevelBuilder_;
 

--- a/Alignment/TrackerAlignment/src/AlignableTracker.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTracker.cc
@@ -30,6 +30,14 @@ AlignableTracker
 }
 
 //_____________________________________________________________________________
+void AlignableTracker::update(const TrackerGeometry* trackerGeometry,
+                              const TrackerTopology* trackerTopology)
+{
+  AlignableTrackerBuilder builder(trackerGeometry, trackerTopology);
+  builder.buildAlignables(this, /* update = */ true);
+}
+
+//_____________________________________________________________________________
 align::Alignables AlignableTracker::merge( const Alignables& list1,
                                            const Alignables& list2 ) const
 {

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -28,7 +28,7 @@ AlignableTrackerBuilder
   trackerGeometry_(trackerGeometry),
   trackerTopology_(trackerTopology),
   alignableObjectId_(trackerGeometry, nullptr, nullptr),
-  alignableMap(nullptr),
+  alignableMap_(nullptr),
   trackerAlignmentLevelBuilder_(trackerTopology, trackerGeometry)
 {
   std::ostringstream ss;
@@ -51,7 +51,7 @@ AlignableTrackerBuilder
 void AlignableTrackerBuilder
 ::buildAlignables(AlignableTracker* trackerAlignables, bool update)
 {
-  alignableMap = &trackerAlignables->alignableMap;
+  alignableMap_ = &trackerAlignables->alignableMap_;
 
   // first, build Alignables on module-level (AlignableDetUnits)
   buildAlignableDetUnits(update);
@@ -67,7 +67,7 @@ void AlignableTrackerBuilder
   buildStripDetector(trackerAlignables);
 
   // tracker itself is of course also an Alignable
-  alignableMap->get("Tracker").push_back(trackerAlignables);
+  alignableMap_->get("Tracker").push_back(trackerAlignables);
   // id is the id of first component (should be TPBBarrel)
   trackerAlignables->theId = trackerAlignables->components()[0]->id();
 }
@@ -126,12 +126,12 @@ void AlignableTrackerBuilder
 {
   numDetUnits = 0;
 
-  auto& alignables = alignableMap->get(moduleName);
+  auto& alignables = alignableMap_->get(moduleName);
   if (!update) alignables.reserve(geomDets.size());
 
   // units are added for each moduleName, which are at moduleName + "Unit"
   // in the pixel Module and ModuleUnit are equivalent
-  auto & aliUnits = alignableMap->get(moduleName+"Unit");
+  auto & aliUnits = alignableMap_->get(moduleName+"Unit");
   if (!update) aliUnits.reserve(geomDets.size()); // minimal number space needed
 
   for (auto& geomDet : geomDets) {
@@ -297,7 +297,7 @@ void AlignableTrackerBuilder
       compositeBuilder.addAlignmentLevel(std::move(level));
     }
     // now build this tracker-level
-    numCompositeAlignables += compositeBuilder.buildAll(*alignableMap, update);
+    numCompositeAlignables += compositeBuilder.buildAll(*alignableMap_, update);
     // finally, reset the builder
     compositeBuilder.clearAlignmentLevels();
   }
@@ -316,9 +316,9 @@ void AlignableTrackerBuilder
   const std::string& pxeName   = alignableObjectId_.idToString(align::TPEEndcap);
   const std::string& pixelName = alignableObjectId_.idToString(align::Pixel);
 
-  auto& pxbAlignables   = alignableMap->find(pxbName);
-  auto& pxeAlignables   = alignableMap->find(pxeName);
-  auto& pixelAlignables = alignableMap->get (pixelName);
+  auto& pxbAlignables   = alignableMap_->find(pxbName);
+  auto& pxeAlignables   = alignableMap_->find(pxeName);
+  auto& pixelAlignables = alignableMap_->get (pixelName);
 
   pixelAlignables.push_back(
     new AlignableComposite(pxbAlignables[0]->id(), align::Pixel, align::RotationType())
@@ -346,11 +346,11 @@ void AlignableTrackerBuilder
   const std::string& tecName   = alignableObjectId_.idToString(align::TECEndcap);
   const std::string& stripName = alignableObjectId_.idToString(align::Strip);
 
-  auto& tibAlignables   = alignableMap->find(tibName);
-  auto& tidAlignables   = alignableMap->find(tidName);
-  auto& tobAlignables   = alignableMap->find(tobName);
-  auto& tecAlignables   = alignableMap->find(tecName);
-  auto& stripAlignables = alignableMap->get (stripName);
+  auto& tibAlignables   = alignableMap_->find(tibName);
+  auto& tidAlignables   = alignableMap_->find(tidName);
+  auto& tobAlignables   = alignableMap_->find(tobName);
+  auto& tecAlignables   = alignableMap_->find(tecName);
+  auto& stripAlignables = alignableMap_->get (stripName);
 
   stripAlignables.push_back(
     new AlignableComposite(tibAlignables[0]->id(), align::Strip, align::RotationType())

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -25,8 +25,8 @@
 AlignableTrackerBuilder
 ::AlignableTrackerBuilder(const TrackerGeometry* trackerGeometry,
                           const TrackerTopology* trackerTopology) :
-  trackerGeometry(trackerGeometry),
-  trackerTopology(trackerTopology),
+  trackerGeometry_(trackerGeometry),
+  trackerTopology_(trackerTopology),
   alignableObjectId_(trackerGeometry, nullptr, nullptr),
   alignableMap(nullptr),
   trackerAlignmentLevelBuilder_(trackerTopology, trackerGeometry)
@@ -49,14 +49,17 @@ AlignableTrackerBuilder
 
 //_____________________________________________________________________________
 void AlignableTrackerBuilder
-::buildAlignables(AlignableTracker* trackerAlignables)
+::buildAlignables(AlignableTracker* trackerAlignables, bool update)
 {
   alignableMap = &trackerAlignables->alignableMap;
 
   // first, build Alignables on module-level (AlignableDetUnits)
-  buildAlignableDetUnits();
+  buildAlignableDetUnits(update);
+
   // now build the composite Alignables (Ladders, Layers etc.)
-  buildAlignableComposites();
+  buildAlignableComposites(update);
+
+  if (update) return;           // everything else not needed for the update
 
   // create pixel-detector
   buildPixelDetector(trackerAlignables);
@@ -77,60 +80,66 @@ void AlignableTrackerBuilder
 
 //_____________________________________________________________________________
 void AlignableTrackerBuilder
-::buildAlignableDetUnits()
+::buildAlignableDetUnits(bool update)
 {
   // PixelBarrel
   convertGeomDetsToAlignables(
-    trackerGeometry->detsPXB(), alignableObjectId_.idToString(align::TPBModule)
+    trackerGeometry_->detsPXB(), alignableObjectId_.idToString(align::TPBModule),
+    update
   );
 
   // PixelEndcap
   convertGeomDetsToAlignables(
-    trackerGeometry->detsPXF(), alignableObjectId_.idToString(align::TPEModule)
+    trackerGeometry_->detsPXF(), alignableObjectId_.idToString(align::TPEModule),
+    update
   );
 
   // TIB
   convertGeomDetsToAlignables(
-    trackerGeometry->detsTIB(), alignableObjectId_.idToString(align::TIBModule)
+    trackerGeometry_->detsTIB(), alignableObjectId_.idToString(align::TIBModule),
+    update
   );
 
   // TID
   convertGeomDetsToAlignables(
-    trackerGeometry->detsTID(), alignableObjectId_.idToString(align::TIDModule)
+    trackerGeometry_->detsTID(), alignableObjectId_.idToString(align::TIDModule),
+    update
   );
 
   // TOB
   convertGeomDetsToAlignables(
-    trackerGeometry->detsTOB(), alignableObjectId_.idToString(align::TOBModule)
+    trackerGeometry_->detsTOB(), alignableObjectId_.idToString(align::TOBModule),
+    update
   );
 
   // TEC
   convertGeomDetsToAlignables(
-    trackerGeometry->detsTEC(), alignableObjectId_.idToString(align::TECModule)
+    trackerGeometry_->detsTEC(), alignableObjectId_.idToString(align::TECModule),
+    update
   );
 }
 
 //_____________________________________________________________________________
 void AlignableTrackerBuilder
 ::convertGeomDetsToAlignables(const TrackingGeometry::DetContainer& geomDets,
-                              const std::string& moduleName)
+                              const std::string& moduleName, bool update)
 {
   numDetUnits = 0;
 
   auto& alignables = alignableMap->get(moduleName);
-  alignables.reserve(geomDets.size());
+  if (!update) alignables.reserve(geomDets.size());
 
   // units are added for each moduleName, which are at moduleName + "Unit"
   // in the pixel Module and ModuleUnit are equivalent
   auto & aliUnits = alignableMap->get(moduleName+"Unit");
-  aliUnits.reserve(geomDets.size()); // minimal number space needed
+  if (!update) aliUnits.reserve(geomDets.size()); // minimal number space needed
 
   for (auto& geomDet : geomDets) {
     int subdetId = geomDet->geographicalId().subdetId(); //don't check det()==Tracker
 
     if (subdetId == PixelSubdetector::PixelBarrel ||
         subdetId == PixelSubdetector::PixelEndcap) {
-      buildPixelDetectorAlignable(geomDet, subdetId, alignables, aliUnits);
+      buildPixelDetectorAlignable(geomDet, subdetId, alignables, aliUnits, update);
 
     } else if (subdetId == SiStripDetId::TIB ||
                subdetId == SiStripDetId::TID ||
@@ -138,7 +147,7 @@ void AlignableTrackerBuilder
                subdetId == SiStripDetId::TEC) {
       // for strip we create also <TIB/TID/TOB/TEC>ModuleUnit list
       // for 1D components of 2D layers
-      buildStripDetectorAlignable(geomDet, subdetId, alignables, aliUnits);
+      buildStripDetectorAlignable(geomDet, subdetId, alignables, aliUnits, update);
 
     } else {
       throw cms::Exception("LogicError")
@@ -163,7 +172,8 @@ void AlignableTrackerBuilder
 //_____________________________________________________________________________
 void AlignableTrackerBuilder
 ::buildPixelDetectorAlignable(const GeomDet* geomDetUnit, int subdetId,
-                              Alignables& aliDets, Alignables& aliDetUnits)
+                              Alignables& aliDets, Alignables& aliDetUnits,
+                              bool update)
 {
   // treat all pixel dets in same way with one AlignableDetUnit
   if (!geomDetUnit->isLeaf()) {
@@ -172,15 +182,39 @@ void AlignableTrackerBuilder
       << ") is not a GeomDetUnit.";
   }
 
-  aliDets.push_back(new AlignableDetUnit(geomDetUnit));
-  aliDetUnits.push_back(aliDets.back());
+  if (update) {
+    auto ali =
+      std::find_if(aliDets.cbegin(), aliDets.cend(),
+                   [&geomDetUnit](const auto& i) {
+                     return i->id() == geomDetUnit->geographicalId().rawId(); });
+    if (ali != aliDets.end()) {
+      // add dynamic cast here to get AlignableDetUnit!
+      auto aliDetUnit = dynamic_cast<AlignableDetUnit*>(*ali);
+      if (aliDetUnit) {
+        aliDetUnit->update(geomDetUnit);
+      } else {
+        throw cms::Exception("LogicError")
+          << "[AlignableTrackerBuilder::buildPixelDetectorAlignable] "
+          << "cast to 'AlignableDetUnit*' failed while it should not\n";
+      }
+    } else {
+      throw cms::Exception("GeometryMismatch")
+        << "[AlignableTrackerBuilder::buildPixelDetectorAlignable] "
+        << "GeomDet with DetId " << geomDetUnit->geographicalId().rawId()
+        << " not found in current geometry.\n";
+    }
+  } else {
+    aliDets.push_back(new AlignableDetUnit(geomDetUnit));
+    aliDetUnits.push_back(aliDets.back());
+  }
   numDetUnits += 1;
 }
 
 //_____________________________________________________________________________
 void AlignableTrackerBuilder
 ::buildStripDetectorAlignable(const GeomDet* geomDet, int subdetId,
-                              Alignables& aliDets, Alignables& aliDetUnits)
+                              Alignables& aliDets, Alignables& aliDetUnits,
+                              bool update)
 {
   // In strip we have:
   // 1) 'Pure' 1D-modules like TOB layers 3-6 (not glued): AlignableDetUnit
@@ -201,17 +235,42 @@ void AlignableTrackerBuilder
       }
 
       // components (AlignableDetUnits) constructed within
-      aliDets.push_back(new AlignableSiStripDet(gluedGeomDet));
+      if (update) {
+        auto ali =
+          std::find_if(aliDets.cbegin(), aliDets.cend(),
+                       [&gluedGeomDet](const auto& i) {
+                         return i->id() == gluedGeomDet->geographicalId().rawId(); });
+        if (ali != aliDets.end()) {
+          auto aliSiStripDet = dynamic_cast<AlignableSiStripDet*>(*ali);
+          if (aliSiStripDet) {
+            aliSiStripDet->update(gluedGeomDet);
+          } else {
+            throw cms::Exception("LogicError")
+              << "[AlignableTrackerBuilder::buildStripDetectorAlignable] "
+              << "cast to 'AlignableSiStripDet*' failed while it should not\n";
+          }
+        } else {
+          throw cms::Exception("GeometryMismatch")
+            << "[AlignableTrackerBuilder::buildStripDetectorAlignable] "
+            << "GeomDet with DetId " << gluedGeomDet->geographicalId().rawId()
+            << " not found in current geometry.\n";
+        }
+      } else {
+        aliDets.push_back(new AlignableSiStripDet(gluedGeomDet));
+      }
       const auto& addAliDetUnits = aliDets.back()->components();
       const auto& nAddedUnits = addAliDetUnits.size();
-      // reserve space for the additional units:
-      aliDetUnits.reserve(aliDetUnits.size() + nAddedUnits -1);
-      aliDetUnits.insert(aliDetUnits.end(), addAliDetUnits.begin(), addAliDetUnits.end());
+
+      if (!update) {
+        // reserve space for the additional units:
+        aliDetUnits.reserve(aliDetUnits.size() + nAddedUnits -1);
+        aliDetUnits.insert(aliDetUnits.end(), addAliDetUnits.begin(), addAliDetUnits.end());
+      }
       numDetUnits += nAddedUnits;
 
     } else {
       // no components: pure 1D-module
-      buildPixelDetectorAlignable(geomDet, subdetId, aliDets, aliDetUnits);
+      buildPixelDetectorAlignable(geomDet, subdetId, aliDets, aliDetUnits, update);
     }
   } // no else: glued components of AlignableDet constructed within
     // AlignableSiStripDet -> AlignableDet, see above
@@ -221,7 +280,7 @@ void AlignableTrackerBuilder
 
 //_____________________________________________________________________________
 void AlignableTrackerBuilder
-::buildAlignableComposites()
+::buildAlignableComposites(bool update)
 {
   unsigned int numCompositeAlignables = 0;
 
@@ -230,7 +289,7 @@ void AlignableTrackerBuilder
   // to get the namespace w/o building the levels
   auto trackerLevels = trackerAlignmentLevelBuilder_.build();
   TrackerAlignableIndexer trackerIndexer{trackerAlignmentLevelBuilder_.trackerNameSpace()};
-  AlignableCompositeBuilder compositeBuilder{trackerTopology, trackerGeometry, trackerIndexer};
+  AlignableCompositeBuilder compositeBuilder{trackerTopology_, trackerGeometry_, trackerIndexer};
 
   for (auto& trackerSubLevels: trackerLevels) {
     // first add all levels of the current subdetector to the builder
@@ -238,7 +297,7 @@ void AlignableTrackerBuilder
       compositeBuilder.addAlignmentLevel(std::move(level));
     }
     // now build this tracker-level
-    numCompositeAlignables += compositeBuilder.buildAll(*alignableMap);
+    numCompositeAlignables += compositeBuilder.buildAll(*alignableMap, update);
     // finally, reset the builder
     compositeBuilder.clearAlignmentLevels();
   }

--- a/Alignment/TrackerAlignment/test/alignment_forGeomComp_cfg_TEMPLATE.py
+++ b/Alignment/TrackerAlignment/test/alignment_forGeomComp_cfg_TEMPLATE.py
@@ -24,7 +24,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 # take your favourite global tag
 from Configuration.AlCa.GlobalTag import GlobalTag 
 process.GlobalTag = GlobalTag(process.GlobalTag, "GLOBALTAG")     
-usedGlobalTag = process.GlobalTag.globaltag._value 
+usedGlobalTag = process.GlobalTag.globaltag.value()
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.LOGFILE = cms.untracked.PSet(
@@ -68,6 +68,17 @@ process.AlignmentProducer.ParameterBuilder.Selector = cms.PSet(
         #  'TrackerTECModuleUnit,101111'
         )
     )
+
+# explicitely specify run ranges to convince algorithm that multi-IOV input is fine
+process.AlignmentProducer.RunRangeSelection = [
+    cms.PSet(
+        RunRanges = cms.vstring("RUNNUMBER"),
+        selector = process.AlignmentProducer.ParameterBuilder.Selector.alignParams
+    )
+] # end of process.AlignmentProducer.RunRangeSelection
+
+# enable alignable updates to convince algorithm that multi-IOV input is fine
+process.AlignmentProducer.enableAlignableUpdates = True
 
 process.AlignmentProducer.doMisalignmentScenario = False #True
 process.AlignmentProducer.applyDbAlignment = True # either globalTag or trackerAlignment


### PR DESCRIPTION
Removes shortcoming of the alignment framework which has not been able to update the alignables after an update of the tracker geometry at an IOV boundary.

Removes also temporary fix of #16135 and enables the usage of multi-IOV input for Millepede.

Added various protection against misconfiguration.
 - consistency check of the configuration during the setup of the alignment campaign
 - consistency checks in the C++ code to detect misconfiguration

The code has been used to derive the 2016 legacy alignment.

The general AlignmentProducer has the new features disabled by default. It is only enabled for Millepede. If other alignment algorithms want to use it a flag has to be set to `True`:
```
process.AlignmentProducer.enableAlignableUpdates = True
```

The code is based on top of #17408, i.e. to better digest the changes, it might be useful to first review and eventually approve #17408.

EDIT: A dedicated presentation on this update has been given at the [Tracker Alignment meeting on 01-Mar-2017](https://indico.cern.ch/event/607508/contributions/2493829/attachments/1420329/2176319/Alignment-MultiIOV_CMS-TkAl_20170301.pdf)
Automatically ported from CMSSW_9_0_X #17475 (original by @ghellwig).
Please wait for a new IB (12 to 24H) before requesting to test this PR.