### PR TITLE
Resolve segfault in MuonGEMHitsHarvestor::dqmEndJob

### DIFF
--- a/Validation/MuonGEMHits/interface/GEMDetLabel.h
+++ b/Validation/MuonGEMHits/interface/GEMDetLabel.h
@@ -1,5 +1,7 @@
+#include <array>
+
 namespace GEMDetLabel {
-  static const std::string l_suffix[4] = {"_l1","_l2","_l1or2","_l1and2"};
-  static const std::string s_suffix[2] = {"_st1","_st2"};
-  static const std::string c_suffix[3] = {"_all","_odd","_even"};
+  static const std::array<std::string, 4> l_suffix = { {"_l1", "_l2", "_l1or2", "_l1and2"} };
+  static const std::array<std::string, 2> s_suffix = { {"_st1","_st2"} };
+  static const std::array<std::string, 3> c_suffix = { {"_all","_odd","_even"} };
 }

--- a/Validation/MuonGEMHits/plugins/MuonGEMHitsHarvestor.cc
+++ b/Validation/MuonGEMHits/plugins/MuonGEMHitsHarvestor.cc
@@ -108,28 +108,28 @@ MuonGEMHitsHarvestor::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter &
   TH1F* track_eta[3];
   TH1F* track_phi[3][3];
 
-  for ( int i = 0 ; i< 3 ; i++) {
+  for (unsigned int i = 0; i < 3; i++) {
     track_eta[i]=nullptr;
-    for( int j=0 ; j<3 ; j++) {
+    for (unsigned int j=0; j < 3; j++) {
       track_phi[i][j]=nullptr;
     }
   }
 
-  for(int i=0 ; i<3 ; i++) {
+  for (unsigned int i = 0; i < s_suffix.size(); i++) {
     string suffix = s_suffix[i];
     string track_eta_name = dbe_path_+"track_eta"+suffix;
     if ( ig.get(track_eta_name.c_str()) != nullptr) track_eta[i] = (TH1F*)ig.get(track_eta_name.c_str())->getTH1F()->Clone();
-    for(int j=0 ; j<4 ; j++) {
+    for (unsigned int j = 0; j < l_suffix.size(); j++) {
       suffix = s_suffix[i]+l_suffix[j];
       ProcessBooking( ibooker, ig, "sh_eta"+suffix,track_eta[i]);
     }
   }
-  for(int i=0 ; i<3; i++) {
-    for( int j=0 ; j<3 ; j++) {
+  for (unsigned int i = 0; i < s_suffix.size(); i++) {
+    for (unsigned int j = 0 ; j < c_suffix.size(); j++) {
       string suffix = s_suffix[i]+c_suffix[j];
       string track_phi_name = dbe_path_+"track_phi"+suffix;
       if ( ig.get(track_phi_name.c_str()) != nullptr) track_phi[i][j] = (TH1F*)ig.get(track_phi_name.c_str())->getTH1F()->Clone();
-      for ( int k=0; k<4 ; k++) {
+      for (unsigned int k = 0; k < l_suffix.size(); k++) {
         suffix = s_suffix[i]+l_suffix[k]+c_suffix[j];
         ProcessBooking( ibooker, ig, "sh_phi"+suffix,track_phi[i][j]);
       }


### PR DESCRIPTION
This was noticed on slc6_amd64_gcc700 SCRAM_ARCH.

The problem is that `s_suffix` has only two labels, yet the code assumes
that it has 3 elements. This is a technical change to make sure that we
never go out-of-bounds.

All 21 failing RelVal now worked:

21 21 21 21 tests passed, 0 0 0 0 failed

runTheMatrix.py -i all -j 32 -l
24034.0,23653.0,23646.0,23634.0,23621.0,23253.0,23246.0,23234.0,23221.0,
21253.0,21246.0,21234.0,21221.0,20453.0,20446.0,20434.0,20421.0,20053.0,
20046.0,20034.0,20021.0

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>