### PR TITLE
Make track algo priority order dynamic

### DIFF
--- a/DQM/BeamMonitor/test/2012_ReducedTrackingSteps_44XOnwards_Test_beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/BeamMonitor/test/2012_ReducedTrackingSteps_44XOnwards_Test_beam_dqm_sourceclient-live_cfg.py
@@ -124,6 +124,7 @@ process.initialStepSeeds.RegionFactoryPSet.RegionPSet.beamSpot = cms.InputTag("o
 
 
 #Reduced tracking steps goes in reco
+process.load("RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder")
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 process.generalTracksForDQM = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('initialStepTracks'),

--- a/FastSimulation/Tracking/python/JetCoreRegionalStep_cff.py
+++ b/FastSimulation/Tracking/python/JetCoreRegionalStep_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 # a dummy track collection
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 jetCoreRegionalStepTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (),

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -20,7 +20,7 @@ from HLTrigger.Configuration.common import *
 
 
 # Dynamic track algo priority order
-def customiseForXXXXX(process):
+def customiseFor17771(process):
     if not hasattr(process, "hltTrackAlgoPriorityOrder"):
         from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
         process.hltTrackAlgoPriorityOrder = trackAlgoPriorityOrder.clone(
@@ -37,6 +37,6 @@ def customiseForXXXXX(process):
 def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
-    process = customiseForXXXXX(process)
+    process = customiseFor17771(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -19,9 +19,24 @@ from HLTrigger.Configuration.common import *
 #     return process
 
 
+# Dynamic track algo priority order
+def customiseForXXXXX(process):
+    if not hasattr(process, "hltTrackAlgoPriorityOrder"):
+        from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
+        process.hltTrackAlgoPriorityOrder = trackAlgoPriorityOrder.clone(
+            ComponentName = "hltTrackAlgoPriorityOrder",
+            algoOrder = [] # HLT iteration order is correct in the hard-coded default
+        )
+
+    for producer in producers_by_type(process, "SimpleTrackListMerger", "TrackCollectionMerger", "TrackListMerger"):
+        if not hasattr(producer, "trackAlgoPriorityOrder"):
+            producer.trackAlgoPriorityOrder = cms.string("hltTrackAlgoPriorityOrder")
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customiseForXXXXX(process)
 
     return process

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
 
 ###### Muon reconstruction module #####
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiEarlyGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),

--- a/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
+++ b/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
@@ -12,6 +12,7 @@ from RecoHI.HiMuonAlgos.HiRegitMuonMixedTripletStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonPixelLessStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonSeededStep_cff import *
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiGeneralAndRegitMuTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiRegitMuInitialStepTracks'),

--- a/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
@@ -32,6 +32,7 @@ hiInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackS
 
 
 # using the tracklist merger with one collection simply applies the quality flags
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiSelectedTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = cms.VInputTag(cms.InputTag('hiGlobalPrimTracks')),

--- a/RecoHI/HiTracking/python/MergeRegitTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeRegitTrackCollectionsHI_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiRegitTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiRegitInitialStepTracks'),

--- a/RecoHI/HiTracking/python/MergeRegit_cff.py
+++ b/RecoHI/HiTracking/python/MergeRegit_cff.py
@@ -1,3 +1,4 @@
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.simpleTrackListMerger_cfi
 hiGeneralAndRegitTracks = RecoTracker.FinalTrackSelectors.simpleTrackListMerger_cfi.simpleTrackListMerger.clone(
     TrackProducer1 = 'hiGeneralTracks',

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiGeneralTracksNoRegitMu = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -179,6 +179,7 @@ hiDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMul
     ) #end of vpset
     ) #end of clone
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiDetachedTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers=cms.VInputTag(cms.InputTag('hiDetachedTripletStepTracks')),

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -175,6 +175,7 @@ hiLowPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiT
     ) #end of clone
 
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiLowPtTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = cms.VInputTag(cms.InputTag('hiLowPtTripletStepTracks')),

--- a/RecoHI/HiTracking/python/hiMergedConformalPixelTracking_cff.py
+++ b/RecoHI/HiTracking/python/hiMergedConformalPixelTracking_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
 from RecoHI.HiTracking.hiMultiTrackSelector_cfi import *
 from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import *
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 # Selector for quality pixel tracks with tapering high-pT cut
 

--- a/RecoLocalTracker/SubCollectionProducers/test/run_simsplit.py
+++ b/RecoLocalTracker/SubCollectionProducers/test/run_simsplit.py
@@ -57,6 +57,7 @@ process.load("TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi
 process.trajectoryCleanerBySharedHits.fractionShared = 0.0
 process.trajectoryCleanerBySharedHits.allowSharedFirstHit = False
 process.load("RecoTracker.FinalTrackSelectors.simpleTrackListMerger_cfi")
+process.load("RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi")
 process.simpleTrackListMerger.ShareFrac = 0.0
 process.simpleTrackListMerger.allowFirstHitShare = False
 

--- a/RecoLocalTracker/SubCollectionProducers/test/run_simsplit_runI.py
+++ b/RecoLocalTracker/SubCollectionProducers/test/run_simsplit_runI.py
@@ -67,6 +67,7 @@ process.load("TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi
 process.trajectoryCleanerBySharedHits.fractionShared = 0.0
 process.trajectoryCleanerBySharedHits.allowSharedFirstHit = False
 process.load("RecoTracker.FinalTrackSelectors.simpleTrackListMerger_cfi")
+process.load("RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi")
 process.simpleTrackListMerger.ShareFrac = 0.0
 process.simpleTrackListMerger.allowFirstHitShare = False
 

--- a/RecoLocalTracker/SubCollectionProducers/test/run_split.py
+++ b/RecoLocalTracker/SubCollectionProducers/test/run_split.py
@@ -65,6 +65,7 @@ process.load("TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi
 process.trajectoryCleanerBySharedHits.fractionShared = 0.0
 process.trajectoryCleanerBySharedHits.allowSharedFirstHit = False
 process.load("RecoTracker.FinalTrackSelectors.simpleTrackListMerger_cfi")
+process.load("RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi")
 process.simpleTrackListMerger.ShareFrac = 0.0
 process.simpleTrackListMerger.allowFirstHitShare = False
 

--- a/RecoLocalTracker/SubCollectionProducers/test/run_split_runI.py
+++ b/RecoLocalTracker/SubCollectionProducers/test/run_split_runI.py
@@ -66,6 +66,7 @@ process.load("TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi
 process.trajectoryCleanerBySharedHits.fractionShared = 0.0
 process.trajectoryCleanerBySharedHits.allowSharedFirstHit = False
 process.load("RecoTracker.FinalTrackSelectors.simpleTrackListMerger_cfi")
+process.load("RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi")
 process.simpleTrackListMerger.ShareFrac = 0.0
 process.simpleTrackListMerger.allowFirstHitShare = False
 

--- a/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
+++ b/RecoMuon/Configuration/python/preDuplicateMergingDisplacedTracks_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 preDuplicateMergingDisplacedTracks = TrackCollectionMerger.clone()
 preDuplicateMergingDisplacedTracks.trackProducers = [

--- a/RecoMuon/L3MuonProducer/test/newL3.py
+++ b/RecoMuon/L3MuonProducer/test/newL3.py
@@ -766,6 +766,12 @@ def addL3ToHLT(process):
 	    res_par = cms.vdouble( 0.003, 0.001 ),
 	    minHitsToBypassChecks = cms.uint32( 20 )
 	)
+	if not hasattr(process, "hltTrackAlgoPriorityOrder"):
+	    from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
+	    process.hltTrackAlgoPriorityOrder = trackAlgoPriorityOrder.clone(
+	        ComponentName = "hltTrackAlgoPriorityOrder",
+	        algoOrder = [] # HLT iteration order is correct in the hard-coded default
+	    )
 	process.hltIterL3Iter2HighPtTkMuMerged = cms.EDProducer( "TrackListMerger",
 	    ShareFrac = cms.double( 0.19 ),
 	    writeOnlyTrkQuals = cms.bool( False ),
@@ -787,7 +793,8 @@ def addL3ToHLT(process):
 	    hasSelector = cms.vint32( 0, 0 ),
 	    TrackProducers = cms.VInputTag( 'hltIterL3Iter0HighPtTkMuTrackSelectionHighPurity','hltIterL3Iter2HighPtTkMuTrackSelectionHighPurity' ),
 	    LostHitPenalty = cms.double( 20.0 ),
-	    newQuality = cms.string( "confirmed" )
+	    newQuality = cms.string( "confirmed" ),
+	    trackAlgoPriorityOrder = cms.string("hltTrackAlgoPriorityOrder"),
 	)
 
 	#Iterative tracking finished

--- a/RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h
@@ -1,0 +1,18 @@
+#ifndef RecoTracker_FinalTrackSelectors_TrackAlgoPriorityOrder_h
+#define RecoTracker_FinalTrackSelectors_TrackAlgoPriorityOrder_h
+
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+
+class TrackAlgoPriorityOrder {
+public:
+  explicit TrackAlgoPriorityOrder(const std::vector<reco::TrackBase::TrackAlgorithm>& algoOrder);
+
+  unsigned int priority(reco::TrackBase::TrackAlgorithm algo) const {
+    return priority_[algo];
+  }
+
+private:
+  std::array<unsigned int, reco::TrackBase::algoSize> priority_;
+};
+
+#endif

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -32,6 +32,7 @@
 <use   name="CondFormats/EgammaObjects"/>
 <use   name="CommonTools/Utils"/>
 <use   name="CommonTools/Statistics"/>
+<use   name="RecoTracker/Record"/>
 <use   name="clhep"/>
 <use   name="roottmva"/>
 <library   file="*.cc" name="RecoTrackerFinalTrackSelectorsPlugins">

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -10,6 +10,8 @@
 
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,6 +25,9 @@
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 
+#include "RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+
 #include <vector>
 #include <algorithm>
 #include <string>
@@ -30,8 +35,6 @@
 #include<memory>
 
 // #include "TMVA/Reader.h"
-
-#include "trackAlgoPriorityOrder.h"
 
 using namespace reco;
 
@@ -73,6 +76,8 @@ class DuplicateListMerger final : public edm::global::EDProducer<> {
   edm::EDGetTokenT<MVACollection> originalMVAValsToken_;
   edm::EDGetTokenT<MVACollection> mergedMVAValsToken_;
 
+  std::string priorityName_;
+
   int diffHitsCut_;
  
 
@@ -101,6 +106,7 @@ void DuplicateListMerger::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("originalMVAVals",edm::InputTag());
   desc.add<edm::InputTag>("candidateSource",edm::InputTag());
   desc.add<edm::InputTag>("candidateComponents",edm::InputTag());
+  desc.add<std::string>("trackAlgoPriorityOrder", "trackAlgoPriorityOrder");
   desc.add<int>("diffHitsCut",5);
   TrackCollectionCloner::fill(desc);
   descriptions.add("DuplicateListMerger", desc);  
@@ -109,7 +115,8 @@ void DuplicateListMerger::fillDescriptions(edm::ConfigurationDescriptions& descr
 DuplicateListMerger::DuplicateListMerger(const edm::ParameterSet& iPara) :
   collectionCloner(*this, iPara, true),
   mergedTrackSource_(iPara.getParameter<edm::InputTag>("mergedSource"),consumesCollector()),
-  originalTrackSource_(iPara.getParameter<edm::InputTag>("originalSource"),consumesCollector())
+  originalTrackSource_(iPara.getParameter<edm::InputTag>("originalSource"),consumesCollector()),
+  priorityName_(iPara.getParameter<std::string>("trackAlgoPriorityOrder"))
 {
   
   diffHitsCut_ = iPara.getParameter<int>("diffHitsCut");
@@ -160,6 +167,10 @@ void DuplicateListMerger::produce(edm::StreamID, edm::Event& iEvent, const edm::
 
   iEvent.getByToken(originalMVAValsToken_,originalMVAStore);
   iEvent.getByToken(mergedMVAValsToken_,mergedMVAStore);
+
+  edm::ESHandle<TrackAlgoPriorityOrder> priorityH;
+  iSetup.get<CkfComponentsRecord>().get(priorityName_, priorityH);
+  auto const & trackAlgoPriorityOrder = *priorityH;
 
   MVACollection mvaVec;
 
@@ -230,8 +241,8 @@ void DuplicateListMerger::produce(edm::StreamID, edm::Event& iEvent, const edm::
     const reco::Track& inTrk1 = originals[(*matchIter0)[1]];
     const reco::Track& inTrk2 = originals[(*matchIter0)[2]];
     oriAlgo[nsel] = std::min(inTrk1.algo(),inTrk2.algo(),
-			     [](reco::TrackBase::TrackAlgorithm a, reco::TrackBase::TrackAlgorithm b) {
-			       return trackAlgoPriorityOrder[a] < trackAlgoPriorityOrder[b];
+			     [&](reco::TrackBase::TrackAlgorithm a, reco::TrackBase::TrackAlgorithm b) {
+			       return trackAlgoPriorityOrder.priority(a) < trackAlgoPriorityOrder.priority(b);
 			     });
 
 

--- a/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
@@ -26,7 +26,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "trackAlgoPriorityOrder.h"
+#include "RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
 // this class is obsolete use TrackListMerger
 class SimpleTrackListMerger : public edm::stream::EDProducer<> {
@@ -64,6 +65,8 @@ class SimpleTrackListMerger : public edm::stream::EDProducer<> {
     edm::EDGetTokenT< TrajTrackAssociationCollection > trackProducer1AssToken;
     edm::EDGetTokenT< std::vector<Trajectory> > trackProducer2TrajToken;
     edm::EDGetTokenT< TrajTrackAssociationCollection > trackProducer2AssToken;
+
+    std::string priorityName_;
   };
 
 
@@ -157,6 +160,7 @@ namespace {
     trackProducer1AssToken = consumes< TrajTrackAssociationCollection >(trackProducer1);
     trackProducer2AssToken = consumes< TrajTrackAssociationCollection >(trackProducer2);
 
+    priorityName_ = conf.getParameter<std::string>("trackAlgoPriorityOrder");
   }
 
 
@@ -195,6 +199,10 @@ namespace {
     //
     edm::ESHandle<TrackerGeometry> theG;
     es.get<TrackerDigiGeometryRecord>().get(theG);
+
+    edm::ESHandle<TrackAlgoPriorityOrder> priorityH;
+    es.get<CkfComponentsRecord>().get(priorityName_, priorityH);
+    auto const & trackAlgoPriorityOrder = *priorityH;
 
 //    using namespace reco;
 
@@ -398,7 +406,7 @@ namespace {
               selected1[i]=0;
 	      selected2[j]=10+newQualityMask;  // add 10 to avoid the case where mask = 1
 	  }else{
-	    if (trackAlgoPriorityOrder[track->algo()] <= trackAlgoPriorityOrder[track2->algo()]) {
+	    if (trackAlgoPriorityOrder.priority(track->algo()) <= trackAlgoPriorityOrder.priority(track2->algo())) {
 	      selected2[j]=0;
 	      selected1[i]=10+newQualityMask; // add 10 to avoid the case where mask = 1
 	    }else{

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackAlgoPriorityOrderESProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackAlgoPriorityOrderESProducer.cc
@@ -1,0 +1,50 @@
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h"
+
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+
+class TrackAlgoPriorityOrderESProducer: public edm::ESProducer {
+public:
+  TrackAlgoPriorityOrderESProducer(const edm::ParameterSet& iConfig);
+  ~TrackAlgoPriorityOrderESProducer() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  std::unique_ptr<TrackAlgoPriorityOrder> produce(const CkfComponentsRecord& iRecord);
+
+private:
+  std::vector<reco::TrackBase::TrackAlgorithm> algoOrder_;
+};
+
+TrackAlgoPriorityOrderESProducer::TrackAlgoPriorityOrderESProducer(const edm::ParameterSet& iConfig) {
+  const auto& algoNames = iConfig.getParameter<std::vector<std::string> >("algoOrder");
+  algoOrder_.reserve(algoNames.size());
+  for(const auto& name: algoNames) {
+    auto algo = reco::TrackBase::algoByName(name);
+    if(algo == reco::TrackBase::undefAlgorithm && name != "undefAlgorithm") {
+      throw cms::Exception("Configuration") << "Incorrect track algo " << name;
+    }
+    algoOrder_.push_back(algo);
+  }
+
+  auto componentName = iConfig.getParameter<std::string>("ComponentName");
+  setWhatProduced(this, componentName);
+}
+
+void TrackAlgoPriorityOrderESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("ComponentName", "trackAlgoPriorityOrder");
+  desc.add<std::vector<std::string> >("algoOrder", std::vector<std::string>());
+  descriptions.add("trackAlgoPriorityOrder", desc);
+}
+
+std::unique_ptr<TrackAlgoPriorityOrder> TrackAlgoPriorityOrderESProducer::produce(const CkfComponentsRecord& iRecord) {
+  return std::make_unique<TrackAlgoPriorityOrder>(algoOrder_);
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_EVENTSETUP_MODULE(TrackAlgoPriorityOrderESProducer);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackAlgoPriorityOrderESProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackAlgoPriorityOrderESProducer.cc
@@ -38,7 +38,7 @@ void TrackAlgoPriorityOrderESProducer::fillDescriptions(edm::ConfigurationDescri
   edm::ParameterSetDescription desc;
   desc.add<std::string>("ComponentName", "trackAlgoPriorityOrder");
   desc.add<std::vector<std::string> >("algoOrder", std::vector<std::string>());
-  descriptions.add("trackAlgoPriorityOrder", desc);
+  descriptions.add("trackAlgoPriorityOrderDefault", desc);
 }
 
 std::unique_ptr<TrackAlgoPriorityOrder> TrackAlgoPriorityOrderESProducer::produce(const CkfComponentsRecord& iRecord) {

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
@@ -19,8 +19,6 @@
 #include <iostream>
 #include <memory>
 
-#include "trackAlgoPriorityOrder.h"
-
 using namespace reco;
 
 namespace {

--- a/RecoTracker/FinalTrackSelectors/plugins/trackAlgoPriorityOrder.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/trackAlgoPriorityOrder.h
@@ -1,1 +1,0 @@
-#include "DataFormats/TrackReco/interface/trackAlgoPriorityOrder.h"

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.FinalTrackSelectors.DuplicateTrackMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.DuplicateListMerger_cfi import *
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 from TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi import Chi2MeasurementEstimator as _Chi2MeasurementEstimator
 duplicateTrackCandidatesChi2Est = _Chi2MeasurementEstimator.clone(

--- a/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/classifierTest_cff.py
@@ -31,6 +31,7 @@ testTrackClassifier3.GBRForestLabel = 'MVASelectorIter3_13TeV'
 testTrackClassifier3.qualityCuts = [-0.5,0.0,0.5]
 
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
 testTrackMerger2 = TrackCollectionMerger.clone()
 testTrackMerger2.trackProducers = ['initialStepTracks','detachedTripletStepTracks']

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 earlyGeneralTracks =  TrackCollectionMerger.clone()

--- a/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 preDuplicateMergingGeneralTracks = TrackCollectionMerger.clone()
 preDuplicateMergingGeneralTracks.trackProducers = [

--- a/RecoTracker/FinalTrackSelectors/python/simpleTrackListMerger_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/simpleTrackListMerger_cfi.py
@@ -41,7 +41,8 @@ simpleTrackListMerger = cms.EDProducer("SimpleTrackListMerger",
     promoteTrackQuality = cms.bool(False),
     allowFirstHitShare = cms.bool(True),
     newQuality = cms.string('confirmed'),
-    copyExtras = cms.untracked.bool(False)
+    copyExtras = cms.untracked.bool(False),
+    trackAlgoPriorityOrder = cms.string("trackAlgoPriorityOrder"),
 )
 
 

--- a/RecoTracker/FinalTrackSelectors/python/trackAlgoPriorityOrder_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackAlgoPriorityOrder_cfi.py
@@ -1,0 +1,9 @@
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrderDefault_cfi import trackAlgoPriorityOrderDefault as _trackAlgoPriorityOrderDefault
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
+
+trackAlgoPriorityOrder = _trackAlgoPriorityOrderDefault.clone(
+    algoOrder = _cfg.iterationAlgos("")
+)
+
+for _eraName, _postfix, _era in _cfg.nonDefaultEras():
+    _era.toModify(trackAlgoPriorityOrder, algoOrder=_cfg.iterationAlgos(_postfix))

--- a/RecoTracker/FinalTrackSelectors/python/trackListMerger_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackListMerger_cfi.py
@@ -43,6 +43,7 @@ trackListMerger = cms.EDProducer("TrackListMerger",
                              cms.PSet( tLists=cms.vint32(2,3,4,5), pQual=cms.bool(True) ),
                              cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True) )
                              ),
+    trackAlgoPriorityOrder = cms.string("trackAlgoPriorityOrder"),
 
     # set new quality for confirmed tracks for each merged pair and then for the final pair
     allowFirstHitShare = cms.bool(True),

--- a/RecoTracker/FinalTrackSelectors/src/ES_TrackAlgoPriorityOrder.cc
+++ b/RecoTracker/FinalTrackSelectors/src/ES_TrackAlgoPriorityOrder.cc
@@ -1,0 +1,3 @@
+#include "RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(TrackAlgoPriorityOrder);

--- a/RecoTracker/FinalTrackSelectors/src/TrackAlgoPriorityOrder.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackAlgoPriorityOrder.cc
@@ -1,0 +1,32 @@
+#include "RecoTracker/FinalTrackSelectors/interface/TrackAlgoPriorityOrder.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "trackAlgoPriorityOrder.h"
+
+
+TrackAlgoPriorityOrder::TrackAlgoPriorityOrder(const std::vector<reco::TrackBase::TrackAlgorithm>& algoOrder):
+  priority_(trackAlgoPriorityOrder) {
+  // with less than 1 element there is nothing to do
+  if(algoOrder.size() <= 1)
+    return;
+
+  // Reordering the algo priorities is just a matter of taking the
+  // current priorities of the algos, sorting them, and inserting back
+  //
+  // iter0  2     2
+  // iter1  4  -> 3
+  // iter2  3     4
+  std::vector<unsigned int> priorities;
+  priorities.reserve(algoOrder.size());
+  for(const auto algo: algoOrder) {
+    priorities.push_back(trackAlgoPriorityOrder[algo]);
+  }
+
+  std::sort(priorities.begin(), priorities.end());
+
+  for(size_t i=0, end=priorities.size(); i!=end; ++i) {
+    priority_[algoOrder[i]] = priorities[i];
+  }
+}

--- a/RecoTracker/FinalTrackSelectors/src/trackAlgoPriorityOrder.h
+++ b/RecoTracker/FinalTrackSelectors/src/trackAlgoPriorityOrder.h
@@ -1,11 +1,15 @@
-#ifndef DataFormats_TrackReco_trackAlgoPriorityOrder_h
-#define DataFormats_TrackReco_trackAlgoPriorityOrder_h
+#ifndef RecoTracker_FinalTrackSelectors_trackAlgoPriorityOrder_h
+#define RecoTracker_FinalTrackSelectors_trackAlgoPriorityOrder_h
 
 #include "DataFormats/TrackReco/interface/TrackBase.h"
 
 #include <array>
 
 /**
+ * To obtain the priority order, please use the TrackAlgoPriorityOrder
+ * class instead. This header is internal to it, and exists in a
+ * separate file only to allow a unit test to be run.
+ *
  * The trackAlgoPriorityOrder maps an reco::TrackBase::TrackAlgorithm
  * enumerator to its priority in track list merging. The mapping is
  * needed because the order of the enumerators themselves does not, in

--- a/RecoTracker/FinalTrackSelectors/test/trackAlgoPriorityOrder_t.cpp
+++ b/RecoTracker/FinalTrackSelectors/test/trackAlgoPriorityOrder_t.cpp
@@ -1,4 +1,4 @@
-#include "RecoTracker/FinalTrackSelectors/plugins/trackAlgoPriorityOrder.h"
+#include "RecoTracker/FinalTrackSelectors/src/trackAlgoPriorityOrder.h"
 
 #include <iostream>
 

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -429,6 +429,7 @@ trackingPhase1QuadProp.toReplaceWith(detachedQuadStep, detachedQuadStepClassifie
      qualityCuts = [-0.5,0.0,0.5],
 ))
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 trackingPhase1PU70.toReplaceWith(detachedQuadStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = [

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -284,6 +284,7 @@ detachedTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector
     ] #end of vpset
 ) #end of clone
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 trackingLowPU.toReplaceWith(detachedTripletStep, RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = [

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -470,6 +470,7 @@ trackingPhase1PU70.toModify(mixedTripletStepSelector,
 ) #end of clone
 
 
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 _trackListMergerBase = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = ['mixedTripletStepTracks',


### PR DESCRIPTION
Currently the "track algo priority order", that is used in track collection merging to dictate the order of iterations, is hardcoded. The order is the one of run2 tracking, but phase1 and phase2 tracking have the iterations in different orders. This PR proposes to make this iteration ordering dynamic via ESProduct `TrackAlgoPriorityOrder` that is configured via tracking eras using `iterativeTkConfig.py`. The `TrackAlgoPriorityOrder` starts with the hardcoded order, and reorders only the algos that are given as parameters.

Tested in CMSSW_9_1_X_2017-03-02-2300. There can be tiny changes in non-run2-tracking in cases the "best algo" gets changed by this reordering and the other track has slightly different parameters. Anything else (run2 tracking, HLT) should have no changes. (and all changes should be caused by the second commit alone, the first one being purely technical)

@rovere @VinInn 