### PR TITLE
Add CA hit ntuplets for early deletion

### DIFF
--- a/RecoTracker/Configuration/python/customiseEarlyDeleteForSeeding.py
+++ b/RecoTracker/Configuration/python/customiseEarlyDeleteForSeeding.py
@@ -21,13 +21,15 @@ def customiseEarlyDeleteForSeeding(process, products):
                 products[name].append(_branchName("RegionsSeedingHitSets", name))
             if module.produceIntermediateHitTriplets:
                 products[name].append(_branchName("IntermediateHitTriplets", name))
+            # LayerHitMapCache of the doublets is forwarded to both
+            # products, hence the dependency
             depends[name].append(module.doublets.getModuleLabel())
         elif cppType in ["MultiHitFromChi2EDProducer"]:
             products[name].extend([
                 _branchName("RegionsSeedingHitSets", name),
                 _branchName("BaseTrackerRecHitsOwned", name)
             ])
-        elif cppType == "PixelQuadrupletEDProducer":
+        elif cppType in ["PixelQuadrupletEDProducer", "CAHitQuadrupletEDProducer", "CAHitTripletEDProducer"]:
             products[name].append(_branchName("RegionsSeedingHitSets", name))
         elif cppType == "PixelQuadrupletMergerEDProducer":
             products[name].extend([


### PR DESCRIPTION
The PR #16635 omitted the CA hit ntuplet producers from the early deletion (they were not used in the standard workflows then). This PR adds their products for early deletion (as after #17766 these become more important).

Tested in 9_0_0_pre5, no changes expected in results, there should be some reduction in 2017/2018 memory use.

@rovere @VinInn @felicepantaleo 