### PR TITLE
SiPixelPhase1 - Filter update

### DIFF
--- a/DQM/SiPixelPhase1Clusters/interface/SiPixelPhase1Clusters.h
+++ b/DQM/SiPixelPhase1Clusters/interface/SiPixelPhase1Clusters.h
@@ -1,7 +1,7 @@
-#ifndef SiPixelPhase1Clusters_h 
-#define SiPixelPhase1Clusters_h 
+#ifndef SiPixelPhase1Clusters_h
+#define SiPixelPhase1Clusters_h
 // -*- C++ -*-
-// 
+//
 // Package:     SiPixelPhase1Clusters
 // Class  :     SiPixelPhase1Clusters
 //
@@ -28,6 +28,11 @@ class SiPixelPhase1Clusters : public SiPixelPhase1Base {
     READOUT_CHARGE,
     READOUT_NCLUSTERS
   };
+  // Uncomment to add trigger event flag enumerators
+  // enum {
+  //   FLAG_HLT,
+  //   FLAG_L1,
+  // }
 
   public:
   explicit SiPixelPhase1Clusters(const edm::ParameterSet& conf);

--- a/DQM/SiPixelPhase1Clusters/interface/SiPixelPhase1Clusters.h
+++ b/DQM/SiPixelPhase1Clusters/interface/SiPixelPhase1Clusters.h
@@ -29,6 +29,7 @@ class SiPixelPhase1Clusters : public SiPixelPhase1Base {
     READOUT_NCLUSTERS
   };
   // Uncomment to add trigger event flag enumerators
+  // Make sure enum corresponds correctly with flags defined in _cfi.py file
   // enum {
   //   FLAG_HLT,
   //   FLAG_L1,

--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -6,7 +6,7 @@ SiPixelPhase1ClustersCharge = DefaultHistoDigiCluster.clone(
   title = "Cluster Charge",
   range_min = 0, range_max = 200e3, range_nbins = 200,
   xlabel = "Charge (electrons)",
-  
+
   specs = VPSet(
     #StandardSpecification2DProfile,
     StandardSpecificationPixelmapProfile,
@@ -219,11 +219,19 @@ SiPixelPhase1ClustersConf = cms.VPSet(
   SiPixelPhase1ClustersReadoutNClusters
 )
 
+## Uncomment to create trigger event flag settings
+# import DQM.SiPixelPhase1Common.TriggerEventFlag_cfi.py as triggerflag
+# SiPixelPhase1ClustersTriggers = cms.VPSet(
+#   triggerflag.genericTriggerEventFlag4HLTdb,
+#   triggerflag.genericTriggerEventFlag4L1bd,
+# )
 
 SiPixelPhase1ClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1Clusters",
         src = cms.InputTag("siPixelClusters"),
         histograms = SiPixelPhase1ClustersConf,
         geometry = SiPixelPhase1Geometry
+        ## Uncomment to expose trigger event flag to analyzer class
+        # , triggerflag = SiPixelPhase1ClustersTriggers,  
 )
 
 SiPixelPhase1ClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",

--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -219,19 +219,18 @@ SiPixelPhase1ClustersConf = cms.VPSet(
   SiPixelPhase1ClustersReadoutNClusters
 )
 
-## Uncomment to create trigger event flag settings
-# import DQM.SiPixelPhase1Common.TriggerEventFlag_cfi.py as triggerflag
-# SiPixelPhase1ClustersTriggers = cms.VPSet(
+## Uncomment to add trigger event flag settings
+import DQM.SiPixelPhase1Common.TriggerEventFlag_cfi as triggerflag
+SiPixelPhase1ClustersTriggers = cms.VPSet(
 #   triggerflag.genericTriggerEventFlag4HLTdb,
 #   triggerflag.genericTriggerEventFlag4L1bd,
-# )
+)
 
 SiPixelPhase1ClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1Clusters",
         src = cms.InputTag("siPixelClusters"),
         histograms = SiPixelPhase1ClustersConf,
-        geometry = SiPixelPhase1Geometry
-        ## Uncomment to expose trigger event flag to analyzer class
-        # , triggerflag = SiPixelPhase1ClustersTriggers,  
+        geometry = SiPixelPhase1Geometry,
+        triggerflag = SiPixelPhase1ClustersTriggers,
 )
 
 SiPixelPhase1ClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -45,7 +45,8 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
     for(SiPixelCluster const& cluster : *it) {
       int row = cluster.x()-0.5, col = cluster.y()-0.5;
       //// Uncomment to activate trigger filtering if statement
-      // if( checktrigger(iEvent,iSetup,FLAG_HLT) && checktrigger(iEvent,iSetup,FLAG_L1) )
+      //// Any logical operation between trigger should be handled manually here
+      // if( checktrigger(iEvent,iSetup,FLAG_HLT) )
       histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
       histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
       histo[SIZE  ].fill(double(cluster.size()  ), id, &iEvent, col, row);

--- a/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
+++ b/DQM/SiPixelPhase1Clusters/src/SiPixelPhase1Clusters.cc
@@ -19,7 +19,7 @@
 
 
 SiPixelPhase1Clusters::SiPixelPhase1Clusters(const edm::ParameterSet& iConfig) :
-  SiPixelPhase1Base(iConfig) 
+  SiPixelPhase1Base(iConfig)
 {
   srcToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("src"));
 }
@@ -29,12 +29,12 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
   iEvent.getByToken(srcToken_, input);
   if (!input.isValid()) return;
 
-  bool hasClusters=false;  
+  bool hasClusters=false;
 
   edm::ESHandle<TrackerGeometry> tracker;
   iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
   assert(tracker.isValid());
-  
+
   edmNew::DetSetVector<SiPixelCluster>::const_iterator it;
   for (it = input->begin(); it != input->end(); ++it) {
     auto id = DetId(it->detId());
@@ -44,6 +44,8 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
 
     for(SiPixelCluster const& cluster : *it) {
       int row = cluster.x()-0.5, col = cluster.y()-0.5;
+      //// Uncomment to activate trigger filtering if statement
+      // if( checktrigger(iEvent,iSetup,FLAG_HLT) && checktrigger(iEvent,iSetup,FLAG_L1) )
       histo[READOUT_CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
       histo[CHARGE].fill(double(cluster.charge()), id, &iEvent, col, row);
       histo[SIZE  ].fill(double(cluster.size()  ), id, &iEvent, col, row);
@@ -77,4 +79,3 @@ void SiPixelPhase1Clusters::analyze(const edm::Event& iEvent, const edm::EventSe
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1Clusters);
-

--- a/DQM/SiPixelPhase1Common/BuildFile.xml
+++ b/DQM/SiPixelPhase1Common/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="Alignment/TrackerAlignment"/>
 <use   name="CondFormats/GeometryObjects"/>
 <use   name="CondFormats/SiPixelObjects"/>
+<use   name="CommonTools/TriggerUtils"/>
 
 <export>
   <lib   name="1"/>

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -37,9 +37,9 @@ PerLadder = cms.PSet(enabled = cms.bool(True)) # histos per ladder, profiles
 PerLayer2D = cms.PSet(enabled = cms.bool(True)) # 2D maps/profiles of layers
 PerLayer1D = cms.PSet(enabled = cms.bool(True)) # normal histos per layer
 PerReadout = cms.PSet(enabled = cms.bool(True)) # "Readout view", also for initial timing
-OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(True)) #switch to overlay digi/clusters curves for timing scan 
+OverlayCurvesForTiming= cms.PSet(enabled = cms.bool(True)) #switch to overlay digi/clusters curves for timing scan
 
-# Default histogram configuration. This is _not_ used automatically, but you 
+# Default histogram configuration. This is _not_ used automatically, but you
 # can import and pass this (or clones of it) in the plugin config.
 DefaultHisto = cms.PSet(
   # Setting this to False hides all plots of this HistogramManager. It does not even record any data.
@@ -52,7 +52,7 @@ DefaultHisto = cms.PSet(
   # If False, no histograms are booked for DetIds where any column is undefined.
   # since or-columns are not supported any longer, this has to be False, otherwise
   # you will see a PXBarrel_UNDEFINED with endcap modules and the other way round.
-  # It could still be useful for debugging, to see if there is more UNDEFINED 
+  # It could still be useful for debugging, to see if there is more UNDEFINED
   # than expected.
   bookUndefined = cms.bool(False),
 
@@ -66,18 +66,18 @@ DefaultHisto = cms.PSet(
   ylabel = cms.string("count"),
   dimensions = cms.int32(1),
   range_min = cms.double(0),
-  range_max = cms.double(100), 
+  range_max = cms.double(100),
   range_nbins = cms.int32(100),
   range_y_min = cms.double(0),
-  range_y_max = cms.double(100), 
+  range_y_max = cms.double(100),
   range_y_nbins = cms.int32(100),
 
   # This structure is output by the SpecficationBuilder.
   specs = cms.VPSet()
-  #  cms.PSet(spec = 
+  #  cms.PSet(spec =
   #    cms.VPset(
   #      cms.PSet(
-  #        type = GROUPBY, 
+  #        type = GROUPBY,
   #        stage = FIRST,
   #        columns = cms.vstring("P1PXBBarrel|P1PXECEndcap", "DetId"),
   #        arg = cms.string("")
@@ -105,7 +105,7 @@ DefaultHistoTrack.topFolderName= cms.string("PixelPhase1/Tracks")
 DefaultHistoReadout=DefaultHisto.clone()
 DefaultHistoReadout.topFolderName= cms.string("PixelPhase1/FED/Readout")
 
-# Commonly used specifications. 
+# Commonly used specifications.
 StandardSpecifications1D = [
     # The column names are either defined in the GeometryInterface.cc or read from TrackerTopology.
     # Endcap names side by side. The "/" separates columns and also defines how the output folders are nested.
@@ -115,7 +115,7 @@ StandardSpecifications1D = [
                             .save()
                             .reduce("MEAN")
                             .groupBy("PXBarrel/Shell/PXLayer", "EXTEND_X")
-                            .save(),                         
+                            .save(),
     Specification(PerLadder).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade")
                             .save()
                             .reduce("MEAN")
@@ -139,9 +139,9 @@ StandardSpecifications1D = [
                             .reduce("MEAN")
                             .groupBy("PXBarrel/Shell/PXLayer/SignedLadder", "EXTEND_X")
                             .save(),
-    Specification().groupBy("PXBarrel/PXLayer")    
+    Specification().groupBy("PXBarrel/PXLayer")
                             .save(),
-    Specification().groupBy("PXForward/PXDisk")    
+    Specification().groupBy("PXForward/PXDisk")
                             .save()
 
 
@@ -149,23 +149,23 @@ StandardSpecifications1D = [
 
 StandardSpecificationTrend = [
     Specification().groupBy("PXBarrel/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXBarrel", "EXTEND_X")
                    .save(),
     Specification().groupBy("PXForward/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXForward", "EXTEND_X")
                    .save()
 ]
 
 StandardSpecificationTrend2D = [
     Specification().groupBy("PXBarrel/PXLayer/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXBarrel/PXLayer", "EXTEND_X")
                    .groupBy("PXBarrel", "EXTEND_Y")
                    .save(),
     Specification().groupBy("PXForward/PXDisk/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXForward/PXDisk","EXTEND_X")
                    .groupBy("PXForward", "EXTEND_Y")
                    .save()
@@ -234,7 +234,7 @@ StandardSpecificationOccupancy = [ #this produces pixel maps with counting
 
 # the same for NDigis and friends. Needed due to technical limitations...
 StandardSpecifications1D_Num = [
-    Specification(PerLadder).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/DetId/Event") 
+    Specification(PerLadder).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/DetId/Event")
                             .reduce("COUNT") # per-event counting
                             .groupBy("PXBarrel/Shell/PXLayer/SignedLadder").save()
                             .reduce("MEAN")
@@ -244,7 +244,7 @@ StandardSpecifications1D_Num = [
                             .reduce("COUNT")
                             .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName")
                             .save(),
-    Specification(PerLadder).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/DetId/Event") 
+    Specification(PerLadder).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/DetId/Event")
                             .reduce("COUNT") # per-event counting
                             .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade").save()
                             .reduce("MEAN")
@@ -270,11 +270,11 @@ StandardSpecifications1D_Num = [
                              .groupBy("PXBarrel/Shell/PXLayer/SignedLadder", "EXTEND_X")
                              .save(),
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXBarrel/PXLayer")
                              .save(),
     Specification().groupBy("PXForward/PXDisk/Event")
-                             .reduce("COUNT")    
+                             .reduce("COUNT")
                              .groupBy("PXForward/PXDisk/")
                              .save()
 ]
@@ -288,7 +288,11 @@ StandardSpecificationInclusive_Num = [#to count inclusively objects in substruct
     Specification().groupBy("PXForward/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward")
-                   .save()
+                   .save(),
+    Specification().groupBy("PXAll/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXAll")
+                   .save(),
 ]
 
 StandardSpecificationTrend_Num = [
@@ -296,7 +300,7 @@ StandardSpecificationTrend_Num = [
     Specification().groupBy("PXBarrel/PXLayer/Event")
                    .reduce("COUNT")
                    .groupBy("PXBarrel/PXLayer/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXBarrel/PXLayer","EXTEND_X")
                    .groupBy("PXBarrel", "EXTEND_Y")
                    .save(),
@@ -309,7 +313,7 @@ StandardSpecificationTrend_Num = [
     Specification().groupBy("PXForward/PXDisk/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward/PXDisk/Lumisection")
-                   .reduce("MEAN") 
+                   .reduce("MEAN")
                    .groupBy("PXForward/PXDisk","EXTEND_X")
                    .groupBy("PXForward", "EXTEND_Y")
                    .save(),
@@ -319,6 +323,12 @@ StandardSpecificationTrend_Num = [
                    .reduce("MEAN")
                    .groupBy("PXForward", "EXTEND_X")
                    .save(),
+    Specification().groupBy("PXAll/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXAll/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXAll", "EXTEND_X")
+                   .save(),
 ]
 
 
@@ -327,7 +337,7 @@ StandardSpecification2DProfile_Num = [
        .groupBy("PXBarrel/PXLayer/SignedLadder/SignedModule" + "/DetId/Event")
        .reduce("COUNT")
        .groupBy("PXBarrel/PXLayer/SignedLadder/SignedModule")
-       .reduce("MEAN") 
+       .reduce("MEAN")
        .groupBy("PXBarrel/PXLayer/SignedLadder", "EXTEND_X")
        .groupBy("PXBarrel/PXLayer", "EXTEND_Y")
        .save(),
@@ -351,4 +361,3 @@ def VPSet(*args):
             e = list(a)
         l = l+e
     return cms.VPSet(l)
-

--- a/DQM/SiPixelPhase1Common/python/TriggerEventFlag_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/TriggerEventFlag_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+genericTriggerEventFlag4HLTdb = cms.PSet(
+   andOr         = cms.bool( False ),
+   dbLabel       = cms.string("SiStripDQMTrigger"), # ("TrackerDQMTrigger"),
+   andOrHlt      = cms.bool(True), # True:=OR; False:=AND
+   hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
+   hltPaths      = cms.vstring("HLT_ZeroBias_v*","HLT_HIZeroBias_v*","HLT_PAL1MinimumBiasHF_OR_SinglePixelTrack_*"),
+   hltDBKey      = cms.string("SiStrip_HLT"),
+   errorReplyHlt = cms.bool( False ),
+   verbosityLevel = cms.uint32(1)
+)
+
+genericTriggerEventFlag4L1bd = cms.PSet(
+   andOr         = cms.bool( False ),
+   dbLabel       = cms.string("SiStripDQMTrigger"), # ("TrackerDQMTrigger"),
+   l1Algorithms  = cms.vstring(""), # cms.vstring( 'L1Tech_BPTX_plus_AND_minus.v0', 'L1_ZeroBias' )
+   andOrL1       = cms.bool( True ),
+#   errorReplyL1  = cms.bool( True ),
+   errorReplyL1  = cms.bool( False ),
+   l1DBKey       = cms.string("SiStrip_L1"),
+   l1BeforeMask  = cms.bool( True ), # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
+   verbosityLevel = cms.uint32(1)
+)

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -97,8 +97,10 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
 
   auto pxbarrel  = [] (InterestingQuantities const& iq) { return iq.sourceModule.subdetId() == PixelSubdetector::PixelBarrel ? 0 : UNDEFINED; };
   auto pxforward = [] (InterestingQuantities const& iq) { return iq.sourceModule.subdetId() == PixelSubdetector::PixelEndcap ? 0 : UNDEFINED; };
+  auto pxall     = [] (InterestingQuantities const& iq) { return 0 ; };
   addExtractor(intern("PXBarrel"),  pxbarrel,  0, 0);
   addExtractor(intern("PXForward"), pxforward, 0, 0);
+  addExtractor(intern("PXAll"),     pxall,     0, 0);
 
   // Redefine the disk numbering to use the sign
   auto pxendcap = extractors[intern("PXEndcap")];
@@ -165,12 +167,12 @@ void GeometryInterface::loadFromTopology(edm::EventSetup const& iSetup, const ed
 }
 
 void GeometryInterface::loadFromSiPixelCoordinates(edm::EventSetup const& iSetup, const edm::ParameterSet& iConfig) {
-  // TODO: SiPixelCoordinates has a large overlap with theis GeometryInterface 
+  // TODO: SiPixelCoordinates has a large overlap with theis GeometryInterface
   // in general.
   // Rough convention is to use own code for things that are easy and fast to
   // determine, and use SiPixelCoordinates for complicated things.
   // SiPixelCoordinates uses lookup maps for everything, so it is faster than
-  // most other code, but still slow on DQM scales. 
+  // most other code, but still slow on DQM scales.
   int phase = iConfig.getParameter<int>("upgradePhase");
 
   // this shared pointer is kept alive by the references in the lambdas that follow.
@@ -180,13 +182,13 @@ void GeometryInterface::loadFromSiPixelCoordinates(edm::EventSetup const& iSetup
   // note that we should reeinit for each event. But this probably won't explode
   // thanks to the massive memoization in SiPixelCoordinates which is completely
   // initialized while booking.
-  coord->init(iSetup); 
+  coord->init(iSetup);
 
   // SiPixelCoordinates uses a different convention for UNDEFINED:
   auto from_coord = [](double in) { return (in == -9999.0) ? UNDEFINED : Value(in); };
 
-  // Rings are a concept that cannot be derived from bitmasks. 
-  addExtractor(intern("PXRing"), 
+  // Rings are a concept that cannot be derived from bitmasks.
+  addExtractor(intern("PXRing"),
     [coord, from_coord] (InterestingQuantities const& iq) {
       return from_coord(coord->ring(iq.sourceModule));
     }
@@ -238,7 +240,7 @@ void GeometryInterface::loadFromSiPixelCoordinates(edm::EventSetup const& iSetup
     }
   );
 
-  // Pixel Map axis. 
+  // Pixel Map axis.
   // TODO: automatic range and binning for phase0 are incorrect.
   // Should be set manually here.
   addExtractor(intern("SignedModuleCoord"), // BPIX x
@@ -276,7 +278,7 @@ void GeometryInterface::loadFromSiPixelCoordinates(edm::EventSetup const& iSetup
       } else {
         return UNDEFINED; // TODO: phase2
       }
-    }, UNDEFINED, UNDEFINED, phase == 1 ? 0.25 : 0.2 
+    }, UNDEFINED, UNDEFINED, phase == 1 ? 0.25 : 0.2
   );
   addExtractor(intern("SignedShiftedBladePanelCoord"), // FPIX-as-one y
     [coord, from_coord, phase] (InterestingQuantities const& iq) {
@@ -431,4 +433,3 @@ std::string GeometryInterface::formatValue(Column col, Value val) {
   if (val == UNDEFINED) value = "_UNDEFINED";
   return format_value[std::make_pair(col, val)] = name+value;
 }
-

--- a/DQM/SiPixelPhase1Common/src/SiPixelPhase1Base.cc
+++ b/DQM/SiPixelPhase1Common/src/SiPixelPhase1Base.cc
@@ -1,0 +1,58 @@
+// -*- C++ -*-
+//
+// Class:      SiPixelPhase1Base
+//
+// Implementations of the class
+//
+// Original Author: Yi-Mu "Enoch" Chen
+
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+
+// Constructor requires manually looping the trigger flag settings
+// Since constructor of GenericTriggerEventFlag requires
+// EDConsumerBase class protected member calls
+SiPixelPhase1Base::SiPixelPhase1Base( const edm::ParameterSet& iConfig ) :
+  DQMEDAnalyzer(),
+  HistogramManagerHolder( iConfig )
+{
+  // Flags will default to empty vector if not specified in configuration file
+  auto flags = iConfig.getUntrackedParameter<edm::VParameterSet>( "triggerflags" , {} );
+
+  for( auto& flag : flags ){
+    triggerlist.emplace_back( new GenericTriggerEventFlag(flag, consumesCollector(), *this) );
+  }
+}
+
+// Booking histograms as required by the DQM
+void
+SiPixelPhase1Base::bookHistograms(
+  DQMStore::IBooker&     iBooker,
+  edm::Run const&        run,
+  edm::EventSetup const& iSetup )
+{
+  for( HistogramManager& histoman : histo ){
+    histoman.book( iBooker, iSetup );
+  }
+
+  // Running trigger flag initialization (per run)
+  for( auto& trigger : triggerlist ){
+    if( trigger->on() ){
+      trigger->initRun( run, iSetup );
+    }
+  }
+}
+
+// trigger checking function
+bool
+SiPixelPhase1Base::checktrigger(
+  const edm::Event&      iEvent,
+  const edm::EventSetup& iSetup,
+  const unsigned         trgidx ) const
+{
+  if( !iEvent.isRealData() ) { return rand()%5; } // Failing the 4/5 time for MC (testing)
+
+  // For actual data
+  if( !triggerlist.at(trgidx)->on() ) { return true; } // if flag is not on, return true regardless
+
+  return triggerlist.at(trgidx)->accept( iEvent, iSetup );
+}

--- a/DQM/SiPixelPhase1Common/src/SiPixelPhase1Base.cc
+++ b/DQM/SiPixelPhase1Common/src/SiPixelPhase1Base.cc
@@ -49,10 +49,11 @@ SiPixelPhase1Base::checktrigger(
   const edm::EventSetup& iSetup,
   const unsigned         trgidx ) const
 {
-  if( !iEvent.isRealData() ) { return rand()%5; } // Failing the 4/5 time for MC (testing)
+  // Always return true for MC
+  if( !iEvent.isRealData() ) { return true; }
 
-  // For actual data
-  if( !triggerlist.at(trgidx)->on() ) { return true; } // if flag is not on, return true regardless
+  // Always return true is flag is not on;
+  if( !triggerlist.at(trgidx)->on() ) { return true; }
 
   return triggerlist.at(trgidx)->accept( iEvent, iSetup );
 }


### PR DESCRIPTION
* Added functionality to `SiPixelPhase1Base` to allow for filter filtering using the `GenericTriggerFlag` class
   * Trigger filtering defined in `SiPixelPhase1Base:checktrigger()`
   * Example codes in comments of `SiPixelPhase1Clusters`, interface similar to the existing `HistogramManger` setting with `enum`s and `cms.VPset`s

* Added new geometry of `PXAll` which is inclusive a inclusive set for `PXBarrel` and `PXForward`
 