### PR TITLE
rebase - TTrackAssociator in L1TrackTrigger Sequence and in FEVT Eventcontent.

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -839,7 +839,9 @@ for _entry in [FEVTDEBUGEventContent,FEVTDEBUGHLTEventContent,FEVTEventContent]:
     phase2_tracker.toModify(_entry, outputCommands = _entry.outputCommands + [
         'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
         'keep *_TTClustersFromPhase2TrackerDigis_*_*',
-        'keep *_TTStubsFromPhase2TrackerDigis_*_*'
+        'keep *_TTStubsFromPhase2TrackerDigis_*_*',
+        'keep *_TTClusterAssociatorFromPixelDigis_*_*',
+        'keep *_TTStubAssociatorFromPixelDigis_*_*'
     ])
 
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import RecoLocalFastTimeFEVT, RecoLocalFastTimeRECO, RecoLocalFastTimeAOD

--- a/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
+++ b/Configuration/StandardSequences/python/L1TrackTrigger_cff.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.TrackTrigger.TrackTrigger_cff import *
-##from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
+from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 
 #L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs*TrackTriggerTTTracks*TrackTriggerAssociatorTracks)
-L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs)
+L1TrackTrigger=cms.Sequence(TrackTriggerClustersStubs*TrackTriggerAssociatorClustersStubs)
 
 TTStubAlgorithm_official_Phase2TrackerDigi_.zMatchingPS = cms.bool(True)
+TTClusterAssociatorFromPixelDigis.digiSimLinks          = cms.InputTag( "simSiPixelDigis","Tracker" )


### PR DESCRIPTION
This is a rebase of #17694

Add TrackTriggerAssociatorClustersStubs to the L1TrackTrigger sequence and configure it, and add keep Associator digis in FEVT* event content.

