### PR TITLE
update 2017 wf in IB: replace TenMuE with ZMM (91X)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -13,10 +13,10 @@ workflows = Matrix()
 
 #just define all of them
 
-#2017 WFs to run in IB (TenMuE_0_200, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
+#2017 WFs to run in IB (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
 #same for 2018
-numWFIB = [10021.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
-           10821.0,10824.0,10825.0,10826.0,10823.0,11024.0,11025.0,11224.0]
+numWFIB = [10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
+           10842.0,10824.0,10825.0,10826.0,10823.0,11024.0,11025.0,11224.0]
 for i,key in enumerate(upgradeKeys[2017]):
     numWF=numWFAll[2017][i]
     for frag in upgradeFragments:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
                      140.53, #2011 HI data
                      1330, #Run2 MC Zmm
                      135.4, #Run 2 Zee ttbar
-                     10021.0, #2017 tenmu
+                     10042.0, #2017 ZMM
                      10024.0, #2017 ttbar
                      10824.0, #2018 ttbar
                      20034.0, #2023D7 ttbar (Run2 calo)


### PR DESCRIPTION
Replacing TenMuE with ZMM wf in IB.
We are not producing anymore TenMuE relval, so there is no TenMuE gensim for input.

Forward port of #17858 (90X)

