### PR TITLE
Extended simulation of thermal neutrons to XS PhysicsList

### DIFF
--- a/SimG4Core/Application/interface/CMSEmParticleList.h
+++ b/SimG4Core/Application/interface/CMSEmParticleList.h
@@ -1,0 +1,24 @@
+#ifndef SimG4Core_Application_CMSEmParticleList_h
+#define SimG4Core_Application_CMSEmParticleList_h 1
+
+// V.Ivanchenko 6 March 2017
+// List of Geant4 basic particle names used in SIM step 
+
+#include "globals.hh"
+
+static const G4int nEmParticles = 39;
+static const G4String EmPartNames[nEmParticles] = 
+{ 
+        "gamma",            "e-",           "e+",           "mu+",        "mu-",
+          "pi+",           "pi-",        "kaon+",         "kaon-",     "proton",
+  "anti_proton",         "alpha",          "He3",    "GenericIon",         "B+",
+           "B-",            "D+",           "D-",           "Ds+",        "Ds-",
+     "anti_He3",    "anti_alpha","anti_deuteron","anti_lambda_c+","anti_omega-",
+"anti_sigma_c+","anti_sigma_c++",  "anti_sigma+",   "anti_sigma-","anti_triton",
+     "sigma_c+",     "sigma_c++",       "sigma+",        "sigma-",       "tau+",
+         "tau-",        "triton",        "xi_c+",           "xi-"
+};
+
+
+#endif
+

--- a/SimG4Core/Application/python/NeutronBGforMuonsXS_Term_cff.py
+++ b/SimG4Core/Application/python/NeutronBGforMuonsXS_Term_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+
+    # fragment allowing to simulate neutron background in muon system
+
+  if hasattr(process,'g4SimHits'):
+    # time window 100 millisecond
+    process.common_maximum_time.MaxTrackTime = cms.double(10000000000.0)
+    process.common_maximum_time.DeadRegions = cms.vstring()
+    # Physics List XS
+    process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/FTFP_BERT_XS_EML')
+    process.g4SimHits.Physics.CutsOnProton  = cms.untracked.bool(False)
+    process.g4SimHits.Physics.FlagFluo    = cms.bool(True)
+    process.g4SimHits.Physics.ThermalNeutrons = cms.untracked.bool(True)
+    # Eta cut
+    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)
+    process.g4SimHits.Generator.MaxEtaCut = cms.double(7.0)
+    # stacking action
+    process.g4SimHits.StackingAction.MaxTrackTime = cms.double(100000000.0)
+    process.g4SimHits.StackingAction.DeadRegions = cms.vstring()
+    process.g4SimHits.StackingAction.KillHeavy = cms.bool(False)
+    process.g4SimHits.StackingAction.GammaThreshold = cms.double(0.0)
+    # stepping action
+    process.g4SimHits.SteppingAction.MaxTrackTime = cms.double(100000000.0)
+    process.g4SimHits.SteppingAction.DeadRegions = cms.vstring()
+    # Russian roulette disabled
+    process.g4SimHits.StackingAction.RusRoGammaEnergyLimit = cms.double(0.0)
+    process.g4SimHits.StackingAction.RusRoNeutronEnergyLimit = cms.double(0.0)
+    # full simulation of HF 
+    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)
+
+    return(process)


### PR DESCRIPTION
By request of muon upgrade TDR, thermal neutron simulation extended two another Physics List used for this study. Time window extended from 0.1 second to 10 second.

Added extra header which will be used soon.

Should not affect mainstream simulation.