### PR TITLE
Fix comparisons used for unit tests

### DIFF
--- a/IOPool/Common/test/proper_RLfjr_output
+++ b/IOPool/Common/test/proper_RLfjr_output
@@ -58,11 +58,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="0"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="0"/>
 </Run>
 
 </Runs>

--- a/IOPool/Common/test/proper_fjr_output
+++ b/IOPool/Common/test/proper_fjr_output
@@ -58,11 +58,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="10"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="15"/>
 </Run>
 
 </Runs>

--- a/IOPool/Common/test/proper_fjrx_output
+++ b/IOPool/Common/test/proper_fjrx_output
@@ -64,11 +64,11 @@
 
 <Runs>
 <Run ID="100">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="10"/>
 </Run>
 
 <Run ID="200">
-   <LumiSection ID="1"/>
+   <LumiSection ID="1" NEvents="15"/>
 </Run>
 
 </Runs>


### PR DESCRIPTION
Recent changes to the framework job report output broke unit tests which were comparing expected reports to actual reports.