### PR TITLE
fix sequences for HE plan1

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -45,8 +45,6 @@ from RecoEgamma.Configuration.RecoEgammaCosmics_cff import *
 
 # local reco
 trackerCosmics = cms.Sequence(offlineBeamSpot*trackerlocalreco*MeasurementTrackerEvent*tracksP5)
-hbhereco = hbheprereco.clone()
-calolocalrecoCosmics.replace(hbheprereco,hbhereco)
 caloCosmics = cms.Sequence(calolocalrecoCosmics*ecalClustersCosmics)
 caloCosmics_HcalNZS = cms.Sequence(calolocalrecoCosmicsNZS*ecalClustersCosmics)
 muonsLocalRecoCosmics = cms.Sequence(muonlocalreco+muonlocalrecoT0Seg)

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -16,7 +16,7 @@ import RecoLocalCalo.Configuration.hcalLocalReco_cff as _hcalLocalReco_cff
 #
 # sequence CaloLocalReco
 #
-hbheprereco = _hcalLocalReco_cff._default_hbheprereco.clone(
+hbhereco = _hcalLocalReco_cff._default_hbheprereco.clone(
     puCorrMethod = 0,
     firstSample = 0,
     samplesToAdd = 10,
@@ -54,7 +54,7 @@ zdcreco = _hcalLocalReco_cff.zdcreco.clone(
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 
-_phase1_hbheprereco = _hcalLocalReco_cff._phase1_hbheprereco.clone(
+_phase1_hbhereco = _hcalLocalReco_cff._phase1_hbheprereco.clone(
     tsFromDB = cms.bool(False),
     recoParamsFromDB = cms.bool(False),
     algorithm = dict(
@@ -74,7 +74,7 @@ _phase1_hfreco = _hcalLocalReco_cff._phase1_hfreco.clone(
 )
 
 
-run2_HCAL_2017.toReplaceWith(hbheprereco, _phase1_hbheprereco )
+run2_HCAL_2017.toReplaceWith(hbhereco, _phase1_hbhereco )
 run2_HF_2017.toReplaceWith(hfreco, _phase1_hfreco )
 
 hfprereco = _hcalLocalReco_cff.hfprereco.clone(
@@ -84,15 +84,18 @@ hfprereco = _hcalLocalReco_cff.hfprereco.clone(
 from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
 
 # redefine hcal sequence
-hcalLocalRecoSequence = cms.Sequence(hbheprereco+hfreco+horeco+zdcreco)
+hcalLocalRecoSequence = cms.Sequence(hbhereco+hfreco+horeco+zdcreco)
 
 _phase1_hcalLocalRecoSequence = hcalLocalRecoSequence.copy()
 _phase1_hcalLocalRecoSequence.insert(0,hfprereco)
 run2_HF_2017.toReplaceWith(hcalLocalRecoSequence, _phase1_hcalLocalRecoSequence)
 
-_plan1_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy() 
-_plan1_hcalLocalRecoSequence += hbheplan1
+# shuffle modules so "hbheplan1" produces final collection of hits named "hbhereco"
+_plan1_hcalLocalRecoSequence = _phase1_hcalLocalRecoSequence.copy()
+hbheprereco = _phase1_hbhereco.clone()
+_plan1_hcalLocalRecoSequence.insert(0,hbheprereco)
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+run2_HEPlan1_2017.toReplaceWith(hbhereco, hbheplan1)
 run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequence, _plan1_hcalLocalRecoSequence)
 
 calolocalrecoCosmics = cms.Sequence(ecalLocalRecoSequenceCosmics+hcalLocalRecoSequence)

--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -40,6 +40,7 @@ _phase1_hfrecoMB = RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi.hfre
     ),
 )
 from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
+hbheplan1.hbheInput = cms.InputTag("hbheprerecoMB")
 
 _phase1_hcalLocalRecoSequenceNZS = hcalLocalRecoSequenceNZS.copy()
 _phase1_hcalLocalRecoSequenceNZS.insert(0,hfprerecoMB)
@@ -51,6 +52,8 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toReplaceWith( hbherecoMB, _phase1_hbherecoMB )
 
 _plan1_hcalLocalRecoSequenceNZS = _phase1_hcalLocalRecoSequenceNZS.copy()
-_plan1_hcalLocalRecoSequenceNZS += hbheplan1
+hbheprerecoMB = _phase1_hbherecoMB.clone()
+_plan1_hcalLocalRecoSequenceNZS.insert(0,hbheprerecoMB)
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
+run2_HEPlan1_2017.toReplaceWith(hbherecoMB, hbheplan1)
 run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequenceNZS, _plan1_hcalLocalRecoSequenceNZS)

--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -39,8 +39,10 @@ _phase1_hfrecoMB = RecoLocalCalo.HcalRecProducers.HFPhase1Reconstructor_cfi.hfre
         rejectAllFailures = cms.bool(False)
     ),
 )
-from RecoLocalCalo.HcalRecProducers.hbheplan1_cfi import hbheplan1
-hbheplan1.hbheInput = cms.InputTag("hbheprerecoMB")
+import RecoLocalCalo.HcalRecProducers.hbheplan1_cfi
+hbheplan1MB = RecoLocalCalo.HcalRecProducers.hbheplan1_cfi.hbheplan1.clone(
+    hbheInput = cms.InputTag("hbheprerecoMB")
+)
 
 _phase1_hcalLocalRecoSequenceNZS = hcalLocalRecoSequenceNZS.copy()
 _phase1_hcalLocalRecoSequenceNZS.insert(0,hfprerecoMB)
@@ -55,5 +57,5 @@ _plan1_hcalLocalRecoSequenceNZS = _phase1_hcalLocalRecoSequenceNZS.copy()
 hbheprerecoMB = _phase1_hbherecoMB.clone()
 _plan1_hcalLocalRecoSequenceNZS.insert(0,hbheprerecoMB)
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
-run2_HEPlan1_2017.toReplaceWith(hbherecoMB, hbheplan1)
+run2_HEPlan1_2017.toReplaceWith(hbherecoMB, hbheplan1MB)
 run2_HEPlan1_2017.toReplaceWith(hcalLocalRecoSequenceNZS, _plan1_hcalLocalRecoSequenceNZS)


### PR DESCRIPTION
The "final" set of HCAL RecHits produced needs to be named `hbhereco` in order for downstream modules to pick up the right collection. This means that, in sequences where `HBHEIsolatedNoiseReflagger` is not run, the `hbheplan1` module needs to be renamed to `hbhereco`. Therefore, where the `HBHEPhase1Reconstructor` would normally be named `hbhereco` in these sequences, it needs to be `hbheprereco` instead.

This change is made for NZS and Cosmic sequences. It should hopefully fix the crash at the Tier0. This PR will be backported to 90X and 84X (once the fix is agreed to work).

@bsunanda: at some later date we need to make AlCa sequences aware of Phase1 changes:
https://github.com/cms-sw/cmssw/blob/master/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
https://github.com/cms-sw/cmssw/blob/master/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
(I just noticed today that these exist.)

attn: @deguio, @hatakeyamak, @abdoulline

