### PR TITLE
CalibCalorimetry/HcalPlugins fix bug found from clang warning

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -909,7 +909,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hbUpgrade.add<int>("mcShape",203);
 	desc_hbUpgrade.add<int>("recoShape",203);
 	desc_hbUpgrade.add<double>("photoelectronsToAnalog",57.5);
-	desc_hbUpgrade.add<std::vector<double>>("darkCurrent",std::vector<double>(0.055));
+	desc_hbUpgrade.add<std::vector<double>>("darkCurrent", std::vector<double>({0.055}));
 	desc.add<edm::ParameterSetDescription>("hbUpgrade", desc_hbUpgrade);
 
 	edm::ParameterSetDescription desc_he;
@@ -937,7 +937,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_heUpgrade.add<int>("mcShape",203);
 	desc_heUpgrade.add<int>("recoShape",203);
 	desc_heUpgrade.add<double>("photoelectronsToAnalog",57.5);
-	desc_heUpgrade.add<std::vector<double>>("darkCurrent",std::vector<double>(0.055));
+	desc_heUpgrade.add<std::vector<double>>("darkCurrent", std::vector<double>({0.055}));
 	desc.add<edm::ParameterSetDescription>("heUpgrade", desc_heUpgrade);
 
 	edm::ParameterSetDescription desc_hf;

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -895,7 +895,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hb.add<int>("mcShape",125);
 	desc_hb.add<int>("recoShape",105);
 	desc_hb.add<double>("photoelectronsToAnalog",0.0);
-	desc_hb.add<std::vector<double>>("darkCurrent",std::vector<double>(0.0));
+	desc_hb.add<std::vector<double>>("darkCurrent",std::vector<double>({0.0}));
 	desc.add<edm::ParameterSetDescription>("hb", desc_hb);
 
 	edm::ParameterSetDescription desc_hbUpgrade;
@@ -923,7 +923,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_he.add<int>("mcShape",125);
 	desc_he.add<int>("recoShape",105);
 	desc_he.add<double>("photoelectronsToAnalog",0.0);
-	desc_he.add<std::vector<double>>("darkCurrent",std::vector<double>(0.0));
+	desc_he.add<std::vector<double>>("darkCurrent",std::vector<double>({0.0}));
 	desc.add<edm::ParameterSetDescription>("he", desc_he);
 
 	edm::ParameterSetDescription desc_heUpgrade;
@@ -951,7 +951,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hf.add<int>("mcShape",301);
 	desc_hf.add<int>("recoShape",301);
 	desc_hf.add<double>("photoelectronsToAnalog",0.0);
-	desc_hf.add<std::vector<double>>("darkCurrent",std::vector<double>(0.0));
+	desc_hf.add<std::vector<double>>("darkCurrent",std::vector<double>({0.0}));
 	desc.add<edm::ParameterSetDescription>("hf", desc_hf);
 
 	edm::ParameterSetDescription desc_hfUpgrade;
@@ -965,7 +965,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_hfUpgrade.add<int>("mcShape",301);
 	desc_hfUpgrade.add<int>("recoShape",301);
 	desc_hfUpgrade.add<double>("photoelectronsToAnalog",0.0);
-	desc_hfUpgrade.add<std::vector<double>>("darkCurrent",std::vector<double>(0.0));
+	desc_hfUpgrade.add<std::vector<double>>("darkCurrent",std::vector<double>({0.0}));
 	desc.add<edm::ParameterSetDescription>("hfUpgrade", desc_hfUpgrade);
   
 	edm::ParameterSetDescription desc_hfrecal;
@@ -986,7 +986,7 @@ void HcalHardcodeCalibrations::fillDescriptions(edm::ConfigurationDescriptions &
 	desc_ho.add<int>("mcShape",201);
 	desc_ho.add<int>("recoShape",201);
 	desc_ho.add<double>("photoelectronsToAnalog",4.0);
-	desc_ho.add<std::vector<double>>("darkCurrent",std::vector<double>(0.0));
+	desc_ho.add<std::vector<double>>("darkCurrent",std::vector<double>({0.0}));
 	desc.add<edm::ParameterSetDescription>("ho", desc_ho);
 
 	edm::ParameterSetDescription validator_sipm;


### PR DESCRIPTION
The value of darkCurrent is initialized to 0 instead of the intended value of 0.55. Adding initializer braces sets the value correctly.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/f60d4bf7e099ce1e597b02cf09f0745b/opt/cmssw/slc6_amd64_gcc530/cms/cmssw-patch/CMSSW_9_1_CLANG_X_2017-03-15-2300/src/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc:912:76: warning: implicit conversion from 'double' to 'size_type' (aka 'unsigned long') changes value from 0.055 to 0 [-Wliteral-conversion]
         desc_hbUpgrade.add<std::vector<double>>("darkCurrent",std::vector<double>(0.055));
                                                              ~~~                 ^~~~~
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/f60d4bf7e099ce1e597b02cf09f0745b/opt/cmssw/slc6_amd64_gcc530/cms/cmssw-patch/CMSSW_9_1_CLANG_X_2017-03-15-2300/src/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc:940:76: warning: implicit conversion from 'double' to 'size_type' (aka 'unsigned long') changes value from 0.055 to 0 [-Wliteral-conversion]
         desc_heUpgrade.add<std::vector<double>>("darkCurrent",std::vector<double>(0.055));
                                                              ~~~                 ^~~~~
