### PR TITLE
Minor improvements to Multifit handling of max sample fallback

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
@@ -33,8 +33,7 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
   const unsigned int nsample = EcalDataFrame::MAXSAMPLES;
   
   double maxamplitude = -std::numeric_limits<double>::max();
-  double maxgainratio = -std::numeric_limits<double>::max();
-  unsigned int iSampleMax = 0;
+  const unsigned int iSampleMax = 5;
   
   double pedval = 0.;
     
@@ -97,11 +96,8 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
         
     amplitudes[iSample] = amplitude;
     
-    if (gainratio > maxgainratio || gainId==0 || amplitude>maxamplitude) {
-    //if (iSample==5) {
+    if (iSample==iSampleMax) {
       maxamplitude = amplitude;
-      maxgainratio = gainratio;
-      iSampleMax = iSample;
       pedval = pedestal;
     }
         

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
@@ -34,6 +34,7 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
   
   double maxamplitude = -std::numeric_limits<double>::max();
   const unsigned int iSampleMax = 5;
+  const unsigned int iFullPulseMax = 9;
   
   double pedval = 0.;
     
@@ -110,7 +111,8 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
   //optionally apply a stricter criteria, assuming slew rate limit is only reached in case where maximum sample has gain switched but previous sample has not
   //option 1: use simple max-sample algorithm
   if (hasGainSwitch && _gainSwitchUseMaxSample) {
-    EcalUncalibratedRecHit rh( dataFrame.id(), maxamplitude, pedval, 0., 0., flags );
+    double maxpulseamplitude = maxamplitude / fullpulse[iFullPulseMax];
+    EcalUncalibratedRecHit rh( dataFrame.id(), maxpulseamplitude, pedval, 0., 0., flags );
     rh.setAmplitudeError(0.);
     for (unsigned int ipulse=0; ipulse<_pulsefunc.BXs().rows(); ++ipulse) {
       int bx = _pulsefunc.BXs().coeff(ipulse);


### PR DESCRIPTION
1) Enforce the use of sample 5 instead of dynamically finding the maximum (should be more robust against possible anomalous rechits)

2) Properly correct for the maximum pulse template value.  (This was so far 1.0 in all production pulse shape tags, but this might change in the future, in which case this extra factor is needed in order to maintain energy scale consistency between the max sample fallback and standard multifit rechits.)

@emanueledimarco @argiro @amassiro 