### PR TITLE
implement "plan 1" and sum SiPM rechits over all depths

### DIFF
--- a/HLTrigger/Configuration/python/common.py
+++ b/HLTrigger/Configuration/python/common.py
@@ -1,3 +1,5 @@
+import itertools
+
 import FWCore.ParameterSet.Config as cms
 
 def producers_by_type(process, *types):
@@ -15,6 +17,22 @@ def analyzers_by_type(process, *types):
 def esproducers_by_type(process, *types):
     "Find all ESProducers in the Process that are instances of the given C++ type."
     return (module for module in process._Process__esproducers.values() if module._TypedParameterizable__type in types)
+
+
+def insert_modules_before(process, target, *modules):
+    "Add the `modules` before the `target` in any Sequence, Paths or EndPath that contains the latter."
+    for sequence in itertools.chain(
+        process._Process__sequences.itervalues(),
+        process._Process__paths.itervalues(),
+        process._Process__endpaths.itervalues()
+    ):
+        try:
+            position = sequence.index(target)
+        except ValueError:
+            continue
+        else:
+            for module in reversed(modules):
+                sequence.insert(position, module)
 
 
 # logic from Modifier.toModify from FWCore/ParameterSet/python/Config.py

--- a/HLTrigger/Configuration/python/customizeHLTforMC.py
+++ b/HLTrigger/Configuration/python/customizeHLTforMC.py
@@ -21,8 +21,13 @@ def customizeHLTforMC(process):
       process.hltHbhereco.timeSlewPars            = cms.vdouble( 12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0 )
       # old response correction, matching the 2015D 25ns data
       process.hltHbhereco.respCorrM3              = cms.double( 1.0 )
-    else:
-      # 2017 Phase I
+    elif process.hltHbhereco._TypedParameterizable__type == 'HBHEPhase1Reconstructor':
+      # 2017 "plan 0"
       process.hltHbhereco.algorithm.respCorrM3    = cms.double( 1.0 )
+
+  if 'hltHbhePhase1Reco' in process.__dict__:
+    if process.hltHbhePhase1Reco._TypedParameterizable__type == 'HBHEPhase1Reconstructor':
+      # 2017 "plan 1"
+      process.hltHbhePhase1Reco.algorithm.respCorrM3 = cms.double( 1.0 )
 
   return process


### PR DESCRIPTION
Introduce a new name `hltHbhePhase1Reco` for the collection of rechits with QIE8/QIE11 and depth segmentation while keeping the original name `hltHbhereco` for the collection of rechits summed over all depths.
Automatically ported from CMSSW_9_0_X #17646 (original by @fwyzard).
Please wait for a new IB (12 to 24H) before requesting to test this PR.