### PR TITLE
Muon HLT for IterL3: porting to new seeding 

### DIFF
--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
@@ -60,11 +60,8 @@ class MuonTrackingRegionBuilder : public TrackingRegionProducer {
     virtual void setEvent(const edm::Event&);
 
     /// Add Fill Descriptions
-    static void fillDescriptions(edm::ParameterSetDescription& descriptions);
-
-    // Separating the offline part of the fillDescriptions() above
-    // TODO: make similar fillDescriptionsHLT, and switch the
-    // fillDescriptions() above take edm::ConfigurationDescriptions&
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    static void fillDescriptionsHLT(edm::ParameterSetDescription& descriptions);
     static void fillDescriptionsOffline(edm::ParameterSetDescription& descriptions);
 
   private:

--- a/RecoMuon/GlobalTrackingTools/plugins/Module.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/Module.cc
@@ -12,3 +12,8 @@ DEFINE_FWK_MODULE(GlobalTrackQualityProducer);
 #include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, MuonTrackingRegionBuilder, "MuonTrackingRegionBuilder");
 
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
+using MuonTrackingRegionEDProducer = TrackingRegionEDProducerT<MuonTrackingRegionBuilder>;
+DEFINE_FWK_MODULE(MuonTrackingRegionEDProducer);
+
+

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
@@ -252,7 +252,7 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
 
 }
 
-void MuonTrackingRegionBuilder::fillDescriptions(edm::ParameterSetDescription& descriptions) {
+void MuonTrackingRegionBuilder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   {
     edm::ParameterSetDescription desc;
     fillDescriptionsOffline(desc);
@@ -260,35 +260,38 @@ void MuonTrackingRegionBuilder::fillDescriptions(edm::ParameterSetDescription& d
   }
   {
     edm::ParameterSetDescription desc;
-    desc.add<double>("EtaR_UpperLimit_Par1",0.25);
-    desc.add<double>("DeltaR",0.2);
-    desc.add<edm::InputTag>("beamSpot",edm::InputTag("hltOnlineBeamSpot"));
-    desc.add<int>("OnDemand",-1);
-    desc.add<edm::InputTag>("vertexCollection",edm::InputTag("pixelVertices"));
-    desc.add<double>("Rescale_phi",3.0);
-    desc.add<bool>("Eta_fixed",false);
-    desc.add<double>("Rescale_eta",3.0);
-    desc.add<double>("PhiR_UpperLimit_Par2",0.2);
-    desc.add<double>("Eta_min",0.05);
-    desc.add<bool>("Phi_fixed",false);
-    desc.add<double>("Phi_min",0.05);
-    desc.add<double>("PhiR_UpperLimit_Par1",0.6);
-    desc.add<double>("EtaR_UpperLimit_Par2",0.15);
-    desc.add<edm::InputTag>("MeasurementTrackerName",edm::InputTag("hltESPMeasurementTracker"));
-    desc.add<bool>("UseVertex",false);
-    desc.add<double>("Rescale_Dz",3.0);
-    desc.add<bool>("Pt_fixed",false);
-    desc.add<bool>("Z_fixed",true);
-    desc.add<double>("Pt_min",1.5);
-    desc.add<double>("DeltaZ",15.9);
-    desc.add<double>("DeltaEta",0.2);
-    desc.add<double>("DeltaPhi",0.2);
-    desc.add<int>("maxRegions",1);
-    desc.add<bool>("precise",true);
-    desc.add<edm::InputTag>("input",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
-    descriptions.add("hltMuonTrackingRegionBuilder",desc);
+    fillDescriptionsHLT(desc);
+    descriptions.add("MuonTrackingRegionBuilderHLT",desc);
   }
   descriptions.setComment("Build a TrackingRegion around a standalone muon. Options to define region around beamspot or primary vertex and dynamic regions are included.");
+}
+void MuonTrackingRegionBuilder::fillDescriptionsHLT(edm::ParameterSetDescription& desc) {
+  desc.add<double>("EtaR_UpperLimit_Par1",0.25);
+  desc.add<double>("DeltaR",0.2);
+  desc.add<edm::InputTag>("beamSpot",edm::InputTag("hltOnlineBeamSpot"));
+  desc.add<int>("OnDemand",-1);
+  desc.add<edm::InputTag>("vertexCollection",edm::InputTag("pixelVertices"));
+  desc.add<double>("Rescale_phi",3.0);
+  desc.add<bool>("Eta_fixed",false);
+  desc.add<double>("Rescale_eta",3.0);
+  desc.add<double>("PhiR_UpperLimit_Par2",0.2);
+  desc.add<double>("Eta_min",0.05);
+  desc.add<bool>("Phi_fixed",false);
+  desc.add<double>("Phi_min",0.05);
+  desc.add<double>("PhiR_UpperLimit_Par1",0.6);
+  desc.add<double>("EtaR_UpperLimit_Par2",0.15);
+  desc.add<edm::InputTag>("MeasurementTrackerName",edm::InputTag("hltESPMeasurementTracker"));
+  desc.add<bool>("UseVertex",false);
+  desc.add<double>("Rescale_Dz",3.0);
+  desc.add<bool>("Pt_fixed",false);
+  desc.add<bool>("Z_fixed",true);
+  desc.add<double>("Pt_min",1.5);
+  desc.add<double>("DeltaZ",15.9);
+  desc.add<double>("DeltaEta",0.2);
+  desc.add<double>("DeltaPhi",0.2);
+  desc.add<int>("maxRegions",1);
+  desc.add<bool>("precise",true);
+  desc.add<edm::InputTag>("input",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
 }
 
 void MuonTrackingRegionBuilder::fillDescriptionsOffline(edm::ParameterSetDescription& desc) {
@@ -318,4 +321,5 @@ void MuonTrackingRegionBuilder::fillDescriptionsOffline(edm::ParameterSetDescrip
   desc.add<int>("maxRegions",1);
   desc.add<bool>("precise",true);
   desc.add<edm::InputTag>("input",edm::InputTag(""));
+
 }

--- a/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
@@ -73,7 +73,7 @@ L3MuonTrajectoryBuilder::~L3MuonTrajectoryBuilder() {
 
 void L3MuonTrajectoryBuilder::fillDescriptions(edm::ParameterSetDescription& desc) {
    edm::ParameterSetDescription descTRB;
-   MuonTrackingRegionBuilder::fillDescriptions(descTRB);
+   MuonTrackingRegionBuilder::fillDescriptionsHLT(descTRB);
    desc.add("MuonTrackingRegionBuilder",descTRB);
 }
 


### PR DESCRIPTION
Modified MuonTrackingRegionBuilder to be compatible with the new seeding algorithm for the iterative tracking.  

Was #17924 in 91X
