### PR TITLE
IOMC/RandomEngine/test fix bug in initialization of sleep timer.

### DIFF
--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -188,8 +188,7 @@ TestRandomNumberServiceGlobal::analyze(edm::StreamID streamID, edm::Event const&
 
   // Add some sleep to encourage all the streams to get events to process.
   if(nStreams_ > 1) {
-    const double t{0.025};
-    sleep(t);
+    usleep(25000);
   }
 
   if(dump_) {

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -188,7 +188,8 @@ TestRandomNumberServiceGlobal::analyze(edm::StreamID streamID, edm::Event const&
 
   // Add some sleep to encourage all the streams to get events to process.
   if(nStreams_ > 1) {
-    sleep(0.025);
+    const double t{0.025};
+    sleep(t);
   }
 
   if(dump_) {


### PR DESCRIPTION
This is a bug because the intent was to sleep 0.025 seconds not 0 seconds.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/f60d4bf7e099ce1e597b02cf09f0745b/opt/cmssw/slc6_amd64_gcc530/cms/cmssw-patch/CMSSW_9_1_CLANG_X_2017-03-15-2300/src/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc:191:11: warning: implicit conversion from 'double' to 'unsigned int' changes value from 0.025 to 0 [-Wliteral-conversion]
     sleep(0.025);
    ~~~~~ ^~~~~