### PR TITLE
Fix MultiTrackValidator sim dxy/dz wrt. PV histograms

### DIFF
--- a/RecoMuon/MuonIdentification/test/ME0MuonAnalyzer.cc
+++ b/RecoMuon/MuonIdentification/test/ME0MuonAnalyzer.cc
@@ -50,9 +50,6 @@
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 
-#include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
-#include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
-
 #include "CommonTools/CandAlgos/interface/GenParticleCustomSelector.h"
 
 #include "RecoMuon/MuonIdentification/plugins/ME0MuonSelector.cc"

--- a/RecoMuon/MuonIdentification/test/testME0MuonAnalyzer_fullreco.py
+++ b/RecoMuon/MuonIdentification/test/testME0MuonAnalyzer_fullreco.py
@@ -93,7 +93,6 @@ process.Test = cms.EDAnalyzer("ME0MuonAnalyzer",
                               chargedOnlyGP = cms.bool(True),
                               statusGP = cms.int32(1),
                               pdgIdGP = cms.vint32(13, -13),
-                              #parametersDefiner = cms.string('LhcParametersDefinerForTP')
                               
 )
 

--- a/SimTracker/TrackAssociation/interface/TrackingParticleIP.h
+++ b/SimTracker/TrackAssociation/interface/TrackingParticleIP.h
@@ -1,0 +1,23 @@
+#ifndef SimTracker_TrackAssociation_TrackingParticleIP
+#define SimTracker_TrackAssociation_TrackingParticleIP
+
+// This file is in this package only because ParametersDefinerForTP is
+
+#include <cmath>
+
+namespace TrackingParticleIP {
+  // As in TrackBase::dxy(Point) and dz(Point)
+  template <typename T_Vertex, typename T_Momentum, typename T_Point>
+  inline auto dxy(const T_Vertex& vertex, const T_Momentum& momentum, const T_Point& point) {
+    return -(vertex.x()-point.x())*std::sin(momentum.phi()) + (vertex.y()-point.y())*std::cos(momentum.phi());
+
+  }
+
+  template <typename T_Vertex, typename T_Momentum, typename T_Point>
+  inline auto dz(const T_Vertex& vertex, const T_Momentum& momentum, const T_Point& point) {
+    return vertex.z()-point.z() - ( (vertex.x()-point.x())*momentum.x() +
+                                    (vertex.y()-point.y())*momentum.y() )/std::sqrt(momentum.perp2()) * momentum.z()/std::sqrt(momentum.perp2());
+  }
+}
+
+#endif

--- a/SimTracker/TrackAssociation/interface/TrackingParticleIP.h
+++ b/SimTracker/TrackAssociation/interface/TrackingParticleIP.h
@@ -16,7 +16,7 @@ namespace TrackingParticleIP {
   template <typename T_Vertex, typename T_Momentum, typename T_Point>
   inline auto dz(const T_Vertex& vertex, const T_Momentum& momentum, const T_Point& point) {
     return vertex.z()-point.z() - ( (vertex.x()-point.x())*momentum.x() +
-                                    (vertex.y()-point.y())*momentum.y() )/std::sqrt(momentum.perp2()) * momentum.z()/std::sqrt(momentum.perp2());
+                                    (vertex.y()-point.y())*momentum.y() ) * momentum.z()/momentum.perp2();
   }
 }
 

--- a/SimTracker/TrackAssociation/src/CosmicParametersDefinerForTP.cc
+++ b/SimTracker/TrackAssociation/src/CosmicParametersDefinerForTP.cc
@@ -185,9 +185,12 @@ TrackingParticle::Point CosmicParametersDefinerForTP::vertex(const edm::Event& i
 
       if(tsAtClosestApproach.isValid()){
 	GlobalPoint v = tsAtClosestApproach.trackStateAtPCA().position();
-	vertex = TrackingParticle::Point(v.x()-bs->x0(),v.y()-bs->y0(),v.z()-bs->z0());
+	vertex = TrackingParticle::Point(v.x(), v.y(), v.z());
       }
       else {
+        // to preserve old behaviour
+        // would be better to flag this somehow to allow ignoring in downstream
+        vertex = TrackingParticle::Point(bs->x0(), bs->y0(), bs->z0());
 	edm::LogVerbatim("CosmicParametersDefinerForTP")
 	  <<"*** WARNING in CosmicParametersDefinerForTP::vertex: tsAtClosestApproach is not valid." <<"\n";
       }

--- a/SimTracker/TrackAssociation/src/ParametersDefinerForTP.cc
+++ b/SimTracker/TrackAssociation/src/ParametersDefinerForTP.cc
@@ -69,7 +69,12 @@ TrackingParticle::Point ParametersDefinerForTP::vertex(const edm::Event& iEvent,
   TrajectoryStateClosestToBeamLine tsAtClosestApproach = tscblBuilder(ftsAtProduction,*bs);//as in TrackProducerAlgorithm
   if(tsAtClosestApproach.isValid()){
     GlobalPoint v = tsAtClosestApproach.trackStateAtPCA().position();
-    vertex = TrackingParticle::Point(v.x()-bs->x0(),v.y()-bs->y0(),v.z()-bs->z0());
+    vertex = TrackingParticle::Point(v.x(),v.y(),v.z());
+  }
+  else {
+    // to preserve old behaviour
+    // would be better to flag this somehow to allow ignoring in downstream
+    vertex = TrackingParticle::Point(bs->x0(), bs->y0(), bs->z0());
   }
   return vertex;
 }

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -16,6 +16,7 @@
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
 #include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
+#include "SimTracker/TrackAssociation/interface/TrackingParticleIP.h"
 
 #include "TMath.h"
 #include <TF1.h>
@@ -369,9 +370,8 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 	    vertexTP = tp->vertex();
 	    TrackingParticle::Vector momentum = Lhc_parametersDefinerTP->momentum(event,setup,tpr);
 	    TrackingParticle::Point vertex = Lhc_parametersDefinerTP->vertex(event,setup,tpr);
-	    dxySim = (-vertex.x()*sin(momentum.phi())+vertex.y()*cos(momentum.phi()));
-	    dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y()) /
-	                          sqrt(momentum.perp2()) * momentum.z()/sqrt(momentum.perp2());
+	    dxySim = TrackingParticleIP::dxy(vertex, momentum, bs.position());
+	    dzSim = TrackingParticleIP::dz(vertex, momentum, bs.position());
 	  }
 	//for cosmics get the momentum and vertex at PCA
 	else if(parametersDefiner=="CosmicParametersDefinerForTP")
@@ -380,9 +380,8 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 	    if(! cosmictpSelector(tpr,&bs,event,setup)) continue;	
 	    momentumTP = Cosmic_parametersDefinerTP->momentum(event,setup,tpr);
 	    vertexTP = Cosmic_parametersDefinerTP->vertex(event,setup,tpr);
-	    dxySim = (-vertexTP.x()*sin(momentumTP.phi())+vertexTP.y()*cos(momentumTP.phi()));
-	    dzSim = vertexTP.z() - (vertexTP.x()*momentumTP.x()+vertexTP.y()*momentumTP.y()) /
-	                            sqrt(momentumTP.perp2()) * momentumTP.z()/sqrt(momentumTP.perp2());
+	    dxySim = TrackingParticleIP::dxy(vertexTP, momentumTP, bs.position());
+	    dzSim = TrackingParticleIP::dz(vertexTP, momentumTP, bs.position());
 	  }
 	edm::LogVerbatim("MuonTrackValidator") <<"--------------------Selected TrackingParticle #"<<tpr.key();
 	edm::LogVerbatim("MuonTrackValidator") <<"momentumTP: pt = "<<sqrt(momentumTP.perp2())<<", pz = "<<momentumTP.z() 
@@ -722,9 +721,8 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 	double thetaSim = momentumTP.theta();
 	double lambdaSim = M_PI/2-momentumTP.theta();
 	double phiSim = momentumTP.phi();
-	double dxySim = (-vertexTP.x()*sin(momentumTP.phi())+vertexTP.y()*cos(momentumTP.phi()));
-	double dzSim = vertexTP.z() - (vertexTP.x()*momentumTP.x()+vertexTP.y()*momentumTP.y()) /
-	                               sqrt(momentumTP.perp2()) * momentumTP.z()/sqrt(momentumTP.perp2());
+	double dxySim = TrackingParticleIP::dxy(vertexTP, momentumTP, bs.position());
+	double dzSim = TrackingParticleIP::dz(vertexTP, momentumTP, bs.position());
 	
 	// removed unused variable, left this in case it has side effects
 	track->parameters();

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -22,6 +22,7 @@
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
 #include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
+#include "SimTracker/TrackAssociation/interface/TrackingParticleIP.h"
 
 #include "DataFormats/TrackReco/interface/DeDxData.h"
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -688,14 +689,12 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 	    //Calcualte the impact parameters w.r.t. PCA
 	    const TrackingParticle::Vector& momentum = std::get<TrackingParticle::Vector>(momVert);
 	    const TrackingParticle::Point& vertex = std::get<TrackingParticle::Point>(momVert);
-	    dxySim = (-vertex.x()*sin(momentum.phi())+vertex.y()*cos(momentum.phi()));
-	    dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y())/sqrt(momentum.perp2())
-	      * momentum.z()/sqrt(momentum.perp2());
+	    dxySim = TrackingParticleIP::dxy(vertex, momentum, bs.position());
+	    dzSim = TrackingParticleIP::dz(vertex, momentum, bs.position());
 
             if(theSimPVPosition) {
-              // As in TrackBase::dxy(Point) and dz(Point)
-              dxyPVSim = -(vertex.x()-theSimPVPosition->x())*sin(momentum.phi()) + (vertex.y()-theSimPVPosition->y())*cos(momentum.phi());
-              dzPVSim = vertex.z()-theSimPVPosition->z() - ( (vertex.x()-theSimPVPosition->x())*momentum.x() + (vertex.y()-theSimPVPosition->y())*momentum.y() )/sqrt(momentum.perp2()) * momentum.z()/sqrt(momentum.perp2());
+              dxyPVSim = TrackingParticleIP::dxy(vertex, momentum, *theSimPVPosition);
+              dzPVSim = TrackingParticleIP::dz(vertex, momentum, *theSimPVPosition);
             }
 	  }
 	//If the TrackingParticle is comics, get the momentum and vertex at PCA
@@ -703,9 +702,8 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 	  {
 	    momentumTP = std::get<TrackingParticle::Vector>(momVert);
 	    vertexTP = std::get<TrackingParticle::Point>(momVert);
-	    dxySim = (-vertexTP.x()*sin(momentumTP.phi())+vertexTP.y()*cos(momentumTP.phi()));
-	    dzSim = vertexTP.z() - (vertexTP.x()*momentumTP.x()+vertexTP.y()*momentumTP.y())/sqrt(momentumTP.perp2())
-	      * momentumTP.z()/sqrt(momentumTP.perp2());
+	    dxySim = TrackingParticleIP::dxy(vertexTP, momentumTP, bs.position());
+	    dzSim = TrackingParticleIP::dz(vertexTP, momentumTP, bs.position());
 
             // Do dxy and dz vs. PV make any sense for cosmics? I guess not
 	  }

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -695,7 +695,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
             if(theSimPVPosition) {
               // As in TrackBase::dxy(Point) and dz(Point)
               dxyPVSim = -(vertex.x()-theSimPVPosition->x())*sin(momentum.phi()) + (vertex.y()-theSimPVPosition->y())*cos(momentum.phi());
-              dzPVSim = vertex.z()-theSimPVPosition->z() - ( (vertex.x()-theSimPVPosition->x()) + (vertex.y()-theSimPVPosition->y()) )/sqrt(momentum.perp2()) * momentum.z()/sqrt(momentum.perp2());
+              dzPVSim = vertex.z()-theSimPVPosition->z() - ( (vertex.x()-theSimPVPosition->x())*momentum.x() + (vertex.y()-theSimPVPosition->y())*momentum.y() )/sqrt(momentum.perp2()) * momentum.z()/sqrt(momentum.perp2());
             }
 	  }
 	//If the TrackingParticle is comics, get the momentum and vertex at PCA

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -72,6 +72,7 @@
 #include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
 #include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
+#include "SimTracker/TrackAssociation/interface/TrackingParticleIP.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 
@@ -363,6 +364,7 @@ private:
 
   void fillTrackingParticles(const edm::Event& iEvent, const edm::EventSetup& iSetup,
                              const edm::RefToBaseVector<reco::Track>& tracks,
+                             const reco::BeamSpot& bs,
                              const TrackingParticleRefVector& tpCollection,
                              const TrackingVertexRefKeyToIndex& tvKeyToIndex,
                              const reco::TrackToTrackingParticleAssociator& associatorByHits,
@@ -1353,7 +1355,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   //tracking particles
   //sort association maps with simHits
   std::sort( tpHitList.begin(), tpHitList.end(), tpHitIndexListLessSort );
-  fillTrackingParticles(iEvent, iSetup, trackRefs, tpCollection, tvKeyToIndex, associatorByHits, tpHitList);
+  fillTrackingParticles(iEvent, iSetup, trackRefs, bs, tpCollection, tvKeyToIndex, associatorByHits, tpHitList);
 
   // vertices
   edm::Handle<reco::VertexCollection> vertices;
@@ -2173,6 +2175,7 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
 
 void TrackingNtuple::fillTrackingParticles(const edm::Event& iEvent, const edm::EventSetup& iSetup,
                                            const edm::RefToBaseVector<reco::Track>& tracks,
+                                           const reco::BeamSpot& bs,
                                            const TrackingParticleRefVector& tpCollection,
                                            const TrackingVertexRefKeyToIndex& tvKeyToIndex,
                                            const reco::TrackToTrackingParticleAssociator& associatorByHits,
@@ -2230,9 +2233,8 @@ void TrackingNtuple::fillTrackingParticles(const edm::Event& iEvent, const edm::
     //Calcualte the impact parameters w.r.t. PCA
     TrackingParticle::Vector momentum = parametersDefiner->momentum(iEvent,iSetup,tp);
     TrackingParticle::Point vertex = parametersDefiner->vertex(iEvent,iSetup,tp);
-    float dxySim = (-vertex.x()*sin(momentum.phi())+vertex.y()*cos(momentum.phi()));
-    float dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y())/sqrt(momentum.perp2())
-      * momentum.z()/sqrt(momentum.perp2());
+    auto dxySim = TrackingParticleIP::dxy(vertex, momentum, bs.position());
+    auto dzSim = TrackingParticleIP::dz(vertex, momentum, bs.position());
     const double lambdaSim = M_PI/2 - momentum.theta();
     sim_pca_pt       .push_back(std::sqrt(momentum.perp2()));
     sim_pca_eta      .push_back(momentum.Eta());

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -7,6 +7,8 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
+#include "SimTracker/TrackAssociation/interface/TrackingParticleIP.h"
+
 
 #include "TMath.h"
 #include <TF1.h>
@@ -1140,9 +1142,8 @@ void MTVHistoProducerAlgoForTracker::fill_ResoAndPull_recoTrack_histos(int count
   double qoverpSim = chargeTP/sqrt(momentumTP.x()*momentumTP.x()+momentumTP.y()*momentumTP.y()+momentumTP.z()*momentumTP.z());
   double lambdaSim = M_PI/2-momentumTP.theta();
   double phiSim    = momentumTP.phi();
-  double dxySim    = (-vertexTP.x()*sin(momentumTP.phi())+vertexTP.y()*cos(momentumTP.phi()));
-  double dzSim     = vertexTP.z() - (vertexTP.x()*momentumTP.x()+vertexTP.y()*momentumTP.y())/sqrt(momentumTP.perp2())
-    * momentumTP.z()/sqrt(momentumTP.perp2());
+  double dxySim    = TrackingParticleIP::dxy(vertexTP, momentumTP, bsPosition);
+  double dzSim     = TrackingParticleIP::dz(vertexTP, momentumTP, bsPosition);
 
 
   //  reco::Track::ParameterVector rParameters = track.parameters(); // UNUSED


### PR DESCRIPTION
There was a bug in how the dxy and dz wrt. PV were calculated for TrackingParticles in `MultiTrackValidator`. It did not take into account the fact that the position of point of closest approach to beamline (PCA) returned by `ParemtersDefinerTP` shifted by the beamspot position, leading to biases in dxy and dz wrt. PV (most noticeably ~1 cm shift in dz). This PR suggests to fix this problem by making the calculation of dxy and dz more uniform between Track and TrackingParticle:
- `ParametersDefinerTP` leaves the PCA position to be wrt. (0,0,0) (as is Track reference point)
- for dxy/dz wrt. a different point than (0,0,0), the point coordinates need to be given explicitly (as for Track)
  * The copy-pasted formulas are now abstracted to templated functions (there is some copy-paste between those and `reco::TrackBase`, dealing with that is left to a later exercise)



Tested in 9_0_0_pre4, expecting changes in MTV sim dxy and dz wrt. PV histograms (should be better centered around 0 now).

@rovere @VinInn 