### PR TITLE
Use std::unique_ptr to manage memory in PileupJetIdProducer

### DIFF
--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -21,7 +21,7 @@ Implementation:
 
 
 // system include files
-//#include <memory>
+#include <memory>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -62,11 +62,11 @@ private:
 	edm::InputTag jets_, vertexes_, jetids_, rho_;
 	std::string jec_;
 	bool runMvas_, produceJetIds_, inputIsCorrected_, applyJec_;
-	std::vector<std::pair<std::string, PileupJetIdAlgo *> > algos_;
+	std::vector<std::pair<std::string, std::unique_ptr<PileupJetIdAlgo>> > algos_;
 	
 	bool residualsFromTxt_;
 	edm::FileInPath residualsTxt_;
-	FactorizedJetCorrector *jecCor_;
+        std::unique_ptr<FactorizedJetCorrector> jecCor_;
 	std::vector<JetCorrectorParameters> jetCorPars_;
 
         edm::EDGetTokenT<edm::View<reco::Jet> > input_jet_token_;


### PR DESCRIPTION
While fixing a memory leak also switched from bare pointers to
using std::unique_ptr.