### PR TITLE
Changes to online DT DQM (840 version of PR17832 for P5 integration)

### DIFF
--- a/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsEra_Run2_2017.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_2017_
+
+Scenario supporting cosmic data taking
+
+"""
+
+import os
+import sys
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.DataProcessing.Impl.cosmics import cosmics
+
+class cosmicsEra_Run2_2017(cosmics):
+    def __init__(self):
+        cosmics.__init__(self)
+        self.eras = Run2_2017
+    """
+    _cosmicsEra_Run2_2017_
+
+    Implement configuration building for data processing for cosmic
+    data taking in Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2017.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+_hcalnzsEra_Run2_2017_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.hcalnzs import hcalnzs
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+class hcalnzsEra_Run2_2017(hcalnzs):
+    def __init__(self):
+        hcalnzs.__init__(self)
+        self.recoSeq=':reconstruction_HcalNZS'
+        self.cbSc='pp'
+        self.eras = Run2_2017
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+    """
+    _hcalnzsEra_Run2_2017_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2017(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run2_2017
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+    """
+    _ppEra_Run2_2017_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingLowPU.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingLowPU.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_trackingLowPU_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2017_trackingLowPU_cff import Run2_2017_trackingLowPU
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2017_trackingLowPU(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run2_2017_trackingLowPU
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+    """
+    _ppEra_Run2_2017_trackingLowPU_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -43,6 +43,10 @@ def customisePostEra_Run2_2016(process):
     _hcalCustoms25ns(process)
     return process
 
+def customisePostEra_Run2_2017(process):
+    _hcalCustoms25ns(process)
+    return process
+
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -9,6 +9,7 @@ testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -76,9 +77,24 @@ class RunAlcaHarvesting:
         process.source.fileNames.append(self.inputLFN)
 
 
+        pklFile = open("RunAlcaHarvestingCfg.pkl", "w")
         psetFile = open("RunAlcaHarvestingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunAlcaHarvestingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -j FrameworkJobReport.xml RunAlcaHarvestingCfg.py"
         print "Now do:\n%s" % cmsRun
         

--- a/Configuration/DataProcessing/test/RunAlcaSkimming.py
+++ b/Configuration/DataProcessing/test/RunAlcaSkimming.py
@@ -9,6 +9,7 @@ testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -66,9 +67,24 @@ class RunAlcaSkimming:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunAlcaSkimmingCfg.pkl", "w")
         psetFile = open("RunAlcaSkimmingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunAlcaSkimmingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunAlcaSkimmingCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/RunDQMHarvesting.py
+++ b/Configuration/DataProcessing/test/RunDQMHarvesting.py
@@ -9,6 +9,7 @@ testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -72,9 +73,24 @@ class RunDQMHarvesting:
         process.source.fileNames.append(self.inputLFN)
 
 
+        pklFile = open("RunDQMHarvestingCfg.pkl", "w")
         psetFile = open("RunDQMHarvestingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunDQMHarvestingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -j FrameworkJobReport.xml RunDQMHarvestingCfg.py"
         print "Now do:\n%s" % cmsRun
         

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -10,6 +10,7 @@ it into cmsRun for testing with a few input files etc from the command line
 import sys
 import getopt
 import traceback
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -105,9 +106,24 @@ class RunExpressProcessing:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunExpressProcessingCfg.pkl", "w")
         psetFile = open("RunExpressProcessingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunExpressProcessingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunExpressProcessingCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -10,6 +10,7 @@ testing with a few input files etc from the command line
 import sys
 import getopt
 import traceback
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -115,9 +116,24 @@ class RunPromptReco:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunPromptRecoCfg.pkl", "w")
         psetFile = open("RunPromptRecoCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunPromptRecoCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunPromptRecoCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/RunVisualizationProcessing.py
+++ b/Configuration/DataProcessing/test/RunVisualizationProcessing.py
@@ -9,6 +9,7 @@ it into cmsRun for testing with a few input files etc from the command line
 
 import sys
 import getopt
+import pickle
 
 from Configuration.DataProcessing.GetScenario import getScenario
 
@@ -108,9 +109,24 @@ class RunVisualizationProcessing:
 
         process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
+        pklFile = open("RunVisualizationProcessingCfg.pkl", "w")
         psetFile = open("RunVisualizationProcessingCfg.py", "w")
-        psetFile.write(process.dumpPython())
-        psetFile.close()
+        try:
+            pickle.dump(process, pklFile)
+            psetFile.write("import FWCore.ParameterSet.Config as cms\n")
+            psetFile.write("import pickle\n")
+            psetFile.write("handle = open('RunVisualizationProcessingCfg.pkl')\n")
+            psetFile.write("process = pickle.load(handle)\n")
+            psetFile.write("handle.close()\n")
+            psetFile.close()
+        except Exception as ex:
+            print("Error writing out PSet:")
+            print(traceback.format_exc())
+            raise ex
+        finally:
+            psetFile.close()
+            pklFile.close()
+
         cmsRun = "cmsRun -e RunVisualizationProcessingCfg.py"
         print "Now do:\n%s" % cmsRun
 

--- a/Configuration/DataProcessing/test/cosmicsEra_Run2_2017_t.py
+++ b/Configuration/DataProcessing/test/cosmicsEra_Run2_2017_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_cosmicsEra_Run2_2017_
+
+Test for CosmicsRun2 Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class cosmicsEra_Run2_2017ScenarioTest(unittest.TestCase):
+    """
+    unittest for cosmicsEra_Run2_2017 scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("cosmicsEra_Run2_2017")
+        except Exception as ex:
+            msg = "Failed to get cosmicsEra_Run2_2017 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception as ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for cosmicsEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception as ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for cosmicsEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception as ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for cosmicsEra_Run2_2017 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("cosmicsEra_Run2_2017")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception as ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for cosmicsEra_Run2_2017 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/ppEra_Run2_2017_t.py
+++ b/Configuration/DataProcessing/test/ppEra_Run2_2017_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_
+
+Test for Collision Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class ppEra_Run2_2017ScenarioTest(unittest.TestCase):
+    """
+    unittest for ppEra_Run2_2017 collisions scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("ppEra_Run2_2017")
+        except Exception as ex:
+            msg = "Failed to get ppEra_Run2_2017 scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception as ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for ppEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception as ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for ppEra_Run2_2017 Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception as ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for ppEra_Run2_2017 Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("ppEra_Run2_2017")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception as ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for ppEra_Run2_2017 scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,7 +22,7 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsEra_Run2_25ns" "hcalnzsEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "cosmicsEra_Run2_2017" "hcalnzsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -36,14 +36,14 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA")
+declare -a arr=("cosmics" "pp" "cosmicsEra_Run2_25ns" "cosmicsEra_Run2_2016" "HeavyIons" "HeavyIonsEra_Run2_HI" "AlCaLumiPixels" "ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "cosmicsEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU" "ppEra_Run2_2017")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA")
+declare -a arr=("ppEra_Run2_50ns" "ppEra_Run2_25ns" "ppEra_Run2_2016" "ppEra_Run2_2016_trackingLowPU" "ppEra_Run2_2016_pA" "ppEra_Run2_2017" "ppEra_Run2_2017_trackingLowPU")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/Eras/python/Era_Run2_2017_trackingLowPU_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_trackingLowPU_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
+
+Run2_2017_trackingLowPU = cms.ModifierChain(Run2_2017, trackingLowPU)
+

--- a/DQM/DTMonitorClient/python/dtFineDelayCorr_cfi.py
+++ b/DQM/DTMonitorClient/python/dtFineDelayCorr_cfi.py
@@ -6,7 +6,7 @@ dtFineDelayCorr = cms.EDAnalyzer("DTFineDelayCorr",
     # run in online environment
     runOnline = cms.untracked.bool(True),
     # kind of trigger data processed by DTLocalTriggerTask
-    hwSources = cms.untracked.vstring('TM','DDU'),
+    hwSources = cms.untracked.vstring('TM'),
     # false if DTLocalTriggerTask used LTC digis
     localrun = cms.untracked.bool(True),                         
     # root folder for booking of histograms

--- a/DQM/DTMonitorClient/python/dtLocalTriggerEfficiencyTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerEfficiencyTest_cfi.py
@@ -6,7 +6,7 @@ triggerEfficiencyTest = cms.EDAnalyzer("DTLocalTriggerEfficiencyTest",
     # run in online environment
     runOnline = cms.untracked.bool(True),
     # kind of trigger data processed by DTLocalTriggerTask
-    hwSources = cms.untracked.vstring('TM','DDU'),
+    hwSources = cms.untracked.vstring('TM'),
     # false if DTLocalTriggerTask used LTC digis
     localrun = cms.untracked.bool(True),
     # root folder for booking of histograms

--- a/DQM/DTMonitorClient/python/dtLocalTriggerLutTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerLutTest_cfi.py
@@ -6,7 +6,7 @@ triggerLutTest = cms.EDAnalyzer("DTLocalTriggerLutTest",
     # run in online environment
     runOnline = cms.untracked.bool(True),
     # kind of trigger data processed by DTLocalTriggerTask
-    hwSources = cms.untracked.vstring('TM','DDU'),
+    hwSources = cms.untracked.vstring('TM'),
     # false if DTLocalTriggerTask used LTC digis
     localrun = cms.untracked.bool(True),
     # enable/disable correlation plot tests

--- a/DQM/DTMonitorClient/python/dtLocalTriggerSynchTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerSynchTest_cfi.py
@@ -6,7 +6,7 @@ triggerSynchTest = cms.EDAnalyzer("DTLocalTriggerSynchTest",
     # run in online environment
     runOnline = cms.untracked.bool(True),
     # kind of trigger data processed by DTLocalTriggerTask
-    hwSources = cms.untracked.vstring('TM','DDU'),
+    hwSources = cms.untracked.vstring('TM'),
     # false if DTLocalTriggerTask used LTC digis
     localrun = cms.untracked.bool(True),                         
     # root folder for booking of histograms

--- a/DQM/DTMonitorClient/python/dtLocalTriggerTest_TP_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerTest_TP_cfi.py
@@ -6,7 +6,7 @@ dtTPTriggerTest = cms.EDAnalyzer("DTLocalTriggerTPTest",
     # run in online environment
     runOnline = cms.untracked.bool(True),
     # kind of trigger data processed by DTLocalTriggerTask
-    hwSources = cms.untracked.vstring('TM','DDU'),
+    hwSources = cms.untracked.vstring('TM'),
     # false if DTLocalTriggerTask used LTC digis
     localrun = cms.untracked.bool(True),                         
     # root folder for booking of histograms

--- a/DQM/DTMonitorClient/python/dtLocalTriggerTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerTest_cfi.py
@@ -6,7 +6,7 @@ triggerTest = cms.EDAnalyzer("DTLocalTriggerTest",
     # run in online environment
     runOnline = cms.untracked.bool(True),
     # kind of trigger data processed by DTLocalTriggerTask
-    hwSources = cms.untracked.vstring('TM','DDU'),
+    hwSources = cms.untracked.vstring('TM'),
     # false if DTLocalTriggerTask used LTC digis
     localrun = cms.untracked.bool(True),                         
     # root folder for booking of histograms

--- a/DQM/DTMonitorClient/python/dtTriggerEfficiencyTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtTriggerEfficiencyTest_cfi.py
@@ -6,7 +6,7 @@ triggerEffTest = cms.EDAnalyzer("DTTriggerEfficiencyTest",
     # run in online environment
     runOnline = cms.untracked.bool(False),
     # kind of trigger data processed by DTLocalTriggerTask
-    hwSources = cms.untracked.vstring('TM','DDU'),
+    hwSources = cms.untracked.vstring('TM'),
     # false if DTLocalTriggerTask used LTC digis
     localrun = cms.untracked.bool(True),
     # root folder for booking of histograms

--- a/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
+++ b/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
@@ -141,14 +141,10 @@ DTDataIntegrityTest::~DTDataIntegrityTest(){
 	for(int rosNumber = 1; rosNumber <= 12; ++rosNumber) { // loop on the ROS
 	  int wheelNumber, sectorNumber;
 	  if (!readOutToGeometry(dduId,rosNumber,wheelNumber,sectorNumber)) {
-	    int result = -2;
 	    float nErrors  = histoFEDSummary->Integral(1,14,rosNumber,rosNumber);
-	    nErrors += histoROSStatus->Integral(2,8,rosNumber,rosNumber);
-	    if(nErrors == 0) { // no errors
-	      result = 0;
-	    } else { // there are errors
-	      result = 2;
-	    }
+	    float nROBErrors = histoROSStatus->Integral(2,8,rosNumber,rosNumber);
+	    nErrors += nROBErrors;
+	    float result =  max((float)0., ((float)nFEDEvts-nROBErrors)/(float)nFEDEvts); 
 	    summaryHisto->setBinContent(sectorNumber,wheelNumber+3,result);
 	    int tdcResult = -2;
 	    float nTDCErrors = histoFEDSummary->Integral(15,15,rosNumber,rosNumber); 
@@ -164,7 +160,7 @@ DTDataIntegrityTest::~DTDataIntegrityTest(){
 	   
 	    if(fedNotReadout) {
 	      // no data in this FED: it is off
-	      summaryHisto->setBinContent(sectorNumber,wheelNumber+3,1);
+	      summaryHisto->setBinContent(sectorNumber,wheelNumber+3,0);
 	      summaryTDCHisto->setBinContent(sectorNumber,wheelNumber+3,1);
 	      glbSummaryHisto->setBinContent(sectorNumber,wheelNumber+3,0);
 	    }
@@ -175,7 +171,7 @@ DTDataIntegrityTest::~DTDataIntegrityTest(){
 	for(int rosNumber = 1; rosNumber <= 12; ++rosNumber) {
 	  int wheelNumber, sectorNumber;
 	  if (!readOutToGeometry(dduId,rosNumber,wheelNumber,sectorNumber)) {
-	    summaryHisto->setBinContent(sectorNumber,wheelNumber+3,1);
+	    summaryHisto->setBinContent(sectorNumber,wheelNumber+3,0);
 	    summaryTDCHisto->setBinContent(sectorNumber,wheelNumber+3,1);
 	    glbSummaryHisto->setBinContent(sectorNumber,wheelNumber+3,0);
 	  } 

--- a/DQM/DTMonitorClient/src/DTLocalTriggerTest.cc
+++ b/DQM/DTMonitorClient/src/DTLocalTriggerTest.cc
@@ -73,15 +73,24 @@ void DTLocalTriggerTest::Bookings(DQMStore::IBooker & ibooker, DQMStore::IGetter
 	  else { 
 	    for (int sect=1; sect<=12; ++sect){
 
-	      bookSectorHistos(ibooker,wh,sect,"BXDistribPhi");
-	      bookSectorHistos(ibooker,wh,sect,"QualDistribPhi");
+	      bookSectorHistos(ibooker,wh,sect,"BXDistribPhiIn");
+	      bookSectorHistos(ibooker,wh,sect,"QualDistribPhiIn");
+              bookSectorHistos(ibooker,wh,sect,"BXDistribPhiOut");
+              bookSectorHistos(ibooker,wh,sect,"QualDistribPhiOut");
 	    }
 
-	    bookWheelHistos(ibooker,wh,"CorrectBXPhi");
-	    bookWheelHistos(ibooker,wh,"ResidualBXPhi");
-	    bookWheelHistos(ibooker,wh,"CorrFractionPhi");
-	    bookWheelHistos(ibooker,wh,"2ndFractionPhi");
-	    bookWheelHistos(ibooker,wh,"TriggerInclusivePhi");
+	    bookWheelHistos(ibooker,wh,"CorrectBXPhiIn");
+	    bookWheelHistos(ibooker,wh,"ResidualBXPhiIn");
+	    bookWheelHistos(ibooker,wh,"CorrFractionPhiIn");
+	    bookWheelHistos(ibooker,wh,"2ndFractionPhiIn");
+	    bookWheelHistos(ibooker,wh,"TriggerInclusivePhiIn");
+
+            bookWheelHistos(ibooker,wh,"CorrectBXPhiOut");
+            bookWheelHistos(ibooker,wh,"ResidualBXPhiOut");
+            bookWheelHistos(ibooker,wh,"CorrFractionPhiOut");
+            bookWheelHistos(ibooker,wh,"2ndFractionPhiOut");
+            bookWheelHistos(ibooker,wh,"TriggerInclusivePhiOut");
+
 	  }
 	}
       }
@@ -100,8 +109,10 @@ void DTLocalTriggerTest::Bookings(DQMStore::IBooker & ibooker, DQMStore::IGetter
 	}
 	else {
 
-	  bookWheelHistos(ibooker,wh,"CorrFractionSummary","Summaries");
-	  bookWheelHistos(ibooker,wh,"2ndFractionSummary","Summaries");
+	  bookWheelHistos(ibooker,wh,"CorrFractionSummaryIn","Summaries");
+	  bookWheelHistos(ibooker,wh,"2ndFractionSummaryIn","Summaries");
+          bookWheelHistos(ibooker,wh,"CorrFractionSummaryOut","Summaries");
+          bookWheelHistos(ibooker,wh,"2ndFractionSummaryOut","Summaries");
 	}
       }
       if (hwSource=="COM") {
@@ -110,12 +121,14 @@ void DTLocalTriggerTest::Bookings(DQMStore::IBooker & ibooker, DQMStore::IGetter
       }
       else {
 
-	bookCmsHistos(ibooker,"CorrFractionSummary");
-	bookCmsHistos(ibooker,"2ndFractionSummary");
+	bookCmsHistos(ibooker,"CorrFractionSummaryIn");
+	bookCmsHistos(ibooker,"2ndFractionSummaryIn");
+        bookCmsHistos(ibooker,"CorrFractionSummaryOut");
+        bookCmsHistos(ibooker,"2ndFractionSummaryOut");
+
       }
       if (hwSource=="TM") {
 
-	bookCmsHistos(ibooker,"TrigGlbSummary","",true);
 	bookCmsHistos(ibooker,"TrigGlbSummary","",true);
       }
        
@@ -186,8 +199,9 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker & ibooker, DQMSto
 		whME[wh].find(fullName("MatchingSummary"))->second->setBinContent(sect,stat,matchSummary);
 
 	      }
-	    }
+	    } //closes COM
 	    else {
+		// IN part
 	      TH2F * BXvsQual      = getHisto<TH2F>(igetter.get(getMEName("BXvsQual_In","LocalTriggerPhiIn", chId)));
 	      TH1F * BestQual      = getHisto<TH1F>(igetter.get(getMEName("BestQual_In","LocalTriggerPhiIn", chId)));
 	      TH2F * Flag1stvsQual = getHisto<TH2F>(igetter.get(getMEName("Flag1stvsQual_In","LocalTriggerPhiIn", chId))); 
@@ -229,9 +243,9 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker & ibooker, DQMSto
 		    secondSummary = 0;
 		  }
 		  
-		  if( secME[sector_id].find(fullName("BXDistribPhi")) == secME[sector_id].end() ){
-		    bookSectorHistos(ibooker,wh,sect,"QualDistribPhi");
-		    bookSectorHistos(ibooker,wh,sect,"BXDistribPhi");
+		  if( secME[sector_id].find(fullName("BXDistribPhiIn")) == secME[sector_id].end() ){
+		    bookSectorHistos(ibooker,wh,sect,"QualDistribPhiIn");
+		    bookSectorHistos(ibooker,wh,sect,"BXDistribPhiIn");
 		  }
 
 		  TH1D* BXDistr   = BXvsQual->ProjectionY();
@@ -244,36 +258,127 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker & ibooker, DQMSto
 		  int iMin = firstBinCenter>-4 ? firstBinCenter : -4;
 		  int iMax = lastBinCenter<20  ? lastBinCenter  : 20;
 		  for (int ibin=iMin+5;ibin<=iMax+5; ++ibin) {
-		    innerME->find(fullName("BXDistribPhi"))->second->setBinContent(ibin,stat,BXDistr->GetBinContent(ibin-5-firstBinCenter+1));
+		    innerME->find(fullName("BXDistribPhiIn"))->second->setBinContent(ibin,stat,BXDistr->GetBinContent(ibin-5-firstBinCenter+1));
 		  }
 		  for (int ibin=1;ibin<=7;++ibin) {
-		    innerME->find(fullName("QualDistribPhi"))->second->setBinContent(ibin,stat,QualDistr->GetBinContent(ibin));
+		    innerME->find(fullName("QualDistribPhiIn"))->second->setBinContent(ibin,stat,QualDistr->GetBinContent(ibin));
 		  }
 
 		  delete BXDistr;
 		  delete QualDistr;
 
-		  if( whME[wh].find(fullName("CorrectBXPhi")) == whME[wh].end() ){
-		    bookWheelHistos(ibooker,wh,"ResidualBXPhi");
-		    bookWheelHistos(ibooker,wh,"CorrectBXPhi");
-		    bookWheelHistos(ibooker,wh,"CorrFractionPhi");
-		    bookWheelHistos(ibooker,wh,"2ndFractionPhi");
-		    bookWheelHistos(ibooker,wh,"TriggerInclusivePhi");
+		  if( whME[wh].find(fullName("CorrectBXPhiIn")) == whME[wh].end() ){
+		    bookWheelHistos(ibooker,wh,"ResidualBXPhiIn");
+		    bookWheelHistos(ibooker,wh,"CorrectBXPhiIn");
+		    bookWheelHistos(ibooker,wh,"CorrFractionPhiIn");
+		    bookWheelHistos(ibooker,wh,"2ndFractionPhiIn");
+		    bookWheelHistos(ibooker,wh,"TriggerInclusivePhiIn");
 		  }
 		  
 		  innerME = &(whME[wh]);
-		  innerME->find(fullName("CorrectBXPhi"))->second->setBinContent(sect,stat,BX_OK+0.00001);
-		  innerME->find(fullName("ResidualBXPhi"))->second->setBinContent(sect,stat,round(25.*(BXMean-BX_OK))+0.00001);
-		  innerME->find(fullName("CorrFractionPhi"))->second->setBinContent(sect,stat,corrFrac);
-		  innerME->find(fullName("TriggerInclusivePhi"))->second->setBinContent(sect,stat,besttrigs);
-		  innerME->find(fullName("2ndFractionPhi"))->second->setBinContent(sect,stat,secondFrac);
+		  innerME->find(fullName("CorrectBXPhiIn"))->second->setBinContent(sect,stat,BX_OK+0.00001);
+		  innerME->find(fullName("ResidualBXPhiIn"))->second->setBinContent(sect,stat,round(25.*(BXMean-BX_OK))+0.00001);
+		  innerME->find(fullName("CorrFractionPhiIn"))->second->setBinContent(sect,stat,corrFrac);
+		  innerME->find(fullName("TriggerInclusivePhiIn"))->second->setBinContent(sect,stat,besttrigs);
+		  innerME->find(fullName("2ndFractionPhiIn"))->second->setBinContent(sect,stat,secondFrac);
 		}
 
-		whME[wh].find(fullName("CorrFractionSummary"))->second->setBinContent(sect,stat,corrSummary);
-		whME[wh].find(fullName("2ndFractionSummary"))->second->setBinContent(sect,stat,secondSummary);
+		whME[wh].find(fullName("CorrFractionSummaryIn"))->second->setBinContent(sect,stat,corrSummary);
+		whME[wh].find(fullName("2ndFractionSummaryIn"))->second->setBinContent(sect,stat,secondSummary);
 
 	      }
 
+	      if (hwSource=="TM"){
+		//Out part
+
+              TH2F * BXvsQual      = getHisto<TH2F>(igetter.get(getMEName("BXvsQual_Out","LocalTriggerPhiOut", chId)));
+              TH1F * BestQual      = getHisto<TH1F>(igetter.get(getMEName("BestQual_Out","LocalTriggerPhiOut", chId)));
+              TH2F * Flag1stvsQual = getHisto<TH2F>(igetter.get(getMEName("Flag1stvsQual_Out","LocalTriggerPhiOut", chId)));
+              if (BXvsQual && Flag1stvsQual && BestQual) {
+                int corrSummary   = 1;
+                int secondSummary = 1;
+
+                if (BestQual->GetEntries()>1) {
+                  TH1D* BXHH    = BXvsQual->ProjectionY("",6,7,"");
+                  TH1D* Flag1st = Flag1stvsQual->ProjectionY();
+                  int BXOK_bin  = BXHH->GetEntries()>=1 ? BXHH->GetMaximumBin() : 51;
+                  double BXMean = BXHH->GetEntries()>=1 ? BXHH->GetMean() : 51;
+                  double BX_OK  = BXvsQual->GetYaxis()->GetBinCenter(BXOK_bin);
+                  double trigsFlag2nd = Flag1st->GetBinContent(2);
+                  double trigs = Flag1st->GetEntries();
+                  double besttrigs = BestQual->GetEntries();
+                  double besttrigsCorr = BestQual->Integral(5,7,"");
+                  delete BXHH;
+                  delete Flag1st;
+
+                  double corrFrac   = besttrigsCorr/besttrigs;
+                  double secondFrac = trigsFlag2nd/trigs;
+                  if (corrFrac < parameters.getUntrackedParameter<double>("corrFracError",.5)){
+                    corrSummary = 2;
+                  }
+                  else if (corrFrac < parameters.getUntrackedParameter<double>("corrFracWarning",.6)){
+                    corrSummary = 3;
+                  }
+                  else {
+                    corrSummary = 0;
+                  }
+                  if (secondFrac > parameters.getUntrackedParameter<double>("secondFracError",.2)){
+                    secondSummary = 2;
+                  }
+                  else if (secondFrac > parameters.getUntrackedParameter<double>("secondFracWarning",.1)){
+                    secondSummary = 3;
+                  }
+                  else {
+                    secondSummary = 0;
+                  }
+
+                  if( secME[sector_id].find(fullName("BXDistribPhiOut")) == secME[sector_id].end() ){
+                    bookSectorHistos(ibooker,wh,sect,"QualDistribPhiOut");
+                    bookSectorHistos(ibooker,wh,sect,"BXDistribPhiOut");
+                  }
+
+                  TH1D* BXDistr   = BXvsQual->ProjectionY();
+                  TH1D* QualDistr = BXvsQual->ProjectionX();
+                  std::map<std::string,MonitorElement*> *innerME = &(secME[sector_id]);
+
+                  int nbinsBX        = BXDistr->GetNbinsX();
+                  int firstBinCenter = static_cast<int>(BXDistr->GetBinCenter(1));
+                  int lastBinCenter  = static_cast<int>(BXDistr->GetBinCenter(nbinsBX));
+                  int iMin = firstBinCenter>-4 ? firstBinCenter : -4;
+                  int iMax = lastBinCenter<20  ? lastBinCenter  : 20;
+                  for (int ibin=iMin+5;ibin<=iMax+5; ++ibin) {
+                    innerME->find(fullName("BXDistribPhiOut"))->second->setBinContent(ibin,stat,BXDistr->GetBinContent(ibin-5-firstBinCenter+1));
+                  }
+                  for (int ibin=1;ibin<=7;++ibin) {
+                    innerME->find(fullName("QualDistribPhiOut"))->second->setBinContent(ibin,stat,QualDistr->GetBinContent(ibin));
+                  }
+
+                  delete BXDistr;
+                  delete QualDistr;
+
+                  if( whME[wh].find(fullName("CorrectBXPhiOut")) == whME[wh].end() ){
+                    bookWheelHistos(ibooker,wh,"ResidualBXPhiOut");
+                    bookWheelHistos(ibooker,wh,"CorrectBXPhiOut");
+                    bookWheelHistos(ibooker,wh,"CorrFractionPhiOut");
+                    bookWheelHistos(ibooker,wh,"2ndFractionPhiOut");
+                    bookWheelHistos(ibooker,wh,"TriggerInclusivePhiOut");
+                  }
+
+                  innerME = &(whME[wh]);
+                  innerME->find(fullName("CorrectBXPhiOut"))->second->setBinContent(sect,stat,BX_OK+0.00001);
+                  innerME->find(fullName("ResidualBXPhiOut"))->second->setBinContent(sect,stat,round(25.*(BXMean-BX_OK))+0.00001);
+                  innerME->find(fullName("CorrFractionPhiOut"))->second->setBinContent(sect,stat,corrFrac);
+                  innerME->find(fullName("TriggerInclusivePhiOut"))->second->setBinContent(sect,stat,besttrigs);
+                  innerME->find(fullName("2ndFractionPhiOut"))->second->setBinContent(sect,stat,secondFrac);
+                }
+
+                whME[wh].find(fullName("CorrFractionSummaryOut"))->second->setBinContent(sect,stat,corrSummary);
+                whME[wh].find(fullName("2ndFractionSummaryOut"))->second->setBinContent(sect,stat,secondSummary);
+
+              }
+
+	      }	// Check on TM source
+		//Theta part
 	      if (hwSource=="DDU") {
 		TH2F * ThetaBXvsQual = getHisto<TH2F>(igetter.get(getMEName("ThetaBXvsQual","LocalTriggerTheta", chId)));
 		TH1F * ThetaBestQual = getHisto<TH1F>(igetter.get(getMEName("ThetaBestQual","LocalTriggerTheta", chId)));
@@ -362,21 +467,22 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker & ibooker, DQMSto
 	  }
 	}
 	else {
-	  TH2F* corrWhSummary   = getHisto<TH2F>(innerME->find(fullName("CorrFractionSummary"))->second);
-	  TH2F* secondWhSummary = getHisto<TH2F>(innerME->find(fullName("2ndFractionSummary"))->second);
+	// In part
+	  TH2F* corrWhSummaryIn   = getHisto<TH2F>(innerME->find(fullName("CorrFractionSummaryIn"))->second);
+	  TH2F* secondWhSummaryIn = getHisto<TH2F>(innerME->find(fullName("2ndFractionSummaryIn"))->second);
 	  for (int sect=1; sect<=12; ++sect){
 	    int corrErr      = 0;
 	    int secondErr    = 0;
 	    int corrNoData   = 0;
 	    int secondNoData = 0;
 	    for (int stat=1; stat<=4; ++stat){
-	      switch (static_cast<int>(corrWhSummary->GetBinContent(sect,stat))) {
+	      switch (static_cast<int>(corrWhSummaryIn->GetBinContent(sect,stat))) {
 	      case 1:
 		corrNoData++;
 	      case 2:
 		corrErr++;
 	      }
-	      switch (static_cast<int>(secondWhSummary->GetBinContent(sect,stat))) {
+	      switch (static_cast<int>(secondWhSummaryIn->GetBinContent(sect,stat))) {
 	      case 1:
 		secondNoData++;
 	      case 2:
@@ -385,9 +491,36 @@ void DTLocalTriggerTest::runClientDiagnostic(DQMStore::IBooker & ibooker, DQMSto
 	    }
 	    if (corrNoData == 4)   corrErr   = 5;
 	    if (secondNoData == 4) secondErr = 5;
-	    cmsME.find(fullName("CorrFractionSummary"))->second->setBinContent(sect,wh+3,corrErr);
-	    cmsME.find(fullName("2ndFractionSummary"))->second->setBinContent(sect,wh+3,secondErr);
+	    cmsME.find(fullName("CorrFractionSummaryIn"))->second->setBinContent(sect,wh+3,corrErr);
+	    cmsME.find(fullName("2ndFractionSummaryIn"))->second->setBinContent(sect,wh+3,secondErr);
 	  }
+	// Out part
+          TH2F* corrWhSummaryOut   = getHisto<TH2F>(innerME->find(fullName("CorrFractionSummaryOut"))->second);
+          TH2F* secondWhSummaryOut = getHisto<TH2F>(innerME->find(fullName("2ndFractionSummaryOut"))->second);
+          for (int sect=1; sect<=12; ++sect){
+            int corrErr      = 0;
+            int secondErr    = 0;
+            int corrNoData   = 0;
+            int secondNoData = 0;
+            for (int stat=1; stat<=4; ++stat){
+              switch (static_cast<int>(corrWhSummaryOut->GetBinContent(sect,stat))) {
+              case 1:
+                corrNoData++;
+              case 2:
+                corrErr++;
+              }
+              switch (static_cast<int>(secondWhSummaryOut->GetBinContent(sect,stat))) {
+              case 1:
+                secondNoData++;
+              case 2:
+                secondErr++;
+              }
+            }
+            if (corrNoData == 4)   corrErr   = 5;
+            if (secondNoData == 4) secondErr = 5;
+            cmsME.find(fullName("CorrFractionSummaryOut"))->second->setBinContent(sect,wh+3,corrErr);
+            cmsME.find(fullName("2ndFractionSummaryOut"))->second->setBinContent(sect,wh+3,secondErr);
+          }
 	}
       }
     }
@@ -409,8 +542,8 @@ void DTLocalTriggerTest::fillGlobalSummary(DQMStore::IGetter & igetter) {
     for (int sect=1; sect<=12; ++sect) {
 
       float maxErr = 8.;
-      int corr   = cmsME.find(fullName("CorrFractionSummary"))->second->getBinContent(sect,wh+3);
-      int second = cmsME.find(fullName("2ndFractionSummary"))->second->getBinContent(sect,wh+3);
+      int corr   = cmsME.find(fullName("CorrFractionSummaryIn"))->second->getBinContent(sect,wh+3);
+      int second = cmsME.find(fullName("2ndFractionSummaryIn"))->second->getBinContent(sect,wh+3);
       int lut=0;
       MonitorElement * lutsME = igetter.get(topFolder(hwSource=="TM") + "Summaries/TrigLutSummary");
       if (lutsME) {

--- a/DQM/DTMonitorModule/python/dtTriggerBaseTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerBaseTask_cfi.py
@@ -6,7 +6,7 @@ dtTriggerBaseMonitor = cms.EDAnalyzer("DTLocalTriggerBaseTask",
     targetBXTM = cms.untracked.int32(0), 
     targetBXDDU = cms.untracked.int32(9),
     bestTrigAccRange = cms.untracked.int32(3),
-    processDDU = cms.untracked.bool(True),
+    processDDU = cms.untracked.bool(False), #Not needed any longer, switches below for Eras do not work...
     processTM = cms.untracked.bool(True),
     nTimeBins = cms.untracked.int32(100),
     nLSTimeBin = cms.untracked.int32(15),    
@@ -22,6 +22,15 @@ dtTriggerBaseMonitor = cms.EDAnalyzer("DTLocalTriggerBaseTask",
     maxBXTM = cms.untracked.int32(2)
 )
 
+from Configuration.Eras.Modifier_run2_common_cff import run2_common
+run2_common.toModify( dtTriggerBaseMonitor, processDDU = cms.untracked.bool(False))
+
 from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
 run2_25ns_specific.toModify( dtTriggerBaseMonitor, processDDU = cms.untracked.bool(False))
+
+from Configuration.Eras.Modifier_run2_HI_specific_cff import run2_HI_specific
+run2_HI_specific.toModify( dtTriggerBaseMonitor, processDDU = cms.untracked.bool(False))
+
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+pA_2016.toModify( dtTriggerBaseMonitor, processDDU = cms.untracked.bool(False))
 

--- a/DQM/DTMonitorModule/python/dtTriggerEfficiencyTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerEfficiencyTask_cfi.py
@@ -12,12 +12,12 @@ dtTriggerEfficiencyMonitor = cms.EDAnalyzer("DTTriggerEfficiencyTask",
     inputTagDDU = cms.untracked.InputTag('muonDTDigis'),
     inputTagSEG = cms.untracked.InputTag('dt4DSegments'),
     inputTagGMT = cms.untracked.InputTag('gtDigis'),
-    processDDU = cms.untracked.bool(True),  # if true enables DDU data analysis
+    processDDU = cms.untracked.bool(False),  # Not needed any longer. Switches below for Eras do not work... 
     processTM = cms.untracked.bool(True), # if true enables TM data analysis
     minBXDDU = cms.untracked.int32(7),  # min BX for DDU eff computation
     maxBXDDU = cms.untracked.int32(15), # max BX for DDU eff computation
 
-    checkRPCtriggers = cms.untracked.bool(True),
+    checkRPCtriggers = cms.untracked.bool(False), #  Not needed any longer. Switches below for Eras do not work...
     nMinHitsPhi = cms.untracked.int32(5),
     phiAccRange = cms.untracked.double(30.),
 
@@ -29,3 +29,12 @@ dtTriggerEfficiencyMonitor = cms.EDAnalyzer("DTTriggerEfficiencyTask",
 #
 from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
 run2_25ns_specific.toModify( dtTriggerEfficiencyMonitor, checkRPCtriggers = cms.untracked.bool(False),processDDU = cms.untracked.bool(False))
+
+from Configuration.Eras.Modifier_run2_HI_specific_cff import run2_HI_specific
+run2_HI_specific.toModify( dtTriggerEfficiencyMonitor, checkRPCtriggers = cms.untracked.bool(False),processDDU = cms.untracked.bool(False))
+
+from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
+pA_2016.toModify( dtTriggerEfficiencyMonitor, checkRPCtriggers = cms.untracked.bool(False),processDDU = cms.untracked.bool(False))
+
+
+

--- a/DQM/DTMonitorModule/python/dtTriggerLutTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerLutTask_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 dtTriggerLutMonitor = cms.EDAnalyzer("DTLocalTriggerLutTask",
     # labels of DDU/TM data and 4D segments
-    inputTagTM = cms.untracked.InputTag("twinMuxStage2Digis:PhIn"),
+    inputTagTMin = cms.untracked.InputTag("twinMuxStage2Digis:PhIn"),
+    inputTagTMout = cms.untracked.InputTag("twinMuxStage2Digis:PhOut"),
     inputTagSEG = cms.untracked.InputTag("dt4DSegments"),
     # set static booking (all the detector)
     staticBooking = cms.untracked.bool(True),

--- a/DQM/DTMonitorModule/python/dtTriggerTask_TP_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerTask_TP_cfi.py
@@ -4,7 +4,8 @@ dtTPTriggerMonitor = cms.EDAnalyzer("DTLocalTriggerTask",
     # set static booking (all the detector)
     staticBooking = cms.untracked.bool(True),
     # labels of DDU/TM data and 4D segments
-    tm_label = cms.untracked.string('twinMuxStage2Digis:PhIn'),
+    tm_labelIn = cms.untracked.string('twinMuxStage2Digis:PhIn'),
+    tm_labelOut = cms.untracked.string('twinMuxStage2Digis:PhOut'),
     ros_label = cms.untracked.string('dtunpacker'),
     seg_label = cms.untracked.string('dt4DSegments'),
     minBXDDU = cms.untracked.int32(0),  # min BX for DDU plots
@@ -12,7 +13,7 @@ dtTPTriggerMonitor = cms.EDAnalyzer("DTLocalTriggerTask",
     minBXTM = cms.untracked.int32(0), # min BX for TM plots
     maxBXTM = cms.untracked.int32(2),  # max BX for TM plots
     process_seg = cms.untracked.bool(False), # if true enables comparisons with reconstructed segments    
-    process_ros = cms.untracked.bool(True),  # if true enables DDU data analysis
+    process_ddu = cms.untracked.bool(True),  # if true enables DDU data analysis
     process_tm = cms.untracked.bool(True),  # if true enables TM data analysis
     testPulseMode = cms.untracked.bool(True), #if true enables test pulse mode
     detailedAnalysis = cms.untracked.bool(False), #if true enables detailed analysis plots
@@ -22,4 +23,9 @@ dtTPTriggerMonitor = cms.EDAnalyzer("DTLocalTriggerTask",
     ResetCycle = cms.untracked.int32(10000)
 )
 
+#
+# Modify for running in run 2 2016 data
+#
+from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
+run2_25ns_specific.toModify( dtTPTriggerMonitor, process_ddu = cms.untracked.bool(False))
 

--- a/DQM/DTMonitorModule/python/dtTriggerTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerTask_cfi.py
@@ -4,7 +4,8 @@ dtTriggerMonitor = cms.EDAnalyzer("DTLocalTriggerTask",
     # set static booking (all the detector)
     staticBooking = cms.untracked.bool(True),
     # labels of DDU/TM data and 4D segments
-    tm_label = cms.untracked.string('twinMuxStage2Digis:PhIn'),
+    tm_labelIn = cms.untracked.string('twinMuxStage2Digis:PhIn'),
+    tm_labelOut = cms.untracked.string('twinMuxStage2Digis:PhOut'),
     tmTh_label = cms.untracked.InputTag("twinMuxStage2Digis","ThIn"),
     ros_label = cms.untracked.string('dtunpacker'),
     seg_label = cms.untracked.string('dt4DSegments'),
@@ -13,7 +14,7 @@ dtTriggerMonitor = cms.EDAnalyzer("DTLocalTriggerTask",
     maxBXTM = cms.untracked.int32(2),  # max BX for TM plots
     minBXTM = cms.untracked.int32(0), # min BX for TM plots
     process_seg = cms.untracked.bool(False), # if true enables comparisons with reconstructed segments    
-    process_ros = cms.untracked.bool(False),  # if true enables DDU data analysis
+    process_ddu = cms.untracked.bool(False),  # if true enables DDU data analysis
     process_tm = cms.untracked.bool(True), # if true enables TM data analysis
     testPulseMode = cms.untracked.bool(False), # if true enables test pluse mode
     detailedAnalysis = cms.untracked.bool(False), #if true enables detailed analysis plots
@@ -23,4 +24,9 @@ dtTriggerMonitor = cms.EDAnalyzer("DTLocalTriggerTask",
     ResetCycle = cms.untracked.int32(10000)
 )
 
+#
+# Modify for running in run 2 2016 data
+#
+from Configuration.Eras.Modifier_run2_25ns_specific_cff import run2_25ns_specific
+run2_25ns_specific.toModify( dtTriggerMonitor, process_ddu = cms.untracked.bool(False))
 

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -1079,10 +1079,10 @@ void DTDataIntegrityTask::fedNonFatal(int dduID) {
 
 std::string DTDataIntegrityTask::topFolder(bool isFEDIntegrity) const {
 
-  string folder = isFEDIntegrity ? fedIntegrityFolder : "DT/00-DataIntegrity";
+  string folder = isFEDIntegrity ? fedIntegrityFolder : "DT/00-DataIntegrity/";
 
-  if (!isFEDIntegrity)
-    folder += (mode==1) ? "_SM/" : (mode==3) ? "_EvF/" : "/";
+//  if (!isFEDIntegrity)
+//    folder += (mode==1) ? "_SM/" : (mode==3) ? "_EvF/" : "/";
 
   return folder;
 

--- a/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
@@ -86,7 +86,9 @@ DTLocalTriggerBaseTask::DTLocalTriggerBaseTask(const edm::ParameterSet& ps) :
       ps.getUntrackedParameter<InputTag>("inputTagDDU"));
 
   if (processTM) theTypes.push_back("TM");
-  if (processDDU) theTypes.push_back("DDU");
+  if (processDDU) {
+	std::cout<<"DDU!!!"<<std::endl; theTypes.push_back("DDU");
+	}
 
   if (tpMode) {
     topFolder("TM") = "DT/11-LocalTriggerTP-TM/";
@@ -342,13 +344,9 @@ void DTLocalTriggerBaseTask::bookHistos(DQMStore::IBooker & ibooker, const DTCha
 
   if (processTM && processDDU) {
     // Book TM/DDU Comparison Plots
-    for (int InOut=0; InOut<2;InOut++){
-    if(InOut==0)   
+    // NOt needed In and Out comparison, only IN in DDU....
     ibooker.setCurrentFolder(topFolder("DDU") + "Wheel" + wheel.str() + "/Sector"
 		       + sector.str() + "/Station" + station.str() + "/LocalTriggerPhiIn");
-    else if(InOut==1)
-    ibooker.setCurrentFolder(topFolder("DDU") + "Wheel" + wheel.str() + "/Sector"
-                       + sector.str() + "/Station" + station.str() + "/LocalTriggerPhiOut");
 
 
     string histoTag = "COM_QualDDUvsQualTM";
@@ -361,7 +359,6 @@ void DTLocalTriggerBaseTask::bookHistos(DQMStore::IBooker & ibooker, const DTCha
     trendHistos[rawId] = new DTTimeEvolutionHisto(ibooker,histoTag+chTag,
 						  "Fraction of DDU-TM matches w.r.t. proc evts",
 						  nTimeBins,nLSTimeBin,true,0);
-  } //InOut loop
   }
 
 }

--- a/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.cc
@@ -36,8 +36,10 @@ DTLocalTriggerLutTask::DTLocalTriggerLutTask(const edm::ParameterSet& ps) : trig
 
   LogTrace("DTDQM|DTMonitorModule|DTLocalTriggerLutTask") << "[DTLocalTriggerLutTask]: Constructor"<<endl;
 
-  tm_Token_   = consumes<L1MuDTChambPhContainer>(
-      ps.getUntrackedParameter<InputTag>("inputTagTM"));
+  tm_TokenIn_   = consumes<L1MuDTChambPhContainer>(
+      ps.getUntrackedParameter<InputTag>("inputTagTMin"));
+  tm_TokenOut_   = consumes<L1MuDTChambPhContainer>(
+      ps.getUntrackedParameter<InputTag>("inputTagTMout"));
   seg_Token_   = consumes<DTRecSegment4DCollection>(
       ps.getUntrackedParameter<InputTag>("inputTagSEG"));
 
@@ -92,12 +94,22 @@ void DTLocalTriggerLutTask::bookHistos(DQMStore::IBooker & ibooker, DTChamberId 
   string chTag = "_W" + wheel.str() + "_Sec" + sector.str() + "_St" + station.str();
   std::map<std::string, MonitorElement*> &chambMap = chHistos[chId.rawId()];
 
-  string hName = "TM_PhiResidual";
+  string hName = "TM_PhiResidualIn";
 
-  chambMap[hName] = ibooker.book1D(hName+chTag,"Trigger local position - Segment local position (correlated triggers)",nPhiBins,-rangePhi,rangePhi);
-  hName = "TM_PhibResidual";
+  chambMap[hName] = ibooker.book1D(hName+chTag,"Trigger local position In - Segment local position (correlated triggers)",nPhiBins,-rangePhi,rangePhi);
 
-  chambMap[hName] = ibooker.book1D(hName+chTag,"Trigger local direction - Segment local direction (correlated triggers)",nPhibBins,-rangePhiB,rangePhiB);
+  hName = "TM_PhiResidualOut";
+
+  chambMap[hName] = ibooker.book1D(hName+chTag,"Trigger local position Out - Segment local position (correlated triggers)",nPhiBins,-rangePhi,rangePhi);
+
+  hName = "TM_PhibResidualIn";
+
+  chambMap[hName] = ibooker.book1D(hName+chTag,"Trigger local direction In - Segment local direction (correlated triggers)",nPhibBins,-rangePhiB,rangePhiB);
+
+  hName = "TM_PhibResidualOut";
+
+  chambMap[hName] = ibooker.book1D(hName+chTag,"Trigger local direction Out - Segment local direction (correlated triggers)",nPhibBins,-rangePhiB,rangePhiB);
+
 
   if (detailedAnalysis) {
 
@@ -162,10 +174,15 @@ void DTLocalTriggerLutTask::analyze(const edm::Event& e, const edm::EventSetup& 
 
   nEvents++;
 
-  edm::Handle<L1MuDTChambPhContainer> trigHandle;
-  e.getByToken(tm_Token_, trigHandle);
-  vector<L1MuDTChambPhDigi> const* trigs = trigHandle->getContainer();
-  searchDccBest(trigs);
+  edm::Handle<L1MuDTChambPhContainer> trigHandleIn;
+  e.getByToken(tm_TokenIn_, trigHandleIn);
+  edm::Handle<L1MuDTChambPhContainer> trigHandleOut;
+  e.getByToken(tm_TokenOut_, trigHandleOut);
+
+  vector<L1MuDTChambPhDigi> const* trigsIn = trigHandleIn->getContainer();
+  searchTMBestIn(trigsIn);
+  vector<L1MuDTChambPhDigi> const* trigsOut = trigHandleOut->getContainer();
+  searchTMBestOut(trigsOut);
 
   Handle<DTRecSegment4DCollection> segments4D;
   e.getByToken(seg_Token_, segments4D);
@@ -217,21 +234,21 @@ void DTLocalTriggerLutTask::analyze(const edm::Event& e, const edm::EventSetup& 
       trigGeomUtils->computeSCCoordinates((*bestTrackIt),scsector,trackPosPhi,trackDirPhi,trackPosEta,trackDirEta);
 
       map<string, MonitorElement*> &chMap = chHistos[chId.rawId()];
-
-      if (trigQualBest[wheel+3][station][scsector] > 3 &&  // residuals only for correlate triggers
-	  trigQualBest[wheel+3][station][scsector] < 7 &&
+      // In part
+      if (trigQualBestIn[wheel+3][station][scsector] > 3 &&  // residuals only for correlate triggers
+	  trigQualBestIn[wheel+3][station][scsector] < 7 &&
 	  nHitsPhi>=7 ) {
 
-	float trigPos = trigGeomUtils->trigPos(trigBest[wheel+3][station][scsector]);
-	float trigDir = trigGeomUtils->trigDir(trigBest[wheel+3][station][scsector]);
+	float trigPos = trigGeomUtils->trigPos(trigBestIn[wheel+3][station][scsector]);
+	float trigDir = trigGeomUtils->trigDir(trigBestIn[wheel+3][station][scsector]);
 	trigGeomUtils->trigToSeg(station,trigPos,trackDirPhi);
 
 	double deltaPos = trigPos-trackPosPhi;
 	deltaPos = overUnderIn ? max(min(deltaPos,rangePhi-0.01),-rangePhi+0.01) : deltaPos;
 	double deltaDir = trigDir-trackDirPhi;
 	deltaDir = overUnderIn ? max(min(deltaDir,rangePhiB-0.01),-rangePhiB+0.01) : deltaDir;
-	chMap.find("TM_PhiResidual")->second->Fill(deltaPos);
-	chMap.find("TM_PhibResidual")->second->Fill(deltaDir);
+	chMap.find("TM_PhiResidualIn")->second->Fill(deltaPos);
+	chMap.find("TM_PhibResidualIn")->second->Fill(deltaDir);
 
 	if (detailedAnalysis){
 	  chMap.find("TM_PhitkvsPhitrig")->second->Fill(trigPos,trackPosPhi);
@@ -240,11 +257,29 @@ void DTLocalTriggerLutTask::analyze(const edm::Event& e, const edm::EventSetup& 
 	  chMap.find("TM_PhiResidualvsTkPos")->second->Fill(trackPosPhi,trigPos-trackPosPhi);
 	}
       }
+
+      // Out part
+      if (trigQualBestOut[wheel+3][station][scsector] > 3 &&  // residuals only for correlate triggers
+          trigQualBestOut[wheel+3][station][scsector] < 7 &&
+          nHitsPhi>=7 ) {
+
+        float trigPos = trigGeomUtils->trigPos(trigBestOut[wheel+3][station][scsector]);
+        float trigDir = trigGeomUtils->trigDir(trigBestOut[wheel+3][station][scsector]);
+        trigGeomUtils->trigToSeg(station,trigPos,trackDirPhi);
+
+        double deltaPos = trigPos-trackPosPhi;
+        deltaPos = overUnderIn ? max(min(deltaPos,rangePhi-0.01),-rangePhi+0.01) : deltaPos;
+        double deltaDir = trigDir-trackDirPhi;
+        deltaDir = overUnderIn ? max(min(deltaDir,rangePhiB-0.01),-rangePhiB+0.01) : deltaDir;
+        chMap.find("TM_PhiResidualOut")->second->Fill(deltaPos);
+        chMap.find("TM_PhibResidualOut")->second->Fill(deltaDir);
+     }
+
     }
   }
 }
 
-void DTLocalTriggerLutTask::searchDccBest( std::vector<L1MuDTChambPhDigi> const* trigs ) {
+void DTLocalTriggerLutTask::searchTMBestIn( std::vector<L1MuDTChambPhDigi> const* trigs) {
 
   string histoType ;
   string histoTag ;
@@ -254,7 +289,7 @@ void DTLocalTriggerLutTask::searchDccBest( std::vector<L1MuDTChambPhDigi> const*
   for (int st=0;st<=4;++st)
     for (int wh=0;wh<=5;++wh)
       for (int sec=0;sec<=12;++sec)
-	trigQualBest[wh][st][sec] = -1;
+	trigQualBestIn[wh][st][sec] = -1;
 
   vector<L1MuDTChambPhDigi>::const_iterator trigIt  = trigs->begin();
   vector<L1MuDTChambPhDigi>::const_iterator trigEnd = trigs->end();
@@ -265,12 +300,44 @@ void DTLocalTriggerLutTask::searchDccBest( std::vector<L1MuDTChambPhDigi> const*
     int st   = trigIt->stNum();
     int qual = trigIt->code();
 
-    if(qual>trigQualBest[wh+3][st][sec] && qual<7) {
-      trigQualBest[wh+3][st][sec]=qual;
-      trigBest[wh+3][st][sec] = &(*trigIt);
+    if(qual>trigQualBestIn[wh+3][st][sec] && qual<7) {
+      trigQualBestIn[wh+3][st][sec]=qual;
+      trigBestIn[wh+3][st][sec] = &(*trigIt);
     }
 
   }
+
+}
+
+
+void DTLocalTriggerLutTask::searchTMBestOut( std::vector<L1MuDTChambPhDigi> const* trigs) {
+
+  string histoType ;
+  string histoTag ;
+
+// define best quality trigger segment
+//   // start from 1 and zero is kept empty
+  for (int st=0;st<=4;++st)
+    for (int wh=0;wh<=5;++wh)
+      for (int sec=0;sec<=12;++sec)
+        trigQualBestOut[wh][st][sec] = -1;
+
+  vector<L1MuDTChambPhDigi>::const_iterator trigIt  = trigs->begin();
+  vector<L1MuDTChambPhDigi>::const_iterator trigEnd = trigs->end();
+  for(; trigIt!=trigEnd; ++trigIt) {
+
+    int wh   = trigIt->whNum();
+    int sec  = trigIt->scNum() + 1; // DTTF -> DT sector range transform
+    int st   = trigIt->stNum();
+    int qual = trigIt->code();
+
+    if(qual>trigQualBestOut[wh+3][st][sec] && qual<7) {
+      trigQualBestOut[wh+3][st][sec]=qual;
+      trigBestOut[wh+3][st][sec] = &(*trigIt);
+    }
+
+  }
+
 }
 
 // Local Variables:

--- a/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
@@ -59,7 +59,8 @@ class DTLocalTriggerLutTask: public DQMEDAnalyzer{
   void dqmBeginRun(const edm::Run& , const edm::EventSetup&) override;
 
   /// Find best (highest qual) TM trigger segments
-  void searchDccBest(std::vector<L1MuDTChambPhDigi> const* trigs);
+  void searchTMBestIn(std::vector<L1MuDTChambPhDigi> const* trigs);
+  void searchTMBestOut(std::vector<L1MuDTChambPhDigi> const* trigs);
 
   /// Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
@@ -86,11 +87,14 @@ class DTLocalTriggerLutTask: public DQMEDAnalyzer{
   bool detailedAnalysis;
   bool overUnderIn;
 
-  edm::EDGetTokenT<L1MuDTChambPhContainer> tm_Token_;
+  edm::EDGetTokenT<L1MuDTChambPhContainer> tm_TokenIn_;
+  edm::EDGetTokenT<L1MuDTChambPhContainer> tm_TokenOut_;
   edm::EDGetTokenT<DTRecSegment4DCollection> seg_Token_;
 
-  int trigQualBest[6][5][13];
-  const L1MuDTChambPhDigi* trigBest[6][5][13];
+  int trigQualBestIn[6][5][13];
+  int trigQualBestOut[6][5][13];
+  const L1MuDTChambPhDigi* trigBestIn[6][5][13];
+  const L1MuDTChambPhDigi* trigBestOut[6][5][13];
   bool track_ok[6][5][15]; // CB controlla se serve
 
   edm::ParameterSet parameters;

--- a/DQM/DTMonitorModule/src/DTLocalTriggerTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerTask.cc
@@ -120,7 +120,7 @@ void DTLocalTriggerTask::bookHistograms(DQMStore::IBooker & ibooker, edm::Run co
 	      bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","TM_QualvsPhirad"+(*trigSrcIt));
 	    }
 
-	    if (parameters.getUntrackedParameter<bool>("process_ros", true)){ // DDU data
+	    if (parameters.getUntrackedParameter<bool>("process_ddu", true)){ // DDU data
 	      bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","DDU_BXvsQual"+(*trigSrcIt));
 	    }
 
@@ -132,7 +132,7 @@ void DTLocalTriggerTask::bookHistograms(DQMStore::IBooker & ibooker, edm::Run co
       for (;trigSrcIt!=trigSrcEnd;++trigSrcIt){
 	for (int wh=-2;wh<3;++wh){
 	  if (parameters.getUntrackedParameter<bool>("process_tm", true) &&
-	      parameters.getUntrackedParameter<bool>("process_ros", true)){ // TM+DDU data
+	      parameters.getUntrackedParameter<bool>("process_ddu", true)){ // TM+DDU data
 	    bookWheelHistos(ibooker, wh,"COM_BXDiff"+(*trigSrcIt));
 	  }
 	  for (int sect=1;sect<13;++sect){
@@ -176,7 +176,7 @@ void DTLocalTriggerTask::bookHistograms(DQMStore::IBooker & ibooker, edm::Run co
 
 	      }
 
-	      if (parameters.getUntrackedParameter<bool>("process_ros", true)){ // DDU data
+	      if (parameters.getUntrackedParameter<bool>("process_ddu", true)){ // DDU data
 
 		bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","DDU_BXvsQual"+(*trigSrcIt));
 		bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","DDU_Flag1stvsQual"+(*trigSrcIt));
@@ -201,7 +201,7 @@ void DTLocalTriggerTask::bookHistograms(DQMStore::IBooker & ibooker, edm::Run co
 	      }
 
 	      if (parameters.getUntrackedParameter<bool>("process_tm", true) &&
-		  parameters.getUntrackedParameter<bool>("process_ros", true)){ // TM+DDU data
+		  parameters.getUntrackedParameter<bool>("process_ddu", true)){ // TM+DDU data
 		bookHistos(ibooker, dtChId,"LocalTriggerPhiIn","COM_QualDDUvsQualTM"+(*trigSrcIt));
 	      }
 
@@ -258,7 +258,7 @@ void DTLocalTriggerTask::analyze(const edm::Event& e, const edm::EventSetup& c){
 
     Handle<DTLocalTriggerCollection> l1DDUTrigs;
     e.getByToken(ros_Token_,l1DDUTrigs);
-    useDDU = l1DDUTrigs.isValid() && parameters.getUntrackedParameter<bool>("process_ros", true) ;
+    useDDU = l1DDUTrigs.isValid() && parameters.getUntrackedParameter<bool>("process_ddu", true) ;
 
     Handle<DTRecSegment4DCollection> all4DSegments;
     e.getByToken(seg_Token_, all4DSegments);
@@ -614,7 +614,7 @@ void DTLocalTriggerTask::runTMAnalysis(std::vector<L1MuDTChambPhDigi> const* phT
 	    uint32_t indexCh = id.rawId();
 	    map<string, MonitorElement*> &innerME = digiHistos[indexCh];
 
-	    innerME.find("TM_BestQual"+trigsrc)->second->Fill(phcode_best[wh+3][st][sc]);  // Best Qual Trigger Phi view
+	    innerME.find("TM_BestQual_In"+trigsrc)->second->Fill(phcode_best[wh+3][st][sc]);  // Best Qual Trigger Phi view
 	  }
           if (thcode_best[wh+3][st][sc]>0 && thcode_best[wh+3][st][sc]<3){
             DTChamberId id(wh,st,sc);

--- a/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.cc
+++ b/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.cc
@@ -131,7 +131,7 @@ void DTTriggerEfficiencyTask::analyze(const edm::Event& e, const edm::EventSetup
   edm::Handle<L1MuDTChambPhContainer> l1DTTPGPh;
   e.getByToken(tm_Token_, l1DTTPGPh);
   vector<L1MuDTChambPhDigi> const*  phTrigs = l1DTTPGPh->getContainer();
-
+  //empty from dttfDigis, needs emulator working?
   vector<L1MuDTChambPhDigi>::const_iterator iph  = phTrigs->begin();
   vector<L1MuDTChambPhDigi>::const_iterator iphe = phTrigs->end();
   for(; iph !=iphe ; ++iph) {
@@ -237,10 +237,11 @@ void DTTriggerEfficiencyTask::analyze(const edm::Event& e, const edm::EventSetup
       vector<string>::const_iterator tagIt  = processTags.begin();
       vector<string>::const_iterator tagEnd = processTags.end();
       for (; tagIt!=tagEnd; ++tagIt) {
-        int qual   = (*tagIt) == "TM" ?
+	int qual = (*tagIt) == "TM" ?
           phBestTM.find(dtChId) != phBestTM.end() ? phBestTM[dtChId]->code() : -1 :
           phBestDDU.find(dtChId) != phBestDDU.end() ? phBestDDU[dtChId]->quality() : -1;
         innerWhME.find((*tagIt) + "_TrigEffDenum")->second->Fill(scsector,station);
+
         if ( qual>=0 && qual<7 ) {
           innerWhME.find((*tagIt) + "_TrigEffNum")->second->Fill(scsector,station);
           if ( qual>=4 ) {

--- a/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
+++ b/HLTrigger/Configuration/python/customizeHLTTrackingForPhaseI2017.py
@@ -27,6 +27,9 @@ def modifyHLTPhaseIPixelGeom(process):
 
 # modify the HLT configuration to run the Phase I tracking in the particle flow sequence
 def customizeHLTForPFTrackingPhaseI2017(process):
+    if not hasattr(process, 'hltPixelLayerTriplets'):
+        #there could also be a message here that the call is done for non-HLT stuff
+        return process;
 
     process.hltPixelLayerTriplets.layerList = cms.vstring(
         'BPix1+BPix2+BPix3',


### PR DESCRIPTION
Summary of changes:

New plots added for IN-OUT differences coming out from TwinMux
DDU plots completely removed due to switching to TwinMux
Removed Data_SM and FEDIntegrity_EvF empty folders: info saved on 00-DataIntegrity
Layouts additions: added Out plots in addition to the default In plots in TriggerSynch, TriggerBasics and TriggerPosLUTs
Change colours in DataIntegritySummary plot and definition to reflect only ROB errors:
Folder 04-LocalTrigger-DDU removed