### PR TITLE
Modularized FWCore, DataFormats

### DIFF
--- a/DataFormats/CLHEP/interface/Migration.h
+++ b/DataFormats/CLHEP/interface/Migration.h
@@ -2,6 +2,7 @@
 #define _CLEHP_2_SMATRIX_MIGRATION_H_
 
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
+#include "DataFormats/Math/interface/AlgebraicObjects.h"
 #include <cstring>
 
 /*

--- a/DataFormats/Common/interface/AssociationMapHelpers.h
+++ b/DataFormats/Common/interface/AssociationMapHelpers.h
@@ -9,6 +9,7 @@
  *
  */
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
 
 #include <utility>
 

--- a/DataFormats/Common/interface/AssociativeIterator.h
+++ b/DataFormats/Common/interface/AssociativeIterator.h
@@ -40,6 +40,7 @@
 
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Common/interface/EDProductGetter.h"
+#include "FWCore/Framework/interface/Event.h"
 
 namespace edm {
     class Event;

--- a/DataFormats/Common/interface/ContainerMaskTraits.h
+++ b/DataFormats/Common/interface/ContainerMaskTraits.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-
+#include <cstddef>
 // user include files
 
 // forward declarations

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -15,6 +15,7 @@
 #include "DataFormats/Common/interface/OrphanHandle.h"
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/WrapperBase.h"
 #include "DataFormats/Provenance/interface/ProductID.h"

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -6,7 +6,7 @@
 WrapperDetail: Metafunction support for compile-time selection of code.
 
 ----------------------------------------------------------------------*/
-
+#include <vector>
 #include <typeinfo>
 namespace edm {
 

--- a/DataFormats/Common/interface/WrapperView.icc
+++ b/DataFormats/Common/interface/WrapperView.icc
@@ -7,9 +7,14 @@ Code from Wrapper.h supporting Views
 
 ----------------------------------------------------------------------*/
 
+#include <cassert>
+
 #include "DataFormats/Common/interface/fwd_fillPtrVector.h"
 #include "DataFormats/Common/interface/fwd_setPtr.h"
 #include "DataFormats/Common/interface/traits.h"
+#include "DataFormats/Common/interface/FillViewHelperVector.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "boost/mpl/if.hpp"
 

--- a/DataFormats/Common/interface/refcore_implementation.h
+++ b/DataFormats/Common/interface/refcore_implementation.h
@@ -26,6 +26,7 @@
 #include <atomic>
 
 // user include files
+#include "DataFormats/Common/interface/EDProductGetter.h"
 
 // forward declarations
 namespace edm {

--- a/DataFormats/GeometryVector/interface/Basic3DVectorLD.h
+++ b/DataFormats/GeometryVector/interface/Basic3DVectorLD.h
@@ -6,6 +6,8 @@
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
+#include "DataFormats/GeometryVector/interface/sseBasic3DVector.h"
+
 // long double specialization
 template <> 
 class Basic3DVector<long double> {

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -16,6 +16,7 @@
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 #include "boost/array.hpp"
+#include "boost/regex.hpp"
 #include <memory>
 
 #include <iosfwd>

--- a/DataFormats/Provenance/src/Provenance.cc
+++ b/DataFormats/Provenance/src/Provenance.cc
@@ -2,8 +2,6 @@
 #include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 
 #include <algorithm>
 #include <cassert>

--- a/DataFormats/Provenance/src/StableProvenance.cc
+++ b/DataFormats/Provenance/src/StableProvenance.cc
@@ -1,6 +1,5 @@
 #include "DataFormats/Provenance/interface/StableProvenance.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <algorithm>
 #include <cassert>

--- a/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
+++ b/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
@@ -1,6 +1,8 @@
 #ifndef TRAJECTORYSTOPREASONS_H
 #define TRAJECTORYSTOPREASONS_H
 
+#include <string>
+
 enum class StopReason {
   UNINITIALIZED = 0,
   MAX_HITS = 1,

--- a/FWCore/Framework/interface/eventSetupGetImplementation.h
+++ b/FWCore/Framework/interface/eventSetupGetImplementation.h
@@ -23,6 +23,7 @@
 // user include files
 #include "FWCore/Framework/interface/HCMethods.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
 
 namespace edm {
   class EventSetup;

--- a/FWCore/Utilities/interface/OffsetToBase.h
+++ b/FWCore/Utilities/interface/OffsetToBase.h
@@ -1,6 +1,7 @@
 #ifndef FWCore_Utilities_OffsetToBase_h
 #define FWCore_Utilities_OffsetToBase_h
 #include <typeinfo>
+#include <cstddef>
 
 /*
  * For any class used in Views, RefToBase, or Ptr,

--- a/FWCore/Utilities/interface/make_sentry.h
+++ b/FWCore/Utilities/interface/make_sentry.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-
+#include <memory>
 // user include files
 
 // forward declarations


### PR DESCRIPTION
First step to modularize FWCore (and the DataFormats libraries used by FWCore). This patch adds all missing includes and removes cyclic includes that cause FWCore to fail compiling with per-header modules.