### PR TITLE
SimCalorimetry/EcalEBTrigPrimAlgos : Comment out unused variables to remove gcc warning.

### DIFF
--- a/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalFenixTcpFormat.cc
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalFenixTcpFormat.cc
@@ -80,7 +80,7 @@ void EcalFenixTcpFormat::process(std::vector<int> &Et, std::vector<int> &fgvb,
 	else
 	  lut_out = (lut_)[myEt] ;
 	
-	int ttFlag = (lut_out & 0x700) >> 8 ;
+	// int ttFlag = (lut_out & 0x700) >> 8 ;
 	myEt = lut_out & 0xff ;
 	//	out[i]=EcalEBTriggerPrimitiveSample( myEt,fgvb[0],sfgvb[0],ttFlag); 
 	out[i]=EcalEBTriggerPrimitiveSample( myEt ); 
@@ -91,7 +91,7 @@ void EcalFenixTcpFormat::process(std::vector<int> &Et, std::vector<int> &fgvb,
   else {
     //std::cout << " FenixTcpFormatter et.size() " << Et.size() << std::endl;
     for (unsigned int i=0; i<Et.size();++i) {
-      int myFgvb=fgvb[i];
+      //int myFgvb=fgvb[i];
       int mysFgvb=sfgvb[i];
       //myEt=Et[i]>>eTTotShift;
       //if (myEt>0x3ff) myEt=0x3ff ;
@@ -121,7 +121,7 @@ void EcalFenixTcpFormat::process(std::vector<int> &Et, std::vector<int> &fgvb,
       else
 	lut_out = (lut_)[myEt] ;
       
-      int ttFlag = (lut_out & 0x700) >> 8 ;
+      //int ttFlag = (lut_out & 0x700) >> 8 ;
       if (tcpFormat_)  {
 	out2[i]=EcalEBTriggerPrimitiveSample( myEt & 0x3ff);
 	//std::cout << " FenixTcpFormatter final et " << (myEt & 0x3ff) << std::endl;


### PR DESCRIPTION
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7339d4514f5638002b3a1b1f515c3f0b/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_1_X_2017-03-16-1100/src/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalFenixTcpFormat.cc:83:6: warning: unused variable 'ttFlag' [-Wunused-variable]
   int ttFlag = (lut_out & 0x700) >> 8 ;
      ^
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7339d4514f5638002b3a1b1f515c3f0b/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_1_X_2017-03-16-1100/src/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalFenixTcpFormat.cc:94:11: warning: unused variable 'myFgvb' [-Wunused-variable]
        int myFgvb=fgvb[i];
           ^
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7339d4514f5638002b3a1b1f515c3f0b/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_1_X_2017-03-16-1100/src/SimCalorimetry/EcalEBTrigPrimAlgos/src/EcalFenixTcpFormat.cc:124:11: warning: unused variable 'ttFlag' [-Wunused-variable]
        int ttFlag = (lut_out & 0x700) >> 8 ;
           ^