### PR TITLE
L1T BlockHeader changes for L1T ZS DQM

### DIFF
--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -199,16 +199,17 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     << "hdr:  " << std::hex << std::setw(8) << std::setfill('0') << block->header().raw() << std::dec
                     << " (ID " << block->header().getID() << ", size " << block->header().getSize()
                     << ", CapID 0x" << std::hex << std::setw(2) << std::setfill('0') << block->header().getCapID()
+                    << ", flags 0x" << std::hex << std::setw(2) << std::setfill('0') << block->header().getFlags()
                     << ")" << std::dec << std::endl;
           for (const auto& word: block->payload()) {
-            if (verbose_) std::cout << "data: " << std::hex << std::setw(8) << std::setfill('0') << word << std::dec << std::endl;
+            std::cout << "data: " << std::hex << std::setw(8) << std::setfill('0') << word << std::dec << std::endl;
           }
         }
 
         unsigned int blockCapId = block->header().getCapID();
         unsigned int blockSize = block->header().getSize() * 4;
         unsigned int blockHeaderSize = sizeof(block->header().raw());
-        bool zsFlagSet = ((block->header().raw() & zsFlagMask_) != 0);
+        bool zsFlagSet = ((block->header().getFlags() & zsFlagMask_) != 0);
         bool toSuppress = false;
 
         capIds_->Fill(blockCapId);
@@ -250,11 +251,13 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
         // check if zero suppression flag agrees
         if (toSuppress && zsFlagSet) {
+          if (verbose_) std::cout << "GOOD block with ZS flag true" << std::endl;
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSGOOD);
           if (capIdDefined) {
             zeroSuppValMap_[blockCapId]->Fill(ZSBLKSGOOD);
           }
         } else if (!toSuppress && !zsFlagSet) {
+          if (verbose_) std::cout << "GOOD block with ZS flag false" << std::endl;
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSGOOD);
           readoutSizeZSMap[maxMasks_] += totalBlockSize;
           readoutSizeZSExpectedMap[maxMasks_] += totalBlockSize;
@@ -264,6 +267,7 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
             readoutSizeZSExpectedMap[blockCapId] += totalBlockSize;
           }
         } else if (!toSuppress && zsFlagSet) {
+          if (verbose_) std::cout << "BAD block with ZS flag true" << std::endl;
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSBAD);
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSBADFALSEPOS);
           readoutSizeZSExpectedMap[maxMasks_] += totalBlockSize;
@@ -275,6 +279,7 @@ void L1TMP7ZeroSupp::analyze(const edm::Event& e, const edm::EventSetup& c) {
             evtGood[blockCapId] = false;
           }
         } else {
+          if (verbose_) std::cout << "BAD block with ZS flag false" << std::endl;
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSBAD);
           zeroSuppValMap_[maxMasks_]->Fill(ZSBLKSBADFALSENEG);
           readoutSizeZSMap[maxMasks_] += totalBlockSize;

--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -11,17 +11,18 @@ namespace l1t {
 
    class BlockHeader {
       public:
-         BlockHeader(unsigned int id, unsigned int size, unsigned int capID=0, block_t type=MP7) : id_(id), size_(size), capID_(capID), type_(type) {};
+         BlockHeader(unsigned int id, unsigned int size, unsigned int capID=0, unsigned int flags=0, block_t type=MP7) : id_(id), size_(size), capID_(capID), flags_(flags), type_(type) {};
          // Create a MP7 block header: everything is contained in the raw uint32
-         BlockHeader(const uint32_t *data) : id_((data[0] >> ID_shift) & ID_mask), size_((data[0] >> size_shift) & size_mask), capID_((data[0] >> capID_shift) & capID_mask), type_(MP7) {};
+         BlockHeader(const uint32_t *data) : id_((data[0] >> ID_shift) & ID_mask), size_((data[0] >> size_shift) & size_mask), capID_((data[0] >> capID_shift) & capID_mask), flags_((data[0] >> flags_shift) & flags_mask), type_(MP7) {};
          // Create a CTP7 block header: size is contained in the general CTP7 header
-         BlockHeader(const uint32_t *data, unsigned int size) : id_((data[0] >> CTP7_shift) & CTP7_mask), size_(size), capID_(0), type_(CTP7) {};
+         BlockHeader(const uint32_t *data, unsigned int size) : id_((data[0] >> CTP7_shift) & CTP7_mask), size_(size), capID_(0), flags_(0), type_(CTP7) {};
 
          bool operator<(const BlockHeader& o) const { return getID() < o.getID(); };
 
          unsigned int getID() const { return id_; };
          unsigned int getSize() const { return size_; };
          unsigned int getCapID() const { return capID_; };
+         unsigned int getFlags() const { return flags_; };
          block_t getType() const { return type_; };
 
          uint32_t raw(block_t type=MP7) const;
@@ -35,10 +36,13 @@ namespace l1t {
          static const unsigned int size_mask = 0xff;
          static const unsigned int capID_shift = 8;
          static const unsigned int capID_mask = 0xff;
+         static const unsigned int flags_shift = 0;
+         static const unsigned int flags_mask = 0xff;
 
          unsigned int id_;
          unsigned int size_;
          unsigned int capID_;
+         unsigned int flags_;
          block_t type_;
    };
 

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -29,7 +29,7 @@ namespace l1t {
    {
       if (type_ == MP7) {
          LogTrace("L1T") << "Writing MP7 link header";
-         return ((id_ & ID_mask) << ID_shift) | ((size_ & size_mask) << size_shift) | ((capID_ & capID_mask) << capID_shift);
+         return ((id_ & ID_mask) << ID_shift) | ((size_ & size_mask) << size_shift) | ((capID_ & capID_mask) << capID_shift) | ((flags_ & flags_mask) << flags_shift);
       }
       // if (type_ == MTF7) {
       //    LogTrace("L1T") << "Writing MTF7 link header";


### PR DESCRIPTION
Added the ZS validation flag to the L1T BlockHeader to be used with the online DQM zero suppression module.