### PR TITLE
[90X] Offline DQM modules for L1Trigger (stage2 calo layer2)

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -27,7 +27,7 @@ DQMOffline_SecondStep_PreDPG = cms.Sequence( dqmDcsInfoClient *
                                              cscOfflineCollisionsClients *
                                              es_dqm_client_offline *
                                              hcalOfflineHarvesting *
-                                             HcalDQMOfflinePostProcessor * 
+                                             HcalDQMOfflinePostProcessor *
                                              dqmFEDIntegrityClient )
 
 DQMOffline_SecondStepDPG = cms.Sequence( dqmRefHistoRootFileGetter *
@@ -77,6 +77,7 @@ DQMOffline_SecondStepPOGMC = cms.Sequence( dqmRefHistoRootFileGetter *
                                            DQMOffline_SecondStep_PrePOGMC *
                                            DQMMessageLoggerClientSeq )
 
+from DQMOffline.L1Trigger.L1TriggerDqmOffline_SecondStep_cff import *
 
 DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  DQMMessageLoggerClientSeq *
@@ -89,7 +90,8 @@ DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  dqmFEDIntegrityClient *
                                  alcaBeamMonitorClient *
                                  runTauEff *
-                                 dqmFastTimerServiceClient
+                                 dqmFastTimerServiceClient *
+                                 DQMHarvestL1Trigger
                                 )
 DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
                                                DQMMessageLoggerClientSeq *
@@ -122,8 +124,8 @@ DQMHarvestHcal = cms.Sequence(hcalOfflineHarvesting)
 
 DQMHarvestJetMET = cms.Sequence( SusyPostProcessorSequence )
 
-DQMHarvestEGamma = cms.Sequence( egammaPostProcessing )                     
+DQMHarvestEGamma = cms.Sequence( egammaPostProcessing )
 
-DQMHarvestBTag = cms.Sequence( bTagCollectorSequenceDATA ) 
+DQMHarvestBTag = cms.Sequence( bTagCollectorSequenceDATA )
 
 DQMHarvestMiniAOD = cms.Sequence( dataCertificationJetMETSequence * muonQualityTests_miniAOD)

--- a/DQMOffline/L1Trigger/interface/L1TDiffHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TDiffHarvesting.h
@@ -1,0 +1,63 @@
+#ifndef DQMOFFLINE_L1TRIGGER_L1TDIFFHARVESTING_H
+#define DQMOFFLINE_L1TRIGGER_L1TDIFFHARVESTING_H
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include <string>
+#include <vector>
+
+namespace dqmoffline {
+namespace l1t {
+
+class L1TDiffHarvesting: public DQMEDHarvester {
+
+public:
+  L1TDiffHarvesting(const edm::ParameterSet& ps);
+  virtual ~L1TDiffHarvesting();
+
+protected:
+
+  virtual void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
+  virtual void dqmEndLuminosityBlock(DQMStore::IGetter &igetter, edm::LuminosityBlock const& lumiBlock,
+      edm::EventSetup const& c);
+
+private:
+  class L1TDiffPlotHandler {
+  public:
+    L1TDiffPlotHandler(const edm::ParameterSet & ps, std::string plotName);
+    L1TDiffPlotHandler(const L1TDiffPlotHandler &handler); // needed for vector collection
+
+    void computeDiff(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
+
+    std::string dir1_;
+    std::string dir2_;
+    std::string outputDir_;
+    std::string plotName_;
+
+    MonitorElement* h1_;
+    MonitorElement* h2_;
+    MonitorElement* h_diff_;
+    MonitorElement::Kind histType1_, histType2_;
+
+    void loadHistograms(DQMStore::IGetter &igetter);
+    bool isValid() const;
+    void bookDiff(DQMStore::IBooker &ibooker);
+
+  };
+
+  typedef std::vector<L1TDiffPlotHandler> L1TDiffPlotHandlers;
+
+  std::vector<edm::ParameterSet> plotCfgs_;
+  L1TDiffPlotHandlers plotHandlers_;
+};
+
+} // l1t
+} // dqmoffline
+
+#endif

--- a/DQMOffline/L1Trigger/interface/L1TDiffHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TDiffHarvesting.h
@@ -53,7 +53,6 @@ private:
 
   typedef std::vector<L1TDiffPlotHandler> L1TDiffPlotHandlers;
 
-  std::vector<edm::ParameterSet> plotCfgs_;
   L1TDiffPlotHandlers plotHandlers_;
 };
 

--- a/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
@@ -1,0 +1,108 @@
+#ifndef DQMOFFLINE_L1TRIGGER_L1TEFFICIENCYHARVESTING_H
+#define DQMOFFLINE_L1TRIGGER_L1TEFFICIENCYHARVESTING_H
+
+/**
+ * \file L1TEfficiencyHarvesting.h
+ *
+ * \author J. Pela, C. Battilana
+ *
+ */
+
+// system include files
+#include <memory>
+#include <unistd.h>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <TString.h>
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+namespace dqmoffline {
+namespace l1t {
+
+//
+// Efficiency helper class declaration
+//
+
+class L1TEfficiencyPlotHandler {
+
+public:
+
+  L1TEfficiencyPlotHandler(const edm::ParameterSet & ps, std::string plotName);
+
+  L1TEfficiencyPlotHandler(const L1TEfficiencyPlotHandler &handler);
+
+  ~L1TEfficiencyPlotHandler()
+  {
+  }
+  ;
+
+  // book efficiency histo
+  void book(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
+
+  // compute efficiency
+  void computeEfficiency(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter);
+
+private:
+
+  std::string numeratorDir_;
+  std::string denominatorDir_;
+  std::string outputDir_;
+  std::string plotName_;
+  std::string numeratorSuffix_;
+  std::string denominatorSuffix_;
+
+  MonitorElement* h_efficiency_;
+
+};
+
+typedef std::vector<L1TEfficiencyPlotHandler> L1TEfficiencyPlotHandlerCollection;
+
+//
+// DQM class declaration
+//
+
+class L1TEfficiencyHarvesting: public DQMEDHarvester {
+
+public:
+
+  L1TEfficiencyHarvesting(const edm::ParameterSet& ps);   // Constructor
+  virtual ~L1TEfficiencyHarvesting();                     // Destructor
+
+protected:
+
+  virtual void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
+  virtual void dqmEndLuminosityBlock(DQMStore::IGetter &igetter, edm::LuminosityBlock const& lumiBlock,
+      edm::EventSetup const& c);
+
+private:
+
+  bool verbose_;
+
+  std::vector<edm::ParameterSet> plotCfgs_;
+
+  L1TEfficiencyPlotHandlerCollection plotHandlers_;
+
+};
+
+} //l1t
+} // dqmoffline
+
+#endif

--- a/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
+++ b/DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h
@@ -14,24 +14,16 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
-#include <TString.h>
-
-#include <iostream>
-#include <fstream>
 #include <vector>
 
 namespace dqmoffline {
@@ -95,8 +87,6 @@ protected:
 private:
 
   bool verbose_;
-
-  std::vector<edm::ParameterSet> plotCfgs_;
 
   L1TEfficiencyPlotHandlerCollection plotHandlers_;
 

--- a/DQMOffline/L1Trigger/interface/L1TFillWithinLimits.h
+++ b/DQMOffline/L1Trigger/interface/L1TFillWithinLimits.h
@@ -1,0 +1,35 @@
+#ifndef DQMOFFLINE_L1TRIGGER_L1TFILLWITHINLIMITS_H
+#define DQMOFFLINE_L1TRIGGER_L1TFILLWITHINLIMITS_H
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+namespace dqmoffline {
+namespace l1t {
+
+
+
+/**
+ * Fills a given MonitorElement within the boundaries of the underlying histogram.
+ * This means that underflow is filled into the first bin and overflow is filled into the last bin.
+ * @param pointer to the DQM MonitorElement
+ * @param fill value
+ * @param optional weight
+ */
+void fillWithinLimits(MonitorElement* mon, double value, double weight=1.);
+/**
+ * Fills a given MonitorElement within the boundaries of the underlying histogram.
+ * This means that underflow is filled into the first bin and overflow is filled into the last bin.
+ * @param pointer to the DQM MonitorElement
+ * @param fill value for X
+ * @param fill value for Y
+ * @param optional weight X
+ * @param optional weight Y
+ */
+void fill2DWithinLimits(MonitorElement* mon, double valueX, double valueY, double weight=1.);
+
+
+double getFillValueWithinLimits(double value, double min, double max);
+}
+}
+
+#endif

--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -1,0 +1,188 @@
+#ifndef L1TStage2CaloLayer2Offline_H
+#define L1TStage2CaloLayer2Offline_H
+
+//Framework
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+//event
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+//Candidate handling
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+// Electron
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+// PFMET
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+
+// Vertex utilities
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+// CaloJets
+#include "DataFormats/JetReco/interface/CaloJet.h"
+
+// Calo MET
+#include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/METReco/interface/CaloMETCollection.h"
+
+// Conversions
+#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+
+// Trigger
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+
+// stage2 collections:
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+
+class L1TStage2CaloLayer2Offline: public DQMEDAnalyzer {
+
+public:
+
+  L1TStage2CaloLayer2Offline(const edm::ParameterSet& ps);
+  virtual ~L1TStage2CaloLayer2Offline();
+
+protected:
+
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+
+private:
+  //histos booking function
+  void bookHistos(DQMStore::IBooker &);
+  void bookEnergySumHistos(DQMStore::IBooker &);
+  void bookJetHistos(DQMStore::IBooker &);
+
+  //other functions
+  double Distance(const reco::Candidate & c1, const reco::Candidate & c2);
+  double DistancePhi(const reco::Candidate & c1, const reco::Candidate & c2);
+  double calcDeltaPhi(double phi1, double phi2);
+
+  void fillEnergySums(edm::Event const& e, const unsigned int nVertex);
+  void fillJets(edm::Event const& e, const unsigned int nVertex);
+
+  //private variables
+  math::XYZPoint PVPoint_;
+
+  //variables from config file
+  edm::EDGetTokenT<reco::CaloJetCollection> theCaloJetCollection_;
+  edm::EDGetTokenT<reco::CaloMETCollection> thecaloMETCollection_;
+  edm::EDGetTokenT<reco::VertexCollection> thePVCollection_;
+  edm::EDGetTokenT<reco::BeamSpot> theBSCollection_;
+  edm::EDGetTokenT<trigger::TriggerEvent> triggerEvent_;
+  edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
+  edm::InputTag triggerFilter_;
+  std::string triggerPath_;
+  std::string histFolder_;
+  std::string efficiencyFolder_;
+
+  edm::EDGetTokenT<l1t::JetBxCollection> stage2CaloLayer2JetToken_;
+  edm::EDGetTokenT<l1t::EtSumBxCollection> stage2CaloLayer2EtSumToken_;
+
+  std::vector<double> jetEfficiencyThresholds_;
+  std::vector<double> metEfficiencyThresholds_;
+  std::vector<double> mhtEfficiencyThresholds_;
+  std::vector<double> ettEfficiencyThresholds_;
+  std::vector<double> httEfficiencyThresholds_;
+
+  std::vector<double> jetEfficiencyBins_;
+  std::vector<double> metEfficiencyBins_;
+  std::vector<double> mhtEfficiencyBins_;
+  std::vector<double> ettEfficiencyBins_;
+  std::vector<double> httEfficiencyBins_;
+
+  // TODO: add turn-on cuts (vectors of doubles)
+  // Histograms
+  MonitorElement* h_nVertex_;
+
+  // energy sums reco vs L1
+  MonitorElement* h_L1METvsCaloMET_;
+  MonitorElement* h_L1MHTvsRecoMHT_;
+  MonitorElement* h_L1METTvsCaloETT_;
+  MonitorElement* h_L1HTTvsRecoHTT_;
+
+  MonitorElement* h_L1METPhivsCaloMETPhi_;
+  MonitorElement* h_L1MHTPhivsRecoMHTPhi_;
+
+  // energy sum resolutions
+  MonitorElement* h_resolutionMET_;
+  MonitorElement* h_resolutionMHT_;
+  MonitorElement* h_resolutionETT_;
+  MonitorElement* h_resolutionHTT_;
+  MonitorElement* h_resolutionMETPhi_;
+  MonitorElement* h_resolutionMHTPhi_;
+
+  // energy sum turn ons
+  std::map<double, MonitorElement*> h_efficiencyMET_pass_;
+  std::map<double, MonitorElement*> h_efficiencyMHT_pass_;
+  std::map<double, MonitorElement*> h_efficiencyETT_pass_;
+  std::map<double, MonitorElement*> h_efficiencyHTT_pass_;
+
+  std::map<double, MonitorElement*> h_efficiencyMET_total_;
+  std::map<double, MonitorElement*> h_efficiencyMHT_total_;
+  std::map<double, MonitorElement*> h_efficiencyETT_total_;
+  std::map<double, MonitorElement*> h_efficiencyHTT_total_;
+
+  // jet reco vs L1
+  MonitorElement* h_L1JetETvsCaloJetET_HB_;
+  MonitorElement* h_L1JetETvsCaloJetET_HE_;
+  MonitorElement* h_L1JetETvsCaloJetET_HF_;
+  MonitorElement* h_L1JetETvsCaloJetET_HB_HE_;
+
+  MonitorElement* h_L1JetPhivsCaloJetPhi_HB_;
+  MonitorElement* h_L1JetPhivsCaloJetPhi_HE_;
+  MonitorElement* h_L1JetPhivsCaloJetPhi_HF_;
+  MonitorElement* h_L1JetPhivsCaloJetPhi_HB_HE_;
+
+  MonitorElement* h_L1JetEtavsCaloJetEta_;
+
+  // jet resolutions
+  MonitorElement* h_resolutionJetET_HB_;
+  MonitorElement* h_resolutionJetET_HE_;
+  MonitorElement* h_resolutionJetET_HF_;
+  MonitorElement* h_resolutionJetET_HB_HE_;
+
+  MonitorElement* h_resolutionJetPhi_HB_;
+  MonitorElement* h_resolutionJetPhi_HE_;
+  MonitorElement* h_resolutionJetPhi_HF_;
+  MonitorElement* h_resolutionJetPhi_HB_HE_;
+
+  MonitorElement* h_resolutionJetEta_;
+
+  // jet turn-ons
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HB_pass_;
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HE_pass_;
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HF_pass_;
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HB_HE_pass_;
+
+  // we could drop the map here, but L1TEfficiency_Harvesting expects
+  // identical names except for the suffix
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HB_total_;
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HE_total_;
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HF_total_;
+  std::map<double, MonitorElement*> h_efficiencyJetEt_HB_HE_total_;
+
+};
+
+#endif

--- a/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h
@@ -74,11 +74,6 @@ private:
   void bookEnergySumHistos(DQMStore::IBooker &);
   void bookJetHistos(DQMStore::IBooker &);
 
-  //other functions
-  double Distance(const reco::Candidate & c1, const reco::Candidate & c2);
-  double DistancePhi(const reco::Candidate & c1, const reco::Candidate & c2);
-  double calcDeltaPhi(double phi1, double phi2);
-
   void fillEnergySums(edm::Event const& e, const unsigned int nVertex);
   void fillJets(edm::Event const& e, const unsigned int nVertex);
 

--- a/DQMOffline/L1Trigger/python/L1TDiffHarvesting_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TDiffHarvesting_cfi.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tDiffHarvesting = cms.EDAnalyzer(
+    "L1TDiffHarvesting",
+    verbose=cms.untracked.bool(False),
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(
+            cms.untracked.PSet(  # EMU comparison
+                dir1=cms.untracked.string(
+                    "L1T/L1TStage2CaloLayer2"),
+                dir2=cms.untracked.string(
+                    "L1TEMU/L1TStage2CaloLayer2"),
+                outputDir=cms.untracked.string(
+                    "L1TEMU/L1TStage2CaloLayer2/Comparison"),
+                plots=cms.untracked.vstring(
+                    "resolutionJetET_HB", "resolutionJetET_HE", "resolutionJetET_HF",
+                    "resolutionJetET_HB_HE", "resolutionJetPhi_HB", "resolutionJetPhi_HE",
+                    "resolutionJetPhi_HF", "resolutionJetPhi_HB_HE", "resolutionJetEta",
+                    "resolutionMET", "resolutionMHT", "resolutionETT", "resolutionHTT",
+                    "resolutionMETPhi", "resolutionMHTPhi",
+                )
+            )
+        )
+    )
+
+)

--- a/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting2_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting2_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+l1tEfficiencyHarvesting = cms.EDAnalyzer(
+    "L1TEfficiencyHarvesting",
+    verbose=cms.untracked.bool(False),
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1T/Efficiency/Muons"),
+            plots=cms.untracked.vstring(
+                "EffvsPt16", "EffvsEta16", "EffvsPhi16",
+                "EffvsPt20", "EffvsEta20", "EffvsPhi20",
+                "EffvsPt25", "EffvsEta25", "EffvsPhi25",
+            )
+        )
+    )
+
+)

--- a/DQMOffline/L1Trigger/python/L1TEfficiencyMouns_Offline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEfficiencyMouns_Offline_cfi.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-l1tEfficiencyMuons_offline = cms.EDAnalyzer("L1TEfficiencyMuons_Offline",
-
-  verbose  = cms.untracked.bool(False),
-  
-)

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
@@ -1,0 +1,63 @@
+import FWCore.ParameterSet.Config as cms
+from DQMOffline.L1Trigger import L1TStage2CaloLayer2Offline_cfi as L1TStep1
+
+variables = {
+    'jet': L1TStep1.jetEfficiencyThresholds,
+    'met': L1TStep1.metEfficiencyThresholds,
+    'mht': L1TStep1.mhtEfficiencyThresholds,
+    'ett': L1TStep1.ettEfficiencyThresholds,
+    'htt': L1TStep1.httEfficiencyThresholds,
+}
+
+plots = {
+    'jet': [
+        "efficiencyJetEt_HB", "efficiencyJetEt_HE", "efficiencyJetEt_HF",
+        "efficiencyJetEt_HB_HE"],
+    'met': ['efficiencyMET'],
+    'mht': ['efficiencyMHT'],
+    'ett': ['efficiencyETT'],
+    'htt': ['efficiencyHTT'],
+}
+
+allEfficiencyPlots = []
+add_plot = allEfficiencyPlots.append
+for variable, thresholds in variables.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+from DQMOffline.L1Trigger.L1TDiffHarvesting_cfi import l1tDiffHarvesting
+
+resolution_plots = [
+    "resolutionJetET_HB", "resolutionJetET_HE", "resolutionJetET_HF",
+    "resolutionJetET_HB_HE", "resolutionJetPhi_HB", "resolutionJetPhi_HE",
+    "resolutionJetPhi_HF", "resolutionJetPhi_HB_HE", "resolutionJetEta",
+    "resolutionMET", "resolutionMHT", "resolutionETT", "resolutionHTT",
+    "resolutionMETPhi", "resolutionMHTPhi",
+]
+plots2D = [
+    "L1METvsCaloMET", 'L1MHTvsRecoMHT', 'L1ETTvsCaloETT', 'L1HTTvsRecoHTT',
+    'L1METPhivsCaloMETPhi', 'L1MHTPhivsRecoMHTPhi',
+    # jets
+    'L1JetETvsCaloJetET_HB', 'L1JetETvsCaloJetET_HE', 'L1JetETvsCaloJetET_HF',
+    'L1JetETvsCaloJetET_HB_HE', 'L1JetETvsCaloJetET_HB', 'L1JetETvsCaloJetET_HE',
+    'L1JetETvsCaloJetET_HF', 'L1JetETvsCaloJetET_HB_HE', 'L1JetEtavsCaloJetEta_HB',
+]
+
+allPlots = []
+allPlots.extend(allEfficiencyPlots)
+allPlots.extend(resolution_plots)
+allPlots.extend(plots2D)
+
+l1tStage2CaloLayer2EmuDiff = l1tDiffHarvesting.clone(
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(  # EMU comparison
+            dir1=cms.untracked.string("L1T/L1TStage2CaloLayer2"),
+            dir2=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2"),
+            outputDir=cms.untracked.string(
+                "L1TEMU/L1TStage2CaloLayer2/Comparison"),
+            plots=cms.untracked.vstring(allPlots)
+        ),
+    )
+)

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Efficiency_cfi.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+from DQMOffline.L1Trigger import L1TStage2CaloLayer2Offline_cfi as L1TStep1
+
+variables = {
+    'jet': L1TStep1.jetEfficiencyThresholds,
+    'met': L1TStep1.metEfficiencyThresholds,
+    'mht': L1TStep1.mhtEfficiencyThresholds,
+    'ett': L1TStep1.ettEfficiencyThresholds,
+    'htt': L1TStep1.httEfficiencyThresholds,
+}
+
+plots = {
+    'jet': [
+        "efficiencyJetEt_HB", "efficiencyJetEt_HE", "efficiencyJetEt_HF",
+        "efficiencyJetEt_HB_HE"],
+    'met': ['efficiencyMET'],
+    'mht': ['efficiencyMHT'],
+    'ett': ['efficiencyETT'],
+    'htt': ['efficiencyHTT'],
+}
+
+allEfficiencyPlots = []
+add_plot = allEfficiencyPlots.append
+for variable, thresholds in variables.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+from DQMOffline.L1Trigger.L1TEfficiencyHarvesting2_cfi import l1tEfficiencyHarvesting
+l1tStage2CaloLayer2Efficiency = l1tEfficiencyHarvesting.clone(
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1T/L1TStage2CaloLayer2/efficiency_raw"),
+            outputDir=cms.untracked.string("L1T/L1TStage2CaloLayer2"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots)
+        ),
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2/efficiency_raw"),
+            outputDir=cms.untracked.string("L1TEMU/L1TStage2CaloLayer2"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots)
+        ),
+    )
+)

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Offline_cfi.py
@@ -1,0 +1,81 @@
+import FWCore.ParameterSet.Config as cms
+
+jetEfficiencyThresholds = [36, 68, 128, 176]
+metEfficiencyThresholds = [40, 60, 80, 100, 120]
+mhtEfficiencyThresholds = [40, 60, 80, 100, 120]
+ettEfficiencyThresholds = [30, 50, 90, 140]
+httEfficiencyThresholds = [120, 160, 200, 240, 280]
+
+jetEfficiencyBins = []
+jetEfficiencyBins.extend(list(xrange(0, 120, 10)))
+jetEfficiencyBins.extend(list(xrange(120, 180, 20)))
+jetEfficiencyBins.extend(list(xrange(180, 300, 40)))
+jetEfficiencyBins.extend(list(xrange(300, 400, 100)))
+
+metEfficiencyBins = []
+metEfficiencyBins.extend(list(xrange(0, 40, 4)))
+metEfficiencyBins.extend(list(xrange(40, 70, 2)))
+metEfficiencyBins.extend(list(xrange(70, 100, 5)))
+metEfficiencyBins.extend(list(xrange(100, 160, 10)))
+metEfficiencyBins.extend(list(xrange(160, 260, 20)))
+
+mhtEfficiencyBins = []
+mhtEfficiencyBins.extend(list(xrange(30, 50, 1)))
+mhtEfficiencyBins.extend(list(xrange(50, 80, 5)))
+mhtEfficiencyBins.extend(list(xrange(80, 140, 10)))
+mhtEfficiencyBins.extend(list(xrange(140, 200, 15)))
+mhtEfficiencyBins.extend(list(xrange(200, 300, 20)))
+mhtEfficiencyBins.extend(list(xrange(300, 400, 50)))
+
+ettEfficiencyBins = []
+ettEfficiencyBins.extend(list(xrange(0, 30, 30)))
+ettEfficiencyBins.extend(list(xrange(30, 50, 10)))
+ettEfficiencyBins.extend(list(xrange(50, 90, 5)))
+ettEfficiencyBins.extend(list(xrange(90, 140, 2)))
+
+httEfficiencyBins = []
+httEfficiencyBins.extend(list(xrange(0, 100, 5)))
+httEfficiencyBins.extend(list(xrange(100, 200, 10)))
+httEfficiencyBins.extend(list(xrange(200, 400, 20)))
+httEfficiencyBins.extend(list(xrange(400, 500, 50)))
+httEfficiencyBins.extend(list(xrange(500, 600, 10)))
+
+l1tStage2CaloLayer2OfflineDQM = cms.EDAnalyzer(
+    "L1TStage2CaloLayer2Offline",
+    electronCollection=cms.InputTag("gedGsfElectrons"),
+    caloJetCollection=cms.InputTag("ak4CaloJets"),
+    caloMETCollection=cms.InputTag("caloMet"),
+    conversionsCollection=cms.InputTag("allConversions"),
+    PVCollection=cms.InputTag("offlinePrimaryVerticesWithBS"),
+    beamSpotCollection=cms.InputTag("offlineBeamSpot"),
+
+    TriggerEvent=cms.InputTag('hltTriggerSummaryAOD', '', 'HLT'),
+    TriggerResults=cms.InputTag('TriggerResults', '', 'HLT'),
+    # last filter of HLTEle27WP80Sequence
+    TriggerFilter=cms.InputTag('hltEle27WP80TrackIsoFilter', '', 'HLT'),
+    TriggerPath=cms.string('HLT_Ele27_WP80_v13'),
+
+
+    stage2CaloLayer2JetSource=cms.InputTag("caloStage2Digis", "Jet"),
+    stage2CaloLayer2EtSumSource=cms.InputTag("caloStage2Digis", "EtSum"),
+
+    histFolder=cms.string('L1T/L1TStage2CaloLayer2'),
+    jetEfficiencyThresholds=cms.vdouble(jetEfficiencyThresholds),
+    metEfficiencyThresholds=cms.vdouble(metEfficiencyThresholds),
+    mhtEfficiencyThresholds=cms.vdouble(mhtEfficiencyThresholds),
+    ettEfficiencyThresholds=cms.vdouble(ettEfficiencyThresholds),
+    httEfficiencyThresholds=cms.vdouble(httEfficiencyThresholds),
+
+    jetEfficiencyBins=cms.vdouble(jetEfficiencyBins),
+    metEfficiencyBins=cms.vdouble(metEfficiencyBins),
+    mhtEfficiencyBins=cms.vdouble(mhtEfficiencyBins),
+    ettEfficiencyBins=cms.vdouble(ettEfficiencyBins),
+    httEfficiencyBins=cms.vdouble(httEfficiencyBins),
+)
+
+l1tStage2CaloLayer2OfflineDQMEmu = l1tStage2CaloLayer2OfflineDQM.clone(
+    stage2CaloLayer2JetSource=cms.InputTag("simCaloStage2Digis"),
+    stage2CaloLayer2EtSumSource=cms.InputTag("simCaloStage2Digis"),
+
+    histFolder=cms.string('L1TEMU/L1TStage2CaloLayer2'),
+)

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.L1Trigger.L1TStage2CaloLayer2Efficiency_cfi import *
+from DQMOffline.L1Trigger.L1TStage2CaloLayer2Diff_cfi import *
+
+# l1tStage2CaloLayer2EmuDiff uses plots produced by
+# l1tStage2CaloLayer2Efficiency
+DQMHarvestL1Trigger = cms.Sequence(
+    l1tStage2CaloLayer2Efficiency * l1tStage2CaloLayer2EmuDiff
+)
+

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -2,16 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 # L1 Trigger DQM sequence for offline DQM
 #
-# used by DQM GUI: DQM/Configuration 
+# used by DQM GUI: DQM/Configuration
 #
 #
 #
-# standard RawToDigi sequence and RECO sequence must be run before the L1 Trigger modules, 
+# standard RawToDigi sequence and RECO sequence must be run before the L1 Trigger modules,
 # labels from the standard sequence are used as default for the L1 Trigger DQM modules
 #
-# V.M. Ghete - HEPHY Vienna - 2011-01-02 
-#                       
-                      
+# V.M. Ghete - HEPHY Vienna - 2011-01-02
+#
+
 
 #
 # DQM L1 Trigger in offline environment
@@ -21,7 +21,7 @@ import DQMServices.Components.DQMEnvironment_cfi
 dqmEnvL1T = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
 dqmEnvL1T.subSystemFolder = 'L1T'
 
-# DQM online L1 Trigger modules, with offline configuration 
+# DQM online L1 Trigger modules, with offline configuration
 from DQMOffline.L1Trigger.L1TMonitorOffline_cff import *
 from DQMOffline.L1Trigger.L1TMonitorClientOffline_cff import *
 
@@ -44,7 +44,8 @@ dqmEnvL1TEMU.subSystemFolder = 'L1TEMU'
 # DQM Offline Step 1 cfi/cff imports
 from DQMOffline.L1Trigger.L1TRate_Offline_cfi import *
 from DQMOffline.L1Trigger.L1TSync_Offline_cfi import *
-from DQMOffline.L1Trigger.L1TEmulatorMonitorOffline_cff import *  
+from DQMOffline.L1Trigger.L1TEmulatorMonitorOffline_cff import *
+from DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi import *
 l1TdeRCT.rctSourceData = 'gctDigis'
 
 # DQM Offline Step 2 cfi/cff imports
@@ -62,7 +63,7 @@ l1tPUM.regionSource = cms.InputTag("gctDigis")
 l1tStage1Layer2.gctCentralJetsSource = cms.InputTag("gctDigis","cenJets")
 l1tStage1Layer2.gctForwardJetsSource = cms.InputTag("gctDigis","forJets")
 l1tStage1Layer2.gctTauJetsSource = cms.InputTag("gctDigis","tauJets")
-l1tStage1Layer2.gctIsoTauJetsSource = cms.InputTag("","")       
+l1tStage1Layer2.gctIsoTauJetsSource = cms.InputTag("","")
 l1tStage1Layer2.gctEnergySumsSource = cms.InputTag("gctDigis")
 l1tStage1Layer2.gctIsoEmSource = cms.InputTag("gctDigis","isoEm")
 l1tStage1Layer2.gctNonIsoEmSource = cms.InputTag("gctDigis","nonIsoEm")
@@ -127,29 +128,31 @@ stage1L1Trigger.toModify(l1compareforstage1, stage1_layer2_ = cms.bool(True))
 stage1L1Trigger.toModify(valStage1GtDigis, GctInputTag = 'caloStage1LegacyFormatDigis')
 
 #
-# define sequences 
+# define sequences
 #
 
 l1TriggerOnline = cms.Sequence(
                                l1tMonitorStage1Online
                                 * dqmEnvL1T
                                )
-                                    
+
 l1TriggerOffline = cms.Sequence(
-                                l1TriggerOnline
-                                 * dqmEnvL1TriggerReco
-                                )
- 
+    l1TriggerOnline *
+    dqmEnvL1TriggerReco *
+    l1tStage2CaloLayer2OfflineDQM
+)
+
 #
- 
+
 l1TriggerEmulatorOnline = cms.Sequence(
                                 l1Stage1HwValEmulatorMonitor
                                 * dqmEnvL1TEMU
                                 )
 
 l1TriggerEmulatorOffline = cms.Sequence(
-                                l1TriggerEmulatorOnline                                
-                                )
+    l1TriggerEmulatorOnline *
+    l1tStage2CaloLayer2OfflineDQMEmu
+)
 #
 
 # DQM Offline Step 1 sequence
@@ -158,9 +161,9 @@ l1TriggerDqmOffline = cms.Sequence(
                                 * l1tRate_Offline
                                 * l1tSync_Offline
                                 * l1TriggerEmulatorOffline
-                                )                                  
+                                )
 
-# DQM Offline Step 2 sequence                                 
+# DQM Offline Step 2 sequence
 l1TriggerDqmOfflineClient = cms.Sequence(
                                 l1tMonitorStage1Client
                                 * l1EmulatorMonitorClient
@@ -168,24 +171,24 @@ l1TriggerDqmOfflineClient = cms.Sequence(
 
 
 #
-#   EMERGENCY   removal of modules or full sequences 
+#   EMERGENCY   removal of modules or full sequences
 # =============
 #
 # un-comment the module line below to remove the module or the sequence
 
 #
-# NOTE: for offline, remove the L1TRate which is reading from cms_orcoff_prod, but also requires 
+# NOTE: for offline, remove the L1TRate which is reading from cms_orcoff_prod, but also requires
 # a hard-coded lxplus path - FIXME check if one can get rid of hard-coded path
 # remove also the corresponding client
 #
 # L1TSync - FIXME - same problems as L1TRate
 
 
-# DQM first step 
+# DQM first step
 #
 
-#l1TriggerDqmOffline.remove(l1TriggerOffline) 
-#l1TriggerDqmOffline.remove(l1TriggerEmulatorOffline) 
+#l1TriggerDqmOffline.remove(l1TriggerOffline)
+#l1TriggerDqmOffline.remove(l1TriggerEmulatorOffline)
 
 #
 
@@ -198,10 +201,10 @@ l1TriggerDqmOfflineClient = cms.Sequence(
 #
 l1tMonitorStage1Online.remove(bxTiming)
 #l1tMonitorOnline.remove(l1tDttf)
-#l1tMonitorOnline.remove(l1tCsctf) 
+#l1tMonitorOnline.remove(l1tCsctf)
 #l1tMonitorOnline.remove(l1tRpctf)
 #l1tMonitorOnline.remove(l1tGmt)
-#l1tMonitorOnline.remove(l1tGt) 
+#l1tMonitorOnline.remove(l1tGt)
 #
 #l1ExtraDqmSeq.remove(dqmGctDigis)
 #l1ExtraDqmSeq.remove(dqmGtDigis)
@@ -218,9 +221,9 @@ l1tMonitorStage1Online.remove(bxTiming)
 
 #l1TriggerEmulatorOffline.remove(l1TriggerEmulatorOnline)
 
-# l1HwValEmulatorMonitor sequence, defined in DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py 
+# l1HwValEmulatorMonitor sequence, defined in DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
 #
-#l1TriggerEmulatorOnline.remove(l1HwValEmulatorMonitor) 
+#l1TriggerEmulatorOnline.remove(l1HwValEmulatorMonitor)
 
 # L1HardwareValidation producers
 #l1HwValEmulatorMonitor.remove(L1HardwareValidation)
@@ -239,13 +242,13 @@ l1tMonitorStage1Online.remove(bxTiming)
 
 #l1TriggerClients.remove(l1tGctClient)
 #l1TriggerClients.remove(l1tDttfClient)
-#l1TriggerClients.remove(l1tCsctfClient) 
+#l1TriggerClients.remove(l1tCsctfClient)
 #l1TriggerClients.remove(l1tRpctfClient)
 #l1TriggerClients.remove(l1tGmtClient)
 #l1TriggerClients.remove(l1tOccupancyClient)
 l1TriggerStage1Clients.remove(l1tTestsSummary)
 #l1TriggerClients.remove(l1tEventInfoClient)
-                              
+
 # l1EmulatorMonitorClient sequence, defined in DQM/L1TMonitorClient/python/L1TEMUMonitorClient_cff.py
 #
 #l1EmulatorMonitorClient.remove(l1EmulatorQualityTests)

--- a/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
@@ -1,0 +1,161 @@
+#include "DQMOffline/L1Trigger/interface/L1TDiffHarvesting.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+namespace dqmoffline {
+namespace l1t {
+
+L1TDiffHarvesting::L1TDiffPlotHandler::L1TDiffPlotHandler(const edm::ParameterSet &ps, std::string plotName) :
+        dir1_(ps.getUntrackedParameter < std::string > ("dir1")),
+        dir2_(ps.getUntrackedParameter < std::string > ("dir2")),
+        outputDir_(ps.getUntrackedParameter < std::string > ("outputDir", dir1_)),
+        plotName_(plotName),
+        h1_(),
+        h2_(),
+        h_diff_(),
+        histType1_(),
+        histType2_()
+{
+
+}
+
+L1TDiffHarvesting::L1TDiffPlotHandler::L1TDiffPlotHandler(const L1TDiffHarvesting::L1TDiffPlotHandler &handler) :
+        dir1_(handler.dir1_),
+        dir2_(handler.dir2_),
+        outputDir_(handler.outputDir_),
+        plotName_(handler.plotName_),
+        h1_(),
+        h2_(),
+        h_diff_(),
+        histType1_(),
+        histType2_()
+{
+
+}
+
+void L1TDiffHarvesting::L1TDiffPlotHandler::computeDiff(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)
+{
+  loadHistograms(igetter);
+  if (!isValid()) {
+    return;
+  }
+  bookDiff(ibooker);
+
+  TH1* h_diff;
+  TH1* h1;
+  TH1* h2;
+  bool is1D(histType1_ == MonitorElement::DQM_KIND_TH1F || histType1_ == MonitorElement::DQM_KIND_TH1D);
+
+  if (is1D) {
+    h_diff = h_diff_->getTH1F();
+    h1 = h1_->getTH1F();
+    h2 = h2_->getTH1F();
+  } else { // TH2
+    h_diff = h_diff_->getTH2F();
+    h1 = h1_->getTH2F();
+    h2 = h2_->getTH2F();
+  }
+  h_diff->Add(h1);
+  h_diff->Add(h2, -1);
+  // if histograms are identical h_diff will have 0 entries -> not good to check if anything happened
+  // let's fix it
+  h_diff->SetEntries(h1->GetEntries() + h2->GetEntries());
+}
+
+void L1TDiffHarvesting::L1TDiffPlotHandler::loadHistograms(DQMStore::IGetter &igetter)
+{
+  std::string h1Name = dir1_ + "/" + plotName_;
+  std::string h2Name = dir2_ + "/" + plotName_;
+  h1_ = igetter.get(h1Name);
+  h2_ = igetter.get(h2Name);
+
+  if (!h1_ || !h2_) {
+    edm::LogError("L1TDiffHarvesting::L1TDiffPlotHandler::loadHistograms")
+        << (!h1_ && !h2_ ? h1Name + " && " + h2Name : !h1_ ? h1Name : h2Name) << " not gettable. Quitting booking"
+        << std::endl;
+
+    return;
+  }
+
+  histType1_ = h1_->kind();
+  histType2_ = h2_->kind();
+
+}
+
+bool L1TDiffHarvesting::L1TDiffPlotHandler::isValid() const
+{
+  if (histType1_ == MonitorElement::DQM_KIND_INVALID) {
+    edm::LogError("L1TDiffHarvesting::L1TDiffPlotHandler::isValid") << " Could not find a supported histogram type"
+        << std::endl;
+    return false;
+  }
+  if (histType1_ != histType2_) {
+    edm::LogError("L1TDiffHarvesting::L1TDiffPlotHandler::isValid")
+        << " Histogram 1 and 2 have different histogram types" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+void L1TDiffHarvesting::L1TDiffPlotHandler::bookDiff(DQMStore::IBooker &ibooker)
+{
+  ibooker.setCurrentFolder(outputDir_);
+
+  bool is1D(histType1_ == MonitorElement::DQM_KIND_TH1F || histType1_ == MonitorElement::DQM_KIND_TH1D);
+  if (is1D) {
+    TH1F* h1 = h1_->getTH1F();
+    double min = h1->GetXaxis()->GetXmin();
+    double max = h1->GetXaxis()->GetXmax();
+    int nBins = h1->GetNbinsX();
+    h_diff_ = ibooker.book1D(plotName_, plotName_, nBins, min, max);
+  } else { // TH2
+    TH2F* h1 = h1_->getTH2F();
+    double minX = h1->GetXaxis()->GetXmin();
+    double maxX = h1->GetXaxis()->GetXmax();
+    double minY = h1->GetYaxis()->GetXmin();
+    double maxY = h1->GetYaxis()->GetXmax();
+    int nBinsX = h1->GetNbinsX();
+    int nBinsY = h1->GetNbinsY();
+
+    h_diff_ = ibooker.book2D(plotName_, plotName_, nBinsX, minX, maxX, nBinsY, minY, maxY);
+  }
+
+}
+
+L1TDiffHarvesting::L1TDiffHarvesting(const edm::ParameterSet& ps) :
+    plotCfgs_(ps.getUntrackedParameter < std::vector<edm::ParameterSet> > ("plotCfgs")), //
+    plotHandlers_()
+{
+  using namespace std;
+  for (auto plotConfig : plotCfgs_) {
+    vector < string > plots = plotConfig.getUntrackedParameter < vector < string >> ("plots");
+    for (auto plot : plots) {
+      plotHandlers_.push_back(L1TDiffPlotHandler(plotConfig, plot));
+    }
+  }
+}
+
+L1TDiffHarvesting::~L1TDiffHarvesting()
+{
+
+}
+
+void L1TDiffHarvesting::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)
+{
+  edm::LogInfo("L1TEfficiencyHarvesting") << "Called endRun." << std::endl;
+
+  for (auto plotHandler : plotHandlers_) {
+    plotHandler.computeDiff(ibooker, igetter);
+  }
+}
+
+void L1TDiffHarvesting::dqmEndLuminosityBlock(DQMStore::IGetter &igetter, edm::LuminosityBlock const& lumiBlock,
+    edm::EventSetup const& c)
+{
+}
+
+DEFINE_FWK_MODULE (L1TDiffHarvesting);
+
+} // l1t
+} // dqmoffline

--- a/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TDiffHarvesting.cc
@@ -124,11 +124,10 @@ void L1TDiffHarvesting::L1TDiffPlotHandler::bookDiff(DQMStore::IBooker &ibooker)
 }
 
 L1TDiffHarvesting::L1TDiffHarvesting(const edm::ParameterSet& ps) :
-    plotCfgs_(ps.getUntrackedParameter < std::vector<edm::ParameterSet> > ("plotCfgs")), //
     plotHandlers_()
 {
   using namespace std;
-  for (auto plotConfig : plotCfgs_) {
+  for (auto plotConfig : ps.getUntrackedParameter < std::vector<edm::ParameterSet> > ("plotCfgs")) {
     vector < string > plots = plotConfig.getUntrackedParameter < vector < string >> ("plots");
     for (auto plot : plots) {
       plotHandlers_.push_back(L1TDiffPlotHandler(plotConfig, plot));

--- a/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
@@ -1,0 +1,178 @@
+/**
+ * \file L1TEfficiencyHarvesting.cc
+ *
+ * \author J. Pela, C. Battilana
+ *
+ */
+
+// L1TMonitor includes
+#include "DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+#include "DataFormats/Common/interface/ConditionsInEdm.h" // Parameters associated to Run, LS and Event
+#include "DataFormats/Luminosity/interface/LumiDetails.h" // Luminosity Information
+#include "DataFormats/Luminosity/interface/LumiSummary.h" // Luminosity Information
+
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
+#include "CondFormats/L1TObjects/interface/L1GtPrescaleFactors.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"            // L1Gt - Masks
+#include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h" // L1Gt - Masks
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
+#include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h"
+
+#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+
+#include "TList.h"
+
+using namespace edm;
+using namespace std;
+
+namespace dqmoffline {
+namespace l1t {
+L1TEfficiencyPlotHandler::L1TEfficiencyPlotHandler(const ParameterSet & ps, std::string plotName) :
+        numeratorDir_(ps.getUntrackedParameter < std::string > ("numeratorDir")),
+        denominatorDir_(ps.getUntrackedParameter < std::string > ("denominatorDir", numeratorDir_)),
+        outputDir_(ps.getUntrackedParameter < std::string > ("outputDir", numeratorDir_)),
+        plotName_(plotName),
+        numeratorSuffix_(ps.getUntrackedParameter < std::string > ("numeratorSuffix", "Num")),
+        denominatorSuffix_(ps.getUntrackedParameter < std::string > ("denominatorSuffix", "Den")),
+        h_efficiency_()
+{
+
+}
+
+L1TEfficiencyPlotHandler::L1TEfficiencyPlotHandler(const L1TEfficiencyPlotHandler &handler) :
+        numeratorDir_(handler.numeratorDir_),
+        denominatorDir_(handler.denominatorDir_),
+        outputDir_(handler.outputDir_),
+        plotName_(handler.plotName_),
+        numeratorSuffix_(handler.numeratorSuffix_),
+        denominatorSuffix_(handler.denominatorSuffix_),
+        h_efficiency_(handler.h_efficiency_)
+{
+
+}
+
+void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)
+{
+
+  edm::LogInfo("L1TEfficiencyPlotHandler") << "Booking efficiency histogram for " << outputDir_ << " and " << plotName_
+      << endl;
+
+  std::string numeratorName = numeratorDir_ + "/" + plotName_ + numeratorSuffix_;
+  std::string denominatorName = denominatorDir_ + "/" + plotName_ + denominatorSuffix_;
+  MonitorElement *num = igetter.get(numeratorName);
+  MonitorElement *den = igetter.get(denominatorName);
+
+  if (!num || !den) {
+
+    edm::LogError("L1TEfficiencyPlotHandler")
+        << (!num && !den ? numeratorName + " && " + denominatorName : !num ? numeratorName : denominatorName)
+        << " not gettable. Quitting booking" << endl;
+    return;
+  }
+
+  TH1F *numH = num->getTH1F();
+  TH1F *denH = den->getTH1F();
+
+  if (!numH || !denH) {
+
+    edm::LogError("L1TEfficiencyPlotHandler")
+        << (!numH && !denH ? numeratorName + " && " + denominatorName : !num ? numeratorName : denominatorName)
+        << " is not TH1F. Quitting booking" << endl;
+
+    return;
+
+  }
+
+  int nBinsNum = numH->GetNbinsX();
+  int nBinsDen = denH->GetNbinsX();
+
+  if (nBinsNum != nBinsDen) {
+    edm::LogError("L1TEfficiencyPlotHandler") << " # bins in " << numeratorName << " and " << denominatorName
+        << " are different. Quitting booking" << endl;
+    return;
+  }
+
+  double min = numH->GetXaxis()->GetXmin();
+  double max = numH->GetXaxis()->GetXmax();
+
+  ibooker.setCurrentFolder(outputDir_);
+  h_efficiency_ = ibooker.book1D(plotName_, plotName_, nBinsNum, min, max);
+
+}
+
+void L1TEfficiencyPlotHandler::computeEfficiency(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)
+{
+  if (!h_efficiency_)
+    return;
+
+  edm::LogInfo("L1TEfficiencyPlotHandler") << " Computing efficiency for " << plotName_ << endl;
+
+  MonitorElement *num = igetter.get(numeratorDir_ + "/" + plotName_ + numeratorSuffix_);
+  MonitorElement *den = igetter.get(denominatorDir_ + "/" + plotName_ + denominatorSuffix_);
+
+  TH1F *numH = num->getTH1F();
+  TH1F *denH = den->getTH1F();
+
+  numH->Sumw2();
+  denH->Sumw2();
+
+  TH1F *effH = h_efficiency_->getTH1F();
+
+  effH->Divide(numH, denH, 1.0, 1.0, "B");
+}
+
+//___________DQM_analyzer_class________________________________________
+L1TEfficiencyHarvesting::L1TEfficiencyHarvesting(const ParameterSet & ps) :
+        verbose_(ps.getUntrackedParameter<bool>("verbose")),
+        plotCfgs_(ps.getUntrackedParameter < std::vector<edm::ParameterSet> > ("plotCfgs")),
+        plotHandlers_()
+{
+  if (verbose_) {
+    edm::LogInfo("L1TEfficiencyHarvesting") << "____________ Storage initialization ____________ " << endl;
+  }
+
+  for (auto plotConfig : plotCfgs_) {
+    vector < string > plots = plotConfig.getUntrackedParameter < vector < string >> ("plots");
+    for (auto plot : plots) {
+      plotHandlers_.push_back(L1TEfficiencyPlotHandler(plotConfig, plot));
+    }
+  }
+}
+
+//_____________________________________________________________________
+L1TEfficiencyHarvesting::~L1TEfficiencyHarvesting()
+{
+}
+
+//_____________________________________________________________________
+void L1TEfficiencyHarvesting::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter)
+{
+  if (verbose_) {
+    edm::LogInfo("L1TEfficiencyHarvesting") << "Called endRun." << endl;
+  }
+
+  for (auto plotHandler : plotHandlers_) {
+    plotHandler.book(ibooker, igetter);
+    plotHandler.computeEfficiency(ibooker, igetter);
+  }
+}
+
+//_____________________________________________________________________
+void L1TEfficiencyHarvesting::dqmEndLuminosityBlock(DQMStore::IGetter &igetter, LuminosityBlock const& lumiBlock,
+    EventSetup const& c)
+{
+  if (verbose_) {
+    edm::LogInfo("L1TEfficiencyHarvesting") << "Called endLuminosityBlock at LS=" << lumiBlock.id().luminosityBlock()
+        << endl;
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE (L1TEfficiencyHarvesting);
+} //l1t
+} // dqmoffline

--- a/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TEfficiencyHarvesting.cc
@@ -7,25 +7,7 @@
 
 // L1TMonitor includes
 #include "DQMOffline/L1Trigger/interface/L1TEfficiencyHarvesting.h"
-
-#include "DQMServices/Core/interface/DQMStore.h"
-
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
-#include "DataFormats/Common/interface/ConditionsInEdm.h" // Parameters associated to Run, LS and Event
-#include "DataFormats/Luminosity/interface/LumiDetails.h" // Luminosity Information
-#include "DataFormats/Luminosity/interface/LumiSummary.h" // Luminosity Information
-
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
-#include "CondFormats/L1TObjects/interface/L1GtPrescaleFactors.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"            // L1Gt - Masks
-#include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h" // L1Gt - Masks
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
-#include "CondFormats/DataRecord/interface/L1GtPrescaleFactorsAlgoTrigRcd.h"
-
-#include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
-
-#include "TList.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 using namespace edm;
 using namespace std;
@@ -129,14 +111,13 @@ void L1TEfficiencyPlotHandler::computeEfficiency(DQMStore::IBooker &ibooker, DQM
 //___________DQM_analyzer_class________________________________________
 L1TEfficiencyHarvesting::L1TEfficiencyHarvesting(const ParameterSet & ps) :
         verbose_(ps.getUntrackedParameter<bool>("verbose")),
-        plotCfgs_(ps.getUntrackedParameter < std::vector<edm::ParameterSet> > ("plotCfgs")),
         plotHandlers_()
 {
   if (verbose_) {
     edm::LogInfo("L1TEfficiencyHarvesting") << "____________ Storage initialization ____________ " << endl;
   }
 
-  for (auto plotConfig : plotCfgs_) {
+  for (auto plotConfig : ps.getUntrackedParameter < std::vector<edm::ParameterSet> > ("plotCfgs")) {
     vector < string > plots = plotConfig.getUntrackedParameter < vector < string >> ("plots");
     for (auto plot : plots) {
       plotHandlers_.push_back(L1TEfficiencyPlotHandler(plotConfig, plot));

--- a/DQMOffline/L1Trigger/src/L1TFillWithinLimits.cc
+++ b/DQMOffline/L1Trigger/src/L1TFillWithinLimits.cc
@@ -1,0 +1,50 @@
+#include "DQMOffline/L1Trigger/interface/L1TFillWithinLimits.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace dqmoffline {
+namespace l1t {
+
+/**
+ * Fills a given
+ * @param
+ */
+void fillWithinLimits(MonitorElement* mon, double value, double weight)
+{
+  TH1 * hist = mon->getTH1F();
+  double min(hist->GetXaxis()->GetXmin());
+  double max(hist->GetXaxis()->GetXmax());
+
+  double fillValue = getFillValueWithinLimits(value, min, max);
+  mon->Fill(fillValue, weight);
+
+}
+void fill2DWithinLimits(MonitorElement* mon, double valueX, double valueY, double weight)
+{
+  TH1 * hist = mon->getTH2F();
+  double minX(hist->GetXaxis()->GetXmin());
+  double minY(hist->GetYaxis()->GetXmin());
+
+  double maxX(hist->GetXaxis()->GetXmax());
+  double maxY(hist->GetYaxis()->GetXmax());
+
+  double fillValueX = getFillValueWithinLimits(valueX, minX, maxX);
+  double fillValueY = getFillValueWithinLimits(valueY, minY, maxY);
+  mon->Fill(fillValueX, fillValueY, weight);
+
+}
+
+double getFillValueWithinLimits(double value, double min, double max)
+{
+  if (value < min)
+    return min;
+
+  if (value > max)
+    return max;
+
+  return value;
+}
+
+}
+}
+

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -1,0 +1,604 @@
+#include "DQMOffline/L1Trigger/interface/L1TStage2CaloLayer2Offline.h"
+#include "DQMOffline/L1Trigger/interface/L1TFillWithinLimits.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+// Geometry
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "TLorentzVector.h"
+
+#include <iostream>
+#include <iomanip>
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <math.h>
+#include <algorithm>
+
+//
+// -------------------------------------- Constructor --------------------------------------------
+//
+L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline(const edm::ParameterSet& ps) :
+        theCaloJetCollection_(
+            consumes < reco::CaloJetCollection > (ps.getParameter < edm::InputTag > ("caloJetCollection"))),
+        thecaloMETCollection_(
+            consumes < reco::CaloMETCollection > (ps.getParameter < edm::InputTag > ("caloMETCollection"))),
+        thePVCollection_(consumes < reco::VertexCollection > (ps.getParameter < edm::InputTag > ("PVCollection"))),
+        theBSCollection_(consumes < reco::BeamSpot > (ps.getParameter < edm::InputTag > ("beamSpotCollection"))),
+        triggerEvent_(consumes < trigger::TriggerEvent > (ps.getParameter < edm::InputTag > ("TriggerEvent"))),
+        triggerResults_(consumes < edm::TriggerResults > (ps.getParameter < edm::InputTag > ("TriggerResults"))),
+        triggerFilter_(ps.getParameter < edm::InputTag > ("TriggerFilter")),
+        triggerPath_(ps.getParameter < std::string > ("TriggerPath")),
+        histFolder_(ps.getParameter < std::string > ("histFolder")),
+        efficiencyFolder_(histFolder_ + "/efficiency_raw"),
+        stage2CaloLayer2JetToken_(
+            consumes < l1t::JetBxCollection > (ps.getParameter < edm::InputTag > ("stage2CaloLayer2JetSource"))),
+        stage2CaloLayer2EtSumToken_(
+            consumes < l1t::EtSumBxCollection > (ps.getParameter < edm::InputTag > ("stage2CaloLayer2EtSumSource"))),
+        jetEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("jetEfficiencyThresholds")),
+        metEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("metEfficiencyThresholds")),
+        mhtEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("mhtEfficiencyThresholds")),
+        ettEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("ettEfficiencyThresholds")),
+        httEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("httEfficiencyThresholds")),
+        jetEfficiencyBins_(ps.getParameter < std::vector<double> > ("jetEfficiencyBins")),
+        metEfficiencyBins_(ps.getParameter < std::vector<double> > ("metEfficiencyBins")),
+        mhtEfficiencyBins_(ps.getParameter < std::vector<double> > ("mhtEfficiencyBins")),
+        ettEfficiencyBins_(ps.getParameter < std::vector<double> > ("ettEfficiencyBins")),
+        httEfficiencyBins_(ps.getParameter < std::vector<double> > ("httEfficiencyBins"))
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "Constructor "
+      << "L1TStage2CaloLayer2Offline::L1TStage2CaloLayer2Offline " << std::endl;
+}
+
+//
+// -- Destructor
+//
+L1TStage2CaloLayer2Offline::~L1TStage2CaloLayer2Offline()
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "Destructor L1TStage2CaloLayer2Offline::~L1TStage2CaloLayer2Offline "
+      << std::endl;
+}
+
+//
+// -------------------------------------- beginRun --------------------------------------------
+//
+void L1TStage2CaloLayer2Offline::dqmBeginRun(edm::Run const &, edm::EventSetup const &)
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "L1TStage2CaloLayer2Offline::beginRun" << std::endl;
+}
+//
+// -------------------------------------- bookHistos --------------------------------------------
+//
+void L1TStage2CaloLayer2Offline::bookHistograms(DQMStore::IBooker & ibooker_, edm::Run const &, edm::EventSetup const &)
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "L1TStage2CaloLayer2Offline::bookHistograms" << std::endl;
+
+  //book at beginRun
+  bookHistos(ibooker_);
+}
+//
+// -------------------------------------- beginLuminosityBlock --------------------------------------------
+//
+void L1TStage2CaloLayer2Offline::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg,
+    edm::EventSetup const& context)
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "L1TStage2CaloLayer2Offline::beginLuminosityBlock" << std::endl;
+}
+
+//
+// -------------------------------------- Analyze --------------------------------------------
+//
+void L1TStage2CaloLayer2Offline::analyze(edm::Event const& e, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "L1TStage2CaloLayer2Offline::analyze" << std::endl;
+
+  edm::Handle<reco::VertexCollection> vertexHandle;
+  e.getByToken(thePVCollection_, vertexHandle);
+  if (!vertexHandle.isValid()) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: vertex " << std::endl;
+    return;
+  }
+
+  unsigned int nVertex = vertexHandle->size();
+  dqmoffline::l1t::fillWithinLimits(h_nVertex_, nVertex);
+
+  // L1T
+  fillEnergySums(e, nVertex);
+  fillJets(e, nVertex);
+}
+
+void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsigned int nVertex)
+{
+  edm::Handle<l1t::EtSumBxCollection> l1EtSums;
+  e.getByToken(stage2CaloLayer2EtSumToken_, l1EtSums);
+
+  edm::Handle<reco::CaloJetCollection> caloJets;
+  e.getByToken(theCaloJetCollection_, caloJets);
+
+  edm::Handle<reco::CaloMETCollection> caloMETs;
+  e.getByToken(thecaloMETCollection_, caloMETs);
+
+  if (!caloJets.isValid()) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
+    return;
+  }
+  if (!caloMETs.isValid()) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: Offline E_{T}^{miss} " << std::endl;
+    return;
+  }
+  if (!l1EtSums.isValid()) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: L1 ET sums " << std::endl;
+    return;
+  }
+
+  int bunchCrossing = 0;
+
+  double l1MET(0);
+  double l1METPhi(0);
+  double l1MHT(0);
+  double l1MHTPhi(0);
+  double l1ETT(0);
+  double l1HTT(0);
+
+  for (auto etSum = l1EtSums->begin(bunchCrossing); etSum != l1EtSums->end(bunchCrossing); ++etSum) {
+    double et = etSum->et();
+    double phi = etSum->phi();
+
+    switch (etSum->getType()) {
+    case l1t::EtSum::EtSumType::kMissingEt:
+      l1MET = et;
+      l1METPhi = phi;
+      break;
+    case l1t::EtSum::EtSumType::kTotalEt:
+      l1ETT = et;
+      break;
+    case l1t::EtSum::EtSumType::kMissingHt:
+      l1MHT = et;
+      l1MHTPhi = phi;
+      break;
+    case l1t::EtSum::EtSumType::kTotalHt:
+      l1HTT = et;
+    default:
+      break;
+    }
+
+  }
+
+  double recoMET(caloMETs->front().et());
+  double recoMETPhi(caloMETs->front().phi());
+  double recoMHT(0);
+  double recoMHTPhi(0);
+  double recoETT(0);
+  double recoHTT(0);
+
+  TVector2 mht(0., 0.);
+
+  for (auto jet = caloJets->begin(); jet != caloJets->end(); ++jet) {
+    double et = jet->et();
+    if (et < 30) {
+      continue;
+    }
+    TVector2 jetVec(0., 0.);
+    jetVec.SetMagPhi(et, jet->phi());
+    recoHTT += et;
+    mht -= jetVec;
+  }
+  recoETT = recoHTT;
+  recoMHT = mht.Mod();
+  // phi in cms is defined between -pi and pi
+  recoMHTPhi = TVector2::Phi_mpi_pi(mht.Phi());
+
+  // if no reco value, relative resolution does not make sense -> sort to overflow
+  double outOfBounds = 9999;
+  double resolutionMET = recoMET > 0 ? (l1MET - recoMET) / recoMET : outOfBounds;
+  double resolutionMETPhi = abs(recoMETPhi) > 0 ? (l1METPhi - recoMETPhi) / recoMETPhi : outOfBounds;
+  double resolutionMHT = recoMHT > 0 ? (l1MHT - recoMHT) / recoMHT : outOfBounds;
+  double resolutionMHTPhi = abs(recoMHTPhi) > 0 ? (l1MHTPhi - recoMHTPhi) / recoMHTPhi : outOfBounds;
+  double resolutionETT = recoETT > 0 ? (l1ETT - recoETT) / recoETT : outOfBounds;
+  double resolutionHTT = recoHTT > 0 ? (l1HTT - recoHTT) / recoHTT : outOfBounds;
+
+  using namespace dqmoffline::l1t;
+  fill2DWithinLimits(h_L1METvsCaloMET_, recoMET, l1MET);
+  fill2DWithinLimits(h_L1MHTvsRecoMHT_, recoMHT, l1MHT);
+  fill2DWithinLimits(h_L1METTvsCaloETT_, recoETT, l1ETT);
+  fill2DWithinLimits(h_L1HTTvsRecoHTT_, recoHTT, l1HTT);
+
+  fill2DWithinLimits(h_L1METPhivsCaloMETPhi_, recoMETPhi, l1METPhi);
+  fill2DWithinLimits(h_L1MHTPhivsRecoMHTPhi_, recoMHTPhi, l1MHTPhi);
+
+  fillWithinLimits(h_resolutionMET_, resolutionMET);
+  fillWithinLimits(h_resolutionMHT_, resolutionMHT);
+  fillWithinLimits(h_resolutionETT_, resolutionETT);
+  fillWithinLimits(h_resolutionHTT_, resolutionHTT);
+
+  fillWithinLimits(h_resolutionMETPhi_, resolutionMETPhi);
+  fillWithinLimits(h_resolutionMHTPhi_, resolutionMHTPhi);
+
+  // efficiencies
+  for (auto threshold : metEfficiencyThresholds_) {
+    fillWithinLimits(h_efficiencyMET_total_[threshold], recoMET);
+    if (l1MET > threshold)
+      fillWithinLimits(h_efficiencyMET_pass_[threshold], recoMET);
+  }
+
+  for (auto threshold : mhtEfficiencyThresholds_) {
+    fillWithinLimits(h_efficiencyMHT_total_[threshold], recoMHT);
+    if (l1MHT > threshold)
+      fillWithinLimits(h_efficiencyMHT_pass_[threshold], recoMHT);
+  }
+
+  for (auto threshold : ettEfficiencyThresholds_) {
+    fillWithinLimits(h_efficiencyETT_total_[threshold], recoETT);
+    if (l1ETT > threshold)
+      fillWithinLimits(h_efficiencyETT_pass_[threshold], recoETT);
+  }
+
+  for (auto threshold : httEfficiencyThresholds_) {
+    fillWithinLimits(h_efficiencyHTT_total_[threshold], recoHTT);
+    if (l1HTT > threshold)
+      fillWithinLimits(h_efficiencyHTT_pass_[threshold], recoHTT);
+  }
+
+}
+
+void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned int nVertex)
+{
+  edm::Handle<l1t::JetBxCollection> l1Jets;
+  e.getByToken(stage2CaloLayer2JetToken_, l1Jets);
+
+  edm::Handle<reco::CaloJetCollection> caloJets;
+  e.getByToken(theCaloJetCollection_, caloJets);
+
+  if (!caloJets.isValid()) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: calo jets " << std::endl;
+    return;
+  }
+  if (!l1Jets.isValid()) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "invalid collection: L1 jets " << std::endl;
+    return;
+  }
+
+  if (caloJets->size() == 0) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "no calo jets found" << std::endl;
+    return;
+  }
+
+  if (l1Jets->size() == 0) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "no L1 jets found" << std::endl;
+    return;
+  }
+
+  auto leadingRecoJet = caloJets->front();
+
+  // find corresponding L1 jet
+  double minDeltaR = 0.3;
+  l1t::Jet closestL1Jet;
+  bool foundMatch = false;
+
+//	for (int bunchCrossing = l1Jets->getFirstBX(); bunchCrossing <= l1Jets->getLastBX(); ++bunchCrossing) {
+  int bunchCrossing = 0;
+  for (auto jet = l1Jets->begin(bunchCrossing); jet != l1Jets->end(bunchCrossing); ++jet) {
+    double currentDeltaR = deltaR(jet->eta(), jet->phi(), leadingRecoJet.eta(), leadingRecoJet.phi());
+    if (currentDeltaR > minDeltaR) {
+      continue;
+    } else {
+      minDeltaR = currentDeltaR;
+      closestL1Jet = *jet;
+      foundMatch = true;
+    }
+
+  }
+//	}
+
+  if (!foundMatch) {
+    edm::LogError("L1TStage2CaloLayer2Offline") << "Could not find a matching L1 Jet " << std::endl;
+    return;
+  }
+
+  double recoEt = leadingRecoJet.et();
+  double recoEta = leadingRecoJet.eta();
+  double recoPhi = leadingRecoJet.phi();
+
+  double l1Et = closestL1Jet.et();
+  double l1Eta = closestL1Jet.eta();
+  double l1Phi = closestL1Jet.phi();
+
+  // if no reco value, relative resolution does not make sense -> sort to overflow
+  double outOfBounds = 9999;
+  double resolutionEt = recoEt > 0 ? (l1Et - recoEt) / recoEt : outOfBounds;
+  double resolutionEta = abs(recoEta) > 0 ? (l1Eta - recoEta) / recoEta : outOfBounds;
+  double resolutionPhi = abs(recoPhi) > 0 ? (l1Phi - recoPhi) / recoPhi : outOfBounds;
+
+  using namespace dqmoffline::l1t;
+  // eta
+  fill2DWithinLimits(h_L1JetEtavsCaloJetEta_, recoEta, l1Eta);
+  fillWithinLimits(h_resolutionJetEta_, resolutionEta);
+
+  if (abs(recoEta) <= 1.479) { // barrel
+    // et
+    fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_HE_, recoEt, l1Et);
+    //resolution
+    fillWithinLimits(h_resolutionJetET_HB_, resolutionEt);
+    fillWithinLimits(h_resolutionJetET_HB_HE_, resolutionEt);
+    // phi
+    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HB_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HB_HE_, recoPhi, l1Phi);
+    // resolution
+    fillWithinLimits(h_resolutionJetPhi_HB_, resolutionPhi);
+    fillWithinLimits(h_resolutionJetPhi_HB_HE_, resolutionPhi);
+
+    // turn-ons
+
+    for (auto threshold : jetEfficiencyThresholds_) {
+      fillWithinLimits(h_efficiencyJetEt_HB_total_[threshold], recoEt);
+      fillWithinLimits(h_efficiencyJetEt_HB_HE_total_[threshold], recoEt);
+      if (l1Et > threshold) {
+        fillWithinLimits(h_efficiencyJetEt_HB_pass_[threshold], recoEt);
+        fillWithinLimits(h_efficiencyJetEt_HB_HE_pass_[threshold], recoEt);
+      }
+    }
+
+  } else if (abs(recoEta) <= 3.0) { // end-cap
+    // et
+    fill2DWithinLimits(h_L1JetETvsCaloJetET_HE_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_HE_, recoEt, l1Et);
+    //resolution
+    fillWithinLimits(h_resolutionJetET_HE_, resolutionEt);
+    fillWithinLimits(h_resolutionJetET_HB_HE_, resolutionEt);
+    // phi
+    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HE_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HB_HE_, recoPhi, l1Phi);
+    // resolution
+    fillWithinLimits(h_resolutionJetPhi_HE_, resolutionPhi);
+    fillWithinLimits(h_resolutionJetPhi_HB_HE_, resolutionPhi);
+
+    // turn-ons
+    for (auto threshold : jetEfficiencyThresholds_) {
+      fillWithinLimits(h_efficiencyJetEt_HE_total_[threshold], recoEt);
+      fillWithinLimits(h_efficiencyJetEt_HB_HE_total_[threshold], recoEt);
+      if (l1Et > threshold) {
+        fillWithinLimits(h_efficiencyJetEt_HE_pass_[threshold], recoEt);
+        fillWithinLimits(h_efficiencyJetEt_HB_HE_pass_[threshold], recoEt);
+      }
+    }
+  } else { // forward jets
+    // et
+    fill2DWithinLimits(h_L1JetETvsCaloJetET_HF_, recoEt, l1Et);
+    // resolution
+    fillWithinLimits(h_resolutionJetET_HF_, resolutionEt);
+    // phi
+    fill2DWithinLimits(h_L1JetPhivsCaloJetPhi_HF_, recoPhi, l1Phi);
+    // resolution
+    fillWithinLimits(h_resolutionJetPhi_HF_, resolutionPhi);
+    // turn-ons
+    for (auto threshold : jetEfficiencyThresholds_) {
+      fillWithinLimits(h_efficiencyJetEt_HF_total_[threshold], recoEt);
+      if (l1Et > threshold) {
+        fillWithinLimits(h_efficiencyJetEt_HF_pass_[threshold], recoEt);
+      }
+    }
+  }
+}
+
+//
+// -------------------------------------- endLuminosityBlock --------------------------------------------
+//
+void L1TStage2CaloLayer2Offline::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "L1TStage2CaloLayer2Offline::endLuminosityBlock" << std::endl;
+}
+
+//
+// -------------------------------------- endRun --------------------------------------------
+//
+void L1TStage2CaloLayer2Offline::endRun(edm::Run const& run, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("L1TStage2CaloLayer2Offline") << "L1TStage2CaloLayer2Offline::endRun" << std::endl;
+}
+
+//
+// -------------------------------------- book histograms --------------------------------------------
+//
+void L1TStage2CaloLayer2Offline::bookHistos(DQMStore::IBooker & ibooker)
+{
+  bookEnergySumHistos(ibooker);
+  bookJetHistos(ibooker);
+}
+
+void L1TStage2CaloLayer2Offline::bookEnergySumHistos(DQMStore::IBooker & ibooker)
+{
+  ibooker.cd();
+  ibooker.setCurrentFolder(histFolder_.c_str());
+
+  h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
+
+  // energy sums reco vs L1
+  h_L1METvsCaloMET_ = ibooker.book2D("L1METvsCaloMET",
+      "L1 E_{T}^{miss} vs Offline E_{T}^{miss};Offline E_{T}^{miss} (GeV);L1 E_{T}^{miss} (GeV)", 500, -0.5, 499.5, 500,
+      -0.5, 499.5);
+  h_L1MHTvsRecoMHT_ = ibooker.book2D("L1MHTvsRecoMHT", "L1 MHT vs reco MHT;reco MHT (GeV);L1 MHT (GeV)", 500, -0.5,
+      499.5, 500, -0.5, 499.5);
+  h_L1METTvsCaloETT_ = ibooker.book2D("L1ETTvsCaloETT", "L1 ETT vs calo ETT;calo ETT (GeV);L1 ETT (GeV)", 500, -0.5,
+      499.5, 500, -0.5, 499.5);
+  h_L1HTTvsRecoHTT_ = ibooker.book2D("L1HTTvsRecoHTT",
+      "L1 Total H_{T} vs Offline Total H_{T};Offline Total H_{T} (GeV);L1 Total H_{T} (GeV)", 500, -0.5, 499.5, 500,
+      -0.5, 499.5);
+
+  h_L1METPhivsCaloMETPhi_ = ibooker.book2D("L1METPhivsCaloMETPhi",
+      "L1 E_{T}^{miss} #phi vs Offline E_{T}^{miss} #phi;Offline E_{T}^{miss} #phi;L1 E_{T}^{miss} #phi", 100, -4, 4,
+      100, -4, 4);
+  h_L1MHTPhivsRecoMHTPhi_ = ibooker.book2D("L1MHTPhivsRecoMHTPhi",
+      "L1 MHT #phi vs reco MHT #phi;reco MHT #phi;L1 MHT #phi", 100, -4, 4, 100, -4, 4);
+
+  // energy sum resolutions
+  h_resolutionMET_ = ibooker.book1D("resolutionMET",
+      "MET resolution; (L1 E_{T}^{miss} - Offline E_{T}^{miss})/Offline E_{T}^{miss}; events", 50, -1, 1.5);
+  h_resolutionMHT_ = ibooker.book1D("resolutionMHT", "MHT resolution; (L1 MHT - reco MHT)/reco MHT; events", 50, -1,
+      1.5);
+  h_resolutionETT_ = ibooker.book1D("resolutionETT", "ETT resolution; (L1 ETT - calo ETT)/calo ETT; events", 50, -1,
+      1.5);
+  h_resolutionHTT_ = ibooker.book1D("resolutionHTT",
+      "HTT resolution; (L1 Total H_{T} - Offline Total H_{T})/Offline Total H_{T}; events", 50, -1, 1.5);
+
+  h_resolutionMETPhi_ = ibooker.book1D("resolutionMETPhi",
+      "MET #phi resolution; (L1 E_{T}^{miss} #phi - reco MET #phi)/reco MET #phi; events", 120, -0.3, 0.3);
+  h_resolutionMHTPhi_ = ibooker.book1D("resolutionMHTPhi",
+      "MET #phi resolution; (L1 MHT #phi - reco MHT #phi)/reco MHT #phi; events", 120, -0.3, 0.3);
+
+  // energy sum turn ons
+  ibooker.setCurrentFolder(efficiencyFolder_.c_str());
+
+  std::vector<float> metBins(metEfficiencyBins_.begin(), metEfficiencyBins_.end());
+  std::vector<float> mhtBins(mhtEfficiencyBins_.begin(), mhtEfficiencyBins_.end());
+  std::vector<float> ettBins(ettEfficiencyBins_.begin(), ettEfficiencyBins_.end());
+  std::vector<float> httBins(httEfficiencyBins_.begin(), httEfficiencyBins_.end());
+
+  for (auto threshold : metEfficiencyThresholds_) {
+    std::string str_threshold = std::to_string(int(threshold));
+    h_efficiencyMET_pass_[threshold] = ibooker.book1D("efficiencyMET_threshold_" + str_threshold + "_Num",
+        "MET efficiency; Offline E_{T}^{miss} (GeV); events", metBins.size() - 1, &(metBins[0]));
+    h_efficiencyMET_total_[threshold] = ibooker.book1D("efficiencyMET_threshold_" + str_threshold + "_Den",
+        "MET efficiency; Offline E_{T}^{miss} (GeV); events", metBins.size() - 1, &(metBins[0]));
+  }
+
+  for (auto threshold : mhtEfficiencyThresholds_) {
+    std::string str_threshold = std::to_string(int(threshold));
+    h_efficiencyMHT_pass_[threshold] = ibooker.book1D("efficiencyMHT_threshold_" + str_threshold + "_Num",
+        "MHT efficiency; Offline MHT (GeV); events", mhtBins.size() - 1, &(mhtBins[0]));
+    h_efficiencyMHT_total_[threshold] = ibooker.book1D("efficiencyMHT_threshold_" + str_threshold + "_Den",
+        "MHT efficiency; Offline MHT (GeV); events", mhtBins.size() - 1, &(mhtBins[0]));
+  }
+
+  for (auto threshold : ettEfficiencyThresholds_) {
+    std::string str_threshold = std::to_string(int(threshold));
+    h_efficiencyETT_pass_[threshold] = ibooker.book1D("efficiencyETT_threshold_" + str_threshold + "_Num",
+        "ETT efficiency; Offline ETT (GeV); events", ettBins.size() - 1, &(ettBins[0]));
+    h_efficiencyETT_total_[threshold] = ibooker.book1D("efficiencyETT_threshold_" + str_threshold + "_Den",
+        "ETT efficiency; Offline ETT (GeV); events", ettBins.size() - 1, &(ettBins[0]));
+  }
+  for (auto threshold : httEfficiencyThresholds_) {
+    std::string str_threshold = std::to_string(int(threshold));
+    h_efficiencyHTT_pass_[threshold] = ibooker.book1D("efficiencyHTT_threshold_" + str_threshold + "_Num",
+        "HTT efficiency; Offline Total H_{T} (GeV); events", httBins.size() - 1, &(httBins[0]));
+    h_efficiencyHTT_total_[threshold] = ibooker.book1D("efficiencyHTT_threshold_" + str_threshold + "_Den",
+        "HTT efficiency; Offline Total H_{T} (GeV); events", httBins.size() - 1, &(httBins[0]));
+  }
+
+  ibooker.cd();
+}
+
+void L1TStage2CaloLayer2Offline::bookJetHistos(DQMStore::IBooker & ibooker)
+{
+  ibooker.cd();
+  ibooker.setCurrentFolder(histFolder_.c_str());
+  // jet reco vs L1
+  h_L1JetETvsCaloJetET_HB_ = ibooker.book2D("L1JetETvsCaloJetET_HB",
+      "L1 Jet E_{T} vs Offline Jet E_{T} (HB); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)", 300, 0, 300, 300, 0, 300);
+  h_L1JetETvsCaloJetET_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HE",
+      "L1 Jet E_{T} vs Offline Jet E_{T} (HE); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)", 300, 0, 300, 300, 0, 300);
+  h_L1JetETvsCaloJetET_HF_ = ibooker.book2D("L1JetETvsCaloJetET_HF",
+      "L1 Jet E_{T} vs Offline Jet E_{T} (HF); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)", 300, 0, 300, 300, 0, 300);
+  h_L1JetETvsCaloJetET_HB_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HB_HE",
+      "L1 Jet E_{T} vs Offline Jet E_{T} (HB+HE); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)", 300, 0, 300, 300, 0,
+      300);
+
+  h_L1JetPhivsCaloJetPhi_HB_ = ibooker.book2D("L1JetETvsCaloJetET_HB",
+      "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HB); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
+  h_L1JetPhivsCaloJetPhi_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HE",
+      "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HE); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
+  h_L1JetPhivsCaloJetPhi_HF_ = ibooker.book2D("L1JetETvsCaloJetET_HF",
+      "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HF); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
+  h_L1JetPhivsCaloJetPhi_HB_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HB_HE",
+      "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HB+HE); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
+
+  h_L1JetEtavsCaloJetEta_ = ibooker.book2D("L1JetEtavsCaloJetEta_HB",
+      "L1 Jet #eta vs Offline Jet #eta; Offline Jet #eta; L1 Jet #eta", 100, -10, 10, 100, -10, 10);
+
+  // jet resolutions
+  h_resolutionJetET_HB_ = ibooker.book1D("resolutionJetET_HB",
+      "jet ET resolution (HB); (L1 Jet E_{T} - Offline Jet E_{T})/Offline Jet E_{T}; events", 50, -1, 1.5);
+  h_resolutionJetET_HE_ = ibooker.book1D("resolutionJetET_HE",
+      "jet ET resolution (HE); (L1 Jet E_{T} - Offline Jet E_{T})/Offline Jet E_{T}; events", 50, -1, 1.5);
+  h_resolutionJetET_HF_ = ibooker.book1D("resolutionJetET_HF",
+      "jet ET resolution (HF); (L1 Jet E_{T} - Offline Jet E_{T})/Offline Jet E_{T}; events", 50, -1, 1.5);
+  h_resolutionJetET_HB_HE_ = ibooker.book1D("resolutionJetET_HB_HE",
+      "jet ET resolution (HB+HE); (L1 Jet E_{T} - Offline Jet E_{T})/Offline Jet E_{T}; events", 50, -1, 1.5);
+
+  h_resolutionJetPhi_HB_ = ibooker.book1D("resolutionJetPhi_HB",
+      "#phi_{jet} resolution (HB); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      0.3);
+  h_resolutionJetPhi_HE_ = ibooker.book1D("resolutionJetPhi_HE",
+      "jet #phi resolution (HE); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      0.3);
+  h_resolutionJetPhi_HF_ = ibooker.book1D("resolutionJetPhi_HF",
+      "jet #phi resolution (HF); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      0.3);
+  h_resolutionJetPhi_HB_HE_ = ibooker.book1D("resolutionJetPhi_HB_HE",
+      "jet #phi resolution (HB+HE); (#phi_{jet}^{L1} - #phi_{jet}^{offline})/#phi_{jet}^{offline}; events", 120, -0.3,
+      0.3);
+
+  h_resolutionJetEta_ = ibooker.book1D("resolutionJetEta",
+      "jet #eta resolution  (HB); (L1 Jet #eta - Offline Jet #eta)/Offline Jet #eta; events", 120, -0.3, 0.3);
+
+  // jet turn-ons
+  ibooker.setCurrentFolder(efficiencyFolder_.c_str());
+  std::vector<float> jetBins(jetEfficiencyBins_.begin(), jetEfficiencyBins_.end());
+  int nBins = jetBins.size() - 1;
+  float* jetBinArray = &(jetBins[0]);
+
+  for (auto threshold : jetEfficiencyThresholds_) {
+    std::string str_threshold = std::to_string(int(threshold));
+    h_efficiencyJetEt_HB_pass_[threshold] = ibooker.book1D("efficiencyJetEt_HB_threshold_" + str_threshold + "_Num",
+        "jet efficiency (HB); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+    h_efficiencyJetEt_HE_pass_[threshold] = ibooker.book1D("efficiencyJetEt_HE_threshold_" + str_threshold + "_Num",
+        "jet efficiency (HE); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+    h_efficiencyJetEt_HF_pass_[threshold] = ibooker.book1D("efficiencyJetEt_HF_threshold_" + str_threshold + "_Num",
+        "jet efficiency (HF); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+    h_efficiencyJetEt_HB_HE_pass_[threshold] = ibooker.book1D(
+        "efficiencyJetEt_HB_HE_threshold_" + str_threshold + "_Num",
+        "jet efficiency (HB+HE); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+
+    h_efficiencyJetEt_HB_total_[threshold] = ibooker.book1D("efficiencyJetEt_HB_threshold_" + str_threshold + "_Den",
+        "jet efficiency (HB); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+    h_efficiencyJetEt_HE_total_[threshold] = ibooker.book1D("efficiencyJetEt_HE_threshold_" + str_threshold + "_Den",
+        "jet efficiency (HE); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+    h_efficiencyJetEt_HF_total_[threshold] = ibooker.book1D("efficiencyJetEt_HF_threshold_" + str_threshold + "_Den",
+        "jet efficiency (HF); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+    h_efficiencyJetEt_HB_HE_total_[threshold] = ibooker.book1D(
+        "efficiencyJetEt_HB_HE_threshold_" + str_threshold + "_Den",
+        "jet efficiency (HB+HE); Offline Jet E_{T} (GeV); events", nBins, jetBinArray);
+  }
+
+  ibooker.cd();
+}
+
+//
+// -------------------------------------- functions --------------------------------------------
+//
+double L1TStage2CaloLayer2Offline::Distance(const reco::Candidate & c1, const reco::Candidate & c2)
+{
+  return deltaR(c1, c2);
+}
+
+double L1TStage2CaloLayer2Offline::DistancePhi(const reco::Candidate & c1, const reco::Candidate & c2)
+{
+  return deltaPhi(c1.p4().phi(), c2.p4().phi());
+}
+
+// This always returns only a positive deltaPhi
+double L1TStage2CaloLayer2Offline::calcDeltaPhi(double phi1, double phi2)
+{
+  double deltaPhi = phi1 - phi2;
+  if (deltaPhi < 0)
+    deltaPhi = -deltaPhi;
+  if (deltaPhi > 3.1415926) {
+    deltaPhi = 2 * 3.1415926 - deltaPhi;
+  }
+  return deltaPhi;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE (L1TStage2CaloLayer2Offline);

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -9,14 +9,6 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "TLorentzVector.h"
 
-#include <iostream>
-#include <iomanip>
-#include <stdio.h>
-#include <string>
-#include <sstream>
-#include <math.h>
-#include <algorithm>
-
 //
 // -------------------------------------- Constructor --------------------------------------------
 //

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -172,8 +172,7 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
     if (et < 30) {
       continue;
     }
-    TVector2 jetVec(0., 0.);
-    jetVec.SetMagPhi(et, jet->phi());
+    TVector2 jetVec(et * cos(jet->phi()), et * sin(jet->phi()));
     recoHTT += et;
     mht -= jetVec;
   }
@@ -185,9 +184,9 @@ void L1TStage2CaloLayer2Offline::fillEnergySums(edm::Event const& e, const unsig
   // if no reco value, relative resolution does not make sense -> sort to overflow
   double outOfBounds = 9999;
   double resolutionMET = recoMET > 0 ? (l1MET - recoMET) / recoMET : outOfBounds;
-  double resolutionMETPhi = abs(recoMETPhi) > 0 ? (l1METPhi - recoMETPhi) / recoMETPhi : outOfBounds;
+  double resolutionMETPhi = std::abs(recoMETPhi) > 0 ? (l1METPhi - recoMETPhi) / recoMETPhi : outOfBounds;
   double resolutionMHT = recoMHT > 0 ? (l1MHT - recoMHT) / recoMHT : outOfBounds;
-  double resolutionMHTPhi = abs(recoMHTPhi) > 0 ? (l1MHTPhi - recoMHTPhi) / recoMHTPhi : outOfBounds;
+  double resolutionMHTPhi = std::abs(recoMHTPhi) > 0 ? (l1MHTPhi - recoMHTPhi) / recoMHTPhi : outOfBounds;
   double resolutionETT = recoETT > 0 ? (l1ETT - recoETT) / recoETT : outOfBounds;
   double resolutionHTT = recoHTT > 0 ? (l1HTT - recoHTT) / recoHTT : outOfBounds;
 
@@ -253,12 +252,12 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   }
 
   if (caloJets->size() == 0) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "no calo jets found" << std::endl;
+    LogDebug("L1TStage2CaloLayer2Offline") << "no calo jets found" << std::endl;
     return;
   }
 
   if (l1Jets->size() == 0) {
-    edm::LogError("L1TStage2CaloLayer2Offline") << "no L1 jets found" << std::endl;
+    LogDebug("L1TStage2CaloLayer2Offline") << "no L1 jets found" << std::endl;
     return;
   }
 
@@ -300,15 +299,15 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
   // if no reco value, relative resolution does not make sense -> sort to overflow
   double outOfBounds = 9999;
   double resolutionEt = recoEt > 0 ? (l1Et - recoEt) / recoEt : outOfBounds;
-  double resolutionEta = abs(recoEta) > 0 ? (l1Eta - recoEta) / recoEta : outOfBounds;
-  double resolutionPhi = abs(recoPhi) > 0 ? (l1Phi - recoPhi) / recoPhi : outOfBounds;
+  double resolutionEta = std::abs(recoEta) > 0 ? (l1Eta - recoEta) / recoEta : outOfBounds;
+  double resolutionPhi = std::abs(recoPhi) > 0 ? (l1Phi - recoPhi) / recoPhi : outOfBounds;
 
   using namespace dqmoffline::l1t;
   // eta
   fill2DWithinLimits(h_L1JetEtavsCaloJetEta_, recoEta, l1Eta);
   fillWithinLimits(h_resolutionJetEta_, resolutionEta);
 
-  if (abs(recoEta) <= 1.479) { // barrel
+  if (std::abs(recoEta) <= 1.479) { // barrel
     // et
     fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_, recoEt, l1Et);
     fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_HE_, recoEt, l1Et);
@@ -333,7 +332,7 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
       }
     }
 
-  } else if (abs(recoEta) <= 3.0) { // end-cap
+  } else if (std::abs(recoEta) <= 3.0) { // end-cap
     // et
     fill2DWithinLimits(h_L1JetETvsCaloJetET_HE_, recoEt, l1Et);
     fill2DWithinLimits(h_L1JetETvsCaloJetET_HB_HE_, recoEt, l1Et);
@@ -565,31 +564,6 @@ void L1TStage2CaloLayer2Offline::bookJetHistos(DQMStore::IBooker & ibooker)
   }
 
   ibooker.cd();
-}
-
-//
-// -------------------------------------- functions --------------------------------------------
-//
-double L1TStage2CaloLayer2Offline::Distance(const reco::Candidate & c1, const reco::Candidate & c2)
-{
-  return deltaR(c1, c2);
-}
-
-double L1TStage2CaloLayer2Offline::DistancePhi(const reco::Candidate & c1, const reco::Candidate & c2)
-{
-  return deltaPhi(c1.p4().phi(), c2.p4().phi());
-}
-
-// This always returns only a positive deltaPhi
-double L1TStage2CaloLayer2Offline::calcDeltaPhi(double phi1, double phi2)
-{
-  double deltaPhi = phi1 - phi2;
-  if (deltaPhi < 0)
-    deltaPhi = -deltaPhi;
-  if (deltaPhi > 3.1415926) {
-    deltaPhi = 2 * 3.1415926 - deltaPhi;
-  }
-  return deltaPhi;
 }
 
 //define this as a plug-in

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -1,0 +1,91 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('L1TStage2EmulatorDQM', eras.Run2_2016)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load(
+    'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+# load DQM
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+process.maxEvents = cms.untracked.PSet(
+    input=cms.untracked.int32(-1)
+)
+
+# Input source
+
+# das_client.py --limit 0 --query "file dataset=/RelValTTbarLepton_13/CMSSW_8_1_0_pre12-81X_mcRun2_asymptotic_v8-v1/GEN-SIM-RECO" > fileList.global
+# download first file
+# export $xrdfile=`head -1 fileList.global`
+# xrdcp root://xrootd-cms.infn.it/$f TEST.root
+# echo "file://$PWD/TEST.root" > fileList.local
+# or use fileList.global
+with open('fileList.local') as f:
+    fileList = f.readlines()
+# das_client.py --limit 0 --query "file dataset=/RelValTTbarLepton_13/CMSSW_8_1_0_pre12-81X_mcRun2_asymptotic_v8-v1/GEN-SIM-DIGI-RAW-HLTDEBUG" > fileListRAW.global
+# export xrdfile=`head -1 fileListRAW.global`
+# xrdcp root://xrootd-cms.infn.it/$xrdfile TEST_RAW.root
+# echo "file://$PWD/TEST_RAW.root" > fileListRAW.local
+# or use fileListRAW.global
+with open('fileListRAW.local') as f:
+    fileListRAW = f.readlines()
+process.source = cms.Source(
+    "PoolSource",
+    fileNames=cms.untracked.vstring(fileList[0]),
+    secondaryFileNames=cms.untracked.vstring(
+        fileListRAW),
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Output definition
+process.DQMoutput = cms.OutputModule(
+    "DQMRootOutputModule",
+    fileName=cms.untracked.string(
+        "L1TOffline_L1TStage2CaloLayer2_job1_RAW2DIGI_RECO_DQM.root")
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+
+process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi')
+process.dqmoffline_step = cms.Path(
+    process.l1tStage2CaloLayer2OfflineDQMEmu +
+    process.l1tStage2CaloLayer2OfflineDQM
+)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+# Schedule definition
+process.schedule = cms.Schedule(
+    process.raw2digi_step, process.dqmoffline_step, process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from
+# L1Trigger.Configuration.customiseReEmul
+from L1Trigger.Configuration.customiseReEmul import L1TReEmulFromRAW
+
+# call to customisation function L1TReEmulFromRAW imported from
+# L1Trigger.Configuration.customiseReEmul
+process = L1TReEmulFromRAW(process)

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('HARVESTING')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load(
+    'Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
+process.load(
+    'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# load DQM
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+# my client and my Tests
+process.load('DQMServices.Examples.test.DQMExample_Step2_cfi')
+process.load('DQMServices.Examples.test.DQMExample_GenericClient_cfi')
+process.load('DQMServices.Examples.test.DQMExample_qTester_cfi')
+
+# L1T
+process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Efficiency_cfi')
+process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Diff_cfi')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input=cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source(
+    "DQMRootSource",
+    fileNames=cms.untracked.vstring(
+        "file:L1TOffline_L1TStage2CaloLayer2_job1_RAW2DIGI_RECO_DQM.root")
+)
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  # for MC
+
+
+# Path and EndPath definitions
+process.myHarvesting = cms.Path(process.DQMExample_Step2)
+process.myEff = cms.Path(
+    process.l1tStage2CaloLayer2Efficiency * process.l1tStage2CaloLayer2EmuDiff
+)
+process.myTest = cms.Path(process.DQMExample_qTester)
+process.dqmsave_step = cms.Path(process.dqmSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(
+    process.myEff,
+    #     process.myTest,
+    #     process.myHarvesting,
+    process.dqmsave_step
+)
+
+process.DQMStore.verbose = cms.untracked.int32(1)
+process.DQMStore.verboseQT = cms.untracked.int32(1)
+
+#process.DQMStore.collateHistograms = cms.untracked.bool(True)
+#process.dqmSaver.saveAtJobEnd = cms.untracked.bool(True)
+#process.dqmSaver.forceRunNumber = cms.untracked.int32(123456)
+
+process.dqmSaver.workflow = '/L1T/L1TStage2CaloLayer2/DQM'


### PR DESCRIPTION
This PR includes Offline DQM components for the Stage 2 Calo Layer 2.
In particular, this DQM focuses on energy sums and jets and their L1T-reco comparison including the L1T emulator.
Also included are the `L1TEfficiencyHarvesting` module, an improved copy of the now diverged `L1TEfficiency_Harvesting` module, and the `L1TDiffHarvesting` module for the comparison between L1T and emulator results. The plan is to reconcile the `L1TEfficiencyHarvesting` and `L1TEfficiency_Harvesting` modules into one in a future PR.

The PR has been tested on TTJet simulation
 - `/RelValTTbarLepton_13/CMSSW_8_1_0_pre12-81X_mcRun2_asymptotic_v8-v1/GEN-SIM-RECO`
 - `/RelValTTbarLepton_13/CMSSW_8_1_0_pre12-81X_mcRun2_asymptotic_v8-v1/GEN-SIM-DIGI-RAW-HLTDEBUG`)

but results from ` runTheMatrix.py -l limited -i all` are still pending.

Edited blocks in python configs have been formatted according to PEP8 style guide.
Automatically ported from CMSSW_9_0_X #16704 (original by @kreczko).
Please wait for a new IB (12 to 24H) before requesting to test this PR.