### PR TITLE
Bin lookup in the JetCorrectorParameters class

### DIFF
--- a/CondCore/JetMETPlugins/src/plugins.cc
+++ b/CondCore/JetMETPlugins/src/plugins.cc
@@ -19,7 +19,7 @@
 #include "CondFormats/DataRecord/interface/JetResolutionRcd.h"
 #include "CondFormats/DataRecord/interface/JetResolutionScaleFactorRcd.h"
 
-REGISTER_PLUGIN(JetCorrectionsRecord, JetCorrectorParametersCollection);
+REGISTER_PLUGIN_INIT(JetCorrectionsRecord, JetCorrectorParametersCollection, JetCorrectorParametersInitializeTransients);
 REGISTER_PLUGIN(METCorrectionsRecord, METCorrectorParametersCollection);
 REGISTER_PLUGIN(MEtXYcorrectRecord, MEtXYcorrectParametersCollection);
 

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -108,13 +108,13 @@ class JetCorrectorParameters
         using tuple_type_Nm1 = typename generate_tuple_type<T,SIZE-1>::type;
       private:
         // Stores the lower and upper bounds of the bins for each binned dimension
-        std::vector<std::vector<float> >                                           mBinBoundaries COND_TRANSIENT;
+        std::vector<std::vector<float> >                                           mBinBoundaries;
         // Maps a set of lower bounds for N binned dimensions to the index in mRecords
-        std::unordered_map<tuple_type, size_t>                                     mIndexMap      COND_TRANSIENT;
+        std::unordered_map<tuple_type, size_t>                                     mIndexMap;
         // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
-        std::unordered_map<tuple_type_Nm1, std::pair<size_t,size_t> >              mMap           COND_TRANSIENT;
+        std::unordered_map<tuple_type_Nm1, std::pair<size_t,size_t> >              mMap;
 
-      COND_SERIALIZABLE;
+      COND_TRANSIENT;
     };
      
     //-------- Constructors --------------

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -51,8 +51,8 @@ class JetCorrectorParameters
         std::vector<std::string> mParVar;
         std::vector<std::string> mBinVar;
     
-    COND_SERIALIZABLE;
-};
+      COND_SERIALIZABLE;
+    };
     //---------------- Record class --------------------------------
     //-- Each Record holds the properties of a bin ----------------- 
     class Record 
@@ -90,8 +90,32 @@ class JetCorrectorParameters
         std::vector<float> mMax;
         std::vector<float> mParameters;
     
-    COND_SERIALIZABLE;
-};
+      COND_SERIALIZABLE;
+    };
+
+    template<typename T, int SIZE>
+    class JetCorrectorParametersHelper
+    {
+      public:
+        unsigned size()                                                                                           const {return mIndexMap.size();}
+        void initTransientMaps();
+        void init(const std::vector<JetCorrectorParameters::Record>& mRecords);
+        void binIndexChecks(unsigned N, const std::vector<float>& fX)                                             const;
+        bool binBoundChecks(unsigned dim, const float& value, const float& min, const float& max)                 const;
+        int  binIndexN(const std::vector<float>& fX, const std::vector<JetCorrectorParameters::Record>& mRecords) const;
+
+        using tuple_type = typename generate_tuple_type<T,SIZE>::type;
+        using tuple_type_Nm1 = typename generate_tuple_type<T,SIZE-1>::type;
+      private:
+        // Stores the lower and upper bounds of the bins for each binned dimension
+        std::vector<std::vector<float> >                                           mBinBoundaries COND_TRANSIENT;
+        // Maps a set of lower bounds for N binned dimensions to the index in mRecords
+        std::unordered_map<tuple_type, size_t>                                     mIndexMap      COND_TRANSIENT;
+        // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
+        std::unordered_map<tuple_type_Nm1, std::pair<size_t,size_t> >              mMap           COND_TRANSIENT;
+
+      COND_SERIALIZABLE;
+    };
      
     //-------- Constructors --------------
     JetCorrectorParameters() { valid_ = false;}
@@ -104,48 +128,38 @@ class JetCorrectorParameters
     const Definitions& definitions()                                                          const {return mDefinitions;   }
     unsigned size()                                                                           const {return mRecords.size();}
     unsigned size(unsigned fVar)                                                              const;
-    void binIndexChecks(unsigned N, const std::vector<float>& fX)                             const;
-    bool binBoundChecks(unsigned dim, const float& value, const float& min, const float& max) const;
+    //void binIndexChecks(unsigned N, const std::vector<float>& fX)                             const;
+    //bool binBoundChecks(unsigned dim, const float& value, const float& min, const float& max) const;
     int binIndex(const std::vector<float>& fX)                                                const;
-    int binIndex1(const std::vector<float>& fX)                                               const;
-
-    //template<typename T, typename R>
-    //int binIndexN(const std::vector<float>& fX) const {
-//
-    //}
-
-    int binIndex2(const std::vector<float>& fX)                                               const;
-    int binIndex3(const std::vector<float>& fX)                                               const;
+    int binIndexN(const std::vector<float>& fX)                                               const;
+    //int binIndex1(const std::vector<float>& fX)                                               const;
+    //int binIndex2(const std::vector<float>& fX)                                               const;
+    //int binIndex3(const std::vector<float>& fX)                                               const;
     int neighbourBin(unsigned fIndex, unsigned fVar, bool fNext)                              const;
     std::vector<float> binCenters(unsigned fVar)                                              const;
     void printScreen()                                                                        const;
     void printFile(const std::string& fFileName)                                              const;
     bool isValid() const { return valid_; }
-    void initTransientMaps(unsigned N);
-    void init(const std::vector<JetCorrectorParameters::Record>& mRecords);
     void init();
 
   private:
     //-------- Member variables ----------
     JetCorrectorParameters::Definitions                                        mDefinitions;
     std::vector<JetCorrectorParameters::Record>                                mRecords;
-    // Stores the lower and upper bounds of the bins for each binned dimension
-    std::vector<std::vector<float> >                                           mBinBoundaries COND_TRANSIENT;
     // Maps a set of lower bounds for N binned dimensions to the index in mRecords
-    std::unordered_map<std::tuple<float,float,float>, size_t>                  mThreeIndexMap COND_TRANSIENT;
-    std::unordered_map<std::tuple<float,float>, size_t>                        mTwoIndexMap   COND_TRANSIENT;
-    std::unordered_map<std::tuple<float>, size_t>                              mOneIndexMap   COND_TRANSIENT;
+    //std::unordered_map<std::tuple<float,float,float>, size_t>                  mThreeIndexMap COND_TRANSIENT;
+    //std::unordered_map<std::tuple<float,float>, size_t>                        mTwoIndexMap   COND_TRANSIENT;
+    //std::unordered_map<std::tuple<float>, size_t>                              mOneIndexMap   COND_TRANSIENT;
     // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
-    std::unordered_map<std::tuple<float,float>, std::pair<size_t,size_t> >     mTwoMap        COND_TRANSIENT;
-    std::unordered_map<std::tuple<float>, std::pair<size_t,size_t> >           mOneMap        COND_TRANSIENT;
+    //std::unordered_map<std::tuple<float,float>, std::pair<size_t,size_t> >     mTwoMap        COND_TRANSIENT;
+    //std::unordered_map<std::tuple<float>, std::pair<size_t,size_t> >           mOneMap        COND_TRANSIENT;
     bool                                                                       valid_; /// is this a valid set?
+
+    std::tuple<JetCorrectorParametersHelper<float,1>, JetCorrectorParametersHelper<float,2>, JetCorrectorParametersHelper<float,3> > helperTuple COND_TRANSIENT; 
+    static const int MAX_SIZE_DIMENSIONALITY = 3 COND_TRANSIENT;
 
   COND_SERIALIZABLE;
 };
-
-//int JetCorrectorParameters::binIndex1(const std::vector<float>& fX) const {
-
-//}
 
 
 class JetCorrectorParametersCollection {
@@ -259,7 +273,6 @@ class JetCorrectorParametersCollection {
  COND_SERIALIZABLE;
 
 };
-
 
 
 #endif

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -8,6 +8,7 @@
 #define JetCorrectorParameters_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/JetMETObjects/interface/Utilities.h"
 
 #include <string>
 #include <vector>
@@ -17,38 +18,6 @@
 #include <iostream>
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-namespace std
-{
-  template<> struct hash<std::tuple<float,float,float> >
-  {
-    typedef std::tuple<float,float,float> argument_type;
-    typedef std::size_t result_type;
-    result_type operator()(argument_type const& t) const
-    {
-      const uint64_t first = reinterpret_cast<const uint32_t&>(std::get<0>(t));
-      const uint64_t second = reinterpret_cast<const uint32_t&>(std::get<1>(t));
-      const uint64_t third = reinterpret_cast<const uint32_t&>(std::get<2>(t));
-      const uint64_t thing1 = (first ^ second)%16;
-      const uint64_t thing2 = (second ^ third)%32;
-      result_type const result ( (first << thing1) ^ (second << thing2) ^ third );
-      return result;
-    }
-  };
-  template<> struct hash<std::tuple<float,float> >
-  {
-    typedef std::tuple<float,float> argument_type;
-    typedef std::size_t result_type;
-    result_type operator()(argument_type const& t) const
-    {
-      const uint64_t first = reinterpret_cast<const uint32_t&>(std::get<0>(t));
-      const uint64_t second = reinterpret_cast<const uint32_t&>(std::get<1>(t));
-      const uint64_t thing1 = (first ^ second)%16;
-      result_type const result ( (first << thing1) ^ second );
-      return result;
-    }
-  };
-}
 
 class JetCorrectorParameters 
 {
@@ -152,7 +121,7 @@ class JetCorrectorParameters
     //-------- Member variables ----------
     JetCorrectorParameters::Definitions                                    mDefinitions;
     std::vector<JetCorrectorParameters::Record>                            mRecords;
-    // Stores the lower bounds of the bins for each binned dimension
+    // Stores the lower and upper bounds of the bins for each binned dimension
     std::vector<std::vector<float> >                                       mBinBoundaries COND_TRANSIENT;
     // Maps a set of lower bounds for three binned dimensions to the index in mRecords
     std::unordered_map<std::tuple<float,float,float>, size_t>              mBinMap        COND_TRANSIENT;

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -100,38 +100,52 @@ class JetCorrectorParameters
 			 const std::vector<JetCorrectorParameters::Record>& fRecords) 
       : mDefinitions(fDefinitions),mRecords(fRecords) { valid_ = true;}
     //-------- Member functions ----------
-    const Record& record(unsigned fBin)                          const {return mRecords[fBin]; }
-    const Definitions& definitions()                             const {return mDefinitions;   }
-    unsigned size()                                              const {return mRecords.size();}
-    unsigned size(unsigned fVar)                                 const;
-    int binIndex(const std::vector<float>& fX)                   const;
-    int binIndex3(const std::vector<float>& fX)                  const;
-    int neighbourBin(unsigned fIndex, unsigned fVar, bool fNext) const;
-    std::vector<float> binCenters(unsigned fVar)                 const;
-    void printScreen()                                           const;
-    void printFile(const std::string& fFileName)                 const;
+    const Record& record(unsigned fBin)                                                       const {return mRecords[fBin]; }
+    const Definitions& definitions()                                                          const {return mDefinitions;   }
+    unsigned size()                                                                           const {return mRecords.size();}
+    unsigned size(unsigned fVar)                                                              const;
+    void binIndexChecks(unsigned N, const std::vector<float>& fX)                             const;
+    bool binBoundChecks(unsigned dim, const float& value, const float& min, const float& max) const;
+    int binIndex(const std::vector<float>& fX)                                                const;
+    int binIndex1(const std::vector<float>& fX)                                               const;
+
+    //template<typename T, typename R>
+    //int binIndexN(const std::vector<float>& fX) const {
+//
+    //}
+
+    int binIndex2(const std::vector<float>& fX)                                               const;
+    int binIndex3(const std::vector<float>& fX)                                               const;
+    int neighbourBin(unsigned fIndex, unsigned fVar, bool fNext)                              const;
+    std::vector<float> binCenters(unsigned fVar)                                              const;
+    void printScreen()                                                                        const;
+    void printFile(const std::string& fFileName)                                              const;
     bool isValid() const { return valid_; }
-    void init(const std::vector<JetCorrectorParameters::Record>& mRecords,
-              std::vector<std::vector<float> >& mBinBoundaries,
-              std::unordered_map<std::tuple<float,float,float>, size_t>& mBinMap,
-              std::unordered_map<std::tuple<float,float>, std::pair<size_t,size_t> >& mPtMap);
+    void initTransientMaps(unsigned N);
+    void init(const std::vector<JetCorrectorParameters::Record>& mRecords);
     void init();
 
   private:
     //-------- Member variables ----------
-    JetCorrectorParameters::Definitions                                    mDefinitions;
-    std::vector<JetCorrectorParameters::Record>                            mRecords;
+    JetCorrectorParameters::Definitions                                        mDefinitions;
+    std::vector<JetCorrectorParameters::Record>                                mRecords;
     // Stores the lower and upper bounds of the bins for each binned dimension
-    std::vector<std::vector<float> >                                       mBinBoundaries COND_TRANSIENT;
-    // Maps a set of lower bounds for three binned dimensions to the index in mRecords
-    std::unordered_map<std::tuple<float,float,float>, size_t>              mBinMap        COND_TRANSIENT;
-    // Maps a set of lower bounds for the first two dimension to the range of lower bound indices mBinBoundaries for a third dimension
-    std::unordered_map<std::tuple<float,float>, std::pair<size_t,size_t> > mPtMap         COND_TRANSIENT;
-    bool                                                                   valid_; /// is this a valid set?
+    std::vector<std::vector<float> >                                           mBinBoundaries COND_TRANSIENT;
+    // Maps a set of lower bounds for N binned dimensions to the index in mRecords
+    std::unordered_map<std::tuple<float,float,float>, size_t>                  mThreeIndexMap COND_TRANSIENT;
+    std::unordered_map<std::tuple<float,float>, size_t>                        mTwoIndexMap   COND_TRANSIENT;
+    std::unordered_map<std::tuple<float>, size_t>                              mOneIndexMap   COND_TRANSIENT;
+    // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
+    std::unordered_map<std::tuple<float,float>, std::pair<size_t,size_t> >     mTwoMap        COND_TRANSIENT;
+    std::unordered_map<std::tuple<float>, std::pair<size_t,size_t> >           mOneMap        COND_TRANSIENT;
+    bool                                                                       valid_; /// is this a valid set?
 
   COND_SERIALIZABLE;
 };
 
+//int JetCorrectorParameters::binIndex1(const std::vector<float>& fX) const {
+
+//}
 
 
 class JetCorrectorParametersCollection {

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -92,11 +92,13 @@ class JetCorrectorParameters
     
       COND_SERIALIZABLE;
     };
-
+    //---------- JetCorrectorParametersHelper class ----------------
+    //-- The helper is used to find the correct Record to access --- 
     template<typename T, int SIZE>
     class JetCorrectorParametersHelper
     {
       public:
+        //-------- Member functions ----------
         unsigned size()                                                                                           const {return mIndexMap.size();}
         void initTransientMaps();
         void init(const std::vector<JetCorrectorParameters::Record>& mRecords);
@@ -107,14 +109,13 @@ class JetCorrectorParameters
         using tuple_type = typename generate_tuple_type<T,SIZE>::type;
         using tuple_type_Nm1 = typename generate_tuple_type<T,SIZE-1>::type;
       private:
+        //-------- Member variables ----------
         // Stores the lower and upper bounds of the bins for each binned dimension
         std::vector<std::vector<float> >                                           mBinBoundaries;
         // Maps a set of lower bounds for N binned dimensions to the index in mRecords
         std::unordered_map<tuple_type, size_t>                                     mIndexMap;
         // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
         std::unordered_map<tuple_type_Nm1, std::pair<size_t,size_t> >              mMap;
-
-      //COND_TRANSIENT;
     };
      
     //-------- Constructors --------------
@@ -128,13 +129,8 @@ class JetCorrectorParameters
     const Definitions& definitions()                                                          const {return mDefinitions;   }
     unsigned size()                                                                           const {return mRecords.size();}
     unsigned size(unsigned fVar)                                                              const;
-    //void binIndexChecks(unsigned N, const std::vector<float>& fX)                             const;
-    //bool binBoundChecks(unsigned dim, const float& value, const float& min, const float& max) const;
     int binIndex(const std::vector<float>& fX)                                                const;
     int binIndexN(const std::vector<float>& fX)                                               const;
-    //int binIndex1(const std::vector<float>& fX)                                               const;
-    //int binIndex2(const std::vector<float>& fX)                                               const;
-    //int binIndex3(const std::vector<float>& fX)                                               const;
     int neighbourBin(unsigned fIndex, unsigned fVar, bool fNext)                              const;
     std::vector<float> binCenters(unsigned fVar)                                              const;
     void printScreen()                                                                        const;
@@ -146,13 +142,6 @@ class JetCorrectorParameters
     //-------- Member variables ----------
     JetCorrectorParameters::Definitions                                        mDefinitions;
     std::vector<JetCorrectorParameters::Record>                                mRecords;
-    // Maps a set of lower bounds for N binned dimensions to the index in mRecords
-    //std::unordered_map<std::tuple<float,float,float>, size_t>                  mThreeIndexMap COND_TRANSIENT;
-    //std::unordered_map<std::tuple<float,float>, size_t>                        mTwoIndexMap   COND_TRANSIENT;
-    //std::unordered_map<std::tuple<float>, size_t>                              mOneIndexMap   COND_TRANSIENT;
-    // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
-    //std::unordered_map<std::tuple<float,float>, std::pair<size_t,size_t> >     mTwoMap        COND_TRANSIENT;
-    //std::unordered_map<std::tuple<float>, std::pair<size_t,size_t> >           mOneMap        COND_TRANSIENT;
     bool                                                                       valid_; /// is this a valid set?
 
     std::tuple<JetCorrectorParametersHelper<float,1>, JetCorrectorParametersHelper<float,2>, JetCorrectorParametersHelper<float,3> > helperTuple COND_TRANSIENT; 

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -233,9 +233,22 @@ class JetCorrectorParametersCollection {
   collection_type                        correctionsL5_;
   collection_type                        correctionsL7_;
 
+  collection_type&                       getCorrections()   {return corrections_;}
+  collection_type&                       getCorrectionsL5() {return correctionsL5_;}
+  collection_type&                       getCorrectionsL7() {return correctionsL7_;}
+
+  friend struct                          JetCorrectorParametersInitializeTransients;
+
  COND_SERIALIZABLE;
 
 };
 
+struct JetCorrectorParametersInitializeTransients {
+  void operator()(JetCorrectorParametersCollection& jcpc) {
+    for (auto & ptype : jcpc.getCorrections())   {ptype.second.init();}
+    for (auto & ptype : jcpc.getCorrectionsL5()) {ptype.second.init();}
+    for (auto & ptype : jcpc.getCorrectionsL7()) {ptype.second.init();}
+  }
+};
 
 #endif

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -114,7 +114,7 @@ class JetCorrectorParameters
         // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
         std::unordered_map<tuple_type_Nm1, std::pair<size_t,size_t> >              mMap;
 
-      COND_TRANSIENT;
+      //COND_TRANSIENT;
     };
      
     //-------- Constructors --------------

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParametersHelper.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParametersHelper.h
@@ -1,0 +1,51 @@
+//
+// Original Author:  Fedor Ratnikov Nov 9, 2007
+// $Id: JetCorrectorParameters.h,v 1.15 2012/03/01 18:24:52 srappocc Exp $
+//
+// Generic parameters for Jet corrections
+//
+#ifndef JetCorrectorParametersHelper_h
+#define JetCorrectorParametersHelper_h
+
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "CondFormats/JetMETObjects/interface/Utilities.h"
+
+#include <string>
+#include <vector>
+#include <tuple>
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+
+//---------- JetCorrectorParametersHelper class ----------------
+//-- The helper is used to find the correct Record to access --- 
+class JetCorrectorParametersHelper
+{
+  public:
+    //-------- Member functions ----------
+    unsigned size()                                                                                           const {return mIndexMap.size();}
+    void initTransientMaps();
+    void init(const JetCorrectorParameters::Definitions& mDefinitions,
+              const std::vector<JetCorrectorParameters::Record>& mRecords);
+    void binIndexChecks(unsigned N, const std::vector<float>& fX)                                             const;
+    bool binBoundChecks(unsigned dim, const float& value, const float& min, const float& max)                 const;
+    int  binIndexN(const std::vector<float>& fX, const std::vector<JetCorrectorParameters::Record>& mRecords) const;
+
+    using tuple_type = typename generate_tuple_type<float,JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY>::type;
+    using tuple_type_Nm1 = typename generate_tuple_type<float,JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY-1>::type;
+  private:
+    //-------- Member variables ----------
+    // Stores the lower and upper bounds of the bins for each binned dimension
+    std::vector<std::vector<float> >                              mBinBoundaries;
+    // Maps a set of lower bounds for N binned dimensions to the index in mRecords
+    std::unordered_map<tuple_type, size_t>                        mIndexMap;
+    // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
+    std::unordered_map<tuple_type_Nm1, std::pair<size_t,size_t> > mMap;
+    // The number of binned dimensions as given by the JetCorrectorParameters::Definitions class
+    unsigned													  SIZE;
+};
+
+#endif

--- a/CondFormats/JetMETObjects/interface/Utilities.h
+++ b/CondFormats/JetMETObjects/interface/Utilities.h
@@ -17,7 +17,7 @@
 
 namespace std
 {
-  //print a tuple
+  //These functions print a tuple using a provided std::ostream
   template<typename Type, unsigned N, unsigned Last>
   struct tuple_printer {
   
@@ -41,9 +41,8 @@ namespace std
       out << ")";
       return out;
   }
-
   //----------------------------------------------------------------------
-  //list of type indices
+  //Returns a list of type indices
   template <size_t... n>
   struct ct_integers_list {
       template <size_t m>
@@ -62,9 +61,9 @@ namespace std
   {
       typedef ct_integers_list<> type;
   };
-
   //----------------------------------------------------------------------
-  //return a subset of the tuple
+  //Return a tuple which is a subset of the original tuple
+  //This function pops an entry off the font of the tuple
   template <size_t... indices, typename Tuple>
   auto tuple_subset(const Tuple& tpl, ct_integers_list<indices...>)
       -> decltype(std::make_tuple(std::get<indices>(tpl)...))
@@ -80,9 +79,8 @@ namespace std
       // this means:
       //   tuple_subset<1, 2, 3, ..., sizeof...(Tail)-1>(tpl, ..)
   }
-
   //----------------------------------------------------------------------
-  // Recursive hashing function for tuples
+  //Recursive hashing function for tuples
   template<typename Head, typename... ndims> struct hash_specialization
   {
     typedef std::tuple<Head,ndims...> argument_type;
@@ -95,7 +93,7 @@ namespace std
       return b^more;
     }
   };
-  // Base cases
+  //Base case
   template<> struct hash_specialization<float>
   {
     typedef std::tuple<float> argument_type;
@@ -107,7 +105,7 @@ namespace std
       return result;
     } 
   };
-  // Overloaded verions of std::hash for tuples
+  //Overloaded verions of std::hash for tuples
   template<typename Head, typename... ndims> struct hash<std::tuple<Head, ndims...> >
   {
     typedef std::tuple<Head,ndims...> argument_type;
@@ -245,6 +243,9 @@ namespace
     return r;
   }
   //------------------------------------------------------------------------
+  //Generates a std::tuple type based on a stored type and the number of
+  // objects in the tuple.
+  //Note: All of the objects will be of the same type
   template<typename /*LEFT_TUPLE*/, typename /*RIGHT_TUPLE*/>
   struct join_tuples
   {
@@ -296,6 +297,7 @@ namespace
   template<> struct gen_seq<0> : seq<>{};
   template<> struct gen_seq<1> : seq<0>{};
   //------------------------------------------------------------------------
+  //Generates a tuple based on a given function (i.e. lambda expression)
   template <typename F, unsigned... Is>
   auto gen_tuple_impl(F func, seq<Is...> )
     -> decltype(std::make_tuple(func(Is)...))

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -251,7 +251,21 @@ int JetCorrectorParameters::binIndex3(const std::vector<float>& fX) const
       sserr<<"# bin variables "<<N<<" is not equal to 3";
       handleError("JetCorrectorParameters",sserr.str());
     }
+  // make sure that fX are within the first and last boundaries of mBinBoundaries
+  for (unsigned idim=0; idim<fX.size(); idim++)
+    {
+      if (fX[idim] < *mBinBoundaries[idim].begin() || fX[idim] < *mBinBoundaries[idim].rbegin())
+        {
+          std::stringstream sserr;
+          sserr<<"dim "<<idim<<" is outside of the bin boundaries";
+          handleError("JetCorrectorParameters",sserr.str());
+          return -1;
+        }
+    }
+
   auto f0 = std::lower_bound(mBinBoundaries[0].begin(),mBinBoundaries[0].end(),fX[0]);
+  // lower_bound finds the entry with the next highest value to fX[0]
+  // so unless the two values are equal, you want the next lowest bin boundary
   if (*f0 != fX[0])
     f0-=1;
   auto f1 = std::lower_bound(mBinBoundaries[1].begin(),mBinBoundaries[1].end(),fX[1]);

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -102,6 +102,7 @@ JetCorrectorParameters::Record::Record(const std::string& fLine,unsigned fNvar) 
     }
 }
 //------------------------------------------------------------------------
+//--- JetCorrectorParameters::JetCorrectorParametersHelper initializer ---
 //--- initializes the mBinMap for quick lookup of mRecords ---------------
 //------------------------------------------------------------------------
 template<typename T, int SIZE>
@@ -165,6 +166,7 @@ void JetCorrectorParameters::JetCorrectorParametersHelper<T,SIZE>::init(const st
     }
 }
 //------------------------------------------------------------------------
+//--- JetCorrectorParameters::JetCorrectorParametersHelper sanity checks -
 //--- checks that some conditions are met before finding the bin index ---
 //------------------------------------------------------------------------
 template<typename T, int SIZE>
@@ -191,6 +193,7 @@ bool JetCorrectorParameters::JetCorrectorParametersHelper<T,SIZE>::binBoundCheck
     return true;
 }
 //------------------------------------------------------------------------
+//--- JetCorrectorParameters::JetCorrectorParametersHelper binIndexN -----
 //--- returns the index of the record defined by fX (non-linear search) --
 //------------------------------------------------------------------------
 template<typename T, int SIZE>
@@ -242,32 +245,6 @@ int JetCorrectorParameters::JetCorrectorParametersHelper<T,SIZE>::binIndexN(cons
   tuple_type to_find = gen_tuple<SIZE>([&](size_t i){return fN[i];});
   return (mIndexMap.find(to_find)!=mIndexMap.end()) ? mIndexMap.at(to_find) : -1;
 }
-//------------------------------------------------------------------------
-//--- partial specialization of binIndexN --------------------------------
-//------------------------------------------------------------------------
-/*
-template<typename T>
-int JetCorrectorParameters::JetCorrectorParametersHelper<T,1>::binIndexN(const std::vector<float>& fX) const
-{
-  unsigned N = mDefinitions.nBinVar();
-  unsigned Nm1 = N-1;
-  binIndexChecks(N,fX);
-
-  //Create a container for the indices
-  std::vector<float> fN(N,-1);
-  std::vector<float>::const_iterator tmpIt;
-
-  // make sure that fX are within the first and last boundaries of mBinBoundaries (other than last dimension)
-  if(!binBoundChecks(0,fX[0],mRecords[0].xMin(0),mRecords[size()-1].xMax(0))) return -1;
-
-  tmpIt = std::lower_bound(mBinBoundaries[Nm1].begin(),mBinBoundaries[Nm1].end(),fX[Nm1]);
-  if (*tmpIt != fX[Nm1] && fX[Nm1]<*(mBinBoundaries[Nm1].begin()))
-    tmpIt-=1;
-  fN[Nm1] = *tmpIt;
-
-  return (mOneIndexMap.find(std::make_tuple(fN[0]))!=mOneIndexMap.end()) ? mOneIndexMap.at(std::make_tuple(fN[0])) : -1;
-}
-*/
 //------------------------------------------------------------------------
 //--- JetCorrectorParameters constructor ---------------------------------
 //--- reads the member variables from a string ---------------------------
@@ -396,98 +373,6 @@ int JetCorrectorParameters::binIndexN(const std::vector<float>& fX) const
       return -1;
     }
 }
-/*
-int JetCorrectorParameters::binIndex2(const std::vector<float>& fX) const
-{
-  unsigned N = mDefinitions.nBinVar();
-  unsigned Nm1 = N-1;
-  binIndexChecks(N,fX);
-
-  //Create a container for the indices
-  std::vector<float> fN(N,-1);
-  std::vector<float>::const_iterator tmpIt;
-
-  // make sure that fX are within the first and last boundaries of mBinBoundaries (other than last dimension)
-  for (unsigned idim=0; idim<fX.size()-1; idim++)
-    {
-      if(!binBoundChecks(idim,fX[idim],*mBinBoundaries[idim].begin(),mRecords[size()-1].xMax(idim))) return -1;
-      tmpIt = std::lower_bound(mBinBoundaries[idim].begin(),mBinBoundaries[idim].end(),fX[idim]);
-      // lower_bound finds the entry with the next highest value to fX[0]
-      // so unless the two values are equal, you want the next lowest bin boundary
-      if (*tmpIt != fX[idim])
-        tmpIt-=1;
-      fN[idim] = *tmpIt;
-    }
-
-  //find the index bounds for the possible values of the last dimension
-  std::pair<size_t,size_t> oneIndex;
-  std::tuple<float> to_find = std::make_tuple(fN[0]);
-  if (mOneMap.find(to_find)!=mOneMap.end())
-    oneIndex = mOneMap.at(to_find);
-  else
-    {
-      std::stringstream sserr;
-      sserr<<"couldn't find the index boundaries for dimension "<<Nm1;
-      handleError("JetCorrectorParameters",sserr.str());
-      return -1;
-    }
-
-  //Check that the requested value is within the bin boundaries for the last dimension
-  if(!binBoundChecks(Nm1,fX[Nm1],mRecords[oneIndex.first].xMin(Nm1),mRecords[oneIndex.second].xMax(Nm1))) return -1;
-  tmpIt = std::lower_bound(mBinBoundaries[Nm1].begin()+oneIndex.first,mBinBoundaries[Nm1].begin()+oneIndex.second,fX[Nm1]);
-  if (*tmpIt != fX[Nm1] && fX[Nm1]<*(mBinBoundaries[Nm1].begin()+oneIndex.second))
-    tmpIt-=1;
-  fN[Nm1] = *tmpIt;
-
-  return (mTwoIndexMap.find(std::make_tuple(fN[0],fN[1]))!=mTwoIndexMap.end()) ?
-          mTwoIndexMap.at(std::make_tuple(fN[0],fN[1])) : -1;
-}
-int JetCorrectorParameters::binIndex3(const std::vector<float>& fX) const
-{
-  unsigned N = mDefinitions.nBinVar();
-  unsigned Nm1 = N-1;
-  binIndexChecks(N,fX);
-
-  //Create a container for the indices
-  std::vector<float> fN(N,-1);
-  std::vector<float>::const_iterator tmpIt;
-
-  // make sure that fX are within the first and last boundaries of mBinBoundaries (other than last dimension)
-  for (unsigned idim=0; idim<fX.size()-1; idim++)
-    {
-      if(!binBoundChecks(idim,fX[idim],*mBinBoundaries[idim].begin(),mRecords[size()-1].xMax(idim))) return -1;
-      tmpIt = std::lower_bound(mBinBoundaries[idim].begin(),mBinBoundaries[idim].end(),fX[idim]);
-      // lower_bound finds the entry with the next highest value to fX[0]
-      // so unless the two values are equal, you want the next lowest bin boundary
-      if (*tmpIt != fX[idim])
-        tmpIt-=1;
-      fN[idim] = *tmpIt;
-    }
-
-  //find the index bounds for the possible values of the last dimension
-  std::pair<size_t,size_t> twoIndex;
-  std::tuple<float,float> to_find = std::make_tuple(fN[0],fN[1]);
-  if (mTwoMap.find(to_find)!=mTwoMap.end())
-    twoIndex = mTwoMap.at(to_find);
-  else
-    {
-      std::stringstream sserr;
-      sserr<<"couldn't find the index boundaries for dimension "<<Nm1;
-      handleError("JetCorrectorParameters",sserr.str());
-      return -1;
-    }
-
-  //Check that the requested value is within the bin boundaries for the last dimension
-  if(!binBoundChecks(Nm1,fX[Nm1],mRecords[twoIndex.first].xMin(Nm1),mRecords[twoIndex.second].xMax(Nm1))) return -1;
-  tmpIt = std::lower_bound(mBinBoundaries[Nm1].begin()+twoIndex.first,mBinBoundaries[Nm1].begin()+twoIndex.second,fX[Nm1]);
-  if (*tmpIt != fX[Nm1] && fX[Nm1]<*(mBinBoundaries[Nm1].begin()+twoIndex.second))
-    tmpIt-=1;
-  fN[Nm1] = *tmpIt;
-
-  return (mThreeIndexMap.find(std::make_tuple(fN[0],fN[1],fN[2]))!=mThreeIndexMap.end()) ?
-          mThreeIndexMap.at(std::make_tuple(fN[0],fN[1],fN[2])) : -1;
-}
-*/
 //------------------------------------------------------------------------
 //--- returns the neighbouring bins of fIndex in the direction of fVar ---
 //------------------------------------------------------------------------

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -171,6 +171,7 @@ JetCorrectorParameters::JetCorrectorParameters(const std::string& fFile, const s
 //------------------------------------------------------------------------
 void JetCorrectorParameters::init()
 {
+  std::sort(mRecords.begin(), mRecords.end());
   helper = std::make_shared<JetCorrectorParametersHelper>();
   helper->init(mDefinitions,mRecords);
 } 

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -147,7 +147,7 @@ void JetCorrectorParameters::JetCorrectorParametersHelper<T,SIZE>::init(const st
         size_t existing_index = mIndexMap.find(tmpTuple)->second;
         std::stringstream sserr;
         sserr<<"Duplicate binning in record found (existing index,current index)=("
-             <<existing_index<<","<<i<<")"<<std::endl<<"\tBins(lower bounds)="<<tmpTuple<<std::endl;
+             <<existing_index<<","<<i<<")"<<std::endl<<"\tBins(lower bounds)="<<tmpTuple;
         handleError("JetCorrectorParameters",sserr.str());
       }
     }

--- a/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
@@ -31,7 +31,7 @@ void JetCorrectorParametersHelper::init(const JetCorrectorParameters::Definition
       std::stringstream sserr;
       sserr<<"The number of binned variables requested ("<<SIZE<<") is greater than the number allowed ("
            <<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY<<")";
-      handleError("JetCorrectorParameters",sserr.str());
+      handleError("JetCorrectorParametersHelper",sserr.str());
     }
 
   initTransientMaps();
@@ -53,13 +53,12 @@ void JetCorrectorParametersHelper::init(const JetCorrectorParameters::Definition
           if(SIZE>1 && (i==nRec-1 || mRecordsLocal[i].xMin(j-1)!=mRecordsLocal[i+1].xMin(j-1))) {
             end = i;
             //mMap.emplace(gen_tuple<SIZE-1>([&](size_t k){return mRecordsLocal[i].xMin(k);}),std::make_pair(start,end));
-            mMap.emplace(gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY-1>([&](size_t k){return (k<SIZE)?mRecordsLocal[i].xMin(k):-9999;}),std::make_pair(start,end));
+            mMap.emplace(gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY-1>([&](size_t k){return (k<SIZE-1)?mRecordsLocal[i].xMin(k):-9999;}),std::make_pair(start,end));
             start = i+1;
           }
         }
       }
       indexMapSize = mIndexMap.size();
-      //tuple_type tmpTuple = gen_tuple<SIZE>([&](size_t k){return mRecordsLocal[i].xMin(k);});
       tuple_type tmpTuple = gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY>([&](size_t k){return (k<SIZE)?mRecordsLocal[i].xMin(k):-9999;});
       mIndexMap.emplace(tmpTuple,i);
       tmpIndexMapSize = mIndexMap.size();
@@ -69,7 +68,7 @@ void JetCorrectorParametersHelper::init(const JetCorrectorParameters::Definition
         std::stringstream sserr;
         sserr<<"Duplicate binning in record found (existing index,current index)=("
              <<existing_index<<","<<i<<")"<<std::endl<<"\tBins(lower bounds)="<<tmpTuple;
-        handleError("JetCorrectorParameters",sserr.str());
+        handleError("JetCorrectorParametersHelper",sserr.str());
       }
     }
   if (mBinBoundaries[SIZE-1].size()!=nRec)
@@ -77,12 +76,12 @@ void JetCorrectorParametersHelper::init(const JetCorrectorParameters::Definition
       std::stringstream sserr;
       sserr<<"Did not find all bin boundaries for dimension "<<SIZE-1<<"!!!"<<std::endl
            <<"Found "<<mBinBoundaries[SIZE-1].size()<<" out of "<<nRec<<" records";
-      handleError("JetCorrectorParameters",sserr.str());
+      handleError("JetCorrectorParametersHelper",sserr.str());
     }
   indexMapSize = mIndexMap.size();
   if (indexMapSize!=nRec)
     {
-      handleError("JetCorrectorParameters","The mapping of bin lower bounds to indices does not contain all possible entries!!!");
+      handleError("JetCorrectorParametersHelper","The mapping of bin lower bounds to indices does not contain all possible entries!!!");
     }
 }
 //------------------------------------------------------------------------
@@ -95,7 +94,7 @@ void JetCorrectorParametersHelper::binIndexChecks(unsigned N, const std::vector<
     {
       std::stringstream sserr;
       sserr<<"# bin variables "<<N<<" doesn't correspont to requested #: "<<fX.size();
-      handleError("JetCorrectorParameters",sserr.str());
+      handleError("JetCorrectorParametersHelper",sserr.str());
     }
 }
 bool JetCorrectorParametersHelper::binBoundChecks(unsigned dim, const float& value, const float& min, const float& max) const
@@ -105,7 +104,7 @@ bool JetCorrectorParametersHelper::binBoundChecks(unsigned dim, const float& val
       std::stringstream sserr;
       sserr<<"Value for dimension "<<dim<<" is outside of the bin boundaries"<<std::endl
            <<"\tRequested "<<value<<" for boundaries ("<<min<<","<<max<<")";
-      handleError("JetCorrectorParameters",sserr.str());
+      handleError("JetCorrectorParametersHelper",sserr.str());
       return false;
     }
     return true;
@@ -125,7 +124,7 @@ int JetCorrectorParametersHelper::binIndexN(const std::vector<float>& fX,
   std::vector<float>::const_iterator tmpIt;
 
   // make sure that fX are within the first and last boundaries of mBinBoundaries (other than last dimension)
-  for (unsigned idim=0; idim<fX.size()-1; idim++)
+  for (unsigned idim=0; idim==0||idim<fX.size()-1; idim++)
   {
     if(!binBoundChecks(idim,fX[idim],*mBinBoundaries[idim].begin(),mRecords[size()-1].xMax(idim))) return -1;
     tmpIt = std::lower_bound(mBinBoundaries[idim].begin(),mBinBoundaries[idim].end(),fX[idim]);
@@ -140,14 +139,14 @@ int JetCorrectorParametersHelper::binIndexN(const std::vector<float>& fX,
   std::pair<size_t,size_t> indexBounds;
   if(SIZE>1)
     {
-      tuple_type_Nm1 to_find_Nm1 = gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY-1>([&](size_t i){return (i<SIZE)?fN[i]:-9999;});
+      tuple_type_Nm1 to_find_Nm1 = gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY-1>([&](size_t i){return (i<Nm1)?fN[i]:-9999;});
       if (mMap.find(to_find_Nm1)!=mMap.end())
         indexBounds = mMap.at(to_find_Nm1);
       else
       {
         std::stringstream sserr;
         sserr<<"couldn't find the index boundaries for dimension "<<Nm1;
-        handleError("JetCorrectorParameters",sserr.str());
+        handleError("JetCorrectorParametersHelper",sserr.str());
         return -1;
       }
 

--- a/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParametersHelper.cc
@@ -1,0 +1,164 @@
+//
+// Original Author:  Alexx Perloff Feb 22, 2017
+// $Id: JetCorrectorParameters.cc,v 1.20 2012/03/01 18:24:53 srappocc Exp $
+//
+// Helper class for JetCorrectorParameters
+//
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParametersHelper.h"
+#include <sstream>
+#include <stdlib.h>
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+
+//------------------------------------------------------------------------
+//--- JetCorrectorParameters::JetCorrectorParametersHelper initializer ---
+//--- initializes the mBinMap for quick lookup of mRecords ---------------
+//------------------------------------------------------------------------
+void JetCorrectorParametersHelper::initTransientMaps()
+{
+  mIndexMap.clear();
+  mMap.clear();
+  mBinBoundaries.clear();
+  mBinBoundaries.assign(JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY,std::vector<float>(0,0));
+}
+void JetCorrectorParametersHelper::init(const JetCorrectorParameters::Definitions& mDefinitionsLocal,
+                                        const std::vector<JetCorrectorParameters::Record>& mRecordsLocal) 
+{
+  SIZE = mDefinitionsLocal.nBinVar();
+  if (SIZE>JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY)
+    {
+      std::stringstream sserr;
+      sserr<<"The number of binned variables requested ("<<SIZE<<") is greater than the number allowed ("
+           <<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY<<")";
+      handleError("JetCorrectorParameters",sserr.str());
+    }
+
+  initTransientMaps();
+  size_t start=0, end=0;
+  size_t nRec = mRecordsLocal.size();
+  size_t indexMapSize=0, tmpIndexMapSize=0;
+  for (unsigned i = 0; i < nRec; ++i)
+    {
+      for (unsigned j=0;j<SIZE;j++)
+      {
+        if(j<SIZE-1 && std::find(mBinBoundaries[j].begin(),mBinBoundaries[j].end(),mRecordsLocal[i].xMin(j))==mBinBoundaries[j].end())
+          mBinBoundaries[j].push_back(mRecordsLocal[i].xMin(j));
+        else if(j==SIZE-1) {
+          if(i==0)
+            mBinBoundaries[j].reserve(mRecordsLocal.size());
+
+          mBinBoundaries[j].push_back(mRecordsLocal[i].xMin(j));
+
+          if(SIZE>1 && (i==nRec-1 || mRecordsLocal[i].xMin(j-1)!=mRecordsLocal[i+1].xMin(j-1))) {
+            end = i;
+            //mMap.emplace(gen_tuple<SIZE-1>([&](size_t k){return mRecordsLocal[i].xMin(k);}),std::make_pair(start,end));
+            mMap.emplace(gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY-1>([&](size_t k){return (k<SIZE)?mRecordsLocal[i].xMin(k):-9999;}),std::make_pair(start,end));
+            start = i+1;
+          }
+        }
+      }
+      indexMapSize = mIndexMap.size();
+      //tuple_type tmpTuple = gen_tuple<SIZE>([&](size_t k){return mRecordsLocal[i].xMin(k);});
+      tuple_type tmpTuple = gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY>([&](size_t k){return (k<SIZE)?mRecordsLocal[i].xMin(k):-9999;});
+      mIndexMap.emplace(tmpTuple,i);
+      tmpIndexMapSize = mIndexMap.size();
+      if(indexMapSize==tmpIndexMapSize)
+      {
+        size_t existing_index = mIndexMap.find(tmpTuple)->second;
+        std::stringstream sserr;
+        sserr<<"Duplicate binning in record found (existing index,current index)=("
+             <<existing_index<<","<<i<<")"<<std::endl<<"\tBins(lower bounds)="<<tmpTuple;
+        handleError("JetCorrectorParameters",sserr.str());
+      }
+    }
+  if (mBinBoundaries[SIZE-1].size()!=nRec)
+    {
+      std::stringstream sserr;
+      sserr<<"Did not find all bin boundaries for dimension "<<SIZE-1<<"!!!"<<std::endl
+           <<"Found "<<mBinBoundaries[SIZE-1].size()<<" out of "<<nRec<<" records";
+      handleError("JetCorrectorParameters",sserr.str());
+    }
+  indexMapSize = mIndexMap.size();
+  if (indexMapSize!=nRec)
+    {
+      handleError("JetCorrectorParameters","The mapping of bin lower bounds to indices does not contain all possible entries!!!");
+    }
+}
+//------------------------------------------------------------------------
+//--- JetCorrectorParameters::JetCorrectorParametersHelper sanity checks -
+//--- checks that some conditions are met before finding the bin index ---
+//------------------------------------------------------------------------
+void JetCorrectorParametersHelper::binIndexChecks(unsigned N, const std::vector<float>& fX) const
+{
+  if (N != fX.size())
+    {
+      std::stringstream sserr;
+      sserr<<"# bin variables "<<N<<" doesn't correspont to requested #: "<<fX.size();
+      handleError("JetCorrectorParameters",sserr.str());
+    }
+}
+bool JetCorrectorParametersHelper::binBoundChecks(unsigned dim, const float& value, const float& min, const float& max) const
+{
+  if (value < min || value > max)
+    {
+      std::stringstream sserr;
+      sserr<<"Value for dimension "<<dim<<" is outside of the bin boundaries"<<std::endl
+           <<"\tRequested "<<value<<" for boundaries ("<<min<<","<<max<<")";
+      handleError("JetCorrectorParameters",sserr.str());
+      return false;
+    }
+    return true;
+}
+//------------------------------------------------------------------------
+//--- JetCorrectorParameters::JetCorrectorParametersHelper binIndexN -----
+//--- returns the index of the record defined by fX (non-linear search) --
+//------------------------------------------------------------------------
+int JetCorrectorParametersHelper::binIndexN(const std::vector<float>& fX,
+                                            const std::vector<JetCorrectorParameters::Record>& mRecords) const
+{
+  unsigned Nm1 = SIZE-1;
+  binIndexChecks(SIZE,fX);
+
+  //Create a container for the indices
+  std::vector<float> fN(SIZE,-1);
+  std::vector<float>::const_iterator tmpIt;
+
+  // make sure that fX are within the first and last boundaries of mBinBoundaries (other than last dimension)
+  for (unsigned idim=0; idim<fX.size()-1; idim++)
+  {
+    if(!binBoundChecks(idim,fX[idim],*mBinBoundaries[idim].begin(),mRecords[size()-1].xMax(idim))) return -1;
+    tmpIt = std::lower_bound(mBinBoundaries[idim].begin(),mBinBoundaries[idim].end(),fX[idim]);
+    // lower_bound finds the entry with the next highest value to fX[0]
+    // so unless the two values are equal, you want the next lowest bin boundary
+    if (*tmpIt != fX[idim])
+      tmpIt-=1;
+    fN[idim] = *tmpIt;
+  }
+
+  //find the index bounds for the possible values of the last dimension
+  std::pair<size_t,size_t> indexBounds;
+  if(SIZE>1)
+    {
+      tuple_type_Nm1 to_find_Nm1 = gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY-1>([&](size_t i){return (i<SIZE)?fN[i]:-9999;});
+      if (mMap.find(to_find_Nm1)!=mMap.end())
+        indexBounds = mMap.at(to_find_Nm1);
+      else
+      {
+        std::stringstream sserr;
+        sserr<<"couldn't find the index boundaries for dimension "<<Nm1;
+        handleError("JetCorrectorParameters",sserr.str());
+        return -1;
+      }
+
+      //Check that the requested value is within the bin boundaries for the last dimension
+      if(!binBoundChecks(Nm1,fX[Nm1],mRecords[indexBounds.first].xMin(Nm1),mRecords[indexBounds.second].xMax(Nm1))) return -1;
+      tmpIt = std::lower_bound(mBinBoundaries[Nm1].begin()+indexBounds.first,mBinBoundaries[Nm1].begin()+indexBounds.second,fX[Nm1]);
+      if (*tmpIt != fX[Nm1] && fX[Nm1]<*(mBinBoundaries[Nm1].begin()+indexBounds.second))
+        tmpIt-=1;
+      fN[Nm1] = *tmpIt;
+    }
+
+  tuple_type to_find = gen_tuple<JetCorrectorParameters::MAX_SIZE_DIMENSIONALITY>([&](size_t i){return (i<SIZE)?fN[i]:-9999;});
+  return (mIndexMap.find(to_find)!=mIndexMap.end()) ? mIndexMap.at(to_find) : -1;
+}

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -38,7 +38,11 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
   float result = 1.;
   float tmp    = 0.0;
   float cor    = 0.0;
-  int bin = mParameters.binIndex(fX);
+  int bin = -1;
+  if (fX.size()==3)
+    bin = mParameters.binIndex3(fX);
+  else
+    bin = mParameters.binIndex(fX);
   if (bin<0)
     return result;
   if (!mDoInterpolation)

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -39,8 +39,9 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
   float tmp    = 0.0;
   float cor    = 0.0;
   int bin = -1;
-  bin = (fX.size()==3) ? mParameters.binIndex3(fX) : (fX.size()==2) ? mParameters.binIndex2(fX) :
-        (fX.size()==1) ? mParameters.binIndex1(fX) : mParameters.binIndex(fX);
+  bin = (fX.size()<=3) ? mParameters.binIndexN(fX) : mParameters.binIndex(fX);
+  //bin = (fX.size()==3) ? mParameters.binIndex3(fX) : (fX.size()==2) ? mParameters.binIndex2(fX) :
+  //      (fX.size()==1) ? mParameters.binIndex1(fX) : mParameters.binIndex(fX);
   //bin = mParameters.binIndex(fX);
   if (bin<0)
     return result;

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -39,10 +39,9 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
   float tmp    = 0.0;
   float cor    = 0.0;
   int bin = -1;
-  if (fX.size()==3)
-    bin = mParameters.binIndex3(fX);
-  else
-    bin = mParameters.binIndex(fX);
+  bin = (fX.size()==3) ? mParameters.binIndex3(fX) : (fX.size()==2) ? mParameters.binIndex2(fX) :
+        (fX.size()==1) ? mParameters.binIndex1(fX) : mParameters.binIndex(fX);
+  //bin = mParameters.binIndex(fX);
   if (bin<0)
     return result;
   if (!mDoInterpolation)

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -39,7 +39,7 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
   float tmp    = 0.0;
   float cor    = 0.0;
   int bin = -1;
-  bin = (fX.size()<=3) ? mParameters.binIndexN(fX) : mParameters.binIndex(fX);
+  bin = (fX.size()<=3 && fX.size()>0) ? mParameters.binIndexN(fX) : mParameters.binIndex(fX);
   if (bin<0)
     return result;
   if (!mDoInterpolation)

--- a/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
+++ b/CondFormats/JetMETObjects/src/SimpleJetCorrector.cc
@@ -40,9 +40,6 @@ float SimpleJetCorrector::correction(const std::vector<float>& fX,const std::vec
   float cor    = 0.0;
   int bin = -1;
   bin = (fX.size()<=3) ? mParameters.binIndexN(fX) : mParameters.binIndex(fX);
-  //bin = (fX.size()==3) ? mParameters.binIndex3(fX) : (fX.size()==2) ? mParameters.binIndex2(fX) :
-  //      (fX.size()==1) ? mParameters.binIndex1(fX) : mParameters.binIndex(fX);
-  //bin = mParameters.binIndex(fX);
   if (bin<0)
     return result;
   if (!mDoInterpolation)

--- a/CondFormats/JetMETObjects/src/classes.h
+++ b/CondFormats/JetMETObjects/src/classes.h
@@ -5,6 +5,9 @@
 JetCorrectorParameters corr;
 JetCorrectorParameters::Definitions def;
 JetCorrectorParameters::Record record;
+JetCorrectorParameters::JetCorrectorParametersHelper<float,1> helper1;
+JetCorrectorParameters::JetCorrectorParametersHelper<float,2> helper2;
+JetCorrectorParameters::JetCorrectorParametersHelper<float,3> helper3;
 std::vector<JetCorrectorParameters> corrv;
 std::vector<JetCorrectorParameters::Record> recordv;
 JetCorrectorParametersCollection coll;

--- a/CondFormats/JetMETObjects/src/classes.h
+++ b/CondFormats/JetMETObjects/src/classes.h
@@ -5,9 +5,6 @@
 JetCorrectorParameters corr;
 JetCorrectorParameters::Definitions def;
 JetCorrectorParameters::Record record;
-JetCorrectorParameters::JetCorrectorParametersHelper<float,1> helper1;
-JetCorrectorParameters::JetCorrectorParametersHelper<float,2> helper2;
-JetCorrectorParameters::JetCorrectorParametersHelper<float,3> helper3;
 std::vector<JetCorrectorParameters> corrv;
 std::vector<JetCorrectorParameters::Record> recordv;
 JetCorrectorParametersCollection coll;

--- a/CondFormats/JetMETObjects/src/classes_def.xml
+++ b/CondFormats/JetMETObjects/src/classes_def.xml
@@ -16,21 +16,6 @@
   <class name="JetCorrectorParametersCollection::pair_type"/>
   <class name="JetCorrectorParameters::Definitions"/>
   <class name="JetCorrectorParameters::Record"/>
-  <class name="JetCorrectorParameters::JetCorrectorParametersHelper<float,1>">
-    <field name="mBinBoundaries" transient="true"/>
-    <field name="mIndexMap"      transient="true"/>
-    <field name="mMap"           transient="true"/>
-  </class>
-  <class name="JetCorrectorParameters::JetCorrectorParametersHelper<float,2>">
-    <field name="mBinBoundaries" transient="true"/>
-    <field name="mIndexMap"      transient="true"/>
-    <field name="mMap"           transient="true"/>
-  </class>
-  <class name="JetCorrectorParameters::JetCorrectorParametersHelper<float,3>">
-    <field name="mBinBoundaries" transient="true"/>
-    <field name="mIndexMap"      transient="true"/>
-    <field name="mMap"           transient="true"/>
-  </class>
   <class name="std::vector<JetCorrectorParameters>"/>
   <class name="std::vector<JetCorrectorParameters::Record>"/>
   <class name="std::vector<JetCorrectorParametersCollection>"/>

--- a/CondFormats/JetMETObjects/src/classes_def.xml
+++ b/CondFormats/JetMETObjects/src/classes_def.xml
@@ -3,23 +3,34 @@
   <class name="FactorizedJetCorrector"/>
   <class name="JetCorrectionUncertainty"/>
   <class name="JetCorrectorParameters">
-     <field name="mBinBoundaries" transient="true"/>
-	 <field name="mThreeIndexMap" transient="true"/>
-	 <field name="mTwoIndexMap"   transient="true"/>
-	 <field name="mOneIndexMap"   transient="true"/>
-	 <field name="mTwoMap"        transient="true"/>
-	 <field name="mOneMap"        transient="true"/>
+    <field name="helperTuple"             transient="true"/>
+    <field name="MAX_SIZE_DIMENSIONALITY" transient="true"/>
   </class>
   <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="std::vector<JetCorrectorParameters::Record> mRecords" target="">
-  <![CDATA[
-         newObj->init(onfile.mRecords); 
-  ]]>
+    <![CDATA[
+         newObj->init(); 
+    ]]>
   </ioread>
   <class name="JetCorrectorParametersCollection"/>
   <class name="JetCorrectorParametersCollection::collection_type"/>
   <class name="JetCorrectorParametersCollection::pair_type"/>
   <class name="JetCorrectorParameters::Definitions"/>
   <class name="JetCorrectorParameters::Record"/>
+  <class name="JetCorrectorParameters::JetCorrectorParametersHelper<float,1>">
+    <field name="mBinBoundaries" transient="true"/>
+    <field name="mIndexMap"      transient="true"/>
+    <field name="mMap"           transient="true"/>
+  </class>
+  <class name="JetCorrectorParameters::JetCorrectorParametersHelper<float,2>">
+    <field name="mBinBoundaries" transient="true"/>
+    <field name="mIndexMap"      transient="true"/>
+    <field name="mMap"           transient="true"/>
+  </class>
+  <class name="JetCorrectorParameters::JetCorrectorParametersHelper<float,3>">
+    <field name="mBinBoundaries" transient="true"/>
+    <field name="mIndexMap"      transient="true"/>
+    <field name="mMap"           transient="true"/>
+  </class>
   <class name="std::vector<JetCorrectorParameters>"/>
   <class name="std::vector<JetCorrectorParameters::Record>"/>
   <class name="std::vector<JetCorrectorParametersCollection>"/>

--- a/CondFormats/JetMETObjects/src/classes_def.xml
+++ b/CondFormats/JetMETObjects/src/classes_def.xml
@@ -4,12 +4,15 @@
   <class name="JetCorrectionUncertainty"/>
   <class name="JetCorrectorParameters">
      <field name="mBinBoundaries" transient="true"/>
-     <field name="mBinMap" transient="true"/>
-     <field name="mPtMap" transient="true"/>
+	 <field name="mThreeIndexMap" transient="true"/>
+	 <field name="mTwoIndexMap"   transient="true"/>
+	 <field name="mOneIndexMap"   transient="true"/>
+	 <field name="mTwoMap"        transient="true"/>
+	 <field name="mOneMap"        transient="true"/>
   </class>
-  <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="std::vector<JetCorrectorParameters::Record> mRecords" target="mBinBoundaries; mBinMap; mPtMap">
+  <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="std::vector<JetCorrectorParameters::Record> mRecords" target="">
   <![CDATA[
-         newObj->init(onfile.mRecords,mBinBoundaries,mBinMap,mPtMap); 
+         newObj->init(onfile.mRecords); 
   ]]>
   </ioread>
   <class name="JetCorrectorParametersCollection"/>

--- a/CondFormats/JetMETObjects/src/classes_def.xml
+++ b/CondFormats/JetMETObjects/src/classes_def.xml
@@ -2,7 +2,16 @@
 <selection>
   <class name="FactorizedJetCorrector"/>
   <class name="JetCorrectionUncertainty"/>
-  <class name="JetCorrectorParameters"/>
+  <class name="JetCorrectorParameters">
+     <field name="mBinBoundaries" transient="true"/>
+     <field name="mBinMap" transient="true"/>
+     <field name="mPtMap" transient="true"/>
+  </class>
+  <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="std::vector<JetCorrectorParameters::Record> mRecords" target="mBinBoundaries; mBinMap; mPtMap">
+  <![CDATA[
+         newObj->init(onfile.mRecords,mBinBoundaries,mBinMap,mPtMap); 
+  ]]>
+  </ioread>
   <class name="JetCorrectorParametersCollection"/>
   <class name="JetCorrectorParametersCollection::collection_type"/>
   <class name="JetCorrectorParametersCollection::pair_type"/>

--- a/CondFormats/JetMETObjects/src/classes_def.xml
+++ b/CondFormats/JetMETObjects/src/classes_def.xml
@@ -3,10 +3,10 @@
   <class name="FactorizedJetCorrector"/>
   <class name="JetCorrectionUncertainty"/>
   <class name="JetCorrectorParameters">
-    <field name="helperTuple"             transient="true"/>
+    <field name="helper"                  transient="true"/>
     <field name="MAX_SIZE_DIMENSIONALITY" transient="true"/>
   </class>
-  <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="std::vector<JetCorrectorParameters::Record> mRecords" target="">
+  <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="JetCorrectorParameters::Definitions mDefinitions; std::vector<JetCorrectorParameters::Record> mRecords;" target="">
     <![CDATA[
          newObj->init(); 
     ]]>

--- a/CondFormats/JetMETObjects/src/classes_def.xml
+++ b/CondFormats/JetMETObjects/src/classes_def.xml
@@ -6,7 +6,7 @@
     <field name="helper"                  transient="true"/>
     <field name="MAX_SIZE_DIMENSIONALITY" transient="true"/>
   </class>
-  <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="JetCorrectorParameters::Definitions mDefinitions; std::vector<JetCorrectorParameters::Record> mRecords;" target="">
+  <ioread sourceClass="JetCorrectorParameters" targetClass="JetCorrectorParameters" version="[0-]" source="JetCorrectorParameters::Definitions mDefinitions; std::vector<JetCorrectorParameters::Record> mRecords;" target="helper">
     <![CDATA[
          newObj->init(); 
     ]]>

--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -271,6 +271,8 @@ def get_serializable_classes_members(node, all_template_types=None, namespace=''
                     clang.cindex.CursorKind.CONVERSION_FUNCTION,
                     clang.cindex.CursorKind.TYPE_REF,
                     clang.cindex.CursorKind.DECL_REF_EXPR,
+                    clang.cindex.CursorKind.CLASS_TEMPLATE,
+                    clang.cindex.CursorKind.TYPE_ALIAS_DECL,
                 ]):
                     logging.debug('Skipping member: %s %s %s %s', member.displayname, member.spelling, member.kind, member.type.kind)
 

--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -295,6 +295,7 @@ def get_serializable_classes_members(node, all_template_types=None, namespace=''
                     raise Exception('Unexposed declaration. This probably means (at the time of writing) that an unknown class was found (may happen, for instance, when the compiler does not find the headers for std::vector, i.e. missing -I option): %s %s %s %s %s' % (member.displayname, member.spelling, member.kind, member.type.kind, statement))
 
                 else:
+                    statement = get_statement(member)
                     raise Exception('Unknown kind. Please fix the script: %s %s %s %s %s' % (member.displayname, member.spelling, member.kind, member.type.kind, statement))
 
             if template_types:


### PR DESCRIPTION
Summary:
 - An update to the the JetCorrectorParameters software in order to speed it up.
 - Involves a new class (JetCorrectorParametersHelper) and some minor changes to the existing code
 - All changes to the JetCorrectorParameters class are transient
 - Changes are backwards compatible

Problem:
The more binned parameters you add to the condition, the slower the correction lookup is. As a concrete example, when you go from being binned in (eta) to being binned in (eta,pt) the condition goes from from 82 records in the lookup to almost 3000 records. If moving from being binned in (eta) to being binned in (eta,rho,pt), you now have 64000 records. Before the fix this slowed down the lookup table substantially.

Solution/Benchmarking:
With the changes there is a speedup for every jet correction lookup, even with one dimension of binning. For 1D corrections (L2L3Residual like) we see a speedup of ~2.3x (assuming binned with 82 eta bins), for 2D (L2L3 MC truth like) we see ~96.6x, and for 3D we see a speedup of ~12000x . All of these were measured using igprof. Also beneficial is the fact that there should be no noticeable change in behavior for the users or to any existing code. Everything is backwards compatible and requires no change to the database (i.e. all of the new code was made transient).

Documentation:
All of this work is documented in a report I gave to the JERC group (https://indico.cern.ch/event/617090/contributions/2490770/attachments/1420000/2175622/2017_02_23-Alexx-JetCorrectorParameters.pdf).

@kpedro88 @schoef 