### PR TITLE
Update tag&probe package for egm [91X PR]

### DIFF
--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -61,6 +61,9 @@
 
   <class name="std::vector<reco::RecoEcalCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::RecoEcalCandidate> >"/>
+
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::RecoEcalCandidate> > >"/>
+
   <class name="edm::Ref<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>
   <class name="edm::RefProd<std::vector<reco::RecoEcalCandidate> >"/>
   <class name="edm::RefVector<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -61,9 +61,6 @@
 
   <class name="std::vector<reco::RecoEcalCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::RecoEcalCandidate> >"/>
-
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::RecoEcalCandidate> > >"/>
-
   <class name="edm::Ref<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>
   <class name="edm::RefProd<std::vector<reco::RecoEcalCandidate> >"/>
   <class name="edm::RefVector<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>

--- a/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
+++ b/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
@@ -12,6 +12,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/METReco/interface/MET.h"
 #include "DataFormats/METReco/interface/METCollection.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
@@ -24,6 +25,9 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
+
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h" 
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 #include <TTree.h>
 #include <boost/utility.hpp>
@@ -170,13 +174,16 @@ class BaseTreeFiller : boost::noncopyable {
         /// How event weights are defined: 'None' = no weights, 'Fixed' = one value specified in cfg file, 'External' = read weight from the event (as double)
         enum WeightMode { None, Fixed, External };
         WeightMode weightMode_;
-        edm::EDGetTokenT<double> weightSrcToken_;
+        edm::EDGetTokenT<GenEventInfoProduct> weightSrcToken_;
 	edm::EDGetTokenT<double> PUweightSrcToken_;
+	edm::EDGetTokenT<double> rhoToken_;
         edm::EDGetTokenT<reco::VertexCollection> recVtxsToken_;
         edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
         edm::EDGetTokenT<reco::CaloMETCollection> metToken_;
         edm::EDGetTokenT<reco::METCollection> tcmetToken_;
         edm::EDGetTokenT<reco::PFMETCollection> pfmetToken_;
+	edm::EDGetTokenT<pat::METCollection>    pfmetTokenMiniAOD_;
+	edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupInfoToken_;
 
         /// Ignore exceptions when evaluating variables
         bool ignoreExceptions_;
@@ -189,20 +196,22 @@ class BaseTreeFiller : boost::noncopyable {
 
         /// Add branches with event variables: met, sum ET, .. etc.
 	bool addEventVariablesInfo_;
-
+	bool addRho_;
+	bool addCaloMet_;
+	
         void addBranches_(TTree *tree, const edm::ParameterSet &iConfig, edm::ConsumesCollector & iC, const std::string &branchNamePrefix="") ;
 
         //implementation notice: these two are 'mutable' because we will fill them from a 'const' method
         mutable TTree * tree_;
-        mutable float weight_;
-	mutable float PUweight_;
+        mutable float  weight_, PUweight_, totWeight_;
         mutable uint32_t run_, lumi_, mNPV_;
         mutable uint64_t event_;
+        mutable int truePU_;
 
         mutable float mPVx_,mPVy_,mPVz_,mBSx_,mBSy_,mBSz_;
-
+	mutable float rho_;
         mutable float mMET_,mSumET_,mMETSign_,mtcMET_,mtcSumET_,
-	  mtcMETSign_,mpfMET_,mpfSumET_,mpfMETSign_;
+	  mtcMETSign_,mpfMET_,mpfSumET_,mpfMETSign_, mpfPhi_;
 };
 
 

--- a/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
+++ b/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
@@ -12,7 +12,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/METReco/interface/MET.h"
 #include "DataFormats/METReco/interface/METCollection.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
@@ -25,9 +24,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
-
-#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h" 
-#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 #include <TTree.h>
 #include <boost/utility.hpp>
@@ -174,16 +170,13 @@ class BaseTreeFiller : boost::noncopyable {
         /// How event weights are defined: 'None' = no weights, 'Fixed' = one value specified in cfg file, 'External' = read weight from the event (as double)
         enum WeightMode { None, Fixed, External };
         WeightMode weightMode_;
-        edm::EDGetTokenT<GenEventInfoProduct> weightSrcToken_;
+        edm::EDGetTokenT<double> weightSrcToken_;
 	edm::EDGetTokenT<double> PUweightSrcToken_;
-	edm::EDGetTokenT<double> rhoToken_;
         edm::EDGetTokenT<reco::VertexCollection> recVtxsToken_;
         edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
         edm::EDGetTokenT<reco::CaloMETCollection> metToken_;
         edm::EDGetTokenT<reco::METCollection> tcmetToken_;
         edm::EDGetTokenT<reco::PFMETCollection> pfmetToken_;
-	edm::EDGetTokenT<pat::METCollection>    pfmetTokenMiniAOD_;
-	edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupInfoToken_;
 
         /// Ignore exceptions when evaluating variables
         bool ignoreExceptions_;
@@ -196,22 +189,20 @@ class BaseTreeFiller : boost::noncopyable {
 
         /// Add branches with event variables: met, sum ET, .. etc.
 	bool addEventVariablesInfo_;
-	bool addRho_;
-	bool addCaloMet_;
-	
+
         void addBranches_(TTree *tree, const edm::ParameterSet &iConfig, edm::ConsumesCollector & iC, const std::string &branchNamePrefix="") ;
 
         //implementation notice: these two are 'mutable' because we will fill them from a 'const' method
         mutable TTree * tree_;
-        mutable float  weight_, PUweight_, totWeight_;
+        mutable float weight_;
+	mutable float PUweight_;
         mutable uint32_t run_, lumi_, mNPV_;
         mutable uint64_t event_;
-        mutable int truePU_;
 
         mutable float mPVx_,mPVy_,mPVz_,mBSx_,mBSy_,mBSz_;
-	mutable float rho_;
+
         mutable float mMET_,mSumET_,mMETSign_,mtcMET_,mtcSumET_,
-	  mtcMETSign_,mpfMET_,mpfSumET_,mpfMETSign_, mpfPhi_;
+	  mtcMETSign_,mpfMET_,mpfSumET_,mpfMETSign_;
 };
 
 

--- a/PhysicsTools/TagAndProbe/interface/TagProbePairMaker.h
+++ b/PhysicsTools/TagAndProbe/interface/TagProbePairMaker.h
@@ -33,7 +33,7 @@ namespace tnp {
             TagProbePairs run(const edm::Event &iEvent) const ;
         private:
             edm::EDGetTokenT<reco::CandidateView> srcToken_;
-            enum Arbitration { None, OneProbe, BestMass, Random2, NonDuplicate, OnePair };
+            enum Arbitration { None, OneProbe, BestMass, Random2, NonDuplicate, OnePair, HighestPt };
             Arbitration arbitration_;
             double arbitrationMass_;
             void arbitrate(TagProbePairs &pairs) const ;

--- a/PhysicsTools/TagAndProbe/interface/TagProbePairMaker.h
+++ b/PhysicsTools/TagAndProbe/interface/TagProbePairMaker.h
@@ -33,7 +33,7 @@ namespace tnp {
             TagProbePairs run(const edm::Event &iEvent) const ;
         private:
             edm::EDGetTokenT<reco::CandidateView> srcToken_;
-            enum Arbitration { None, OneProbe, BestMass, Random2, NonDuplicate, OnePair, HighestPt };
+            enum Arbitration { None, OneProbe, BestMass, Random2, NonDuplicate, OnePair };
             Arbitration arbitration_;
             double arbitrationMass_;
             void arbitrate(TagProbePairs &pairs) const ;

--- a/PhysicsTools/TagAndProbe/plugins/RecoEcalCandidateSelector.cc
+++ b/PhysicsTools/TagAndProbe/plugins/RecoEcalCandidateSelector.cc
@@ -2,6 +2,7 @@
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
 
 typedef SingleObjectSelector<
    std::vector<reco::RecoEcalCandidate>, 
@@ -10,3 +11,20 @@ typedef SingleObjectSelector<
    > RecoEcalCandidateSelector;
 
 DEFINE_FWK_MODULE( RecoEcalCandidateSelector );
+
+
+typedef SingleObjectSelector<
+  reco::RecoEcalCandidateCollection, 
+  StringCutObjectSelector<reco::RecoEcalCandidate>,
+  reco::RecoEcalCandidateRefVector
+  > RecoEcalCandidateRefSelector;
+
+
+//typedef SingleObjectSelector<
+//   std::vector<reco::RecoEcalCandidate>, 
+//   StringCutObjectSelector<reco::RecoEcalCandidate>,
+//   std::vector<reco::RecoEcalCandidate>
+//   > RecoEcalCandidateSelector;
+
+DEFINE_FWK_MODULE( RecoEcalCandidateRefSelector );
+

--- a/PhysicsTools/TagAndProbe/plugins/RecoEcalCandidateSelector.cc
+++ b/PhysicsTools/TagAndProbe/plugins/RecoEcalCandidateSelector.cc
@@ -2,7 +2,6 @@
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
-#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
 
 typedef SingleObjectSelector<
    std::vector<reco::RecoEcalCandidate>, 
@@ -11,20 +10,3 @@ typedef SingleObjectSelector<
    > RecoEcalCandidateSelector;
 
 DEFINE_FWK_MODULE( RecoEcalCandidateSelector );
-
-
-typedef SingleObjectSelector<
-  reco::RecoEcalCandidateCollection, 
-  StringCutObjectSelector<reco::RecoEcalCandidate>,
-  reco::RecoEcalCandidateRefVector
-  > RecoEcalCandidateRefSelector;
-
-
-//typedef SingleObjectSelector<
-//   std::vector<reco::RecoEcalCandidate>, 
-//   StringCutObjectSelector<reco::RecoEcalCandidate>,
-//   std::vector<reco::RecoEcalCandidate>
-//   > RecoEcalCandidateSelector;
-
-DEFINE_FWK_MODULE( RecoEcalCandidateRefSelector );
-

--- a/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
+++ b/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
@@ -2,14 +2,10 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-
 #include "PhysicsTools/TagAndProbe/interface/ColinsSoperVariables.h"
 
 #include <TList.h>
 #include <TObjString.h>
-
-#include <iostream>
-using namespace std;
 
 tnp::ProbeVariable::~ProbeVariable() {}
 
@@ -47,60 +43,41 @@ tnp::BaseTreeFiller::BaseTreeFiller(const char *name, const edm::ParameterSet& i
         weight_ = iConfig.getParameter<double>("eventWeight");
     } else if (iConfig.existsAs<edm::InputTag>("eventWeight")) {
         weightMode_ = External;
-        weightSrcToken_ = iC.consumes<GenEventInfoProduct>(iConfig.getParameter<edm::InputTag>("eventWeight"));
+        weightSrcToken_ = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("eventWeight"));
     } else {
         weightMode_ = None;
     }
     if (weightMode_ != None) {
         tree_->Branch("weight", &weight_, "weight/F");
-	tree_->Branch("totWeight", &totWeight_, "totWeight/F");
     }
-
     storePUweight_ = iConfig.existsAs<edm::InputTag>("PUWeightSrc") ? true: false;
-    if(storePUweight_) {      
-      PUweightSrcToken_   = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("PUWeightSrc"));
+    if(storePUweight_) {
+      PUweightSrcToken_   = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("PUWeightSrc")); 
       tree_->Branch("PUweight", &PUweight_, "PUweight/F");
-    }    
-    
-    if( iConfig.existsAs<edm::InputTag>("pileupInfoTag") ) 
-      pileupInfoToken_= iC.consumes<std::vector<PileupSummaryInfo> >(iConfig.getParameter<edm::InputTag>("pileupInfoTag"));
+    }
 
     addRunLumiInfo_ = iConfig.existsAs<bool>("addRunLumiInfo") ? iConfig.getParameter<bool>("addRunLumiInfo") : false;
     if (addRunLumiInfo_) {
          tree_->Branch("run",  &run_,  "run/i");
          tree_->Branch("lumi", &lumi_, "lumi/i");
          tree_->Branch("event", &event_, "event/l");
-	 tree_->Branch("truePU", &truePU_, "truePU/I");
     }
     addEventVariablesInfo_ = iConfig.existsAs<bool>("addEventVariablesInfo") ? iConfig.getParameter<bool>("addEventVariablesInfo") : false;
     if (addEventVariablesInfo_) {
-      /// FC (EGM) - add possibility to customize collections (can run other miniAOD)
-      edm::InputTag bsIT    = iConfig.existsAs<edm::InputTag>("beamSpot") ?  iConfig.getParameter<edm::InputTag>("beamSpot") : edm::InputTag("offlineBeamSpot");
-      edm::InputTag vtxIT   = iConfig.existsAs<edm::InputTag>("vertexCollection") ?  iConfig.getParameter<edm::InputTag>("vertexCollection") : edm::InputTag("offlinePrimaryVertices");
-      edm::InputTag pfMetIT = iConfig.existsAs<edm::InputTag>("pfMet") ?  iConfig.getParameter<edm::InputTag>("pfMet") : edm::InputTag("pfMet");
-      edm::InputTag tcMetIT = iConfig.existsAs<edm::InputTag>("tcMet") ?  iConfig.getParameter<edm::InputTag>("tcMet") : edm::InputTag("tcMet");
-      edm::InputTag clMetIT = iConfig.existsAs<edm::InputTag>("clMet") ?  iConfig.getParameter<edm::InputTag>("clMet") : edm::InputTag("met");
- 
-      recVtxsToken_      = iC.consumes<reco::VertexCollection>(vtxIT);
-      beamSpotToken_     = iC.consumes<reco::BeamSpot>(bsIT);
-      pfmetToken_        = iC.mayConsume<reco::PFMETCollection>(pfMetIT);
-      pfmetTokenMiniAOD_ = iC.mayConsume<pat::METCollection>(pfMetIT);
-      addCaloMet_ = iConfig.existsAs<bool>("addCaloMet") ? iConfig.getParameter<bool>("addCaloMet") : true;      
-      tree_->Branch("event_nPV"             ,&mNPV_                 ,"mNPV/I");
-      if( addCaloMet_ ) {
-	metToken_   = iC.mayConsume<reco::CaloMETCollection>(clMetIT);
-	tcmetToken_ = iC.mayConsume<reco::METCollection>(    tcMetIT);
-	tree_->Branch("event_met_calomet"    ,&mMET_                ,"mMET/F");
-	tree_->Branch("event_met_calosumet"  ,&mSumET_              ,"mSumET/F");
-	tree_->Branch("event_met_calometsignificance",&mMETSign_    ,"mMETSign/F");
-	tree_->Branch("event_met_tcmet"    ,&mtcMET_                ,"mtcMET/F");
-	tree_->Branch("event_met_tcsumet"  ,&mtcSumET_              ,"mtcSumET/F");
-	tree_->Branch("event_met_tcmetsignificance",&mtcMETSign_    ,"mtcMETSign/F");
-      }      
+      recVtxsToken_ = iC.consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
+      beamSpotToken_ = iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
+      metToken_ = iC.consumes<reco::CaloMETCollection>(edm::InputTag("met"));
+      tcmetToken_ = iC.consumes<reco::METCollection>(edm::InputTag("tcMet"));
+      pfmetToken_ = iC.consumes<reco::PFMETCollection>(edm::InputTag("pfMet"));
+      tree_->Branch("event_nPV"        ,&mNPV_                 ,"mNPV/I");
+      tree_->Branch("event_met_calomet"    ,&mMET_                ,"mMET/F");
+      tree_->Branch("event_met_calosumet"  ,&mSumET_              ,"mSumET/F");
+      tree_->Branch("event_met_calometsignificance",&mMETSign_    ,"mMETSign/F");
+      tree_->Branch("event_met_tcmet"    ,&mtcMET_                ,"mtcMET/F");
+      tree_->Branch("event_met_tcsumet"  ,&mtcSumET_              ,"mtcSumET/F");
+      tree_->Branch("event_met_tcmetsignificance",&mtcMETSign_    ,"mtcMETSign/F");
       tree_->Branch("event_met_pfmet"    ,&mpfMET_                ,"mpfMET/F");
-      tree_->Branch("event_met_pfphi"    ,&mpfPhi_                ,"mpfPhi/F");
       tree_->Branch("event_met_pfsumet"  ,&mpfSumET_              ,"mpfSumET/F");
-      
       tree_->Branch("event_met_pfmetsignificance",&mpfMETSign_    ,"mpfMETSign/F");
       tree_->Branch("event_PrimaryVertex_x"  ,&mPVx_              ,"mPVx/F");
       tree_->Branch("event_PrimaryVertex_y"  ,&mPVy_              ,"mPVy/F");
@@ -109,13 +86,6 @@ tnp::BaseTreeFiller::BaseTreeFiller(const char *name, const edm::ParameterSet& i
       tree_->Branch("event_BeamSpot_y"       ,&mBSy_              ,"mBSy/F");
       tree_->Branch("event_BeamSpot_z"       ,&mBSz_              ,"mBSz/F");
     }
-
-    addRho_ = iConfig.existsAs<edm::InputTag>("rho") ? true : false;
-    if (addRho_) {
-      rhoToken_ = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
-      tree_->Branch("event_rho"    ,&rho_   ,"rho/F");
-    }
-    
 
     ignoreExceptions_ = iConfig.existsAs<bool>("ignoreExceptions") ? iConfig.getParameter<bool>("ignoreExceptions") : false;
 }
@@ -126,7 +96,7 @@ tnp::BaseTreeFiller::BaseTreeFiller(BaseTreeFiller &main, const edm::ParameterSe
   tree_(0)
 {
     addRunLumiInfo_ = main.addRunLumiInfo_;
-    storePUweight_  = main.storePUweight_;
+    storePUweight_ = main.storePUweight_;
     addBranches_(main.tree_, iConfig, iC, branchNamePrefix);
 }
 
@@ -175,14 +145,6 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
     lumi_ = iEvent.id().luminosityBlock();
     event_ = iEvent.id().event();
 
-    truePU_ = 0;
-    if (!iEvent.isRealData() and !pileupInfoToken_.isUninitialized()) {
-      edm::Handle<std::vector<PileupSummaryInfo> > PupInfo;
-      iEvent.getByToken(pileupInfoToken_, PupInfo);
-      truePU_ = PupInfo->begin()->getTrueNumInteractions();
-    }
-
-    totWeight_ = 1.;
     for (std::vector<tnp::ProbeVariable>::const_iterator it = vars_.begin(), ed = vars_.end(); it != ed; ++it) {
         it->init(iEvent);
     }
@@ -190,22 +152,17 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
         it->init(iEvent);
     }
     if (weightMode_ == External) {
-      // edm::Handle<double> weight;
-      //        iEvent.getByToken(weightSrcToken_, weight);
-      //        weight_ = *weight;
-	edm::Handle<GenEventInfoProduct> weight;
-	iEvent.getByToken(weightSrcToken_, weight);
-	weight_ = weight->weight();
-	totWeight_ *= weight_;
+        edm::Handle<double> weight;
+        iEvent.getByToken(weightSrcToken_, weight);
+        weight_ = *weight;
     }
 
     ///// ********** Pileup weight: needed for MC re-weighting for PU ************* 
-    PUweight_ = 1;
-    if(storePUweight_  and !PUweightSrcToken_.isUninitialized() ) {
-      edm::Handle<double> weightPU;
-      bool isPresent = iEvent.getByToken(PUweightSrcToken_, weightPU);
-      if(isPresent) PUweight_ = float(*weightPU);
-      totWeight_ *= PUweight_;
+     edm::Handle<std::vector<float> > weightPU;
+     if(storePUweight_) {
+       bool isPresent = iEvent.getByToken(PUweightSrcToken_, weightPU);
+       if(isPresent) PUweight_ = (*weightPU).at(0);
+       else PUweight_ = 1.0;
      }
      
     if (addEventVariablesInfo_) {
@@ -231,6 +188,7 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
           }
         }
 
+
         //////////// Beam spot //////////////
         edm::Handle<reco::BeamSpot> beamSpot;
         iEvent.getByToken(beamSpotToken_, beamSpot);
@@ -238,7 +196,7 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
         mBSy_ = beamSpot->position().Y();
         mBSz_ = beamSpot->position().Z();
 
-	if( addCaloMet_) {
+
         ////////////// CaloMET //////
         edm::Handle<reco::CaloMETCollection> met;
         iEvent.getByToken(metToken_,met);
@@ -252,7 +210,7 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
           mSumET_ = (*met)[0].sumEt();
           mMETSign_ = (*met)[0].significance();
         }
-	
+
         /////// TcMET information /////
         edm::Handle<reco::METCollection> tcmet;
         iEvent.getByToken(tcmetToken_, tcmet);
@@ -266,49 +224,29 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
           mtcSumET_ = (*tcmet)[0].sumEt();
           mtcMETSign_ = (*tcmet)[0].significance();
         }
-	}
-	
+
         /////// PfMET information /////
         edm::Handle<reco::PFMETCollection> pfmet;
         iEvent.getByToken(pfmetToken_, pfmet);
-	if(  pfmet.isValid() ) {	  
-	  if (pfmet->size() == 0) {
-	    mpfMET_   = -1;
-	    mpfSumET_ = -1;
-	    mpfMETSign_ = -1;
-	  }
-	  else {
-	    mpfMET_   = (*pfmet)[0].et();
-	    mpfPhi_   = (*pfmet)[0].phi();
-	    mpfSumET_ = (*pfmet)[0].sumEt();
-	    mpfMETSign_ = (*pfmet)[0].significance();
-	  }
-	} else {
-	  edm::Handle<pat::METCollection> pfmet2;
-	  iEvent.getByToken(pfmetTokenMiniAOD_, pfmet2);
-	  const pat::MET &met = pfmet2->front();
-	  mpfMET_     = met.pt();
-	  mpfPhi_     = met.phi();
-	  mpfSumET_   = met.sumEt();
-	  mpfMETSign_ = met.significance();
-	}
-       
-	if (addRho_) {
-	  edm::Handle<double> rhos;
-	  iEvent.getByToken(rhoToken_, rhos);
-	  rho_ = (float) *rhos;
-	}
+        if (pfmet->size() == 0) {
+          mpfMET_   = -1;
+          mpfSumET_ = -1;
+          mpfMETSign_ = -1;
+        }
+        else {
+          mpfMET_   = (*pfmet)[0].et();
+          mpfSumET_ = (*pfmet)[0].sumEt();
+          mpfMETSign_ = (*pfmet)[0].significance();
+        }
     }
- 
-    
+
 }
 
 void tnp::BaseTreeFiller::fill(const reco::CandidateBaseRef &probe) const {
     for (std::vector<tnp::ProbeVariable>::const_iterator it = vars_.begin(), ed = vars_.end(); it != ed; ++it) {
-      if (ignoreExceptions_)  {
+        if (ignoreExceptions_)  {
             try{ it->fill(probe); } catch(cms::Exception &ex ){}
         } else {
-	  
             it->fill(probe);
         }
     }

--- a/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
+++ b/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
@@ -2,10 +2,14 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
+
 #include "PhysicsTools/TagAndProbe/interface/ColinsSoperVariables.h"
 
 #include <TList.h>
 #include <TObjString.h>
+
+#include <iostream>
+using namespace std;
 
 tnp::ProbeVariable::~ProbeVariable() {}
 
@@ -43,41 +47,60 @@ tnp::BaseTreeFiller::BaseTreeFiller(const char *name, const edm::ParameterSet& i
         weight_ = iConfig.getParameter<double>("eventWeight");
     } else if (iConfig.existsAs<edm::InputTag>("eventWeight")) {
         weightMode_ = External;
-        weightSrcToken_ = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("eventWeight"));
+        weightSrcToken_ = iC.consumes<GenEventInfoProduct>(iConfig.getParameter<edm::InputTag>("eventWeight"));
     } else {
         weightMode_ = None;
     }
     if (weightMode_ != None) {
         tree_->Branch("weight", &weight_, "weight/F");
+	tree_->Branch("totWeight", &totWeight_, "totWeight/F");
     }
+
     storePUweight_ = iConfig.existsAs<edm::InputTag>("PUWeightSrc") ? true: false;
-    if(storePUweight_) {
-      PUweightSrcToken_   = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("PUWeightSrc")); 
+    if(storePUweight_) {      
+      PUweightSrcToken_   = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("PUWeightSrc"));
       tree_->Branch("PUweight", &PUweight_, "PUweight/F");
-    }
+    }    
+    
+    if( iConfig.existsAs<edm::InputTag>("pileupInfoTag") ) 
+      pileupInfoToken_= iC.consumes<std::vector<PileupSummaryInfo> >(iConfig.getParameter<edm::InputTag>("pileupInfoTag"));
 
     addRunLumiInfo_ = iConfig.existsAs<bool>("addRunLumiInfo") ? iConfig.getParameter<bool>("addRunLumiInfo") : false;
     if (addRunLumiInfo_) {
          tree_->Branch("run",  &run_,  "run/i");
          tree_->Branch("lumi", &lumi_, "lumi/i");
          tree_->Branch("event", &event_, "event/l");
+	 tree_->Branch("truePU", &truePU_, "truePU/I");
     }
     addEventVariablesInfo_ = iConfig.existsAs<bool>("addEventVariablesInfo") ? iConfig.getParameter<bool>("addEventVariablesInfo") : false;
     if (addEventVariablesInfo_) {
-      recVtxsToken_ = iC.consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
-      beamSpotToken_ = iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
-      metToken_ = iC.consumes<reco::CaloMETCollection>(edm::InputTag("met"));
-      tcmetToken_ = iC.consumes<reco::METCollection>(edm::InputTag("tcMet"));
-      pfmetToken_ = iC.consumes<reco::PFMETCollection>(edm::InputTag("pfMet"));
-      tree_->Branch("event_nPV"        ,&mNPV_                 ,"mNPV/I");
-      tree_->Branch("event_met_calomet"    ,&mMET_                ,"mMET/F");
-      tree_->Branch("event_met_calosumet"  ,&mSumET_              ,"mSumET/F");
-      tree_->Branch("event_met_calometsignificance",&mMETSign_    ,"mMETSign/F");
-      tree_->Branch("event_met_tcmet"    ,&mtcMET_                ,"mtcMET/F");
-      tree_->Branch("event_met_tcsumet"  ,&mtcSumET_              ,"mtcSumET/F");
-      tree_->Branch("event_met_tcmetsignificance",&mtcMETSign_    ,"mtcMETSign/F");
+      /// FC (EGM) - add possibility to customize collections (can run other miniAOD)
+      edm::InputTag bsIT    = iConfig.existsAs<edm::InputTag>("beamSpot") ?  iConfig.getParameter<edm::InputTag>("beamSpot") : edm::InputTag("offlineBeamSpot");
+      edm::InputTag vtxIT   = iConfig.existsAs<edm::InputTag>("vertexCollection") ?  iConfig.getParameter<edm::InputTag>("vertexCollection") : edm::InputTag("offlinePrimaryVertices");
+      edm::InputTag pfMetIT = iConfig.existsAs<edm::InputTag>("pfMet") ?  iConfig.getParameter<edm::InputTag>("pfMet") : edm::InputTag("pfMet");
+      edm::InputTag tcMetIT = iConfig.existsAs<edm::InputTag>("tcMet") ?  iConfig.getParameter<edm::InputTag>("tcMet") : edm::InputTag("tcMet");
+      edm::InputTag clMetIT = iConfig.existsAs<edm::InputTag>("clMet") ?  iConfig.getParameter<edm::InputTag>("clMet") : edm::InputTag("met");
+ 
+      recVtxsToken_      = iC.consumes<reco::VertexCollection>(vtxIT);
+      beamSpotToken_     = iC.consumes<reco::BeamSpot>(bsIT);
+      pfmetToken_        = iC.mayConsume<reco::PFMETCollection>(pfMetIT);
+      pfmetTokenMiniAOD_ = iC.mayConsume<pat::METCollection>(pfMetIT);
+      addCaloMet_ = iConfig.existsAs<bool>("addCaloMet") ? iConfig.getParameter<bool>("addCaloMet") : true;      
+      tree_->Branch("event_nPV"             ,&mNPV_                 ,"mNPV/I");
+      if( addCaloMet_ ) {
+	metToken_   = iC.mayConsume<reco::CaloMETCollection>(clMetIT);
+	tcmetToken_ = iC.mayConsume<reco::METCollection>(    tcMetIT);
+	tree_->Branch("event_met_calomet"    ,&mMET_                ,"mMET/F");
+	tree_->Branch("event_met_calosumet"  ,&mSumET_              ,"mSumET/F");
+	tree_->Branch("event_met_calometsignificance",&mMETSign_    ,"mMETSign/F");
+	tree_->Branch("event_met_tcmet"    ,&mtcMET_                ,"mtcMET/F");
+	tree_->Branch("event_met_tcsumet"  ,&mtcSumET_              ,"mtcSumET/F");
+	tree_->Branch("event_met_tcmetsignificance",&mtcMETSign_    ,"mtcMETSign/F");
+      }      
       tree_->Branch("event_met_pfmet"    ,&mpfMET_                ,"mpfMET/F");
+      tree_->Branch("event_met_pfphi"    ,&mpfPhi_                ,"mpfPhi/F");
       tree_->Branch("event_met_pfsumet"  ,&mpfSumET_              ,"mpfSumET/F");
+      
       tree_->Branch("event_met_pfmetsignificance",&mpfMETSign_    ,"mpfMETSign/F");
       tree_->Branch("event_PrimaryVertex_x"  ,&mPVx_              ,"mPVx/F");
       tree_->Branch("event_PrimaryVertex_y"  ,&mPVy_              ,"mPVy/F");
@@ -86,6 +109,13 @@ tnp::BaseTreeFiller::BaseTreeFiller(const char *name, const edm::ParameterSet& i
       tree_->Branch("event_BeamSpot_y"       ,&mBSy_              ,"mBSy/F");
       tree_->Branch("event_BeamSpot_z"       ,&mBSz_              ,"mBSz/F");
     }
+
+    addRho_ = iConfig.existsAs<edm::InputTag>("rho") ? true : false;
+    if (addRho_) {
+      rhoToken_ = iC.consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
+      tree_->Branch("event_rho"    ,&rho_   ,"rho/F");
+    }
+    
 
     ignoreExceptions_ = iConfig.existsAs<bool>("ignoreExceptions") ? iConfig.getParameter<bool>("ignoreExceptions") : false;
 }
@@ -96,7 +126,7 @@ tnp::BaseTreeFiller::BaseTreeFiller(BaseTreeFiller &main, const edm::ParameterSe
   tree_(0)
 {
     addRunLumiInfo_ = main.addRunLumiInfo_;
-    storePUweight_ = main.storePUweight_;
+    storePUweight_  = main.storePUweight_;
     addBranches_(main.tree_, iConfig, iC, branchNamePrefix);
 }
 
@@ -145,6 +175,14 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
     lumi_ = iEvent.id().luminosityBlock();
     event_ = iEvent.id().event();
 
+    truePU_ = 0;
+    if (!iEvent.isRealData() and !pileupInfoToken_.isUninitialized()) {
+      edm::Handle<std::vector<PileupSummaryInfo> > PupInfo;
+      iEvent.getByToken(pileupInfoToken_, PupInfo);
+      truePU_ = PupInfo->begin()->getTrueNumInteractions();
+    }
+
+    totWeight_ = 1.;
     for (std::vector<tnp::ProbeVariable>::const_iterator it = vars_.begin(), ed = vars_.end(); it != ed; ++it) {
         it->init(iEvent);
     }
@@ -152,17 +190,22 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
         it->init(iEvent);
     }
     if (weightMode_ == External) {
-        edm::Handle<double> weight;
-        iEvent.getByToken(weightSrcToken_, weight);
-        weight_ = *weight;
+      // edm::Handle<double> weight;
+      //        iEvent.getByToken(weightSrcToken_, weight);
+      //        weight_ = *weight;
+	edm::Handle<GenEventInfoProduct> weight;
+	iEvent.getByToken(weightSrcToken_, weight);
+	weight_ = weight->weight();
+	totWeight_ *= weight_;
     }
 
     ///// ********** Pileup weight: needed for MC re-weighting for PU ************* 
-     edm::Handle<std::vector<float> > weightPU;
-     if(storePUweight_) {
-       bool isPresent = iEvent.getByToken(PUweightSrcToken_, weightPU);
-       if(isPresent) PUweight_ = (*weightPU).at(0);
-       else PUweight_ = 1.0;
+    PUweight_ = 1;
+    if(storePUweight_  and !PUweightSrcToken_.isUninitialized() ) {
+      edm::Handle<double> weightPU;
+      bool isPresent = iEvent.getByToken(PUweightSrcToken_, weightPU);
+      if(isPresent) PUweight_ = float(*weightPU);
+      totWeight_ *= PUweight_;
      }
      
     if (addEventVariablesInfo_) {
@@ -188,7 +231,6 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
           }
         }
 
-
         //////////// Beam spot //////////////
         edm::Handle<reco::BeamSpot> beamSpot;
         iEvent.getByToken(beamSpotToken_, beamSpot);
@@ -196,7 +238,7 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
         mBSy_ = beamSpot->position().Y();
         mBSz_ = beamSpot->position().Z();
 
-
+	if( addCaloMet_) {
         ////////////// CaloMET //////
         edm::Handle<reco::CaloMETCollection> met;
         iEvent.getByToken(metToken_,met);
@@ -210,7 +252,7 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
           mSumET_ = (*met)[0].sumEt();
           mMETSign_ = (*met)[0].significance();
         }
-
+	
         /////// TcMET information /////
         edm::Handle<reco::METCollection> tcmet;
         iEvent.getByToken(tcmetToken_, tcmet);
@@ -224,29 +266,49 @@ void tnp::BaseTreeFiller::init(const edm::Event &iEvent) const {
           mtcSumET_ = (*tcmet)[0].sumEt();
           mtcMETSign_ = (*tcmet)[0].significance();
         }
-
+	}
+	
         /////// PfMET information /////
         edm::Handle<reco::PFMETCollection> pfmet;
         iEvent.getByToken(pfmetToken_, pfmet);
-        if (pfmet->size() == 0) {
-          mpfMET_   = -1;
-          mpfSumET_ = -1;
-          mpfMETSign_ = -1;
-        }
-        else {
-          mpfMET_   = (*pfmet)[0].et();
-          mpfSumET_ = (*pfmet)[0].sumEt();
-          mpfMETSign_ = (*pfmet)[0].significance();
-        }
+	if(  pfmet.isValid() ) {	  
+	  if (pfmet->size() == 0) {
+	    mpfMET_   = -1;
+	    mpfSumET_ = -1;
+	    mpfMETSign_ = -1;
+	  }
+	  else {
+	    mpfMET_   = (*pfmet)[0].et();
+	    mpfPhi_   = (*pfmet)[0].phi();
+	    mpfSumET_ = (*pfmet)[0].sumEt();
+	    mpfMETSign_ = (*pfmet)[0].significance();
+	  }
+	} else {
+	  edm::Handle<pat::METCollection> pfmet2;
+	  iEvent.getByToken(pfmetTokenMiniAOD_, pfmet2);
+	  const pat::MET &met = pfmet2->front();
+	  mpfMET_     = met.pt();
+	  mpfPhi_     = met.phi();
+	  mpfSumET_   = met.sumEt();
+	  mpfMETSign_ = met.significance();
+	}
+       
+	if (addRho_) {
+	  edm::Handle<double> rhos;
+	  iEvent.getByToken(rhoToken_, rhos);
+	  rho_ = (float) *rhos;
+	}
     }
-
+ 
+    
 }
 
 void tnp::BaseTreeFiller::fill(const reco::CandidateBaseRef &probe) const {
     for (std::vector<tnp::ProbeVariable>::const_iterator it = vars_.begin(), ed = vars_.end(); it != ed; ++it) {
-        if (ignoreExceptions_)  {
+      if (ignoreExceptions_)  {
             try{ it->fill(probe); } catch(cms::Exception &ex ){}
         } else {
+	  
             it->fill(probe);
         }
     }

--- a/PhysicsTools/TagAndProbe/src/TagProbePairMaker.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbePairMaker.cc
@@ -20,6 +20,8 @@ tnp::TagProbePairMaker::TagProbePairMaker(const edm::ParameterSet &iConfig, edm:
   } else if (arbitration == "Random2") {
     arbitration_ = Random2;
     randGen_ = new TRandom2(7777);
+  } else if (arbitration == "HighestPt") {
+    arbitration_ = HighestPt;
   } else throw cms::Exception("Configuration") << "TagProbePairMakerOnTheFly: the only currently "
 					       << "allowed values for 'arbitration' are "
 					       << "'None', 'OneProbe', 'BestMass', 'Random2'\n";
@@ -147,7 +149,14 @@ tnp::TagProbePairMaker::arbitrate(TagProbePairs &pairs) const
 	  }
 	  // and invalidate it2
 	  it2->tag = reco::CandidateBaseRef(); --nclean;
-	} else if (arbitration_ == Random2) {
+	} else if (arbitration_ == HighestPt) {
+          // but the best one in the first  iterator
+          if ( it2->probe->pt() > it->probe->pt()  ) {
+            std::swap(*it, *it2);
+          }
+          // and invalidate it2
+          it2->tag = reco::CandidateBaseRef(); --nclean;
+        } else if (arbitration_ == Random2) {
 	  numberOfProbes++;
 	  if (numberOfProbes>1) {
 	    //std::cout << "more than 2 probes!" << std::endl;

--- a/PhysicsTools/TagAndProbe/src/TagProbePairMaker.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbePairMaker.cc
@@ -20,8 +20,6 @@ tnp::TagProbePairMaker::TagProbePairMaker(const edm::ParameterSet &iConfig, edm:
   } else if (arbitration == "Random2") {
     arbitration_ = Random2;
     randGen_ = new TRandom2(7777);
-  } else if (arbitration == "HighestPt") {
-    arbitration_ = HighestPt;
   } else throw cms::Exception("Configuration") << "TagProbePairMakerOnTheFly: the only currently "
 					       << "allowed values for 'arbitration' are "
 					       << "'None', 'OneProbe', 'BestMass', 'Random2'\n";
@@ -149,14 +147,7 @@ tnp::TagProbePairMaker::arbitrate(TagProbePairs &pairs) const
 	  }
 	  // and invalidate it2
 	  it2->tag = reco::CandidateBaseRef(); --nclean;
-	} else if (arbitration_ == HighestPt) {
-          // but the best one in the first  iterator
-          if ( it2->probe->pt() > it->probe->pt()  ) {
-            std::swap(*it, *it2);
-          }
-          // and invalidate it2
-          it2->tag = reco::CandidateBaseRef(); --nclean;
-        } else if (arbitration_ == Random2) {
+	} else if (arbitration_ == Random2) {
 	  numberOfProbes++;
 	  if (numberOfProbes>1) {
 	    //std::cout << "more than 2 probes!" << std::endl;


### PR DESCRIPTION
egm tnp package has diverged from central repository for quite a while now.
Fix this by:

updating the central PhysicsTools/TagAndProbe to fulfil egm needs (this PR)
add a new package in cms-analysis for egm specific tnp tree making
This PR has been reviewed by muon conveners so that it does not change the muon tnp tree contents.
@HuguesBrun

It will be needed for legacy re-reco analysis and hence will also be committed in 80X.