### PR TITLE
Revert "narrower anode time window switched to True"

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
+++ b/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
@@ -28,9 +28,9 @@ csc2DRecHits = cms.EDProducer("CSCRecHitDProducer",
     CSCWireClusterDeltaT = cms.int32(1),
     #
     #    wire time window used for reconstruction
-    CSCUseReducedWireTimeWindow = cms.bool(True),
-    CSCWireTimeWindowLow = cms.int32(6),
-    CSCWireTimeWindowHigh = cms.int32(10),
+    CSCUseReducedWireTimeWindow = cms.bool(False),
+    CSCWireTimeWindowLow = cms.int32(0),
+    CSCWireTimeWindowHigh = cms.int32(15),
     #
     #    Calibration info:
     CSCUseCalibrations = cms.bool(True),


### PR DESCRIPTION
Reverts cms-sw/cmssw#17521
Based on communication with @ptcox based on feedback from relvals in 900pre5 in MC.
- beam halo MC is broken completely
- regular pp MC segments are shorter and the RU algorithm apparently does not recover the length on average  over the samples; so, this is uncomfortably shorter

The window reduction will be checked again after follow up on MC/simulation side