### PR TITLE
Some cleanup for SIM

### DIFF
--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -335,6 +335,8 @@ void RunManager::initG4(const edm::EventSetup & es)
 
   if("" != m_WriteFile) {
     G4GDMLParser gdml;
+    gdml.SetRegionExport(true);
+    gdml.SetEnergyCutsExport(true);
     gdml.Write(m_WriteFile, world->GetWorldVolume(), true);
   }
 

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -75,6 +75,8 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
 {    
   m_currentRun = nullptr;
   m_UIsession.reset(new CustomUIsession());
+  m_physicsList.reset(nullptr);
+  m_world.reset(nullptr);
   m_kernel = new G4MTRunManagerKernel();
 
   m_check = p.getUntrackedParameter<bool>("CheckOverlap",false);
@@ -200,7 +202,9 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   // geometry dump
   if("" != m_WriteFile) {
-    G4GDMLParser gdml(new G4GDMLReadStructure(), new CMSGDMLWriteStructure());
+    G4GDMLParser gdml;
+    gdml.SetRegionExport(true);
+    gdml.SetEnergyCutsExport(true);
     gdml.Write(m_WriteFile, m_world->GetWorldVolume(), true);
   }
 

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.hh
@@ -19,9 +19,9 @@
 class CMSDarkPairProduction : public G4PairProductionRelModel
 {
 public:
-  CMSDarkPairProduction(const G4ParticleDefinition* p = 0,
-		      const G4double df = 1E0,
-                      const G4String& nam = "BetheHeitlerLPM");
+  CMSDarkPairProduction(const G4ParticleDefinition* p = nullptr,
+		        G4double df = 1.0,
+                        const G4String& nam = "BetheHeitlerLPM");
 
   virtual ~CMSDarkPairProduction();
 
@@ -33,11 +33,8 @@ public:
                       G4double cut=0.,
                       G4double emax=DBL_MAX);
 
-  void SampleSecondaries(std::vector<G4DynamicParticle*>* fvect,
-               	      const G4MaterialCutsCouple* couple,
-               	      const G4DynamicParticle* aDynamicGamma,
-                      G4double e1,
-                      G4double e2); 
+private:
 
+  G4double dark_factor;
 };
 #endif

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.hh
@@ -44,6 +44,8 @@ protected:
 
 private:
   G4bool  isInitialised;
+  G4double darkFactor;
+
 };
 
   

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
@@ -13,14 +13,10 @@
 using namespace std;
 
 static const G4double xsfactor =
-  4*fine_structure_const*classic_electr_radius*classic_electr_radius;
+  4*CLHEP::fine_structure_const*CLHEP::classic_electr_radius*CLHEP::classic_electr_radius;
 
-static G4double dark_factor;
-
-CMSDarkPairProduction::CMSDarkPairProduction(const G4ParticleDefinition* p,G4double df,const G4String& nam) : G4PairProductionRelModel(p,nam){
-  dark_factor = df;
-
-}
+CMSDarkPairProduction::CMSDarkPairProduction(const G4ParticleDefinition* p,G4double df,
+   const G4String& nam) : G4PairProductionRelModel(p,nam), dark_factor(df) {}
 
 CMSDarkPairProduction::~CMSDarkPairProduction(){}
 
@@ -41,14 +37,3 @@ G4double CMSDarkPairProduction::ComputeCrossSectionPerAtom(const G4ParticleDefin
   crossSection *= dark_factor * xsfactor*Z*(Z+xi);
   return crossSection;
 }
-void
-CMSDarkPairProduction::SampleSecondaries(std::vector<G4DynamicParticle*>* fvect,
-               const G4MaterialCutsCouple* couple,
-               const G4DynamicParticle* aDynamicGamma,
-               G4double e1,
-               G4double e2)
-{
-G4PairProductionRelModel::SampleSecondaries(fvect, couple, aDynamicGamma, e1, e2);
-        
-}
-

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
@@ -12,18 +12,14 @@
 #include "G4PairProductionRelModel.hh"
 #include "G4Electron.hh"
 
-
 using namespace std;
-
-static G4double darkFactor;
 
 CMSDarkPairProductionProcess::CMSDarkPairProductionProcess(
   G4double df,
   const G4String& processName,  
   G4ProcessType type):G4VEmProcess (processName, type),
-    isInitialised(false)
+		      isInitialised(false), darkFactor(df)
 { 
-  darkFactor = df;
   SetMinKinEnergy(2.0*electron_mass_c2);
   SetProcessSubType(fGammaConversion);
   SetStartFromNullFlag(true);

--- a/SimG4Core/Geometry/src/G4CheckOverlap.cc
+++ b/SimG4Core/Geometry/src/G4CheckOverlap.cc
@@ -126,6 +126,10 @@ G4CheckOverlap::G4CheckOverlap(const edm::ParameterSet &p) {
 	       << " Mother LV: " <<  ((*pvs)[i])->GetMotherLogical()->GetName() << G4endl;
 	G4cout << "       Translation: " << ((*pvs)[i])->GetObjectTranslation() << G4endl;
 	G4cout << "       Rotation:    " << ((*pvs)[i])->GetObjectRotationValue() << G4endl;
+	if(gdmlFlag) {
+	  G4GDMLParser gdml;
+	  gdml.Write(PVname+".gdml", (*pvs)[i], true);
+	}
       }
     }
   }

--- a/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheck_cfg.py
@@ -4,6 +4,8 @@ process = cms.Process("G4PrintGeometry")
 
 #process.load('Configuration.Geometry.GeometryExtended2015_cff')
 process.load('Configuration.Geometry.GeometryExtended2017_cff')
+#process.load('Geometry.CMSCommonData.cmsExtendedGeometry2017XML_cfi')
+#process.load('SimG4Core.PrintGeomInfo.cmsBeamPipeXML_cfi')
 
 from SimG4Core.PrintGeomInfo.g4TestGeometry_cfi import *
 process = checkOverlap(process)


### PR DESCRIPTION
Few fixes which are not relevant to mainstream production:
1) Dump of  gdml has a slightly new interface in Geant4 10.2 - modifications are verified by check of consumers of CMS gdml 
2) Added extra possibility to dump gdml via Physical Volume name
3) Fixed few static analysis warnings 

Automatically ported from CMSSW_9_0_X #17670 (original by @civanch).
Please wait for a new IB (12 to 24H) before requesting to test this PR.