### PR TITLE
Converted BaseEvtVtxGenerator to stream module

### DIFF
--- a/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
@@ -3,27 +3,24 @@
 /*
 */
 
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "TMatrixD.h"
-
-/*
-namespace HepMC {
-   class GenEvent;
-}
-*/
 
 namespace HepMC {
    class FourVector ;
 }
 
 namespace CLHEP {
-   //class Hep3Vector;
    class HepRandomEngine;
 }
 
-class BaseEvtVtxGenerator : public edm::EDProducer
+namespace edm {
+   class HepMCProduct;
+}
+
+class BaseEvtVtxGenerator : public edm::stream::EDProducer<>
 {
    public:
       
@@ -33,26 +30,18 @@ class BaseEvtVtxGenerator : public edm::EDProducer
       
    virtual void produce( edm::Event&, const edm::EventSetup&) override;
 
-   //virtual CLHEP::Hep3Vector* newVertex() = 0;
-   virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) = 0 ;
+   virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const = 0 ;
    /** This method - and the comment - is a left-over from COBRA-OSCAR time :
     *  return the last generated event vertex.
     *  If no vertex has been generated yet, a NULL pointer is returned. */
    //virtual CLHEP::Hep3Vector* lastVertex() { return fVertex; }
-   virtual HepMC::FourVector* lastVertex() { return fVertex; }
+   //virtual HepMC::FourVector* lastVertex() { return fVertex; }
    
-   virtual TMatrixD* GetInvLorentzBoost() = 0;
-   
-   protected:
-
-   //CLHEP::Hep3Vector*       fVertex;
-   HepMC::FourVector*       fVertex ;
-   TMatrixD *boost_;
-   double fTimeOffset;
-   
+   virtual TMatrixD const* GetInvLorentzBoost() const = 0;
+      
    private :
 
-   edm::InputTag            sourceLabel;
+   edm::EDGetTokenT<edm::HepMCProduct> sourceToken;
    
 };
 

--- a/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
@@ -24,9 +24,9 @@ public:
 
   /// return a new event vertex
   //virtual CLHEP::Hep3Vector * newVertex();
-  virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) ;
+  virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
 
-  virtual TMatrixD* GetInvLorentzBoost() {
+  virtual TMatrixD* GetInvLorentzBoost() const override {
 	  return 0;
   }
 

--- a/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BeamProfileVtxGenerator.h
@@ -26,7 +26,7 @@ public:
   //virtual CLHEP::Hep3Vector * newVertex();
   virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
 
-  virtual TMatrixD* GetInvLorentzBoost() const override {
+  virtual TMatrixD const* GetInvLorentzBoost() const override {
 	  return 0;
   }
 

--- a/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
@@ -37,9 +37,9 @@ public:
 
   /// return a new event vertex
   //virtual CLHEP::Hep3Vector * newVertex();
-  virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) override ;
+  virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override ;
 
-  virtual TMatrixD* GetInvLorentzBoost() override;
+  virtual TMatrixD const* GetInvLorentzBoost() const override;
 
     
   /// set resolution in Z in cm
@@ -52,38 +52,33 @@ public:
   /// set mean in Z in cm
   void Z0(double m=0) { fZ0=m; }
 
-  /// set half crossing angle
-  void Phi(double m=0) { phi_=m; }
-  /// angle between crossing plane and horizontal plane
-  void Alpha(double m=0) { alpha_=m; }
-
   /// set beta_star
   void betastar(double m=0) { fbetastar=m; }
   /// emittance (no the normalized)
   void emittance(double m=0) { femittance=m; }
 
   /// beta function
-  double BetaFunction(double z, double z0);
+  double BetaFunction(double z, double z0) const;
     
 private:
   /** Copy constructor */
   BetafuncEvtVtxGenerator(const BetafuncEvtVtxGenerator &p);
   /** Copy assignment operator */
   BetafuncEvtVtxGenerator&  operator = (const BetafuncEvtVtxGenerator & rhs );
-  
+
+  void setBoost(double alpha, double phi);
 private:
 
   bool readDB_;
 
-  double alpha_, phi_;
-  //TMatrixD boost_;
-  
   double fX0, fY0, fZ0;
   double fSigmaZ;
   //double fdxdz, fdydz;
   double fbetastar, femittance;
   //  double falpha;
   double fTimeOffset;
+
+  TMatrixD boost_;
 
   void update(const edm::EventSetup& iEventSetup);
   edm::ESWatcher<SimBeamSpotObjectsRcd> parameterWatcher_;

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -23,7 +23,7 @@ public:
   //virtual CLHEP::Hep3Vector* newVertex();
   virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override ;
 
-  virtual const TMatrixD* GetInvLorentzBoost() const {
+  virtual const TMatrixD* GetInvLorentzBoost() const override {
 	  return 0;
   }
 

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -21,9 +21,9 @@ public:
 
   /// return a new event vertex
   //virtual CLHEP::Hep3Vector* newVertex();
-  virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) ;
+  virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override ;
 
-  virtual TMatrixD* GetInvLorentzBoost() {
+  virtual const TMatrixD* GetInvLorentzBoost() const {
 	  return 0;
   }
 

--- a/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
@@ -23,7 +23,7 @@ public:
   //virtual CLHEP::Hep3Vector* newVertex();
   virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
 
-  virtual TMatrixD* GetInvLorentzBoost() const override {
+  virtual TMatrixD const* GetInvLorentzBoost() const override {
 	  return 0;
   }
 

--- a/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
@@ -21,9 +21,9 @@ public:
 
   /// return a new event vertex
   //virtual CLHEP::Hep3Vector* newVertex();
-  virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) ;
+  virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
 
-  virtual TMatrixD* GetInvLorentzBoost() {
+  virtual TMatrixD* GetInvLorentzBoost() const override {
 	  return 0;
   }
 

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -34,9 +34,9 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
     /// return a new event vertex
-    virtual HepMC::FourVector* newVertex(CLHEP::HepRandomEngine*) ;
+    virtual HepMC::FourVector newVertex(CLHEP::HepRandomEngine*) const override;
 
-    virtual TMatrixD* GetInvLorentzBoost() {return 0;};
+    virtual TMatrixD const* GetInvLorentzBoost() const override {return 0;};
    
 private:
     /** Copy constructor */

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -28,8 +28,6 @@ using namespace CLHEP;
 
 
 BaseEvtVtxGenerator::BaseEvtVtxGenerator( const ParameterSet& pset ) 
-	: fVertex(0), boost_(0), fTimeOffset(0),
-	  sourceLabel(pset.getParameter<edm::InputTag>("src"))
 {
    Service<RandomNumberGenerator> rng;
    if ( ! rng.isAvailable()) {
@@ -40,16 +38,12 @@ BaseEvtVtxGenerator::BaseEvtVtxGenerator( const ParameterSet& pset )
           "in the configuration file or remove the modules that require it.";
    }
 
-   consumes<edm::HepMCProduct>(sourceLabel);
+   sourceToken=consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"));
    produces<edm::HepMCProduct>();
 }
 
 BaseEvtVtxGenerator::~BaseEvtVtxGenerator() 
 {
-   delete fVertex ;
-   if (boost_ != nullptr ) delete boost_;
-   // no need since now it's done in HepMCProduct
-   // delete fEvt ;
 }
 
 void BaseEvtVtxGenerator::produce( Event& evt, const EventSetup& )
@@ -59,7 +53,7 @@ void BaseEvtVtxGenerator::produce( Event& evt, const EventSetup& )
 
    Handle<HepMCProduct> HepUnsmearedMCEvt ;
    
-   evt.getByLabel( sourceLabel, HepUnsmearedMCEvt ) ;
+   evt.getByToken( sourceToken, HepUnsmearedMCEvt ) ;
    
    // Copy the HepMC::GenEvent
    HepMC::GenEvent* genevt = new HepMC::GenEvent(*HepUnsmearedMCEvt->GetEvent());

--- a/IOMC/EventVertexGenerators/src/BeamProfileVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BeamProfileVtxGenerator.cc
@@ -86,7 +86,7 @@ BeamProfileVtxGenerator::~BeamProfileVtxGenerator() {
 
 
 //Hep3Vector * BeamProfileVtxGenerator::newVertex() {
-HepMC::FourVector* BeamProfileVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
+HepMC::FourVector BeamProfileVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
   double aX, aY;
   if (ffile) {
     double r1 = engine->flat();
@@ -157,15 +157,11 @@ HepMC::FourVector* BeamProfileVtxGenerator::newVertex(CLHEP::HepRandomEngine* en
      yp = pv.y() ;
      zp = pv.z() ;
   }
-  //if (fVertex == 0) fVertex = new CLHEP::Hep3Vector;
-  //fVertex->set(xp, yp, zp);
-  if (fVertex == 0 ) fVertex = new HepMC::FourVector() ;
-  fVertex->set(xp, yp, zp, fTimeOffset );
 
   LogDebug("VertexGenerator") << "BeamProfileVtxGenerator: Vertex created "
 			      << "at (" << xp << ", " << yp << ", "
 			      << zp << ", " << fTimeOffset << ")";
-  return fVertex;
+  return HepMC::FourVector(xp, yp, zp, fTimeOffset );;
 }
 
 void BeamProfileVtxGenerator::sigmaX(double s) { 

--- a/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
@@ -46,12 +46,12 @@ BetafuncEvtVtxGenerator::BetafuncEvtVtxGenerator(const edm::ParameterSet & p )
     fY0 =        p.getParameter<double>("Y0")*cm;
     fZ0 =        p.getParameter<double>("Z0")*cm;
     fSigmaZ =    p.getParameter<double>("SigmaZ")*cm;
-    alpha_ =     p.getParameter<double>("Alpha")*radian;
-    phi_ =       p.getParameter<double>("Phi")*radian;
     fbetastar =  p.getParameter<double>("BetaStar")*cm;
     femittance = p.getParameter<double>("Emittance")*cm; // this is not the normalized emittance
     fTimeOffset = p.getParameter<double>("TimeOffset")*ns*c_light; // HepMC time units are mm
-    
+
+    setBoost(p.getParameter<double>("Alpha")*radian,
+             p.getParameter<double>("Phi")*radian);
     if (fSigmaZ <= 0) {
       throw cms::Exception("Configuration")
 	<< "Error in BetafuncEvtVtxGenerator: "
@@ -80,21 +80,16 @@ void BetafuncEvtVtxGenerator::update(const edm::EventSetup& iEventSetup){
     fY0=beamhandle->fY0;
     fZ0=beamhandle->fZ0;
     //    falpha=beamhandle->fAlpha;
-    alpha_=beamhandle->fAlpha;
-    phi_=beamhandle->fPhi;
     fSigmaZ=beamhandle->fSigmaZ;
     fTimeOffset=beamhandle->fTimeOffset;
     fbetastar=beamhandle->fbetastar;
     femittance=beamhandle->femittance;
+    setBoost(beamhandle->fAlpha,beamhandle->fPhi);
 
-    //re-initialize the boost matrix
-    delete boost_;
-    boost_=0;
   }
 }
 
-//Hep3Vector* BetafuncEvtVtxGenerator::newVertex() {
-HepMC::FourVector* BetafuncEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
+HepMC::FourVector BetafuncEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
 
 	
 	double X,Y,Z;
@@ -115,18 +110,48 @@ HepMC::FourVector* BetafuncEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* en
 	double tmp_sigt = CLHEP::RandGaussQ::shoot(engine, 0., fSigmaZ);
 	double T = tmp_sigt + fTimeOffset; 
 
-	if ( fVertex == 0 ) fVertex = new HepMC::FourVector();
-	fVertex->set(X,Y,Z,T);
-		
-	return fVertex;
+	return HepMC::FourVector(X,Y,Z,T);
 }
 
-double BetafuncEvtVtxGenerator::BetaFunction(double z, double z0)
+double BetafuncEvtVtxGenerator::BetaFunction(double z, double z0) const
 {
 	return sqrt(femittance*(fbetastar+(((z-z0)*(z-z0))/fbetastar)));
 
 }
 
+void BetafuncEvtVtxGenerator::setBoost(double alpha, double phi) 
+{
+  //boost_.ResizeTo(4,4);
+  //boost_ = new TMatrixD(4,4);
+  TMatrixD tmpboost(4,4);
+  
+  //if ( (alpha_ == 0) && (phi_==0) ) { boost_->Zero(); return boost_; }
+  
+  // Lorentz boost to frame where the collision is head-on
+  // phi is the half crossing angle in the plane ZS
+  // alpha is the angle to the S axis from the X axis in the XY plane
+  
+  tmpboost(0,0) = 1./cos(phi);
+  tmpboost(0,1) = - cos(alpha)*sin(phi);
+  tmpboost(0,2) = - tan(phi)*sin(phi);
+  tmpboost(0,3) = - sin(alpha)*sin(phi);
+  tmpboost(1,0) = - cos(alpha)*tan(phi);
+  tmpboost(1,1) = 1.;
+  tmpboost(1,2) = cos(alpha)*tan(phi);
+  tmpboost(1,3) = 0.;
+  tmpboost(2,0) = 0.;
+  tmpboost(2,1) = - cos(alpha)*sin(phi);
+  tmpboost(2,2) = cos(phi);
+  tmpboost(2,3) = - sin(alpha)*sin(phi);
+  tmpboost(3,0) = - sin(alpha)*tan(phi);
+  tmpboost(3,1) = 0.;
+  tmpboost(3,2) = sin(alpha)*tan(phi);
+  tmpboost(3,3) = 1.;
+  
+  tmpboost.Invert();
+  boost_ = tmpboost;
+  //boost_->Print();
+}
 
 void BetafuncEvtVtxGenerator::sigmaZ(double s) 
 { 
@@ -140,43 +165,7 @@ void BetafuncEvtVtxGenerator::sigmaZ(double s)
 	}
 }
 
-TMatrixD* BetafuncEvtVtxGenerator::GetInvLorentzBoost() {
+TMatrixD const* BetafuncEvtVtxGenerator::GetInvLorentzBoost() const {
 
-	//alpha_ = 0;
-	//phi_ = 142.e-6;
-	
-	if (boost_ != 0 ) return boost_;
-	
-	//boost_.ResizeTo(4,4);
-	//boost_ = new TMatrixD(4,4);
-	TMatrixD tmpboost(4,4);
-	
-	//if ( (alpha_ == 0) && (phi_==0) ) { boost_->Zero(); return boost_; }
-	
-	// Lorentz boost to frame where the collision is head-on
-	// phi is the half crossing angle in the plane ZS
-	// alpha is the angle to the S axis from the X axis in the XY plane
-	
-	tmpboost(0,0) = 1./cos(phi_);
-	tmpboost(0,1) = - cos(alpha_)*sin(phi_);
-	tmpboost(0,2) = - tan(phi_)*sin(phi_);
-	tmpboost(0,3) = - sin(alpha_)*sin(phi_);
-	tmpboost(1,0) = - cos(alpha_)*tan(phi_);
-	tmpboost(1,1) = 1.;
-	tmpboost(1,2) = cos(alpha_)*tan(phi_);
-	tmpboost(1,3) = 0.;
-	tmpboost(2,0) = 0.;
-	tmpboost(2,1) = - cos(alpha_)*sin(phi_);
-	tmpboost(2,2) = cos(phi_);
-	tmpboost(2,3) = - sin(alpha_)*sin(phi_);
-	tmpboost(3,0) = - sin(alpha_)*tan(phi_);
-	tmpboost(3,1) = 0.;
-	tmpboost(3,2) = sin(alpha_)*tan(phi_);
-	tmpboost(3,3) = 1.;
-
-	tmpboost.Invert();
-	boost_ = new TMatrixD(tmpboost);
-	//boost_->Print();
-	
-	return boost_;
+  return &boost_;
 }

--- a/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
@@ -38,7 +38,8 @@ ________________________________________________________________________
 
 
 BetafuncEvtVtxGenerator::BetafuncEvtVtxGenerator(const edm::ParameterSet & p )
-: BaseEvtVtxGenerator(p)
+: BaseEvtVtxGenerator(p),
+  boost_(4,4)
 { 
   readDB_=p.getParameter<bool>("readDB");
   if (!readDB_){

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -44,19 +44,14 @@ FlatEvtVtxGenerator::~FlatEvtVtxGenerator()
 }
 
 //Hep3Vector * FlatEvtVtxGenerator::newVertex() {
-HepMC::FourVector* FlatEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
+HepMC::FourVector FlatEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
   double aX,aY,aZ,aT;
   aX = CLHEP::RandFlat::shoot(engine, fMinX, fMaxX);
   aY = CLHEP::RandFlat::shoot(engine, fMinY, fMaxY);
   aZ = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
   aT = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
 
-  //if (fVertex == 0) fVertex = new CLHEP::Hep3Vector;
-  //fVertex->set(aX,aY,aZ);
-  if ( fVertex == 0 ) fVertex = new HepMC::FourVector() ;
-  fVertex->set(aX,aY,aZ,aT+fTimeOffset);
-
-  return fVertex;
+  return HepMC::FourVector(aX,aY,aZ,aT+fTimeOffset);
 }
 
 void FlatEvtVtxGenerator::minX(double min) 

--- a/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
@@ -44,19 +44,14 @@ GaussEvtVtxGenerator::~GaussEvtVtxGenerator()
 }
 
 
-//Hep3Vector* GaussEvtVtxGenerator::newVertex() {
-HepMC::FourVector* GaussEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
+HepMC::FourVector GaussEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
   double X,Y,Z,T;
   X = CLHEP::RandGaussQ::shoot(engine, fMeanX, fSigmaX);
   Y = CLHEP::RandGaussQ::shoot(engine, fMeanY, fSigmaY);
   Z = CLHEP::RandGaussQ::shoot(engine, fMeanZ, fSigmaZ);
   T = CLHEP::RandGaussQ::shoot(engine, fTimeOffset, fSigmaZ);
 
-  //if (fVertex == 0) fVertex = new CLHEP::Hep3Vector;
-  if ( fVertex == 0 ) fVertex = new HepMC::FourVector() ;
-  fVertex->set( X, Y, Z, T);
-
-  return fVertex;
+  return HepMC::FourVector( X, Y, Z, T);
 }
 
 void GaussEvtVtxGenerator::sigmaX(double s) 

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -85,7 +85,7 @@ HLLHCEvtVtxGenerator::~HLLHCEvtVtxGenerator()
 }
 
 
-HepMC::FourVector* HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) {
+HepMC::FourVector HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
 
   double imax=intensity(0.,0.,0.,0.);
 
@@ -110,10 +110,7 @@ HepMC::FourVector* HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engin
   
   if (count>9999) edm::LogError("Too many tries ") 
                     << " count : "<<count<<endl;
-  
-  if(fVertex == 0)
-    fVertex = new HepMC::FourVector();
-  
+    
   //---convert to mm
   x*=1000.0;
   y*=1000.0;
@@ -125,9 +122,7 @@ HepMC::FourVector* HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engin
   z+=fMeanZ;
   t+=fTimeOffset;
   
-  fVertex->set( x, y, z, t );
-  
-  return fVertex;
+  return HepMC::FourVector( x, y, z, t );
 }
 
 

--- a/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/HepMCProduct.h
@@ -26,9 +26,12 @@ namespace edm {
 
 		void addHepMCData(HepMC::GenEvent *evt);
 
-		void applyVtxGen(HepMC::FourVector *vtxShift);
+		void applyVtxGen(HepMC::FourVector const* vtxShift) {
+                  applyVtxGen(*vtxShift);
+                }
+		void applyVtxGen(HepMC::FourVector const& vtxShift);
 
-		void boostToLab(TMatrixD *lorentz, std::string type);
+		void boostToLab(TMatrixD const* lorentz, std::string const& type);
 
 		const HepMC::GenEvent &getHepMCData() const;
 

--- a/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/HepMCProduct.cc
@@ -36,7 +36,7 @@ void HepMCProduct::addHepMCData( HepMC::GenEvent  *evt){
   
 }
 
-void HepMCProduct::applyVtxGen( HepMC::FourVector* vtxShift )
+void HepMCProduct::applyVtxGen( HepMC::FourVector const& vtxShift )
 {
 	//std::cout<< " applyVtxGen called " << isVtxGenApplied_ << endl;
 	//fTimeOffset = 0;
@@ -47,10 +47,10 @@ void HepMCProduct::applyVtxGen( HepMC::FourVector* vtxShift )
                                           vt!=evt_->vertices_end(); ++vt )
    {
             
-      double x = (*vt)->position().x() + vtxShift->x() ;
-      double y = (*vt)->position().y() + vtxShift->y() ;
-      double z = (*vt)->position().z() + vtxShift->z() ;
-      double t = (*vt)->position().t() + vtxShift->t() ;
+      double x = (*vt)->position().x() + vtxShift.x() ;
+      double y = (*vt)->position().y() + vtxShift.y() ;
+      double z = (*vt)->position().z() + vtxShift.z() ;
+      double t = (*vt)->position().t() + vtxShift.t() ;
       //std::cout << " vertex (x,y,z)= " << x <<" " << y << " " << z << std::endl;
       (*vt)->set_position( HepMC::FourVector(x,y,z,t) ) ;      
    }
@@ -61,7 +61,7 @@ void HepMCProduct::applyVtxGen( HepMC::FourVector* vtxShift )
 
 } 
 
-void HepMCProduct::boostToLab( TMatrixD* lorentz, std::string type ) {
+void HepMCProduct::boostToLab( TMatrixD const* lorentz, std::string const& type ) {
 
 	//std::cout << "from boostToLab:" << std::endl;
 	


### PR DESCRIPTION
Measurements of GEN+SIM steps with large number of threads showed the vertex generator used was stalling. This converts all the vertex generators inheriting from BaseEvtVtxGenerator into stream modules.