### PR TITLE
Unit Test Fix for PhysicsTools/UtilityAlgos

### DIFF
--- a/PhysicsTools/UtilAlgos/test/fwliteWithPythonConfig_cfg.py
+++ b/PhysicsTools/UtilAlgos/test/fwliteWithPythonConfig_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.PSet()
 
 process.fwliteInput = cms.PSet(
-    fileNames   = cms.vstring('root://eoscms//eos/cms/store/relval/CMSSW_7_2_0_pre5/RelValProdTTbar/GEN-SIM-RECO/START72_V1-v1/00000/022350A9-AC30-E411-B225-0025905A6076.root'), ## mandatory
+    fileNames   = cms.vstring('root://eoscms.cern.ch//eos/cms/store/relval/CMSSW_7_2_0_pre5/RelValProdTTbar/GEN-SIM-RECO/START72_V1-v1/00000/022350A9-AC30-E411-B225-0025905A6076.root'), ## mandatory
     maxEvents   = cms.int32(100),                            ## optional
     outputEvery = cms.uint32(10),                            ## optional
 )


### PR DESCRIPTION
This fixes the address of the input file to work at sites in which you need eoscms.cern.ch rather than eoscms. Specifically this is RAL but might be others too. 