### PR TITLE
Update of Phase2 Traker Digitizer validation suite

### DIFF
--- a/SimTracker/SiPhase2Digitizer/python/Phase2TrackerValidateDigi_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/Phase2TrackerValidateDigi_cfi.py
@@ -23,7 +23,7 @@ digiValid = cms.EDAnalyzer("Phase2TrackerValidateDigi",
     SimTrackSource = cms.InputTag("g4SimHits"),
     SimVertexSource = cms.InputTag("g4SimHits"),
     GeometryType = cms.string('idealForDigi'),
-    PtCutOff      = cms.double(10.0),                           
+    PtCutOff      = cms.double(9.5),                           
     EtaCutOff      = cms.double(3.5),                           
     TrackPtH = cms.PSet(
         Nbins  = cms.int32(50),
@@ -80,32 +80,32 @@ digiValid = cms.EDAnalyzer("Phase2TrackerValidateDigi",
         Nxbins = cms.int32(45),
         xmin   = cms.double(-4.5),
         xmax   = cms.double(4.5),
-        Nybins = cms.int32(200),
+        Nybins = cms.int32(100),
         ymin   = cms.double(0.),
-        ymax   = cms.double(40.)
+        ymax   = cms.double(50.)
     ),
    TOFPhiMapH = cms.PSet(
         Nxbins = cms.int32(64),
         xmin   = cms.double(-3.2),
         xmax   = cms.double(3.2),
-        Nybins = cms.int32(200),
+        Nybins = cms.int32(100),
         ymin   = cms.double(0.),
-        ymax   = cms.double(40.)
+        ymax   = cms.double(50.)
     ),
    TOFZMapH = cms.PSet(
         Nxbins = cms.int32(3000),
         xmin   = cms.double(-300.),
         xmax   = cms.double(300.),
-        Nybins = cms.int32(200),
+        Nybins = cms.int32(100),
         ymin   = cms.double(0.),
-        ymax   = cms.double(40.)
+        ymax   = cms.double(50.)
     ),
     TOFRMapH = cms.PSet(
         Nxbins = cms.int32(1200),
         xmin   = cms.double(0.),
         xmax   = cms.double(120.),
-        Nybins = cms.int32(200),
+        Nybins = cms.int32(100),
         ymin   = cms.double(0.),
-        ymax   = cms.double(40.)
+        ymax   = cms.double(50.)
     )
 )

--- a/SimTracker/SiPhase2Digitizer/python/TBeamTest_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/TBeamTest_cfi.py
@@ -1,36 +1,43 @@
 import FWCore.ParameterSet.Config as cms
 
 tbeamTest = cms.EDAnalyzer("TBeamTest",
-    Verbosity = cms.bool(False),
-    TopFolderName = cms.string("TBeamSimulation"),
-    OuterTrackerDigiSource    = cms.InputTag("mix", "Tracker"),
-    OuterTrackerDigiSimSource = cms.InputTag("simSiPixelDigis","Tracker"), 
+    TopFolderName = cms.string("TBeamTest"),
+    OuterTrackerDigiSource = cms.InputTag("mix", "Tracker"),
+    OuterTrackerDigiSimSource = cms.InputTag("simSiPixelDigis", "Tracker"),
     SimTrackSource = cms.InputTag("g4SimHits"),
-    PhiMin  = cms.double(-13.5),                         
-    PhiMax  = cms.double(13.5),
-    NumbeOfDigisH = cms.PSet(
-           Nbins = cms.int32(10),
+    GeometryType = cms.string('idealForDigi'),
+    PhiAngles= cms.vdouble(0, 1.3, 2, 3.1, 4.2, 5.0, 6.2, 7.0, 8.1, 8.5, 9.2, 9.9, 10.5, 11.0, 11.5, 12.5, 13.3, 13.9, 15),
+    NumberOfDigisH = cms.PSet(
+           Nbins = cms.int32(200),
            xmin = cms.double(-0.5),
-           xmax = cms.double(9.5)
+           xmax = cms.double(200.5)
     ),
     PositionOfDigisH = cms.PSet(
-           Nxbins = cms.int32(1028),
-           xmin   = cms.double(-0.5),
-           xmax   = cms.double(1027.5)
+           Nxbins = cms.int32(1016),
+           xmin   = cms.double(0.5),
+           xmax   = cms.double(1016.5),
+           Nybins = cms.int32(10),
+           ymin   = cms.double(0.5),
+           ymax   = cms.double(10.5)
     ),
+    DigiChargeH = cms.PSet(
+      Nbins = cms.int32(261),
+      xmin   = cms.double(0.5),
+      xmax   = cms.double(260.5)
+    ), 
     NumberOfClustersH = cms.PSet(
-           Nbins = cms.int32(20),
+           Nbins = cms.int32(200),
            xmin = cms.double(-0.5),
-           xmax = cms.double(19.5)
+           xmax = cms.double(200.5)
     ),
     ClusterWidthH = cms.PSet(
-           Nbins = cms.int32(10),
+           Nbins = cms.int32(16),
            xmin   = cms.double(-0.5),
-           xmax   = cms.double(9.5)
+           xmax   = cms.double(15.5),
     ),
     ClusterPositionH = cms.PSet(
-      Nbins = cms.int32(1028),
-      xmin   = cms.double(-0.5),
-      xmax   = cms.double(1027.5)
-    )  
+        Nbins = cms.int32(1016),
+        xmin   = cms.double(0.5),
+        xmax   = cms.double(1016.5)
+    )
 )

--- a/SimTracker/SiPhase2Digitizer/test/BuildFile.xml
+++ b/SimTracker/SiPhase2Digitizer/test/BuildFile.xml
@@ -23,3 +23,7 @@
   <flags   EDM_PLUGIN="1"/>
   <flags CXXFLAGS="-g3"/>
 </library>
+<library   file="TBeamTest.cc" name="TBeamTest">
+  <flags   EDM_PLUGIN="1"/>
+  <flags CXXFLAGS="-g3"/>
+</library>

--- a/SimTracker/SiPhase2Digitizer/test/DigiTest_cfg.py
+++ b/SimTracker/SiPhase2Digitizer/test/DigiTest_cfg.py
@@ -1,7 +1,3 @@
-
-
-
-
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.Eras import eras

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.h
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.h
@@ -40,28 +40,28 @@ public:
     MonitorElement* SimTrackPt;  
     MonitorElement* SimTrackEta;  
     MonitorElement* SimTrackPhi;  
-    MonitorElement* SimTrackPtP;  
-    MonitorElement* SimTrackEtaP;  
-    MonitorElement* SimTrackPhiP;  
-    MonitorElement* SimTrackPtS;  
-    MonitorElement* SimTrackEtaS;  
-    MonitorElement* SimTrackPhiS;  
     MonitorElement* MatchedTrackPt;
     MonitorElement* MatchedTrackPhi;
     MonitorElement* MatchedTrackEta;
-    MonitorElement* MatchedTrackPtP;
-    MonitorElement* MatchedTrackPhiP;
-    MonitorElement* MatchedTrackEtaP;
-    MonitorElement* MatchedTrackPtS;
-    MonitorElement* MatchedTrackPhiS;
-    MonitorElement* MatchedTrackEtaS;
-    MonitorElement* SimHitElossP;  
-    MonitorElement* SimHitElossS;  
+    MonitorElement* MissedHitTrackPt;
+    MonitorElement* MissedHitTrackPhi;
+    MonitorElement* MissedHitTrackEta;
+    MonitorElement* MissedDigiTrackPt;
+    MonitorElement* MissedDigiTrackPhi;
+    MonitorElement* MissedDigiTrackEta;
+    MonitorElement* MissedDigiSimHitElossP;
+    MonitorElement* MissedDigiSimHitElossS;
+    MonitorElement* MatchedSimHitElossP;  
+    MonitorElement* MatchedSimHitElossS;  
     MonitorElement* SimHitDx;
     MonitorElement* SimHitDy;
     MonitorElement* SimHitDz;
     MonitorElement* BunchXTimeBin;
     MonitorElement* FractionOfOOTDigis;
+    MonitorElement* MissedDigiLocalXposVsYPos;
+    MonitorElement* MissedDigiTimeWindow;
+    int nHits;
+    int nDigis;
   };
 
 private:
@@ -69,12 +69,15 @@ private:
   MonitorElement* nSimulatedTracks;  
   MonitorElement* nSimulatedTracksP;  
   MonitorElement* nSimulatedTracksS;  
+
   MonitorElement* SimulatedTrackPt;  
   MonitorElement* SimulatedTrackEta;  
   MonitorElement* SimulatedTrackPhi;  
+
   MonitorElement* SimulatedTrackPtP;  
   MonitorElement* SimulatedTrackEtaP;  
   MonitorElement* SimulatedTrackPhiP;  
+
   MonitorElement* SimulatedTrackPtS;  
   MonitorElement* SimulatedTrackEtaS;  
   MonitorElement* SimulatedTrackPhiS;  
@@ -89,7 +92,6 @@ private:
   MonitorElement* SimulatedTOFPhiMap;
   MonitorElement* SimulatedTOFRMap;
   MonitorElement* SimulatedTOFZMap;
-
   float etaCut_;
   float ptCut_;
 


### PR DESCRIPTION
 A few new histograms to check SimHit and DIgi inefficiencies.Some unused histograms are removed. The Beam Test analysis code has been updated as well. The update was presented in the TrackerPhase2 Simulation meeting on 6th May[1].

[1] https://indico.cern.ch/event/607515/contributions/2497130/attachments/1422461/2180466/DigiStudy_Status_Mar06_2017.pdf

@boudoul @delaere @atricomi
