### PR TITLE
from 768 to 512 strips for ME0 geometry

### DIFF
--- a/Geometry/GEMGeometryBuilder/data/v7/GEMSpecs.xml
+++ b/Geometry/GEMGeometryBuilder/data/v7/GEMSpecs.xml
@@ -3,7 +3,7 @@
   <SpecParSection label="GEMSpecs.xml">
     <SpecPar name="nStripsME0" eval="true">
       <PartSelector path="//GHA0.."/>
-      <Parameter name="nStrips" value="768"/>
+      <Parameter name="nStrips" value="512"/>
     </SpecPar>
     <SpecPar name="nStripsGE11" eval="true">
       <PartSelector path="//GHA1.."/>


### PR DESCRIPTION
change number of strips in ME0Geometry
to 512, the default for Muon TDR sample prod