### PR TITLE
Use tbb::spawn instead of tbb::enqueue for stream 0 begin transitions

### DIFF
--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -437,7 +437,14 @@ namespace edm {
       }
     });
     
-    tbb::task::enqueue( *task);
+    if(streamID_.value() == 0) {
+      //Enqueueing will start another thread if there is only
+      // one thread in the job. Having stream == 0 use spawn
+      // avoids starting up another thread when there is only one stream.
+      tbb::task::spawn( *task);
+    } else {
+      tbb::task::enqueue( *task);
+    }
   }
   
   


### PR DESCRIPTION
Using tbb::task::enqueue for a job with one thread will cause TBB to start another thread. This causes numerous problems. Therefore when starting a stream begin transition, always have stream 0 do a spawn so in the 1 thread case TBB will run the task on the main thread.