### PR TITLE
Refactorize track-time stamping for PF to run after all tracks are imported.

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -17,10 +17,7 @@ public:
     src_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("source"))),
     muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
     DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
-    NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
-    useTiming_(conf.existsAs<edm::InputTag>("timeValueMap")),
-    srcTime_(useTiming_ ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
-    srcTimeError_(useTiming_ ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
+    NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),    
     useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
     cleanBadConvBrems_(conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
     debug_(conf.getUntrackedParameter<bool>("debug",false)) {
@@ -41,8 +38,6 @@ private:
   edm::EDGetTokenT<reco::MuonCollection> muons_;
   const std::vector<double> DPtovPtCut_;
   const std::vector<unsigned> NHitCut_;
-  const bool useTiming_;
-  edm::EDGetTokenT<edm::ValueMap<float>> srcTime_, srcTimeError_;
   const bool useIterTracking_,cleanBadConvBrems_,debug_;
 
   std::unique_ptr<PFMuonAlgo> pfmu_;
@@ -64,11 +59,7 @@ importToBlock( const edm::Event& e,
   elems.reserve(elems.size() + tracks->size());
   std::vector<bool> mask(tracks->size(),true);
   reco::MuonRef muonref;
-  edm::Handle<edm::ValueMap<float>> timeH, timeErrH;
-  if (useTiming_) {
-    e.getByToken(srcTime_, timeH);
-    e.getByToken(srcTimeError_, timeErrH);
-  }
+  
   // remove converted brems with bad pT resolution if requested
   // this reproduces the old behavior of PFBlockAlgo
   if( cleanBadConvBrems_ ) {
@@ -148,10 +139,7 @@ importToBlock( const edm::Event& e,
 	std::cout << "Potential Muon P " <<  pftrackref->trackRef()->p() 
 		  << " pt " << pftrackref->trackRef()->p() << std::endl; 
       }
-      if( muId != -1 ) trkElem->setMuonRef(muonref);
-      if ( useTiming_ ) {
-        trkElem->setTime( (*timeH)[pftrackref->trackRef()], (*timeErrH)[pftrackref->trackRef()] );
-      }
+      if( muId != -1 ) trkElem->setMuonRef(muonref);      
       elems.emplace_back(trkElem);
     }
   }

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc
@@ -18,10 +18,7 @@ public:
     veto_(sumes.consumes<reco::PFRecTrackCollection>(conf.getParameter<edm::InputTag>("veto"))),
     muons_(sumes.consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
     DPtovPtCut_(conf.getParameter<std::vector<double> >("DPtOverPtCuts_byTrackAlgo")),
-    NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),
-    useTiming_(conf.existsAs<edm::InputTag>("timeValueMap")),
-    srcTime_(useTiming_ ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeValueMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
-    srcTimeError_(useTiming_ ? sumes.consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("timeErrorMap")) : edm::EDGetTokenT<edm::ValueMap<float>>()),
+    NHitCut_(conf.getParameter<std::vector<unsigned> >("NHitCuts_byTrackAlgo")),    
     useIterTracking_(conf.getParameter<bool>("useIterativeTracking")),
     cleanBadConvBrems_(conf.existsAs<bool>("cleanBadConvertedBrems") ? conf.getParameter<bool>("cleanBadConvertedBrems") : false),
     debug_(conf.getUntrackedParameter<bool>("debug",false)) {
@@ -41,9 +38,7 @@ private:
   edm::EDGetTokenT<reco::PFRecTrackCollection> src_, veto_;
   edm::EDGetTokenT<reco::MuonCollection> muons_;
   const std::vector<double> DPtovPtCut_;
-  const std::vector<unsigned> NHitCut_;
-  const bool useTiming_;
-  edm::EDGetTokenT<edm::ValueMap<float>> srcTime_, srcTimeError_;
+  const std::vector<unsigned> NHitCut_;  
   const bool useIterTracking_,cleanBadConvBrems_,debug_;
 
   std::unique_ptr<PFMuonAlgo> pfmu_;
@@ -72,11 +67,7 @@ importToBlock( const edm::Event& e,
   elems.reserve(elems.size() + tracks->size());
   std::vector<bool> mask(tracks->size(),true);
   reco::MuonRef muonref;
-  edm::Handle<edm::ValueMap<float>> timeH, timeErrH;
-  if (useTiming_) {
-    e.getByToken(srcTime_, timeH);
-    e.getByToken(srcTimeError_, timeErrH);
-  }
+  
   // remove converted brems with bad pT resolution if requested
   // this reproduces the old behavior of PFBlockAlgo
   if( cleanBadConvBrems_ ) {
@@ -157,10 +148,7 @@ importToBlock( const edm::Event& e,
 	std::cout << "Potential Muon P " <<  pftrackref->trackRef()->p() 
 		  << " pt " << pftrackref->trackRef()->p() << std::endl; 
       }
-      if( muId != -1 ) trkElem->setMuonRef(muonref);
-      if ( useTiming_ ) {
-        trkElem->setTime( (*timeH)[pftrackref->trackRef()], (*timeErrH)[pftrackref->trackRef()] );
-      }
+      if( muId != -1 ) trkElem->setMuonRef(muonref);      
       elems.emplace_back(trkElem);
     }
   }

--- a/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/TrackTimingImporter.cc
@@ -1,0 +1,66 @@
+#include "RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
+#include "RecoParticleFlow/PFTracking/interface/PFTrackAlgoTools.h"
+
+// this doesn't actually import anything, 
+// but rather applies time stamps to tracks after they are all inserted
+
+class TrackTimingImporter : public BlockElementImporterBase {
+public:
+  TrackTimingImporter(const edm::ParameterSet& conf,
+		    edm::ConsumesCollector& sumes) :
+    BlockElementImporterBase(conf,sumes),    
+    srcTime_( sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeValueMap")) ),
+    srcTimeError_( sumes.consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("timeErrorMap")) ),
+    debug_(conf.getUntrackedParameter<bool>("debug",false)) {    
+  }
+  
+  void importToBlock( const edm::Event& ,
+		      ElementList& ) const override;
+
+private:
+    
+  edm::EDGetTokenT<edm::ValueMap<float> > srcTime_, srcTimeError_;
+  const bool debug_;
+  
+};
+
+DEFINE_EDM_PLUGIN(BlockElementImporterFactory, 
+		  TrackTimingImporter, 
+		  "TrackTimingImporter");
+
+void TrackTimingImporter::
+importToBlock( const edm::Event& e, 
+	       BlockElementImporterBase::ElementList& elems ) const {
+  typedef BlockElementImporterBase::ElementList::value_type ElementType;  
+  
+  edm::Handle<edm::ValueMap<float> > timeH, timeErrH;
+  
+  e.getByToken(srcTime_, timeH);
+  e.getByToken(srcTimeError_, timeErrH);
+    
+  auto TKs_end = std::partition(elems.begin(),elems.end(),
+				[](const ElementType& a){
+			        return a->type() == reco::PFBlockElement::TRACK;
+				});  
+  auto btk_elems = elems.begin();  
+  // now we actually insert tracks, again tagging muons along the way
+  reco::PFRecTrackRef pftrackref;  
+  for( auto track = btk_elems;  track != TKs_end; ++track) {
+    const auto& ref = (*track)->trackRef();
+    (*track)->setTime( (*timeH)[ref], (*timeErrH)[ref] );
+    if( debug_ ) {
+      edm::LogInfo("TrackTimingImporter") 
+      	<< "Track with pT / eta " << ref->pt() << " / " << ref->eta() 
+	<< " has time: " << (*track)->time() << " +/- " << (*track)->timeError() << std::endl;
+    }
+    
+  }
+}

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -175,12 +175,13 @@ phase2_hgcal.toModify(
 
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-_addTiming = {}
-for idx in _findIndicesByModule('GeneralTracksImporter') + _findIndicesByModule('GeneralTracksImporterWithVeto'):
-    _addTiming[idx] = dict( 
-            timeValueMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel"),
-            timeErrorMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution")
-    ) 
+_addTiming = particleFlowBlock.elementImporters.copy()
+_addTiming.append( cms.PSet( importerName = cms.string("TrackTimingImporter"),
+                             timeValueMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel"),
+                             timeErrorMap = cms.InputTag("trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution")
+                             ) 
+                   )
+
 phase2_timing.toModify(
     particleFlowBlock,
     elementImporters = _addTiming


### PR DESCRIPTION
Fixes cases where some tracks that were imported did not receive time stamps since they came in from the non-generic importing steps (attached conversions and such).

@bendavid