### PR TITLE
Report # events per Lumi for output files in framework job report

### DIFF
--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -106,7 +106,7 @@ namespace edm {
 
       struct RunReport {
         RunNumber runNumber;
-        std::set<unsigned int> lumiSections;
+        std::map<unsigned int,unsigned long> lumiSectionsToNEvents;
       };
 
       /**\struct InputFile
@@ -195,7 +195,7 @@ namespace edm {
          * Associate a Lumi Section to all open output files
          *
          */
-        void associateLumiSection(JobReport::Token token, unsigned int runNumber, unsigned int lumiSection);
+        void associateLumiSection(JobReport::Token token, unsigned int runNumber, unsigned int lumiSection, unsigned long nEvents);
 
         /*
          * Associate a Lumi Section to all open input files
@@ -336,7 +336,7 @@ namespace edm {
       /// for output files, call only if lumi section is written to
       /// the output file
       ///
-      void reportLumiSection(JobReport::Token token, unsigned int run, unsigned int lumiSectId);
+      void reportLumiSection(JobReport::Token token, unsigned int run, unsigned int lumiSectId, unsigned long nEvents=0);
 
       ///
       /// API for reporting a Lumi Section to the job report.

--- a/IOPool/Common/test/proper_RLfjr_output
+++ b/IOPool/Common/test/proper_RLfjr_output
@@ -58,11 +58,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="0"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="0"/>
 </Run>
 
 </Runs>

--- a/IOPool/Common/test/proper_fjr_output
+++ b/IOPool/Common/test/proper_fjr_output
@@ -58,11 +58,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="10"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="15"/>
 </Run>
 
 </Runs>

--- a/IOPool/Common/test/proper_fjrx_output
+++ b/IOPool/Common/test/proper_fjrx_output
@@ -64,11 +64,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="10"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="15"/>
 </Run>
 
 </Runs>

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -76,6 +76,7 @@ namespace edm {
       lumiEntryNumber_(0LL),
       runEntryNumber_(0LL),
       indexIntoFile_(),
+      nEventsInLumi_(0),
       metaDataTree_(nullptr),
       parameterSetsTree_(nullptr),
       parentageTree_(nullptr),
@@ -421,6 +422,7 @@ namespace edm {
     // Report event written
     Service<JobReport> reportSvc;
     reportSvc->eventWrittenToFile(reportToken_, e.id().run(), e.id().event());
+    ++nEventsInLumi_;
   }
 
   void RootOutputFile::writeLuminosityBlock(LuminosityBlockPrincipal const& lb, ModuleCallingContext const* mcc) {
@@ -440,7 +442,8 @@ namespace edm {
     lumiTree_.optimizeBaskets(10ULL*1024*1024);
 
     Service<JobReport> reportSvc;
-    reportSvc->reportLumiSection(reportToken_, lb.id().run(), lb.id().luminosityBlock());
+    reportSvc->reportLumiSection(reportToken_, lb.id().run(), lb.id().luminosityBlock(),nEventsInLumi_);
+    nEventsInLumi_ = 0;
   }
 
   void RootOutputFile::writeRun(RunPrincipal const& r, ModuleCallingContext const* mcc) {

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -108,6 +108,7 @@ namespace edm {
     IndexIntoFile::EntryNumber_t lumiEntryNumber_;
     IndexIntoFile::EntryNumber_t runEntryNumber_;
     IndexIntoFile indexIntoFile_;
+    unsigned long nEventsInLumi_;
     TTree* metaDataTree_;
     TTree* parameterSetsTree_;
     TTree* parentageTree_;


### PR DESCRIPTION
DMWM needs to obtain the number of events written per LuminosityBlock for each output file.