### PR TITLE
bsunanda:Run2-alca74 Make IsoTrack AlCaReco as well as tree makers to be equally useful for all possible isolation strategy

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -90,8 +90,7 @@ private:
   std::string                   theTrackQuality_, processName_;
   double                        maxRestrictionP_, slopeRestrictionP_;
   double                        a_mipR_, a_coneR_, a_charIsoR_;
-  double                        pTrackMin_, eEcalMax_, eIsolate1_, eIsolate2_;
-  bool                          useEtaVaryingCut_;
+  double                        pTrackMin_, eEcalMax_, eIsolate_;
   unsigned int                  nRun_, nAll_, nGood_;
   edm::InputTag                 triggerEvent_, theTriggerResultsLabel;
   edm::InputTag                 labelGenTrack_, labelRecVtx_;
@@ -147,9 +146,7 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
   // maxRestrictionP_ = 8 GeV as came from a study
   maxRestrictionP_                    = iConfig.getParameter<double>("MaxTrackP");
   slopeRestrictionP_                  = iConfig.getParameter<double>("SlopeTrackP");
-  eIsolate1_                          = iConfig.getParameter<double>("IsolationEnergyStr");
-  eIsolate2_                          = iConfig.getParameter<double>("IsolationEnergySft");
-  useEtaVaryingCut_                   = iConfig.getParameter<bool>("UseEtaVaryingCut");
+  eIsolate_                           = iConfig.getParameter<double>("IsolationEnergy");
   triggerEvent_                       = iConfig.getParameter<edm::InputTag>("TriggerEventLabel");
   theTriggerResultsLabel              = iConfig.getParameter<edm::InputTag>("TriggerResultLabel");
   labelGenTrack_                      = iConfig.getParameter<edm::InputTag>("TrackLabel");
@@ -186,8 +183,7 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
 			       <<"\t a_mipR "          << a_mipR_
 			       <<"\t maxRestrictionP_ "<< maxRestrictionP_
 			       <<"\t slopeRestrictionP_ " << slopeRestrictionP_
-			       <<"\t eIsolateStrong_ " << eIsolate1_
-			       <<"\t eIsolateSoft_ "   << eIsolate2_;
+			       <<"\t eIsolate_ "       << eIsolate_;
   for (unsigned int k=0; k<trigNames_.size(); ++k)
     edm::LogInfo("HcalIsoTrack") << "Trigger[" << k << "] " << trigNames_[k];
 } // AlCaIsoTracksFilter::AlCaIsoTracksFilter  constructor
@@ -345,9 +341,8 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
 						      trkCaloDirections,
 						      a_charIsoR_, 
 						      nNearTRKs, false);
-	  double eIsolation = (useEtaVaryingCut_) ? (maxRestrictionP_*exp(slopeRestrictionP_*((double)(ieta)))) : 0.0;
-	  if (eIsolation < eIsolate1_) eIsolation = eIsolate1_;
-	  if (eIsolation < eIsolate2_) eIsolation = eIsolate2_;
+	  double eIsolation = (maxRestrictionP_*exp(slopeRestrictionP_*((double)(ieta))));
+	  if (eIsolation < eIsolate_) eIsolation = eIsolate_;
 	  LogDebug("HcalIsoTrack") << "This track : " << nTracks 
 				   << " (pt|eta|phi|p) :"  << pTrack->pt() 
 				   << "|" << pTrack->eta() << "|" 

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -88,9 +88,10 @@ private:
   std::vector<std::string>      trigNames_, HLTNames_;
   spr::trackSelectionParameters selectionParameter_;
   std::string                   theTrackQuality_, processName_;
-  double                        maxRestrictionPt_, slopeRestrictionPt_;
+  double                        maxRestrictionP_, slopeRestrictionP_;
   double                        a_mipR_, a_coneR_, a_charIsoR_;
-  double                        pTrackMin_, eEcalMax_, eIsolation_;
+  double                        pTrackMin_, eEcalMax_, eIsolate1_, eIsolate2_;
+  bool                          useEtaVaryingCut_;
   unsigned int                  nRun_, nAll_, nGood_;
   edm::InputTag                 triggerEvent_, theTriggerResultsLabel;
   edm::InputTag                 labelGenTrack_, labelRecVtx_;
@@ -124,9 +125,7 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
   theTrackQuality_                    = iConfig.getParameter<std::string>("TrackQuality");
   processName_                        = iConfig.getParameter<std::string>("ProcessName");
   reco::TrackBase::TrackQuality trackQuality_=reco::TrackBase::qualityByName(theTrackQuality_);
-  maxRestrictionPt_                   = iConfig.getParameter<double>("MinTrackPt");
-  slopeRestrictionPt_                 = iConfig.getParameter<double>("SlopeTrackPt");
-  selectionParameter_.minPt           = maxRestrictionPt_;
+  selectionParameter_.minPt           = iConfig.getParameter<double>("MinTrackPt");;
   selectionParameter_.minQuality      = trackQuality_;
   selectionParameter_.maxDxyPV        = iConfig.getParameter<double>("MaxDxyPV");
   selectionParameter_.maxDzPV         = iConfig.getParameter<double>("MaxDzPV");
@@ -141,7 +140,16 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
   a_mipR_                             = iConfig.getParameter<double>("ConeRadiusMIP");
   pTrackMin_                          = iConfig.getParameter<double>("MinimumTrackP");
   eEcalMax_                           = iConfig.getParameter<double>("MaximumEcalEnergy");
-  eIsolation_                         = iConfig.getParameter<double>("IsolationEnergy");
+  // Different isolation cuts are described in DN-2016/029
+  // Tight cut uses 2 GeV; Loose cut uses 10 GeV
+  // Eta dependent cut uses (maxRestrictionP_ * exp(|ieta|*log(2.5)/18))
+  // with the factor for exponential slopeRestrictionP_ = log(2.5)/18
+  // maxRestrictionP_ = 8 GeV as came from a study
+  maxRestrictionP_                    = iConfig.getParameter<double>("MaxTrackP");
+  slopeRestrictionP_                  = iConfig.getParameter<double>("SlopeTrackP");
+  eIsolate1_                          = iConfig.getParameter<double>("IsolationEnergyStr");
+  eIsolate2_                          = iConfig.getParameter<double>("IsolationEnergySft");
+  useEtaVaryingCut_                   = iConfig.getParameter<bool>("UseEtaVaryingCut");
   triggerEvent_                       = iConfig.getParameter<edm::InputTag>("TriggerEventLabel");
   theTriggerResultsLabel              = iConfig.getParameter<edm::InputTag>("TriggerResultLabel");
   labelGenTrack_                      = iConfig.getParameter<edm::InputTag>("TrackLabel");
@@ -162,8 +170,7 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
   tok_hbhe_     = consumes<HBHERecHitCollection>(labelHBHE_);
 
   edm::LogInfo("HcalIsoTrack") <<"Parameters read from config file \n" 
-			       <<"\t minPt "          << maxRestrictionPt_
-			       <<":"                   << slopeRestrictionPt_
+			       <<"\t minPt "           << selectionParameter_.minPt
 			       <<"\t theTrackQuality " << theTrackQuality_
 			       <<"\t minQuality "      << selectionParameter_.minQuality
 			       <<"\t maxDxyPV "        << selectionParameter_.maxDxyPV          
@@ -176,7 +183,11 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
 			       <<"\t maxOutMiss "      << selectionParameter_.maxOutMiss
 			       <<"\t a_coneR "         << a_coneR_
 			       <<"\t a_charIsoR "      << a_charIsoR_
-			       <<"\t a_mipR "          << a_mipR_;
+			       <<"\t a_mipR "          << a_mipR_
+			       <<"\t maxRestrictionP_ "<< maxRestrictionP_
+			       <<"\t slopeRestrictionP_ " << slopeRestrictionP_
+			       <<"\t eIsolateStrong_ " << eIsolate1_
+			       <<"\t eIsolateSoft_ "   << eIsolate2_;
   for (unsigned int k=0; k<trigNames_.size(); ++k)
     edm::LogInfo("HcalIsoTrack") << "Trigger[" << k << "] " << trigNames_[k];
 } // AlCaIsoTracksFilter::AlCaIsoTracksFilter  constructor
@@ -316,7 +327,6 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
 	  HcalDetId detId = (HcalDetId)(trkDetItr->detIdHCAL);
 	  ieta = detId.ietaAbs();
 	}
-	selectionParameter_.minPt = maxRestrictionPt_ - std::abs((double)ieta)*slopeRestrictionPt_;
 	bool qltyFlag  = spr::goodTrack(pTrack,leadPV,selectionParameter_,false);
 	LogDebug("HcalIsoTrack") << "qltyFlag|okECAL|okHCAL : " << qltyFlag
 				 << "|" << trkDetItr->okECAL << "|" 
@@ -335,13 +345,17 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
 						      trkCaloDirections,
 						      a_charIsoR_, 
 						      nNearTRKs, false);
+	  double eIsolation = (useEtaVaryingCut_) ? (maxRestrictionP_*exp(slopeRestrictionP_*((double)(ieta)))) : 0.0;
+	  if (eIsolation < eIsolate1_) eIsolation = eIsolate1_;
+	  if (eIsolation < eIsolate2_) eIsolation = eIsolate2_;
 	  LogDebug("HcalIsoTrack") << "This track : " << nTracks 
 				   << " (pt|eta|phi|p) :"  << pTrack->pt() 
 				   << "|" << pTrack->eta() << "|" 
 				   << pTrack->phi() << "|" << t_p
 				   << "e_MIP " << eMipDR 
-				   << " Chg Isolation " << hmaxNearP;
-	  if (t_p>pTrackMin_ && eMipDR<eEcalMax_ && hmaxNearP<eIsolation_) {
+				   << " Chg Isolation " << hmaxNearP
+				   << ":" << eIsolation;
+	  if (t_p>pTrackMin_ && eMipDR<eEcalMax_ && hmaxNearP<eIsolation) {
 	    accept = true;
 	    break;
 	  }

--- a/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cfi.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cfi.py
@@ -10,10 +10,10 @@ AlcaIsoTracksFilter = cms.EDFilter("AlCaIsoTracksFilter",
                                    TriggerEventLabel = cms.InputTag("hltTriggerSummaryAOD","","HLT"),
                                    TriggerResultLabel= cms.InputTag("TriggerResults","","HLT"),
                                    Triggers          = cms.vstring(),
-                                   TrackQuality      = cms.string("highPurity"),
                                    ProcessName       = cms.string("HLT"),
-                                   MinTrackPt        = cms.double(10.0),
-                                   SlopeTrackPt      = cms.double(0.16),
+# following 10 parameters are parameters to select good tracks
+                                   TrackQuality      = cms.string("highPurity"),
+                                   MinTrackPt        = cms.double(1.0),
                                    MaxDxyPV          = cms.double(10.0),
                                    MaxDzPV           = cms.double(100.0),
                                    MaxChi2           = cms.double(5.0),
@@ -22,9 +22,16 @@ AlcaIsoTracksFilter = cms.EDFilter("AlCaIsoTracksFilter",
                                    MinLayerCrossed   = cms.int32(8),
                                    MaxInMiss         = cms.int32(2),
                                    MaxOutMiss        = cms.int32(2),
+# Minimum momentum of selected isolated track and signal zone
                                    ConeRadius        = cms.double(34.98),
-                                   ConeRadiusMIP     = cms.double(14.0),
                                    MinimumTrackP     = cms.double(20.0),
+# signal zone in ECAL and MIP energy cutoff
+                                   ConeRadiusMIP     = cms.double(14.0),
                                    MaximumEcalEnergy = cms.double(2.0),
-                                   IsolationEnergy   = cms.double(10.0),
+# following 4 parameters are for isolation cuts and described in the code
+                                   MaxTrackP         = cms.double(8.0),
+                                   SlopeTrackP       = cms.double(0.05090504066),
+                                   IsolationEnergyStr= cms.double(2.0),
+                                   IsolationEnergySft= cms.double(10.0),
+                                   UseEtaVaryingCut  = cms.bool(False)
 )

--- a/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cfi.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cfi.py
@@ -28,10 +28,8 @@ AlcaIsoTracksFilter = cms.EDFilter("AlCaIsoTracksFilter",
 # signal zone in ECAL and MIP energy cutoff
                                    ConeRadiusMIP     = cms.double(14.0),
                                    MaximumEcalEnergy = cms.double(2.0),
-# following 4 parameters are for isolation cuts and described in the code
+# following 3 parameters are for isolation cuts and described in the code
                                    MaxTrackP         = cms.double(8.0),
                                    SlopeTrackP       = cms.double(0.05090504066),
-                                   IsolationEnergyStr= cms.double(2.0),
-                                   IsolationEnergySft= cms.double(10.0),
-                                   UseEtaVaryingCut  = cms.bool(False)
+                                   IsolationEnergy   = cms.double(10.0)
 )

--- a/Calibration/HcalAlCaRecoProducers/python/alcaisotrk_cfi.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaisotrk_cfi.py
@@ -13,10 +13,10 @@ IsoProd = cms.EDProducer("AlCaIsoTracksProducer",
                          TriggerResultLabel= cms.InputTag("TriggerResults","","HLT"),
                          IsoTrackLabel     = cms.string("HcalIsolatedTrackCollection"),
                          Triggers          = cms.vstring("HLT_IsoTrackHB","HLT_IsoTrackHE"),
-                         TrackQuality      = cms.string("highPurity"),
                          ProcessName       = cms.string("HLT"),
-                         MinTrackPt        = cms.double(10.0),
-                         SlopeTrackPt      = cms.double(6.0),
+# following 10 parameters are parameters to select good tracks
+                         TrackQuality      = cms.string("highPurity"),
+                         MinTrackPt        = cms.double(1.0),
                          MaxDxyPV          = cms.double(10.0),
                          MaxDzPV           = cms.double(100.0),
                          MaxChi2           = cms.double(5.0),
@@ -25,10 +25,17 @@ IsoProd = cms.EDProducer("AlCaIsoTracksProducer",
                          MinLayerCrossed   = cms.int32(8),
                          MaxInMiss         = cms.int32(2),
                          MaxOutMiss        = cms.int32(2),
+# Minimum momentum of selected isolated track and signal zone
                          ConeRadius        = cms.double(34.98),
-                         ConeRadiusMIP     = cms.double(14.0),
                          MinimumTrackP     = cms.double(10.0),
+# signal zone in ECAL and MIP energy cutoff
+                         ConeRadiusMIP     = cms.double(14.0),
                          MaximumEcalEnergy = cms.double(2.0),
-                         IsolationEnergy   = cms.double(32.0),
+# following 4 parameters are for isolation cuts and described in the code
+                         MaxTrackP         = cms.double(8.0),
+                         SlopeTrackP       = cms.double(0.05090504066),
+                         IsolationEnergyStr= cms.double(2.0),
+                         IsolationEnergySft= cms.double(10.0),
+                         UseEtaVaryingCut  = cms.bool(False)
 )
 

--- a/Calibration/HcalAlCaRecoProducers/python/alcaisotrk_cfi.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaisotrk_cfi.py
@@ -31,11 +31,9 @@ IsoProd = cms.EDProducer("AlCaIsoTracksProducer",
 # signal zone in ECAL and MIP energy cutoff
                          ConeRadiusMIP     = cms.double(14.0),
                          MaximumEcalEnergy = cms.double(2.0),
-# following 4 parameters are for isolation cuts and described in the code
+# following 3 parameters are for isolation cuts and described in the code
                          MaxTrackP         = cms.double(8.0),
                          SlopeTrackP       = cms.double(0.05090504066),
-                         IsolationEnergyStr= cms.double(2.0),
-                         IsolationEnergySft= cms.double(10.0),
-                         UseEtaVaryingCut  = cms.bool(False)
+                         IsolationEnergy   = cms.double(10.0)
 )
 

--- a/Calibration/HcalAlCaRecoProducers/src/AlCaIsoTracksProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/src/AlCaIsoTracksProducer.cc
@@ -113,8 +113,7 @@ private:
   std::string                     theTrackQuality_, processName_;
   double                          maxRestrictionP_, slopeRestrictionP_;
   double                          a_mipR_, a_coneR_, a_charIsoR_;
-  double                          pTrackMin_, eEcalMax_, eIsolate1_,eIsolate2_;
-  bool                            useEtaVaryingCut_;
+  double                          pTrackMin_, eEcalMax_, eIsolate_;
   edm::InputTag                   labelTriggerEvent_, labelTriggerResults_;
   edm::InputTag                   labelGenTrack_, labelRecVtx_,  labelHltGT_;
   edm::InputTag                   labelEB_, labelEE_, labelHBHE_, labelBS_;
@@ -163,9 +162,7 @@ AlCaIsoTracksProducer::AlCaIsoTracksProducer(edm::ParameterSet const& iConfig, c
   // maxRestrictionP_ = 8 GeV as came from a study
   maxRestrictionP_                    = iConfig.getParameter<double>("MaxTrackP");
   slopeRestrictionP_                  = iConfig.getParameter<double>("SlopeTrackP");
-  eIsolate1_                          = iConfig.getParameter<double>("IsolationEnergyStr");
-  eIsolate2_                          = iConfig.getParameter<double>("IsolationEnergySft");
-  useEtaVaryingCut_                   = iConfig.getParameter<bool>("UseEtaVaryingCut");
+  eIsolate_                           = iConfig.getParameter<double>("IsolationEnergy");
   labelGenTrack_                      = iConfig.getParameter<edm::InputTag>("TrackLabel");
   labelRecVtx_                        = iConfig.getParameter<edm::InputTag>("VertexLabel");
   labelBS_                            = iConfig.getParameter<edm::InputTag>("BeamSpotLabel");
@@ -207,8 +204,7 @@ AlCaIsoTracksProducer::AlCaIsoTracksProducer(edm::ParameterSet const& iConfig, c
 			       <<"\t eEcalMax "        << eEcalMax_
 			       <<"\t maxRestrictionP_ "<< maxRestrictionP_
 			       <<"\t slopeRestrictionP_ " << slopeRestrictionP_
-			       <<"\t eIsolateStrong_ " << eIsolate1_
-			       <<"\t eIsolateSoft_ "   << eIsolate2_
+			       <<"\t eIsolate_ "       << eIsolate_
 			       <<"\tProcess "          << processName_;
   for (unsigned int k=0; k<trigNames_.size(); ++k)
     edm::LogInfo("HcalIsoTrack") << "Trigger[" << k << "] " << trigNames_[k];
@@ -470,9 +466,8 @@ AlCaIsoTracksProducer::select(edm::Handle<edm::TriggerResults>& triggerResults,
 						  nNearTRKs, false);
       HcalDetId detId = (HcalDetId)(trkDetItr->detIdHCAL);
       int       ieta = detId.ietaAbs();
-      double eIsolation = (useEtaVaryingCut_) ? (maxRestrictionP_*exp(slopeRestrictionP_*((double)(ieta)))) : 0.0;
-      if (eIsolation < eIsolate1_) eIsolation = eIsolate1_;
-      if (eIsolation < eIsolate2_) eIsolation = eIsolate2_;
+      double eIsolation = (maxRestrictionP_*exp(slopeRestrictionP_*((double)(ieta))));
+      if (eIsolation < eIsolate_) eIsolation = eIsolate_;
 #ifdef DebugLog
       edm::LogInfo("HcalIsoTrack") << "This track : " << nTracks 
 				   << " (pt|eta|phi|p) :"  << pTrack->pt() 

--- a/Calibration/HcalAlCaRecoProducers/src/AlCaIsoTracksProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/src/AlCaIsoTracksProducer.cc
@@ -1,3 +1,4 @@
+
 // -*- C++ -*-
 //#define DebugLog
 
@@ -110,9 +111,10 @@ private:
   unsigned int                    nRun_, nAll_, nGood_;
   spr::trackSelectionParameters   selectionParameter_;
   std::string                     theTrackQuality_, processName_;
-  double                          maxRestrictionPt_, slopeRestrictionPt_;
+  double                          maxRestrictionP_, slopeRestrictionP_;
   double                          a_mipR_, a_coneR_, a_charIsoR_;
-  double                          pTrackMin_, eEcalMax_, eIsolation_;
+  double                          pTrackMin_, eEcalMax_, eIsolate1_,eIsolate2_;
+  bool                            useEtaVaryingCut_;
   edm::InputTag                   labelTriggerEvent_, labelTriggerResults_;
   edm::InputTag                   labelGenTrack_, labelRecVtx_,  labelHltGT_;
   edm::InputTag                   labelEB_, labelEE_, labelHBHE_, labelBS_;
@@ -139,9 +141,7 @@ AlCaIsoTracksProducer::AlCaIsoTracksProducer(edm::ParameterSet const& iConfig, c
   trigNames_                          = iConfig.getParameter<std::vector<std::string> >("Triggers");
   theTrackQuality_                    = iConfig.getParameter<std::string>("TrackQuality");
   processName_                        = iConfig.getParameter<std::string>("ProcessName");
-  maxRestrictionPt_                   = iConfig.getParameter<double>("MinTrackPt");
-  slopeRestrictionPt_                 = iConfig.getParameter<double>("SlopeTrackPt");
-  selectionParameter_.minPt           = (slopeRestrictionPt_ > 0) ? (maxRestrictionPt_ - 2.5/slopeRestrictionPt_) : maxRestrictionPt_;
+  selectionParameter_.minPt           = iConfig.getParameter<double>("MinTrackPt");;
   selectionParameter_.minQuality      = reco::TrackBase::qualityByName(theTrackQuality_);
   selectionParameter_.maxDxyPV        = iConfig.getParameter<double>("MaxDxyPV");
   selectionParameter_.maxDzPV         = iConfig.getParameter<double>("MaxDzPV");
@@ -156,7 +156,16 @@ AlCaIsoTracksProducer::AlCaIsoTracksProducer(edm::ParameterSet const& iConfig, c
   a_mipR_                             = iConfig.getParameter<double>("ConeRadiusMIP");
   pTrackMin_                          = iConfig.getParameter<double>("MinimumTrackP");
   eEcalMax_                           = iConfig.getParameter<double>("MaximumEcalEnergy");
-  eIsolation_                         = iConfig.getParameter<double>("IsolationEnergy");
+  // Different isolation cuts are described in DN-2016/029
+  // Tight cut uses 2 GeV; Loose cut uses 10 GeV
+  // Eta dependent cut uses (maxRestrictionP_ * exp(|ieta|*log(2.5)/18))
+  // with the factor for exponential slopeRestrictionP_ = log(2.5)/18
+  // maxRestrictionP_ = 8 GeV as came from a study
+  maxRestrictionP_                    = iConfig.getParameter<double>("MaxTrackP");
+  slopeRestrictionP_                  = iConfig.getParameter<double>("SlopeTrackP");
+  eIsolate1_                          = iConfig.getParameter<double>("IsolationEnergyStr");
+  eIsolate2_                          = iConfig.getParameter<double>("IsolationEnergySft");
+  useEtaVaryingCut_                   = iConfig.getParameter<bool>("UseEtaVaryingCut");
   labelGenTrack_                      = iConfig.getParameter<edm::InputTag>("TrackLabel");
   labelRecVtx_                        = iConfig.getParameter<edm::InputTag>("VertexLabel");
   labelBS_                            = iConfig.getParameter<edm::InputTag>("BeamSpotLabel");
@@ -180,8 +189,7 @@ AlCaIsoTracksProducer::AlCaIsoTracksProducer(edm::ParameterSet const& iConfig, c
   tok_hbhe_     = consumes<HBHERecHitCollection>(labelHBHE_);
 
   edm::LogInfo("HcalIsoTrack") <<"Parameters read from config file \n" 
-			       <<"\t minPt "           << maxRestrictionPt_
-			       <<":"                   << slopeRestrictionPt_
+			       <<"\t minPt "           << selectionParameter_.minPt
 			       <<"\t theTrackQuality " << theTrackQuality_
 			       <<"\t minQuality "      << selectionParameter_.minQuality
 			       <<"\t maxDxyPV "        << selectionParameter_.maxDxyPV          
@@ -197,8 +205,11 @@ AlCaIsoTracksProducer::AlCaIsoTracksProducer(edm::ParameterSet const& iConfig, c
 			       <<"\t a_mipR "          << a_mipR_
 			       <<"\t pTrackMin "       << pTrackMin_
 			       <<"\t eEcalMax "        << eEcalMax_
-			       <<"\t eIsolation "      << eIsolation_
-			       << "\tProcess "         << processName_;
+			       <<"\t maxRestrictionP_ "<< maxRestrictionP_
+			       <<"\t slopeRestrictionP_ " << slopeRestrictionP_
+			       <<"\t eIsolateStrong_ " << eIsolate1_
+			       <<"\t eIsolateSoft_ "   << eIsolate2_
+			       <<"\tProcess "          << processName_;
   for (unsigned int k=0; k<trigNames_.size(); ++k)
     edm::LogInfo("HcalIsoTrack") << "Trigger[" << k << "] " << trigNames_[k];
 
@@ -437,7 +448,6 @@ AlCaIsoTracksProducer::select(edm::Handle<edm::TriggerResults>& triggerResults,
 				 << pTrack->phi() << "|" << pTrack->p();
 #endif	    
     //Selection of good track
-    selectionParameter_.minPt = maxRestrictionPt_ - std::abs(pTrack->eta())/slopeRestrictionPt_;
     bool qltyFlag  = spr::goodTrack(pTrack,leadPV,selectionParameter_,false);
 #ifdef DebugLog
     edm::LogInfo("HcalIsoTrack") << "qltyFlag|okECAL|okHCAL : " << qltyFlag
@@ -458,15 +468,21 @@ AlCaIsoTracksProducer::select(edm::Handle<edm::TriggerResults>& triggerResults,
 						  trkCaloDirections,
 						  a_charIsoR_,
 						  nNearTRKs, false);
+      HcalDetId detId = (HcalDetId)(trkDetItr->detIdHCAL);
+      int       ieta = detId.ietaAbs();
+      double eIsolation = (useEtaVaryingCut_) ? (maxRestrictionP_*exp(slopeRestrictionP_*((double)(ieta)))) : 0.0;
+      if (eIsolation < eIsolate1_) eIsolation = eIsolate1_;
+      if (eIsolation < eIsolate2_) eIsolation = eIsolate2_;
 #ifdef DebugLog
       edm::LogInfo("HcalIsoTrack") << "This track : " << nTracks 
 				   << " (pt|eta|phi|p) :"  << pTrack->pt() 
 				   << "|" << pTrack->eta() << "|" 
 				   << pTrack->phi() << "|" << t_p 
 				   << " e_MIP " << eMipDR 
-				   << " Chg Isolation " << hmaxNearP;
+				   << " Chg Isolation " << hmaxNearP
+				   << ":" << eIsolation;
 #endif
-      if (t_p>pTrackMin_ && eMipDR<eEcalMax_ && hmaxNearP<eIsolation_) {
+      if (t_p>pTrackMin_ && eMipDR<eEcalMax_ && hmaxNearP<eIsolation) {
 	reco::HcalIsolatedTrackCandidate newCandidate(v4);
 	newCandidate.SetMaxP(hmaxNearP);
 	newCandidate.SetEnergyEcal(eMipDR);

--- a/Calibration/HcalCalibAlgos/python/isoAnalyzer_cfi.py
+++ b/Calibration/HcalCalibAlgos/python/isoAnalyzer_cfi.py
@@ -2,12 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 HcalIsoTrkAnalyzer = cms.EDAnalyzer("HcalIsoTrkAnalyzer",
                                     Triggers          = cms.vstring("HLT_PFJet40","HLT_PFJet60","HLT_PFJet80","HLT_PFJet140","HLT_PFJet200","HLT_PFJet260","HLT_PFJet320","HLT_PFJet400","HLT_PFJet450","HLT_PFJet500"),
-                                    TrackQuality      = cms.string("highPurity"),
                                     ProcessName       = cms.string("HLT"),
                                     L1Filter          = cms.string(""),
                                     L2Filter          = cms.string("L2Filter"),
                                     L3Filter          = cms.string("Filter"),
-                                    MinTrackPt        = cms.double(10.0),
+# following 10 parameters are parameters to select good tracks
+                                    TrackQuality      = cms.string("highPurity"),
+                                    MinTrackPt        = cms.double(1.0),
                                     MaxDxyPV          = cms.double(0.02),
                                     MaxDzPV           = cms.double(0.02),
                                     MaxChi2           = cms.double(5.0),
@@ -16,14 +17,18 @@ HcalIsoTrkAnalyzer = cms.EDAnalyzer("HcalIsoTrkAnalyzer",
                                     MinLayerCrossed   = cms.int32(8),
                                     MaxInMiss         = cms.int32(0),
                                     MaxOutMiss        = cms.int32(0),
-                                    ConeRadius        = cms.double(34.98),
-                                    ConeRadiusMIP     = cms.double(14.0),
+# Minimum momentum of selected isolated track and signal zone
                                     MinimumTrackP     = cms.double(20.0),
+                                    ConeRadius        = cms.double(34.98),
+# signal zone in ECAL and MIP energy cutoff
+                                    ConeRadiusMIP     = cms.double(14.0),
                                     MaximumEcalEnergy = cms.double(2.0),
+# following 4 parameters are for isolation cuts and described in the code
                                     MaxTrackP         = cms.double(8.0),
                                     SlopeTrackP       = cms.double(0.05090504066),
                                     IsolationEnergyStr= cms.double(2.0),
                                     IsolationEnergySft= cms.double(10.0),
+# various labels for collections used in the code
                                     TriggerEventLabel = cms.InputTag("hltTriggerSummaryAOD","","HLT"),
                                     TriggerResultLabel= cms.InputTag("TriggerResults","","HLT"),
                                     TrackLabel        = cms.string("generalTracks"),
@@ -34,6 +39,8 @@ HcalIsoTrkAnalyzer = cms.EDAnalyzer("HcalIsoTrkAnalyzer",
                                     BeamSpotLabel     = cms.string("offlineBeamSpot"),
                                     ModuleName        = cms.untracked.string(""),
                                     ProducerName      = cms.untracked.string(""),
+#  Various flags used for selecting tracks, choice of energy Method2/0
+#  Data type 0/1 for single jet trigger or others
                                     IgnoreTriggers    = cms.untracked.bool(False),
                                     UseRaw            = cms.untracked.bool(False),
                                     HcalScale         = cms.untracked.double(1.0),

--- a/Calibration/HcalCalibAlgos/python/isoAnalyzer_cfi.py
+++ b/Calibration/HcalCalibAlgos/python/isoAnalyzer_cfi.py
@@ -45,5 +45,5 @@ HcalIsoTrkAnalyzer = cms.EDAnalyzer("HcalIsoTrkAnalyzer",
                                     UseRaw            = cms.untracked.bool(False),
                                     HcalScale         = cms.untracked.double(1.0),
                                     DataType          = cms.untracked.int32(0),
-                                    Mode              = cms.untracked.int32(11),
+                                    OutMode           = cms.untracked.int32(11),
 )

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrkAnalyzer.cc
@@ -196,7 +196,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig) :
   useRaw_                             = iConfig.getUntrackedParameter<bool>("UseRaw", false);
   hcalScale_                          = iConfig.getUntrackedParameter<double>("HcalScale", 1.0);
   dataType_                           = iConfig.getUntrackedParameter<int>("DataType", 0);
-  mode_                               = iConfig.getUntrackedParameter<int>("OutMode", 0);
+  mode_                               = iConfig.getUntrackedParameter<int>("OutMode", 11);
 
   // define tokens for access
   tok_trigEvt_  = consumes<trigger::TriggerEvent>(triggerEvent_);

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrkAnalyzer.cc
@@ -173,6 +173,11 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig) :
   a_mipR_                             = iConfig.getParameter<double>("ConeRadiusMIP");
   pTrackMin_                          = iConfig.getParameter<double>("MinimumTrackP");
   eEcalMax_                           = iConfig.getParameter<double>("MaximumEcalEnergy");
+  // Different isolation cuts are described in DN-2016/029
+  // Tight cut uses 2 GeV; Loose cut uses 10 GeV
+  // Eta dependent cut uses (maxRestrictionP_ * exp(|ieta|*log(2.5)/18))
+  // with the factor for exponential slopeRestrictionP_ = log(2.5)/18
+  // maxRestrictionP_ = 8 GeV as came from a study
   maxRestrictionP_                    = iConfig.getParameter<double>("MaxTrackP");
   slopeRestrictionP_                  = iConfig.getParameter<double>("SlopeTrackP");
   eIsolate1_                          = iConfig.getParameter<double>("IsolationEnergyStr");

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
@@ -565,7 +565,7 @@ void IsoTrackCalib::analyze(const edm::Event& iEvent,
 				       << " hit enery is  = "  << t_HitEnergies->at(lll);
 	    }
 	  }
-	  if (t_p>20.0 && t_eMipDR<2.0 && t_hmaxNearP<2.0) {
+	  if (t_p>20.0 && t_eMipDR<2.0 && t_hmaxNearP<10.0) {
 	    tree->Fill();
 	  }
 	}


### PR DESCRIPTION
Correct for soft and eta-dependent isolation strategy. There are eta dependent isolation energy cut off versus a eta-independent cut off. The value whichever is larger is used as the cut off 
Automatically ported from CMSSW_9_0_X #17100 (original by @bsunanda).
Please wait for a new IB (12 to 24H) before requesting to test this PR.