### PR TITLE
revert change to CaloCluster in warning cleanup

### DIFF
--- a/DataFormats/CaloRecHit/src/CaloCluster.cc
+++ b/DataFormats/CaloRecHit/src/CaloCluster.cc
@@ -27,7 +27,7 @@ string CaloCluster::printHitAndFraction(unsigned i) const {
 }
 
 
-std::ostream& operator<<(std::ostream& out, 
+std::ostream& reco::operator<<(std::ostream& out, 
 			 const CaloCluster& cluster) {
   
   if(!out) return out;


### PR DESCRIPTION
as it causes an error in the IBs that I don't understand