### PR TITLE
XorShift128Plus Random Engine for RandomNumberGeneratorService

### DIFF
--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -56,6 +56,7 @@ namespace edm {
     const std::uint32_t RandomNumberGeneratorService::maxSeedRanecu =   2147483647U;
     const std::uint32_t RandomNumberGeneratorService::maxSeedHepJames =  900000000U;
     const std::uint32_t RandomNumberGeneratorService::maxSeedTRandom3 = 4294967295U;
+    const std::uint32_t RandomNumberGeneratorService::maxSeedXorShift128Plus = std::numeric_limits<uint32_t>::max();
 
     RandomNumberGeneratorService::RandomNumberGeneratorService(ParameterSet const& pset,
                                                                ActivityRegistry& activityRegistry):
@@ -144,6 +145,25 @@ namespace edm {
               << "The RanecuEngine seeds should be in the range 0 to 2147483647.\n"
               << "The seeds passed to the RandomNumberGenerationService from the\n"
                  "configuration file were " << initialSeedSet[0] << " and " << initialSeedSet[1]
+              << "\nThis was for the module with label \"" << label << "\".\n";
+          }
+        } else if( engineName == std::string("XorShift128Plus") ) {
+          if( initialSeedSet.Size() != 4U ) {
+            throw Exception(errors::Configuration)
+              << "Random engines of type \"XorShift128Plus\" require 4 seeds\n"
+              << "be specified with the parameter named \"initialSeedSet\".\n"
+              << "Either \"initialSeedSet\" was not in the configuration\n"
+              << "or its size was not 4 for the module with label \"" << label << "\".\n" ;
+          }
+          if(initialSeedSet[0] > maxSeedXorShift128Plus ||
+             initialSeedSet[1] > maxSeedXorShift128Plus || 
+             initialSeedSet[2] > maxSeedXorShift128Plus ||
+             initialSeedSet[3] > maxSeedXorShift128Plus) {  // They need to fit in a 31 bit integer
+            throw Exception(errors::Configuration)
+              << "The XorShift128Plus seeds should be in the range 0 to " << maxSeedXorShift128Plus << ".\n"
+              << "The seeds passed to the RandomNumberGenerationService from the\n"
+                 "configuration file were " << initialSeedSet[0] << " , " << initialSeedSet[1]
+              << " , " << initialSeedSet[2] << " , and " << initialSeedSet[3]
               << "\nThis was for the module with label \"" << label << "\".\n";
           }
         }

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -1258,14 +1258,26 @@ namespace edm {
         seedL[1] = static_cast<long int>(seeds[1]);
         labelAndEngine.engine()->setSeeds(seedL,0);
       } else if ( engineName == "XorShift128Plus" ) {
-        assert(seeds.size() == 4U);        
-        for( unsigned i = 0; i < 4; i++ ) {
-          labelAndEngine.setSeed(seeds[i], i);
+        assert(seeds.size() == 4U); 
+        std::uint32_t seed0 = seeds[0];
+        if( (maxSeedXorShift128Plus - seed0) >= offset1 ) {
+          seed0 += offset1;
+        } else {
+          seed0 = offset1 - (maxSeedXorShift128Plus - seed0) - 1U;
+        }
+        if((maxSeedXorShift128Plus - seed0) >= offset2) {
+          seed0 += offset2;
+        } else {
+          seed0 = offset2 - (maxSeedXorShift128Plus - seed0) - 1U;
+        }             
+
+        for( unsigned i = 0; i < 4; ++i ) {
+          labelAndEngine.setSeed( (i == 0 ? seed0 : seeds[i]), i);
         }
         long int seedL[4];
         for( unsigned i = 0; i < 4; ++i ) { 
-          seedL[i] = static_cast<long int>(seeds[i]) ; 
-        }        
+          seedL[i] = static_cast<long int>((i == 0 ? seed0 : seeds[i])); 
+        }
         labelAndEngine.engine()->setSeeds(seedL,0);
       } else {
         assert(seeds.size() == 1U);

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -279,6 +279,7 @@ namespace edm {
       static const std::uint32_t maxSeedRanecu;
       static const std::uint32_t maxSeedHepJames;
       static const std::uint32_t maxSeedTRandom3;
+      static const std::uint32_t maxSeedXorShift128Plus;
     };
   }
 }

--- a/IOMC/RandomEngine/src/XorShift128PlusAdaptor.cc
+++ b/IOMC/RandomEngine/src/XorShift128PlusAdaptor.cc
@@ -1,0 +1,192 @@
+#include "IOMC/RandomEngine/src/XorShift128PlusAdaptor.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "CLHEP/Random/engineIDulong.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "TBufferFile.h"
+
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdint.h>
+#include <string>
+#include <time.h>
+#include <limits>
+
+namespace edm {
+
+XorShift128PlusAdaptor::XorShift128PlusAdaptor() {
+  srand(time(NULL));
+  for( auto& seed : seeds ) {
+    seed = rand();
+  }
+}
+
+XorShift128PlusAdaptor::XorShift128PlusAdaptor( const std::array<uint64_t,2>& inseeds ) {  
+  if( inseeds[0] == 0 && inseeds[1] == 0 ) {
+    Grumble(std::string("XorShift128Plus cannot be seeded with all zeroes!"));
+  }
+
+  for( unsigned i = 0; i < inseeds.size(); ++i ) {
+    seeds[2*i] = inseeds[i]&0xffffffff;
+    seeds[2*i+1] = (inseeds[i]>>32)&0xffffffff;    
+  }
+  
+}
+
+XorShift128PlusAdaptor::XorShift128PlusAdaptor( const std::array<uint32_t,4>& inseeds ) {
+  if( inseeds[0] == 0 && inseeds[1] == 0  && 
+      inseeds[2] == 0 && inseeds[3] == 0 ) {
+    Grumble(std::string("XorShift128Plus cannot be seeded with all zeroes!"));
+  }
+
+  for( unsigned i = 0; i < inseeds.size(); ++i ) {
+    seeds[i] = inseeds[i];
+  }  
+}
+
+XorShift128PlusAdaptor::XorShift128PlusAdaptor(std::istream&) {
+  Grumble(std::string("Cannot instantiate a TRandom engine from an istream"));
+}
+
+XorShift128PlusAdaptor::~XorShift128PlusAdaptor() {
+}
+
+std::ostream& XorShift128PlusAdaptor::put(std::ostream& os) const {
+  Grumble(std::string("put(std::ostream) not available for TRandom engines"));
+  return os;
+}
+
+std::vector<unsigned long> XorShift128PlusAdaptor::put() const {
+  std::vector<unsigned long> v;
+  v.reserve(5);
+  v.push_back(CLHEP::engineIDulong<XorShift128PlusAdaptor>());
+  for(int i = 0; i < 4; ++i) v.push_back(seeds[i]);
+  return v;
+}
+
+uint64_t  XorShift128PlusAdaptor::getNumber() {
+  uint64_t s1 = (uint64_t)seeds[0] + (((uint64_t)seeds[1])<<32);
+  const uint64_t s0 = (uint64_t)seeds[2] + (((uint64_t)seeds[3])<<32);
+  seeds[0] = s0&0xffffffff;
+  seeds[1] = (s0>>32)&0xffffffff;
+  s1 ^= s1 << 23; // a
+  s1 = s1 ^ s0 ^ (s1 >> 18) ^ (s0 >> 5);// b, c
+  seeds[2] = s1&0xffffffff; 
+  seeds[3] = (s1>>32)&0xffffffff;
+  return s1 + s0; 
+}
+
+double XorShift128PlusAdaptor::flat() { 
+  return ((double)getNumber())/((double)std::numeric_limits<uint64_t>::max()); 
+}
+
+void XorShift128PlusAdaptor::flatArray(int const size, double* vect) {
+  for( int i = 0; i < size; ++i ) {
+    vect[i] = flat();
+  }
+}
+
+void XorShift128PlusAdaptor::setSeed(long seed, int idx) { 
+  if(idx > 2) Grumble(std::string("XorShift128Plus only has two seeds, setting to %2 of idx!"));
+  const int realidx = idx%4;
+  seeds[realidx]  = (uint32_t)seed;
+}
+
+// Sets the state of the algorithm according to the zero terminated
+// array of seeds. It is allowed to ignore one or many seeds in this array.
+void XorShift128PlusAdaptor::setSeeds(long const* inseeds, int) { 
+  for(unsigned i = 0; i < 4; ++i ) {
+    if( seeds[i] == 0 ) break;
+    seeds[i] = (uint32_t)inseeds[i];
+  }
+}
+
+// Saves the current engine status in the named file
+void XorShift128PlusAdaptor::saveStatus(char const filename[]) const {
+  std::ofstream outFile( filename, std::ios::app ) ;  
+  if (!outFile.bad()) {
+    outFile << "Uvec\n";
+    std::vector<unsigned long> v = put();
+    for (unsigned int i=0; i<v.size(); ++i) {
+      outFile << v[i] << "\n";
+    }
+  }
+}
+
+// Reads from named file the the last saved engine status and restores it.
+void XorShift128PlusAdaptor::restoreStatus(char const filename[]) {
+  std::ifstream inFile( filename, std::ios::in);
+  if (!checkFile ( inFile, filename, engineName(), "restoreStatus" )) {
+    edm::LogVerbatim("XorShift128Plus") << "  -- Engine state remains unchanged\n";
+    return;
+  }
+  if ( CLHEP::possibleKeywordInput ( inFile, "Uvec", theSeed ) ) {
+    std::vector<unsigned long> v;
+    unsigned long xin;
+    for (unsigned int ivec=0; ivec < VECTOR_STATE_SIZE; ++ivec) {
+      inFile >> xin;
+      if (!inFile) {
+        inFile.clear(std::ios::badbit | inFile.rdstate());
+        edm::LogVerbatim("XorShift128Plus") << "\nXorShift128Plus state (vector) description improper."
+                                            << "\nrestoreStatus has failed."
+                                            << "\nInput stream is probably mispositioned now." << std::endl;
+        return;
+      }
+      v.push_back(xin);
+    }
+    getState(v);
+    return;
+  }
+  
+  if (!inFile.bad() && !inFile.eof()) {
+    for (int i=0; i<4; ++i)
+      inFile >> seeds[i];
+  }
+}
+
+void XorShift128PlusAdaptor::showStatus() const {
+  edm::LogVerbatim("XorShift128Plus") << std::endl;
+  edm::LogVerbatim("XorShift128Plus") << "--------- XorShift128Plus engine status ---------" << std::endl;
+  edm::LogVerbatim("XorShift128Plus") << " Current seeds = "
+                                      << seeds[0] << ", "
+                                      << seeds[1] << ", " 
+                                      << seeds[2] << ", "
+                                      << seeds[3] << std::endl;
+  edm::LogVerbatim("XorShift128Plus") << "----------------------------------------" << std::endl;
+}
+
+std::istream& XorShift128PlusAdaptor::get(std::istream& is) {
+  Grumble(std::string("get(std::istream) not available for TRandom engines"));
+  return getState(is);
+}
+
+std::istream& XorShift128PlusAdaptor::getState(std::istream& is) {
+  Grumble(std::string("getState(std::istream) not available for TRandom engines"));
+  return is;
+}
+
+bool XorShift128PlusAdaptor::get(std::vector<unsigned long> const& v) {
+  if(v.empty() || v.size() != VECTOR_STATE_SIZE)  return false;
+  if(v[0] != CLHEP::engineIDulong<XorShift128PlusAdaptor>()) return false;
+  
+  for(unsigned i = 0; i < 4; ++i ) {
+    seeds[i] = v[i+1];
+  }
+
+  return true;
+}
+
+void XorShift128PlusAdaptor::Grumble(std::string const& errortext) const {
+
+// Throw an edm::Exception for unimplemented functions
+   std::ostringstream sstr;
+   sstr << "Unimplemented Feature: " << errortext << '\n';
+   edm::Exception except(edm::errors::UnimplementedFeature, sstr.str());
+   throw except;
+}
+
+}  // namespace edm

--- a/IOMC/RandomEngine/src/XorShift128PlusAdaptor.cc
+++ b/IOMC/RandomEngine/src/XorShift128PlusAdaptor.cc
@@ -15,6 +15,9 @@
 #include <string>
 #include <time.h>
 
+namespace {
+  constexpr double uint64_norm = 1.0/((double)std::numeric_limits<uint64_t>::max());
+}
 
 namespace edm {
 
@@ -90,8 +93,7 @@ uint64_t  XorShift128PlusAdaptor::getNumber() {
 }
 
 double XorShift128PlusAdaptor::flat() { 
-  const double result = ((double)getNumber())/((double)std::numeric_limits<uint64_t>::max());
-  return result; 
+  return uint64_norm*getNumber(); 
 }
 
 void XorShift128PlusAdaptor::flatArray(int const size, double* vect) {

--- a/IOMC/RandomEngine/src/XorShift128PlusAdaptor.cc
+++ b/IOMC/RandomEngine/src/XorShift128PlusAdaptor.cc
@@ -35,7 +35,6 @@ XorShift128PlusAdaptor::XorShift128PlusAdaptor( const std::array<uint64_t,2>& in
     Grumble(std::string("XorShift128Plus cannot be seeded with all zeroes!"));
   }
   seeds = inseeds;
-  state = seeds;
   theSeeds = reinterpret_cast<const int64_t*>(seeds.data());
 }
 
@@ -52,9 +51,9 @@ XorShift128PlusAdaptor::XorShift128PlusAdaptor( const std::array<uint32_t,4>& in
   seeds.fill(0ULL);
   for( size_t i = 0; i < inseeds.size() && i < 4; ++i ) {
     uint64_t temp = inseeds[i];
-    seeds[i/2] = ( temp <<( i%2 ? 0 : 32 ) ); 
+    seeds[i/2] += ( temp <<( i%2 ? 0 : 32 ) ); 
   }
-  state = seeds;
+  
   theSeeds = reinterpret_cast<const int64_t*>(seeds.data());
 }
 
@@ -75,25 +74,23 @@ std::vector<unsigned long> XorShift128PlusAdaptor::put() const {
   v.reserve(5);
   v.push_back(CLHEP::engineIDulong<XorShift128PlusAdaptor>());
   for(int i = 0; i < 2; ++i) {
-    v.push_back(state[i]&uint_max);
-    v.push_back((state[i]>>32)&uint_max);
+    v.push_back(seeds[i]&uint_max);
+    v.push_back((seeds[i]>>32)&uint_max);
   }
   return v;
 }
 
 uint64_t  XorShift128PlusAdaptor::getNumber() {
-  uint64_t x = state[0];
-  const uint64_t y = state[1];
-  state[0] = y;
+  uint64_t x = seeds[0];
+  const uint64_t y = seeds[1];
+  seeds[0] = y;
   x ^= x << 23; // a
-  state[1] = x ^ y ^ (x >> 17) ^ (y >> 26); // b, c
-  return state[1] + y;
+  seeds[1] = x ^ y ^ (x >> 17) ^ (y >> 26); // b, c
+  return seeds[1] + y;
 }
 
 double XorShift128PlusAdaptor::flat() { 
-  const uint64_t number = getNumber();
-  const double result = ((double)number)/((double)std::numeric_limits<uint64_t>::max());
-  std::cout << "xorshift128plus ::flat() = " << number << ' ' << result << std::endl;
+  const double result = ((double)getNumber())/((double)std::numeric_limits<uint64_t>::max());
   return result; 
 }
 
@@ -104,24 +101,23 @@ void XorShift128PlusAdaptor::flatArray(int const size, double* vect) {
 }
 
 void XorShift128PlusAdaptor::setSeed(long seed, int idx) { 
-  if(idx > 4) Grumble(std::string("XorShift128Plus only has four seeds!"));
+  if(idx >= 4) Grumble(std::string("XorShift128Plus only has four seeds!"));
   const int shift   = 32*(idx%2);
   const int realidx = idx/2;
-  seeds[realidx]  = (uint64_t)seed << (shift*32);
-  state = seeds;
+  seeds[realidx] = seeds[realidx] & ~((uint64_t)uint_max << shift*32);
+  seeds[realidx] += (uint64_t)seed << (shift*32);
   theSeeds = reinterpret_cast<const int64_t*>(seeds.data());
 }
 
 // Sets the state of the algorithm according to the zero terminated
 // array of seeds. It is allowed to ignore one or many seeds in this array.
 void XorShift128PlusAdaptor::setSeeds(long const* inseeds, int) { 
+  seeds.fill(0ULL);
   for(unsigned i = 0; i < 4; ++i ) {
-    if( seeds[i] == 0 ) break;
     const int shift   = 32*(i%2);
     const int realidx = i/2;
-    seeds[realidx]  = (uint64_t)inseeds[i] << shift;
+    seeds[realidx] += (uint64_t)inseeds[i] << shift;
   }
-  state = seeds;
   theSeeds = reinterpret_cast<const int64_t*>(seeds.data());
 }
 
@@ -192,12 +188,12 @@ bool XorShift128PlusAdaptor::get(std::vector<unsigned long> const& v) {
   if(v.empty() || v.size() != VECTOR_STATE_SIZE)  return false;
   if(v[0] != CLHEP::engineIDulong<XorShift128PlusAdaptor>()) return false;
   
+  seeds.fill(0ULL);
   for(unsigned i = 0; i < 4; ++i ) {
-    const int shift   = 32*i%2;
+    const int shift   = 32*(i%2);
     const int realidx = i/2;
-    seeds[realidx] = (uint64_t) v[i+1] << shift;
+    seeds[realidx] += (uint64_t)(v[i+1]) << shift;
   }
-  state = seeds;
   return true;
 }
 

--- a/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
+++ b/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
@@ -77,9 +77,7 @@ namespace edm {
     uint64_t getNumber();
 
     void Grumble(std::string const& errortext) const;
-
-
-    std::array<uint64_t, 2> state;
+    
     std::array<uint64_t, 2> seeds;
 
     static const unsigned int VECTOR_STATE_SIZE = 5; //convert from 64 to 32 bit

--- a/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
+++ b/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
@@ -65,7 +65,7 @@ namespace edm {
 
     // Returns the engine name as a string
     std::string name() const { return engineName(); }
-    static std::string engineName() { return std::string("XorShift128PlusAdaptor"); }
+    static std::string engineName() { return std::string("XorShift128Plus"); }
 
     std::vector<unsigned long> put () const;
     bool get (std::vector<unsigned long> const& v);
@@ -77,9 +77,9 @@ namespace edm {
 
     void Grumble(std::string const& errortext) const;
 
-    std::array<uint32_t, 4> seeds;
+    std::array<uint64_t, 2> seeds;
 
-    static const unsigned int VECTOR_STATE_SIZE = 5;
+    static const unsigned int VECTOR_STATE_SIZE = 5; //convert from 64 to 32 bit
   }; // XorShift128PlusAdaptor
 
 }  // namespace edm

--- a/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
+++ b/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
@@ -1,0 +1,87 @@
+#ifndef IOMC_RandomEngine_XorShift128PlusAdaptor_h
+#define IOMC_RandomEngine_XorShift128PlusAdaptor_h
+
+#include "CLHEP/Random/RandomEngine.h"
+
+#include <cmath>
+#include <cstdint>
+#include <atomic>
+#include <array>
+
+// This implements the "xorshift128plus" randomnumber generator from
+// http://xorshift.di.unimi.it/xorshift128plus.c
+// as a CLHEP::RandomEngine
+// its period is 2^128 - 1
+// This is one of the fastest PRNGs available that actually generates 
+// passes standard tests.
+
+namespace edm {
+
+  class XorShift128PlusAdaptor : public CLHEP::HepRandomEngine {
+
+  public:
+    // Constructors and destructor.
+    XorShift128PlusAdaptor();
+    XorShift128PlusAdaptor( const std::array<uint64_t,2>& inseeds );
+    XorShift128PlusAdaptor( const std::array<uint32_t,4>& inseeds );
+    XorShift128PlusAdaptor( std::istream & is );
+    virtual ~XorShift128PlusAdaptor();
+
+    // Returns a pseudo random number in ]0,1[ (i. e., excluding the end points).
+    double flat();
+
+    // Fills an array "vect" of specified size with flat random values.
+    void flatArray(int const size, double* vect);
+
+    // Sets the state of the algorithm according to seed.
+    void setSeed(long seed, int);
+
+    // Sets the state of the algorithm according to the zero terminated
+    // array of seeds. It is allowed to ignore one or many seeds in this array.
+    void setSeeds(long const* seeds, int);
+
+    // Saves the current engine status in the named file
+    void saveStatus(char const filename[] = "TRandom.conf") const;
+
+    // Reads from named file the the last saved engine status and restores it.
+    void restoreStatus(char const filename[] = "TRandom.conf" );
+
+    // Dumps the current engine status on the screen.
+    void showStatus() const;
+
+    // Returns a float flat ]0,1[
+    operator float() { return (float)flat(); }
+
+    // Returns an unsigned int (32-bit) flat 
+    operator unsigned int() { return (unsigned int)(getNumber()&0xffffffff); }
+    
+    // returns a uint64_t
+    operator uint64_t() { return getNumber(); } 
+
+    virtual std::ostream & put (std::ostream & os) const;
+    virtual std::istream & get (std::istream & is);
+    std::string beginTag ( ) { return engineName()+std::string("-begin"); }
+    virtual std::istream & getState ( std::istream & is );
+
+    // Returns the engine name as a string
+    std::string name() const { return engineName(); }
+    static std::string engineName() { return std::string("XorShift128PlusAdaptor"); }
+
+    std::vector<unsigned long> put () const;
+    bool get (std::vector<unsigned long> const& v);
+    bool getState (std::vector<unsigned long> const& v) { return get(v); }
+    
+  private:
+
+    uint64_t getNumber();
+
+    void Grumble(std::string const& errortext) const;
+
+    std::array<uint32_t, 4> seeds;
+
+    static const unsigned int VECTOR_STATE_SIZE = 5;
+  }; // XorShift128PlusAdaptor
+
+}  // namespace edm
+
+#endif // IOMC_RandomEngine_XorShift128PlusAdaptor_h

--- a/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
+++ b/IOMC/RandomEngine/src/XorShift128PlusAdaptor.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <atomic>
 #include <array>
+#include <limits>
 
 // This implements the "xorshift128plus" randomnumber generator from
 // http://xorshift.di.unimi.it/xorshift128plus.c
@@ -77,9 +78,13 @@ namespace edm {
 
     void Grumble(std::string const& errortext) const;
 
+
+    std::array<uint64_t, 2> state;
     std::array<uint64_t, 2> seeds;
 
     static const unsigned int VECTOR_STATE_SIZE = 5; //convert from 64 to 32 bit
+    static constexpr uint32_t uint_max = std::numeric_limits<uint32_t>::max();
+    static constexpr double   uint_norm = 1.0/(double)uint_max;
   }; // XorShift128PlusAdaptor
 
 }  // namespace edm

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -72,6 +72,7 @@ the text file containing the states.
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Random/JamesRandom.h"
 #include "CLHEP/Random/RanecuEngine.h"
+#include "IOMC/RandomEngine/src/XorShift128PlusAdaptor.h"
 
 #include <fstream>
 #include <iostream>
@@ -83,6 +84,7 @@ the text file containing the states.
 
 namespace {
   std::mutex write_mutex;
+  constexpr uint32_t maxSeedXorShift128Plus = std::numeric_limits<uint32_t>::max();
 }
 
 class TestRandomNumberServiceStreamCache {
@@ -242,7 +244,7 @@ TestRandomNumberServiceGlobal::analyze(edm::StreamID streamID, edm::Event const&
        randomNumberEvent2_ != cache->referenceRandomNumbers_.at(2 + 4 * (cache->countEvents_ + skippedEvents_.at(cache->countEvents_))) ||
        randomNumberEvent3_ != cache->referenceRandomNumbers_.at(3 + 4 * (cache->countEvents_ + skippedEvents_.at(cache->countEvents_)))) {
         throw cms::Exception("TestRandomNumberService")
-          << "TestRandomNumberServiceGlobal::analyze: Random sequence does not match expected sequence";
+          << "TestRandomNumberServiceGlobal::analyze: Random sequence does not match expected sequence (skipped)";
       }
     }
   }
@@ -337,10 +339,27 @@ TestRandomNumberServiceGlobal::globalBeginLuminosityBlock(edm::LuminosityBlock c
   }
 
   if(engineName_ == "RanecuEngine") {
-    lumiCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new CLHEP::RanecuEngine()); // propagate_const<T> has no reset() function
+    lumiCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new CLHEP::RanecuEngine()); // propagate_const<T> has no reset() functions
     long int seedL[2];
     seedL[0] = static_cast<long int>(seed0);
     seedL[1] = static_cast<long int>(seeds_.at(1));
+    lumiCache->referenceEngine_->setSeeds(seedL,0);
+  }
+  else if ( engineName_ == "XorShift128Plus") {
+    lumiCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new edm::XorShift128PlusAdaptor()); // propagate_const<T> has no reset() function
+    long int seedL[4];
+    std::uint32_t seed0 = seeds_[0];
+    if( (maxSeedXorShift128Plus - seed0) >= nStreams_ ) {
+      seed0 += nStreams_;
+    } else {
+      seed0 = nStreams_ - (maxSeedXorShift128Plus - seed0) - 1U;
+    }    
+    if(lumi.luminosityBlockAuxiliary().luminosityBlock() < seedByLumi_.size()) {
+      seed0 = seedByLumi_.at(lumi.luminosityBlockAuxiliary().luminosityBlock());
+    }
+    for( unsigned i = 0; i < seeds_.size(); ++i ) {
+      seedL[i] = static_cast<long int>(i == 0 ? seed0 : seeds_.at(i));
+    }
     lumiCache->referenceEngine_->setSeeds(seedL,0);
   }
   else {
@@ -359,10 +378,13 @@ TestRandomNumberServiceGlobal::globalBeginLuminosityBlock(edm::LuminosityBlock c
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine& engine = rng->getEngine(lumi.index());
 
-  if(engine.flat() != lumiCache->referenceRandomNumbers_.at(0) ||
-     engine.flat() != lumiCache->referenceRandomNumbers_.at(1)) {
+  const auto flat1 = engine.flat();
+  const auto flat2 = engine.flat();
+
+  if(flat1 != lumiCache->referenceRandomNumbers_.at(0) ||
+     flat2 != lumiCache->referenceRandomNumbers_.at(1)) {
     throw cms::Exception("TestRandomNumberService")
-      << "TestRandomNumberServiceGlobal::globalBeginLuminosityBlock: Random sequence does not match expected sequence";
+      << "TestRandomNumberServiceGlobal::globalBeginLuminosityBlock: Random sequence does not match expected sequence (flat)";
   }
 
   return lumiCache;
@@ -393,6 +415,26 @@ TestRandomNumberServiceGlobal::beginStream(edm::StreamID streamID) const {
     long int seedL[2];
     seedL[0] = static_cast<long int>(seeds_.at(0) + streamID.value() + offset_);
     seedL[1] = static_cast<long int>(seeds_.at(1));
+    streamCache->referenceEngine_->setSeeds(seedL,0);
+  }
+  else if ( engineName_ == "XorShift128Plus") {
+    streamCache->referenceEngine_ = std::shared_ptr<CLHEP::HepRandomEngine>(new edm::XorShift128PlusAdaptor()); // propagate_const<T> has no reset() function
+    long int seedL[4];
+    std::uint32_t offset1 = streamID.value(), offset2 = offset_;
+    std::uint32_t seed0 = seeds_[0];
+    if( (maxSeedXorShift128Plus - seed0) >= offset1 ) {
+      seed0 += offset1;
+    } else {
+      seed0 = offset1 - (maxSeedXorShift128Plus - seed0) - 1U;
+    }
+    if((maxSeedXorShift128Plus - seed0) >= offset2) {
+      seed0 += offset2;
+    } else {
+      seed0 = offset2 - (maxSeedXorShift128Plus - seed0) - 1U;
+    }        
+    for( unsigned i = 0; i < seeds_.size(); ++i ) {
+      seedL[i] = static_cast<long int>(i == 0 ? seed0 : seeds_[i]);
+    }
     streamCache->referenceEngine_->setSeeds(seedL,0);
   }
   else {

--- a/IOMC/RandomEngine/test/testMultiProcess_cfg.py
+++ b/IOMC/RandomEngine/test/testMultiProcess_cfg.py
@@ -29,6 +29,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(84)
     ),
     t5 = cms.PSet(
+        initialSeedSet = cms.untracked.uint32(454, 232, 535, 989),
+        engineName = cms.untracked.string('XorShift128Plus')
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(191),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -56,6 +60,7 @@ process.t1 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t2 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t3 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t4 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 
 process.randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
@@ -63,5 +68,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testMultiProcess.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.randomEngineStateProducer)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5+process.randomEngineStateProducer)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testMultiProcess_cfg.py
+++ b/IOMC/RandomEngine/test/testMultiProcess_cfg.py
@@ -29,8 +29,8 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(84)
     ),
     t5 = cms.PSet(
-        initialSeedSet = cms.untracked.uint32(454, 232, 535, 989),
-        engineName = cms.untracked.string('XorShift128Plus')
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(454, 232, 535, 989)       
     ),
     t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(191),

--- a/IOMC/RandomEngine/test/testMultiStreamReplay1_cfg.py
+++ b/IOMC/RandomEngine/test/testMultiStreamReplay1_cfg.py
@@ -33,6 +33,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(7)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),                                               
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(7),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -73,6 +77,14 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             nStreams = cms.untracked.uint32(3),
                             multiStreamReplay = cms.untracked.bool(True)
 )
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            offset = cms.untracked.uint32(0),
+                            maxEvents = cms.untracked.uint32(5),
+                            nStreams = cms.untracked.uint32(3),
+                            multiStreamReplay = cms.untracked.bool(True)
+)
 
 process.randomEngineStateProducer2 = cms.EDProducer("RandomEngineStateProducer")
 
@@ -80,5 +92,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testMultiStreamReplay1.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.randomEngineStateProducer2)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4++process.t5+process.randomEngineStateProducer2)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testMultiStreamReplay1_cfg.py
+++ b/IOMC/RandomEngine/test/testMultiStreamReplay1_cfg.py
@@ -79,7 +79,7 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
 )
 process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             engineName = cms.untracked.string('XorShift128Plus'),
-                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            seeds = cms.untracked.vuint32(7, 8, 9, 10),
                             offset = cms.untracked.uint32(0),
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(3),
@@ -92,5 +92,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testMultiStreamReplay1.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4++process.t5+process.randomEngineStateProducer2)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5+process.randomEngineStateProducer2)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testMultiStreamReplay2_cfg.py
+++ b/IOMC/RandomEngine/test/testMultiStreamReplay2_cfg.py
@@ -86,11 +86,11 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
 )
 process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             engineName = cms.untracked.string('XorShift128Plus'),
-                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            seeds = cms.untracked.vuint32(7, 8, 9, 10),
                             offset = cms.untracked.uint32(0),
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(3),
-                            seedByLumi = cms.untracked.vuint32(0, 88, 88, 208, 208),
+                            seedByLumi = cms.untracked.vuint32(0, 10, 10, 208, 208),
                             multiStreamReplay = cms.untracked.bool(True)
 )
 
@@ -100,5 +100,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testMultiStreamReplay2.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.randomEngineStateProducer)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5+process.randomEngineStateProducer)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testMultiStreamReplay2_cfg.py
+++ b/IOMC/RandomEngine/test/testMultiStreamReplay2_cfg.py
@@ -25,6 +25,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(7)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(7),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -78,6 +82,15 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(1),
                             seedByLumi = cms.untracked.vuint32(0, 87, 87, 207, 207),
+                            multiStreamReplay = cms.untracked.bool(True)
+)
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            offset = cms.untracked.uint32(0),
+                            maxEvents = cms.untracked.uint32(5),
+                            nStreams = cms.untracked.uint32(3),
+                            seedByLumi = cms.untracked.vuint32(0, 88, 88, 208, 208),
                             multiStreamReplay = cms.untracked.bool(True)
 )
 

--- a/IOMC/RandomEngine/test/testMultiStream_cfg.py
+++ b/IOMC/RandomEngine/test/testMultiStream_cfg.py
@@ -27,6 +27,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(84)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),                                               
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(191),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -74,6 +78,13 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(3)
 )
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(7, 8, 9, 10),
+                            offset = cms.untracked.uint32(0),
+                            maxEvents = cms.untracked.uint32(5),
+                            nStreams = cms.untracked.uint32(3)
+)
 
 process.randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
@@ -81,5 +92,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testMultiStream.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.randomEngineStateProducer)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5+process.randomEngineStateProducer)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testRandomService1_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomService1_cfg.py
@@ -58,6 +58,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(84)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(191),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -113,6 +117,13 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(1)
 )
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(7, 8, 9, 10),
+                            offset = cms.untracked.uint32(0),
+                            maxEvents = cms.untracked.uint32(5),
+                            nStreams = cms.untracked.uint32(1)
+)
 
 # If you do not want to save the state of the random engines
 # leave this line out.
@@ -126,5 +137,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testRandomService1.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.randomEngineStateProducer)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5+process.randomEngineStateProducer)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testRandomService2_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomService2_cfg.py
@@ -27,7 +27,7 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
     ),
     t5 = cms.PSet(
         engineName = cms.untracked.string('XorShift128Plus'),
-        initialSeedSet = cms.untracked.vuint32(101, 202, 303, 404)
+        initialSeedSet = cms.untracked.vuint32(101, 8, 9, 10)
     ),                                               
     t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(205),
@@ -79,7 +79,7 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
 )
 process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             engineName = cms.untracked.string('XorShift128Plus'),
-                            seeds = cms.untracked.vuint32(101, 202, 303, 404),
+                            seeds = cms.untracked.vuint32(101, 8, 9, 10),
                             offset = cms.untracked.uint32(0),
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(1)

--- a/IOMC/RandomEngine/test/testRandomService2_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomService2_cfg.py
@@ -26,6 +26,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(204)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(101, 202, 303, 404)
+    ),                                               
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(205),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -73,6 +77,13 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(1)
 )
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(101, 202, 303, 404),
+                            offset = cms.untracked.uint32(0),
+                            maxEvents = cms.untracked.uint32(5),
+                            nStreams = cms.untracked.uint32(1)
+)
 
 process.randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
@@ -80,5 +91,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testRandomService2.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.randomEngineStateProducer)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5+process.randomEngineStateProducer)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testRandomService3_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomService3_cfg.py
@@ -24,6 +24,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(84)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(1, 2, 3, 4)
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(191),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -72,6 +76,13 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(1)
 )
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            offset = cms.untracked.uint32(2),
+                            maxEvents = cms.untracked.uint32(5),
+                            nStreams = cms.untracked.uint32(1)
+)
 
 process.randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
@@ -79,5 +90,5 @@ process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('testRandomService3.root')
 )
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.randomEngineStateProducer)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5+process.randomEngineStateProducer)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testRandomService3_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomService3_cfg.py
@@ -25,7 +25,7 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
     ),
     t5 = cms.PSet(
         engineName = cms.untracked.string('XorShift128Plus'),
-        initialSeedSet = cms.untracked.vuint32(1, 2, 3, 4)
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9 , 10)
     ),
     t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(191),
@@ -78,7 +78,7 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
 )
 process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             engineName = cms.untracked.string('XorShift128Plus'),
-                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            seeds = cms.untracked.vuint32(7, 8, 9, 10),
                             offset = cms.untracked.uint32(2),
                             maxEvents = cms.untracked.uint32(5),
                             nStreams = cms.untracked.uint32(1)

--- a/IOMC/RandomEngine/test/testRandomServiceTest1_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomServiceTest1_cfg.py
@@ -36,7 +36,7 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
     ),
     t5 = cms.PSet(
         engineName = cms.untracked.string('XorShift128Plus'),
-        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+        initialSeedSet = cms.untracked.vuint32(8, 9, 10, 11)
     ),
     t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(7),
@@ -84,12 +84,12 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
 )
 process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             engineName = cms.untracked.string('XorShift128Plus'),
-                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            seeds = cms.untracked.vuint32(7, 8, 9, 10),
                             offset = cms.untracked.uint32(0),
                             maxEvents = cms.untracked.uint32(15),
                             nStreams = cms.untracked.uint32(1),
                             skippedEvents = cms.untracked.vuint32(2),
-                            seedByLumi = cms.untracked.vuint32(0, 86, 86, 206, 206),
+                            seedByLumi = cms.untracked.vuint32(0, 8, 8, 102, 102),
 )
 
 

--- a/IOMC/RandomEngine/test/testRandomServiceTest1_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomServiceTest1_cfg.py
@@ -35,6 +35,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(7)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(7),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -78,6 +82,16 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             skippedEvents = cms.untracked.vuint32(2),
                             seedByLumi = cms.untracked.vuint32(0, 85, 85, 205, 205)
 )
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            offset = cms.untracked.uint32(0),
+                            maxEvents = cms.untracked.uint32(15),
+                            nStreams = cms.untracked.uint32(1),
+                            skippedEvents = cms.untracked.vuint32(2),
+                            seedByLumi = cms.untracked.vuint32(0, 86, 86, 206, 206),
+)
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4)
+
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testRandomServiceTest2_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomServiceTest2_cfg.py
@@ -84,12 +84,12 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
 )
 process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             engineName = cms.untracked.string('XorShift128Plus'),
-                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            seeds = cms.untracked.vuint32(7, 8, 9, 10),
                             offset = cms.untracked.uint32(2),
                             maxEvents = cms.untracked.uint32(15),
                             nStreams = cms.untracked.uint32(1),
                             skippedEvents = cms.untracked.vuint32(4),
-                            seedByLumi = cms.untracked.vuint32(0, 86, 86, 206, 206),
+                            seedByLumi = cms.untracked.vuint32(0, 8, 8, 102, 102),
 )
 
 

--- a/IOMC/RandomEngine/test/testRandomServiceTest2_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomServiceTest2_cfg.py
@@ -35,6 +35,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(7)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(7),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -78,6 +82,16 @@ process.t4 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
                             skippedEvents = cms.untracked.vuint32(4),
                             seedByLumi = cms.untracked.vuint32(0, 85, 85, 205, 205)
 )
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceGlobal",
+                            engineName = cms.untracked.string('XorShift128Plus'),
+                            seeds = cms.untracked.vuint32(84, 85, 86, 87),
+                            offset = cms.untracked.uint32(2),
+                            maxEvents = cms.untracked.uint32(15),
+                            nStreams = cms.untracked.uint32(1),
+                            skippedEvents = cms.untracked.vuint32(4),
+                            seedByLumi = cms.untracked.vuint32(0, 86, 86, 206, 206),
+)
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4)
+
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testRandomServiceTest3_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomServiceTest3_cfg.py
@@ -31,6 +31,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(7)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(7),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -42,6 +46,7 @@ process.t1 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t2 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t3 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t4 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/testRandomServiceTest4_cfg.py
+++ b/IOMC/RandomEngine/test/testRandomServiceTest4_cfg.py
@@ -36,6 +36,10 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
         initialSeed = cms.untracked.uint32(7)
     ),
     t5 = cms.PSet(
+        engineName = cms.untracked.string('XorShift128Plus'),
+        initialSeedSet = cms.untracked.vuint32(7, 8, 9, 10)
+    ),
+    t6 = cms.PSet(
         initialSeed = cms.untracked.uint32(7),
         engineName = cms.untracked.string('TRandom3')
     ),
@@ -47,6 +51,7 @@ process.t1 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t2 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t3 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 process.t4 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
+process.t5 = cms.EDAnalyzer("TestRandomNumberServiceAnalyzer")
 
-process.p = cms.Path(process.t1+process.t2+process.t3+process.t4)
+process.p = cms.Path(process.t1+process.t2+process.t3+process.t4+process.t5)
 process.o = cms.EndPath(process.out)

--- a/IOMC/RandomEngine/test/unit_test_outputs/child0FirstEvent.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/child0FirstEvent.txt
@@ -2,3 +2,4 @@ t1 Event random numbers 0.422889 0.0392907 0.291227 1.61244 Lumi random numbers 
 t2 Event random numbers 0.999981 0.203459 0.668007 7.73632 Lumi random numbers 3.66345e-05 0.440199 0.548889
 t3 Event random numbers 0.257042 0.565658 0.683788 1.8103 Lumi random numbers 0.202607 0.993071 0.207093
 t4 Event random numbers 0.133504 0.85941 0.256103 11.7224 Lumi random numbers 0.00202554 0.718933 0.136718
+t5 Event random numbers 0.453129 0.0566487 0.0583806 4.15485 Lumi random numbers 0.453129 0.0566487 0.058392

--- a/IOMC/RandomEngine/test/unit_test_outputs/child1FirstEvent.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/child1FirstEvent.txt
@@ -2,3 +2,4 @@ t1 Event random numbers 0.616179 0.838397 0.174838 12.6847 Lumi random numbers 0
 t2 Event random numbers 0.999999 0.949039 0.294968 4.06209 Lumi random numbers 3.66345e-05 0.440199 0.548889
 t3 Event random numbers 0.046041 0.56008 0.370242 7.37113 Lumi random numbers 0.202607 0.993071 0.207093
 t4 Event random numbers 0.425331 0.542731 0.653642 8.09904 Lumi random numbers 0.00202554 0.718933 0.136718
+t5 Event random numbers 0.453129 0.0566487 0.0583844 4.15479 Lumi random numbers 0.453129 0.0566487 0.058392

--- a/IOMC/RandomEngine/test/unit_test_outputs/child2FirstEvent.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/child2FirstEvent.txt
@@ -2,3 +2,4 @@ t1 Event random numbers 0.640315 0.910505 0.671651 22.3338 Lumi random numbers 0
 t2 Event random numbers 1.80015e-05 0.694619 0.921928 1.38104 Lumi random numbers 3.66345e-05 0.440199 0.548889
 t3 Event random numbers 0.620374 0.900031 0.508953 6.30709 Lumi random numbers 0.202607 0.993071 0.207093
 t4 Event random numbers 0.726032 0.789293 0.892713 7.02106 Lumi random numbers 0.00202554 0.718933 0.136718
+t5 Event random numbers 0.453129 0.0566487 0.0583882 4.15473 Lumi random numbers 0.453129 0.0566487 0.058392

--- a/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
@@ -7,7 +7,8 @@ RandomNumberGeneratorService dump
         t2  3  RanecuEngine  1  2
         t3  4  TRandom3  83
         t4  5  HepJamesRandom  84
-        t5  4294967295  TRandom3  191
+        t5  6  XorShift128Plus  7  8  9  10
+        t6  4294967295  TRandom3  191
     nStreams_ = 3
     saveFileName_ = StashStateStream.data
     saveFileNameRecorded_ = 0
@@ -25,16 +26,19 @@ RandomNumberGeneratorService dump
         t2 1 2 RanecuEngine  engine does not know seeds
         t3 83 TRandom3  engine does not know seeds
         t4 84 HepJamesRandom  84
+        t5 7 8 9 10 XorShift128Plus  engine does not know seeds
         Stream 1
         t1 82 HepJamesRandom  82
         t2 2 2 RanecuEngine  engine does not know seeds
         t3 84 TRandom3  engine does not know seeds
         t4 85 HepJamesRandom  85
+        t5 8 8 9 10 XorShift128Plus  engine does not know seeds
         Stream 2
         t1 83 HepJamesRandom  83
         t2 3 2 RanecuEngine  engine does not know seeds
         t3 85 TRandom3  engine does not know seeds
         t4 86 HepJamesRandom  86
+        t5 9 8 9 10 XorShift128Plus  engine does not know seeds
 
     lumiEngines_
         lumiIndex 0
@@ -42,3 +46,4 @@ RandomNumberGeneratorService dump
         t2 4 2 RanecuEngine  engine does not know seeds
         t3 86 TRandom3  engine does not know seeds
         t4 87 HepJamesRandom  87
+        t5 10 8 9 10 XorShift128Plus  engine does not know seeds

--- a/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
@@ -7,7 +7,8 @@ RandomNumberGeneratorService dump
         t2  3  RanecuEngine  1  2
         t3  4  TRandom3  83
         t4  5  HepJamesRandom  84
-        t5  4294967295  TRandom3  191
+        t5  6  XorShift128Plus  7  8  9  10
+        t6  4294967295  TRandom3  191
     nStreams_ = 1
     saveFileName_ = StashState1.data
     saveFileNameRecorded_ = 0
@@ -25,6 +26,7 @@ RandomNumberGeneratorService dump
         t2 1 2 RanecuEngine  engine does not know seeds
         t3 83 TRandom3  engine does not know seeds
         t4 84 HepJamesRandom  84
+        t5 7 8 9 10 XorShift128Plus  engine does not know seeds
 
     lumiEngines_
         lumiIndex 0
@@ -32,6 +34,7 @@ RandomNumberGeneratorService dump
         t2 2 2 RanecuEngine  engine does not know seeds
         t3 84 TRandom3  engine does not know seeds
         t4 85 HepJamesRandom  85
+        t5 8 8 9 10 XorShift128Plus  engine does not know seeds
 *** TestRandomNumberServiceGlobal beginLuminosityBlock 83
 TRandom3
 *** TestRandomNumberServiceGlobal analyze 83


### PR DESCRIPTION
Implement the "xorshift128+" engine, a very fast random number generator with period 2^128 -1 that passes the standard tests. This is necessary as part of trying to speed up HGCal digitization, where calling HepJamesRandom becomes very expensive. This achieves a factor of ~3 speed up in the RNG over HepJamesRandom.

Implementation taken from:
https://en.wikipedia.org/wiki/Xorshift#xorshift.2B

Please let me know if there are any unit tests or standard tests I should perform.

Automatically ported from CMSSW_8_1_X #13921 (original by @lgray).
Automatically ported from CMSSW_9_0_X #16649 (original by @lgray).
Please wait for a new IB (12 to 24H) before requesting to test this PR.