### PR TITLE
MatacqProduce: added support for multiple matacq files per run

### DIFF
--- a/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
+++ b/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
@@ -160,6 +160,10 @@ private:
 
   uint32_t getRunNumber(edm::Event& ev) const;
   uint32_t getOrbitId(edm::Event& ev) const;
+
+  
+  bool getOrbitRange(uint32_t& firstOrb, uint32_t& lastOrb);
+
   int getCalibTriggerType(edm::Event& ev) const;
 
   /** Loading orbit correction table from file. @see orbitOffsetFile_

--- a/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <sys/stat.h>
+#include <glob.h>
 
 using namespace std;
 using namespace boost;
@@ -209,7 +210,7 @@ MatacqProducer::addMatacqData(edm::Event& event){
 	const uint32_t orbitId   = getOrbitId(event);
       
 	LogInfo("Matacq") << "Run " << runNumber << "\t Orbit " << orbitId << "\n";
-      
+	
 	bool fileChange;
 	if(doOrbitOffset_){
 	  map<uint32_t,uint32_t>::iterator it = orbitOffset_.find(runNumber);
@@ -541,35 +542,95 @@ MatacqProducer::getMatacqEvent(uint32_t runNumber,
 bool
 MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId,
 			      bool* fileChange){
-  if(openedFileRunNumber_!=0
-     && openedFileRunNumber_==runNumber){
-    if(fileChange!=0) *fileChange = false;
-    return misOpened();
+  if(openedFileRunNumber_ != 0
+     && openedFileRunNumber_ == runNumber){
+    uint32_t firstOrb, lastOrb;
+    getOrbitRange(firstOrb, lastOrb);
+    //    if(orbitId < firstOrb || orbitId > lastOrb) continue;
+    if(firstOrb <= orbitId && orbitId <= lastOrb){
+      if(fileChange!=0) *fileChange = false;
+      return misOpened();
+    }
   }
 
-  if(fileNames_.size()==0) return 0;
+  if(fileNames_.size()==0) return false;
 
-  const string runNumberFormat = "%08d";
+  const string runNumberFormat = "%08d{,_*}";
   string sRunNumber = str(boost::format(runNumberFormat) % runNumber);
   //cout << "Run number string: " << sRunNumber << "\n";
   bool found = false;
   string fname;
-  for(unsigned i=0; i < fileNames_.size() && !found; ++i){
-    fname = fileNames_[i];
-    boost::algorithm::replace_all(fname, "%run_subdir%",
-				  runSubDir(runNumber));
-    boost::algorithm::replace_all(fname, "%run_number%", sRunNumber);
-
-    if(verbosity_>0) cout << "[Matacq " << now() << "] "
-			  << "Looking for a file with path "
-			  << fname << "\n";
-    
-    if(mcheck(fname)){
-      LogInfo("Matacq") << "Uses matacq data file: '" << fname << "'\n";
-      found = true;
+  uint32_t maxOrb = 0;
+  //we make two iterations to handle the case where the event is procesed
+  //before the matacq data are available. In such case we would have
+  //orbitId > maxOrb (maxOrb: orbit of last written matacq event)
+  for(int itry = 0; itry < 2 && (orbitId > maxOrb); ++itry){
+    if(itry > 0){
+      int n_sec = 1;
+      std::cout << "[Matacq " << now() << "] Event orbit id (" << orbitId << ") goes "
+	"beyound the range of available one. Waiting for " << n_sec << " seconds in case "
+	"it was not written yet to disk.";
+      sleep(n_sec);
     }
-  }
-  if(!found){
+    
+    for(unsigned i=0; i < fileNames_.size() && !found; ++i){
+      fname = fileNames_[i];
+      boost::algorithm::replace_all(fname, "%run_subdir%",
+				    runSubDir(runNumber));
+      boost::algorithm::replace_all(fname, "%run_number%", sRunNumber);
+
+      glob_t g;
+      int rc  = glob(fname.c_str(), GLOB_BRACE, 0, &g);
+      if(rc){
+	if(verbosity_ > 1){
+	  switch(rc){
+	  case GLOB_NOSPACE:
+	    std::cout << "[Matacq " << now() << "] Running out of memory while calling glob function to look for matacq file paths\n";
+	    break;
+	  case GLOB_ABORTED:
+	    std::cout << "[Matacq " << now() << "] Read error while calling glob function to look for matacq file paths\n";
+	    break;
+	  case GLOB_NOMATCH:
+	    //ok. No message to report.
+	    break;
+	  }
+	  continue;
+	}
+      } //rc
+      for(unsigned iglob = 0; iglob < g.gl_pathc; ++iglob){
+	char* thePath = g.gl_pathv[iglob];
+	//FIXME: add sanity check on the path
+	static int nOpenErrors = 0;
+	const int maxOpenErrors = 50;
+	if(!mopen(thePath) && nOpenErrors < maxOpenErrors){
+	  std::cout << "[Matacq " << now() << "] Failed to open file " << thePath;
+	  ++nOpenErrors;
+	  if(nOpenErrors == maxOpenErrors){
+	    std::cout << nOpenErrors << "This is the " << maxOpenErrors
+		      << "th occurence of this error. Report of this error is now disabled.\n";
+	  } else{
+	    std::cout << "\n";
+	  }
+	}
+	uint32_t firstOrb;
+	uint32_t lastOrb;
+	getOrbitRange(firstOrb, lastOrb);
+	if(lastOrb > maxOrb) maxOrb = lastOrb;
+	if(firstOrb <= orbitId && orbitId <= lastOrb){
+	  found = true;
+	  //continue;
+	  fname = thePath;
+	  if(verbosity_ > 1) std::cout << "[Matacq " << now() << "] Switching to file " << fname << "\n";
+	  break;
+	}
+      } //next iglob
+      globfree(&g);
+    }//next filenames
+  } //next itry
+  
+  if(found){
+    LogInfo("Matacq") << "Uses matacq data file: '" << fname << "'\n";
+  } else{
     if(verbosity_>=0) cout << "[Matacq " << now() << "] no matacq file found "
 			"for run " << runNumber << "\n";
     eventSkipCounter_ = onErrorDisablingEvtCnt_;
@@ -577,22 +638,18 @@ MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId,
     if(fileChange!=0) *fileChange = false;
     return 0;
   }
-  
-  if(!mopen(fname)){
-    LogWarning("Matacq") << "Failed to open file " << fname << "\n";
-    eventSkipCounter_ = onErrorDisablingEvtCnt_;
-    openedFileRunNumber_ = 0;
-    if(fileChange!=0) *fileChange = false;
-    return false;
-  } else{
+
+   if(found){
     openedFileRunNumber_ = runNumber;
     lastOrb_ = 0;
     posEstim_.init(this);
     if(fileChange!=0) *fileChange = true;
     return true;
+  } else{
+    return false;
   }
 }
- 
+
 
 uint32_t MatacqProducer::getRunNumber(edm::Event& ev) const{
   return ev.run();
@@ -638,7 +695,7 @@ uint32_t MatacqProducer::getOrbitId(edm::Event& ev) const{
     //    throw cms::Exception("NotFound")
     //  << "Failed to retrieve orbit ID of event "<< ev.id();
     LogWarning("NotFound") << "Failed to retrieve orbit ID of event "
-				<< ev.id();
+			   << ev.id();
   }
   return orbit;
 }
@@ -1065,4 +1122,31 @@ void MatacqProducer::newRun(int prevRun, int newRun){
     stats_.nNonLaserEventsWithMatacq = 0;
 
     
+}
+
+bool MatacqProducer::getOrbitRange(uint32_t& firstOrb, uint32_t& lastOrb){
+  filepos_t pos = -1;
+  filepos_t fsize = -1;
+  mtell(pos);
+  msize(fsize);
+  const unsigned headerSize = 8*8;
+  unsigned char header[headerSize];
+  //FIXME: Don't we need here to rewind?
+  mseek(0);
+  if(!mread((char*)header, headerSize, 0, false)) return false;
+  firstOrb = MatacqRawEvent::getOrbitId(header, headerSize);
+  int len = (int)MatacqRawEvent::getDccLen(header, headerSize);
+  //number of complete events. If last event is partially written,
+  //it won't be included in the count.
+  unsigned nEvts = fsize / (len*64);
+  //Position of last complete event:
+  filepos_t lastEvtPos = (nEvts - 1) * len * 64;
+  mseek(lastEvtPos);
+  mread((char*)header, headerSize, 0, false);
+  lastOrb = MatacqRawEvent::getOrbitId(header, headerSize);
+  
+  //restore file position:
+  mseek(pos);
+
+  return true;
 }


### PR DESCRIPTION
The code which was updated is used on the ECAL laser monitoring farm located at P5. It is not used in neither in the reconstruction nor the simulation. The change implements the change advertised in the elog http://cmsonline.cern.ch/cms-elog/969816.

