### PR TITLE
Remove addEndJob logic/customization in cmsDriver

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -124,7 +124,7 @@ def OptionsFromItems(items):
     options.step = options.step.replace("SIM_CHAIN","GEN,SIM,DIGI,L1,DIGI2RAW")
 
     # add on the end of job sequence...
-    addEndJob = True
+    addEndJob = False
     if ("FASTSIM" in options.step and not "VALIDATION" in options.step) or "HARVESTING" in options.step or "ALCAHARVEST" in options.step or "ALCAOUTPUT" in options.step or options.step == "": 
         addEndJob = False
     if ("SKIM" in options.step and not "RECO" in options.step):

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -123,20 +123,6 @@ def OptionsFromItems(items):
 
     options.step = options.step.replace("SIM_CHAIN","GEN,SIM,DIGI,L1,DIGI2RAW")
 
-    # add on the end of job sequence...
-    addEndJob = False
-    if ("FASTSIM" in options.step and not "VALIDATION" in options.step) or "HARVESTING" in options.step or "ALCAHARVEST" in options.step or "ALCAOUTPUT" in options.step or options.step == "": 
-        addEndJob = False
-    if ("SKIM" in options.step and not "RECO" in options.step):
-        addEndJob = False
-    if ("ENDJOB" in options.step):
-        addEndJob = False
-    if ('DQMIO' in options.datatier):
-        addEndJob = False
-    if addEndJob:    
-        options.step=options.step+',ENDJOB'
-
-
     #determine the type of file on input
     if options.filetype==defaultOptions.filetype:
         if options.filein.lower().endswith(".lhe") or options.filein.lower().endswith(".lhef") or options.filein.startswith("lhe:"):

--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -80,7 +80,7 @@ def customise(process):
     process.local_validation = cms.Path(process.ecalSimValid+process.hcalSimValid)
     process.schedule.append(process.local_validation) 
 
-    process.schedule.append(process.endjob_step)
+    #process.schedule.append(process.endjob_step)
     #process.schedule.append(process.out_step)
     process.schedule.append(getattr(process,process.outputModules_().iteritems().next()[0]+"_step"))
 


### PR DESCRIPTION
This removes the obsolete "addEndJob = True" logic in the cmsDriverOptions.py

It should not be necessary - most central wolkflows had this flag disabled.
This also fixes "extensive" logging in a few of runTheMatrix tests, where a legacy endJob module was added, even though it was not needed to be added.

Jobs which still need the endJob, should explicitly pass "ENDJOB" step to the cmsDriver.