### PR TITLE
Add GEM copad processor and LUT generator class

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -342,6 +342,7 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 # Upgrade era customizations involving GEMs and RPCs
 # ==================================================
 copadParam = cms.PSet(
+     verbosity = cms.uint32(0),
      maxDeltaRoll = cms.uint32(0),
      maxDeltaPadGE11 = cms.uint32(5),
      maxDeltaPadGE21 = cms.uint32(5),

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -343,10 +343,9 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 # ==================================================
 copadParam = cms.PSet(
      verbosity = cms.uint32(0),
-     maxDeltaRoll = cms.uint32(0),
-     maxDeltaPadGE11 = cms.uint32(5),
-     maxDeltaPadGE21 = cms.uint32(5),
-     maxDeltaBX = cms.uint32(0)
+     maxDeltaPadGE11 = cms.uint32(1),
+     maxDeltaPadGE21 = cms.uint32(2),
+     maxDeltaBX = cms.uint32(1)
  )
 
 # to be used by ME11 chambers with GEM-CSC ILT

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -341,6 +341,12 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 
 # Upgrade era customizations involving GEMs and RPCs
 # ==================================================
+copadParam = cms.PSet(
+     maxDeltaRoll = cms.uint32(0),
+     maxDeltaPadGE11 = cms.uint32(5),
+     maxDeltaPadGE21 = cms.uint32(5),
+     maxDeltaBX = cms.uint32(0)
+ )
 
 # to be used by ME11 chambers with GEM-CSC ILT
 me11tmbSLHCGEM = cms.PSet(
@@ -368,10 +374,6 @@ me11tmbSLHCGEM = cms.PSet(
 
     ## use old dataformat
     useOldLCTDataFormat = cms.bool(True),
-
-    ## copad construction
-    maxDeltaBXInCoPad = cms.int32(1),
-    maxDeltaPadInCoPad = cms.int32(1),
 
     ## matching to pads in case LowQ CLCT
     maxDeltaBXPadEven = cms.int32(1),
@@ -431,10 +433,6 @@ me21tmbSLHCGEM = cms.PSet(
 
     ## use old dataformat
     useOldLCTDataFormat = cms.bool(True),
-
-    ## copad construction
-    maxDeltaBXInCoPad = cms.int32(1),
-    maxDeltaPadInCoPad = cms.int32(2),
 
     ## matching to pads in case LowQ CLCT
     maxDeltaBXPad = cms.int32(1),
@@ -512,25 +510,26 @@ run2_common.toModify( cscTriggerPrimitiveDigis,
 ## GEM-CSC ILT in ME1/1
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
-                        GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),
-                        commonParam = dict(
-                            isSLHC = cms.bool(True),
-                            smartME1aME1b = cms.bool(True),
-                            runME11ILT = cms.bool(True)),
-                        clctSLHC = dict(clctNplanesHitPattern = 3),
-                        me11tmbSLHCGEM = me11tmbSLHCGEM
-)
+                   GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),
+                   commonParam = dict(isSLHC = cms.bool(True),
+                                      smartME1aME1b = cms.bool(True),
+                                      runME11ILT = cms.bool(True)),
+                   clctSLHC = dict(clctNplanesHitPattern = 3),
+                   me11tmbSLHCGEM = me11tmbSLHCGEM,
+                   copadParam = copadParam
+                   )
 
 ## GEM-CSC ILT in ME2/1, CSC-RPC ILT in ME3/1 and ME4/1
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( cscTriggerPrimitiveDigis,
-                           RPCDigiProducer = cms.InputTag("simMuonRPCDigis"),
-                           commonParam = dict(runME21ILT = cms.bool(True),
-                                              runME3141ILT = cms.bool(False)),
-                           alctSLHCME21 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 3),
-                           clctSLHCME21 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 3),
-                           alctSLHCME3141 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 3),
-                           clctSLHCME3141 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 3),
-                           me21tmbSLHCGEM = me21tmbSLHCGEM,
-                           me3141tmbSLHCRPC = me3141tmbSLHCRPC
+                      RPCDigiProducer = cms.InputTag("simMuonRPCDigis"),
+                      commonParam = dict(runME21ILT = cms.bool(True),
+                                         runME3141ILT = cms.bool(False)),
+                      alctSLHCME21 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 3),
+                      clctSLHCME21 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 3),
+                      alctSLHCME3141 = cscTriggerPrimitiveDigis.alctSLHC.clone(alctNplanesHitPattern = 3),
+                      clctSLHCME3141 = cscTriggerPrimitiveDigis.clctSLHC.clone(clctNplanesHitPattern = 3),
+                      me21tmbSLHCGEM = me21tmbSLHCGEM,
+                      me3141tmbSLHCRPC = me3141tmbSLHCRPC,
+                      copadParam = copadParam
 )

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
@@ -1,0 +1,307 @@
+#include "L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.h"
+#include "Geometry/GEMGeometry/interface/GEMEtaPartitionSpecs.h"
+
+void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned theStation, unsigned theSector, unsigned theSubsector, unsigned theTrigChamber)
+{
+  bool gemGeometryAvailable(false);
+  if (gem_g != nullptr) {
+    std::cout<< "+++ generateLUTsME11() called for ME11 chamber! +++ \n";
+    gemGeometryAvailable = true;
+  }
+  
+  // CSC geometry
+  CSCTriggerGeomManager* geo_manager(CSCTriggerGeometry::get());
+  const CSCChamber* cscChamberME1b(geo_manager->chamber(theEndcap, theStation, theSector, theSubsector, theTrigChamber));
+  const CSCDetId me1bId(cscChamberME1b->id());
+  const CSCDetId me1aId(me1bId.endcap(), 1, 4, me1bId.chamber());
+  const CSCChamber* cscChamberME1a(csc_g->chamber(me1aId));
+  
+  // check for GEM geometry
+  if (not gemGeometryAvailable){
+    std::cout << "+++ generateLUTsME11() called for ME11 chamber without valid GEM geometry! +++ \n";
+    return;
+  }
+  
+  // CSC trigger geometry
+  const CSCLayer* keyLayerME1b(cscChamberME1b->layer(3));
+  const CSCLayerGeometry* keyLayerGeometryME1b(keyLayerME1b->geometry());
+  const CSCLayer* keyLayerME1a(cscChamberME1a->layer(3));
+  const CSCLayerGeometry* keyLayerGeometryME1a(keyLayerME1a->geometry());
+  
+  const int region((theEndcap == 1) ? 1: -1);
+  const GEMDetId gem_id(region, 1, theStation, 1, me1bId.chamber(), 0);
+  const GEMChamber* gemChamber(gem_g->chamber(gem_id));
+  
+  // LUT<roll,<etaMin,etaMax> >    
+  std::map<int,std::pair<double,double> > gemRollToEtaLimits_;
+
+  int n = 1;
+  for(auto roll : gemChamber->etaPartitions()) {
+    const float half_striplength(roll->specs()->specificTopology().stripLength()/2.);
+    const LocalPoint lp_top(0., half_striplength, 0.);
+    const LocalPoint lp_bottom(0., -half_striplength, 0.);
+    const GlobalPoint gp_top(roll->toGlobal(lp_top));
+    const GlobalPoint gp_bottom(roll->toGlobal(lp_bottom));
+    gemRollToEtaLimits_[n] = std::make_pair(gp_top.eta(), gp_bottom.eta());
+    ++n;
+  }
+
+  std::cout << "GEM roll to eta limits" << std::endl;
+  for(auto p : gemRollToEtaLimits_) {
+    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+  }
+  
+  // LUT<WG,<etaMin,etaMax> >
+  std::map<int,std::pair<double,double> > cscWGToEtaLimits_;
+ 
+  const int numberOfWG(keyLayerGeometryME1b->numberOfWireGroups());
+  n = 1;
+  for (int i = 0; i< numberOfWG; ++i){
+    const float middle_wire(keyLayerGeometryME1b->middleWireOfGroup(i));
+    const std::pair<LocalPoint, LocalPoint> wire_ends(keyLayerGeometryME1b->wireTopology()->wireEnds(middle_wire));
+
+    const GlobalPoint gp_top(keyLayerME1b->toGlobal(wire_ends.first));
+    const GlobalPoint gp_bottom(keyLayerME1b->toGlobal(wire_ends.first));
+    cscWGToEtaLimits_[n] = std::make_pair(gp_top.eta(), gp_bottom.eta());
+    ++n;
+  }
+
+  std::cout << "ME1b "<< me1bId <<std::endl;
+  std::cout << "WG roll to eta limits" << std::endl;
+  for(auto p : cscWGToEtaLimits_) {
+    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+  }
+  
+  // LUT <WG,rollMin,rollMax>
+  std::map<int,std::pair<int,int>> cscWgToGemRoll_;
+
+  for (int i = 0; i< numberOfWG; ++i){
+    auto etaMin(cscWGToEtaLimits_[i].first);
+    auto etaMax(cscWGToEtaLimits_[i].second);
+    cscWgToGemRoll_[i] = std::make_pair(assignGEMRoll(gemRollToEtaLimits_, etaMin), assignGEMRoll(gemRollToEtaLimits_, etaMax));
+  }
+  std::cout << "WG to ROLL" << std::endl;
+  int i = 1;
+  for(auto p : cscWgToGemRoll_) {
+    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+  
+
+  // map of HS to pad
+  std::map<int,std::pair<int,int>> cscHsToGemPadME1a_;
+  std::map<int,std::pair<int,int>> cscHsToGemPadME1b_;
+  
+  // pick any roll
+  auto randRoll(gemChamber->etaPartition(2));
+  
+  // ME1a
+  auto nStripsME1a(keyLayerGeometryME1a->numberOfStrips());
+  for (float i = 0; i< nStripsME1a; i = i+0.5){
+    const LocalPoint lpCSC(keyLayerGeometryME1a->topology()->localPosition(i));
+    const GlobalPoint gp(keyLayerME1a->toGlobal(lpCSC));
+    const LocalPoint lpGEM(randRoll->toLocal(gp));
+    const int HS(i/0.5);
+    const bool edge(HS < 4 or HS > 93);
+    const float pad(edge ? -99 : randRoll->pad(lpGEM));
+    cscHsToGemPadME1a_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
+  }
+ 
+  // ME1b
+  auto nStripsME1b(keyLayerGeometryME1b->numberOfStrips());
+  for (float i = 0; i< nStripsME1b; i = i+0.5){
+    const LocalPoint lpCSC(keyLayerGeometryME1b->topology()->localPosition(i));
+    const GlobalPoint gp(keyLayerME1b->toGlobal(lpCSC));
+    const LocalPoint lpGEM(randRoll->toLocal(gp));
+    const int HS(i/0.5);
+    const bool edge(HS < 5 or HS > 124);
+    const float pad(edge ? -99 : randRoll->pad(lpGEM));
+    cscHsToGemPadME1b_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
+  }
+
+  std::cout << "CSC HS to GEM pad LUT in ME1a";
+  i = 1;
+  for(auto p : cscHsToGemPadME1a_) {
+    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+  std::cout << "CSC HS to GEM pad LUT in ME1b";
+  i = 1;
+  for(auto p : cscHsToGemPadME1b_) {
+    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+  
+  // map pad to HS
+  std::map<int,int> gemPadToCscHsME1a_;
+  std::map<int,int> gemPadToCscHsME1b_;
+  
+  const int nGEMPads(randRoll->npads());
+  for (int i = 0; i< nGEMPads; ++i){
+    const LocalPoint lpGEM(randRoll->centreOfPad(i));
+    const GlobalPoint gp(randRoll->toGlobal(lpGEM));
+    const LocalPoint lpCSCME1a(keyLayerME1a->toLocal(gp));
+    const LocalPoint lpCSCME1b(keyLayerME1b->toLocal(gp));
+    const float stripME1a(keyLayerGeometryME1a->strip(lpCSCME1a));
+    const float stripME1b(keyLayerGeometryME1b->strip(lpCSCME1b));
+    gemPadToCscHsME1a_[i] = (int) (stripME1a)/0.5;
+    gemPadToCscHsME1b_[i] = (int) (stripME1b)/0.5;
+  }
+
+  std::cout << "GEM pad to CSC HS LUT in ME1a";
+  i = 1;
+  for(auto p : gemPadToCscHsME1a_) {
+    std::cout << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+  std::cout << "GEM pad to CSC HS LUT in ME1b";
+  i = 1;
+  for(auto p : gemPadToCscHsME1b_) {
+    std::cout << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+}
+
+void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned theStation, unsigned theSector, unsigned theSubsector, unsigned theTrigChamber)
+{
+  bool gemGeometryAvailable(false);
+  if (gem_g != nullptr) {
+    std::cout<< "+++ generateLUTsME11() called for ME21 chamber! +++ \n";
+    gemGeometryAvailable = true;
+  }
+
+  // retrieve CSCChamber geometry                                                                                                                                       
+  CSCTriggerGeomManager* geo_manager(CSCTriggerGeometry::get());
+  const CSCChamber* cscChamber(geo_manager->chamber(theEndcap, theStation, theSector, theSubsector, theTrigChamber));
+  const CSCDetId csc_id(cscChamber->id());
+    
+  // check for GEM geometry
+  if (not gemGeometryAvailable){
+    std::cout << "+++ generateLUTsME11() called for ME21 chamber without valid GEM geometry! +++ \n";
+    return;
+  }
+  
+  // trigger geometry
+  const CSCLayer* keyLayer(cscChamber->layer(3));
+  const CSCLayerGeometry* keyLayerGeometry(keyLayer->geometry());
+  
+  const int region((theEndcap == 1) ? 1: -1);
+  const GEMDetId gem_id(region, 1, 2, 1, csc_id.chamber(), 0);
+  const GEMChamber* gemChamber(gem_g->chamber(gem_id));
+  
+  std::cout << "ME21 "<< csc_id <<std::endl;
+
+  // LUT<roll,<etaMin,etaMax> >    
+  std::map<int,std::pair<double,double> > gemRollToEtaLimits_;
+  int n = 1;
+  for(auto roll : gemChamber->etaPartitions()) {
+    const float half_striplength(roll->specs()->specificTopology().stripLength()/2.);
+    const LocalPoint lp_top(0., half_striplength, 0.);
+    const LocalPoint lp_bottom(0., -half_striplength, 0.);
+    const GlobalPoint gp_top(roll->toGlobal(lp_top));
+    const GlobalPoint gp_bottom(roll->toGlobal(lp_bottom));
+    gemRollToEtaLimits_[n] = std::make_pair(gp_top.eta(), gp_bottom.eta());
+    ++n;
+  }
+
+  std::cout << "GEM roll to eta limits" << std::endl;
+  for(auto p : gemRollToEtaLimits_) {
+    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+  }
+
+  // LUT<WG,<etaMin,etaMax> >
+  std::map<int,double> cscWGToEtaLimits_;
+  const int numberOfWG(keyLayerGeometry->numberOfWireGroups());
+  n = 1;
+  for (int i = 0; i< numberOfWG; ++i){
+    const LocalPoint wire_loc(keyLayerGeometry->localCenterOfWireGroup(i));
+    const GlobalPoint gp(keyLayer->toGlobal(wire_loc));
+    cscWGToEtaLimits_[n] = gp.eta();
+    ++n;
+  }
+
+  std::cout << "WG to eta limits" << std::endl;
+  for(auto p : cscWGToEtaLimits_) {
+    std::cout << "{"<< p.first << ", " << p.second << "}, " << std::endl;
+  }
+
+  // LUT <WG,rollMin,rollMax>
+  std::map<int,int> cscWgToGemRoll_;
+  for (int i = 0; i< numberOfWG; ++i){
+    auto eta(cscWGToEtaLimits_[i]);
+    cscWgToGemRoll_[i] = assignGEMRoll(gemRollToEtaLimits_, eta);
+  }
+
+  std::cout << "WG to roll" << std::endl;
+  int i = 1;
+  for(auto p : cscWgToGemRoll_) {
+    std::cout << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+  
+  // map of pad to HS
+  std::map<int,int> gemPadToCscHs_;
+  std::map<int,std::pair<int,int>> cscHsToGemPad_;
+
+  auto randRoll(gemChamber->etaPartition(2));
+  auto nStrips(keyLayerGeometry->numberOfStrips());
+  for (float i = 0; i< nStrips; i = i+0.5){
+    const LocalPoint lpCSC(keyLayerGeometry->topology()->localPosition(i));
+    const GlobalPoint gp(keyLayer->toGlobal(lpCSC));
+    const LocalPoint lpGEM(randRoll->toLocal(gp));
+    const int HS(i/0.5);
+    //      const bool edge(HS < 5 or HS > 155);
+    //const float pad(edge ? -99 : randRoll->pad(lpGEM));
+    const float pad(randRoll->pad(lpGEM));
+    // HS are wrapped-around
+    cscHsToGemPad_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
+  }
+
+  std::cout << "CSC HS to GEM pad LUT in ME21";
+  i = 1;
+  for(auto p : cscHsToGemPad_) {
+    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+  
+  // pick any roll 
+  const int nGEMPads(randRoll->npads());
+  for (int i = 0; i< nGEMPads; ++i){
+    const LocalPoint lpGEM(randRoll->centreOfPad(i));
+    const GlobalPoint gp(randRoll->toGlobal(lpGEM));
+    const LocalPoint lpCSC(keyLayer->toLocal(gp));
+    const float strip(keyLayerGeometry->strip(lpCSC));
+    // HS are wrapped-around
+    gemPadToCscHs_[i] = (int) (strip)/0.5;
+  }
+  
+  std::cout << "GEM pad to CSC HS LUT in ME21";
+  i = 1;
+  for(auto p : gemPadToCscHs_) {
+    std::cout << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) std::cout << std::endl;
+    i++;
+  }
+}
+
+
+int CSCGEMTriggerLUTGenerator::assignGEMRoll(const std::map<int,std::pair<double,double> >& gemRollToEtaLimits_, double eta)
+{
+  int result = -99;
+  for(auto p : gemRollToEtaLimits_) {
+    const float minEta((p.second).first);
+    const float maxEta((p.second).second);
+    if (minEta <= eta and eta <= maxEta) {
+      result = p.first;
+      break;
+    }
+  }
+  return result;
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
@@ -1,11 +1,13 @@
 #include "L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.h"
 #include "Geometry/GEMGeometry/interface/GEMEtaPartitionSpecs.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned theStation, unsigned theSector, unsigned theSubsector, unsigned theTrigChamber)
 {
   bool gemGeometryAvailable(false);
   if (gem_g != nullptr) {
-    std::cout<< "+++ generateLUTsME11() called for ME11 chamber! +++ \n";
+    LogTrace("CSCGEMTriggerLUTGenerator")
+      << "+++ generateLUTsME11() called for ME11 chamber! +++ \n";
     gemGeometryAvailable = true;
   }
   
@@ -18,7 +20,8 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
   
   // check for GEM geometry
   if (not gemGeometryAvailable){
-    std::cout << "+++ generateLUTsME11() called for ME11 chamber without valid GEM geometry! +++ \n";
+    LogTrace("CSCGEMTriggerLUTGenerator")
+      << "+++ generateLUTsME11() called for ME11 chamber without valid GEM geometry! +++ \n";
     return;
   }
   
@@ -46,9 +49,10 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     ++n;
   }
 
-  std::cout << "GEM roll to eta limits" << std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator")
+    << "GEM roll to eta limits" << std::endl;
   for(auto p : gemRollToEtaLimits_) {
-    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
   }
   
   // LUT<WG,<etaMin,etaMax> >
@@ -66,10 +70,10 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     ++n;
   }
 
-  std::cout << "ME1b "<< me1bId <<std::endl;
-  std::cout << "WG roll to eta limits" << std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "ME1b "<< me1bId <<std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "WG roll to eta limits" << std::endl;
   for(auto p : cscWGToEtaLimits_) {
-    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
   }
   
   // LUT <WG,rollMin,rollMax>
@@ -83,8 +87,8 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
   std::cout << "WG to ROLL" << std::endl;
   int i = 1;
   for(auto p : cscWgToGemRoll_) {
-    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   
@@ -123,15 +127,15 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
   std::cout << "CSC HS to GEM pad LUT in ME1a";
   i = 1;
   for(auto p : cscHsToGemPadME1a_) {
-    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   std::cout << "CSC HS to GEM pad LUT in ME1b";
   i = 1;
   for(auto p : cscHsToGemPadME1b_) {
-    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   
@@ -154,15 +158,15 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
   std::cout << "GEM pad to CSC HS LUT in ME1a";
   i = 1;
   for(auto p : gemPadToCscHsME1a_) {
-    std::cout << "{"<< p.first << ", " << p.second << "}, ";
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   std::cout << "GEM pad to CSC HS LUT in ME1b";
   i = 1;
   for(auto p : gemPadToCscHsME1b_) {
-    std::cout << "{"<< p.first << ", " << p.second << "}, ";
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
 }
@@ -171,7 +175,7 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
 {
   bool gemGeometryAvailable(false);
   if (gem_g != nullptr) {
-    std::cout<< "+++ generateLUTsME11() called for ME21 chamber! +++ \n";
+    LogTrace("CSCGEMTriggerLUTGenerator") << "+++ generateLUTsME11() called for ME21 chamber! +++ \n";
     gemGeometryAvailable = true;
   }
 
@@ -182,7 +186,7 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     
   // check for GEM geometry
   if (not gemGeometryAvailable){
-    std::cout << "+++ generateLUTsME11() called for ME21 chamber without valid GEM geometry! +++ \n";
+    LogTrace("CSCGEMTriggerLUTGenerator") << "+++ generateLUTsME11() called for ME21 chamber without valid GEM geometry! +++ \n";
     return;
   }
   
@@ -194,7 +198,7 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
   const GEMDetId gem_id(region, 1, 2, 1, csc_id.chamber(), 0);
   const GEMChamber* gemChamber(gem_g->chamber(gem_id));
   
-  std::cout << "ME21 "<< csc_id <<std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "ME21 "<< csc_id <<std::endl;
 
   // LUT<roll,<etaMin,etaMax> >    
   std::map<int,std::pair<double,double> > gemRollToEtaLimits_;
@@ -209,9 +213,9 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     ++n;
   }
 
-  std::cout << "GEM roll to eta limits" << std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "GEM roll to eta limits" << std::endl;
   for(auto p : gemRollToEtaLimits_) {
-    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
   }
 
   // LUT<WG,<etaMin,etaMax> >
@@ -225,9 +229,9 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     ++n;
   }
 
-  std::cout << "WG to eta limits" << std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "WG to eta limits" << std::endl;
   for(auto p : cscWGToEtaLimits_) {
-    std::cout << "{"<< p.first << ", " << p.second << "}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, " << std::endl;
   }
 
   // LUT <WG,rollMin,rollMax>
@@ -240,8 +244,8 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
   std::cout << "WG to roll" << std::endl;
   int i = 1;
   for(auto p : cscWgToGemRoll_) {
-    std::cout << "{"<< p.first << ", " << p.second << "}, ";
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   
@@ -263,11 +267,11 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     cscHsToGemPad_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
   }
 
-  std::cout << "CSC HS to GEM pad LUT in ME21";
+  LogTrace("CSCGEMTriggerLUTGenerator") << "CSC HS to GEM pad LUT in ME21";
   i = 1;
   for(auto p : cscHsToGemPad_) {
-    std::cout << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   
@@ -282,11 +286,11 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     gemPadToCscHs_[i] = (int) (strip)/0.5;
   }
   
-  std::cout << "GEM pad to CSC HS LUT in ME21";
+  LogTrace("CSCGEMTriggerLUTGenerator") << "GEM pad to CSC HS LUT in ME21";
   i = 1;
   for(auto p : gemPadToCscHs_) {
-    std::cout << "{"<< p.first << ", " << p.second << "}, ";
-    if (i%8==0) std::cout << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
@@ -84,7 +84,7 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     auto etaMax(cscWGToEtaLimits_[i].second);
     cscWgToGemRoll_[i] = std::make_pair(assignGEMRoll(gemRollToEtaLimits_, etaMin), assignGEMRoll(gemRollToEtaLimits_, etaMax));
   }
-  std::cout << "WG to ROLL" << std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "WG to ROLL" << std::endl;
   int i = 1;
   for(auto p : cscWgToGemRoll_) {
     LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
@@ -124,14 +124,14 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     cscHsToGemPadME1b_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
   }
 
-  std::cout << "CSC HS to GEM pad LUT in ME1a";
+  LogTrace("CSCGEMTriggerLUTGenerator") << "CSC HS to GEM pad LUT in ME1a";
   i = 1;
   for(auto p : cscHsToGemPadME1a_) {
     LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
-  std::cout << "CSC HS to GEM pad LUT in ME1b";
+  LogTrace("CSCGEMTriggerLUTGenerator") << "CSC HS to GEM pad LUT in ME1b";
   i = 1;
   for(auto p : cscHsToGemPadME1b_) {
     LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
@@ -155,14 +155,14 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     gemPadToCscHsME1b_[i] = (int) (stripME1b)/0.5;
   }
 
-  std::cout << "GEM pad to CSC HS LUT in ME1a";
+  LogTrace("CSCGEMTriggerLUTGenerator") << "GEM pad to CSC HS LUT in ME1a";
   i = 1;
   for(auto p : gemPadToCscHsME1a_) {
     LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
-  std::cout << "GEM pad to CSC HS LUT in ME1b";
+  LogTrace("CSCGEMTriggerLUTGenerator") << "GEM pad to CSC HS LUT in ME1b";
   i = 1;
   for(auto p : gemPadToCscHsME1b_) {
     LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
@@ -241,7 +241,7 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     cscWgToGemRoll_[i] = assignGEMRoll(gemRollToEtaLimits_, eta);
   }
 
-  std::cout << "WG to roll" << std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "WG to roll" << std::endl;
   int i = 1;
   for(auto p : cscWgToGemRoll_) {
     LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.cc
@@ -36,66 +36,61 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
   const GEMChamber* gemChamber(gem_g->chamber(gem_id));
   
   // LUT<roll,<etaMin,etaMax> >    
-  std::map<int,std::pair<double,double> > gemRollToEtaLimits_;
+  std::vector<std::pair<double,double> > gemRollToEtaLimits_;
 
-  int n = 1;
   for(auto roll : gemChamber->etaPartitions()) {
     const float half_striplength(roll->specs()->specificTopology().stripLength()/2.);
     const LocalPoint lp_top(0., half_striplength, 0.);
     const LocalPoint lp_bottom(0., -half_striplength, 0.);
     const GlobalPoint gp_top(roll->toGlobal(lp_top));
     const GlobalPoint gp_bottom(roll->toGlobal(lp_bottom));
-    gemRollToEtaLimits_[n] = std::make_pair(gp_top.eta(), gp_bottom.eta());
-    ++n;
+    gemRollToEtaLimits_.push_back(std::make_pair(gp_top.eta(), gp_bottom.eta()));
   }
 
-  LogTrace("CSCGEMTriggerLUTGenerator")
-    << "GEM roll to eta limits" << std::endl;
+  LogTrace("CSCGEMTriggerLUTGenerator") << "GEM roll to eta limits" << std::endl;
   for(auto p : gemRollToEtaLimits_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{" << p.first << ", " << p.second << "}, " << std::endl;
   }
   
   // LUT<WG,<etaMin,etaMax> >
-  std::map<int,std::pair<double,double> > cscWGToEtaLimits_;
+  std::vector<std::pair<double,double> > cscWGToEtaLimits_;
  
   const int numberOfWG(keyLayerGeometryME1b->numberOfWireGroups());
-  n = 1;
   for (int i = 0; i< numberOfWG; ++i){
     const float middle_wire(keyLayerGeometryME1b->middleWireOfGroup(i));
     const std::pair<LocalPoint, LocalPoint> wire_ends(keyLayerGeometryME1b->wireTopology()->wireEnds(middle_wire));
 
     const GlobalPoint gp_top(keyLayerME1b->toGlobal(wire_ends.first));
     const GlobalPoint gp_bottom(keyLayerME1b->toGlobal(wire_ends.first));
-    cscWGToEtaLimits_[n] = std::make_pair(gp_top.eta(), gp_bottom.eta());
-    ++n;
+    cscWGToEtaLimits_.push_back(std::make_pair(gp_top.eta(), gp_bottom.eta()));
   }
 
   LogTrace("CSCGEMTriggerLUTGenerator") << "ME1b "<< me1bId <<std::endl;
   LogTrace("CSCGEMTriggerLUTGenerator") << "WG roll to eta limits" << std::endl;
   for(auto p : cscWGToEtaLimits_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{" << p.first << ", " << p.second << "}, " << std::endl;
   }
   
   // LUT <WG,rollMin,rollMax>
-  std::map<int,std::pair<int,int>> cscWgToGemRoll_;
+  std::vector<std::pair<int,int> > cscWgToGemRoll_;
 
   for (int i = 0; i< numberOfWG; ++i){
     auto etaMin(cscWGToEtaLimits_[i].first);
     auto etaMax(cscWGToEtaLimits_[i].second);
-    cscWgToGemRoll_[i] = std::make_pair(assignGEMRoll(gemRollToEtaLimits_, etaMin), assignGEMRoll(gemRollToEtaLimits_, etaMax));
+    cscWgToGemRoll_.push_back(std::make_pair(assignGEMRoll(gemRollToEtaLimits_, etaMin), assignGEMRoll(gemRollToEtaLimits_, etaMax)));
   }
+  int i = 0;
   LogTrace("CSCGEMTriggerLUTGenerator") << "WG to ROLL" << std::endl;
-  int i = 1;
   for(auto p : cscWgToGemRoll_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{" << p.first << ", " << p.second << "}, " << std::endl;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   
 
   // map of HS to pad
-  std::map<int,std::pair<int,int>> cscHsToGemPadME1a_;
-  std::map<int,std::pair<int,int>> cscHsToGemPadME1b_;
+  std::vector<std::pair<int,int> > cscHsToGemPadME1a_;
+  std::vector<std::pair<int,int> > cscHsToGemPadME1b_;
   
   // pick any roll
   auto randRoll(gemChamber->etaPartition(2));
@@ -109,7 +104,7 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     const int HS(i/0.5);
     const bool edge(HS < 4 or HS > 93);
     const float pad(edge ? -99 : randRoll->pad(lpGEM));
-    cscHsToGemPadME1a_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
+    cscHsToGemPadME1a_.push_back(std::make_pair(std::floor(pad),std::ceil(pad)));
   }
  
   // ME1b
@@ -121,27 +116,27 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     const int HS(i/0.5);
     const bool edge(HS < 5 or HS > 124);
     const float pad(edge ? -99 : randRoll->pad(lpGEM));
-    cscHsToGemPadME1b_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
+    cscHsToGemPadME1b_.push_back(std::make_pair(std::floor(pad),std::ceil(pad)));
   }
 
   LogTrace("CSCGEMTriggerLUTGenerator") << "CSC HS to GEM pad LUT in ME1a";
   i = 1;
   for(auto p : cscHsToGemPadME1a_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{" << p.first << ", " << p.second << "}, " << std::endl;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   LogTrace("CSCGEMTriggerLUTGenerator") << "CSC HS to GEM pad LUT in ME1b";
   i = 1;
   for(auto p : cscHsToGemPadME1b_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, ";
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{" << p.first << ", " << p.second << "}, " << std::endl;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   
   // map pad to HS
-  std::map<int,int> gemPadToCscHsME1a_;
-  std::map<int,int> gemPadToCscHsME1b_;
+  std::vector<int> gemPadToCscHsME1a_;
+  std::vector<int> gemPadToCscHsME1b_;
   
   const int nGEMPads(randRoll->npads());
   for (int i = 0; i< nGEMPads; ++i){
@@ -151,21 +146,21 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME11(unsigned theEndcap, unsigned th
     const LocalPoint lpCSCME1b(keyLayerME1b->toLocal(gp));
     const float stripME1a(keyLayerGeometryME1a->strip(lpCSCME1a));
     const float stripME1b(keyLayerGeometryME1b->strip(lpCSCME1b));
-    gemPadToCscHsME1a_[i] = (int) (stripME1a)/0.5;
-    gemPadToCscHsME1b_[i] = (int) (stripME1b)/0.5;
+    gemPadToCscHsME1a_.push_back( (int) (stripME1a)/0.5);
+    gemPadToCscHsME1b_.push_back( (int) (stripME1b)/0.5);
   }
 
   LogTrace("CSCGEMTriggerLUTGenerator") << "GEM pad to CSC HS LUT in ME1a";
   i = 1;
   for(auto p : gemPadToCscHsME1a_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    LogTrace("CSCGEMTriggerLUTGenerator") << p;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   LogTrace("CSCGEMTriggerLUTGenerator") << "GEM pad to CSC HS LUT in ME1b";
   i = 1;
   for(auto p : gemPadToCscHsME1b_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    LogTrace("CSCGEMTriggerLUTGenerator") << p;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
@@ -201,7 +196,7 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
   LogTrace("CSCGEMTriggerLUTGenerator") << "ME21 "<< csc_id <<std::endl;
 
   // LUT<roll,<etaMin,etaMax> >    
-  std::map<int,std::pair<double,double> > gemRollToEtaLimits_;
+  std::vector<std::pair<double,double> > gemRollToEtaLimits_;
   int n = 1;
   for(auto roll : gemChamber->etaPartitions()) {
     const float half_striplength(roll->specs()->specificTopology().stripLength()/2.);
@@ -215,43 +210,43 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
 
   LogTrace("CSCGEMTriggerLUTGenerator") << "GEM roll to eta limits" << std::endl;
   for(auto p : gemRollToEtaLimits_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, " << std::endl;
   }
 
   // LUT<WG,<etaMin,etaMax> >
-  std::map<int,double> cscWGToEtaLimits_;
+  std::vector<double> cscWGToEtaLimits_;
   const int numberOfWG(keyLayerGeometry->numberOfWireGroups());
   n = 1;
   for (int i = 0; i< numberOfWG; ++i){
     const LocalPoint wire_loc(keyLayerGeometry->localCenterOfWireGroup(i));
     const GlobalPoint gp(keyLayer->toGlobal(wire_loc));
-    cscWGToEtaLimits_[n] = gp.eta();
+    cscWGToEtaLimits_.push_back( gp.eta() );
     ++n;
   }
 
   LogTrace("CSCGEMTriggerLUTGenerator") << "WG to eta limits" << std::endl;
   for(auto p : cscWGToEtaLimits_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, " << std::endl;
+    LogTrace("CSCGEMTriggerLUTGenerator") << p << std::endl;
   }
 
   // LUT <WG,rollMin,rollMax>
-  std::map<int,int> cscWgToGemRoll_;
+  std::vector<int> cscWgToGemRoll_;
   for (int i = 0; i< numberOfWG; ++i){
     auto eta(cscWGToEtaLimits_[i]);
-    cscWgToGemRoll_[i] = assignGEMRoll(gemRollToEtaLimits_, eta);
+    cscWgToGemRoll_.push_back( assignGEMRoll(gemRollToEtaLimits_, eta) );
   }
 
   LogTrace("CSCGEMTriggerLUTGenerator") << "WG to roll" << std::endl;
   int i = 1;
   for(auto p : cscWgToGemRoll_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    LogTrace("CSCGEMTriggerLUTGenerator") << p;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
   
-  // map of pad to HS
-  std::map<int,int> gemPadToCscHs_;
-  std::map<int,std::pair<int,int>> cscHsToGemPad_;
+  // vector of pad to HS
+  std::vector<int> gemPadToCscHs_;
+  std::vector<std::pair<int,int>> cscHsToGemPad_;
 
   auto randRoll(gemChamber->etaPartition(2));
   auto nStrips(keyLayerGeometry->numberOfStrips());
@@ -260,17 +255,16 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     const GlobalPoint gp(keyLayer->toGlobal(lpCSC));
     const LocalPoint lpGEM(randRoll->toLocal(gp));
     const int HS(i/0.5);
-    //      const bool edge(HS < 5 or HS > 155);
-    //const float pad(edge ? -99 : randRoll->pad(lpGEM));
-    const float pad(randRoll->pad(lpGEM));
+    const bool edge(HS < 5 or HS > 155);
+    const float pad(edge ? -99 : randRoll->pad(lpGEM));
     // HS are wrapped-around
-    cscHsToGemPad_[HS] = std::make_pair(std::floor(pad),std::ceil(pad));
+    cscHsToGemPad_.push_back( std::make_pair(std::floor(pad),std::ceil(pad)) );
   }
 
   LogTrace("CSCGEMTriggerLUTGenerator") << "CSC HS to GEM pad LUT in ME21";
   i = 1;
   for(auto p : cscHsToGemPad_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", {" << (p.second).first << ", " << (p.second).second << "}}, "; 
+    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, " << std::endl;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
@@ -283,29 +277,29 @@ void CSCGEMTriggerLUTGenerator::generateLUTsME21(unsigned theEndcap, unsigned th
     const LocalPoint lpCSC(keyLayer->toLocal(gp));
     const float strip(keyLayerGeometry->strip(lpCSC));
     // HS are wrapped-around
-    gemPadToCscHs_[i] = (int) (strip)/0.5;
+    gemPadToCscHs_.push_back( (int) (strip)/0.5 );
   }
   
   LogTrace("CSCGEMTriggerLUTGenerator") << "GEM pad to CSC HS LUT in ME21";
   i = 1;
   for(auto p : gemPadToCscHs_) {
-    LogTrace("CSCGEMTriggerLUTGenerator") << "{"<< p.first << ", " << p.second << "}, ";
+    LogTrace("CSCGEMTriggerLUTGenerator") << p;
     if (i%8==0) LogTrace("CSCGEMTriggerLUTGenerator") << std::endl;
     i++;
   }
 }
 
 
-int CSCGEMTriggerLUTGenerator::assignGEMRoll(const std::map<int,std::pair<double,double> >& gemRollToEtaLimits_, double eta)
+int CSCGEMTriggerLUTGenerator::assignGEMRoll(const std::vector<std::pair<double,double> >& gemRollToEtaLimits_, double eta)
 {
-  int result = -99;
+  int roll = 1;
   for(auto p : gemRollToEtaLimits_) {
-    const float minEta((p.second).first);
-    const float maxEta((p.second).second);
+    roll++;
+    const float minEta(p.first);
+    const float maxEta(p.second);
     if (minEta <= eta and eta <= maxEta) {
-      result = p.first;
-      break;
+      return roll;
     }
   }
-  return result;
+  return -99;
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.h
@@ -7,7 +7,6 @@
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 
 #include <vector>
-#include <map>
 
 class CSCGEMTriggerLUTGenerator
 {
@@ -23,7 +22,7 @@ public:
   void generateLUTsME11(unsigned theEndcap, unsigned theStation, unsigned theSector, unsigned theSubSector, unsigned theTrigChamber);
   void generateLUTsME21(unsigned theEndcap, unsigned theStation, unsigned theSector, unsigned theSubSector, unsigned theTrigChamber);
 
-  int assignGEMRoll(const std::map<int,std::pair<double,double> >&, double eta);
+  int assignGEMRoll(const std::vector<std::pair<double,double> >&, double eta);
   
  private:
   const CSCGeometry* csc_g;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMTriggerLUTGenerator.h
@@ -1,0 +1,33 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_CSCGEMTriggerLUTGenerator_h
+#define L1Trigger_CSCTriggerPrimitives_CSCGEMTriggerLUTGenerator_h
+
+#include "L1Trigger/CSCCommonTrigger/interface/CSCTriggerGeometry.h"
+#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+
+#include <vector>
+#include <map>
+
+class CSCGEMTriggerLUTGenerator
+{
+public:
+
+  CSCGEMTriggerLUTGenerator() {}
+  ~CSCGEMTriggerLUTGenerator() {}
+  
+  /// set CSC and GEM geometries for the matching needs
+  void setCSCGeometry(const CSCGeometry *g) { csc_g = g; }
+  void setGEMGeometry(const GEMGeometry *g) { gem_g = g; }
+  
+  void generateLUTsME11(unsigned theEndcap, unsigned theStation, unsigned theSector, unsigned theSubSector, unsigned theTrigChamber);
+  void generateLUTsME21(unsigned theEndcap, unsigned theStation, unsigned theSector, unsigned theSubSector, unsigned theTrigChamber);
+
+  int assignGEMRoll(const std::map<int,std::pair<double,double> >&, double eta);
+  
+ private:
+  const CSCGeometry* csc_g;
+  const GEMGeometry* gem_g;
+};
+
+#endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -200,10 +200,11 @@ CSCMotherboardME11GEM::CSCMotherboardME11GEM(unsigned endcap, unsigned station,
   const edm::ParameterSet alctParams(conf.getParameter<edm::ParameterSet>("alctSLHC"));
   const edm::ParameterSet clctParams(conf.getParameter<edm::ParameterSet>("clctSLHC"));
   const edm::ParameterSet me11tmbParams(conf.getParameter<edm::ParameterSet>("me11tmbSLHCGEM"));
+  const edm::ParameterSet coPadParams(conf.getParameter<edm::ParameterSet>("copadParam"));
 
   clct1a.reset( new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, me11tmbParams) );
   clct1a->setRing(4);
-
+  coPadProcessor.reset( new GEMCoPadProcessor(endcap, station, 1, chamber, coPadParams) );
   match_earliest_alct_me11_only = me11tmbParams.getParameter<bool>("matchEarliestAlctME11Only");
   match_earliest_clct_me11_only = me11tmbParams.getParameter<bool>("matchEarliestClctME11Only");
 
@@ -237,10 +238,6 @@ CSCMotherboardME11GEM::CSCMotherboardME11GEM(unsigned endcap, unsigned station,
   debug_gem_matching = me11tmbParams.getParameter<bool>("debugMatching");
   debug_luts = me11tmbParams.getParameter<bool>("debugLUTs");
   debug_gem_dphi = me11tmbParams.getParameter<bool>("debugGEMDphi");
-
-  //  deltas used to construct GEM coincidence pads
-  maxDeltaBXInCoPad_ = me11tmbParams.getParameter<int>("maxDeltaBXInCoPad");
-  maxDeltaPadInCoPad_ = me11tmbParams.getParameter<int>("maxDeltaPadInCoPad");
 
   //  deltas used to match to GEM pads
   maxDeltaBXPadEven_ = me11tmbParams.getParameter<int>("maxDeltaBXPadEven");
@@ -363,6 +360,7 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
   alctV = alct->run(wiredc); // run anodeLCT
   clctV1b = clct->run(compdc); // run cathodeLCT in ME1/b
   clctV1a = clct1a->run(compdc); // run cathodeLCT in ME1/a
+  gemCoPadV = coPadProcessor->run(gemPads); // run copad processor in GE1/1
 
   bool gemGeometryAvailable(false);
   if (gem_g != nullptr) {
@@ -494,15 +492,11 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
       }
     }
 
-    // build coincidence pads
-    std::unique_ptr<GEMCoPadDigiCollection> pCoPads(new GEMCoPadDigiCollection());
-    buildCoincidencePads(gemPads, *pCoPads, me1bId);
-    
     // retrieve pads and copads in a certain BX window for this CSC 
     pads_.clear();
     coPads_.clear();
     retrieveGEMPads(gemPads, gem_id);
-    retrieveGEMCoPads(pCoPads.get(), gem_id);
+    retrieveGEMCoPads();
   }
   
   const bool hasPads(pads_.size()!=0);
@@ -1546,46 +1540,6 @@ void CSCMotherboardME11GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
   return;
 }
 
-void CSCMotherboardME11GEM::buildCoincidencePads(const GEMPadDigiCollection* out_pads, 
-	                                         GEMCoPadDigiCollection& out_co_pads,
-						 CSCDetId csc_id)
-{
-  gemCoPadV.clear();
-
-  // Build coincidences
-  for (auto det_range = out_pads->begin(); det_range != out_pads->end(); ++det_range) {
-    const GEMDetId& id = (*det_range).first;
-   // same chamber
-    if (id.region() != csc_id.zendcap() or id.station() != csc_id.station() or 
-	id.ring() != csc_id.ring() or id.chamber() != csc_id.chamber()) continue;
-
-    // all coincidences detIDs will have layer=1
-    if (id.layer() != 1) continue;
-    
-    // find the corresponding id with layer=2
-    GEMDetId co_id(id.region(), id.ring(), id.station(), 2, id.chamber(), id.roll());
-    
-    auto co_pads_range = out_pads->get(co_id);
-    // empty range = no possible coincidence pads
-    if (co_pads_range.first == co_pads_range.second) continue;
-      
-    // now let's correlate the pads in two layers of this partition
-    const auto& pads_range = (*det_range).second;
-    for (auto p = pads_range.first; p != pads_range.second; ++p) {
-      for (auto co_p = co_pads_range.first; co_p != co_pads_range.second; ++co_p) {
-        // check the match in pad
-        if (std::abs(p->pad() - co_p->pad()) > maxDeltaPadInCoPad_) continue;
-        // check the match in BX
-        if (std::abs(p->bx() - co_p->bx()) > maxDeltaBXInCoPad_ ) continue;
-
-        // make a new coincidence pad digi
-        gemCoPadV.push_back(GEMCoPadDigi(id.roll(),*p,*co_p));
-        out_co_pads.insertDigi(id, GEMCoPadDigi(id.roll(),*p,*co_p));
-      }
-    }
-  }
-}
-
 
 void CSCMotherboardME11GEM::createGEMRollEtaLUT(bool isEven)
 {
@@ -1927,21 +1881,12 @@ void CSCMotherboardME11GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads,
   }
 }
 
-void CSCMotherboardME11GEM::retrieveGEMCoPads(const GEMCoPadDigiCollection* gemPads, unsigned id)
+void CSCMotherboardME11GEM::retrieveGEMCoPads()
 {
-  auto superChamber(gem_g->superChamber(id));
-  for (auto ch : superChamber->chambers()) {
-    for (auto roll : ch->etaPartitions()) {
-      GEMDetId roll_id(roll->id());
-      auto pads_in_det = gemPads->get(roll_id);
-      for (auto pad = pads_in_det.first; pad != pads_in_det.second; ++pad) {
-	const int bx_shifted(lct_central_bx + (pad->second()).bx());
-	for (int bx = bx_shifted - maxDeltaBXPad_;bx <= bx_shifted + maxDeltaBXPad_; ++bx) {
-	  if(bx != lct_central_bx) continue;
-	  coPads_[bx].push_back(std::make_pair(roll_id, (*pad).second()));  
-	}
-      }
-    }
+  for (auto copad: gemCoPadV){
+    if (copad.first().bx() != lct_central_bx) continue;
+    coPads_[copad.bx(1)].push_back(std::make_pair(copad.roll(), copad.first()));  
+    coPads_[copad.bx(1)].push_back(std::make_pair(copad.roll(), copad.second()));  
   }
 }
 
@@ -2050,7 +1995,8 @@ CSCMotherboardME11GEM::matchingGEMPads(const CSCCLCTDigi& clct, const CSCALCTDig
 }
 
 
-std::vector<GEMCoPadDigi> CSCMotherboardME11GEM::readoutCoPads()
+std::vector<GEMCoPadDigi> 
+CSCMotherboardME11GEM::readoutCoPads()
 {
   return gemCoPadV;
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -1664,10 +1664,10 @@ CSCCorrelatedLCTDigi CSCMotherboardME11GEM::constructLCTsGEM(const CSCCLCTDigi& 
     int bx = gem.bx() + lct_central_bx;;
     
     // ALCT WG
-    int wg();
+    int wg(5);
     
     // construct correlated LCT; temporarily assign track number of 0.
-    return CSCCorrelatedLCTDigi(0, 1, quality, 0, 0, pattern, 0, bx, 0, 0, 0, theTrigChamber);
+    return CSCCorrelatedLCTDigi(0, 1, quality, wg, 0, pattern, 0, bx, 0, 0, 0, theTrigChamber);
   }
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.h
@@ -14,6 +14,7 @@
 #include "L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h"
+#include "L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h"
 
 class CSCGeometry;
 class CSCChamber;
@@ -81,6 +82,9 @@ class CSCMotherboardME11GEM : public CSCMotherboard
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs(enum ME11Part me1ab);
   std::vector<GEMCoPadDigi> readoutCoPads();
 
+  /** additional processor for GEMs */
+  std::unique_ptr<GEMCoPadProcessor> coPadProcessor;
+
   /// set CSC and GEM geometries for the matching needs
   void setCSCGeometry(const CSCGeometry *g) { csc_g = g; }
   void setGEMGeometry(const GEMGeometry *g) { gem_g = g; }
@@ -125,12 +129,8 @@ class CSCMotherboardME11GEM : public CSCMotherboard
   void correlateLCTsGEM(CSCCLCTDigi bestCLCT, CSCCLCTDigi secondCLCT, GEMPadDigi gemPad, int roll,
 			CSCCorrelatedLCTDigi& lct1, CSCCorrelatedLCTDigi& lct2, int me);
 
-  void buildCoincidencePads(const GEMPadDigiCollection* out_pads, 
-			    GEMCoPadDigiCollection& out_co_pads,
-			    CSCDetId csc_id);
-
   void retrieveGEMPads(const GEMPadDigiCollection* pads, unsigned id);
-  void retrieveGEMCoPads(const GEMCoPadDigiCollection* pads, unsigned id);
+  void retrieveGEMCoPads();
 
   void createGEMRollEtaLUT(bool isEven);
 
@@ -196,10 +196,6 @@ class CSCMotherboardME11GEM : public CSCMotherboard
   bool debug_gem_matching;
   bool debug_luts;
   bool debug_gem_dphi;
-
-  //  deltas used to construct GEM coincidence pads
-  int maxDeltaBXInCoPad_;
-  int maxDeltaPadInCoPad_;
 
   //  deltas used to match to GEM pads
   int maxDeltaBXPad_;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.h
@@ -14,6 +14,7 @@
 #include "L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h"
+#include "L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h"
 
 class CSCGeometry;
 class CSCChamber;
@@ -22,7 +23,7 @@ class GEMSuperChamber;
 
 class CSCMotherboardME21GEM : public CSCMotherboard
 {
-  typedef std::pair<unsigned int, const GEMPadDigi*> GEMPadBX;
+  typedef std::pair<unsigned int, const GEMPadDigi> GEMPadBX;
   typedef std::vector<GEMPadBX> GEMPadsBX;
   typedef std::map<int, GEMPadsBX> GEMPads;
 
@@ -47,12 +48,8 @@ class CSCMotherboardME21GEM : public CSCMotherboard
   void setCSCGeometry(const CSCGeometry *g) { csc_g = g; }
   void setGEMGeometry(const GEMGeometry *g) { gem_g = g; }
 
-  void buildCoincidencePads(const GEMPadDigiCollection* out_pads, 
-                            GEMCoPadDigiCollection& out_co_pads,
-			    CSCDetId csc_id);
-
   void retrieveGEMPads(const GEMPadDigiCollection* pads, unsigned id);
-  void retrieveGEMCoPads(const GEMCoPadDigiCollection* pads, unsigned id);
+  void retrieveGEMCoPads();
 
   std::map<int,std::pair<double,double> > createGEMRollEtaLUT();
 
@@ -96,6 +93,9 @@ class CSCMotherboardME21GEM : public CSCMotherboard
                                         bool oldDataFormat = true); 
   CSCCorrelatedLCTDigi constructLCTsGEM(const CSCALCTDigi& alct, const CSCCLCTDigi& clct, 
 					bool hasPad, bool hasCoPad); 
+
+  /** additional processor for GEMs */
+  std::unique_ptr<GEMCoPadProcessor> coPadProcessor;
 
   /** Methods to sort the LCTs */
   std::vector<CSCCorrelatedLCTDigi> sortLCTsByQuality(int bx);
@@ -146,10 +146,6 @@ class CSCMotherboardME21GEM : public CSCMotherboard
   bool debug_gem_matching;
   bool debug_luts;
   bool debug_gem_dphi;
-
-  //  deltas used to construct GEM coincidence pads
-  int maxDeltaBXInCoPad_;
-  int maxDeltaPadInCoPad_;
 
   //  deltas used to match to GEM pads
   int maxDeltaBXPad_;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -335,8 +335,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 	      std::vector<CSCCLCTDigi> clctV1a = tmb11GEM->clct1a->readoutCLCTs();
 	      std::vector<int> preTriggerBXs1a = tmb11GEM->clct1a->preTriggerBXs();
 	      
-	      std::vector<GEMCoPadDigi> copads = tmb11GEM->readoutCoPads();
-	      
+	      std::vector<GEMCoPadDigi> copads = tmb11GEM->coPadProcessor->readoutCoPads();
 	      // perform simple separation of ALCTs into 1/a and 1/b
 	      // for 'smart' case. Some duplication occurs for WG [10,15]
 	      std::vector<CSCALCTDigi> tmpV(alctV);
@@ -453,7 +452,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 	      std::vector<CSCCLCTDigi> clctV = tmb21GEM->clct->readoutCLCTs();
 	      std::vector<int> preTriggerBXs = tmb21GEM->clct->preTriggerBXs();
 	      
-	      std::vector<GEMCoPadDigi> copads = tmb21GEM->readoutCoPads();
+	      std::vector<GEMCoPadDigi> copads = tmb21GEM->coPadProcessor->readoutCoPads();
 	      
 	      if (!(alctV.empty() && clctV.empty() && lctV.empty())) {
 		LogTrace("L1CSCTrigger")

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -2,8 +2,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <algorithm>
-#include <iomanip>
-#include <iostream>
 #include <set>
 
 //----------------
@@ -15,9 +13,8 @@ GEMCoPadProcessor::GEMCoPadProcessor(unsigned endcap,
 				     unsigned ring,
 				     unsigned chamber,
 				     const edm::ParameterSet& copad) :
-  theEndcap(endcap), theStation(station), theRing(ring),
-  theChamber(chamber) {
-  
+  theEndcap(endcap), theStation(station), theRing(ring), theChamber(chamber) 
+{
   // Verbosity level, set to 0 (no print) by default.
   infoV        = copad.getParameter<unsigned int>("verbosity");
   maxDeltaPadGE11_ = copad.getParameter<unsigned int>("maxDeltaPadGE11");
@@ -26,8 +23,7 @@ GEMCoPadProcessor::GEMCoPadProcessor(unsigned endcap,
 }
 
 GEMCoPadProcessor::GEMCoPadProcessor() :
-  		     theEndcap(1), theStation(1), theRing(1),
-                     theChamber(1) 
+  theEndcap(1), theStation(1), theRing(1), theChamber(1) 
 {
   infoV = 0;
   maxDeltaPadGE11_ = 0;

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -75,7 +75,7 @@ GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads)
 	    (theStation==2 and deltaPad > maxDeltaPadGE21_)) continue;
 
         // check the match in BX
-        if (std::abs(p->bx() - co_p->bx()) > maxDeltaBX_) continue;
+        if ((unsigned)std::abs(p->bx() - co_p->bx()) > maxDeltaBX_) continue;
 	
         // make a new coincidence pad digi
         gemCoPadV.push_back(GEMCoPadDigi(id.roll(),*p,*co_p));

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -90,7 +90,7 @@ GEMCoPadProcessor::run(const GEMPadDigiClusterCollection* in_clusters)
 }
 
 
-std::vector<GEMCoPadDigi>
+const std::vector<GEMCoPadDigi>&
 GEMCoPadProcessor::readoutCoPads()
 {
   return gemCoPadV;

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -19,10 +19,10 @@ GEMCoPadProcessor::GEMCoPadProcessor(unsigned endcap,
   theChamber(chamber) {
   
   // Verbosity level, set to 0 (no print) by default.
-  infoV        = copad.getParameter<int>("verbosity");
-  maxDeltaPadGE11_ = copad.getParameter<int>("maxDeltaPadGE11");
-  maxDeltaPadGE21_ = copad.getParameter<int>("maxDeltaPadGE21");
-  maxDeltaBX_ = copad.getParameter<int>("maxDeltaBX");
+  infoV        = copad.getParameter<unsigned int>("verbosity");
+  maxDeltaPadGE11_ = copad.getParameter<unsigned int>("maxDeltaPadGE11");
+  maxDeltaPadGE21_ = copad.getParameter<unsigned int>("maxDeltaPadGE21");
+  maxDeltaBX_ = copad.getParameter<unsigned int>("maxDeltaBX");
 }
 
 GEMCoPadProcessor::GEMCoPadProcessor() :
@@ -69,7 +69,7 @@ GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads)
     for (auto p = pads_range.first; p != pads_range.second; ++p) {
       for (auto co_p = co_pads_range.first; co_p != co_pads_range.second; ++co_p) {
 	
-	const int deltaPad(std::abs(p->pad() - co_p->pad()));
+	const unsigned int deltaPad(std::abs(p->pad() - co_p->pad()));
         // check the match in pad
         if ((theStation==1 and deltaPad > maxDeltaPadGE11_) or
 	    (theStation==2 and deltaPad > maxDeltaPadGE21_)) continue;

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -1,0 +1,117 @@
+#include "L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <set>
+
+//----------------
+// Constructors --
+//----------------
+
+GEMCoPadProcessor::GEMCoPadProcessor(unsigned endcap,
+				     unsigned station,
+				     unsigned ring,
+				     unsigned chamber,
+				     const edm::ParameterSet& copad) :
+  theEndcap(endcap), theStation(station), theRing(ring),
+  theChamber(chamber) {
+  
+  // Verbosity level, set to 0 (no print) by default.
+  infoV        = copad.getParameter<int>("verbosity");
+  maxDeltaPadGE11_ = copad.getParameter<int>("maxDeltaPadGE11");
+  maxDeltaPadGE21_ = copad.getParameter<int>("maxDeltaPadGE21");
+  maxDeltaBX_ = copad.getParameter<int>("maxDeltaBX");
+}
+
+GEMCoPadProcessor::GEMCoPadProcessor() :
+  		     theEndcap(1), theStation(1), theRing(1),
+                     theChamber(1) 
+{
+  infoV = 0;
+  maxDeltaPadGE11_ = 0;
+  maxDeltaPadGE21_ = 0;
+  maxDeltaBX_ = 0;
+}
+
+void
+GEMCoPadProcessor::clear()
+{
+  gemCoPadV.clear();
+}
+
+std::vector<GEMCoPadDigi>
+GEMCoPadProcessor::run(const GEMPadDigiCollection* in_pads) 
+{
+  const int region((theEndcap == 1) ? 1: -1);
+  
+  // Build coincidences
+  for (auto det_range = in_pads->begin(); det_range != in_pads->end(); ++det_range) {
+    const GEMDetId& id = (*det_range).first;
+    
+    // same chamber (no restriction on the roll number)
+    if (id.region() != region or id.station() != theStation or 
+	id.ring() != theRing or id.chamber() != theChamber) continue;
+    
+    // all coincidences detIDs will have layer=1
+    if (id.layer() != 1) continue;
+    
+    // find the corresponding id with layer=2 and same roll number
+    GEMDetId co_id(id.region(), id.ring(), id.station(), 2, id.chamber(), id.roll());
+    
+    auto co_pads_range = in_pads->get(co_id);
+    // empty range = no possible coincidence pads
+    if (co_pads_range.first == co_pads_range.second) continue;
+    
+    // now let's correlate the pads in two layers of this partition
+    const auto& pads_range = (*det_range).second;
+    for (auto p = pads_range.first; p != pads_range.second; ++p) {
+      for (auto co_p = co_pads_range.first; co_p != co_pads_range.second; ++co_p) {
+	
+	const int deltaPad(std::abs(p->pad() - co_p->pad()));
+        // check the match in pad
+        if ((theStation==1 and deltaPad > maxDeltaPadGE11_) or
+	    (theStation==2 and deltaPad > maxDeltaPadGE21_)) continue;
+
+        // check the match in BX
+        if (std::abs(p->bx() - co_p->bx()) > maxDeltaBX_) continue;
+	
+        // make a new coincidence pad digi
+        gemCoPadV.push_back(GEMCoPadDigi(id.roll(),*p,*co_p));
+      }
+    }
+  }
+  return gemCoPadV;
+}
+
+std::vector<GEMCoPadDigi> 
+GEMCoPadProcessor::run(const GEMPadDigiClusterCollection* in_clusters)
+{
+  std::unique_ptr<GEMPadDigiCollection> out_pads(new GEMPadDigiCollection());
+  declusterize(in_clusters, *out_pads);
+  return run(out_pads.get());
+}
+
+
+std::vector<GEMCoPadDigi>
+GEMCoPadProcessor::readoutCoPads()
+{
+  return gemCoPadV;
+}
+
+void
+GEMCoPadProcessor::declusterize(const GEMPadDigiClusterCollection* in_clusters,
+				GEMPadDigiCollection& out_pads)
+{
+  GEMPadDigiClusterCollection::DigiRangeIterator detUnitIt;
+  for (detUnitIt = in_clusters->begin();detUnitIt != in_clusters->end(); ++detUnitIt) {
+    const GEMDetId& id = (*detUnitIt).first;
+    const GEMPadDigiClusterCollection::Range& range = (*detUnitIt).second;
+    for (GEMPadDigiClusterCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt) {
+      for (auto p: digiIt->pads()){
+	out_pads.insertDigi(id, GEMPadDigi(p, digiIt->bx()));
+      }
+    }
+  }
+}

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h
@@ -46,21 +46,20 @@ class GEMCoPadProcessor
   // declusterizes the clusters into single pad digis
   void declusterize(const GEMPadDigiClusterCollection*, GEMPadDigiCollection&);
 
-  /** Verbosity level: 0: no print (default).
-   *                   1: print only CoPads found.
-   *                   2: info at every step of the algorithm.
-   *                   3: add special-purpose prints. */
-  int infoV;
-
   /** Chamber id (trigger-type labels). */
   const int theEndcap;
   const int theStation;
   const int theRing;
   const int theChamber;
 
-  int maxDeltaPadGE11_;
-  int maxDeltaPadGE21_;
-  int maxDeltaBX_;
+  /** Verbosity level: 0: no print (default).
+   *                   1: print only CoPads found.
+   *                   2: info at every step of the algorithm.
+   *                   3: add special-purpose prints. */
+  unsigned int infoV;
+  unsigned int maxDeltaPadGE11_;
+  unsigned int maxDeltaPadGE21_;
+  unsigned int maxDeltaBX_;
 
   // output collection
   std::vector<GEMCoPadDigi> gemCoPadV;

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h
@@ -40,7 +40,7 @@ class GEMCoPadProcessor
   enum {MAX_CoPad_BINS = 3};
 
   /** Returns vector of CoPads in the read-out time window, if any. */
-  std::vector<GEMCoPadDigi> readoutCoPads();
+  const std::vector<GEMCoPadDigi>& readoutCoPads();
 
  private:
   // declusterizes the clusters into single pad digis

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.h
@@ -1,0 +1,69 @@
+#ifndef L1Trigger_CSCTriggerPrimitives_GEMCoPadProcessor_h
+#define L1Trigger_CSCTriggerPrimitives_GEMCoPadProcessor_h
+
+/** \class GEMCoPadProcessor
+ *
+ * \author Sven Dildick (TAMU)
+ *
+ */
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMCoPadDigi.h"
+
+#include <vector>
+
+class GEMCoPadProcessor
+{
+ public:
+  /** Normal constructor. */
+  GEMCoPadProcessor(unsigned endcap, unsigned station, unsigned ring,
+		    unsigned chamber,
+		    const edm::ParameterSet& copad);
+  
+  /** Default constructor. Used for testing. */
+  GEMCoPadProcessor();
+
+  /** Clear copad vector */
+  void clear();
+
+  /** Runs the CoPad processor code. Called in normal running -- gets info from
+      a collection of pad digis. */
+  std::vector<GEMCoPadDigi> run(const GEMPadDigiCollection*);
+
+  /** Runs the CoPad processor code. Called in normal running -- gets info from
+      a collection of pad digi clusters. */
+  std::vector<GEMCoPadDigi> run(const GEMPadDigiClusterCollection*);
+
+  /** Maximum number of time bins. */
+  enum {MAX_CoPad_BINS = 3};
+
+  /** Returns vector of CoPads in the read-out time window, if any. */
+  std::vector<GEMCoPadDigi> readoutCoPads();
+
+ private:
+  // declusterizes the clusters into single pad digis
+  void declusterize(const GEMPadDigiClusterCollection*, GEMPadDigiCollection&);
+
+  /** Verbosity level: 0: no print (default).
+   *                   1: print only CoPads found.
+   *                   2: info at every step of the algorithm.
+   *                   3: add special-purpose prints. */
+  int infoV;
+
+  /** Chamber id (trigger-type labels). */
+  const int theEndcap;
+  const int theStation;
+  const int theRing;
+  const int theChamber;
+
+  int maxDeltaPadGE11_;
+  int maxDeltaPadGE21_;
+  int maxDeltaBX_;
+
+  // output collection
+  std::vector<GEMCoPadDigi> gemCoPadV;
+};
+
+#endif


### PR DESCRIPTION
* A GEMCoPadProcessor was added which builds coincidence pads for GE11 and GE21. This work is part of a somewhat larger project to clean up the GEM-CSC integrated trigger code in view of a future implementation in firmware. The GEMCoPadProcessor class has a similar function as the ALCT and CLCT processors; it produces trigger primitives from digis. The GEMCoPadProcessor can produce copads starting from a GEMPadDigiCollection (current default) or from a GEMPadDigiClusterCollection. The extra class reduces code duplication in the GE11 and GE21 integrated local triggers. It has its own parameterset in the python configuration. The parameters "maxDeltaPadGE11" and "maxDeltaPadGE21" will be optimized in the future.

* A look-up-table generator was added. It produces LUT that match GEM pads with CSC halfstrips, GEM rolls with CSC wiregroups, etc. The LUT generating code in the CSCMotherBoardMEX1GEM classes will be cleaned up later.

@tahuang1991