### PR TITLE
Speed up the use of DDFilteredViews

### DIFF
--- a/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
+++ b/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
@@ -137,10 +137,7 @@ void CocoaAnalyzer::ReadXMLFile( const edm::EventSetup& evts )
 	  // get all parts labelled with COCOA using a SpecPar
   DDSpecificsFilter filter;
   filter.setCriteria(val,  // name & value of a variable 
-		     DDCompOp::matches,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true  // use merged-specifics or simple-specifics
+		     DDCompOp::equals
 		     );
   DDFilteredView fv(*cpv);
   fv.addFilter(filter);

--- a/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
+++ b/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
@@ -132,15 +132,10 @@ void CocoaAnalyzer::ReadXMLFile( const edm::EventSetup& evts )
   //  It stores these objects in a private data member, opt
   std::string attribute = "COCOA"; 
   std::string value     = "COCOA";
-  DDValue val(attribute, value, 0.0);
   
 	  // get all parts labelled with COCOA using a SpecPar
-  DDSpecificsFilter filter;
-  filter.setCriteria(val,  // name & value of a variable 
-		     DDCompOp::equals
-		     );
-  DDFilteredView fv(*cpv);
-  fv.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fv(*cpv, filter);
   bool doCOCOA = fv.firstChild();
   
   // Loop on parts

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
@@ -19,10 +19,7 @@ DTGeometryParserFromDDD::DTGeometryParserFromDDD(const DDCompactView* cview, con
     // Asking only for the Muon DTs
     DDSpecificsFilter filter;
     filter.setCriteria(val,  // name & value of a variable 
-		       DDCompOp::matches,
-		       DDLogOp::AND, 
-		       true, // compare strings otherwise doubles
-		       true  // use merged-specifics or simple-specifics
+		       DDCompOp::equals
 		       );
     DDFilteredView fview(*cview);
     fview.addFilter(filter);

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
@@ -14,15 +14,10 @@ DTGeometryParserFromDDD::DTGeometryParserFromDDD(const DDCompactView* cview, con
   try {
     std::string attribute = "MuStructure"; 
     std::string value     = "MuonBarrelDT";
-    DDValue val(attribute, value, 0.0);
 
     // Asking only for the Muon DTs
-    DDSpecificsFilter filter;
-    filter.setCriteria(val,  // name & value of a variable 
-		       DDCompOp::equals
-		       );
-    DDFilteredView fview(*cview);
-    fview.addFilter(filter);
+    DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+    DDFilteredView fview(*cview,filter);
 
     parseGeometry(fview, muonConstants, theLayerIdWiresMap);
   }

--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -10,7 +10,7 @@ class DDExpandedView;
 class DDQuery;
 
 //! comparison operators to be used with this filter
-enum class DDCompOp { equals, matches, not_equals, not_matches};
+enum class DDCompOp { equals, not_equals};
   
 //! A Filter accepts or rejects a DDExpandedNode based on a user-coded decision rule
 class DDFilter

--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -10,11 +10,8 @@ class DDExpandedView;
 class DDQuery;
 
 //! comparison operators to be used with this filter
-enum class DDCompOp { equals, matches, not_equals, not_matches, smaller, bigger, smaller_equals, bigger_equals };
+enum class DDCompOp { equals, matches, not_equals, not_matches};
   
-//! logical operations to obtain one result from two filter comparisons
-enum class DDLogOp { AND };
-
 //! A Filter accepts or rejects a DDExpandedNode based on a user-coded decision rule
 class DDFilter
 {
@@ -39,30 +36,20 @@ public:
   
   ~DDSpecificsFilter();
   
-  bool accept(const DDExpandedView &) const; 
+  bool accept(const DDExpandedView &) const override final; 
 	      
   void setCriteria(const DDValue & nameVal, // name & value of a variable 
-                   DDCompOp, 
-		   DDLogOp l = DDLogOp::AND, 
-		   bool asString = true, // compare strings otherwise doubles
-		   bool merged = true // use merged-specifics or simple-specifics
-		   );
+                   DDCompOp );
 		      
   struct SpecificCriterion {
     SpecificCriterion(const DDValue & nameVal, 
-		      DDCompOp op,
-		      bool asString,
-		      bool merged)
+		      DDCompOp op)
      : nameVal_(nameVal), 
-       comp_(op), 
-       asString_(asString),
-       merged_(merged)
+       comp_(op) 
      { }
      
      DDValue nameVal_;
      DDCompOp comp_;
-     bool asString_;
-     bool merged_;
   };
   
 protected:  

--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -26,6 +26,15 @@ public:
   virtual bool accept(const DDExpandedView &) const = 0;  
 };
 
+//! A DDFilter that always returns true
+class DDPassAllFilter : public DDFilter
+{
+public:
+  bool accept(const DDExpandedView &) const override final {
+    return true;
+  }
+};
+
 //! The DDGenericFilter is a runtime-parametrized Filter looking on DDSpecifcs
 class DDSpecificsFilter : public DDFilter
 {

--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -60,6 +60,54 @@ protected:
 };
 
 std::ostream & operator<<(std::ostream & os, const DDSpecificsFilter & f);
+
+class DDSpecificsAnyValueFilter : public DDFilter {
+public:
+  explicit DDSpecificsAnyValueFilter(const std::string& iAttribute):
+    attribute_(iAttribute,"",0 )
+    {}
+
+  bool accept(const DDExpandedView &) const override final; 
+
+private:
+  DDValue attribute_;
+
+};
+
+class DDSpecificsMatchesValueFilter : public DDFilter {
+public:
+  explicit DDSpecificsMatchesValueFilter(const DDValue& iValue):
+    value_(iValue)
+    {}
+
+  bool accept(const DDExpandedView &) const override final; 
+
+private:
+  DDValue value_;
+
+};
+
+template<typename F1, typename F2>
+class DDAndFilter : public DDFilter {
+public:
+  DDAndFilter(F1 iF1, F2 iF2):
+    f1_(std::move(iF1)),
+    f2_(std::move(iF2)) {}
+
+  bool accept(const DDExpandedView & node) const override final {
+    return f1_.accept(node) && f2_.accept(node);
+  }
+private:
+  F1 f1_;
+  F2 f2_;
+};
+
+template<typename F1, typename F2>
+  DDAndFilter<F1,F2> make_and_ddfilter(F1 f1, F2 f2) 
+{
+  return DDAndFilter<F1,F2>(std::move(f1), std::move(f2));
+}
+
 #endif
 
 

--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -13,7 +13,7 @@ class DDQuery;
 enum class DDCompOp { equals, matches, not_equals, not_matches, smaller, bigger, smaller_equals, bigger_equals };
   
 //! logical operations to obtain one result from two filter comparisons
-enum class DDLogOp { AND, OR };
+enum class DDLogOp { AND };
 
 //! A Filter accepts or rejects a DDExpandedNode based on a user-coded decision rule
 class DDFilter
@@ -70,7 +70,6 @@ protected:
   bool accept_impl(const DDExpandedView &) const;
 
   std::vector<SpecificCriterion> criteria_; 
-  std::vector<DDLogOp> logOps_;
 };
 
 std::ostream & operator<<(std::ostream & os, const DDSpecificsFilter & f);

--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -70,9 +70,9 @@ protected:
 
 std::ostream & operator<<(std::ostream & os, const DDSpecificsFilter & f);
 
-class DDSpecificsAnyValueFilter : public DDFilter {
+class DDSpecificsHasNamedValueFilter : public DDFilter {
 public:
-  explicit DDSpecificsAnyValueFilter(const std::string& iAttribute):
+  explicit DDSpecificsHasNamedValueFilter(const std::string& iAttribute):
     attribute_(iAttribute,"",0 )
     {}
 

--- a/DetectorDescription/Core/interface/DDFilteredView.h
+++ b/DetectorDescription/Core/interface/DDFilteredView.h
@@ -89,7 +89,6 @@ private:
 
   DDExpandedView epv_;
   std::vector<DDFilter const *> criteria_;
-  std::vector<DDLogOp> logOps_; // logical operation for merging the result of 2 filters
   std::vector<DDGeoHistory> parents_; // filtered-parents
 };
 

--- a/DetectorDescription/Core/interface/DDFilteredView.h
+++ b/DetectorDescription/Core/interface/DDFilteredView.h
@@ -24,7 +24,7 @@ public:
   
   ~DDFilteredView();
   
-  void addFilter(const DDFilter &, DDLogOp op = DDLogOp::AND);
+  void addFilter(const DDFilter &);
   
     //! The logical-part of the current node in the filtered-view
   const DDLogicalPart & logicalPart() const;

--- a/DetectorDescription/Core/interface/DDFilteredView.h
+++ b/DetectorDescription/Core/interface/DDFilteredView.h
@@ -19,14 +19,13 @@ class DDFilteredView
 {
 public:
   typedef DDExpandedView::nav_type nav_type;
+
+  //!Keeps a pointer to the DDfilter
+  DDFilteredView(const DDCompactView &, const DDFilter&);
+
+  DDFilteredView() = delete;
   
-  DDFilteredView(const DDCompactView &);
-  
-  ~DDFilteredView();
-  
-  void addFilter(const DDFilter &);
-  
-    //! The logical-part of the current node in the filtered-view
+   //! The logical-part of the current node in the filtered-view
   const DDLogicalPart & logicalPart() const;
   
   //! The absolute translation of the current node
@@ -88,7 +87,7 @@ private:
   bool filter();
 
   DDExpandedView epv_;
-  std::vector<DDFilter const *> criteria_;
+  DDFilter const* filter_;
   std::vector<DDGeoHistory> parents_; // filtered-parents
 };
 

--- a/DetectorDescription/Core/interface/DDQuery.h
+++ b/DetectorDescription/Core/interface/DDQuery.h
@@ -24,7 +24,7 @@ public:
   
   virtual const std::vector<DDExpandedNode> & exec();
   
-  virtual void addFilter(const DDFilter &, DDLogOp op = DDLogOp::AND);
+  virtual void addFilter(const DDFilter &);
   
   virtual void setScope(const DDScope &);
   
@@ -33,7 +33,6 @@ protected:
   const DDScope * scope_;
   
   std::vector<std::pair<bool, DDFilter *> > criteria_; // one filter and the result on the current node
-  std::vector<DDLogOp> logOps_; // logical operation for merging the result of 2 filters
   std::vector<DDExpandedNode> result_; // query result
 };
 

--- a/DetectorDescription/Core/src/DDFilter.cc
+++ b/DetectorDescription/Core/src/DDFilter.cc
@@ -42,204 +42,11 @@ namespace {
       return ( crit.nameVal_.strings() == it->second.strings() );
     case DDCompOp::not_equals: case DDCompOp::not_matches:
       return ( crit.nameVal_.strings() != it->second.strings() );
-    case DDCompOp::smaller_equals:
-      return ( it->second.strings() <= crit.nameVal_.strings() );
-    case DDCompOp::smaller:
-      return ( it->second.strings() < crit.nameVal_.strings() );
-    case DDCompOp::bigger_equals:
-      return ( it->second.strings() >= crit.nameVal_.strings() );
-    case DDCompOp::bigger:	 
-      return ( it->second.strings() > crit.nameVal_.strings() );
     default:
       return false;
     }
     return false;
-  }		 
-  
-  inline bool sfd_compare(const DDSpecificsFilter::SpecificCriterion & crit,
-		   const DDsvalues_type & sv)
-  {
-    DDsvalues_type::const_iterator it = find(sv,crit.nameVal_.id());
-    if (it == sv.end()) return false;
-    if (it->second.isEvaluated() ) {
-      switch (crit.comp_) {
-      case DDCompOp::equals: case DDCompOp::matches:
-	return (crit.nameVal_.doubles() == it->second.doubles() );
-      case DDCompOp::not_equals: case DDCompOp::not_matches:
-	return (crit.nameVal_.doubles() != it->second.doubles() );
-      case DDCompOp::smaller_equals:
-	return ( it->second.doubles() <= crit.nameVal_.doubles() );
-      case DDCompOp::smaller:
-	return ( it->second.doubles() < crit.nameVal_.doubles() );
-      case DDCompOp::bigger_equals:
-	return ( it->second.doubles() >= crit.nameVal_.doubles() );
-      case DDCompOp::bigger:	 
-	return ( it->second.doubles() > crit.nameVal_.doubles() );
-      default:
-	return false;
-      }
-    } else {
-      edm::LogWarning("DD:Filter") << "Attempt to access a DDValue as doubles but DDValue is NOT Evaluated!" 
-				   << crit.nameVal_.name();
-    }
-    return false;
-  }		 
-  
-  inline bool sfs_compare_nm (const DDSpecificsFilter::SpecificCriterion & crit,
-		       const std::vector<const DDsvalues_type *> & specs)
-  {
-    // The meaning of this is defined for each operator below.
-    bool result = false; 
-    
-    // go through all specifics
-    for( const auto& spit : specs ) {
-      // go through all DDValues of the current specific.     
-      for( const auto& it : *spit ) {
-	
-	size_t ci = 0; // criteria values index
-	size_t si = 0; // specs values index
-	// compare all the crit values to all the specs values when the name matches.
-	
-	while ( !result && ci < crit.nameVal_.strings().size()) {
-	  if (it.second.id() == crit.nameVal_.id()) {	
-	    while ( !result && si < it.second.strings().size()) {
-	      switch (crit.comp_) {
-		// equals means at least one value in crit matches one value
-		// in specs.
-		//
-		// not equals means that no values in crit match no values in specs
-		//  (see below the ! (not))
-		// 
-		// Maybe we should have an 'in' or 'contains' operator and equals would meaning
-		// would be changed to mean ALL equal.
-	      case DDCompOp::equals: 
-	      case DDCompOp::matches:
-	      case DDCompOp::not_equals: 
-	      case DDCompOp::not_matches: 
-		result = ( crit.nameVal_.strings()[ci] == it.second.strings()[si] );
-		break;
-		
-		// less than or equals means that ALL values in specs
-		// are less than or equals ALL values in crit.  therefore
-		// if even ONE is bigger, then this is false.
-	      case DDCompOp::smaller_equals:
-		result = ( it.second.strings()[si] > crit.nameVal_.strings()[ci] );
-		break;
-		
-		// less than means that all are strictly less than, therefore
-		// if one is greater than or equal, then this is false
-	      case DDCompOp::smaller:
-		result = ( it.second.strings()[si] >= crit.nameVal_.strings()[ci] );
-		break;
-		
-		// greater or equal to means that all values in specs are
-		// greater than or equals to all values in crit.  therefore
-		// if even ONE is less than, then this is false
-	      case DDCompOp::bigger_equals:
-		result = ( it.second.strings()[si] < crit.nameVal_.strings()[ci] );
-		break;
-		
-		// greater means that all values in specs are greater than
-		// all values in crit.  therefore if even one is less than or
-		// equal to crit, then this is false;
-	      case DDCompOp::bigger:	 
-		result = ( it.second.strings() <= crit.nameVal_.strings() );
-	      }
-	      si ++;
-	    }
-	    
-	    if ( crit.comp_ == DDCompOp::not_equals 
-		 || crit.comp_ == DDCompOp::not_matches
-		 || crit.comp_ == DDCompOp::smaller_equals 
-		 || crit.comp_ == DDCompOp::smaller
-		 || crit.comp_ == DDCompOp::bigger)
-	      result = !result;
-	  }
-	  ++ci;
-	}
-      }
-    }
-    
-    return result;
-  }		 
-  
-  inline bool sfd_compare_nm(const DDSpecificsFilter::SpecificCriterion & crit,
-		      const std::vector<const DDsvalues_type *> & specs)
-  {
-    // The meaning of this is defined for each operator below.
-    bool result = false; 
-    
-    // go through all specifics
-    for( const auto& spit : specs ) {
-      // go through all DDValues of the current specific.     
-      for( const auto& it : *spit ) {
-	if ( !it.second.isEvaluated() ) {
-	  edm::LogWarning("DD:Filter") << "(nm) Attempt to access a DDValue as doubles but DDValue is NOT Evaluated!" 
-				       << crit.nameVal_.name();
-	  continue; // go on to next one, do not attempt to acess doubles()
-	}
-	size_t ci = 0; // criteria values index
-	size_t si = 0; // specs values index
-	// compare all the crit values to all the specs values when the name matches.
-	
-	while ( !result && ci < crit.nameVal_.doubles().size()) {	  
-	  if (it.second.id() == crit.nameVal_.id()) {
-	    while ( !result && si < it.second.doubles().size()) {
-	      switch (crit.comp_) {
-		
-		// equals means at least one value in crit matches one value
-		// in specs.
-		//
-		// not equals means that no values in crit match no values in specs
-		//  (see below the ! (not))
-	      case DDCompOp::equals: 
-	      case DDCompOp::matches:
-	      case DDCompOp::not_equals: 
-	      case DDCompOp::not_matches: 
-		result = ( crit.nameVal_.doubles()[ci] == it.second.doubles()[si] );
-		break;
-		
-		// less than or equals means that ALL values in specs
-		// are less than or equals ALL values in crit.  therefore
-		// if even ONE is bigger, then this is false.
-	      case DDCompOp::smaller_equals:
-		result = ( it.second.doubles()[si] > crit.nameVal_.doubles()[ci] );
-		break;
-		
-		// less than means that all are strictly less than, therefore
-		// if one is greater than or equal, then this is false
-	      case DDCompOp::smaller:
-		result = ( it.second.doubles()[si] >= crit.nameVal_.doubles()[ci] );
-		break;
-		
-		// greater or equal to means that all values in specs are
-		// greater than or equals to all values in crit.  therefore
-		// if even ONE is less than, then this is false
-	      case DDCompOp::bigger_equals:
-		result = ( it.second.doubles()[si] < crit.nameVal_.doubles()[ci] );
-		break;
-		
-		// greater means that all values in specs are greater than
-		// all values in crit.  therefore if even one is less than or
-		// equal to crit, then this is false;
-	      case DDCompOp::bigger:	 
-		result = ( it.second.doubles() <= crit.nameVal_.doubles() );
-	      }
-	      si ++;
-	    }
-	    if ( crit.comp_ == DDCompOp::not_equals 
-		 || crit.comp_ == DDCompOp::not_matches
-		 || crit.comp_ == DDCompOp::smaller_equals 
-		 || crit.comp_ == DDCompOp::smaller
-		 || crit.comp_ == DDCompOp::bigger)
-	      result = !result;
-	  }
-	  ++ci;
-	}
-      }
-    }    
-    return result;
-  }
+  }		   
 }
 
 // ================================================================================================
@@ -251,13 +58,9 @@ DDSpecificsFilter::~DDSpecificsFilter() {}
 
 
 void DDSpecificsFilter::setCriteria(const DDValue & nameVal, // name & value of a variable 
-                   DDCompOp op, 
-		   DDLogOp l, 
-		   bool asStrin, // compare std::strings otherwise doubles
-		   bool merged // use merged-specifics or simple-specifics
-		   )
+                                    DDCompOp op)
 {
-  criteria_.push_back(SpecificCriterion(nameVal,op,asStrin,merged));
+  criteria_.push_back(SpecificCriterion(nameVal,op));
  }		   
 
 bool DDSpecificsFilter::accept(const DDExpandedView & node) const
@@ -276,28 +79,10 @@ bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
     bool locres=false;
     if (logp.hasDDValue(it->nameVal_)) { 
       
-      if (it->merged_) {
-	
-	if (sv.empty())  node.mergedSpecificsV(sv);
-	
-	if (it->asString_) { // merged specifics & compare std::strings
-	  locres = sfs_compare(*it,sv); 
-	}
-	else { // merged specifics & compare doubles
-	  locres = sfd_compare(*it,sv);
-	}
-      }
-      else {
-	
-	if (specs.empty()) node.specificsV(specs);
-	
-	if (it->asString_) { // non-merged specifics & compare std::strings
-	  locres = sfs_compare_nm(*it, specs);
-	}
-	else { // non-merged specifics & compare doubles
-	  locres = sfd_compare_nm(*it, specs);
-	}  
-      }
+      if (sv.empty())  node.mergedSpecificsV(sv);
+      
+      locres = sfs_compare(*it,sv); 
+
     }
     result &= locres;
     // avoid useless evaluations

--- a/DetectorDescription/Core/src/DDFilter.cc
+++ b/DetectorDescription/Core/src/DDFilter.cc
@@ -110,10 +110,17 @@ DDSpecificsAnyValueFilter::accept(const DDExpandedView& node) const {
     
     const auto& hist = node.geoHistory();
     for(auto const& spec: specs) {
-      if(DDCompareEqual(hist,*spec.first)()) {
-        for(auto const& v: *(spec.second) ) {
-          if(attribute_.id() == v.first) {
+      for(auto const& v: *(spec.second) ) {
+        if(attribute_.id() == v.first) {
+          //DDCompareEqual is slow so only call
+          // when needed
+          if(DDCompareEqual(hist,*spec.first)()) {
             return true;
+          } else {
+            //since we know this isn't in the correct
+            // geometry path we do not have to check
+            // anymore attributes
+            break;
           }
         }
       }
@@ -132,10 +139,15 @@ DDSpecificsMatchesValueFilter::accept(const DDExpandedView& node) const {
     
     const auto& hist = node.geoHistory();
     for(auto const& spec: specs) {
-      if(DDCompareEqual(hist,*spec.first)()) {
-        for(auto const& v: *(spec.second) ) {
-          if(value_.id() == v.first) {
+      for(auto const& v: *(spec.second) ) {
+        if(value_.id() == v.first) {
+          if(DDCompareEqual(hist,*spec.first)()) {
             return (value_.strings() == v.second.strings());
+          } else {
+            //since we know this isn't in the correct
+            // geometry path we do not have to check
+            // anymore attributes
+            break;
           }
         }
       }

--- a/DetectorDescription/Core/src/DDFilter.cc
+++ b/DetectorDescription/Core/src/DDFilter.cc
@@ -101,7 +101,7 @@ bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
 }
 
 bool
-DDSpecificsAnyValueFilter::accept(const DDExpandedView& node) const {
+DDSpecificsHasNamedValueFilter::accept(const DDExpandedView& node) const {
   const DDLogicalPart & logp = node.logicalPart();
 
   if (logp.hasDDValue(attribute_)) { 

--- a/DetectorDescription/Core/src/DDFilter.cc
+++ b/DetectorDescription/Core/src/DDFilter.cc
@@ -99,3 +99,48 @@ bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
   }
   return result;
 }
+
+bool
+DDSpecificsAnyValueFilter::accept(const DDExpandedView& node) const {
+  const DDLogicalPart & logp = node.logicalPart();
+
+  if (logp.hasDDValue(attribute_)) { 
+      
+    const auto& specs = logp.attachedSpecifics();
+    
+    const auto& hist = node.geoHistory();
+    for(auto const& spec: specs) {
+      if(DDCompareEqual(hist,*spec.first)()) {
+        for(auto const& v: *(spec.second) ) {
+          if(attribute_.id() == v.first) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+bool
+DDSpecificsMatchesValueFilter::accept(const DDExpandedView& node) const {
+  const DDLogicalPart & logp = node.logicalPart();
+
+  if (logp.hasDDValue(value_)) { 
+    
+    const auto& specs = logp.attachedSpecifics();
+    
+    const auto& hist = node.geoHistory();
+    for(auto const& spec: specs) {
+      if(DDCompareEqual(hist,*spec.first)()) {
+        for(auto const& v: *(spec.second) ) {
+          if(value_.id() == v.first) {
+            return (value_.strings() == v.second.strings());
+          }
+        }
+      }
+    }
+  }
+  return false;
+
+}

--- a/DetectorDescription/Core/src/DDFilter.cc
+++ b/DetectorDescription/Core/src/DDFilter.cc
@@ -258,7 +258,6 @@ void DDSpecificsFilter::setCriteria(const DDValue & nameVal, // name & value of 
 		   )
 {
   criteria_.push_back(SpecificCriterion(nameVal,op,asStrin,merged));
-  logOps_.push_back(l);
  }		   
 
 bool DDSpecificsFilter::accept(const DDExpandedView & node) const
@@ -269,14 +268,10 @@ bool DDSpecificsFilter::accept(const DDExpandedView & node) const
 bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
 {
   bool result = true;
-  auto logOpIt = logOps_.begin();
   const DDLogicalPart & logp = node.logicalPart();
   DDsvalues_type  sv;
   std::vector<const DDsvalues_type *> specs;
-  for( auto it = begin(criteria_); it != end(criteria_); ++it, ++logOpIt ) {
-    // avoid useless evaluations
-    if ( (   result &&(*logOpIt)==DDLogOp::OR ) ||
-	 ( (!result)&&(*logOpIt)==DDLogOp::AND) ) continue; 
+  for( auto it = begin(criteria_); it != end(criteria_); ++it) {
 
     bool locres=false;
     if (logp.hasDDValue(it->nameVal_)) { 
@@ -304,11 +299,10 @@ bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
 	}  
       }
     }
-    if (*logOpIt==DDLogOp::AND) {
-      result &= locres;
-    }
-    else {
-      result |= locres;
+    result &= locres;
+    // avoid useless evaluations
+    if(!result) {
+      break;
     }
   }
   return result;

--- a/DetectorDescription/Core/src/DDFilter.cc
+++ b/DetectorDescription/Core/src/DDFilter.cc
@@ -68,12 +68,12 @@ bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
           for(auto const& v: *(spec.second) ) {
             if(it->nameVal_.id() == v.first) {
               switch (it->comp_) {
-              case DDCompOp::equals: case DDCompOp::matches:
+              case DDCompOp::equals:
                 {
                   locres= (it->nameVal_.strings() == v.second.strings());
                   break;
                 }
-              case DDCompOp::not_equals: case DDCompOp::not_matches:
+              case DDCompOp::not_equals:
                 {
                   locres= ( it->nameVal_.strings() != v.second.strings() );
                   break;

--- a/DetectorDescription/Core/src/DDFilteredView.cc
+++ b/DetectorDescription/Core/src/DDFilteredView.cc
@@ -23,10 +23,9 @@ const DDLogicalPart & DDFilteredView::logicalPart() const
   return epv_.logicalPart();
 }
 
-void DDFilteredView::addFilter(const DDFilter & f, DDLogOp op)
+void DDFilteredView::addFilter(const DDFilter & f, DDLogOp )
 {
   criteria_.push_back(&f); 
-  logOps_.push_back(op);
 }
  
 const DDTranslation & DDFilteredView::translation() const
@@ -227,21 +226,13 @@ void DDFilteredView::reset()
 bool DDFilteredView::filter()
 {
   bool result = true;
-  auto logOpIt = logOps_.begin();
   // loop over all user-supplied criteria (==filters)
-  for( auto it = begin(criteria_); it != end(criteria_); ++it, ++logOpIt) {
-    // avoid useless evaluations
-    if(( result && ( *logOpIt ) == DDLogOp::OR ) ||
-       (( !result ) && ( *logOpIt ) == DDLogOp::AND )) continue; 
-    
+  for( auto it = begin(criteria_); it != end(criteria_); ++it) {
     bool locres = (*it)->accept(epv_);
     
-    // now do the logical-operations on the results encountered so far:
-    if (*logOpIt == DDLogOp::AND) { // AND
-      result &= locres; 
-    }
-    else { // OR
-      result |= locres;  
+    result &= locres; 
+    if(!result) {
+      break;
     }
   } // <-- loop over filters     
   return result;

--- a/DetectorDescription/Core/src/DDFilteredView.cc
+++ b/DetectorDescription/Core/src/DDFilteredView.cc
@@ -23,7 +23,7 @@ const DDLogicalPart & DDFilteredView::logicalPart() const
   return epv_.logicalPart();
 }
 
-void DDFilteredView::addFilter(const DDFilter & f, DDLogOp )
+void DDFilteredView::addFilter(const DDFilter & f)
 {
   criteria_.push_back(&f); 
 }

--- a/DetectorDescription/Core/src/DDFilteredView.cc
+++ b/DetectorDescription/Core/src/DDFilteredView.cc
@@ -9,25 +9,17 @@
 class DDCompactView;
 class DDLogicalPart;
 
-DDFilteredView::DDFilteredView(const DDCompactView & cpv)
- : epv_(cpv)
+DDFilteredView::DDFilteredView(const DDCompactView & cpv, const DDFilter& fltr)
+: epv_(cpv), filter_(&fltr)
 {
    parents_.push_back(epv_.geoHistory());
 }
-
-DDFilteredView::~DDFilteredView()
-{ }
 
 const DDLogicalPart & DDFilteredView::logicalPart() const
 {
   return epv_.logicalPart();
 }
 
-void DDFilteredView::addFilter(const DDFilter & f)
-{
-  criteria_.push_back(&f); 
-}
- 
 const DDTranslation & DDFilteredView::translation() const
 {
    return epv_.translation();
@@ -225,17 +217,7 @@ void DDFilteredView::reset()
 
 bool DDFilteredView::filter()
 {
-  bool result = true;
-  // loop over all user-supplied criteria (==filters)
-  for( auto it = begin(criteria_); it != end(criteria_); ++it) {
-    bool locres = (*it)->accept(epv_);
-    
-    result &= locres; 
-    if(!result) {
-      break;
-    }
-  } // <-- loop over filters     
-  return result;
+  return filter_->accept(epv_) ;
 }
 
 DDFilteredView::nav_type DDFilteredView::navPos() const

--- a/DetectorDescription/Core/test/BuildFile.xml
+++ b/DetectorDescription/Core/test/BuildFile.xml
@@ -1,11 +1,13 @@
 <use   name="DetectorDescription/Core"/>
 <use   name="boost"/>
+<use   name="rootmath"/>
 <use   name="cppunit"/>
 <use   name="FWCore/ParameterSet"/>
 <bin   name="testCore" file="testRunner.cpp,DDIsValid.cppunit.cc">
 </bin>
 <bin   name="testStrVector" file="testRunner.cpp,DDStrVector.cppunit.cc">
 </bin>
+<bin   name="testDDFilter" file="DDFilter.cppunit.cc,testRunner.cpp"/>
 <bin   name="testShapes" file="testShapes.cpp">
 </bin>
 <bin   file="clhepToROOTMath.cpp">

--- a/DetectorDescription/Core/test/DDFilter.cppunit.cc
+++ b/DetectorDescription/Core/test/DDFilter.cppunit.cc
@@ -1,0 +1,399 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include "Math/RotationX.h"
+
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "DetectorDescription/Core/interface/DDLogicalPart.h"
+#include "DetectorDescription/Core/interface/DDMaterial.h"
+#include "DetectorDescription/Core/interface/DDName.h"
+#include "DetectorDescription/Core/interface/DDSolid.h"
+#include "DetectorDescription/Core/interface/DDSpecifics.h"
+#include "DetectorDescription/Core/interface/DDFilteredView.h"
+#include "DetectorDescription/Core/interface/DDFilter.h"
+
+#include "cppunit/TestAssert.h"
+#include "cppunit/TestFixture.h"
+
+
+class testDDFilter : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testDDFilter);
+  CPPUNIT_TEST(checkFilters);
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp(){}
+  void tearDown() {}
+  void checkFilters();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testDDFilter);
+
+namespace {
+  std::vector<std::string> getNames(DDFilteredView& fv) {
+    std::vector<std::string> returnValue;
+    bool dodet = fv.firstChild();
+    while(dodet) {
+      auto const& lp = fv.logicalPart();
+      returnValue.push_back(lp.name().name());
+      dodet = fv.next();
+    }
+    return returnValue;
+  }
+
+  
+}
+
+void testDDFilter::checkFilters() {
+  //Create the geometry
+  DDCompactView cv{};
+
+
+  {
+    double const kPI = std::acos(-1.);
+
+    auto const& root = cv.root();
+
+    DDMaterial mat{"Stuff"};
+
+    {
+      //Central
+      auto outershape = DDSolidFactory::tubs("OuterShape",
+                                             1.,
+                                             0.5,1.,
+                                             0.,
+                                             2*kPI);
+
+      DDLogicalPart outerlp{ "Outer", mat, outershape };
+
+      cv.position(outerlp,root,0, DDTranslation{}, DDRotation{});
+            {
+        DDValue val{"Volume","Outer",0};
+        DDsvalues_type values;
+        values.push_back(DDsvalues_Content_type(val,val));
+
+        DDSpecifics ds{"OuterVolume", {"//Outer.*"}, values}; 
+        }
+
+      auto middleshape = DDSolidFactory::tubs("MiddleShape",
+                                              1.,
+                                              0.2,0.49,
+                                              0., 2*kPI);
+      DDLogicalPart middlelp{"Middle",mat,middleshape };
+      cv.position(middlelp, outerlp, 0, DDTranslation{}, DDRotation{});
+      {
+        DDValue val{"Volume","Middle",0};
+        DDsvalues_type values;
+        values.push_back(DDsvalues_Content_type(val,val));
+
+        DDSpecifics ds{"MiddleVolume", {"//Middle.*"}, values}; 
+        } 
+
+
+      auto innershape = DDSolidFactory::tubs("InnerShape",
+                                             1.,
+                                             0.19,0.05,
+                                             0., 2*kPI);
+      DDLogicalPart innerlp{"Inner",mat,innershape };
+      cv.position(innerlp, middlelp, 0, DDTranslation{}, DDRotation{});
+      
+      {
+        DDValue val{"Volume","Inner",0};
+        DDsvalues_type values;
+        values.push_back(DDsvalues_Content_type(val,val));
+
+        DDSpecifics ds{"InnerVolume", {"//Inner.*"}, values}; 
+      }
+      
+
+    }
+    {
+      //Endcaps
+      auto endshape = DDSolidFactory::tubs("EndShape",
+                                             0.1,
+                                             0.05,1.,
+                                             0.,
+                                             2*kPI);
+
+      DDLogicalPart endlp{"End", mat, endshape};
+      cv.position(endlp,root,0,DDTranslation{0.,0.,-(1.0+0.1)},DDRotation{});
+      {
+        DDValue val{"Volume","EMinus",0};
+        DDsvalues_type values;
+        values.push_back(DDsvalues_Content_type(val,val));
+
+        DDSpecifics ds{"EMinusVolume", {"//End[0]"}, values}; 
+        } 
+
+      const DDRotation kXFlip = DDrot("xflip", new DDRotationMatrix{ ROOT::Math::RotationX{ kPI} } ); 
+      cv.position(endlp,root,1,DDTranslation{0.,0.,1.0+0.1},kXFlip);
+      {
+        DDValue val{"Volume","EPlus",0};
+        DDsvalues_type values;
+        values.push_back(DDsvalues_Content_type(val,val));
+
+        DDSpecifics ds{"EPlusVolume", {"//End[1]"}, values}; 
+        } 
+
+      {
+        DDValue val{"Endcap","",0};
+        DDsvalues_type values;
+        values.push_back(DDsvalues_Content_type(val,val));
+
+        DDSpecifics ds{"Endcap", {"//End.*"}, values}; 
+      }
+
+    }
+    cv.lockdown();
+
+    {
+      DDSpecificsFilter f;
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End","End"};
+
+      CPPUNIT_ASSERT( names == expectedNames );
+      
+    }
+    {
+      DDValue tofind("Volume","Outer",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer"};
+      CPPUNIT_ASSERT( names == expectedNames );
+      
+    }
+
+    {
+      DDValue tofind("Volume","Outer",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Middle","Inner","End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Volume","Middle",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Middle"};
+      CPPUNIT_ASSERT( names == expectedNames );
+      
+    }
+
+    {
+      DDValue tofind("Volume","Middle",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer","Inner","End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Volume","EPlus",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EPlus",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Volume","DoesntExist",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Volume","DoesntExist",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Endcap","",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Endcap","",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {};
+      for(auto const& n: names) {
+        std::cout <<n;
+      }
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDValue tofind2("Endcap","",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      f.setCriteria(tofind2, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDValue tofind2("Endcap","",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind2, DDCompOp::equals);
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDValue tofind2("Endcap","any",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      f.setCriteria(tofind2, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDValue tofind2("Endcap","any",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind2, DDCompOp::not_equals);
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDValue tofind2("Endcap","",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      f.setCriteria(tofind2, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDValue tofind2("Endcap","",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind2, DDCompOp::not_equals);
+      f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+  }
+
+  //CPPUNIT_ASSERT (bad==0);
+}
+

--- a/DetectorDescription/Core/test/DDFilter.cppunit.cc
+++ b/DetectorDescription/Core/test/DDFilter.cppunit.cc
@@ -367,7 +367,7 @@ void testDDFilter::checkFilters() {
     }
 
     {
-      DDSpecificsAnyValueFilter f("Volume");
+      DDSpecificsHasNamedValueFilter f("Volume");
       DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
@@ -376,7 +376,7 @@ void testDDFilter::checkFilters() {
     }
 
     {
-      DDSpecificsAnyValueFilter f("DoesntExist");
+      DDSpecificsHasNamedValueFilter f("DoesntExist");
       DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
@@ -432,7 +432,7 @@ void testDDFilter::checkFilters() {
 
     {
 
-      DDSpecificsAnyValueFilter f("Endcap");
+      DDSpecificsHasNamedValueFilter f("Endcap");
       DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
@@ -501,7 +501,7 @@ void testDDFilter::checkFilters() {
 
     {
       auto f = make_and_ddfilter(DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)},
-                                 DDSpecificsAnyValueFilter{"Endcap"});
+                                 DDSpecificsHasNamedValueFilter{"Endcap"});
       DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
@@ -523,7 +523,7 @@ void testDDFilter::checkFilters() {
     }
 
     {
-      auto f = make_and_ddfilter(DDSpecificsAnyValueFilter{"Endcap"},
+      auto f = make_and_ddfilter(DDSpecificsHasNamedValueFilter{"Endcap"},
                                  DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)});
       DDFilteredView fv(cv,f);
 

--- a/DetectorDescription/Core/test/DDFilter.cppunit.cc
+++ b/DetectorDescription/Core/test/DDFilter.cppunit.cc
@@ -123,9 +123,12 @@ void testDDFilter::checkFilters() {
         DDValue val{"Volume","EMinus",0};
         DDsvalues_type values;
         values.push_back(DDsvalues_Content_type(val,val));
-
+        {
+          DDValue val{"Side","-",0};
+          values.push_back(DDsvalues_Content_type(val,val));
+        }
         DDSpecifics ds{"EMinusVolume", {"//End[0]"}, values}; 
-        } 
+      } 
 
       const DDRotation kXFlip = DDrot("xflip", new DDRotationMatrix{ ROOT::Math::RotationX{ kPI} } ); 
       cv.position(endlp,root,1,DDTranslation{0.,0.,1.0+0.1},kXFlip);
@@ -133,9 +136,13 @@ void testDDFilter::checkFilters() {
         DDValue val{"Volume","EPlus",0};
         DDsvalues_type values;
         values.push_back(DDsvalues_Content_type(val,val));
+        {
+          DDValue val{"Side","+",0};
+          values.push_back(DDsvalues_Content_type(val,val));
+        }
 
         DDSpecifics ds{"EPlusVolume", {"//End[1]"}, values}; 
-        } 
+      } 
 
       {
         DDValue val{"Endcap","",0};
@@ -173,6 +180,17 @@ void testDDFilter::checkFilters() {
     }
 
     {
+      DDSpecificsMatchesValueFilter f{DDValue("Volume","Outer",0)};
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer"};
+      CPPUNIT_ASSERT( names == expectedNames );
+      
+    }
+
+    {
       DDValue tofind("Volume","Outer",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
@@ -188,6 +206,17 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","Middle",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Middle"};
+      CPPUNIT_ASSERT( names == expectedNames );
+      
+    }
+
+    {
+      DDSpecificsMatchesValueFilter f(DDValue("Volume","Middle",0));
       DDFilteredView fv(cv);
       fv.addFilter(f);
 
@@ -222,6 +251,16 @@ void testDDFilter::checkFilters() {
     }
 
     {
+      DDSpecificsMatchesValueFilter f(DDValue("Volume","EPlus",0));
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
       DDValue tofind("Volume","EPlus",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
@@ -246,6 +285,62 @@ void testDDFilter::checkFilters() {
     }
 
     {
+      DDSpecificsMatchesValueFilter f{DDValue("Volume","EMinus",0)};
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      //Test one LogicalPart with different Specifics
+      // based on placement
+      {
+        DDValue tofind("Side","-",0);
+        DDSpecificsFilter f;
+        f.setCriteria(tofind, DDCompOp::equals);
+        DDFilteredView fv(cv);
+        fv.addFilter(f);
+        
+        auto const names = getNames(fv);
+        std::vector<std::string> const expectedNames = {"End"};
+        CPPUNIT_ASSERT( names == expectedNames );      
+      }
+      {
+        DDSpecificsMatchesValueFilter f{DDValue("Side","-",0)};
+        DDFilteredView fv(cv);
+        fv.addFilter(f);
+        
+        auto const names = getNames(fv);
+        std::vector<std::string> const expectedNames = {"End"};
+        CPPUNIT_ASSERT( names == expectedNames );      
+      }
+
+      {
+        DDValue tofind("Side","+",0);
+        DDSpecificsFilter f;
+        f.setCriteria(tofind, DDCompOp::equals);
+        DDFilteredView fv(cv);
+        fv.addFilter(f);
+        
+        auto const names = getNames(fv);
+        std::vector<std::string> const expectedNames = {"End"};
+        CPPUNIT_ASSERT( names == expectedNames );      
+      }
+      {
+        DDSpecificsMatchesValueFilter f{DDValue("Side","+",0)};
+        DDFilteredView fv(cv);
+        fv.addFilter(f);
+        
+        auto const names = getNames(fv);
+        std::vector<std::string> const expectedNames = {"End"};
+        CPPUNIT_ASSERT( names == expectedNames );      
+      }
+    }
+
+    {
       DDValue tofind("Volume","EMinus",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
@@ -270,6 +365,16 @@ void testDDFilter::checkFilters() {
     }
 
     {
+      DDSpecificsMatchesValueFilter f{DDValue("Volume","DoesntExist",0)};
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
       DDValue tofind("Volume","DoesntExist",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
@@ -282,9 +387,40 @@ void testDDFilter::checkFilters() {
     }
 
     {
+      DDSpecificsAnyValueFilter f("Volume");
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      DDSpecificsAnyValueFilter f("DoesntExist");
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
       DDValue tofind("Endcap","",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+      
+      DDSpecificsMatchesValueFilter f{DDValue("Endcap","",0)};
       DDFilteredView fv(cv);
       fv.addFilter(f);
 
@@ -309,11 +445,45 @@ void testDDFilter::checkFilters() {
     }
 
     {
+      DDValue tofind("Endcap","DoesntExist",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
+
+      DDSpecificsAnyValueFilter f("Endcap");
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End","End"};
+      CPPUNIT_ASSERT( names == expectedNames );
+    }
+
+    {
       DDValue tofind("Volume","EMinus",0);
       DDValue tofind2("Endcap","",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
       f.setCriteria(tofind2, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {      
+      auto f = make_and_ddfilter(DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)},
+                               DDSpecificsMatchesValueFilter{DDValue("Endcap","",0)} );
       DDFilteredView fv(cv);
       fv.addFilter(f);
 
@@ -328,6 +498,17 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind2, DDCompOp::equals);
       f.setCriteria(tofind, DDCompOp::equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      auto f = make_and_ddfilter(DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)},
+                               DDSpecificsMatchesValueFilter{DDValue("Endcap","",0)});
       DDFilteredView fv(cv);
       fv.addFilter(f);
 
@@ -351,6 +532,17 @@ void testDDFilter::checkFilters() {
     }
 
     {
+      auto f = make_and_ddfilter(DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)},
+                                 DDSpecificsAnyValueFilter{"Endcap"});
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
       DDValue tofind("Volume","EMinus",0);
       DDValue tofind2("Endcap","any",0);
       DDSpecificsFilter f;
@@ -361,6 +553,31 @@ void testDDFilter::checkFilters() {
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      auto f = make_and_ddfilter(DDSpecificsAnyValueFilter{"Endcap"},
+                                 DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)});
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {"End"};
+      CPPUNIT_ASSERT( names == expectedNames );      
+    }
+
+    {
+      DDValue tofind("Volume","EMinus",0);
+      DDValue tofind2("Endcap","",0);
+      DDSpecificsFilter f;
+      f.setCriteria(tofind, DDCompOp::equals);
+      f.setCriteria(tofind2, DDCompOp::not_equals);
+      DDFilteredView fv(cv);
+      fv.addFilter(f);
+
+      auto const names = getNames(fv);
+      std::vector<std::string> const expectedNames = {};
       CPPUNIT_ASSERT( names == expectedNames );      
     }
 

--- a/DetectorDescription/Core/test/DDFilter.cppunit.cc
+++ b/DetectorDescription/Core/test/DDFilter.cppunit.cc
@@ -157,8 +157,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsFilter f;
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End","End"};
@@ -170,8 +169,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","Outer",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer"};
@@ -181,8 +179,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsMatchesValueFilter f{DDValue("Volume","Outer",0)};
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer"};
@@ -194,8 +191,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","Outer",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Middle","Inner","End","End"};
@@ -206,8 +202,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","Middle",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Middle"};
@@ -217,8 +212,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsMatchesValueFilter f(DDValue("Volume","Middle",0));
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Middle"};
@@ -230,8 +224,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","Middle",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer","Inner","End","End"};
@@ -242,8 +235,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","EPlus",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -252,8 +244,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsMatchesValueFilter f(DDValue("Volume","EPlus",0));
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -264,8 +255,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","EPlus",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End"};
@@ -276,8 +266,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","EMinus",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -286,8 +275,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsMatchesValueFilter f{DDValue("Volume","EMinus",0)};
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -301,8 +289,7 @@ void testDDFilter::checkFilters() {
         DDValue tofind("Side","-",0);
         DDSpecificsFilter f;
         f.setCriteria(tofind, DDCompOp::equals);
-        DDFilteredView fv(cv);
-        fv.addFilter(f);
+        DDFilteredView fv(cv,f);
         
         auto const names = getNames(fv);
         std::vector<std::string> const expectedNames = {"End"};
@@ -310,8 +297,7 @@ void testDDFilter::checkFilters() {
       }
       {
         DDSpecificsMatchesValueFilter f{DDValue("Side","-",0)};
-        DDFilteredView fv(cv);
-        fv.addFilter(f);
+        DDFilteredView fv(cv,f);
         
         auto const names = getNames(fv);
         std::vector<std::string> const expectedNames = {"End"};
@@ -322,8 +308,7 @@ void testDDFilter::checkFilters() {
         DDValue tofind("Side","+",0);
         DDSpecificsFilter f;
         f.setCriteria(tofind, DDCompOp::equals);
-        DDFilteredView fv(cv);
-        fv.addFilter(f);
+        DDFilteredView fv(cv,f);
         
         auto const names = getNames(fv);
         std::vector<std::string> const expectedNames = {"End"};
@@ -331,8 +316,7 @@ void testDDFilter::checkFilters() {
       }
       {
         DDSpecificsMatchesValueFilter f{DDValue("Side","+",0)};
-        DDFilteredView fv(cv);
-        fv.addFilter(f);
+        DDFilteredView fv(cv,f);
         
         auto const names = getNames(fv);
         std::vector<std::string> const expectedNames = {"End"};
@@ -344,8 +328,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","EMinus",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End"};
@@ -356,8 +339,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","DoesntExist",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {};
@@ -366,8 +348,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsMatchesValueFilter f{DDValue("Volume","DoesntExist",0)};
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {};
@@ -378,8 +359,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Volume","DoesntExist",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End","End"};
@@ -388,8 +368,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsAnyValueFilter f("Volume");
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"Outer","Middle","Inner","End","End"};
@@ -398,8 +377,7 @@ void testDDFilter::checkFilters() {
 
     {
       DDSpecificsAnyValueFilter f("DoesntExist");
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {};
@@ -410,8 +388,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Endcap","",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End","End"};
@@ -421,8 +398,7 @@ void testDDFilter::checkFilters() {
     {
       
       DDSpecificsMatchesValueFilter f{DDValue("Endcap","",0)};
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End","End"};
@@ -433,8 +409,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Endcap","",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {};
@@ -448,8 +423,7 @@ void testDDFilter::checkFilters() {
       DDValue tofind("Endcap","DoesntExist",0);
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End","End"};
@@ -459,8 +433,7 @@ void testDDFilter::checkFilters() {
     {
 
       DDSpecificsAnyValueFilter f("Endcap");
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End","End"};
@@ -473,8 +446,7 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
       f.setCriteria(tofind2, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -484,8 +456,7 @@ void testDDFilter::checkFilters() {
     {      
       auto f = make_and_ddfilter(DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)},
                                DDSpecificsMatchesValueFilter{DDValue("Endcap","",0)} );
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -498,8 +469,7 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind2, DDCompOp::equals);
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -509,8 +479,7 @@ void testDDFilter::checkFilters() {
     {
       auto f = make_and_ddfilter(DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)},
                                DDSpecificsMatchesValueFilter{DDValue("Endcap","",0)});
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -523,8 +492,7 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
       f.setCriteria(tofind2, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -534,8 +502,7 @@ void testDDFilter::checkFilters() {
     {
       auto f = make_and_ddfilter(DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)},
                                  DDSpecificsAnyValueFilter{"Endcap"});
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -548,8 +515,7 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind2, DDCompOp::not_equals);
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -559,8 +525,7 @@ void testDDFilter::checkFilters() {
     {
       auto f = make_and_ddfilter(DDSpecificsAnyValueFilter{"Endcap"},
                                  DDSpecificsMatchesValueFilter{DDValue("Volume","EMinus",0)});
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {"End"};
@@ -573,8 +538,7 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
       f.setCriteria(tofind2, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {};
@@ -587,8 +551,7 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind, DDCompOp::equals);
       f.setCriteria(tofind2, DDCompOp::not_equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {};
@@ -601,8 +564,7 @@ void testDDFilter::checkFilters() {
       DDSpecificsFilter f;
       f.setCriteria(tofind2, DDCompOp::not_equals);
       f.setCriteria(tofind, DDCompOp::equals);
-      DDFilteredView fv(cv);
-      fv.addFilter(f);
+      DDFilteredView fv(cv,f);
 
       auto const names = getNames(fv);
       std::vector<std::string> const expectedNames = {};

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -328,7 +328,6 @@ void tutorial()
   cop["<="]  = DDCompOp::smaller_equals;
   std::map<std::string,DDLogOp> lop;
   lop["AND"] = DDLogOp::AND;
-  lop["OR"] = DDLogOp::OR;
   bool moreFilters = true;
   bool moreQueries = true;
   bool moreFilterCriteria = true;

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -322,28 +322,21 @@ void tutorial()
   std::map<std::string,DDCompOp> cop;
   cop["=="] = DDCompOp::equals;
   cop["!="] = DDCompOp::not_equals;
-  cop["<"]  = DDCompOp::smaller;
-  cop[">"]  = DDCompOp::bigger;
-  cop[">="]  = DDCompOp::bigger_equals;
-  cop["<="]  = DDCompOp::smaller_equals;
-  std::map<std::string,DDLogOp> lop;
-  lop["AND"] = DDLogOp::AND;
   bool moreFilters = true;
   bool moreQueries = true;
   bool moreFilterCriteria = true;
   std::string flog, ls, p, cs, v, q;
   while(moreQueries) {
-    std::vector<std::pair<DDLogOp,DDSpecificsFilter*> > vecF;
+    std::vector< DDSpecificsFilter* > vecF;
     while(moreFilters) { 
       DDSpecificsFilter * f = new DDSpecificsFilter();
       std::string flog;
       std::string asString;
-      bool asStringBool = false;
       std::cout << "filter LogOp = ";
       std::cin >> flog;
       if(flog=="end") 
 	break;
-      vecF.push_back(std::make_pair(lop[flog],f));
+      vecF.push_back(f);
       while (moreFilterCriteria) {
 	std::cout << " logic   = ";
 	std::cin >> ls;
@@ -355,12 +348,7 @@ void tutorial()
 	std::cin >> cs;
 	std::cout << " par-val = ";
 	std::cin >> v;
-	std::cout << " as-std::string[y/n] = ";
-	std::cin >> asString;
       
-	if (asString=="y") 
-	  asStringBool = true;
-	
 	double dv = 0.;
 	try {
 	  dv = ExprEvalSingleton::instance().eval("",v);
@@ -369,18 +357,18 @@ void tutorial()
 	  dv = 0;
 	}
 	DDValue ddval(p,v,dv);
-	vecF.back().second->setCriteria(ddval,cop[cs],lop[ls],asStringBool);
+	vecF.back()->setCriteria(ddval,cop[cs]);
       
       }//<- moreFilterCriteria
     }//<- morFilters
    
     DDScope scope;
     DDQuery query(ccv);
-    std::vector<std::pair<DDLogOp,DDSpecificsFilter*> >::size_type loop=0;
+    std::vector<DDSpecificsFilter*>::size_type loop=0;
     for(; loop < vecF.size(); ++loop) {
-      DDFilter * filter = vecF[loop].second;  
+      DDFilter * filter = vecF[loop];  
       const DDFilter & fi = *filter;
-      query.addFilter( fi, vecF[loop].first );
+      query.addFilter( fi );
     }  
     std::cout << "The Scope is now: " << std::endl << scope << std::endl;
     std::string ans;
@@ -471,8 +459,8 @@ void tutorial()
     DDFilteredView fv(compactview);
 
     if (ans=="y") {
-      for (std::vector<std::pair<DDLogOp,DDSpecificsFilter*> >::size_type j=0; j<vecF.size(); ++j) {
-	fv.addFilter(*(vecF[j].second), DDLogOp::AND);
+      for (std::vector<DDSpecificsFilter* >::size_type j=0; j<vecF.size(); ++j) {
+	fv.addFilter(*(vecF[j]) );
       }
     
       //bool looop = true;
@@ -588,8 +576,8 @@ void tutorial()
    
     loop=0;
     for(; loop<vecF.size(); ++loop) {
-      delete vecF[loop].second; // delete the filters
-      vecF[loop].second=0;
+      delete vecF[loop]; // delete the filters
+      vecF[loop]=0;
     } 
   }
 

--- a/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
+++ b/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
@@ -20,11 +20,20 @@ public:
 private:
   std::string m_attribute;
   std::string m_value;
+  bool m_shouldPrint;
+  DDCompOp m_comp;
 };
 
 DDFilteredViewAnalyzer::DDFilteredViewAnalyzer( const edm::ParameterSet& pset ) {
   m_attribute = pset.getParameter< std::string >( "attribute" );
   m_value = pset.getParameter< std::string >( "value" );
+  
+  m_shouldPrint = pset.getUntrackedParameter<bool>("shouldPrint",true);
+  if(pset.getUntrackedParameter<bool>("compareNotEquals",true) ) {
+    m_comp = DDCompOp::not_equals;
+  } else {
+    m_comp= DDCompOp::equals;
+  }
 }
 
 void
@@ -36,7 +45,7 @@ DDFilteredViewAnalyzer::analyze( const edm::Event& ,
   DDValue val( m_attribute, m_value, 0.0 );
   DDSpecificsFilter filter;
   filter.setCriteria( val,  // name & value of a variable 
-  		      DDCompOp::not_equals,
+  		      m_comp,
   		      DDLogOp::AND, 
   		      true, // compare strings otherwise doubles
   		      true  // use merged-specifics or simple-specifics
@@ -49,7 +58,9 @@ DDFilteredViewAnalyzer::analyze( const edm::Event& ,
     int i = 0;
     while( dodet ) {
       dodet = fv.next();
-      std::cout << i++ << ": " << fv.logicalPart().name() << std::endl;
+      if(m_shouldPrint) {
+        std::cout << i++ << ": " << fv.logicalPart().name() << std::endl;
+      }
     }
   }
   else

--- a/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
+++ b/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
@@ -45,10 +45,7 @@ DDFilteredViewAnalyzer::analyze( const edm::Event& ,
   DDValue val( m_attribute, m_value, 0.0 );
   DDSpecificsFilter filter;
   filter.setCriteria( val,  // name & value of a variable 
-  		      m_comp,
-  		      DDLogOp::AND, 
-  		      true, // compare strings otherwise doubles
-  		      true  // use merged-specifics or simple-specifics
+  		      m_comp
   		     );
   DDFilteredView fv( *cpv );
   fv.addFilter( filter );

--- a/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
+++ b/Geometry/CMSCommonData/test/DDFilteredViewAnalyzer.cc
@@ -47,8 +47,7 @@ DDFilteredViewAnalyzer::analyze( const edm::Event& ,
   filter.setCriteria( val,  // name & value of a variable 
   		      m_comp
   		     );
-  DDFilteredView fv( *cpv );
-  fv.addFilter( filter );
+  DDFilteredView fv( *cpv,filter );
   if( fv.firstChild()) {
     std::cout << "Found attribute " << m_attribute.c_str() << " with value " << m_value.c_str() << std::endl;
     bool dodet = true;

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -34,10 +34,7 @@ bool CSCGeometryParsFromDD::build( const DDCompactView* cview
 
   DDSpecificsFilter filter;
   filter.setCriteria(muval, // name & value of a variable 
-		     DDCompOp::equals,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true // use merged-specifics or simple-specifics
+		     DDCompOp::equals
 		     );
 
   DDFilteredView fv( *cview );

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -28,14 +28,10 @@ bool CSCGeometryParsFromDD::build( const DDCompactView* cview
 				   ) {
   std::string attribute = "MuStructure";      // could come from outside
   std::string value     = "MuonEndcapCSC";    // could come from outside
-  DDValue muval(attribute, value, 0.0);
 
   // Asking for a specific section of the MuStructure
 
-  DDSpecificsFilter filter;
-  filter.setCriteria(muval, // name & value of a variable 
-		     DDCompOp::equals
-		     );
+  DDSpecificsMatchesValueFilter filter{ DDValue(attribute, value, 0.0) };
 
   DDFilteredView fv( *cview, filter );
 

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -37,8 +37,7 @@ bool CSCGeometryParsFromDD::build( const DDCompactView* cview
 		     DDCompOp::equals
 		     );
 
-  DDFilteredView fv( *cview );
-  fv.addFilter(filter);
+  DDFilteredView fv( *cview, filter );
 
   bool doSubDets = fv.firstChild();
 

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
@@ -60,7 +60,8 @@ private:
   unsigned int getDetIdForDDDNode( const DDFilteredView& fv ) ;
 
   typename T::NumberingScheme m_scheme;
-  DDSpecificsFilter  m_filter;
+  DDAndFilter<DDSpecificsMatchesValueFilter,
+              DDSpecificsMatchesValueFilter> m_filter;
 };
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -73,8 +73,7 @@ CaloGeometryLoader<T>::makeGeometry( const DDCompactView*  cpv        ,
 				     const Alignments*     alignments ,
 				     const Alignments*     globals      )
 {
-   DDFilteredView fv0 ( *cpv ) ;
-   fv0.addFilter( m_filter ) ;
+   DDFilteredView fv0 ( *cpv, m_filter ) ;
 
    fillNamedParams( fv0, geom ) ;
 
@@ -82,8 +81,7 @@ CaloGeometryLoader<T>::makeGeometry( const DDCompactView*  cpv        ,
    geom->allocatePar( T::k_NumberOfParametersPerShape*T::k_NumberOfShapes,
 		      T::k_NumberOfParametersPerShape ) ;
 
-   DDFilteredView fv( *cpv ) ;
-   fv.addFilter( m_filter ) ;
+   DDFilteredView fv( *cpv, m_filter ) ;
  
    unsigned int counter ( 0 ) ;
    for( bool doSubDets = fv.firstChild(); doSubDets ; doSubDets = fv.nextSibling() )

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -42,18 +42,12 @@ CaloGeometryLoader<T>::CaloGeometryLoader()
    m_filter.setCriteria( DDValue( "SensitiveDetector",
 				  "EcalSensitiveDetector",
 				  0                        ),
-			 DDCompOp::equals,
-			 DDLogOp::AND,
-			 true,
-			 true                               ) ;
+			 DDCompOp::equals           ) ;
 
    m_filter.setCriteria( DDValue( "ReadOutName",
 				  T::hitString(),
 				  0                  ),
-			 DDCompOp::equals,
-			 DDLogOp::AND,
-			 true,
-			 true                       ) ;
+			 DDCompOp::equals           ) ;
 }
 
 template <class T>

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -37,17 +37,14 @@ const double
 CaloGeometryLoader<T>::k_ScaleFromDDDtoGeant ( 0.1 ) ;
 
 template <class T>
-CaloGeometryLoader<T>::CaloGeometryLoader() 
+CaloGeometryLoader<T>::CaloGeometryLoader() :
+m_filter(DDSpecificsMatchesValueFilter{DDValue( "SensitiveDetector",
+                                                "EcalSensitiveDetector",
+				                0                        )},
+         DDSpecificsMatchesValueFilter{DDValue( "ReadOutName",
+   				                T::hitString(),
+				                0              )})
 {
-   m_filter.setCriteria( DDValue( "SensitiveDetector",
-				  "EcalSensitiveDetector",
-				  0                        ),
-			 DDCompOp::equals           ) ;
-
-   m_filter.setCriteria( DDValue( "ReadOutName",
-				  T::hitString(),
-				  0                  ),
-			 DDCompOp::equals           ) ;
 }
 
 template <class T>

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -42,15 +42,11 @@ void DTGeometryBuilderFromDDD::build(std::shared_ptr<DTGeometry> theGeometry,
 
   std::string attribute = "MuStructure"; 
   std::string value     = "MuonBarrelDT";
-  DDValue val(attribute, value, 0.0);
 
   // Asking only for the Muon DTs
-  DDSpecificsFilter filter;
-  filter.setCriteria(val,  // name & value of a variable 
-		     DDCompOp::equals
-		     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+
+  DDFilteredView fview(*cview,filter);
   buildGeometry(theGeometry, fview, muonConstants);
 }
 

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -47,10 +47,7 @@ void DTGeometryBuilderFromDDD::build(std::shared_ptr<DTGeometry> theGeometry,
   // Asking only for the Muon DTs
   DDSpecificsFilter filter;
   filter.setCriteria(val,  // name & value of a variable 
-		     DDCompOp::matches,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true  // use merged-specifics or simple-specifics
+		     DDCompOp::equals
 		     );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
@@ -43,15 +43,10 @@ void DTGeometryParsFromDD::build(const DDCompactView* cview,
 
   std::string attribute = "MuStructure"; 
   std::string value     = "MuonBarrelDT";
-  DDValue val(attribute, value, 0.0);
 
   // Asking only for the Muon DTs
-  DDSpecificsFilter filter;
-  filter.setCriteria(val,  // name & value of a variable 
-		     DDCompOp::equals
-		     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview(*cview,filter);
   buildGeometry(fview, muonConstants, rig);
   //cout << "RecoIdealGeometry " << rig.size() << endl;
 }

--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
@@ -48,10 +48,7 @@ void DTGeometryParsFromDD::build(const DDCompactView* cview,
   // Asking only for the Muon DTs
   DDSpecificsFilter filter;
   filter.setCriteria(val,  // name & value of a variable 
-		     DDCompOp::matches,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true  // use merged-specifics or simple-specifics
+		     DDCompOp::equals
 		     );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -136,17 +136,11 @@ DDFilter* EcalTBHodoscopeGeometryLoaderFromDDD::getDDFilter()
    filter->setCriteria( DDValue( "SensitiveDetector",
 				 "EcalTBH4BeamDetector",
 				 0 ),
-			DDCompOp::equals,
-			DDLogOp::AND,
-			true,
-			true ) ;
+			DDCompOp::equals ) ;
 
    filter->setCriteria( DDValue( "ReadOutName",
 				 "EcalTBH4BeamHits",
 				 0 ),
-			DDCompOp::equals,
-			DDLogOp::AND,
-			true,
-			true ) ;
+			DDCompOp::equals ) ;
    return filter;
 }

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -41,8 +41,7 @@ EcalTBHodoscopeGeometryLoaderFromDDD::makeGeometry(
   
    DDFilter* filter = getDDFilter();
 
-   DDFilteredView fv(*cpv);
-   fv.addFilter(*filter);
+   DDFilteredView fv(*cpv,*filter);
   
    bool doSubDets;
    for (doSubDets = fv.firstChild(); doSubDets ; doSubDets = fv.nextSibling())

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -15,6 +15,7 @@ typedef CaloCellGeometry::CCGFloat CCGFloat ;
 
 #include <iostream>
 #include <vector>
+#include <memory>
 
 std::auto_ptr<CaloSubdetectorGeometry> 
 EcalTBHodoscopeGeometryLoaderFromDDD::load( const DDCompactView* cpv ) 
@@ -39,7 +40,7 @@ EcalTBHodoscopeGeometryLoaderFromDDD::makeGeometry(
    if( ebg->cornersMgr() == 0 ) ebg->allocateCorners( EBDetId::kSizeForDenseIndexing ) ;
    if( ebg->parMgr()     == 0 ) ebg->allocatePar( 10, 3 ) ;
   
-   DDFilter* filter = getDDFilter();
+   std::unique_ptr<DDFilter> filter{getDDFilter()};
 
    DDFilteredView fv(*cpv,*filter);
   
@@ -130,16 +131,12 @@ EcalTBHodoscopeGeometryLoaderFromDDD::getDetIdForDDDNode(
 
 DDFilter* EcalTBHodoscopeGeometryLoaderFromDDD::getDDFilter()
 {
-   DDSpecificsFilter *filter = new DDSpecificsFilter();
-
-   filter->setCriteria( DDValue( "SensitiveDetector",
-				 "EcalTBH4BeamDetector",
-				 0 ),
-			DDCompOp::equals ) ;
-
-   filter->setCriteria( DDValue( "ReadOutName",
-				 "EcalTBH4BeamHits",
-				 0 ),
-			DDCompOp::equals ) ;
-   return filter;
+   return new DDAndFilter<DDSpecificsMatchesValueFilter,
+                          DDSpecificsMatchesValueFilter>(
+                             DDSpecificsMatchesValueFilter{DDValue( "SensitiveDetector",
+                                                                    "EcalTBH4BeamDetector",
+                                                                    0 )},
+                             DDSpecificsMatchesValueFilter{DDValue( "ReadOutName",
+                                                                    "EcalTBH4BeamHits",
+                                                                    0 )});
 }

--- a/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
+++ b/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
@@ -56,8 +56,7 @@ CaloGeometryLoaderTest<T>::makeGeometry( const DDCompactView*  cpv        ,
    geom->allocatePar( T::k_NumberOfParametersPerShape*T::k_NumberOfShapes,
 		      T::k_NumberOfParametersPerShape ) ;
 
-   DDFilteredView fv ( *cpv ) ;
-   fv.addFilter( m_filter ) ;
+   DDFilteredView fv ( *cpv, m_filter ) ;
 
    unsigned int counter ( 0 ) ;
    for( bool doSubDets = fv.firstChild(); doSubDets ; doSubDets = fv.nextSibling() )

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
@@ -36,14 +36,10 @@ GEMGeometry* GEMGeometryBuilderFromDDD::build(const DDCompactView* cview, const 
   std::string attribute = "MuStructure"; // "ReadOutName"; // could come from .orcarc
   std::string value     = "MuonEndCapGEM"; // "MuonGEMHits"; // could come from .orcarc
 
-  DDValue val(attribute, value, 0.0);
+  
   // Asking only for the MuonGEM's
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable 
-  		     DDCompOp::equals
-  		     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview(*cview,filter);
 
   return this->buildGeometry(fview, muonConstants);
 }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
@@ -40,10 +40,7 @@ GEMGeometry* GEMGeometryBuilderFromDDD::build(const DDCompactView* cview, const 
   // Asking only for the MuonGEM's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-  		     DDCompOp::matches,
-  		     DDLogOp::AND, 
-  		     true, // compare strings otherwise doubles
-  		     true // use merged-specifics or simple-specifics
+  		     DDCompOp::equals
   		     );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -38,10 +38,7 @@ GEMGeometryParsFromDD::build(const DDCompactView* cview,
   // Asking only for the MuonGEM's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-		     DDCompOp::matches,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true // use merged-specifics or simple-specifics
+		     DDCompOp::equals
 		     );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -33,15 +33,10 @@ GEMGeometryParsFromDD::build(const DDCompactView* cview,
 {
   std::string attribute = "ReadOutName"; // could come from .orcarc
   std::string value     = "MuonGEMHits";    // could come from .orcarc
-  DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonGEM's
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable 
-		     DDCompOp::equals
-		     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview(*cview,filter);
 
   this->buildGeometry(fview, muonConstants, rgeo);
 }

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
@@ -41,15 +41,10 @@ ME0Geometry* ME0GeometryBuilderFromDDD::build(const DDCompactView* cview, const 
 {
   std::string attribute = "ReadOutName";
   std::string value     = "MuonME0Hits";
-  DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonME0's
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable 
-		     DDCompOp::equals
-		     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview(*cview,filter);
 
   return this->buildGeometry(fview, muonConstants);
 }

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
@@ -46,10 +46,7 @@ ME0Geometry* ME0GeometryBuilderFromDDD::build(const DDCompactView* cview, const 
   // Asking only for the MuonME0's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-		     DDCompOp::matches,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true // use merged-specifics or simple-specifics
+		     DDCompOp::equals
 		     );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
@@ -33,15 +33,9 @@ ME0Geometry* ME0GeometryBuilderFromDDD10EtaPart::build(const DDCompactView* cvie
   std::string attribute = "MuStructure";
   std::string value     = "MuonEndCapME0";
 
-  DDValue val(attribute, value, 0.0);
-
   // Asking only for the MuonME0's
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable
-                     DDCompOp::equals
-                     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview(*cview,filter);
 
   return this->buildGeometry(fview, muonConstants);
 }

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD10EtaPart.cc
@@ -38,10 +38,7 @@ ME0Geometry* ME0GeometryBuilderFromDDD10EtaPart::build(const DDCompactView* cvie
   // Asking only for the MuonME0's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable
-                     DDCompOp::matches,
-                     DDLogOp::AND,
-                     true, // compare strings otherwise doubles
-                     true // use merged-specifics or simple-specifics
+                     DDCompOp::equals
                      );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
@@ -21,10 +21,7 @@ ME0GeometryParsFromDD::build( const DDCompactView* cview,
   // Asking only for the MuonME0's
   DDSpecificsFilter filter;
   filter.setCriteria( val,  // name & value of a variable 
-		      DDCompOp::matches,
-		      DDLogOp::AND, 
-		      true, // compare strings otherwise doubles
-		      true  // use merged-specifics or simple-specifics
+		      DDCompOp::equals
 		      );
   DDFilteredView fview( *cview );
   fview.addFilter( filter );

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryParsFromDD.cc
@@ -16,15 +16,10 @@ ME0GeometryParsFromDD::build( const DDCompactView* cview,
 {
   std::string attribute = "ReadOutName";
   std::string value     = "MuonME0Hits";
-  DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonME0's
-  DDSpecificsFilter filter;
-  filter.setCriteria( val,  // name & value of a variable 
-		      DDCompOp::equals
-		      );
-  DDFilteredView fview( *cview );
-  fview.addFilter( filter );
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview( *cview, filter );
 
   this->buildGeometry( fview, muonConstants, rgeo );
 }

--- a/Geometry/HGCalCommonData/src/FastTimeParametersFromDD.cc
+++ b/Geometry/HGCalCommonData/src/FastTimeParametersFromDD.cc
@@ -26,10 +26,8 @@ bool FastTimeParametersFromDD::build(const DDCompactView* cpv,
   std::string attribute = "Volume"; 
   std::string value     = name;
   DDValue val(attribute, value, 0.0);
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, DDCompOp::equals);
-  DDFilteredView fv(*cpv);
-  fv.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{val};
+  DDFilteredView fv(*cpv,filter);
   bool ok = fv.firstChild();
 
   if (ok) {

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -281,10 +281,8 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
   std::vector<HGCalGeomParameters::cellParameters> wafers;  
   std::string attribute = "Volume";
   DDValue val1(attribute, sdTag2, 0.0);
-  DDSpecificsFilter filter1;
-  filter1.setCriteria(val1, DDCompOp::equals);
-  DDFilteredView fv1(*cpv);
-  fv1.addFilter(filter1);
+  DDSpecificsMatchesValueFilter filter1{val1};
+  DDFilteredView fv1(*cpv,filter1);
   bool ok = fv1.firstChild();
   if (!ok) {
     edm::LogError("HGCalGeom") << " Attribute " << val1
@@ -347,10 +345,8 @@ void HGCalGeomParameters::loadGeometryHexagon(const DDFilteredView& _fv,
   std::map<int,int>         wafertype;
   std::map<int,HGCalGeomParameters::cellParameters> cellsf, cellsc;
   DDValue val2(attribute, sdTag3, 0.0);
-  DDSpecificsFilter filter2;
-  filter2.setCriteria(val2, DDCompOp::equals);
-  DDFilteredView fv2(*cpv);
-  fv2.addFilter(filter2);
+  DDSpecificsMatchesValueFilter filter2{val2};
+  DDFilteredView fv2(*cpv,filter2);
   ok = fv2.firstChild();
   if (!ok) {
     edm::LogError("HGCalGeom") << " Attribute " << val2
@@ -701,11 +697,8 @@ void HGCalGeomParameters::loadSpecParsHexagon(const DDFilteredView& fv,
 
   //Wafer size
   std::string attribute = "Volume";
-  DDValue val1(attribute, sdTag1, 0.0);
-  DDSpecificsFilter filter1;
-  filter1.setCriteria(val1, DDCompOp::equals);
-  DDFilteredView fv1(*cpv);
-  fv1.addFilter(filter1);
+  DDSpecificsMatchesValueFilter filter1{DDValue(attribute, sdTag1, 0.0)};
+  DDFilteredView fv1(*cpv,filter1);
   if (fv1.firstChild()) {
     DDsvalues_type sv(fv1.mergedSpecifics());
     int nmin(0);
@@ -717,11 +710,8 @@ void HGCalGeomParameters::loadSpecParsHexagon(const DDFilteredView& fv,
 #endif
 
   //Cell size
-  DDValue val2(attribute, sdTag2, 0.0);
-  DDSpecificsFilter filter2;
-  filter2.setCriteria(val2, DDCompOp::equals);
-  DDFilteredView fv2(*cpv);
-  fv2.addFilter(filter2);
+  DDSpecificsMatchesValueFilter filter2{DDValue(attribute, sdTag2, 0.0)};
+  DDFilteredView fv2(*cpv,filter2);
   if (fv2.firstChild()) {
     DDsvalues_type sv(fv2.mergedSpecifics());
     int nmin(0);
@@ -857,13 +847,8 @@ void HGCalGeomParameters::loadCellParsHexagon(const DDCompactView* cpv,
 
   //Special parameters for cell parameters
   std::string attribute = "OnlyForHGCalNumbering"; 
-  std::string value     = "any";
-  DDValue val1(attribute, value, 0.0);
-  DDSpecificsFilter filter1;
-  filter1.setCriteria(val1, DDCompOp::not_equals
-                      );
-  DDFilteredView fv1(*cpv);
-  fv1.addFilter(filter1);
+  DDSpecificsAnyValueFilter filter1{attribute};
+  DDFilteredView fv1(*cpv,filter1);
   bool ok = fv1.firstChild();
 
   if (ok) {

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -847,7 +847,7 @@ void HGCalGeomParameters::loadCellParsHexagon(const DDCompactView* cpv,
 
   //Special parameters for cell parameters
   std::string attribute = "OnlyForHGCalNumbering"; 
-  DDSpecificsAnyValueFilter filter1{attribute};
+  DDSpecificsHasNamedValueFilter filter1{attribute};
   DDFilteredView fv1(*cpv,filter1);
   bool ok = fv1.firstChild();
 

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -860,9 +860,7 @@ void HGCalGeomParameters::loadCellParsHexagon(const DDCompactView* cpv,
   std::string value     = "any";
   DDValue val1(attribute, value, 0.0);
   DDSpecificsFilter filter1;
-  filter1.setCriteria(val1, DDCompOp::not_equals,
-                      DDLogOp::AND, true, // compare strings otherwise doubles
-                      true  // use merged-specifics or simple-specifics
+  filter1.setCriteria(val1, DDCompOp::not_equals
                       );
   DDFilteredView fv1(*cpv);
   fv1.addFilter(filter1);

--- a/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
@@ -49,10 +49,8 @@ bool HGCalParametersFromDD::build(const DDCompactView* cpv,
   std::string attribute = "Volume"; 
   std::string value     = name;
   DDValue val(attribute, value, 0.0);
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, DDCompOp::equals);
-  DDFilteredView fv(*cpv);
-  fv.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{val};
+  DDFilteredView fv(*cpv,filter);
   bool ok = fv.firstChild();
 
   if (ok) {

--- a/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
@@ -48,9 +48,7 @@ bool HcalParametersFromDD::build(const DDCompactView* cpv,
   std::string value     = "any";
   DDValue val1(attribute, value, 0.0);
   DDSpecificsFilter filter1;
-  filter1.setCriteria(val1, DDCompOp::not_equals,
-		      DDLogOp::AND, true, // compare strings otherwise doubles
-		      true  // use merged-specifics or simple-specifics
+  filter1.setCriteria(val1, DDCompOp::not_equals
 		      );
   DDFilteredView fv1(*cpv);
   fv1.addFilter(filter1);
@@ -110,9 +108,7 @@ bool HcalParametersFromDD::build(const DDCompactView* cpv,
   DDValue val2( attribute, value, 0.0 );
   DDSpecificsFilter filter2;
   filter2.setCriteria(val2,
-		      DDCompOp::not_equals,
-		      DDLogOp::AND, true, // compare strings 
-		      true  // use merged-specifics or simple-specifics
+		      DDCompOp::not_equals
 		      );
   DDFilteredView fv2(*cpv);
   fv2.addFilter(filter2);

--- a/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
@@ -45,13 +45,8 @@ bool HcalParametersFromDD::build(const DDCompactView* cpv,
 
   //Special parameters at simulation level
   std::string attribute = "OnlyForHcalSimNumbering"; 
-  std::string value     = "any";
-  DDValue val1(attribute, value, 0.0);
-  DDSpecificsFilter filter1;
-  filter1.setCriteria(val1, DDCompOp::not_equals
-		      );
-  DDFilteredView fv1(*cpv);
-  fv1.addFilter(filter1);
+  DDSpecificsAnyValueFilter filter1{attribute};
+  DDFilteredView fv1(*cpv,filter1);
   bool ok = fv1.firstChild();
 
   const int nEtaMax=100;
@@ -105,13 +100,8 @@ bool HcalParametersFromDD::build(const DDCompactView* cpv,
   }
   //Special parameters at reconstruction level
   attribute = "OnlyForHcalRecNumbering"; 
-  DDValue val2( attribute, value, 0.0 );
-  DDSpecificsFilter filter2;
-  filter2.setCriteria(val2,
-		      DDCompOp::not_equals
-		      );
-  DDFilteredView fv2(*cpv);
-  fv2.addFilter(filter2);
+  DDSpecificsAnyValueFilter filter2{attribute};
+  DDFilteredView fv2(*cpv,filter2);
   ok = fv2.firstChild();
   if (ok) {
     DDsvalues_type sv(fv2.mergedSpecifics());

--- a/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
@@ -45,7 +45,7 @@ bool HcalParametersFromDD::build(const DDCompactView* cpv,
 
   //Special parameters at simulation level
   std::string attribute = "OnlyForHcalSimNumbering"; 
-  DDSpecificsAnyValueFilter filter1{attribute};
+  DDSpecificsHasNamedValueFilter filter1{attribute};
   DDFilteredView fv1(*cpv,filter1);
   bool ok = fv1.firstChild();
 
@@ -100,7 +100,7 @@ bool HcalParametersFromDD::build(const DDCompactView* cpv,
   }
   //Special parameters at reconstruction level
   attribute = "OnlyForHcalRecNumbering"; 
-  DDSpecificsAnyValueFilter filter2{attribute};
+  DDSpecificsHasNamedValueFilter filter2{attribute};
   DDFilteredView fv2(*cpv,filter2);
   ok = fv2.firstChild();
   if (ok) {

--- a/Geometry/MuonNumbering/interface/MuonSimHitNumberingScheme.h
+++ b/Geometry/MuonNumbering/interface/MuonSimHitNumberingScheme.h
@@ -15,12 +15,14 @@
 class MuonBaseNumber;
 class MuonSubDetector;
 class DDCompactView; 
+class MuonDDDConstants;
 
 class MuonSimHitNumberingScheme : public MuonNumberingScheme {
 
  public:
 
   MuonSimHitNumberingScheme(MuonSubDetector*, const DDCompactView& cpv);
+  MuonSimHitNumberingScheme(MuonSubDetector*, const MuonDDDConstants& muonConstants);
   ~MuonSimHitNumberingScheme();
   
   virtual int baseNumberToUnitNumber(const MuonBaseNumber&);

--- a/Geometry/MuonNumbering/src/MuonDDDConstants.cc
+++ b/Geometry/MuonNumbering/src/MuonDDDConstants.cc
@@ -16,7 +16,7 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
 #endif
   std::string attribute = "OnlyForMuonNumbering"; 
   
-  DDSpecificsAnyValueFilter filter(attribute);
+  DDSpecificsHasNamedValueFilter filter(attribute);
   DDFilteredView fview(cpv,filter);
   
   DDValue val2("level");

--- a/Geometry/MuonNumbering/src/MuonDDDConstants.cc
+++ b/Geometry/MuonNumbering/src/MuonDDDConstants.cc
@@ -17,8 +17,7 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
   std::string attribute = "OnlyForMuonNumbering"; 
   
   DDSpecificsAnyValueFilter filter(attribute);
-  DDFilteredView fview(cpv);
-  fview.addFilter(filter);
+  DDFilteredView fview(cpv,filter);
   
   DDValue val2("level");
   const DDsvalues_type params(fview.mergedSpecifics());

--- a/Geometry/MuonNumbering/src/MuonDDDConstants.cc
+++ b/Geometry/MuonNumbering/src/MuonDDDConstants.cc
@@ -15,13 +15,8 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
   std::cout << "MuonDDDConstants;:MuonDDDConstants ( const DDCompactView& cpv ) constructor " << std::endl;
 #endif
   std::string attribute = "OnlyForMuonNumbering"; 
-  std::string value     = "any";
-  DDValue val(attribute, value, 0.0);
   
-  DDSpecificsFilter filter;
-  filter.setCriteria(val,
-		     DDCompOp::not_equals
-		     );
+  DDSpecificsAnyValueFilter filter(attribute);
   DDFilteredView fview(cpv);
   fview.addFilter(filter);
   

--- a/Geometry/MuonNumbering/src/MuonDDDConstants.cc
+++ b/Geometry/MuonNumbering/src/MuonDDDConstants.cc
@@ -20,10 +20,7 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
   
   DDSpecificsFilter filter;
   filter.setCriteria(val,
-		     DDCompOp::not_equals,
-		     DDLogOp::AND, 
-		     true, // compare strings otherwise doubles
-		     true  // use merged-specifics or simple-specifics
+		     DDCompOp::not_equals
 		     );
   DDFilteredView fview(cpv);
   fview.addFilter(filter);

--- a/Geometry/MuonNumbering/src/MuonSimHitNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/MuonSimHitNumberingScheme.cc
@@ -6,23 +6,28 @@
 #include "Geometry/MuonNumbering/interface/ME0NumberingScheme.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonSubDetector.h"
+#include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 
 //#define LOCAL_DEBUG
 
-MuonSimHitNumberingScheme::MuonSimHitNumberingScheme(MuonSubDetector* d, const DDCompactView& cpv) {
+MuonSimHitNumberingScheme::MuonSimHitNumberingScheme(MuonSubDetector* d, const DDCompactView& cpv) :
+  MuonSimHitNumberingScheme(d,MuonDDDConstants(cpv)){ }
+
+MuonSimHitNumberingScheme::MuonSimHitNumberingScheme(MuonSubDetector* d, const MuonDDDConstants& muonConstants) {
   theDetector=d;
   if (theDetector->isBarrel()) {
-    theNumbering=new DTNumberingScheme(cpv);
+    theNumbering=new DTNumberingScheme(muonConstants);
   } else if (theDetector->isEndcap()) {
-    theNumbering=new CSCNumberingScheme(cpv);
+    theNumbering=new CSCNumberingScheme(muonConstants);
   } else if (theDetector->isRPC()) {
-    theNumbering=new RPCNumberingScheme(cpv);
+    theNumbering=new RPCNumberingScheme(muonConstants);
   } else if (theDetector->isGEM()) {
-    theNumbering=new GEMNumberingScheme(cpv);
+    theNumbering=new GEMNumberingScheme(muonConstants);
   } else if (theDetector->isME0()) {
-    theNumbering=new ME0NumberingScheme(cpv);
+    theNumbering=new ME0NumberingScheme(muonConstants);
   } 
 }
+
 
 MuonSimHitNumberingScheme::~MuonSimHitNumberingScheme() {
   delete theNumbering;

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -41,10 +41,7 @@ RPCGeometry* RPCGeometryBuilderFromDDD::build(const DDCompactView* cview, const 
   // Asking only for the MuonRPC's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable
-                     DDCompOp::matches,
-                     DDLogOp::AND,
-                     true, // compare strings otherwise doubles
-                     true // use merged-specifics or simple-specifics
+                     DDCompOp::equals
                      );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -36,15 +36,10 @@ RPCGeometry* RPCGeometryBuilderFromDDD::build(const DDCompactView* cview, const 
 {
   const std::string attribute = "ReadOutName"; // could come from .orcarc
   const std::string value     = "MuonRPCHits";    // could come from .orcarc
-  DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonRPC's
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable
-                     DDCompOp::equals
-                     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview(*cview,filter);
 
   return this->buildGeometry(fview, muonConstants);
 }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -38,10 +38,7 @@ void RPCGeometryParsFromDD::build(const DDCompactView* cview,
   // Asking only for the MuonRPC's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable
-                     DDCompOp::matches,
-                     DDLogOp::AND,
-                     true, // compare strings otherwise doubles
-                     true // use merged-specifics or simple-specifics
+                     DDCompOp::equals
                      );
   DDFilteredView fview(*cview);
   fview.addFilter(filter);

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -33,15 +33,10 @@ void RPCGeometryParsFromDD::build(const DDCompactView* cview,
 {
   const std::string attribute = "ReadOutName";
   const std::string value     = "MuonRPCHits";
-  DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonRPC's
-  DDSpecificsFilter filter;
-  filter.setCriteria(val, // name & value of a variable
-                     DDCompOp::equals
-                     );
-  DDFilteredView fview(*cview);
-  fview.addFilter(filter);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
+  DDFilteredView fview(*cview,filter);
 
   this->buildGeometry(fview, muonConstants, rgeo);
 }

--- a/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
@@ -15,13 +15,9 @@ const GeometricDet*
 DDDCmsTrackerContruction::construct( const DDCompactView* cpv, std::vector<int> detidShifts)
 {
   attribute = "TkDDDStructure"; // could come from .orcarc
-  std::string value = "any";
-  DDSpecificsFilter filter;
-  DDValue ddv( attribute, value, 0 );
-  filter.setCriteria( ddv, DDCompOp::not_equals );
+  DDSpecificsAnyValueFilter filter{ attribute };
   
-  DDFilteredView fv( *cpv ); 
-  fv.addFilter( filter );
+  DDFilteredView fv( *cpv, filter ); 
   if( theCmsTrackerStringToEnum.type( ExtractStringFromDDD::getString(attribute,&fv)) != GeometricDet::Tracker )
   {
     fv.firstChild();

--- a/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
@@ -15,7 +15,7 @@ const GeometricDet*
 DDDCmsTrackerContruction::construct( const DDCompactView* cpv, std::vector<int> detidShifts)
 {
   attribute = "TkDDDStructure"; // could come from .orcarc
-  DDSpecificsAnyValueFilter filter{ attribute };
+  DDSpecificsHasNamedValueFilter filter{ attribute };
   
   DDFilteredView fv( *cpv, filter ); 
   if( theCmsTrackerStringToEnum.type( ExtractStringFromDDD::getString(attribute,&fv)) != GeometricDet::Tracker )

--- a/Geometry/VeryForwardGeometryBuilder/src/DDDTotemRPConstruction.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DDDTotemRPConstruction.cc
@@ -32,7 +32,8 @@ DDDTotemRPContruction::DDDTotemRPContruction()
 const DetGeomDesc* DDDTotemRPContruction::construct(const DDCompactView* cpv)
 {
   // create DDFilteredView and apply the filter
-  DDFilteredView fv(*cpv);
+  DDPassAllFilter filter;
+  DDFilteredView fv(*cpv, filter);
 
   // conversion to DetGeomDesc structure
   // create the root node and recursively propagates through the tree

--- a/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
@@ -100,13 +100,8 @@ TestSpecParAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
    const DDCompactView& cpv(*pDD);
    if ( specStrValue_ != "frederf" ) {
      std::cout << "specName = " << specName_ << " and specStrValue = " << specStrValue_ << std::endl;
-     DDValue fval(specName_, specStrValue_, 0.0);
-     DDSpecificsFilter filter;
-     filter.setCriteria(fval, // name & value of a variable 
-			DDCompOp::equals
-			);
-     DDFilteredView fv(cpv);
-     fv.addFilter(filter);
+     DDSpecificsMatchesValueFilter filter{DDValue(specName_, specStrValue_, 0.0)};
+     DDFilteredView fv(cpv,filter);
      bool doit = fv.firstChild();
      std::vector<const DDsvalues_type *> spec = fv.specifics();
      std::vector<const DDsvalues_type *>::const_iterator spit = spec.begin();

--- a/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
@@ -103,10 +103,7 @@ TestSpecParAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
      DDValue fval(specName_, specStrValue_, 0.0);
      DDSpecificsFilter filter;
      filter.setCriteria(fval, // name & value of a variable 
-			DDCompOp::equals,
-			DDLogOp::AND, 
-			true, // compare strings otherwise doubles
-			true // use merged-specifics or simple-specifics
+			DDCompOp::equals
 			);
      DDFilteredView fv(cpv);
      fv.addFilter(filter);

--- a/SLHCUpgradeSimulations/Geometry/src/PrintGeomMatInfo.cc
+++ b/SLHCUpgradeSimulations/Geometry/src/PrintGeomMatInfo.cc
@@ -111,13 +111,10 @@ void PrintGeomMatInfo::update(const BeginOfJob * job)
 	for (unsigned int i=0; i<names.size(); i++) {
 	    std::string attribute = "ReadOutName";
 	    std::string sd        = names[i];
-	    DDSpecificsFilter filter;
-	    DDValue           ddv(attribute,sd,0);
-	    filter.setCriteria(ddv,DDCompOp::equals);
-	    DDFilteredView fv(*pDD);
+	    DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
+	    DDFilteredView fv(*pDD,filter);
 	    std::cout << "PrintGeomMatInfo:: Get Filtered view for " 
 		      << attribute << " = " << sd << std::endl;
-	    fv.addFilter(filter);
 	    bool dodet = fv.firstChild();
  
 	    std::string spaces = spacesFromLeafDepth(1);

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -44,8 +44,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
   //Get the names 
   G4String attribute = "ReadOutName"; 
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
-  DDFilteredView fv(cpv);
-  fv.addFilter(filter);
+  DDFilteredView fv(cpv,filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
 

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -43,9 +43,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
 
   //Get the names 
   G4String attribute = "ReadOutName"; 
-  DDSpecificsFilter filter;
-  DDValue           ddv(attribute,name,0);
-  filter.setCriteria(ddv,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -76,9 +76,7 @@ ECalSD::ECalSD(G4String name, const DDCompactView & cpv,
 
   //Material list for HB/HE/HO sensitive detectors
   std::string attribute = "ReadOutName";
-  DDSpecificsFilter filter;
-  DDValue           ddv(attribute,name,0);
-  filter.setCriteria(ddv,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();
@@ -325,9 +323,7 @@ void ECalSD::setNumberingScheme(EcalNumberingScheme* scheme) {
 void ECalSD::initMap(G4String sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
-  DDSpecificsFilter filter;
-  DDValue           ddv(attribute,sd,0);
-  filter.setCriteria(ddv,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -77,8 +77,7 @@ ECalSD::ECalSD(G4String name, const DDCompactView & cpv,
   //Material list for HB/HE/HO sensitive detectors
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
-  DDFilteredView fv(cpv);
-  fv.addFilter(filter);
+  DDFilteredView fv(cpv,filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
   // Use of Weight
@@ -324,8 +323,7 @@ void ECalSD::initMap(G4String sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
-  DDFilteredView fv(cpv);
-  fv.addFilter(filter);
+  DDFilteredView fv(cpv,filter);
   fv.firstChild();
 
   std::vector<G4LogicalVolume*> lvused;

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -270,8 +270,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   value     = "any";
   DDSpecificsFilter filter2;
   DDValue           ddv2(attribute,value,0);
-  filter2.setCriteria(ddv2, DDCompOp::not_equals,
-                      DDLogOp::AND, true, true);
+  filter2.setCriteria(ddv2, DDCompOp::not_equals);
   DDFilteredView fv2(cpv);
   fv2.addFilter(filter2);
   bool dodet = fv2.firstChild();

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -252,7 +252,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   const G4MaterialTable * matTab = G4Material::GetMaterialTable();
   std::vector<G4Material*>::const_iterator matite;
   attribute = "OnlyForHcalSimNumbering"; 
-  DDSpecificsAnyValueFilter filter2{attribute};
+  DDSpecificsHasNamedValueFilter filter2{attribute};
   DDFilteredView fv2(cpv,filter2);
   bool dodet = fv2.firstChild();
   DDsvalues_type sv(fv2.mergedSpecifics());

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -136,8 +136,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     attribute = "Volume";
     value     = "HF";
     DDSpecificsMatchesValueFilter filter0{DDValue(attribute,value,0)};
-    DDFilteredView fv0(cpv);
-    fv0.addFilter(filter0);
+    DDFilteredView fv0(cpv,filter0);
     hfNames = getNames(fv0);
     fv0.firstChild();
     DDsvalues_type sv0(fv0.mergedSpecifics());
@@ -164,8 +163,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     // HF Fibre volume names
     value     = "HFFibre";
     DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-    DDFilteredView fv1(cpv);
-    fv1.addFilter(filter1);
+    DDFilteredView fv1(cpv,filter1);
     fibreNames = getNames(fv1);
     edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
                             << " = " << value << ":";
@@ -186,8 +184,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     // HF PMT volume names
     value     = "HFPMT";
     DDSpecificsMatchesValueFilter filter3{DDValue(attribute,value,0)};
-    DDFilteredView fv3(cpv);
-    fv3.addFilter(filter3);
+    DDFilteredView fv3(cpv,filter3);
     std::vector<G4String> pmtNames = getNames(fv3);
     edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute 
 			    << " = " << value << " have " << pmtNames.size() 
@@ -209,8 +206,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     // HF Fibre bundles
     value     = "HFFibreBundleStraight";
     DDSpecificsMatchesValueFilter filter4{DDValue(attribute,value,0)};
-    DDFilteredView fv4(cpv);
-    fv4.addFilter(filter4);
+    DDFilteredView fv4(cpv,filter4);
     std::vector<G4String> fibreNames = getNames(fv4);
     edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
                             << " = " << value << " have " << fibreNames.size()
@@ -231,8 +227,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     // Geometry parameters for HF
     value     = "HFFibreBundleConical";
     DDSpecificsMatchesValueFilter filter5{DDValue(attribute,value,0)};
-    DDFilteredView fv5(cpv);
-    fv5.addFilter(filter5);
+    DDFilteredView fv5(cpv,filter5);
     fibreNames = getNames(fv5);
     edm::LogInfo("HcalSim") << "HCalSD: Names to be tested for " << attribute
 			    << " = " << value << " have " << fibreNames.size() 
@@ -258,8 +253,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   std::vector<G4Material*>::const_iterator matite;
   attribute = "OnlyForHcalSimNumbering"; 
   DDSpecificsAnyValueFilter filter2{attribute};
-  DDFilteredView fv2(cpv);
-  fv2.addFilter(filter2);
+  DDFilteredView fv2(cpv,filter2);
   bool dodet = fv2.firstChild();
   DDsvalues_type sv(fv2.mergedSpecifics());
 

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -135,9 +135,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     // HF volume names
     attribute = "Volume";
     value     = "HF";
-    DDSpecificsFilter filter0;
-    DDValue           ddv0(attribute, value, 0);
-    filter0.setCriteria(ddv0, DDCompOp::equals);
+    DDSpecificsMatchesValueFilter filter0{DDValue(attribute,value,0)};
     DDFilteredView fv0(cpv);
     fv0.addFilter(filter0);
     hfNames = getNames(fv0);
@@ -165,9 +163,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   
     // HF Fibre volume names
     value     = "HFFibre";
-    DDSpecificsFilter filter1;
-    DDValue           ddv1(attribute,value,0);
-    filter1.setCriteria(ddv1, DDCompOp::equals);
+    DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
     DDFilteredView fv1(cpv);
     fv1.addFilter(filter1);
     fibreNames = getNames(fv1);
@@ -189,9 +185,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   
     // HF PMT volume names
     value     = "HFPMT";
-    DDSpecificsFilter filter3;
-    DDValue           ddv3(attribute,value,0);
-    filter3.setCriteria(ddv3,DDCompOp::equals);
+    DDSpecificsMatchesValueFilter filter3{DDValue(attribute,value,0)};
     DDFilteredView fv3(cpv);
     fv3.addFilter(filter3);
     std::vector<G4String> pmtNames = getNames(fv3);
@@ -214,9 +208,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   
     // HF Fibre bundles
     value     = "HFFibreBundleStraight";
-    DDSpecificsFilter filter4;
-    DDValue           ddv4(attribute,value,0);
-    filter4.setCriteria(ddv4,DDCompOp::equals);
+    DDSpecificsMatchesValueFilter filter4{DDValue(attribute,value,0)};
     DDFilteredView fv4(cpv);
     fv4.addFilter(filter4);
     std::vector<G4String> fibreNames = getNames(fv4);
@@ -238,9 +230,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
 
     // Geometry parameters for HF
     value     = "HFFibreBundleConical";
-    DDSpecificsFilter filter5;
-    DDValue           ddv5(attribute,value,0);
-    filter5.setCriteria(ddv5,DDCompOp::equals);
+    DDSpecificsMatchesValueFilter filter5{DDValue(attribute,value,0)};
     DDFilteredView fv5(cpv);
     fv5.addFilter(filter5);
     fibreNames = getNames(fv5);
@@ -267,10 +257,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   const G4MaterialTable * matTab = G4Material::GetMaterialTable();
   std::vector<G4Material*>::const_iterator matite;
   attribute = "OnlyForHcalSimNumbering"; 
-  value     = "any";
-  DDSpecificsFilter filter2;
-  DDValue           ddv2(attribute,value,0);
-  filter2.setCriteria(ddv2, DDCompOp::not_equals);
+  DDSpecificsAnyValueFilter filter2{attribute};
   DDFilteredView fv2(cpv);
   fv2.addFilter(filter2);
   bool dodet = fv2.firstChild();

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -28,8 +28,7 @@ HFFibre::HFFibre(std::string & name, const DDCompactView & cpv,
   std::string attribute = "Volume"; 
   std::string value     = "HF";
   DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-  DDFilteredView fv1(cpv);
-  fv1.addFilter(filter1);
+  DDFilteredView fv1(cpv,filter1);
   bool dodet = fv1.firstChild();
 
   if (dodet) {

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -27,9 +27,7 @@ HFFibre::HFFibre(std::string & name, const DDCompactView & cpv,
 
   std::string attribute = "Volume"; 
   std::string value     = "HF";
-  DDSpecificsFilter filter1;
-  DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   bool dodet = fv1.firstChild();

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -37,8 +37,7 @@ HFShowerFibreBundle::HFShowerFibreBundle(std::string & name,
   std::string attribute = "Volume";
   std::string value     = "HFPMT";
   DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-  DDFilteredView fv1(cpv);
-  fv1.addFilter(filter1);
+  DDFilteredView fv1(cpv,filter1);
   if (fv1.firstChild()) {
     DDsvalues_type sv1(fv1.mergedSpecifics());
     std::vector<double> neta;

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -36,9 +36,7 @@ HFShowerFibreBundle::HFShowerFibreBundle(std::string & name,
   //Special Geometry parameters
   std::string attribute = "Volume";
   std::string value     = "HFPMT";
-  DDSpecificsFilter filter1;
-  DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   if (fv1.firstChild()) {

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -29,8 +29,7 @@ HFShowerPMT::HFShowerPMT(std::string & name, const DDCompactView & cpv,
   std::string attribute = "Volume";
   std::string value     = "HFPMT";
   DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-  DDFilteredView fv1(cpv);
-  fv1.addFilter(filter1);
+  DDFilteredView fv1(cpv,filter1);
   if (fv1.firstChild()) {
     DDsvalues_type sv1(fv1.mergedSpecifics());
     std::vector<double> neta;

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -28,9 +28,7 @@ HFShowerPMT::HFShowerPMT(std::string & name, const DDCompactView & cpv,
   //Special Geometry parameters
   std::string attribute = "Volume";
   std::string value     = "HFPMT";
-  DDSpecificsFilter filter1;
-  DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   if (fv1.firstChild()) {

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -195,8 +195,7 @@ void DreamSD::initMap(G4String sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
-  DDFilteredView fv(cpv);
-  fv.addFilter(filter);
+  DDFilteredView fv(cpv,filter);
   fv.firstChild();
 
   const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -194,9 +194,7 @@ uint32_t DreamSD::setDetUnitId(G4Step * aStep) {
 void DreamSD::initMap(G4String sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
-  DDSpecificsFilter filter;
-  DDValue           ddv(attribute,sd,0);
-  filter.setCriteria(ddv,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/Forward/src/FastTimerSD.cc
+++ b/SimG4CMS/Forward/src/FastTimerSD.cc
@@ -80,8 +80,7 @@ FastTimerSD::FastTimerSD(std::string name, const DDCompactView & cpv,
     
   std::string attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
-  DDFilteredView fv(cpv);
-  fv.addFilter(filter);
+  DDFilteredView fv(cpv,filter);
   fv.firstChild();
   DDsvalues_type sv(fv.mergedSpecifics());
   std::vector<int> temp = dbl_to_int(getDDDArray("Type",sv));

--- a/SimG4CMS/Forward/src/FastTimerSD.cc
+++ b/SimG4CMS/Forward/src/FastTimerSD.cc
@@ -79,9 +79,7 @@ FastTimerSD::FastTimerSD(std::string name, const DDCompactView & cpv,
   }
     
   std::string attribute = "ReadOutName";
-  DDSpecificsFilter filter;
-  DDValue           ddv(attribute,name,0);
-  filter.setCriteria(ddv,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,name,0)};
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -121,8 +121,7 @@ void HcalTB02SD::initMap(G4String sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
-  DDFilteredView fv(cpv);
-  fv.addFilter(filter);
+  DDFilteredView fv(cpv,filter);
   fv.firstChild();
 
   bool dodet=true;

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -120,9 +120,7 @@ void HcalTB02SD::setNumberingScheme(HcalTB02NumberingScheme* scheme) {
 void HcalTB02SD::initMap(G4String sd, const DDCompactView & cpv) {
 
   G4String attribute = "ReadOutName";
-  DDSpecificsFilter filter;
-  DDValue           ddv(attribute,sd,0);
-  filter.setCriteria(ddv,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -41,9 +41,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(G4String name, const DDCompactView & cpv,
   // Wire Chamber volume names
   attribute = "Volume";
   value     = "WireChamber";
-  DDSpecificsFilter filter1;
-  DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   wcNames = getNames(fv1);
@@ -56,9 +54,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(G4String name, const DDCompactView & cpv,
 
   //Material list for scintillator detector
   attribute = "ReadOutName";
-  DDSpecificsFilter filter2;
-  DDValue           ddv2(attribute,name,0);
-  filter2.setCriteria(ddv2,DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter2{DDValue(attribute,name,0)};
   DDFilteredView fv2(cpv);
   fv2.addFilter(filter2);
   bool dodet = fv2.firstChild();

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -42,8 +42,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(G4String name, const DDCompactView & cpv,
   attribute = "Volume";
   value     = "WireChamber";
   DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-  DDFilteredView fv1(cpv);
-  fv1.addFilter(filter1);
+  DDFilteredView fv1(cpv,filter1);
   wcNames = getNames(fv1);
   edm::LogInfo("HcalTB06BeamSD") 
     << "HcalTB06BeamSD:: Names to be tested for " 
@@ -55,8 +54,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(G4String name, const DDCompactView & cpv,
   //Material list for scintillator detector
   attribute = "ReadOutName";
   DDSpecificsMatchesValueFilter filter2{DDValue(attribute,name,0)};
-  DDFilteredView fv2(cpv);
-  fv2.addFilter(filter2);
+  DDFilteredView fv2(cpv,filter2);
   bool dodet = fv2.firstChild();
 
   std::vector<G4String> matNames;

--- a/SimG4CMS/Muon/interface/MuonFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonFrameRotation.h
@@ -18,7 +18,6 @@ class DDCompactView;
 
 class MuonFrameRotation {
  public:
-  MuonFrameRotation( const DDCompactView& cpv ) { };
   MuonFrameRotation( ) { };
   virtual ~MuonFrameRotation(){};
   virtual Local3DPoint transformPoint(const Local3DPoint &,const G4Step *) const = 0;

--- a/SimG4CMS/Muon/interface/MuonG4Numbering.h
+++ b/SimG4CMS/Muon/interface/MuonG4Numbering.h
@@ -21,11 +21,13 @@
 class G4Step;
 class MuonBaseNumber;
 class DDCompactView;
+class MuonDDDConstants;
 
 class MuonG4Numbering {
  public:
 
   MuonG4Numbering(const DDCompactView& cpv);
+  MuonG4Numbering(const MuonDDDConstants& muonConstants);
   ~MuonG4Numbering(){};
   
   MuonBaseNumber PhysicalVolumeToBaseNumber(const G4Step* aStep);

--- a/SimG4CMS/Muon/interface/MuonGEMFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonGEMFrameRotation.h
@@ -16,12 +16,12 @@
 
 #include "G4Step.hh"
 
-class DDCompactView;
+class MuonDDDConstants;
 
 class MuonGEMFrameRotation : public MuonFrameRotation {
 
 public:
-  MuonGEMFrameRotation( const DDCompactView& cpv );
+  MuonGEMFrameRotation( const MuonDDDConstants& muonConstants );
   virtual ~MuonGEMFrameRotation();
   virtual Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const;
 

--- a/SimG4CMS/Muon/interface/MuonME0FrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonME0FrameRotation.h
@@ -17,12 +17,12 @@
 
 #include "G4Step.hh"
 
-class DDCompactView;
+class MuonDDDConstants;
 
 class MuonME0FrameRotation : public MuonFrameRotation {
 
 public:
-  MuonME0FrameRotation( const DDCompactView& cpv );
+  MuonME0FrameRotation( const MuonDDDConstants& muonConstants );
   virtual ~MuonME0FrameRotation();
   virtual Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const;
 

--- a/SimG4CMS/Muon/interface/MuonRPCFrameRotation.h
+++ b/SimG4CMS/Muon/interface/MuonRPCFrameRotation.h
@@ -16,11 +16,11 @@
 #include "G4Step.hh"
 
 class MuonG4Numbering;
-class DDCompactView;
+class MuonDDDConstants;
 
 class MuonRPCFrameRotation : public MuonFrameRotation {
  public:
-  MuonRPCFrameRotation( const DDCompactView& cpv );
+  MuonRPCFrameRotation( const MuonDDDConstants& constants );
   virtual ~MuonRPCFrameRotation();
   virtual Local3DPoint transformPoint(const Local3DPoint &, const G4Step *) const;
  private:

--- a/SimG4CMS/Muon/src/MuonG4Numbering.cc
+++ b/SimG4CMS/Muon/src/MuonG4Numbering.cc
@@ -11,8 +11,10 @@
 
 //#define LOCAL_DEBUG
 
-MuonG4Numbering::MuonG4Numbering(const DDCompactView& cpv){
-  MuonDDDConstants muonConstants(cpv);
+MuonG4Numbering::MuonG4Numbering(const DDCompactView& cpv):
+  MuonG4Numbering(MuonDDDConstants(cpv)) {}
+
+MuonG4Numbering::MuonG4Numbering(const MuonDDDConstants& muonConstants){
   theLevelPart=muonConstants.getValue("level");
   theSuperPart=muonConstants.getValue("super");
   theBasePart=muonConstants.getValue("base");

--- a/SimG4CMS/Muon/src/MuonGEMFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonGEMFrameRotation.cc
@@ -7,9 +7,8 @@
 
 //#define LOCAL_DEBUG
 
-MuonGEMFrameRotation::MuonGEMFrameRotation(const DDCompactView& cpv) : MuonFrameRotation::MuonFrameRotation(cpv) {
-  g4numbering     = new MuonG4Numbering(cpv);
-  MuonDDDConstants muonConstants(cpv);
+MuonGEMFrameRotation::MuonGEMFrameRotation(const MuonDDDConstants& muonConstants) : MuonFrameRotation::MuonFrameRotation() {
+  g4numbering     = new MuonG4Numbering(muonConstants);
   int theLevelPart= muonConstants.getValue("level");
   theSectorLevel  = muonConstants.getValue("mg_sector")/theLevelPart;
 #ifdef LOCAL_DEBUG

--- a/SimG4CMS/Muon/src/MuonME0FrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonME0FrameRotation.cc
@@ -8,9 +8,8 @@
 
 //#define LOCAL_DEBUG
 
-MuonME0FrameRotation::MuonME0FrameRotation(const DDCompactView& cpv) : MuonFrameRotation::MuonFrameRotation(cpv) {
-  g4numbering     = new MuonG4Numbering(cpv);
-  MuonDDDConstants muonConstants(cpv);
+MuonME0FrameRotation::MuonME0FrameRotation(const MuonDDDConstants& muonConstants) : MuonFrameRotation::MuonFrameRotation() {
+  g4numbering     = new MuonG4Numbering(muonConstants);
   int theLevelPart= muonConstants.getValue("level");
   theSectorLevel  = muonConstants.getValue("mg_sector")/theLevelPart;
 #ifdef LOCAL_DEBUG

--- a/SimG4CMS/Muon/src/MuonRPCFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonRPCFrameRotation.cc
@@ -6,9 +6,9 @@
 #include "G4StepPoint.hh"
 #include "G4TouchableHistory.hh"
 
-MuonRPCFrameRotation::MuonRPCFrameRotation(const DDCompactView& cpv) : MuonFrameRotation::MuonFrameRotation(cpv) {
-  g4numbering = new MuonG4Numbering(cpv);
-  MuonDDDConstants muonConstants(cpv);
+MuonRPCFrameRotation::MuonRPCFrameRotation(const MuonDDDConstants& muonConstants) : 
+MuonFrameRotation::MuonFrameRotation() {
+  g4numbering = new MuonG4Numbering(muonConstants);
   int theLevelPart=muonConstants.getValue("level");
   theRegion=muonConstants.getValue("mr_region")/theLevelPart;
 }

--- a/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
+++ b/SimG4CMS/Muon/src/MuonSensitiveDetector.cc
@@ -5,6 +5,7 @@
 #include "SimG4CMS/Muon/interface/MuonGEMFrameRotation.h"
 #include "SimG4CMS/Muon/interface/MuonME0FrameRotation.h"
 #include "Geometry/MuonNumbering/interface/MuonSubDetector.h"
+#include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
 
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 
@@ -51,26 +52,28 @@ MuonSensitiveDetector::MuonSensitiveDetector(std::string name,
 
   LogDebug("MuonSimDebug") << "create MuonFrameRotation"<<std::endl;
 
+ //The constants take time to calculate and are needed by many helpers
+ MuonDDDConstants constants(cpv);
  if (detector->isEndcap()) {
    //    cout << "MuonFrameRotation create MuonEndcapFrameRotation"<<endl;
     theRotation=new MuonEndcapFrameRotation();
   } else if (detector->isRPC()) {
     //    cout << "MuonFrameRotation create MuonRPCFrameRotation"<<endl;
-    theRotation=new MuonRPCFrameRotation( cpv );
+    theRotation=new MuonRPCFrameRotation( constants );
   } else if (detector->isGEM()) {
     //    cout << "MuonFrameRotation create MuonGEMFrameRotation"<<endl;
-    theRotation=new MuonGEMFrameRotation( cpv );
+    theRotation=new MuonGEMFrameRotation( constants );
   } else if (detector->isME0()) {
     //    cout << "MuonFrameRotation create MuonME0FrameRotation"<<endl;
-    theRotation=new MuonME0FrameRotation( cpv );
+    theRotation=new MuonME0FrameRotation( constants );
   }  else {
     theRotation = 0;
   }
   LogDebug("MuonSimDebug") << "create MuonSlaveSD"<<std::endl;
   slaveMuon  = new MuonSlaveSD(detector,theManager);
   LogDebug("MuonSimDebug") << "create MuonSimHitNumberingScheme"<<std::endl;
-  numbering  = new MuonSimHitNumberingScheme(detector, cpv);
-  g4numbering = new MuonG4Numbering(cpv);
+  numbering  = new MuonSimHitNumberingScheme(detector, constants);
+  g4numbering = new MuonG4Numbering(constants);
   
 
   //

--- a/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
@@ -80,9 +80,7 @@ void PrintGeomInfoAction::update(const BeginOfJob * job) {
     for (unsigned int i=0; i<names.size(); i++) {
       std::string attribute = "ReadOutName";
       std::string sd        = names[i];
-      DDSpecificsFilter filter;
-      DDValue           ddv(attribute,sd,0);
-      filter.setCriteria(ddv,DDCompOp::equals);
+      DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
       DDFilteredView fv(*pDD);
       std::cout << "PrintGeomInfoAction:: Get Filtered view for " 
 		<< attribute << " = " << sd << std::endl;

--- a/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
@@ -81,10 +81,9 @@ void PrintGeomInfoAction::update(const BeginOfJob * job) {
       std::string attribute = "ReadOutName";
       std::string sd        = names[i];
       DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
-      DDFilteredView fv(*pDD);
+      DDFilteredView fv(*pDD,filter);
       std::cout << "PrintGeomInfoAction:: Get Filtered view for " 
 		<< attribute << " = " << sd << std::endl;
-      fv.addFilter(filter);
       bool dodet = fv.firstChild();
       
       std::string spaces = spacesFromLeafDepth(1);

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -452,8 +452,7 @@ ListGroups::analyze(const edm::Event& evt, const edm::EventSetup& setup) {
   setup.get<IdealGeometryRecord>().get( hDdd );
   DDFilteredView fv(*hDdd);
 
-  DDSpecificsFilter filter;
-  filter.setCriteria(DDValue("TrackingMaterialGroup", ""), DDCompOp::not_equals);
+  DDSpecificsAnyValueFilter filter{"TrackingMaterialGroup"};
   fv.addFilter(filter);
 
   while (fv.next()) {

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -450,10 +450,9 @@ void
 ListGroups::analyze(const edm::Event& evt, const edm::EventSetup& setup) {
   edm::ESTransientHandle<DDCompactView> hDdd;
   setup.get<IdealGeometryRecord>().get( hDdd );
-  DDFilteredView fv(*hDdd);
 
   DDSpecificsAnyValueFilter filter{"TrackingMaterialGroup"};
-  fv.addFilter(filter);
+  DDFilteredView fv(*hDdd,filter);
 
   while (fv.next()) {
     // print the group name and full hierarchy of all items

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -451,7 +451,7 @@ ListGroups::analyze(const edm::Event& evt, const edm::EventSetup& setup) {
   edm::ESTransientHandle<DDCompactView> hDdd;
   setup.get<IdealGeometryRecord>().get( hDdd );
 
-  DDSpecificsAnyValueFilter filter{"TrackingMaterialGroup"};
+  DDSpecificsHasNamedValueFilter filter{"TrackingMaterialGroup"};
   DDFilteredView fv(*hDdd,filter);
 
   while (fv.next()) {

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
@@ -102,7 +102,7 @@ ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
 
   std::string attribute = "TkDDDStructure";
   CmsTrackerStringToEnum theCmsTrackerStringToEnum;
-  DDSpecificsAnyValueFilter filter{attribute};
+  DDSpecificsHasNamedValueFilter filter{attribute};
   DDFilteredView fv(*hDdd,filter);
   if (theCmsTrackerStringToEnum.type(dddGetString(attribute, fv)) != GeometricDet::Tracker) {
     fv.firstChild();

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
@@ -102,8 +102,7 @@ ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
 
   std::string attribute = "TkDDDStructure";
   CmsTrackerStringToEnum theCmsTrackerStringToEnum;
-  DDSpecificsFilter filter;
-  filter.setCriteria(DDValue(attribute, "any", 0), DDCompOp::not_equals);
+  DDSpecificsAnyValueFilter filter{attribute};
   DDFilteredView fv(*hDdd);
   fv.addFilter(filter);
   if (theCmsTrackerStringToEnum.type(dddGetString(attribute, fv)) != GeometricDet::Tracker) {

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
@@ -103,8 +103,7 @@ ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
   std::string attribute = "TkDDDStructure";
   CmsTrackerStringToEnum theCmsTrackerStringToEnum;
   DDSpecificsAnyValueFilter filter{attribute};
-  DDFilteredView fv(*hDdd);
-  fv.addFilter(filter);
+  DDFilteredView fv(*hDdd,filter);
   if (theCmsTrackerStringToEnum.type(dddGetString(attribute, fv)) != GeometricDet::Tracker) {
     fv.firstChild();
     if (theCmsTrackerStringToEnum.type(dddGetString(attribute, fv)) != GeometricDet::Tracker)

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
@@ -30,9 +30,8 @@ MaterialAccountingGroup::MaterialAccountingGroup( const std::string & name, cons
   m_file( 0 )
 {
   // retrieve the elements from DDD
-  DDFilteredView fv( geometry );
   DDSpecificsMatchesValueFilter filter{DDValue("TrackingMaterialGroup", name)};
-  fv.addFilter(filter);
+  DDFilteredView fv( geometry,filter );
   LogTrace("MaterialAccountingGroup") << "Elements within: " << name << std::endl;
   while (fv.next()) {
     // DD3Vector and DDTranslation are the same type as math::XYZVector

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
@@ -31,8 +31,7 @@ MaterialAccountingGroup::MaterialAccountingGroup( const std::string & name, cons
 {
   // retrieve the elements from DDD
   DDFilteredView fv( geometry );
-  DDSpecificsFilter filter;
-  filter.setCriteria(DDValue("TrackingMaterialGroup", name), DDCompOp::equals);
+  DDSpecificsMatchesValueFilter filter{DDValue("TrackingMaterialGroup", name)};
   fv.addFilter(filter);
   LogTrace("MaterialAccountingGroup") << "Elements within: " << name << std::endl;
   while (fv.next()) {

--- a/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
@@ -39,11 +39,8 @@ void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView & cpv) {
   if (fillHistos) {
     std::string attribute = "ReadOutName";
     std::string value     = "HcalHits";
-    DDSpecificsFilter filter1;
-    DDValue           ddv1(attribute,value,0);
-    filter1.setCriteria(ddv1,DDCompOp::equals);
-    DDFilteredView fv1(cpv);
-    fv1.addFilter(filter1);
+    DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
+    DDFilteredView fv1(cpv,filter1);
     sensitives = getNames(fv1);
     edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Names to be "
 				   << "tested for " << attribute << " = " 
@@ -55,11 +52,8 @@ void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView & cpv) {
 
     attribute = "Volume";
     value     = "HF";
-    DDSpecificsFilter filter2;
-    DDValue           ddv2(attribute,value,0);
-    filter2.setCriteria(ddv2,DDCompOp::equals);
-    DDFilteredView fv2(cpv);
-    fv2.addFilter(filter2);
+    DDSpecificsMatchesValueFilter filter2{DDValue(attribute,value,0)};
+    DDFilteredView fv2(cpv,filter2);
     hfNames = getNames(fv2);
     fv2.firstChild();
     DDsvalues_type sv(fv2.mergedSpecifics());
@@ -80,11 +74,8 @@ void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView & cpv) {
     attribute = "ReadOutName";
     for (int k=0; k<2; k++) {
       value     = ecalRO[k];
-      DDSpecificsFilter filter3;
-      DDValue           ddv3(attribute,value,0);
-      filter3.setCriteria(ddv3,DDCompOp::equals);
-      DDFilteredView fv3(cpv);
-      fv3.addFilter(filter3);
+      DDSpecificsMatchesValueFilter filter3{DDValue(attribute,value,0)};
+      DDFilteredView fv3(cpv,filter3);
       std::vector<std::string> senstmp = getNames(fv3);
       edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Names to be"
 				     << " tested for " << attribute << " = " 

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -276,12 +276,9 @@ bool HGCalSimHitValidation::defineGeometry(edm::ESTransientHandle<DDCompactView>
     const DDCompactView & cview = *ddViewH;
     std::string attribute = "Volume"; 
     std::string value     = nameDetector_;
-    DDValue val(attribute, value, 0);
   
-    DDSpecificsFilter filter;
-    filter.setCriteria(val, DDCompOp::equals);
-    DDFilteredView fv(cview);
-    fv.addFilter(filter);
+    DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0)};
+    DDFilteredView fv(cview,filter);
     bool dodet = fv.firstChild();
   
     while (dodet) {


### PR DESCRIPTION
Profiling of multi-threaded GEN+SIM jobs showed that the initialization time in RunManagerMTWorker::initializeThread was severely impacting the total event throughput for jobs with large numbers of streams (>100) and only modest numbers of events per stream. Using 12 cores on a standard Xeon system under CMSSW_9_0_0_pre5 the call to initializeThread took 517 seconds. After all the changes in this pull request it now takes 51 seconds.

The changes were
-Replace DDSpecificsFilter with filters that are specifics to the needs of the query.
-Have DDFilteredView only take one DDFilter (no code used more than one every anyway).
-Test DDFilters with a standard unit test.