### PR TITLE
ECAL offline selective readout

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -1,0 +1,254 @@
+#ifndef RecoParticleFlow_PFClusterProducer_PFEcalBarrelRecHitCreator_h
+#define RecoParticleFlow_PFClusterProducer_PFEcalBarrelRecHitCreator_h
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
+
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/TruncatedPyramid.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
+#include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
+#include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
+#include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
+#include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
+
+template <typename Geometry,PFLayer::Layer Layer,int Detector>
+  class PFEcalBarrelRecHitCreator :  public  PFRecHitCreatorBase {
+
+ public:  
+  PFEcalBarrelRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
+    PFRecHitCreatorBase(iConfig,iC)
+    {
+      recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+      srFlagToken_ = iC.consumes<EBSrFlagCollection>(iConfig.getParameter<edm::InputTag>("srFlags"));
+      SREtaSize_ = iConfig.getUntrackedParameter<int> ("SREtaSize",1);
+      SRPhiSize_ = iConfig.getUntrackedParameter<int> ("SRPhiSize",1);
+      crystalsinTT_.resize(2448);
+      TTHighInterest_.resize(2448,0);
+      theTTDetIds_.resize(2448);
+      neighboringTTs_.resize(2448);
+    }
+    
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+
+      beginEvent(iEvent,iSetup);
+      
+      edm::Handle<EcalRecHitCollection> recHitHandle;
+
+      edm::ESHandle<CaloGeometry> geoHandle;
+      iSetup.get<CaloGeometryRecord>().get(geoHandle);
+  
+      iEvent.getByToken(srFlagToken_,srFlagHandle_);
+
+      // get the ecal geometry
+      const CaloSubdetectorGeometry *gTmp = 
+	geoHandle->getSubdetectorGeometry(DetId::Ecal, Detector);
+
+      const Geometry *ecalGeo =dynamic_cast< const Geometry* > (gTmp);
+
+      iEvent.getByToken(recHitToken_,recHitHandle);
+      for(const auto& erh : *recHitHandle ) {      
+	const DetId& detid = erh.detid();
+	auto energy = erh.energy();
+	auto time = erh.time();
+        bool hi = isHighInterest(detid);
+
+	const CaloCellGeometry * thisCell= ecalGeo->getGeometry(detid);
+  
+	// find rechit geometry
+	if(!thisCell) {
+	  edm::LogError("PFEcalBarrelRecHitCreator")
+	    <<"warning detid "<<detid.rawId()
+	    <<" not found in geometry"<<std::endl;
+	  continue;
+	}
+
+	out->emplace_back(thisCell, detid.rawId(),Layer,
+			   energy); 
+
+        auto & rh = out->back();
+	
+	bool rcleaned = false;
+	bool keep=true;
+
+	//Apply Q tests
+	for( const auto& qtest : qualityTests_ ) {
+	  if (!qtest->test(rh,erh,rcleaned,hi)) {
+	    keep = false;	    
+	  }
+	}
+	  
+	if(keep) {
+	  rh.setTime(time);
+	  rh.setDepth(1);
+	} 
+        else {
+	  if (rcleaned) 
+	    cleaned->push_back(std::move(out->back()));
+          out->pop_back();
+        }
+      }
+    }
+
+    void init(const edm::EventSetup &es) {
+
+      edm::ESHandle<CaloGeometry> pG;
+      es.get<CaloGeometryRecord>().get(pG);   
+
+      //  edm::ESHandle<CaloTopology> theCaloTopology;
+      //  es.get<CaloTopologyRecord>().get(theCaloTopology);     
+
+      edm::ESHandle<EcalTrigTowerConstituentsMap> hetm;
+      es.get<IdealGeometryRecord>().get(hetm);
+      eTTmap_ = &(*hetm);
+  
+      const EcalBarrelGeometry * myEcalBarrelGeometry = dynamic_cast<const EcalBarrelGeometry*>(pG->getSubdetectorGeometry(DetId::Ecal,EcalBarrel));
+      // std::cout << "Got the geometry " << myEcalBarrelGeometry << std::endl;
+      const std::vector<DetId>& vec(myEcalBarrelGeometry->getValidDetIds(DetId::Ecal,EcalBarrel));
+      unsigned size=vec.size();    
+      for(unsigned ic=0; ic<size; ++ic) 
+        {
+          EBDetId myDetId(vec[ic]);
+          int crystalHashedIndex=myDetId.hashedIndex();
+          /// barrelRawId_[crystalHashedIndex]=vec[ic].rawId();
+          // save the Trigger tower DetIds
+          EcalTrigTowerDetId towid= eTTmap_->towerOf(EBDetId(vec[ic]));
+          int TThashedindex=towid.hashedIndex();      
+          theTTDetIds_[TThashedindex]=towid;                  
+          crystalsinTT_[TThashedindex].push_back(crystalHashedIndex);
+        }
+      unsigned nTTs=theTTDetIds_.size();
+
+      //  EBDetId myDetId(-58,203);
+      ////  std::cout << " CellID " << myDetId << std::endl;
+      //  EcalTrigTowerDetId towid= eTTmap_->towerOf(myDetId);
+      ////  std::cout << " EcalTrigTowerDetId ieta, iphi" << towid.ieta() << " , " << towid.iphi() << std::endl;
+      ////  std::cout << " Constituents of this tower " <<towid.hashedIndex() << std::endl;
+      //  const std::vector<int> & xtals(crystalsinTT_[towid.hashedIndex()]);
+      //  unsigned Size=xtals.size();
+      //  for(unsigned i=0;i<Size;++i)
+      //    {
+      //      std::cout << EBDetId(barrelRawId_[xtals[i]]) << std::endl;
+      //    }
+
+      // now loop on each TT and save its neighbors. 
+
+      for(unsigned iTT=0;iTT<nTTs;++iTT)
+        {
+          int ietaPivot=theTTDetIds_[iTT].ieta();
+          int iphiPivot=theTTDetIds_[iTT].iphi();
+          int TThashedIndex=theTTDetIds_[iTT].hashedIndex();
+          //      std::cout << " TT Pivot " << TThashedIndex << " " << ietaPivot << " " << iphiPivot << " iz " << theTTDetIds_[iTT].zside() << std::endl;
+          int ietamin=std::max(ietaPivot-SREtaSize_,-17);
+          if(ietamin==0) ietamin=-1;
+          int ietamax=std::min(ietaPivot+SREtaSize_,17);
+          if(ietamax==0) ietamax=1;
+          int iphimin=iphiPivot-SRPhiSize_;
+          int iphimax=iphiPivot+SRPhiSize_;
+          for(int ieta=ietamin;ieta<=ietamax;)
+            {
+              int iz=(ieta>0)? 1 : -1; 
+              for(int iphi=iphimin;iphi<=iphimax;)
+                {
+                  int riphi=iphi;
+                  if(riphi<1) riphi+=72;
+                  else if(riphi>72) riphi-=72;
+                  EcalTrigTowerDetId neighborTTDetId(iz,EcalBarrel,abs(ieta),riphi);
+                  //      std::cout << " Voisin " << ieta << " " << riphi << " " <<neighborTTDetId.hashedIndex()<< " " << neighborTTDetId.ieta() << " " << neighborTTDetId.iphi() << std::endl;
+                  if(ieta!=ietaPivot||riphi!=iphiPivot)
+                    {
+                      neighboringTTs_[TThashedIndex].push_back(neighborTTDetId.hashedIndex());
+                    }
+                  ++iphi;
+
+                }
+              ++ieta;
+              if(ieta==0) ieta=1;
+            }
+        }
+
+      // std::cout << "EB Made the array " << std::endl;
+
+    }
+      
+
+ protected:
+
+
+    bool isHighInterest(const EBDetId& detid) {
+
+      EcalTrigTowerDetId towid = detid.tower();
+      int tthi = towid.hashedIndex();
+
+      if(TTHighInterest_[tthi]!=0) return (TTHighInterest_[tthi]>0);
+
+      TTHighInterest_[tthi] = srFullReadOut(towid) ? 1:-1;
+
+      // if high interest, can leave ; otherwise look at the neighbours
+      if( TTHighInterest_[tthi]==1) {
+        theTTofHighInterest_.push_back(tthi);
+        return true;
+      }
+
+      // now look if a neighboring TT is of high interest
+      const std::vector<int> & tts(neighboringTTs_[tthi]);
+      // a tower is of high interest if it or one of its neighbour is above the SR threshold
+      unsigned size=tts.size();
+      bool result=false;
+      for(unsigned itt=0;itt<size&&!result;++itt) {
+        towid = theTTDetIds_[tts[itt]];
+        if(srFullReadOut(towid)) result=true;
+      }
+
+      TTHighInterest_[tthi]=(result)? 1:-1;
+      theTTofHighInterest_.push_back(tthi);
+      return result;
+    }
+
+    bool srFullReadOut(EcalTrigTowerDetId& towid) {
+      EBSrFlagCollection::const_iterator srf = srFlagHandle_->find(towid);
+      if(srf == srFlagHandle_->end()) return false;
+      return ((srf->value() & ~EcalSrFlag::SRF_FORCED_MASK) == EcalSrFlag::SRF_FULL);  
+    }
+
+    edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
+    edm::EDGetTokenT<EBSrFlagCollection> srFlagToken_;
+
+    const EcalTrigTowerConstituentsMap* eTTmap_;  
+    // Array of the DetIds
+    std::vector<EcalTrigTowerDetId> theTTDetIds_;
+    // neighboring TT DetIds
+    std::vector<std::vector<int> > neighboringTTs_;
+    // the crystals in a given TT 
+    std::vector<std::vector<int> > crystalsinTT_;
+    // the towers which have been looked at 
+    std::vector<int> theTTofHighInterest_;
+    // the status of the towers. A tower is of high interest if it or one of its neighbour is above the threshold
+    std::vector<int> TTHighInterest_;
+
+    // selective readout flags collection
+    edm::Handle<EBSrFlagCollection> srFlagHandle_;
+
+    // selective readout threshold
+    int SREtaSize_;
+    int SRPhiSize_;
+
+};
+
+
+typedef PFEcalBarrelRecHitCreator<EcalBarrelGeometry,PFLayer::ECAL_BARREL,EcalBarrel> PFEBRecHitCreator;
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -1,0 +1,244 @@
+#ifndef RecoParticleFlow_PFClusterProducer_PFEcalEndcapRecHitCreator_h
+#define RecoParticleFlow_PFClusterProducer_PFEcalEndcapRecHitCreator_h
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
+
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+
+
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/TruncatedPyramid.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
+#include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
+#include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
+#include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
+#include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
+#include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
+
+template <typename Geometry,PFLayer::Layer Layer,int Detector>
+  class PFEcalEndcapRecHitCreator :  public  PFRecHitCreatorBase {
+
+ public:  
+  PFEcalEndcapRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
+    PFRecHitCreatorBase(iConfig,iC)
+    {
+      recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+      srFlagToken_ = iC.consumes<EBSrFlagCollection>(iConfig.getParameter<edm::InputTag>("srFlags"));
+
+      towerOf_.resize(EEDetId::kSizeForDenseIndexing);
+      theTTDetIds_.resize(1440);
+      SCofTT_.resize(1440);
+      SCHighInterest_.resize(633,0);
+      TTofSC_.resize(633);
+      CrystalsinSC_.resize(633);
+    }
+
+    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) {
+
+      beginEvent(iEvent,iSetup);
+ 
+      edm::Handle<EcalRecHitCollection> recHitHandle;
+
+      edm::ESHandle<CaloGeometry> geoHandle;
+      iSetup.get<CaloGeometryRecord>().get(geoHandle);
+  
+      iEvent.getByToken(srFlagToken_,srFlagHandle_);
+
+      // get the ecal geometry
+      const CaloSubdetectorGeometry *gTmp = 
+	geoHandle->getSubdetectorGeometry(DetId::Ecal, Detector);
+
+      const Geometry *ecalGeo =dynamic_cast< const Geometry* > (gTmp);
+
+      iEvent.getByToken(recHitToken_,recHitHandle);
+      for(const auto& erh : *recHitHandle ) {      
+	const DetId& detid = erh.detid();
+	auto energy = erh.energy();
+	auto time = erh.time();
+        bool hi = isHighInterest(detid);
+
+	const CaloCellGeometry * thisCell= ecalGeo->getGeometry(detid);
+  
+	// find rechit geometry
+	if(!thisCell) {
+	  edm::LogError("PFEcalEndcapRecHitCreator")
+	    <<"warning detid "<<detid.rawId()
+	    <<" not found in geometry"<<std::endl;
+	  continue;
+	}
+
+	out->emplace_back(thisCell, detid.rawId(),Layer,
+			   energy); 
+
+        auto & rh = out->back();
+	
+	bool rcleaned = false;
+	bool keep=true;
+
+	//Apply Q tests
+	for( const auto& qtest : qualityTests_ ) {
+	  if (!qtest->test(rh,erh,rcleaned,hi)) {
+	    keep = false;	    
+	  }
+	}
+	  
+	if(keep) {
+	  rh.setTime(time);
+	  rh.setDepth(1);
+	} 
+        else {
+	  if (rcleaned) 
+	    cleaned->push_back(std::move(out->back()));
+          out->pop_back();
+        }
+      }
+    }
+
+    void init(const edm::EventSetup &es) {
+
+      edm::ESHandle<CaloGeometry> pG;
+      es.get<CaloGeometryRecord>().get(pG);   
+
+      //  edm::ESHandle<CaloTopology> theCaloTopology;
+      //  es.get<CaloTopologyRecord>().get(theCaloTopology);     
+
+      edm::ESHandle<EcalTrigTowerConstituentsMap> hetm;
+      es.get<IdealGeometryRecord>().get(hetm);
+      eTTmap_ = &(*hetm);
+  
+      const EcalEndcapGeometry * myEcalEndcapGeometry = dynamic_cast<const EcalEndcapGeometry*>(pG->getSubdetectorGeometry(DetId::Ecal,EcalEndcap));
+      // std::cout << " Got the geometry " << myEcalEndcapGeometry << std::endl;
+      const std::vector<DetId>& vec(myEcalEndcapGeometry->getValidDetIds(DetId::Ecal,EcalEndcap));
+      unsigned size=vec.size();    
+      for(unsigned ic=0; ic<size; ++ic) 
+        {
+          EEDetId myDetId(vec[ic]);
+          int cellhashedindex=myDetId.hashedIndex();
+          /// endcapRawId_[crystalHashedIndex]=vec[ic].rawId();
+          // a bit of trigger tower and SuperCrystals algebra
+          // first get the trigger tower 
+          EcalTrigTowerDetId towid1= eTTmap_->towerOf(vec[ic]);
+          int tthashedindex=TThashedIndexforEE(towid1);
+          towerOf_[cellhashedindex]=tthashedindex;
+
+          // get the SC of the cell
+          int schi=SChashedIndex(EEDetId(vec[ic]));
+          if(schi<0) 
+            {
+              //  std::cout << " OOps " << schi << std::endl;
+              EEDetId myID(vec[ic]);
+              //  std::cout << " DetId " << myID << " " << myID.isc() << " " <<  myID.zside() <<  " " << myID.isc()+(myID.zside()+1)*158 << std::endl;
+            }
+      
+          theTTDetIds_[tthashedindex]=towid1;
+
+          // check if this SC is already in the list of the corresponding TT
+          std::vector<int>::const_iterator itcheck=find(SCofTT_[tthashedindex].begin(),
+                                                        SCofTT_[tthashedindex].end(),
+                                                        schi);
+          if(itcheck==SCofTT_[tthashedindex].end())
+            SCofTT_[tthashedindex].push_back(schi);
+      
+          // check if this crystal is already in the list of crystals per sc
+          itcheck=find(CrystalsinSC_[schi].begin(),CrystalsinSC_[schi].end(),cellhashedindex);
+          if(itcheck==CrystalsinSC_[schi].end())
+            CrystalsinSC_[schi].push_back(cellhashedindex);
+
+          // check if the TT is already in the list of sc
+          //      std::cout << " SCHI " << schi << " " << TTofSC_.size() << std::endl;
+          //      std::cout << TTofSC_[schi].size() << std::endl;
+          itcheck=find(TTofSC_[schi].begin(),TTofSC_[schi].end(),tthashedindex);
+          if(itcheck==TTofSC_[schi].end())
+            TTofSC_[schi].push_back(tthashedindex);
+        }
+      // std::cout << " Made the array " << std::endl;
+
+    }
+
+ protected:
+
+
+    bool isHighInterest(const EEDetId& detid) {
+
+      int schi=SChashedIndex(detid);
+      //  std::cout <<  detid << "  " << schi << " ";
+      // check if it has already been treated or not
+      // 0 <=> not treated
+      // 1 <=> high interest
+      // -1 <=> low interest
+      //  std::cout << SCHighInterest_[schi] << std::endl;
+      if(SCHighInterest_[schi]!=0) return (SCHighInterest_[schi]>0);
+
+      // now look if a TT contributing is of high interest
+      const std::vector<int> & tts(TTofSC_[schi]);
+      unsigned size=tts.size();
+      bool result=false;
+      for(unsigned itt=0;itt<size&&!result;++itt)
+        {
+          EcalTrigTowerDetId towid = theTTDetIds_[tts[itt]];
+          if(srFullReadOut(towid)) result=true;
+        }
+      SCHighInterest_[schi]=(result)? 1:-1;
+      theFiredSC_.push_back(schi);
+      return result;
+    }
+
+    bool srFullReadOut(EcalTrigTowerDetId& towid) {
+      EBSrFlagCollection::const_iterator srf = srFlagHandle_->find(towid);
+      if(srf == srFlagHandle_->end()) return false;
+      return ((srf->value() & ~EcalSrFlag::SRF_FORCED_MASK) == EcalSrFlag::SRF_FULL);  
+    }
+
+    edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
+    edm::EDGetTokenT<EBSrFlagCollection> srFlagToken_;
+
+    const EcalTrigTowerConstituentsMap* eTTmap_;  
+
+    // arraws for the selective readout emulation
+    // fast EEDetId -> TT hashedindex conversion
+    std::vector<int>  towerOf_;
+    // vector of the original DetId if needed
+    std::vector<EcalTrigTowerDetId> theTTDetIds_;
+    // list of SC "contained" in a TT.
+    std::vector<std::vector<int> > SCofTT_;
+    // list of TT of a given sc
+    std::vector<std::vector<int> > TTofSC_;
+    // status of each SC 
+    std::vector<int> SCHighInterest_;
+    // list of fired SC
+    std::vector<int> theFiredSC_;
+    // the list of fired TT
+    std::vector<int> theFiredTTs_;
+    // the cells in each SC
+    std::vector<std::vector<int> > CrystalsinSC_;
+
+    // selective readout flags collection
+    edm::Handle<EBSrFlagCollection> srFlagHandle_;
+
+ private:
+    // there are 2448 TT in the barrel. 
+    inline int TThashedIndexforEE(int originalhi) const {return originalhi-2448;}
+    inline int TThashedIndexforEE(const EcalTrigTowerDetId &detid) const {return detid.hashedIndex()-2448;}
+    // the number of the SuperCrystals goes from 1 to 316 (with some holes) in each EE
+    // z should -1 or 1 
+    inline int SChashedIndex(int SC,int z) const {return SC+(z+1)*158;}
+    inline int SChashedIndex(const EEDetId& detid) const {
+      //    std::cout << "In SC hashedIndex " <<  detid.isc() << " " << detid.zside() << " " << detid.isc()+(detid.zside()+1)*158 << std::endl;
+      return detid.isc()+(detid.zside()+1)*158;
+    }
+
+};
+
+
+typedef PFEcalEndcapRecHitCreator<EcalEndcapGeometry,PFLayer::ECAL_ENDCAP,EcalEndcap> PFEERecHitCreator;
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h
@@ -71,10 +71,11 @@ template <typename Geometry,PFLayer::Layer Layer,int Detector>
 	
 	bool rcleaned = false;
 	bool keep=true;
+        bool hi = true; // this is std version for which the PF ZS is always applied
 
 	//Apply Q tests
 	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned)) {
+	  if (!qtest->test(rh,erh,rcleaned,hi)) {
 	    keep = false;	    
 	  }
 	}

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreatorMaxSample.h
@@ -71,10 +71,11 @@ template <typename Geometry,PFLayer::Layer Layer,int Detector>
 
 	bool rcleaned = false;
 	bool keep=true;
+        bool hi = true; // this is std version for which the PF ZS is always applied
 
 	//Apply Q tests
 	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned)) {
+	  if (!qtest->test(rh,erh,rcleaned,hi)) {
 	    keep = false;	    
 	  }
 	}

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -84,10 +84,11 @@ class PFPSRecHitCreator final :  public  PFRecHitCreatorBase {
 	
 	bool rcleaned = false;
 	bool keep=true;
+        bool hi = true; // all ES rhs are produced, independently on the ECAL SRP decision
 
 	//Apply Q tests
 	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned)) {
+	  if (!qtest->test(rh,erh,rcleaned,hi)) {
 	    keep = false;	    
 	  }
 	}

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
@@ -35,6 +35,7 @@ class PFRecHitCreatorBase {
     }
   }
 
+  virtual void init(const edm::EventSetup &es) { }
 
   virtual void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&,std::unique_ptr<reco::PFRecHitCollection>& ,const edm::Event&,const edm::EventSetup&)=0;
 
@@ -44,7 +45,6 @@ class PFRecHitCreatorBase {
     for (unsigned int i=0;i<qualityTests_.size();++i)
 	qualityTests_[i]->beginEvent(event,setup);
   }
-
 
 
   std::vector<std::unique_ptr<PFRecHitQTestBase> > qualityTests_;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
@@ -37,7 +37,7 @@ class PFRecHitQTestBase {
   virtual void beginEvent(const edm::Event&,const edm::EventSetup&)=0;
 
 
-  virtual bool test( reco::PFRecHit& ,const EcalRecHit&,bool&)=0;
+  virtual bool test( reco::PFRecHit& ,const EcalRecHit&,bool&,bool)=0;
   virtual bool test( reco::PFRecHit& ,const HBHERecHit&,bool&)=0;
   virtual bool test( reco::PFRecHit& ,const HFRecHit&,bool&)=0;
   virtual bool test( reco::PFRecHit& ,const HORecHit&,bool&)=0;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -27,8 +27,8 @@ class PFRecHitQTestThreshold : public PFRecHitQTestBase {
     void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
-      return pass(hit);
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
+      return fullReadOut || pass(hit);
     }
     bool test(reco::PFRecHit& hit,const HBHERecHit& rh,bool& clean){
       return pass(hit);
@@ -126,7 +126,7 @@ class PFRecHitQTestHCALChannel : public PFRecHitQTestBase {
       hcalSevLvlComputer_  =  hcalSevLvlComputerHndl.product();
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
       return true;
     }
     bool test(reco::PFRecHit& hit,const HBHERecHit& rh,bool& clean){
@@ -212,7 +212,7 @@ class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
     void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
       return true;
     }
     bool test(reco::PFRecHit& hit,const HBHERecHit& rh,bool& clean){
@@ -281,7 +281,7 @@ class PFRecHitQTestHCALThresholdVsDepth : public PFRecHitQTestBase {
     void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
       return true;
     }
     bool test(reco::PFRecHit& hit,const HBHERecHit& rh,bool& clean){
@@ -346,7 +346,7 @@ class PFRecHitQTestHOThreshold : public PFRecHitQTestBase {
     void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
       return true;
     }
     bool test(reco::PFRecHit& hit,const HBHERecHit& rh,bool& clean){
@@ -402,7 +402,7 @@ class PFRecHitQTestECAL : public PFRecHitQTestBase {
     void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
       if (skipTTRecoveredHits_ && rh.checkFlag(EcalRecHit::kTowerRecovered))
 	{
 	  clean=true;
@@ -475,7 +475,7 @@ class PFRecHitQTestES : public PFRecHitQTestBase {
   void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
   }
 
-  bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+  bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
 
     if ( rh.energy() < thresholdCleaning_ ) {
       clean=false;
@@ -546,7 +546,7 @@ class PFRecHitQTestHCALCalib29 : public PFRecHitQTestBase {
     void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean){
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut){
       return true;
     }
     bool test(reco::PFRecHit& hit,const HBHERecHit& rh,bool& clean){
@@ -599,7 +599,7 @@ class PFRecHitQTestThresholdInMIPs : public PFRecHitQTestBase {
     void beginEvent(const edm::Event& event,const edm::EventSetup& iSetup) {
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean) {
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut) {
       throw cms::Exception("WrongDetector")
 	<< "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
       return false;
@@ -671,7 +671,7 @@ class PFRecHitQTestThresholdInThicknessNormalizedMIPs : public PFRecHitQTestBase
       ddd_ = &(geoHandle->topology().dddConstants());
     }
 
-    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean) {
+    bool test(reco::PFRecHit& hit,const EcalRecHit& rh,bool& clean,bool fullReadOut) {
       throw cms::Exception("WrongDetector")
 	<< "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
       return false;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -29,6 +29,7 @@ namespace {
   edm::ParameterSet navSet = iConfig.getParameter<edm::ParameterSet>("navigator");
 
   navigator_.reset(PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"),navSet));
+  init_ = false;
     
 }
 
@@ -55,6 +56,10 @@ void
    out->reserve(localRA1.upper());
    cleaned->reserve(localRA2.upper());
    for( const auto& creator : creators_ ) {
+     if (!init_) { // should go in beginRun
+       creator->init(iSetup);
+       init_ = true;
+     }
      creator->importRecHits(out,cleaned,iEvent,iSetup);
    }
    if (out->capacity()>2*out->size()) out->shrink_to_fit();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
@@ -29,6 +29,7 @@ class PFRecHitProducer final : public edm::stream::EDProducer<> {
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
       std::vector<std::unique_ptr<PFRecHitCreatorBase> > creators_;
       std::unique_ptr<PFRecHitNavigatorBase> navigator_;
+      bool init_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -15,6 +15,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
            cms.PSet(
              name = cms.string("PFEBRecHitCreator"),
              src  = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+             srFlags = cms.InputTag("ecalDigis"),
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestThreshold"),
@@ -32,6 +33,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
           cms.PSet(
             name = cms.string("PFEERecHitCreator"),
             src  = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
+            srFlags = cms.InputTag("ecalDigis"),
             qualityTests = cms.VPSet(
                  cms.PSet(
                  name = cms.string("PFRecHitQTestThreshold"),

--- a/RecoParticleFlow/PFClusterProducer/src/RecHitCreators.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/RecHitCreators.cc
@@ -1,8 +1,10 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h"
+//#include "RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreator.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreatorMaxSample.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreator.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h"


### PR DESCRIPTION
This change is to implement a match of the online selective readout algorithm, basically:

- when the hit belongs to a region which the trigger flagged as "high-interest"("medium interest"), read in full-readout a set of (one) readout units
- when the hit belongs to a "low-interest region", apply the zero-suppression

Right now the offline ZS was done in two places:

1. ECAL -> PF rechit translation (including offline zero-suppression)
2. gathering threholds of hits in a PFCluster

in 2016 thresholds in 1. and 2. coincided and were lower than online zero-suppression. Since online ZS is on uncalibrated amplitude, this possibly produced time- and eta-dependent effects (radiation / transparency loss). In 2017 the online ZS will be much harder, so worsening these effects. 

This allows to decouple what happens in a high-interest region (online = full-readout ; offline = stay with low cluster gathering thresholds) to what happens in low-interest region (online = zs ; offline = raise the ZS in PFRecHit QTest to a value higher than online, but done on calibrated energy).

Few details more in this [presentation at the ECAL DPG](https://indico.cern.ch/event/600314/contributions/2423735/).

With this PR, which puts in the algorithm of the match of online-offline decisions, but NOT changes thresholds neither in 1. nor in 2., should just abuse of the technical checks of the release integration, and should not introduce changes. Also something to check is the increase in the memory of the job at the beginning of the job, since it creates the mapping between crystals and trigger towers.

The second change will be just a change in the thresholds in 2., matching the ones decided for the online running in 2017.

@bendavid @amassiro @shervin86 @argiro @crovelli please also follow this
