### PR TITLE
Proper memory cleanup

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
@@ -228,7 +228,11 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
 } // HcalSeverityLevelComputer::HcalSeverityLevelComputer
 
 
-HcalSeverityLevelComputer::~HcalSeverityLevelComputer() {}
+HcalSeverityLevelComputer::~HcalSeverityLevelComputer()
+{
+    delete DropChannel_;
+    delete RecoveredRecHit_;
+}
 
   
 int HcalSeverityLevelComputer::getSeverityLevel(const DetId& myid, const uint32_t& myflag, 

--- a/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/ZdcHitReconstructor.cc
@@ -22,6 +22,12 @@ ZdcHitReconstructor::ZdcHitReconstructor(edm::ParameterSet const& conf):
 	conf.getParameter<int>("recoMethod"),
 	conf.getParameter<int>("lowGainOffset"),
 	conf.getParameter<double>("lowGainFrac")),
+  saturationFlagSetter_(nullptr),
+  HFTimingTrustFlagSetter_(nullptr),
+  hbheHSCPFlagSetter_(nullptr),
+  hbheTimingShapedFlagSetter_(nullptr),
+  hfrechitbit_(nullptr),
+  hfdigibit_(nullptr),
   det_(DetId::Hcal),
   correctTiming_(conf.getParameter<bool>("correctTiming")),
   setNoiseFlags_(conf.getParameter<bool>("setNoiseFlags")),
@@ -30,8 +36,8 @@ ZdcHitReconstructor::ZdcHitReconstructor(edm::ParameterSet const& conf):
   setTimingTrustFlags_(conf.getParameter<bool>("setTimingTrustFlags")),
   dropZSmarkedPassed_(conf.getParameter<bool>("dropZSmarkedPassed")),
   AuxTSvec_(conf.getParameter<std::vector<int> >("AuxTSvec")),
-  myobject(0),
-  theTopology(0)
+  myobject(nullptr),
+  theTopology(nullptr)
   
 { 
   tok_input_hcal = consumes<ZDCDigiCollection>(conf.getParameter<edm::InputTag>("digiLabelhcal"));
@@ -59,8 +65,11 @@ ZdcHitReconstructor::ZdcHitReconstructor(edm::ParameterSet const& conf):
   
 }
 
-ZdcHitReconstructor::~ZdcHitReconstructor() {;
+ZdcHitReconstructor::~ZdcHitReconstructor()
+{
+    delete saturationFlagSetter_;
 }
+
 void ZdcHitReconstructor::beginRun(edm::Run const&r, edm::EventSetup const & es){
 
    edm::ESHandle<HcalLongRecoParams> p;


### PR DESCRIPTION
Fixing minor memory leaks in the HCAL reco software reported by valgrind.
Adding explicit initialization of pointers inside ZdcHitReconstructor constructor.

This PR will not change any relval results.
