### PR TITLE
Switch phase1 initialStep seed creator to ConsecutiveHitsTripletOnly

### DIFF
--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -108,7 +108,22 @@ trackingPhase2PU140.toModify(initialStepHitTriplets,
     produceSeedingHitSets = False,
     produceIntermediateHitTriplets = True,
 )
-trackingPhase1.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
+from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer_cff import seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
+_initialStepSeedsConsecutiveHitsTripletOnly = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.clone(
+    seedingHitSets = "initialStepHitTriplets",
+    SeedComparitorPSet = dict(# FIXME: is this defined in any cfi that could be imported instead of copy-paste?
+        ComponentName = 'PixelClusterShapeSeedComparitor',
+        FilterAtHelixStage = cms.bool(False),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(False),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache')
+    ),
+)
+trackingPhase1QuadProp.toReplaceWith(initialStepSeeds, _initialStepSeedsConsecutiveHitsTripletOnly)
+trackingPhase1.toReplaceWith(initialStepSeeds, _initialStepSeedsConsecutiveHitsTripletOnly.clone(
+        seedingHitSets = "initialStepHitQuadruplets"
+))
 trackingPhase2PU140.toModify(initialStepSeeds, seedingHitSets = "initialStepHitQuadruplets")
 
 # temporary...


### PR DESCRIPTION
This PR switches the phase1 initialStep seed initial kinematics to be calculated from first three hits (`SeedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer`) instead of first two hits + beamspot position (`SeedCreatorFromRegionConsecutiveHitsEDProducer`), as in detachedQuad iteration. The motivation is to decouple initialStep seed initial kinematics from beamspot position (e.g. to avoid possible bias in beamspot determination itself).

Here are MTV plots with 1000 ttbar+PU35 events in 9_0_0_pre4+#17537+#17511+#17544 (effectively pre5 tracking)
https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_9_0_0_pre4_phase1ConsecutiveHitsTripletOnlySeedCreator/
for both CA seeding and old seeding. There are small variations (most notably some migration of tracks from initialStep to lowPtQuadStep).

Tested in 9_0_0_pre5, expecting tiny changes in phase1 tracking as shown above (no changes in phase0/2).

@rovere @VinInn @felicepantaleo 