### PR TITLE
Report # events per Lumi for output files in framework job report

### DIFF
--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -108,7 +108,7 @@ namespace edm {
 
       struct RunReport {
         RunNumber runNumber;
-        std::set<unsigned int> lumiSections;
+        std::map<unsigned int,unsigned long> lumiSectionsToNEvents;
       };
 
       /**\struct InputFile
@@ -197,7 +197,7 @@ namespace edm {
          * Associate a Lumi Section to all open output files
          *
          */
-        void associateLumiSection(JobReport::Token token, unsigned int runNumber, unsigned int lumiSection);
+        void associateLumiSection(JobReport::Token token, unsigned int runNumber, unsigned int lumiSection, unsigned long nEvents);
 
         /*
          * Associate a Lumi Section to all open input files
@@ -341,7 +341,7 @@ namespace edm {
       /// for output files, call only if lumi section is written to
       /// the output file
       ///
-      void reportLumiSection(JobReport::Token token, unsigned int run, unsigned int lumiSectId);
+      void reportLumiSection(JobReport::Token token, unsigned int run, unsigned int lumiSectId, unsigned long nEvents=0);
 
       ///
       /// API for reporting a Lumi Section to the job report.

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -98,8 +98,13 @@ namespace edm {
        << rep.runNumber
        << "\">\n";
 
-    for(auto il : rep.lumiSections) {
-      os << "   <LumiSection ID=\"" << il << "\"/>\n";
+    for(auto const& il : rep.lumiSectionsToNEvents) {
+      if(std::numeric_limits<unsigned long>::max() == il.second) {
+        os << "   <LumiSection ID=\"" << il.first << "\"/>\n";
+        
+      } else {
+        os << "   <LumiSection ID=\"" << il.first << "\" NEvents=\""<<il.second<< "\"/>\n";
+      }
     }
     os << "</Run>\n";
     return os;
@@ -291,13 +296,13 @@ namespace edm {
     }
   }
 
-  void JobReport::JobReportImpl::associateLumiSection(JobReport::Token token, unsigned int runNumber, unsigned int lumiSect) {
+  void JobReport::JobReportImpl::associateLumiSection(JobReport::Token token, unsigned int runNumber, unsigned int lumiSect, unsigned long nEvents) {
     std::map<RunNumber, RunReport>& theMap = outputFiles_.at(token).runReports;
     std::map<RunNumber, RunReport>::iterator iter(theMap.lower_bound(runNumber));
     if(iter == theMap.end() || runNumber < iter->first) {    // not found
-      theMap.emplace_hint(iter, runNumber, JobReport::RunReport{ runNumber, {lumiSect}});  // insert it
+      theMap.emplace_hint(iter, runNumber, JobReport::RunReport{ runNumber, {{{lumiSect,nEvents}}}});  // insert it
     } else {
-      iter->second.lumiSections.insert(lumiSect);
+      iter->second.lumiSectionsToNEvents[lumiSect]+=nEvents;
     }
   }
 
@@ -307,9 +312,9 @@ namespace edm {
         std::map<RunNumber, RunReport>& theMap = inputFile.runReports;
         std::map<RunNumber, RunReport>::iterator iter(theMap.lower_bound(runNumber));
         if(iter == theMap.end() || runNumber < iter->first) {    // not found
-          theMap.emplace_hint(iter, runNumber, JobReport::RunReport{ runNumber, {lumiSect}});  // insert it
+          theMap.emplace_hint(iter, runNumber, JobReport::RunReport{ runNumber, {{lumiSect,std::numeric_limits<unsigned long>::max()}}});  // insert it
         } else {
-          iter->second.lumiSections.insert(lumiSect);
+          iter->second.lumiSectionsToNEvents[lumiSect]=std::numeric_limits<unsigned long>::max();
         }
       }
     }
@@ -535,8 +540,8 @@ namespace edm {
   }
 
   void
-  JobReport::reportLumiSection(JobReport::Token token, unsigned int run, unsigned int lumiSectId) {
-    impl_->associateLumiSection(token, run, lumiSectId);
+  JobReport::reportLumiSection(JobReport::Token token, unsigned int run, unsigned int lumiSectId, unsigned long nEvents) {
+    impl_->associateLumiSection(token, run, lumiSectId,nEvents);
   }
 
   void

--- a/IOPool/Common/test/proper_RLfjr_output
+++ b/IOPool/Common/test/proper_RLfjr_output
@@ -58,11 +58,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="0"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="0"/>
 </Run>
 
 </Runs>

--- a/IOPool/Common/test/proper_fjr_output
+++ b/IOPool/Common/test/proper_fjr_output
@@ -58,11 +58,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="10"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="15"/>
 </Run>
 
 </Runs>

--- a/IOPool/Common/test/proper_fjrx_output
+++ b/IOPool/Common/test/proper_fjrx_output
@@ -64,11 +64,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="10"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="15"/>
 </Run>
 
 </Runs>

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -88,6 +88,7 @@ namespace edm {
       lumiEntryNumber_(0LL),
       runEntryNumber_(0LL),
       indexIntoFile_(),
+      nEventsInLumi_(0),
       metaDataTree_(nullptr),
       parameterSetsTree_(nullptr),
       parentageTree_(nullptr),
@@ -432,6 +433,7 @@ namespace edm {
     // Report event written
     Service<JobReport> reportSvc;
     reportSvc->eventWrittenToFile(reportToken_, e.id().run(), e.id().event());
+    ++nEventsInLumi_;
   }
 
   void RootOutputFile::writeLuminosityBlock(LuminosityBlockForOutput const& lb) {
@@ -451,7 +453,8 @@ namespace edm {
     lumiTree_.optimizeBaskets(10ULL*1024*1024);
 
     Service<JobReport> reportSvc;
-    reportSvc->reportLumiSection(reportToken_, lb.id().run(), lb.id().luminosityBlock());
+    reportSvc->reportLumiSection(reportToken_, lb.id().run(), lb.id().luminosityBlock(),nEventsInLumi_);
+    nEventsInLumi_ = 0;
   }
 
   void RootOutputFile::writeRun(RunForOutput const& r) {

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -116,6 +116,7 @@ namespace edm {
     IndexIntoFile::EntryNumber_t lumiEntryNumber_;
     IndexIntoFile::EntryNumber_t runEntryNumber_;
     IndexIntoFile indexIntoFile_;
+    unsigned long nEventsInLumi_;
     edm::propagate_const<TTree*> metaDataTree_;
     edm::propagate_const<TTree*> parameterSetsTree_;
     edm::propagate_const<TTree*> parentageTree_;


### PR DESCRIPTION
DMWM needs to obtain the number of events written per LuminosityBlock for each output file.