### PR TITLE
Cleaning pixel certification to prevent crash at Tier0 [90X]

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_Certification_cff.py
@@ -6,6 +6,8 @@ from DQMOffline.Configuration.DQMOffline_DAQ_cff import *
 from DQMOffline.Configuration.DQMOffline_DCS_cff import *
 from DQMOffline.Configuration.DQMOffline_CRT_cff import *
 
+from Configuration.StandardSequences.Eras import eras
+
 DQMOffline_Certification = cms.Sequence(daq_dqmoffline*dcs_dqmoffline*crt_dqmoffline)
 
 DQMCertCommon = cms.Sequence(siStripDaqInfo * sipixelDaqInfo * 
@@ -24,3 +26,10 @@ DQMCertEcal = cms.Sequence(ecalDaqInfoTask * ecalPreshowerDaqInfoTask *
                            ecalCertification * ecalPreshowerDataCertificationTask)
 
 DQMCertJetMET = cms.Sequence(dataCertificationJetMETSequence)
+
+from DQM.SiPixelPhase1Config.SiPixelPhase1OfflineDQM_harvesting_cff import *
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+
+phase1Pixel.toReplaceWith(DQMCertCommon, DQMCertCommon.copyAndExclude([ # FIXME
+    sipixelCertification # segfaults when included
+]))


### PR DESCRIPTION
This PR is meant to cure the crash at Tier0 reported here :
https://hypernews.cern.ch/HyperNews/CMS/get/dqmDevel/2366.html
Equivalent in 91x : #17855 
