### PR TITLE
Migration of workflow injection to Unified

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -3,6 +3,7 @@ import json
 import os
 import copy
 import multiprocessing
+import time
 
 def performInjectionOptionTest(opt):
     if opt.show:
@@ -51,6 +52,10 @@ class MatrixInjector(object):
         self.keep = opt.keep
         self.memoryOffset = opt.memoryOffset
         self.memPerCore = opt.memPerCore
+        self.batchName = ''
+        self.batchTime = str(int(time.time()))
+        if(opt.batchName):
+            self.batchName = '__'+opt.batchName+'-'+self.batchTime
 
         #wagemt stuff
         if not self.wmagent:
@@ -109,7 +114,8 @@ class MatrixInjector(object):
             "Multicore" : 1,   # do not set multicore for the whole chain
             "Memory" : 3000,
             "SizePerEvent" : 1234,
-            "TimePerEvent" : 0.1
+            "TimePerEvent" : 0.1,
+            "PrepID": os.getenv('CMSSW_VERSION')
             }
 
         self.defaultHarvest={
@@ -352,6 +358,9 @@ class MatrixInjector(object):
                                 chainDict['nowmTasklist'][-1]['AcquisitionEra']=chainDict['CMSSWVersion']
                                 chainDict['nowmTasklist'][-1]['ProcessingString']=processStrPrefix+chainDict['nowmTasklist'][-1]['GlobalTag'].replace('::All','')+thisLabel
 
+                            if (self.batchName):
+                                chainDict['nowmTasklist'][-1]['Campaign'] = chainDict['nowmTasklist'][-1]['AcquisitionEra']+self.batchName
+
                             # specify different ProcessingString for double miniAOD dataset
                             if ('DBLMINIAODMCUP15NODQM' in step): 
                                 chainDict['nowmTasklist'][-1]['ProcessingString']=chainDict['nowmTasklist'][-1]['ProcessingString']+'_miniAOD' 
@@ -371,7 +380,12 @@ class MatrixInjector(object):
                     if processStrPrefix or thisLabel:
                         chainDict['RequestString']+='_'+processStrPrefix+thisLabel
 
-                        
+### PrepID
+                    chainDict['PrepID'] = chainDict['CMSSWVersion']+'__'+self.batchTime+'-'+s[1].split('+')[0]
+                    if(self.batchName):
+                        chainDict['PrepID'] = chainDict['CMSSWVersion']+self.batchName+'-'+s[1].split('+')[0]
+                        if( 'HIN' in self.batchName ):
+                            chainDict['SubRequestType'] = "HIRelVal"
                         
             #wrap up for this one
             import pprint
@@ -420,7 +434,9 @@ class MatrixInjector(object):
                 chainDict['AcquisitionEra'] = chainDict['nowmTasklist'][0]['AcquisitionEra']
                 chainDict['ProcessingString'] = chainDict['nowmTasklist'][0]['ProcessingString']
                 
-            chainDict['Campaign'] = chainDict['AcquisitionEra']
+#####  batch name appended to Campaign name
+#            chainDict['Campaign'] = chainDict['AcquisitionEra']
+            chainDict['Campaign'] = chainDict['AcquisitionEra']+self.batchName
                
             ## clean things up now
             itask=0

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -76,6 +76,12 @@ if __name__ == '__main__':
 
     parser = optparse.OptionParser(usage)
 
+    parser.add_option('-b','--batchName',
+                      help='relval batch: suffix to be appended to Campaign name',
+                      dest='batchName',
+                      default=''
+                     )
+
     parser.add_option('-m','--memoryOffset',
                       help='memory of the wf for single core',
                       dest='memoryOffset',


### PR DESCRIPTION
Changes to relval matrix injection parameters to be compliant with Unified and to identify
a batch of relvals:
 - adding batch name and time stamp in Campaign name
 - unique prepID for each wf
 - adding -b option in runTheMatrix to specify batch name via command line
 - Different SubRequestType for HIN wf