### PR TITLE
Fix memory leak in BasicHepMCValidation

### DIFF
--- a/Validation/EventGenerator/interface/BasicHepMCValidation.h
+++ b/Validation/EventGenerator/interface/BasicHepMCValidation.h
@@ -129,7 +129,7 @@ class BasicHepMCValidation : public DQMEDAnalyzer{
       }
       
       const HepMC::GenParticle* GetFinal(const HepMC::GenParticle* p){ // includes mixing (assuming mixing is not occurring more than 5 times back and forth)
-        HepMC::GenParticle* aPart = new HepMC::GenParticle(*p);
+        const HepMC::GenParticle* aPart = p;
 	for (unsigned int iMix = 0; iMix < 10; iMix++) {
 	  bool foundSimilar = false;
 	  if(aPart->end_vertex()){ 


### PR DESCRIPTION
The code was creating a new HepMC::GenParticle and never deleting it.
Turns out there was no need to create a new one for the algorithm.