### PR TITLE
include hcalRecAlgos ES producer in cosmic workflow

### DIFF
--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -13,6 +13,7 @@ from RecoLocalCalo.EcalRecAlgos.EcalSeverityLevelESProducer_cfi import *
 #
 #HCAL reconstruction
 import RecoLocalCalo.Configuration.hcalLocalReco_cff as _hcalLocalReco_cff
+from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
 #
 # sequence CaloLocalReco
 #


### PR DESCRIPTION
Apparently this is needed now in cosmic workflows, as exceptions have been observed in several workflows.

Will be backported to 90X, 84X.

attn: @slava77, @abdoulline, @igv4321