### PR TITLE
Add IfLogDebug and IfLogTrace to MessageLogger.h

### DIFF
--- a/FWCore/MessageLogger/interface/MessageLogger.h
+++ b/FWCore/MessageLogger/interface/MessageLogger.h
@@ -119,6 +119,8 @@
 // 26 wmtan 7/22/11 Fix clang compilation errors for LogDebug and LogTrace
 //                  by making MessageSender copyable, and holding
 //                  the ErrorObj in a shared pointer with a custom deleter.
+//
+// 27 mkortela 2/27/17 Add IfLogTrace and IfLogDebug
 // =================================================
 
 // system include files
@@ -505,6 +507,22 @@ public:
 #define LogDebug(id) (edm::MessageDrop::debugAlwaysSuppressed || !edm::MessageDrop::instance()->debugEnabled) ? edm::LogDebug_() : edm::LogDebug_(id, __FILE__, __LINE__)
 #define LogTrace(id) (edm::MessageDrop::debugAlwaysSuppressed || !edm::MessageDrop::instance()->debugEnabled) ? edm::LogTrace_() : edm::LogTrace_(id)
 #endif
+
+// change log 27
+//
+// These macros reduce the need to pollute the code with #ifdefs. The
+// idea is that the condition is checked only if debugging is enabled.
+// That way the condition expression may use variables that are
+// declared only if EDM_ML_DEBUG is enabled. If it is disabled, rely
+// on the fact that LogDebug/LogTrace should compile to no-op.
+#ifdef EDM_ML_DEBUG
+#define IfLogDebug(cond, cat) if(cond) LogDebug(cat)
+#define IfLogTrace(cond, cat) if(cond) LogTrace(cat)
+#else
+#define IfLogDebug(cond, cat) LogDebug(cat)
+#define IfLogTrace(cond, cat) LogTrace(cat)
+#endif
+
 
 #endif  // MessageLogger_MessageLogger_h
 

--- a/FWCore/MessageService/test/UnitTestClient_H.cc
+++ b/FWCore/MessageService/test/UnitTestClient_H.cc
@@ -14,8 +14,17 @@ void
                            , edm::EventSetup const & /*unused*/
                               )
 {
+#ifdef EDM_ML_DEBUG
+       const bool debug1 = true;
+       const bool debug2 = false;
+#endif
+
        LogTrace    ("cat_A") << "LogTrace was used to send this mess" << "age";
        LogDebug    ("cat_B") << "LogDebug was used to send this other message";
+       IfLogTrace(debug1, "cat_A") << "IfLogTrace was used to send this message";
+       IfLogTrace(debug2, "cat_A") << "IfLogTrace was used to not send this message";
+       IfLogDebug(debug1, "cat_B") << "IfLogDebug was used to send this other message";
+       IfLogDebug(debug2, "cat_B") << "IfLogDebug was used to not send other this message";
   edm::LogVerbatim ("cat_A") << "LogVerbatim was us" << "ed to send this message";
   edm::LogInfo     ("cat_B") << "LogInfo was used to send this other message";
 }  // MessageLoggerClient::analyze()

--- a/FWCore/MessageService/test/UnitTestClient_H.cc
+++ b/FWCore/MessageService/test/UnitTestClient_H.cc
@@ -1,3 +1,7 @@
+#ifdef EDM_ML_DEBUG
+#undef EDM_ML_DEBUG
+#endif
+
 #include "FWCore/MessageService/test/UnitTestClient_H.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -14,17 +18,12 @@ void
                            , edm::EventSetup const & /*unused*/
                               )
 {
-#ifdef EDM_ML_DEBUG
-       const bool debug1 = true;
-       const bool debug2 = false;
-#endif
-
        LogTrace    ("cat_A") << "LogTrace was used to send this mess" << "age";
        LogDebug    ("cat_B") << "LogDebug was used to send this other message";
-       IfLogTrace(debug1, "cat_A") << "IfLogTrace was used to send this message";
-       IfLogTrace(debug2, "cat_A") << "IfLogTrace was used to not send this message";
-       IfLogDebug(debug1, "cat_B") << "IfLogDebug was used to send this other message";
-       IfLogDebug(debug2, "cat_B") << "IfLogDebug was used to not send other this message";
+       IfLogTrace(nonexistent, "cat_A") << "IfLogTrace was used to send this message"; // check that these compile with non-existent variable as the condition
+       IfLogTrace(nonexistent, "cat_A") << "IfLogTrace was used to not send this message";
+       IfLogDebug(nonexistent, "cat_B") << "IfLogDebug was used to send this other message";
+       IfLogDebug(nonexistent, "cat_B") << "IfLogDebug was used to not send other this message";
   edm::LogVerbatim ("cat_A") << "LogVerbatim was us" << "ed to send this message";
   edm::LogInfo     ("cat_B") << "LogInfo was used to send this other message";
 }  // MessageLoggerClient::analyze()

--- a/FWCore/MessageService/test/UnitTestClient_Hd.cc
+++ b/FWCore/MessageService/test/UnitTestClient_Hd.cc
@@ -16,17 +16,12 @@ void
                            , edm::EventSetup const & /*unused*/
                               )
 {
-#ifdef EDM_ML_DEBUG
-       const bool debug1 = true;
-       const bool debug2 = false;
-#endif
-
        LogTrace    ("cat_A") << "LogTrace was used to send this mess" << "age";
        LogDebug    ("cat_B") << "LogDebug was used to send this other message";
-       IfLogTrace(debug1, "cat_A") << "IfLogTrace was used to send this message";
-       IfLogTrace(debug2, "cat_A") << "IfLogTrace was used to not send this message";
-       IfLogDebug(debug1, "cat_B") << "IfLogDebug was used to send this other message";
-       IfLogDebug(debug2, "cat_B") << "IfLogDebug was used to not send other this message";
+       IfLogTrace(true , "cat_A") << "IfLogTrace was used to send this message";
+       IfLogTrace(false, "cat_A") << "IfLogTrace was used to not send this message";
+       IfLogDebug(true , "cat_B") << "IfLogDebug was used to send this other message";
+       IfLogDebug(false, "cat_B") << "IfLogDebug was used to not send other this message";
   edm::LogVerbatim ("cat_A") << "LogVerbatim was us" << "ed to send this message";
   edm::LogInfo     ("cat_B") << "LogInfo was used to send this other message";
 }  // MessageLoggerClient::analyze()

--- a/FWCore/MessageService/test/UnitTestClient_Hd.cc
+++ b/FWCore/MessageService/test/UnitTestClient_Hd.cc
@@ -16,8 +16,17 @@ void
                            , edm::EventSetup const & /*unused*/
                               )
 {
+#ifdef EDM_ML_DEBUG
+       const bool debug1 = true;
+       const bool debug2 = false;
+#endif
+
        LogTrace    ("cat_A") << "LogTrace was used to send this mess" << "age";
        LogDebug    ("cat_B") << "LogDebug was used to send this other message";
+       IfLogTrace(debug1, "cat_A") << "IfLogTrace was used to send this message";
+       IfLogTrace(debug2, "cat_A") << "IfLogTrace was used to not send this message";
+       IfLogDebug(debug1, "cat_B") << "IfLogDebug was used to send this other message";
+       IfLogDebug(debug2, "cat_B") << "IfLogDebug was used to not send other this message";
   edm::LogVerbatim ("cat_A") << "LogVerbatim was us" << "ed to send this message";
   edm::LogInfo     ("cat_B") << "LogInfo was used to send this other message";
 }  // MessageLoggerClient::analyze()

--- a/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
@@ -1,9 +1,9 @@
 LogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:25
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:20
 LogDebug was used to send this other message
 %MSG
 IfLogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:28
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:23
 IfLogDebug was used to send this other message
 %MSG
 LogVerbatim was used to send this message
@@ -11,11 +11,11 @@ LogVerbatim was used to send this message
 LogInfo was used to send this other message
 %MSG
 LogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:25
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:20
 LogDebug was used to send this other message
 %MSG
 IfLogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:28
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:23
 IfLogDebug was used to send this other message
 %MSG
 LogVerbatim was used to send this message

--- a/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u13d_debugs.log
@@ -1,14 +1,22 @@
 LogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:20
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:25
 LogDebug was used to send this other message
+%MSG
+IfLogTrace was used to send this message
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1 UnitTestClient_Hd.cc:28
+IfLogDebug was used to send this other message
 %MSG
 LogVerbatim was used to send this message
 %MSG-i cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 1
 LogInfo was used to send this other message
 %MSG
 LogTrace was used to send this message
-%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:20
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:25
 LogDebug was used to send this other message
+%MSG
+IfLogTrace was used to send this message
+%MSG-d cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2 UnitTestClient_Hd.cc:28
+IfLogDebug was used to send this other message
 %MSG
 LogVerbatim was used to send this message
 %MSG-i cat_B:  UnitTestClient_Hd:sendSomeMessages Run: 1 Event: 2

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -32,18 +32,6 @@
 
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 
-// Having this macro reduces the need to pollute the code with
-// #ifdefs. The idea is that the condition is checked only if
-// debugging is enabled. That way the condition expression may use
-// variables that are declared only if EDM_ML_DEBUG is enabled. If it
-// is disabled, rely on the fact that LogTrace should compile to
-// no-op.
-#ifdef EDM_ML_DEBUG
-#define IfLogTrace(cond, cat) if(cond) LogTrace(cat)
-#else
-#define IfLogTrace(cond, cat) LogTrace(cat)
-#endif
-
 using namespace reco;
 namespace {
   class  DuplicateTrackMerger final : public edm::stream::EDProducer<> {

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -43,18 +43,6 @@
 #include <map>
 #include <limits>
 
-// Having this macro reduces the need to pollute the code with
-// #ifdefs. The idea is that the condition is checked only if
-// debugging is enabled. That way the condition expression may use
-// variables that are declared only if EDM_ML_DEBUG is enabled. If it
-// is disabled, rely on the fact that LogTrace should compile to
-// no-op.
-#ifdef EDM_ML_DEBUG
-#define IfLogTrace(cond, cat) if(cond) LogTrace(cat)
-#else
-#define IfLogTrace(cond, cat) LogTrace(cat)
-#endif
-
 using namespace std;
 
 typedef PixelRecoRange<float> Range;


### PR DESCRIPTION
The implementation of `IfLogTrace` was moved from `RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc` and `RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc` where it was already used.

(see also https://github.com/cms-sw/cmssw/pull/17511#discussion_r102993914)

Tested in 9_0_0_pre5, no changes expected.