### PR TITLE
fix for ECAL selective readout

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -40,21 +40,21 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '90X_upgrade2017_design_IdealBS_v18',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '90X_upgrade2017_realistic_v18',
+    'phase1_2017_realistic'    : '90X_upgrade2017_realistic_v19',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '90X_upgrade2017cosmics_realistic_deco_v16',
+    'phase1_2017_cosmics'      : '90X_upgrade2017cosmics_realistic_deco_v17',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '90X_upgrade2017cosmics_realistic_peak_v17',
+    'phase1_2017_cosmics_peak' : '90X_upgrade2017cosmics_realistic_peak_v18',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '90X_upgrade2018_design_IdealBS_v14',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '90X_upgrade2018_realistic_v15',
+    'phase1_2018_realistic'    : '90X_upgrade2018_realistic_v16',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '90X_upgrade2018cosmics_realistic_deco_v15',
+    'phase1_2018_cosmics'      :   '90X_upgrade2018cosmics_realistic_deco_v16',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '90X_upgrade2023_realistic_v8'
+    'phase2_realistic'         : '90X_upgrade2023_realistic_v9'
 }
 
 aliases = {


### PR DESCRIPTION
This PR deploys the fix to ECAL selective readout already introduced in the lat ocmmit of the 90x https://github.com/cms-sw/cmssw/pull/17886

# Summary of changes in Global Tags


## Upgrade

   * **PhaseII realistic scenario** : [90X_upgrade2023_realistic_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2023_realistic_v9) as [90X_upgrade2023_realistic_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2023_realistic_v8) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2023_realistic_v9/90X_upgrade2023_realistic_v8):
      * ECAL: 2017 selective readout (fix) https://indico.cern.ch/event/615692/contributions/2484421/

   * **PhaseI 2017 cosmics peak scenario** : [90X_upgrade2017cosmics_realistic_peak_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v18) as [90X_upgrade2017cosmics_realistic_peak_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v17) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017cosmics_realistic_peak_v18/90X_upgrade2017cosmics_realistic_peak_v17):
      * ECAL: 2017 selective readout (*fix*) - https://indico.cern.ch/event/615692/contributions/2484421/


   * **PhaseI 2017 cosmics scenario** : [90X_upgrade2017cosmics_realistic_deco_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_deco_v17) as [90X_upgrade2017cosmics_realistic_deco_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017cosmics_realistic_deco_v16) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017cosmics_realistic_deco_v17/90X_upgrade2017cosmics_realistic_deco_v16):
      * ECAL: 2017 selective readout (*fix*) - https://indico.cern.ch/event/615692/contributions/2484421/




   * **PhaseI 2017 realistic scenario** : [90X_upgrade2017_realistic_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v19) as [90X_upgrade2017_realistic_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2017_realistic_v18) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2017_realistic_v19/90X_upgrade2017_realistic_v18):
      * ECAL: 2017 selective readout (*fix*) - https://indico.cern.ch/event/615692/contributions/2484421/

   * **PhaseI 2018 cosmics scenario** : [90X_upgrade2018cosmics_realistic_deco_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018cosmics_realistic_deco_v16) as [90X_upgrade2018cosmics_realistic_deco_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018cosmics_realistic_deco_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018cosmics_realistic_deco_v16/90X_upgrade2018cosmics_realistic_deco_v15):
      * ECAL: 2017 selective readout (*fix*) - https://indico.cern.ch/event/615692/contributions/2484421/


   * **PhaseI 2018 realistic scenario** : [90X_upgrade2018_realistic_v16](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_realistic_v16) as [90X_upgrade2018_realistic_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/90X_upgrade2018_realistic_v15) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/90X_upgrade2018_realistic_v16/90X_upgrade2018_realistic_v15):
      * ECAL: 2017 selective readout (*fix*) - https://indico.cern.ch/event/615692/contributions/2484421/
