### PR TITLE
Update tag&probe package for egm [80X PR]

### DIFF
--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -61,6 +61,9 @@
 
   <class name="std::vector<reco::RecoEcalCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::RecoEcalCandidate> >"/>
+
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::RecoEcalCandidate> > >"/>
+
   <class name="edm::Ref<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>
   <class name="edm::RefProd<std::vector<reco::RecoEcalCandidate> >"/>
   <class name="edm::RefVector<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoEcalCandidate>,reco::RecoEcalCandidate> >"/>

--- a/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
+++ b/PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h
@@ -12,6 +12,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/METReco/interface/MET.h"
 #include "DataFormats/METReco/interface/METCollection.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
@@ -24,6 +25,9 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
+
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h" 
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 #include <TTree.h>
 #include <boost/utility.hpp>
@@ -170,13 +174,16 @@ class BaseTreeFiller : boost::noncopyable {
         /// How event weights are defined: 'None' = no weights, 'Fixed' = one value specified in cfg file, 'External' = read weight from the event (as double)
         enum WeightMode { None, Fixed, External };
         WeightMode weightMode_;
-        edm::EDGetTokenT<double> weightSrcToken_;
+        edm::EDGetTokenT<GenEventInfoProduct> weightSrcToken_;
 	edm::EDGetTokenT<double> PUweightSrcToken_;
+	edm::EDGetTokenT<double> rhoToken_;
         edm::EDGetTokenT<reco::VertexCollection> recVtxsToken_;
         edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
         edm::EDGetTokenT<reco::CaloMETCollection> metToken_;
         edm::EDGetTokenT<reco::METCollection> tcmetToken_;
         edm::EDGetTokenT<reco::PFMETCollection> pfmetToken_;
+	edm::EDGetTokenT<pat::METCollection>    pfmetTokenMiniAOD_;
+	edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupInfoToken_;
 
         /// Ignore exceptions when evaluating variables
         bool ignoreExceptions_;
@@ -189,20 +196,22 @@ class BaseTreeFiller : boost::noncopyable {
 
         /// Add branches with event variables: met, sum ET, .. etc.
 	bool addEventVariablesInfo_;
-
+	bool addRho_;
+	bool addCaloMet_;
+	
         void addBranches_(TTree *tree, const edm::ParameterSet &iConfig, edm::ConsumesCollector & iC, const std::string &branchNamePrefix="") ;
 
         //implementation notice: these two are 'mutable' because we will fill them from a 'const' method
         mutable TTree * tree_;
-        mutable float weight_;
-	mutable float PUweight_;
+        mutable float  weight_, PUweight_, totWeight_;
         mutable uint32_t run_, lumi_, mNPV_;
         mutable uint64_t event_;
+        mutable int truePU_;
 
         mutable float mPVx_,mPVy_,mPVz_,mBSx_,mBSy_,mBSz_;
-
+	mutable float rho_;
         mutable float mMET_,mSumET_,mMETSign_,mtcMET_,mtcSumET_,
-	  mtcMETSign_,mpfMET_,mpfSumET_,mpfMETSign_;
+	  mtcMETSign_,mpfMET_,mpfSumET_,mpfMETSign_, mpfPhi_;
 };
 
 

--- a/PhysicsTools/TagAndProbe/interface/TagProbePairMaker.h
+++ b/PhysicsTools/TagAndProbe/interface/TagProbePairMaker.h
@@ -33,7 +33,7 @@ namespace tnp {
             TagProbePairs run(const edm::Event &iEvent) const ;
         private:
             edm::EDGetTokenT<reco::CandidateView> srcToken_;
-            enum Arbitration { None, OneProbe, BestMass, Random2, NonDuplicate, OnePair };
+            enum Arbitration { None, OneProbe, BestMass, Random2, NonDuplicate, OnePair, HighestPt };
             Arbitration arbitration_;
             double arbitrationMass_;
             void arbitrate(TagProbePairs &pairs) const ;

--- a/PhysicsTools/TagAndProbe/plugins/RecoEcalCandidateSelector.cc
+++ b/PhysicsTools/TagAndProbe/plugins/RecoEcalCandidateSelector.cc
@@ -2,6 +2,7 @@
 #include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
 
 typedef SingleObjectSelector<
    std::vector<reco::RecoEcalCandidate>, 
@@ -10,3 +11,20 @@ typedef SingleObjectSelector<
    > RecoEcalCandidateSelector;
 
 DEFINE_FWK_MODULE( RecoEcalCandidateSelector );
+
+
+typedef SingleObjectSelector<
+  reco::RecoEcalCandidateCollection, 
+  StringCutObjectSelector<reco::RecoEcalCandidate>,
+  reco::RecoEcalCandidateRefVector
+  > RecoEcalCandidateRefSelector;
+
+
+//typedef SingleObjectSelector<
+//   std::vector<reco::RecoEcalCandidate>, 
+//   StringCutObjectSelector<reco::RecoEcalCandidate>,
+//   std::vector<reco::RecoEcalCandidate>
+//   > RecoEcalCandidateSelector;
+
+DEFINE_FWK_MODULE( RecoEcalCandidateRefSelector );
+

--- a/PhysicsTools/TagAndProbe/src/TagProbePairMaker.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbePairMaker.cc
@@ -20,6 +20,8 @@ tnp::TagProbePairMaker::TagProbePairMaker(const edm::ParameterSet &iConfig, edm:
   } else if (arbitration == "Random2") {
     arbitration_ = Random2;
     randGen_ = new TRandom2(7777);
+  } else if (arbitration == "HighestPt") {
+    arbitration_ = HighestPt;
   } else throw cms::Exception("Configuration") << "TagProbePairMakerOnTheFly: the only currently "
 					       << "allowed values for 'arbitration' are "
 					       << "'None', 'OneProbe', 'BestMass', 'Random2'\n";
@@ -147,7 +149,14 @@ tnp::TagProbePairMaker::arbitrate(TagProbePairs &pairs) const
 	  }
 	  // and invalidate it2
 	  it2->tag = reco::CandidateBaseRef(); --nclean;
-	} else if (arbitration_ == Random2) {
+	} else if (arbitration_ == HighestPt) {
+          // but the best one in the first  iterator
+          if ( it2->probe->pt() > it->probe->pt()  ) {
+            std::swap(*it, *it2);
+          }
+          // and invalidate it2
+          it2->tag = reco::CandidateBaseRef(); --nclean;
+        } else if (arbitration_ == Random2) {
 	  numberOfProbes++;
 	  if (numberOfProbes>1) {
 	    //std::cout << "more than 2 probes!" << std::endl;


### PR DESCRIPTION
same as PR #17820

egm tnp package has diverged from central repository for quite a while now.
Fix this by:

updating the central PhysicsTools/TagAndProbe to fulfil egm needs 
add a new package in cms-analysis for egm specific tnp tree making
This PR has been reviewed by muon conveners so that it does not change the muon tnp tree contents.
@HuguesBrun

It will be needed for legacy re-reco analysis and hence will also be committed in 80X (this PR) .