### PR TITLE
fix rotation in me0geometry

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
@@ -366,8 +366,7 @@ ME0GeometryBuilderFromDDD10EtaPart::boundPlane(const DDFilteredView& fv,
   Basic3DVector<float> newX(1.,0.,0.);
   Basic3DVector<float> newY(0.,0.,1.);
   Basic3DVector<float> newZ(0.,1.,0.);
-  // Odd chambers are inverted in gem.xml
-  if (isOddChamber) newY *= -1;
+  newY *= -1;
 
   rotResult.rotateAxes(newX, newY, newZ);
 


### PR DESCRIPTION
fix rotation in me0geometry - in me0 even and odd chambers are not inverted
this has been split from #17648 

@calabria @pietverwilligen @kpedro88
