### PR TITLE
Removed legacy b tagging using tight track selection from MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -164,30 +164,6 @@ def miniAOD_customizeCommon(process):
     process.patJets.userData.userFunctionLabels = cms.vstring('vtxMass','vtxNtracks','vtx3DVal','vtx3DSig','vtxPx','vtxPy','vtxPz','vtxPosX','vtxPosY','vtxPosZ')
     process.patJets.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfos"))
     process.patJets.addTagInfos = cms.bool(True)
-
-    ## Legacy tight b-tag track selection
-    ## (this will run below-specified taggers with the tight b-tag track selection enabled
-    ## and will add an extra set of b-tag discriminators to 'selectedPatJets'
-    ## with the 'tight' prefix added to the usual discriminator names)
-    from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
-    updateJetCollection(
-        process,
-        jetSource = cms.InputTag('selectedPatJets'),
-        ## updateJetCollection defaults to MiniAOD inputs. Here, this needs to be changed to RECO/AOD inputs
-        pvSource = cms.InputTag('offlinePrimaryVertices'),
-        pfCandidates = cms.InputTag('particleFlow'),
-        svSource = cms.InputTag('inclusiveCandidateSecondaryVertices'),
-        muSource = cms.InputTag('muons'),
-        elSource = cms.InputTag('gedGsfElectrons'),
-        ##
-        jetCorrections = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''),
-        btagDiscriminators = ["pfCombinedSecondaryVertexV2BJetTags", "pfCombinedInclusiveSecondaryVertexV2BJetTags",
-                              "pfCombinedCvsLJetTags", "pfCombinedCvsBJetTags"],
-        runIVF = True,
-        tightBTagNTkHits = True,
-        btagPrefix = 'tight',
-        postfix = 'BTAG' # added to avoid problems with unrunnable schedule
-    )
     #
     ## PU JetID
     process.load("RecoJets.JetProducers.PileupJetID_cfi")

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedJets_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 slimmedJets = cms.EDProducer("PATJetSlimmer",
-   src = cms.InputTag("selectedUpdatedPatJetsBTAG"),
+   src = cms.InputTag("selectedPatJets"),
    packedPFCandidates = cms.InputTag("packedPFCandidates"),
    dropJetVars = cms.string("1"),
    dropDaughters = cms.string("0"),


### PR DESCRIPTION
This PR addresses the issue discussed in https://github.com/cms-sw/cmssw/issues/17573