### PR TITLE
Handle SiPM nonlinearity in premixing

### DIFF
--- a/CalibFormats/CaloObjects/interface/CaloSamples.h
+++ b/CalibFormats/CaloObjects/interface/CaloSamples.h
@@ -70,11 +70,12 @@ public:
 
   void resetPrecise();
 
+  //preserved for use in other packages - no longer used in this class
   static const int MAXSAMPLES=10;
 private:
   DetId id_;
-  double data_[MAXSAMPLES]; // 
   int size_, presamples_;
+  std::vector<double> data_; // 
   float deltaTprecise_;
   std::vector<float> preciseData_;
   int preciseSize_,precisePresamples_;

--- a/CalibFormats/CaloObjects/interface/IntegerCaloSamples.h
+++ b/CalibFormats/CaloObjects/interface/IntegerCaloSamples.h
@@ -2,7 +2,6 @@
 #define INTEGERCALOSAMPLES_H 1
 
 #include <ostream>
-#include <vector>
 #include "DataFormats/DetId/interface/DetId.h"
 
 /** \class IntegerCaloSamples
@@ -37,8 +36,8 @@ public:
   static const int MAXSAMPLES=10;
 private:
   DetId id_;
+  uint32_t data_[MAXSAMPLES]; // 
   int size_, presamples_;
-  std::vector<uint32_t> data_; // 
 };
 
 std::ostream& operator<<(std::ostream& s, const IntegerCaloSamples& samps);

--- a/CalibFormats/CaloObjects/interface/IntegerCaloSamples.h
+++ b/CalibFormats/CaloObjects/interface/IntegerCaloSamples.h
@@ -2,6 +2,7 @@
 #define INTEGERCALOSAMPLES_H 1
 
 #include <ostream>
+#include <vector>
 #include "DataFormats/DetId/interface/DetId.h"
 
 /** \class IntegerCaloSamples
@@ -36,8 +37,8 @@ public:
   static const int MAXSAMPLES=10;
 private:
   DetId id_;
-  uint32_t data_[MAXSAMPLES]; // 
   int size_, presamples_;
+  std::vector<uint32_t> data_; // 
 };
 
 std::ostream& operator<<(std::ostream& s, const IntegerCaloSamples& samps);

--- a/CalibFormats/CaloObjects/src/CaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/CaloSamples.cc
@@ -3,14 +3,13 @@
 #include <math.h>
 #include <iostream>
 
-const int CaloSamples::MAXSAMPLES;
-
 CaloSamples::CaloSamples() : id_(), size_(0), presamples_(0), preciseSize_(0), precisePresamples_(0) { setBlank() ; }
 
 CaloSamples::CaloSamples(const DetId& id, int size) :
    id_          ( id   ) , 
    size_        ( size ) , 
    presamples_  ( 0    ) ,
+   data_        (size_, 0.0),
    deltaTprecise_ (0.0f) ,
    preciseSize_(0), 
    precisePresamples_(0) { setBlank() ; }
@@ -19,6 +18,7 @@ CaloSamples::CaloSamples(const DetId& id, int size, int presize) :
    id_          ( id   ) , 
    size_        ( size ) , 
    presamples_  ( 0    ) ,
+   data_        (size_, 0.0),
    deltaTprecise_ (0.0f) ,
    preciseSize_(presize), 
    precisePresamples_(0) { setBlank() ; }
@@ -33,14 +33,14 @@ void CaloSamples::setPresamples( int pre ) {
 }
 
 CaloSamples& CaloSamples::scale( double value ) {
-   for (int i=0; i<MAXSAMPLES; i++) data_[i]*=value;
+   for (int i=0; i<size_; i++) data_[i]*=value;
    for (std::vector<float>::iterator j=preciseData_.begin() ; j!=preciseData_.end(); ++j)
      (*j)*=value;
    return (*this);
 }
 
 CaloSamples& CaloSamples::operator+=(double value) {  
-   for (int i=0; i<MAXSAMPLES; i++) data_[i]+=value;
+   for (int i=0; i<size_; i++) data_[i]+=value;
    for (std::vector<float>::iterator j=preciseData_.begin() ; j!=preciseData_.end(); ++j)
      (*j)+=value*deltaTprecise_/25.0; // note that the scale is conserved!
   return (*this);
@@ -68,18 +68,18 @@ CaloSamples& CaloSamples::operator+=(const CaloSamples & other) {
 CaloSamples &
 CaloSamples::offsetTime(double offset)
 {
-  double data[MAXSAMPLES];
-  for( int i ( 0 ) ; i != MAXSAMPLES ; ++i )
+  std::vector<double> data(size_,0.0);
+  for( int i ( 0 ) ; i != size_ ; ++i )
   {
     double t = i*25. - offset;
     int firstbin = floor(t/25.);
     double f = t/25. - firstbin;
     int nextbin = firstbin + 1;
-    double v1 = (firstbin < 0 || firstbin >= MAXSAMPLES) ? 0. : data_[firstbin];
-    double v2 = (nextbin < 0  || nextbin  >= MAXSAMPLES) ? 0. : data_[nextbin];
+    double v1 = (firstbin < 0 || firstbin >= size_) ? 0. : data_[firstbin];
+    double v2 = (nextbin < 0  || nextbin  >= size_) ? 0. : data_[nextbin];
     data[i] = (v1*(1.-f)+v2*f);
   }
-  for( int i ( 0 ) ; i != MAXSAMPLES ; ++i )
+  for( int i ( 0 ) ; i != size_ ; ++i )
   {
     data_[i] = data[i];
   }
@@ -89,7 +89,7 @@ CaloSamples::offsetTime(double offset)
 bool 
 CaloSamples::isBlank() const // are the samples blank (zero?)
 {
-   for( int i ( 0 ) ; i != MAXSAMPLES ; ++i )
+   for( int i ( 0 ) ; i != size_ ; ++i )
    {
       if( 1.e-6 < fabs( data_[i] ) ) return false ;
    }
@@ -99,7 +99,7 @@ CaloSamples::isBlank() const // are the samples blank (zero?)
 void 
 CaloSamples::setBlank() // keep id, presamples, size but zero out data
 {
-   std::fill( data_ , data_ + MAXSAMPLES, (double)0.0 ) ;
+   std::fill( data_.begin() , data_.end(), (double)0.0 ) ;
    std::fill( preciseData_.begin() , preciseData_.end(), (double)0.0 ) ;
 }
 

--- a/CalibFormats/CaloObjects/src/IntegerCaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/IntegerCaloSamples.cc
@@ -1,11 +1,9 @@
 #include "CalibFormats/CaloObjects/interface/IntegerCaloSamples.h"
 
-IntegerCaloSamples::IntegerCaloSamples() : id_(), size_(0), presamples_(0) {
-  for (int i=0; i<MAXSAMPLES; i++) data_[i]=0;
+IntegerCaloSamples::IntegerCaloSamples() : id_(), size_(0), presamples_(0), data_(size_,0) {
 }
 
-IntegerCaloSamples::IntegerCaloSamples(const DetId& id, int size) : id_(id), size_(size), presamples_(0) {
-  for (int i=0; i<MAXSAMPLES; i++) data_[i]=0;
+IntegerCaloSamples::IntegerCaloSamples(const DetId& id, int size) : id_(id), size_(size), presamples_(0), data_(size_,0) {
 }
 
 void IntegerCaloSamples::setPresamples(int pre) {

--- a/CalibFormats/CaloObjects/src/IntegerCaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/IntegerCaloSamples.cc
@@ -1,9 +1,11 @@
 #include "CalibFormats/CaloObjects/interface/IntegerCaloSamples.h"
 
-IntegerCaloSamples::IntegerCaloSamples() : id_(), size_(0), presamples_(0), data_(size_,0) {
+IntegerCaloSamples::IntegerCaloSamples() : id_(), size_(0), presamples_(0) {
+  for (int i=0; i<MAXSAMPLES; i++) data_[i]=0;
 }
 
-IntegerCaloSamples::IntegerCaloSamples(const DetId& id, int size) : id_(id), size_(size), presamples_(0), data_(size_,0) {
+IntegerCaloSamples::IntegerCaloSamples(const DetId& id, int size) : id_(id), size_(size), presamples_(0) {
+  for (int i=0; i<MAXSAMPLES; i++) data_[i]=0;
 }
 
 void IntegerCaloSamples::setPresamples(int pre) {

--- a/CalibFormats/CaloObjects/src/classes_def.xml
+++ b/CalibFormats/CaloObjects/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="CaloSamples" ClassVersion="3">
+  <class name="CaloSamples" ClassVersion="4">
+   <version ClassVersion="4" checksum="2007418822"/>
    <version ClassVersion="3" checksum="4242646275"/>
   </class>
   <class name="std::vector<CaloSamples>"/>

--- a/Configuration/StandardSequences/python/Digi_PreMix_cff.py
+++ b/Configuration/StandardSequences/python/Digi_PreMix_cff.py
@@ -20,6 +20,9 @@ simMuonRPCDigis.doBkgNoise = False
 simEcalDigis.UseFullReadout = cms.bool(True)
 # This is extra, since the configuration skips it anyway.  Belts and suspenders.
 pdigi.remove(simEcalPreshowerDigis)
+# remove HCAL TP sim - not needed, sometimes breaks
+hcalDigiSequence.remove(simHcalTriggerPrimitiveDigis)
+hcalDigiSequence.remove(simHcalTTPDigis)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen():

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -114,8 +114,8 @@ class HcalUHTRData {
   inline uint32_t crateId() const { return uint32_t(m_raw64[1])&0xFF; }
   /** \brief Get the board slot */
   inline uint32_t slot() const { return uint32_t(m_raw64[1]>>8)&0xF; }
-  /** \brief Get the presamples, clearing last bit */
-  inline uint32_t presamples() const { return uint32_t((m_raw64[1]&~0x8000)>>12)&0xF; }
+  /** \brief Get the presamples */
+  inline uint32_t presamples() const { return uint32_t(m_raw64[1]>>12)&0xF; }
 
   /** \brief Was this channel passed as part of Mark&Pass ZS?*/
   bool wasMarkAndPassZS(int fiber, int fiberchan) const;
@@ -127,8 +127,6 @@ class HcalUHTRData {
   /** \brief Get the HTR firmware flavor */
   int getFirmwareFlavor() const { return uint32_t(m_raw64[1]>>32)&0xFF; }
 
-  //** \brief Check for simulated HTR with flag word kept */
-  bool wasSimulatedHTR() const { return (((m_raw64[1]&0x8000)>>15)&0x1)==1; }
 
 protected:
   int m_formatVersion;

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -151,8 +151,7 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       int presamples = qiedf.presamples();
 
       if( ! uhtrs.exist(uhtrIndex) ){
-        //special setting to keep flag word for QIE11 premixing
-        uhtrs.newUHTR( uhtrIndex , presamples , true );
+	uhtrs.newUHTR( uhtrIndex , presamples );
       }
       uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
     }

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -324,7 +324,6 @@ public:
   static const int MASK_PAYLOAD_FORMAT = 0xF;
   static const int OFFSET_FW_VERSION = 48;
   static const int MASK_FW_VERSION = 0xFFFF;
-  static const int MASK_PRESAMPLES_MSB = 0x8000;
 
   UHTRpacker(){}
 
@@ -396,7 +395,7 @@ public:
      return header;
   }
 
-  uhtrData* newUHTR( int uhtrIndex , int ps, bool specialSimPremixBit = false, int orn = 0 , int bcn = 0 , uint64_t evt = 0 ){
+  uhtrData* newUHTR( int uhtrIndex , int ps = 0, int orn = 0 , int bcn = 0 , uint64_t evt = 0 ){
     
     // initialize vector of 16-bit words
     uhtrs[uhtrIndex] = uhtrData(8);
@@ -427,12 +426,6 @@ public:
     uhtrHeader2 |= (eventType&MASK_EVENT_TYPE)<<OFFSET_EVENT_TYPE;
     uhtrHeader2 |= (payloadFormat&MASK_PAYLOAD_FORMAT)<<OFFSET_PAYLOAD_FORMAT;
     uhtrHeader2 |= (fwVersion&MASK_FW_VERSION)<<OFFSET_FW_VERSION;
-
-    //special setting to keep flag word for premixing in simulation:
-    //set MSB of presamples
-    if(specialSimPremixBit){
-        uhtrHeader2 |= MASK_PRESAMPLES_MSB;
-    }
 
     // push header into vector of 16-bit words
     for (unsigned int i = 0; i< 4; ++i){
@@ -516,7 +509,7 @@ public:
     HcalElectronicsId eid(readoutMap->lookup(detid));
     // loop over words in dataframe
     for(edm::DataFrame::iterator dfi=qiedf.begin() ; dfi!=qiedf.end(); ++dfi){      
-      if( dfi >= qiedf.end() ){ //include flag word
+      if( dfi >= qiedf.end()-QIE11DataFrame::FLAG_WORDS ){
          continue;
       }
       if( dfi == qiedf.begin() && QIE11DataFrame::HEADER_WORDS == 1 ){

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -623,8 +623,6 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           for (++i; i != iend && !i.isHeader(); ++i) {
               ns++;
           }
-          //account for packed flag word from simulation
-          if(uhtr.wasSimulatedHTR()) ns--;
           // Check QEI11 container exists
           if (colls.qie11 == 0) {
               colls.qie11 = new QIE11DigiCollection(ns);

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -199,6 +199,8 @@ L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     expectedTotalET += et;
   }
 
+
+ if(hcalTPs.isValid()){
   for ( const auto& hcalTp : *hcalTPs ) {
     if ( unpackHcalMask && ((hcalTp.sample(0).raw()>>13) & 0x1) ) continue;
     int caloEta = hcalTp.id().ieta();
@@ -237,6 +239,7 @@ L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       LOG_ERROR << "Illegal Tower: caloEta = " << caloEta << std::endl;
     }
   }
+ }
   
    //Process
   if(!layer1->process()) {

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -64,7 +64,7 @@ public:
   virtual void add(const PCaloHit & hit, CLHEP::HepRandomEngine*);
 
   /// add a signal, in units of pe
-  void add(const CaloSamples & signal);
+  virtual void add(const CaloSamples & signal);
 
   /// if you want to reject hits, for example, from a certain subdetector, set this
   void setHitFilter(const CaloVHitFilter * filter) {

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h
@@ -95,12 +95,12 @@ public:
   /// Collects the digis
 
   void run(DigiCollection & output, CLHEP::HepRandomEngine* engine) {
-    theHitResponse->finalizeHits(engine);
-    //std::cout << " In CaloTDigitizer, after finalize hits " << std::endl;
-
     assert(theDetIds->size() != 0);
 
     if(theNoiseSignalGenerator != 0) addNoiseSignals(engine);
+
+    theHitResponse->finalizeHits(engine);
+    //std::cout << " In CaloTDigitizer, after finalize hits " << std::endl;
 
     theElectronicsSim->newEvent(engine);
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVPECorrection.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVPECorrection.h
@@ -14,6 +14,7 @@ namespace CLHEP {
 class CaloVPECorrection
 {
 public:
+  virtual ~CaloVPECorrection() {}
   virtual double correctPE(const DetId & detId, double npe, CLHEP::HepRandomEngine*) const = 0;
 };
 

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -102,14 +102,7 @@ void CaloHitResponse::add(const CaloSamples & signal)
     theAnalogSignalMap[id] = signal;
 
   } else  {
-    // need a "+=" to CaloSamples
-    int sampleSize =  oldSignal->size();
-    assert(sampleSize <= signal.size());
-    assert(signal.presamples() == oldSignal->presamples());
-
-    for(int i = 0; i < sampleSize; ++i) {
-      (*oldSignal)[i] += signal[i];
-    }
+    (*oldSignal) += signal;
   }
 }
 

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -12,7 +12,10 @@ SimCalorimetryFEVTDEBUG = cms.PSet(
         'drop ZDCDataFramesSorted_mix_simHcalUnsuppressedDigis*_*',
         'keep *_simHcalTriggerPrimitiveDigis_*_*',
         'keep *_mix_HcalSamples_*',
-        'keep *_mix_HcalHits_*')
+        'keep *_mixData_HcalSamples_*',
+        'keep *_mix_HcalHits_*',
+        'keep *_mixData_HcalHits_*',
+    )
 )
 SimCalorimetryRAW = cms.PSet(
     outputCommands = cms.untracked.vstring('keep EBSrFlagsSorted_simEcalDigis_*_*', 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
@@ -4,6 +4,7 @@
 
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalSiPM.h"
+#include "SimCalorimetry/HcalSimAlgos/interface/HcalSiPMShape.h"
 
 #include <map>
 #include <set>
@@ -61,6 +62,8 @@ private:
   photonTimeMap precisionTimedPhotons;
 
   const std::vector<DetId>* theDetIds;
+
+  std::map<int,HcalSiPMShape> shapeMap;
 };
 
 #endif //HcalSimAlgos_HcalSiPMHitResponse_h

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
@@ -25,7 +25,7 @@ class HcalSiPMHitResponse : public CaloHitResponse {
 
 public:
   HcalSiPMHitResponse(const CaloVSimParameterMap * parameterMap, 
-		      const CaloShapes * shapes, bool PreMix1 = false);
+		      const CaloShapes * shapes, bool PreMix1 = false, bool HighFidelity = true);
 
   virtual ~HcalSiPMHitResponse();
 
@@ -54,6 +54,7 @@ protected:
 private:
   HcalSiPM theSiPM;
   bool PreMixDigis;
+  bool HighFidelityPreMix;
   int nbins;
   double dt, invdt;
 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
@@ -39,7 +39,7 @@ public:
 
   virtual void add(const PCaloHit& hit, CLHEP::HepRandomEngine*) override;
 
-  virtual void add(const CaloSamples& signal);
+  virtual void add(const CaloSamples& signal) override;
 
   virtual void addPEnoise(CLHEP::HepRandomEngine* engine);
 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSiPMHitResponse.h
@@ -46,6 +46,8 @@ public:
 
   virtual void setDetIds(const std::vector<DetId> & detIds);
 
+  virtual int getReadoutFrameSize(const DetId& id) const;
+
 protected:
   virtual CaloSamples makeSiPMSignal(DetId const& id, photonTimeHist const& photons, CLHEP::HepRandomEngine*);
 

--- a/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
+++ b/SimCalorimetry/HcalSimAlgos/python/AddCaloSamplesAnalyzer.py
@@ -1,13 +1,32 @@
 import FWCore.ParameterSet.Config as cms
 
 def customise(process):
+    # handle normal mixing or premixing
+    hcaldigi = None
     if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):
-        process.mix.digitizers.hcal.debugCaloSamples = cms.bool(True)
+        hcaldigi = process.mix.digitizers.hcal
+        cstag = "mix"
+    if hasattr(process,'mixData'):
+        hcaldigi = process.mixData
+        cstag = "mixData"
+    if hcaldigi is None:
+        raise Exception("CaloSamplesAnalyzer requires a mix module, none found!")
 
-    from SimCalorimetry.HcalSimProducers.hcalUnsuppressedDigis_cfi import hcalSimBlock
+    hcaldigi.debugCaloSamples = cms.bool(True)
     process.CaloSamplesAnalyzer = cms.EDAnalyzer("CaloSamplesAnalyzer",
-        hcalSimBlock,
-        CaloSamplesTag = cms.InputTag("mix","HcalSamples"),
+        # from hcalSimParameters
+        hf1 = hcaldigi.hf1,
+        hf2 = hcaldigi.hf2,
+        ho = hcaldigi.ho,
+        hb = hcaldigi.hb,
+        he = hcaldigi.he,
+        zdc = hcaldigi.zdc,
+        hoZecotek = hcaldigi.hoZecotek,
+        hoHamamatsu = hcaldigi.hoHamamatsu,
+        # from hcalUnsuppressedDigis
+        hitsProducer = hcaldigi.hitsProducer,
+        TestNumbering = hcaldigi.TestNumbering,
+        CaloSamplesTag = cms.InputTag(cstag,"HcalSamples"),
     )
 
     process.TFileService = cms.Service("TFileService",

--- a/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalAmplifier.cc
@@ -47,7 +47,7 @@ void HcalAmplifier::amplify(CaloSamples & frame, CLHEP::HepRandomEngine* engine)
   }
   pe2fC(frame);
   // don't bother for blank signals
-  if(theTimeSlewSim && frame[4] > 1.e-6)
+  if(theTimeSlewSim && frame.size()>4 && frame[4] > 1.e-6)
   {
     theTimeSlewSim->delay(frame, engine);
   }

--- a/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalElectronicsSim.cc
@@ -79,18 +79,17 @@ void HcalElectronicsSim::premix<QIE10DataFrame>(CaloSamples & frame, QIE10DataFr
 
 template<>
 void HcalElectronicsSim::premix<QIE11DataFrame>(CaloSamples & frame, QIE11DataFrame & result, double preMixFactor, unsigned preMixBits){
-  uint16_t flag = 0;
   for(int isample = 0; isample !=frame.size(); ++isample) {
     uint16_t theADC = round(preMixFactor*frame[isample]);
+    int tdcErrorBit = 0;
 
     if(theADC > preMixBits) {
       theADC = result[isample].adc();
-	  flag |= 1<<isample; // set error bit as a flag
+      tdcErrorBit = 1; //use TDC bits for error bit
     }
 
-    result.setSample(isample, theADC, result[isample].tdc(), result[isample].soi());
+    result.setSample(isample, theADC, tdcErrorBit, result[isample].soi());
   }
-  result.setFlags(flag);
 }
 
 template<class Digi>

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPM.cc
@@ -21,6 +21,7 @@ HcalSiPM::HcalSiPM(int nCells, double tau) :
 }
 
 HcalSiPM::~HcalSiPM() {
+  if (nonlin) delete nonlin;
 }
 
 //================================================================================

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -9,7 +9,6 @@
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloVHitCorrection.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloVShape.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "SimCalorimetry/HcalSimAlgos/interface/HcalSiPMShape.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
 
 #include "CLHEP/Random/RandPoissonQ.h"
@@ -21,7 +20,13 @@ HcalSiPMHitResponse::HcalSiPMHitResponse(const CaloVSimParameterMap * parameterM
 					 const CaloShapes * shapes, bool PreMix1, bool HighFidelity) :
   CaloHitResponse(parameterMap, shapes), theSiPM(), PreMixDigis(PreMix1), HighFidelityPreMix(HighFidelity),
   nbins((PreMixDigis and HighFidelityPreMix) ? 1 : BUNCHSPACE*HcalPulseShapes::invDeltaTSiPM_), 
-  dt(HcalPulseShapes::deltaTSiPM_), invdt(HcalPulseShapes::invDeltaTSiPM_) {}
+  dt(HcalPulseShapes::deltaTSiPM_), invdt(HcalPulseShapes::invDeltaTSiPM_)
+{
+  //fill shape map
+  shapeMap.emplace(HcalShapes::ZECOTEK,HcalShapes::ZECOTEK);
+  shapeMap.emplace(HcalShapes::HAMAMATSU,HcalShapes::HAMAMATSU);
+  shapeMap.emplace(HcalShapes::HE2017,HcalShapes::HE2017);
+}
 
 HcalSiPMHitResponse::~HcalSiPMHitResponse() {}
 
@@ -213,7 +218,7 @@ CaloSamples HcalSiPMHitResponse::makeSiPMSignal(DetId const& id,
   unsigned int sumPE(0);
   double sumHits(0.);
 
-  HcalSiPMShape sipmPulseShape(pars.signalShape(id));
+  auto& sipmPulseShape(shapeMap[pars.signalShape(id)]);
 
   std::list< std::pair<double, double> > pulses;
   std::list< std::pair<double, double> >::iterator pulse;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMShape.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMShape.cc
@@ -10,7 +10,7 @@ HcalSiPMShape::HcalSiPMShape(unsigned int signalShape) : CaloVShape(), nBins_(Hc
 HcalSiPMShape::HcalSiPMShape(const HcalSiPMShape & other) : CaloVShape(other), nBins_(other.nBins_), nt_(other.nt_) {}
 
 double HcalSiPMShape::operator () (double time) const {
-  int jtime = static_cast<int>(time*HcalPulseShapes::invDeltaTSiPM_ + 0.5);
+  int jtime(time*HcalPulseShapes::invDeltaTSiPM_ + 0.5);
   if (jtime>=0 && jtime<nBins_) 
     return nt_[jtime];
   return 0.;

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSignalGenerator.cc
@@ -88,9 +88,11 @@ CaloSamples HcalSignalGenerator<HcalQIE11DigitizerTraits>::samplesInPE(const Hca
   bool overflow = false;
   // find and list them
 
-  uint16_t flag = digi.flags();
   for(int isample=0; isample<digi.samples(); ++isample) {
-    if((flag>>isample)&1) overflow = true; 
+    if(digi[isample].tdc()==1){
+      overflow = true; 
+      break;
+    }
   }
 
   if(overflow) {  // do full conversion, go back and overwrite fake entries
@@ -101,7 +103,7 @@ CaloSamples HcalSignalGenerator<HcalQIE11DigitizerTraits>::samplesInPE(const Hca
 
     // overwrite with coded information
     for(int isample=0; isample<digi.samples(); ++isample) {
-      if(!((flag>>isample)&1)) result[isample] = float(digi[isample].adc())/HcalQIE11DigitizerTraits::PreMixFactor;
+      if(digi[isample].tdc()==0) result[isample] = float(digi[isample].adc())/HcalQIE11DigitizerTraits::PreMixFactor;
     }
   }
   else {  // saves creating the coder, etc., every time

--- a/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
+++ b/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc
@@ -100,6 +100,7 @@ class CaloSamplesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResource
 //
 CaloSamplesAnalyzer::CaloSamplesAnalyzer(const edm::ParameterSet& iConfig) :
 	tree(NULL), theGeometry(NULL), theRecNumber(NULL), theResponse(new CaloHitResponse(NULL,(CaloShapes*)NULL)), theParameterMap(new HcalSimParameterMap(iConfig)),
+	TestNumbering(iConfig.getParameter<bool>("TestNumbering")),
 	tok_sim(consumes<std::vector<PCaloHit>>(edm::InputTag(iConfig.getParameter<std::string>("hitsProducer"), "HcalHits"))),
 	tok_calo(consumes<std::vector<CaloSamples>>(iConfig.getParameter<edm::InputTag>("CaloSamplesTag")))
 {

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -41,9 +41,9 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
   theParameterMap(new HcalSimParameterMap(ps)),
   theShapes(new HcalShapes()),
   theHBHEResponse(new CaloHitResponse(theParameterMap, theShapes)),
-  theHBHESiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes, ps.getParameter<bool>("HcalPreMixStage1"))),
+  theHBHESiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes, ps.getParameter<bool>("HcalPreMixStage1"), true)),
   theHOResponse(new CaloHitResponse(theParameterMap, theShapes)),   
-  theHOSiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes)),
+  theHOSiPMResponse(new HcalSiPMHitResponse(theParameterMap, theShapes, ps.getParameter<bool>("HcalPreMixStage1"), false)),
   theHFResponse(new CaloHitResponse(theParameterMap, theShapes)),
   theHFQIE10Response(new CaloHitResponse(theParameterMap, theShapes)),
   theZDCResponse(new CaloHitResponse(theParameterMap, theShapes)),
@@ -141,7 +141,6 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector
     theHODigitizer = new HODigitizer(theHOResponse, theHOElectronicsSim, doEmpty);
   }
   if(doHOSiPM) {
-    theHOSiPMResponse = new HcalSiPMHitResponse(theParameterMap, theShapes);
     theHOSiPMResponse->setHitFilter(&theHOSiPMHitFilter);
     theHOSiPMDigitizer = new HODigitizer(theHOSiPMResponse, theHOElectronicsSim, doEmpty);
   }

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -243,6 +243,8 @@ HcalDigitizer::~HcalDigitizer() {
   delete theHBHEQIE11Amplifier;
   delete theCoderFactory;
   if (theRelabeller)           delete theRelabeller;
+  if(theTimeSlewSim) delete theTimeSlewSim;
+  if(theIonFeedback) delete theIonFeedback;
 }
 
 

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -449,7 +449,8 @@ void HcalDigitizer::finalizeEvent(edm::Event& e, const edm::EventSetup& eventSet
   std::unique_ptr<QIE11DigiCollection> hbheQIE11Result(
     new QIE11DigiCollection(
       theHBHEQIE11DetIds.size()>0 ? 
-      theParameterMap->simParameters(theHBHEQIE11DetIds[0]).readoutFrameSize() : 
+      ((HcalSiPMHitResponse *)theHBHESiPMResponse)->getReadoutFrameSize(theHBHEQIE11DetIds[0]) :
+//      theParameterMap->simParameters(theHBHEQIE11DetIds[0]).readoutFrameSize() : 
       QIE11DigiCollection::MAXSAMPLES
     )
   );

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -136,6 +136,13 @@ namespace edm
       produces<QIE10DigiCollection>("HFQIE10DigiCollection");
       produces<QIE11DigiCollection>("HBHEQIE11DigiCollection");
 
+      if(ps.getParameter<bool>("debugCaloSamples")){
+        produces<CaloSamplesCollection>("HcalSamples");
+      }
+      if(ps.getParameter<bool>("injectTestHits")){
+        produces<edm::PCaloHitContainer>("HcalHits");
+      }
+
       if(MergeHcalDigisProd_) HcalDigiWorkerProd_ = new DataMixingHcalDigiWorkerProd(ps, consumesCollector());
       else HcalDigiWorker_ = new DataMixingHcalDigiWorker(ps, consumesCollector());
 


### PR DESCRIPTION
The SiPM simulation is inherently nonlinear due to pixel saturation/recovery. This requires knowing when all photoelectrons arrive at the SiPM, with fine time binning (0.5ns). For regular mixing, this is handled appropriately, because all SimHits are treated the same way. However, premixing by default adds CaloSamples, which have already gone through the full electronics simulation. Because of the nonlinearity in SiPMs, those CaloSamples should not just be added linearly.

The solution is:
1. In premix stage 1, skip pixel saturation/recovery and SiPM pulse shape smearing: just put "raw" photoelectrons (after photostatistics and Y11 time offset) into CaloSamples, and store CaloSamples -> QIE11 data frames with 500 samples (0.5ns binning)
2. Redefine `HcalSiPMHitResponse::add(const CaloSamples& signal)` to add photoelectrons to intermediate array (must be called before `finalizeHits()`)

[These slides](https://indico.cern.ch/event/622214/contributions/2509760/attachments/1427537/2190910/sipm_premixing_nonlinearity.pdf) have more details, as well as a contrived simulation with high energy deposits for both signal and PU to demonstrate the problem and solution.

Storing 500 samples per dataframe instead of 10 leads to a 10% increase in the size of the premixed input file for the 2018 scenario (full HE upgrade) using `AVE_35_BX_25ns`. The increase for 2017 with HE Plan1 is less than 1%.

This PR also:
* improves the debugging tools introduced in #16907 to work with premixing
* removes hardcoded `MAXSAMPLES = 10` from CaloSamples classes (This was previously implemented very inconsistently/unsafely - any size could be set, but the underlying data array was fixed at size 10. Now these classes just use vectors.)
* uses QIE11 TDC bits to store the error bit for premixing, instead of the flag word (much simpler and more extensible, probably should have been done in the first place), therefore now-unneeded changes from #16057 are reverted

This PR will be backported to 90X.

attn: @mdhildreth, @igv4321, @abdoulline, @jmmans 