### PR TITLE
Improving Track Information in miniAOD : 80X

### DIFF
--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -33,6 +33,8 @@ void pat::PackedCandidate::packVtx(bool unpackAfterwards) {
     packedDxy_ = MiniFloatConverter::float32to16(dxy_*100);
     packedDz_   = pvRef.isNonnull() ? MiniFloatConverter::float32to16(dz_*100) : int16_t(std::round(dz_/40.f*std::numeric_limits<int16_t>::max()));
     packedDPhi_ =  int16_t(std::round(dphi_/3.2f*std::numeric_limits<int16_t>::max()));
+    packedDEta_ =  MiniFloatConverter::float32to16(deta_);
+    packedDTrkPt_ = MiniFloatConverter::float32to16(dtrkpt_);
     packedCovarianceDxyDxy_ = MiniFloatConverter::float32to16(dxydxy_*10000.);
     packedCovarianceDxyDz_ = MiniFloatConverter::float32to16(dxydz_*10000.);
     packedCovarianceDzDz_ = MiniFloatConverter::float32to16(dzdz_*10000.);
@@ -93,6 +95,8 @@ void pat::PackedCandidate::unpack() const {
 void pat::PackedCandidate::unpackVtx() const {
     reco::VertexRef pvRef = vertexRef();
     dphi_ = int16_t(packedDPhi_)*3.2f/std::numeric_limits<int16_t>::max(),
+    deta_ = MiniFloatConverter::float16to32(packedDEta_);
+    dtrkpt_ = MiniFloatConverter::float16to32(packedDTrkPt_);
     dxy_ = MiniFloatConverter::float16to32(packedDxy_)/100.;
     dz_   = pvRef.isNonnull() ? MiniFloatConverter::float16to32(packedDz_)/100. : int16_t(packedDz_)*40.f/std::numeric_limits<int16_t>::max();
     Point pv = pvRef.isNonnull() ? pvRef->position() : Point();
@@ -170,7 +174,7 @@ void pat::PackedCandidate::unpackTrk() const {
     m(3,4)=dxydz_;
     m(4,3)=dxydz_;
     m(4,4)=dzdz_;
-    math::RhoEtaPhiVector p3(p4_.load()->pt(),p4_.load()->eta(),phiAtVtx());
+    math::RhoEtaPhiVector p3(ptTrk(),etaAtVtx(),phiAtVtx());
     int numberOfStripLayers = stripLayersWithMeasurement(), numberOfPixelLayers = pixelLayersWithMeasurement();
     int numberOfPixelHits = this->numberOfPixelHits();
     int numberOfHits = this->numberOfHits();

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -281,7 +281,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="27">
+  <class name="pat::PackedCandidate" ClassVersion="28">
+    <version ClassVersion="28" checksum="1956349111"/>  
     <version ClassVersion="27" checksum="2418936168"/>
     <version ClassVersion="26" checksum="2986327792"/>
     <version ClassVersion="25" checksum="3654469025"/>
@@ -305,7 +306,9 @@
     <field name="vertex_" transient="true" />
     <field name="dxy_" transient="true" />
     <field name="dz_" transient="true" />
+    <field name="dtrkpt_" transient="true" />
     <field name="dphi_" transient="true" />
+    <field name="deta_" transient="true" />
     <field name="dxydxy_" transient="true" />
     <field name="dzdz_" transient="true" />
     <field name="dxydz_" transient="true" />

--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -77,10 +77,14 @@ testPackedCandidate::testPackUnpack() {
   pat::PackedCandidate::LorentzVector lv(1.,1.,0., std::sqrt(2.+0.120*0.120));
   pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
 
-  pat::PackedCandidate::Point v(-0.005,0.005,0.1);
+  pat::PackedCandidate::Point v(-0.005,0.005,0.1); 
+  float trkPt=plv.Pt()+0.5;
+  float trkEta=plv.Eta()-0.1;
+  float trkPhi=-3./4.*3.1416;
+
 
   //invalid Refs use a special key
-  pat::PackedCandidate pc(lv, v, 1., -3./4.*3.1416, 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
+  pat::PackedCandidate pc(lv, v, trkPt,trkEta,trkPhi, 11, reco::VertexRefProd(), reco::VertexRef().key());
 
   pc.pack(true);
   pc.packVtx(true);
@@ -95,18 +99,27 @@ testPackedCandidate::testPackUnpack() {
   CPPUNIT_ASSERT(tolerance(pc.p4().E(),lv.E(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
-  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));
+  CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));  
+  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
 }
 
 void testPackedCandidate::testSimulateReadFromRoot() {
 
+  
+
   pat::PackedCandidate::LorentzVector lv(1.,1.,0., std::sqrt(2. +0.120*0.120));
   pat::PackedCandidate::PolarLorentzVector plv(lv.Pt(), lv.Eta(), lv.Phi(), lv.M());
-
   pat::PackedCandidate::Point v(-0.005,0.005,0.1);
 
+  float trkPt=plv.Pt()+0.5;
+  float trkEta=plv.Eta()-0.1;
+  float trkPhi=-3./4.*3.1416;
+
+
   //invalid Refs use a special key
-  pat::PackedCandidate pc(lv, v, 1., -3./4.*3.1416, 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
+  pat::PackedCandidate pc(lv, v, trkPt,trkEta,trkPhi, 11, reco::VertexRefProd(), reco::VertexRef().key());
 
   //  CPPUNIT_ASSERT(pc.polarP4() == plv);
   //  CPPUNIT_ASSERT(pc.p4() == lv);
@@ -130,7 +143,9 @@ void testPackedCandidate::testSimulateReadFromRoot() {
   CPPUNIT_ASSERT(tolerance(pc.vertex().X(),v.X(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().Y(),v.Y(), 0.001));
   CPPUNIT_ASSERT(tolerance(pc.vertex().Z(),v.Z(), 0.01));
-  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().p(),lv.P(),0.001));
+  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().pt(),trkPt,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().eta(),trkEta,0.001));
+  CPPUNIT_ASSERT(tolerance(pc.pseudoTrack().phi(),trkPhi,0.001));
   
 }
 

--- a/DataFormats/PatCandidates/test/testPackedCandidate.cc
+++ b/DataFormats/PatCandidates/test/testPackedCandidate.cc
@@ -48,7 +48,7 @@ void testPackedCandidate::testCopyConstructor() {
   pat::PackedCandidate::Point v(0.01,0.02,0.);
 
   //invalid Refs use a special key
-  pat::PackedCandidate pc(lv, v, 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
+  pat::PackedCandidate pc(lv, v, 1., 1., 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
 
   //these by design do not work
   //  CPPUNIT_ASSERT(pc.polarP4() == plv);
@@ -80,7 +80,7 @@ testPackedCandidate::testPackUnpack() {
   pat::PackedCandidate::Point v(-0.005,0.005,0.1);
 
   //invalid Refs use a special key
-  pat::PackedCandidate pc(lv, v, -3./4.*3.1416, 11, reco::VertexRefProd(), reco::VertexRef().key());
+  pat::PackedCandidate pc(lv, v, 1., -3./4.*3.1416, 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
 
   pc.pack(true);
   pc.packVtx(true);
@@ -106,7 +106,7 @@ void testPackedCandidate::testSimulateReadFromRoot() {
   pat::PackedCandidate::Point v(-0.005,0.005,0.1);
 
   //invalid Refs use a special key
-  pat::PackedCandidate pc(lv, v, -3./4.*3.1416, 11, reco::VertexRefProd(), reco::VertexRef().key());
+  pat::PackedCandidate pc(lv, v, 1., -3./4.*3.1416, 1., 11, reco::VertexRefProd(), reco::VertexRef().key());
 
   //  CPPUNIT_ASSERT(pc.polarP4() == plv);
   //  CPPUNIT_ASSERT(pc.p4() == lv);

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -24,6 +24,16 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Common/interface/Association.h"
 
+namespace {
+  bool passesQuality(const reco::Track& trk,const std::vector<reco::TrackBase::TrackQuality>& allowedQuals){
+    for(const auto& qual : allowedQuals){
+      if(trk.quality(qual)) return true;
+    }
+    return false;
+  }
+  
+
+}
 
 namespace pat {
   class PATLostTracks : public edm::global::EDProducer<> {
@@ -33,32 +43,56 @@ namespace pat {
     
     virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
     
+  private:  
+    enum class TrkStatus {
+      NOTUSED=0,
+      PFCAND,
+      PFCANDNOTRKPROPS,
+      PFELECTRON,
+      PFPOSITRON,
+      VTX
+    };
+    bool passTrkCuts(const reco::Track& tr)const; 
+    void addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
+			    const reco::TrackRef& trk,
+			    const reco::VertexRef& pvSlimmed,
+			    const reco::VertexRefProd& pvSlimmedColl,
+			    const reco::Vertex& pvOrig,
+			    const TrkStatus trkStatus)const;  
+
   private:
-    const edm::EDGetTokenT<reco::PFCandidateCollection>    Cands_;
+    const edm::EDGetTokenT<reco::PFCandidateCollection>    cands_;
     const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
-    const edm::EDGetTokenT<reco::TrackCollection>         Tracks_;
-    const edm::EDGetTokenT<reco::VertexCollection>         Vertices_;
-    const edm::EDGetTokenT<reco::VertexCollection>         PV_;
-    const edm::EDGetTokenT<reco::VertexCollection>         PVOrigs_;
+    const edm::EDGetTokenT<reco::TrackCollection>          tracks_;
+    const edm::EDGetTokenT<reco::VertexCollection>         vertices_;
+    const edm::EDGetTokenT<reco::VertexCollection>         pv_;
+    const edm::EDGetTokenT<reco::VertexCollection>         pvOrigs_;
     const double minPt_;
     const double minHits_;
     const double minPixelHits_;
+    const double minPtToStoreProps_;
+    std::vector<reco::TrackBase::TrackQuality> qualsToAutoAccept_;
   };
 }
 
 pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
-  Cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
+  cands_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("inputCandidates"))),
   map_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-  Tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
-  Vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
-  PV_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
-  PVOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
+  tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTracks"))),
+  vertices_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices"))),
+  pv_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+  pvOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
   minPt_(iConfig.getParameter<double>("minPt")),
   minHits_(iConfig.getParameter<uint32_t>("minHits")),
-  minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits"))
+  minPixelHits_(iConfig.getParameter<uint32_t>("minPixelHits")),
+  minPtToStoreProps_(iConfig.getParameter<double>("minPtToStoreProps"))
 {
+  std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string> >("qualsToAutoAccept"));
+  std::transform(trkQuals.begin(),trkQuals.end(),std::back_inserter(qualsToAutoAccept_),reco::TrackBase::qualityByName);
+
   produces< std::vector<reco::Track> > ();
   produces< std::vector<pat::PackedCandidate> > ();
+  produces< std::vector<pat::PackedCandidate> > ("eleTracks");
   produces< edm::Association<pat::PackedCandidateCollection> > ();
 }
 
@@ -67,85 +101,123 @@ pat::PATLostTracks::~PATLostTracks() {}
 void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
     edm::Handle<reco::PFCandidateCollection> cands;
-    iEvent.getByToken( Cands_, cands );
+    iEvent.getByToken( cands_, cands );
     std::vector<reco::Candidate>::const_iterator cand;
 
     edm::Handle<edm::Association<pat::PackedCandidateCollection> > pf2pc;
     iEvent.getByToken(map_,pf2pc);
 
     edm::Handle<reco::TrackCollection> tracks;
-    iEvent.getByToken( Tracks_, tracks );
+    iEvent.getByToken( tracks_, tracks );
     
     edm::Handle<reco::VertexCollection> vertices;
-    iEvent.getByToken( Vertices_, vertices );
+    iEvent.getByToken( vertices_, vertices );
 
     edm::Handle<reco::VertexCollection> pvs;
-    iEvent.getByToken( PV_, pvs );
-    reco::VertexRef PV(pvs.id());
-    reco::VertexRefProd PVRefProd(pvs);
+    iEvent.getByToken( pv_, pvs );
+    reco::VertexRef pv(pvs.id());
+    reco::VertexRefProd pvRefProd(pvs);
     if (!pvs->empty()) {
-        PV = reco::VertexRef(pvs, 0);
+        pv = reco::VertexRef(pvs, 0);
     }
-    edm::Handle<reco::VertexCollection> PVOrigs;
-    iEvent.getByToken( PVOrigs_, PVOrigs );
-    const reco::Vertex & PVOrig = (*PVOrigs)[0];
+    edm::Handle<reco::VertexCollection> pvOrigs;
+    iEvent.getByToken( pvOrigs_, pvOrigs );
+    const reco::Vertex & pvOrig = (*pvOrigs)[0];
 
-    std::auto_ptr< std::vector<reco::Track> > outPtrP( new std::vector<reco::Track> );
-    std::vector<int> used(tracks->size(),0);
-
-    std::auto_ptr< std::vector<pat::PackedCandidate> > outPtrC( new std::vector<pat::PackedCandidate> );
-
+    auto outPtrTrks = std::make_unique<std::vector<reco::Track>>();
+    auto outPtrTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+    auto outPtrEleTrksAsCands = std::make_unique<std::vector<pat::PackedCandidate>>();
+     
+    std::vector<TrkStatus> trkStatus(tracks->size(),TrkStatus::NOTUSED);
     //Mark all tracks used in candidates	
+    //check if packed candidates are storing the tracks by seeing if number of hits >0 	
+    //currently we dont use that information though
+    //electrons will never store their track (they store the GSF track)
     for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
         edm::Ref<reco::PFCandidateCollection> r(cands,ic);
         const reco::PFCandidate &cand=(*cands)[ic];
-        if (cand.charge()) {
-	    if(cand.trackRef().isNonnull() && cand.trackRef().id() ==tracks.id() && (*pf2pc)[r]->numberOfHits() > 0) // also check if packed candidates are storing the tracks for this one
-	    {
-		used[cand.trackRef().key()]=1;
-            }
+        if(cand.charge() && cand.trackRef().isNonnull() && cand.trackRef().id() == tracks.id() ) { 
+	  
+	  if(cand.pdgId()==11) trkStatus[cand.trackRef().key()]=TrkStatus::PFELECTRON;	  
+	  else if(cand.pdgId()==-11) trkStatus[cand.trackRef().key()]=TrkStatus::PFPOSITRON;
+	  else if((*pf2pc)[r]->numberOfHits() > 0) trkStatus[cand.trackRef().key()]=TrkStatus::PFCAND; 
+	  else trkStatus[cand.trackRef().key()]=TrkStatus::PFCANDNOTRKPROPS; 
 	}
     }
 
     //Mark all tracks used in secondary vertices
-    for(unsigned int i=0; i < vertices->size(); i++){
- 	const reco::Vertex & sv = (*vertices)[i]; 
-	for(reco::Vertex::trackRef_iterator it = sv.tracks_begin(),e=sv.tracks_end(); it!=e;it++){
-	    if(used[it->key()]==0)  used[it->key()]=2; // mark as white list 
+    for(const auto& secVert : *vertices){
+        for(auto trkIt = secVert.tracks_begin();trkIt!=secVert.tracks_end();trkIt++){
+	    if(trkStatus[trkIt->key()]==TrkStatus::NOTUSED)  trkStatus[trkIt->key()]=TrkStatus::VTX;
 	}
     }
 
-    std::vector<int> mapping(tracks->size(),-1);
-    int j=0;
-    for(unsigned int i=0; i < used.size(); i++)
-    {
-	const reco::Track & tr = (*tracks)[i];
-	if(used[i] == 2 || 
-	  (used[i]==0 && tr.pt() > minPt_ && tr.numberOfValidHits() >= minHits_ && tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_ ) 
-          )
-		{
-			outPtrP->push_back(tr);
-			reco::Candidate::PolarLorentzVector p4(tr.pt(),tr.eta(),tr.phi(),0.13957018);
-			outPtrC->push_back(pat::PackedCandidate(p4,tr.vertex(),tr.phi(),211*tr.charge(),PVRefProd,PV.key()));
-			outPtrC->back().setTrackProperties((*tracks)[i]);
-		        if(PVOrig.trackWeight(edm::Ref<reco::TrackCollection>(tracks,i)) > 0.5) {
-		                outPtrC->back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
-			}
-
-			mapping[i]=j;
-			j++;
-		}
+    std::vector<int> mapping(tracks->size(),-1);  
+    int lostTrkIndx=0;
+    for(unsigned int trkIndx=0; trkIndx < tracks->size(); trkIndx++){
+        reco::TrackRef trk(tracks,trkIndx);
+	if( trkStatus[trkIndx] == TrkStatus::VTX || 
+	   (trkStatus[trkIndx]==TrkStatus::NOTUSED && passTrkCuts(*trk)) ) { 
+	
+	    outPtrTrks->emplace_back(*trk);
+	    addPackedCandidate(*outPtrTrksAsCands,trk,pv,pvRefProd,pvOrig,trkStatus[trkIndx]);
+	
+	    //for creating the reco::Track -> pat::PackedCandidate map
+	    //not done for the lostTrack:eleTracks collection
+	    mapping[trkIndx]=lostTrkIndx;
+	    lostTrkIndx++;
+	}else if( (trkStatus[trkIndx]==TrkStatus::PFELECTRON || trkStatus[trkIndx]==TrkStatus::PFPOSITRON ) 
+		  && passTrkCuts(*trk) ) {
+	  addPackedCandidate(*outPtrEleTrksAsCands,trk,pv,pvRefProd,pvOrig,trkStatus[trkIndx]);
+			      
+	
+      }	      
     } 
-    iEvent.put(outPtrP);
-    edm::OrphanHandle<pat::PackedCandidateCollection> oh =   iEvent.put(outPtrC);
-    std::auto_ptr<edm::Association<pat::PackedCandidateCollection> > tk2pc(new edm::Association<pat::PackedCandidateCollection>(oh   ));
+    
+    iEvent.put(std::move(outPtrTrks));
+    iEvent.put(std::move(outPtrEleTrksAsCands),"eleTracks");
+    edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put(std::move(outPtrTrksAsCands));
+    auto tk2pc = std::make_unique<edm::Association<pat::PackedCandidateCollection>>(oh);
     edm::Association<pat::PackedCandidateCollection>::Filler tk2pcFiller(*tk2pc);
     tk2pcFiller.insert(tracks, mapping.begin(), mapping.end());
     tk2pcFiller.fill() ; 
-    iEvent.put(tk2pc);
+    iEvent.put(std::move(tk2pc));
 
+}  
+
+bool pat::PATLostTracks::passTrkCuts(const reco::Track& tr)const
+{
+  
+    bool passTrkPt = tr.pt() > minPt_;
+    bool passTrkHits = tr.numberOfValidHits() >= minHits_ && 
+                       tr.hitPattern().numberOfValidPixelHits() >= minPixelHits_;
+    bool passTrkQual = passesQuality(tr,qualsToAutoAccept_);
+    return (passTrkPt && passTrkHits) || passTrkQual;
 }
 
+void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& cands,
+					    const reco::TrackRef& trk,
+					    const reco::VertexRef& pvSlimmed,
+					    const reco::VertexRefProd& pvSlimmedColl,
+					    const reco::Vertex& pvOrig,
+					    const pat::PATLostTracks::TrkStatus trkStatus)const
+{
+    const float mass = 0.13957018;
+    
+    int id=211*trk->charge();
+    if(trkStatus==TrkStatus::PFELECTRON) id=11;
+    else if(trkStatus==TrkStatus::PFPOSITRON) id=-11; 
+    
+    reco::Candidate::PolarLorentzVector p4(trk->pt(),trk->eta(),trk->phi(),mass);
+    cands.emplace_back(pat::PackedCandidate(p4,trk->vertex(),
+					    trk->pt(),trk->eta(),trk->phi(),
+					    id,pvSlimmedColl,pvSlimmed.key()));
+
+    if(trk->pt()>minPtToStoreProps_ || trkStatus==TrkStatus::VTX) cands.back().setTrackProperties(*trk);
+    if(pvOrig.trackWeight(trk) > 0.5) {
+         cands.back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
+    }
+}
 
 using pat::PATLostTracks;
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -90,6 +90,13 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
   std::vector<std::string> trkQuals(iConfig.getParameter<std::vector<std::string> >("qualsToAutoAccept"));
   std::transform(trkQuals.begin(),trkQuals.end(),std::back_inserter(qualsToAutoAccept_),reco::TrackBase::qualityByName);
 
+  if(std::find(qualsToAutoAccept_.begin(),qualsToAutoAccept_.end(),reco::TrackBase::undefQuality)!=qualsToAutoAccept_.end()){
+    std::ostringstream msg;
+    msg<<" PATLostTracks has a quality requirement which resolves to undefQuality. This usually means a typo and is therefore treated a config error\nquality requirements:\n   ";
+    for(const auto& trkQual : trkQuals) msg <<trkQual<<" ";
+    throw cms::Exception("Configuration") << msg.str();
+  } 
+
   produces< std::vector<reco::Track> > ();
   produces< std::vector<pat::PackedCandidate> > ();
   produces< std::vector<pat::PackedCandidate> > ("eleTracks");

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -190,7 +190,9 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 
     for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
         const reco::PFCandidate &cand=(*cands)[ic];
+	float trkPt = cand.pt();
         float phiAtVtx = cand.phi();
+        float etaAtVtx = cand.eta();
         const reco::Track *ctrack = 0;
         if ((abs(cand.pdgId()) == 11 || cand.pdgId() == 22) && cand.gsfTrackRef().isNonnull()) {
             ctrack = &*cand.gsfTrackRef();
@@ -215,7 +217,9 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
           //   vtx = tsos.globalPosition();
           //          phiAtVtx = tsos.globalDirection().phi();
           vtx = ctrack->referencePoint();
+	  trkPt = ctrack->pt();
           phiAtVtx = ctrack->phi();
+	  etaAtVtx = ctrack->eta();
           int nlost = ctrack->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
           if (nlost == 0) { 
             if (ctrack->hitPattern().hasValidHitInFirstPixelBarrel()) {
@@ -226,14 +230,16 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
           }
 
 
-          outPtrP->push_back( pat::PackedCandidate(cand.polarP4(), vtx, phiAtVtx, cand.pdgId(), PVRefProd, PV.key()));
+          outPtrP->push_back( pat::PackedCandidate(cand.polarP4(), vtx, trkPt, etaAtVtx, phiAtVtx, cand.pdgId(), PVRefProd, PV.key()));
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(qualityMap[quality]));
           if(cand.trackRef().isNonnull() && PVOrig->trackWeight(cand.trackRef()) > 0.5 && quality == 7) {
                   outPtrP->back().setAssociationQuality(pat::PackedCandidate::UsedInFitTight);
           }
           // properties of the best track 
           outPtrP->back().setLostInnerHits( lostHits );
-          if(outPtrP->back().pt() > minPtForTrackProperties_ || whiteList.find(ic)!=whiteList.end()) {
+          if(outPtrP->back().pt() > minPtForTrackProperties_ ||
+	     outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
+	     whiteList.find(ic)!=whiteList.end()) {
             outPtrP->back().setTrackProperties(*ctrack);
             //outPtrP->back().setTrackProperties(*ctrack,tsos.curvilinearError());
           }
@@ -250,7 +256,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
             PVpos = PV->position();
           }
 
-          outPtrP->push_back( pat::PackedCandidate(cand.polarP4(), PVpos, cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
+          outPtrP->push_back( pat::PackedCandidate(cand.polarP4(), PVpos, cand.pt(), cand.eta(), cand.phi(), cand.pdgId(), PVRefProd, PV.key()));
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
         }
 

--- a/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py
@@ -8,6 +8,8 @@ lostTracks = cms.EDProducer("PATLostTracks",
     primaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     originalVertices = cms.InputTag("offlinePrimaryVertices"),
     minPt = cms.double(0.95),	
-    minHits = cms.uint32(8),	
+    minHits = cms.uint32(8),
     minPixelHits = cms.uint32(1),	
+    qualsToAutoAccept = cms.vstring("highPurity"),
+    minPtToStoreProps = cms.double(0.95)
 )


### PR DESCRIPTION
This is the 80X flavour version as requested by x-pog of https://github.com/cms-sw/cmssw/pull/17909

It stores trk pt and eta as well as storing all high purity tracks including those which come from electrons. For more details see the 90X PR.

The average event size increase was measured using the /RelValTTbar_13/CMSSW_8_0_21-PU25ns_80X_mcRun2_asymptotic_2016_TrancheIV_v6_Tr4GT_v6-v1/GEN-SIM-RECO ttbar relval. 

Size increase 
patPackedCandidates_packedPFCandidates__PAT. 87539.3 15788.5
patPackedCandidates_lostTracks__PAT. 278.553 121.174

to

patPackedCandidates_packedPFCandidates__PAT. 94988 15849.3
patPackedCandidates_lostTracks__PAT. 1114.2 348.642
patPackedCandidates_lostTracks_eleTracks_PAT. 201.602 90.3766

for  a total size of ~400 bytes, of which about half of which is due to <1 GeV high purity tracks been added. 
