### PR TITLE
pr90x Configure TTStubAlgorithm from L1TrackTrigger sequence for TiltedTracker

### DIFF
--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -5,3 +5,5 @@ from L1Trigger.TrackTrigger.TrackTrigger_cff import *
 
 #L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
 L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs)
+
+TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.cc
@@ -31,8 +31,7 @@ TrackerParametersESModule::fillDescriptions( edm::ConfigurationDescriptions & de
 TrackerParametersESModule::ReturnType
 TrackerParametersESModule::produce( const PTrackerParametersRcd& iRecord )
 {
-  //edm::LogInfo("TrackerParametersESModule")
-  std::cout <<  "TrackerParametersESModule::produce(const PTrackerParametersRcd& iRecord)" << std::endl;
+  edm::LogInfo("TrackerParametersESModule") <<  "TrackerParametersESModule::produce(const PTrackerParametersRcd& iRecord)" << std::endl;
   edm::ESTransientHandle<DDCompactView> cpv;
   iRecord.getRecord<IdealGeometryRecord>().get( cpv );
     


### PR DESCRIPTION
90x This is needed for L1T MC production.
TTStubAlgorithm is already included in the L1TrackTrigger sequence,
Just configure it properly:

- Configure TTStubAlgorithm to use zMatchingPS (True) needed when TiltedTracker used. 
- Also, Silence the TrackerParametersESModule.