### PR TITLE
updating configuration file to  merge BadChennels from different sources

### DIFF
--- a/DQM/SiStripMonitorClient/test/mergeBadChannel_Template_cfg.py
+++ b/DQM/SiStripMonitorClient/test/mergeBadChannel_Template_cfg.py
@@ -62,16 +62,18 @@ process.source = cms.Source("EmptyIOVSource",
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
-process.load("CalibTracker.SiStripESProducers.fake.SiStripBadModuleFedErrFakeESSource_cfi")
-process.siStripBadModuleFedErrFakeESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
-process.SiStripBadModuleFedErrService.FileName = cms.string(options.dqmFile)
+process.load("CalibTracker.SiStripESProducers.SiStripBadModuleFedErrESSource_cfi")
+process.siStripBadModuleFedErrESSource.appendToDataLabel = cms.string('BadModules_from_FEDBadChannel')
+process.siStripBadModuleFedErrESSource.ReadFromFile = cms.bool(True)
+process.siStripBadModuleFedErrESSource.FileName = cms.string(options.dqmFile)
 
 process.siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')),
-       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),
-       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')),
-       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string(''))
-)
+       cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+       cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+       cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string('')),            # List of FEDs exluded during data taking          
+       cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+       cms.PSet(record = cms.string('SiStripBadModuleFedErrRcd'), tag = cms.string('BadModules_from_FEDBadChannel')) # BadChannel list from FED erroes              
+       )
 process.siStripQualityESProducer.ReduceGranularity = cms.bool(False)
 process.siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
 


### PR DESCRIPTION
This configuration file creates a merged SiStrip BadComponents from different sources. This is use by the Tracker Offline shift crews only. @fioriNTU 