### PR TITLE
Ignoring calibration channels in the dataframes

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -428,7 +428,15 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
     {
         const DFrame& frame(*it);
         const HcalDetId cell(frame.id());
-        const HcalRecoParam* param_ts = paramTS_->getValues(cell.rawId());
+
+        // Protection against calibration channels which are not
+        // in the database but can still come in the QIE11DataFrame
+        // in the laser calibs, etc.
+        const HcalSubdetector subdet = cell.subdet();
+        if (!(subdet == HcalSubdetector::HcalBarrel ||
+              subdet == HcalSubdetector::HcalEndcap ||
+              subdet == HcalSubdetector::HcalOuter))
+            continue;
 
         // Check if the database tells us to drop this channel
         const HcalChannelStatus* mydigistatus = qual.getValues(cell.rawId());
@@ -445,6 +453,7 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
             continue;
 
         // Basic ADC decoding tools
+        const HcalRecoParam* param_ts = paramTS_->getValues(cell.rawId());
         const HcalCalibrations& calib = cond.getHcalCalibrations(cell);
         const HcalCalibrationWidths& calibWidth = cond.getHcalCalibrationWidths(cell);
         const HcalQIECoder* channelCoder = cond.getHcalCoder(cell);


### PR DESCRIPTION
This PR fixes the problem described at
http://cmsonline.cern.ch/cms-elog/969131

Apparently, we can have calibration channels (which do not have associated database records) in the QIE11 dataframes. These channels can not be processed by the HBHEPhase1Reconstructor and must be ignored.

To be backported to 9_0 and 8_4.

This PR will not modify any relval results
