### PR TITLE
Switch phase1 tracking to use CA seeding by default

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -6,8 +6,8 @@ from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 
-Run2_2017 = cms.ModifierChain(Run2_2016, phase1Pixel, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, trackingPhase1QuadProp, run2_GEM_2017)
+Run2_2017 = cms.ModifierChain(Run2_2016, phase1Pixel, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, trackingPhase1, run2_GEM_2017)
 

--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1CA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1CA_cff.py
@@ -1,6 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from Configuration.Eras.ModifierChain_run2_2017_noTrackingModifier_cff import run2_2017_noTrackingModifier
-from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-
-Run2_2017_trackingPhase1CA = cms.ModifierChain(run2_2017_noTrackingModifier, trackingPhase1)

--- a/Configuration/Eras/python/Era_Run2_2017_trackingPhase1QuadProp_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingPhase1QuadProp_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.ModifierChain_run2_2017_noTrackingModifier_cff import run2_2017_noTrackingModifier
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+
+Run2_2017_trackingPhase1QuadProp = cms.ModifierChain(run2_2017_noTrackingModifier, trackingPhase1QuadProp)
+

--- a/Configuration/Eras/python/ModifierChain_run2_2017_noTrackingModifier_cff.py
+++ b/Configuration/Eras/python/ModifierChain_run2_2017_noTrackingModifier_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 
-run2_2017_noTrackingModifier = Run2_2017.copyAndExclude([trackingPhase1QuadProp])
+run2_2017_noTrackingModifier = Run2_2017.copyAndExclude([trackingPhase1])

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -55,15 +55,15 @@ def _trackingRun2(stepList):
             continue
         res.append(s)
     return res
-def _trackingPhase1CA(stepList):
+def _trackingPhase1QuadProp(stepList):
     res = []
     for step in stepList:
         s = step
         if 'RecoFull' in step:
             if 'trackingOnly' in step:
-                s = s.replace('Only', 'OnlyPhase1CA')
+                s = s.replace('Only', 'OnlyPhase1QuadProp')
             else:
-                s = s.replace('Full', 'Full_trackingPhase1CA')
+                s = s.replace('Full', 'Full_trackingPhase1QuadProp')
         if 'ALCA' in s:
             continue
         res.append(s)
@@ -88,6 +88,6 @@ def _trackingLowPU(stepList):
 workflows[10024.1] = [ workflows[10024.0][0], _trackingOnly(workflows[10024.0][1]) ]
 workflows[10024.2] = [ workflows[10024.0][0], _trackingRun2(workflows[10024.0][1]) ]
 workflows[10024.3] = [ workflows[10024.1][0], _trackingRun2(workflows[10024.1][1]) ]
-workflows[10024.4] = [ workflows[10024.0][0], _trackingPhase1CA(workflows[10024.0][1]) ]
-workflows[10024.5] = [ workflows[10024.1][0], _trackingPhase1CA(workflows[10024.1][1]) ]
+workflows[10024.4] = [ workflows[10024.0][0], _trackingPhase1QuadProp(workflows[10024.0][1]) ]
+workflows[10024.5] = [ workflows[10024.1][0], _trackingPhase1QuadProp(workflows[10024.1][1]) ]
 workflows[10024.6] = [ workflows[10024.0][0], _trackingLowPU(workflows[10024.0][1]) ]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1960,6 +1960,6 @@ for step in upgradeSteps:
 # 2017 tracking specific eras
 steps['RecoFull_trackingRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_2017']])
 steps['RecoFull_trackingOnlyRun2_2017'] = merge([{'--era': 'Run2_2017_trackingRun2'}, steps['RecoFull_trackingOnly_2017']])
-steps['RecoFull_trackingPhase1CA_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1CA'}, steps['RecoFull_2017']])
-steps['RecoFull_trackingOnlyPhase1CA_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1CA'}, steps['RecoFull_trackingOnly_2017']])
+steps['RecoFull_trackingPhase1QuadProp_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1QuadProp'}, steps['RecoFull_2017']])
+steps['RecoFull_trackingOnlyPhase1QuadProp_2017'] = merge([{'--era': 'Run2_2017_trackingPhase1QuadProp'}, steps['RecoFull_trackingOnly_2017']])
 steps['RecoFull_trackingLowPU_2017'] = merge([{'--era': 'Run2_2017_trackingLowPU'}, steps['RecoFull_2017']])

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,7 +21,7 @@ class Eras (object):
                  'Run2_2016_pA',
                  'Run2_2017',
                  'Run2_2017_trackingRun2',
-                 'Run2_2017_trackingPhase1CA',
+                 'Run2_2017_trackingPhase1QuadProp',
                  'Run2_2017_trackingLowPU',
                  'Run2_2018',
                  'Run3',


### PR DESCRIPTION
This PR switches the phase1 tracking to use the CA seeding by default (effectively reverting the last commit of #16911). The current default seeding is kept in special workflows (using the same workflow numbers as the special CA workflows had before).

Here are MTV plots comparing CA seeding to the current default with 1000 ttbar+35PU events in 900pre4+#17537+#17511+#17544 (which should correspond to 900pre5 for tracking)
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_9_0_0_pre4_phase1ca/
Here are also some b tagging performance plots from the same events
https://cms-btag-validation.web.cern.ch/cms-btag-validation/CA-tracking900pre4/plots123/
(thanks to @JyothsnaKomaragiri)

Tested in CMSSW_9_1_X_2017-03-02-2300, expecting changes like above in phase1 workflows, no changes expected in phase0/2.

@rovere @VinInn @felicepantaleo @ebrondol 