### PR TITLE
Fix DCS error in offline tracker maps

### DIFF
--- a/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 
 class DQMStore;
 class MonitorElement;
@@ -86,7 +87,7 @@ private:
     MonitorElement* DcsFractionME;
     int TotalDetectors;
     std::vector<uint32_t> FaultyDetectors;
-    std::map<uint32_t,uint16_t> NLumiDetectorIsFaulty;
+    std::unordered_map<uint32_t,uint16_t> NLumiDetectorIsFaulty;
   };
 
   std::map <std::string, SubDetMEs> SubDetMEsMap;

--- a/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
@@ -99,6 +99,7 @@ private:
 
   int nLumiAnalysed_;
 
+  bool IsLumiGoodDcs_;
   int nGoodDcsLumi_;
   float MinAcceptableDcsDetFrac_ = 0.90;
   float MaxAcceptableBadDcsLumi_ = 2;

--- a/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
@@ -86,7 +86,7 @@ private:
     MonitorElement* DcsFractionME;
     int TotalDetectors;
     std::vector<uint32_t> FaultyDetectors;
-    std::map<uint32_t,uint32_t> NLumiDetectorIsFaulty;
+    std::map<uint32_t,uint16_t> NLumiDetectorIsFaulty;
   };
 
   std::map <std::string, SubDetMEs> SubDetMEsMap;

--- a/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
@@ -97,6 +97,8 @@ private:
   edm::ESHandle<SiStripDetVOff> siStripDetVOff_;
   int  nFEDConnected_;
 
+  int nLumiAnalysed_;
+
   int nGoodDcsLumi_;
   float MinAcceptableDcsDetFrac_ = 0.90;
   float MaxAcceptableBadDcsLumiFrac_ = 0.10;

--- a/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
@@ -86,6 +86,7 @@ private:
     MonitorElement* DcsFractionME;
     int TotalDetectors;
     std::vector<uint32_t> FaultyDetectors;
+    std::map<uint32_t,uint32_t> NLumiDetectorIsFaulty;
   };
 
   std::map <std::string, SubDetMEs> SubDetMEsMap;
@@ -96,7 +97,9 @@ private:
   edm::ESHandle<SiStripDetVOff> siStripDetVOff_;
   int  nFEDConnected_;
 
-  int nLumiAnalysed_;
+  int nGoodDcsLumi_;
+  float MinAcceptableDcsDetFrac_ = 0.90;
+  float MaxAcceptableBadDcsLumiFrac_ = 0.10;
 
   edm::ESHandle< SiStripDetCabling > detCabling_;
 };

--- a/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripDcsInfo.h
@@ -101,7 +101,7 @@ private:
 
   int nGoodDcsLumi_;
   float MinAcceptableDcsDetFrac_ = 0.90;
-  float MaxAcceptableBadDcsLumiFrac_ = 0.10;
+  float MaxAcceptableBadDcsLumi_ = 2;
 
   edm::ESHandle< SiStripDetCabling > detCabling_;
 };

--- a/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
@@ -335,8 +335,8 @@ void SiStripDcsInfo::addBadModules() {
 
   for (std::map<std::string, SubDetMEs>::iterator it = SubDetMEsMap.begin(); it != SubDetMEsMap.end(); it++) {
 
-    std::map<uint32_t,uint16_t> lumiCountBadModules = it->second.NLumiDetectorIsFaulty;
-    for(std::map<uint32_t,uint16_t>::iterator ilumibad = lumiCountBadModules.begin(); 
+    std::unordered_map<uint32_t,uint16_t> lumiCountBadModules = it->second.NLumiDetectorIsFaulty;
+    for(std::unordered_map<uint32_t,uint16_t>::iterator ilumibad = lumiCountBadModules.begin(); 
         ilumibad != lumiCountBadModules.end(); ilumibad++) {
       uint32_t ibad = (*ilumibad).first;
       uint32_t nBadLumi = (*ilumibad).second;

--- a/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
@@ -335,8 +335,8 @@ void SiStripDcsInfo::addBadModules() {
 
   for (std::map<std::string, SubDetMEs>::iterator it = SubDetMEsMap.begin(); it != SubDetMEsMap.end(); it++) {
 
-    std::map<uint32_t,uint32_t> lumiCountBadModules = it->second.NLumiDetectorIsFaulty;
-    for(std::map<uint32_t,uint32_t>::iterator ilumibad = lumiCountBadModules.begin(); 
+    std::map<uint32_t,uint16_t> lumiCountBadModules = it->second.NLumiDetectorIsFaulty;
+    for(std::map<uint32_t,uint16_t>::iterator ilumibad = lumiCountBadModules.begin(); 
         ilumibad != lumiCountBadModules.end(); ilumibad++) {
       uint32_t ibad = (*ilumibad).first;
       uint32_t nBadLumi = (*ilumibad).second;

--- a/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
@@ -35,8 +35,8 @@ SiStripDcsInfo::SiStripDcsInfo(edm::ParameterSet const& pSet) :
     m_cacheIDCabling_(0),
     m_cacheIDDcs_(0),
     bookedStatus_(false),
-    nGoodDcsLumi_(0),
-    nLumiAnalysed_(0)
+    nLumiAnalysed_(0),
+    nGoodDcsLumi_(0)
 { 
   // Create MessageSender
   LogDebug( "SiStripDcsInfo") << "SiStripDcsInfo::Deleting SiStripDcsInfo ";
@@ -341,7 +341,6 @@ void SiStripDcsInfo::addBadModules() {
       uint32_t nBadLumi = (*ilumibad).second;
       float nBadDcsLumiFrac = 1.;
       if(nGoodDcsLumi_ > 0) { nBadDcsLumiFrac = nBadLumi/(float)nGoodDcsLumi_; }
-      std::cout << "%%%%%%%%%% detector is faulty, fraction: " << ibad << " " << nBadLumi << " out of " << nGoodDcsLumi_ << std::endl;
       if(nBadDcsLumiFrac < MaxAcceptableBadDcsLumiFrac_) continue;
       std::string bad_module_folder = mechanical_dir + "/" +
                                       it->second.folder_name + "/"     

--- a/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
@@ -339,9 +339,7 @@ void SiStripDcsInfo::addBadModules() {
         ilumibad != lumiCountBadModules.end(); ilumibad++) {
       uint32_t ibad = (*ilumibad).first;
       uint32_t nBadLumi = (*ilumibad).second;
-      float nBadDcsLumiFrac = 1.;
-      if(nGoodDcsLumi_ > 0) { nBadDcsLumiFrac = nBadLumi/(float)nGoodDcsLumi_; }
-      if(nBadDcsLumiFrac < MaxAcceptableBadDcsLumiFrac_) continue;
+      if(nBadLumi < MaxAcceptableBadDcsLumi_) continue;
       std::string bad_module_folder = mechanical_dir + "/" +
                                       it->second.folder_name + "/"     
                                       "BadModuleList";      

--- a/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripDcsInfo.cc
@@ -35,7 +35,8 @@ SiStripDcsInfo::SiStripDcsInfo(edm::ParameterSet const& pSet) :
     m_cacheIDCabling_(0),
     m_cacheIDDcs_(0),
     bookedStatus_(false),
-    nGoodDcsLumi_(0)
+    nGoodDcsLumi_(0),
+    nLumiAnalysed_(0)
 { 
   // Create MessageSender
   LogDebug( "SiStripDcsInfo") << "SiStripDcsInfo::Deleting SiStripDcsInfo ";
@@ -144,6 +145,7 @@ void SiStripDcsInfo::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, e
     it->second.FaultyDetectors.clear();
   }
   readStatus(eSetup);
+  nLumiAnalysed_++;   
 }
 
 //


### PR DESCRIPTION
Change DCS error check in offline code to per-lumi instead of end-of-run.

DCS checking made at end-of-run sometimes produced purple (DCS error) tracker maps because tracker may have been off at that point. Per-lumi averaging fixes this.

Jira ticket:
https://its.cern.ch/jira/browse/CMSTRKDQM-1