### PR TITLE
fix GEM geometry - HCAL emap - HCAL resoCorr HEP17 - SiStrip bad channels [91x version]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,21 +38,23 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'   :  '90X_upgrade2017_design_IdealBS_v16',
+    'phase1_2017_design'       :  '90X_upgrade2017_design_IdealBS_v18',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '90X_upgrade2017_realistic_v16',
-    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in peak mode
-    'phase1_2017_cosmics'  : '90X_upgrade2017cosmics_realistic_peak_v15',
+    'phase1_2017_realistic'    : '90X_upgrade2017_realistic_v17',
+    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
+    'phase1_2017_cosmics'      : '90X_upgrade2017cosmics_realistic_deco_v15',
+    # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
+    'phase1_2017_cosmics_peak' : '90X_upgrade2017cosmics_realistic_peak_v16',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'   : '90X_upgrade2018_design_IdealBS_v13',
+    'phase1_2018_design'       : '90X_upgrade2018_design_IdealBS_v14',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic': '90X_upgrade2018_realistic_v13',
-    # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_cosmics':   '90X_upgrade2018cosmics_realistic_peak_v12',
+    'phase1_2018_realistic'    : '90X_upgrade2018_realistic_v14',
+    # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
+    'phase1_2018_cosmics'      :   '90X_upgrade2018cosmics_realistic_deco_v14',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
-    'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
+    'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'     : '90X_upgrade2023_realistic_v6'
+    'phase2_realistic'         : '90X_upgrade2023_realistic_v7'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -42,9 +42,9 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
     'phase1_2017_realistic'    : '90X_upgrade2017_realistic_v18',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '90X_upgrade2017cosmics_realistic_deco_v15',
+    'phase1_2017_cosmics'      : '90X_upgrade2017cosmics_realistic_deco_v16',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '90X_upgrade2017cosmics_realistic_peak_v16',
+    'phase1_2017_cosmics_peak' : '90X_upgrade2017cosmics_realistic_peak_v17',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '90X_upgrade2018_design_IdealBS_v14',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,7 +40,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '90X_upgrade2017_design_IdealBS_v18',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '90X_upgrade2017_realistic_v17',
+    'phase1_2017_realistic'    : '90X_upgrade2017_realistic_v18',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'      : '90X_upgrade2017cosmics_realistic_deco_v15',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
@@ -48,13 +48,13 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '90X_upgrade2018_design_IdealBS_v14',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '90X_upgrade2018_realistic_v14',
+    'phase1_2018_realistic'    : '90X_upgrade2018_realistic_v15',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'      :   '90X_upgrade2018cosmics_realistic_deco_v14',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '90X_upgrade2023_realistic_v7'
+    'phase2_realistic'         : '90X_upgrade2023_realistic_v8'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,21 +22,21 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '90X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '90X_dataRun2_v5',
+    'run1_data'         :   '90X_dataRun2_v6',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '90X_dataRun2_v5',
+    'run2_data'         :   '90X_dataRun2_v6',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '90X_dataRun2_relval_v5',
+    'run2_data_relval'  :   '90X_dataRun2_relval_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '90X_dataRun2_PromptLike_v5',
+    'run2_data_promptlike' : '90X_dataRun2_PromptLike_v6',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '90X_dataRun2_HLT_frozen_v3',
+    'run1_hlt'          :   '90X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '90X_dataRun2_HLT_frozen_v3',
+    'run2_hlt'          :   '90X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '90X_dataRun2_HLT_relval_v3',
+    'run2_hlt_relval'   :   '90X_dataRun2_HLT_relval_v4',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v3',
+    'run2_hlt_hi'       :   '90X_dataRun2_HLTHI_frozen_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '90X_upgrade2017_design_IdealBS_v18',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -50,7 +50,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    : '90X_upgrade2018_realistic_v15',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '90X_upgrade2018cosmics_realistic_deco_v14',
+    'phase1_2018_cosmics'      :   '90X_upgrade2018cosmics_realistic_deco_v15',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
This PR will lead to the same set of GT's in 91X as this other PR https://github.com/cms-sw/cmssw/pull/17886 in do in 90x

Since in 91x, a set of updates
("Summer16 JECs, GEM reco geometry and ESEE Intercalib" - see PR https://github.com/cms-sw/cmssw/pull/17702 ; the equivalent 90x https://github.com/cms-sw/cmssw/pull/17649 is yet to be merged )
has already been merged,
the changes expected in this PR are fewer than have been observed for the 90x https://github.com/cms-sw/cmssw/pull/17886

The changes expected are described in the [further down in this chat](https://github.com/cms-sw/cmssw/pull/17905#issuecomment-286274828), since commits have been added
