### PR TITLE
PhysicsTools/KinFitter: fix gcc5 strict-overflow warning.

### DIFF
--- a/PhysicsTools/KinFitter/src/TKinFitter.cc
+++ b/PhysicsTools/KinFitter/src/TKinFitter.cc
@@ -1287,7 +1287,7 @@ void TKinFitter::printMatrix(const TMatrixD &matrix, const TString& name) {
       if (iCol < iSheet+colsPerSheet) log << std::setw(8) << iCol << "    |";
       log << "\n"
 	   << topbar << " \n";
-      }
+    }
     for(Int_t iRow = 0; iRow < nRows; iRow++) {
       log << std::setw(4) << iRow << " |";
       for (Int_t iCol = iSheet; iCol < nCols; iCol++) {

--- a/PhysicsTools/KinFitter/src/TKinFitter.cc
+++ b/PhysicsTools/KinFitter/src/TKinFitter.cc
@@ -1282,18 +1282,18 @@ void TKinFitter::printMatrix(const TMatrixD &matrix, const TString& name) {
 
   for (Int_t iSheet = 0; iSheet < nCols; iSheet += colsPerSheet) {
     log << "\n"
-	<< "     |";
-    for (Int_t iCol = iSheet; iCol < nCols; iCol++)
-      if (iCol < iSheet+colsPerSheet) 
-      log << std::setw(8) << iCol << "    |";
-    log << "\n"
-	<< topbar << " \n";
+	 << "     |";
+    for (Int_t iCol = iSheet; iCol < nCols; iCol++) {
+      if (iCol < iSheet+colsPerSheet) log << std::setw(8) << iCol << "    |";
+      log << "\n"
+	   << topbar << " \n";
+      }
     for(Int_t iRow = 0; iRow < nRows; iRow++) {
       log << std::setw(4) << iRow << " |";
-      for (Int_t iCol = iSheet; iCol < nCols; iCol++)
-          if (iCol < iSheet+colsPerSheet ) 
-	log << std::setw(12) << matrix(iRow, iCol) << " ";
-      log << "\n";
+      for (Int_t iCol = iSheet; iCol < nCols; iCol++) {
+          if (iCol < iSheet+colsPerSheet ) log << std::setw(12) << matrix(iRow, iCol) << " ";
+          log << "\n";
+      }
     }
   }
 

--- a/PhysicsTools/KinFitter/src/TKinFitter.cc
+++ b/PhysicsTools/KinFitter/src/TKinFitter.cc
@@ -1284,16 +1284,14 @@ void TKinFitter::printMatrix(const TMatrixD &matrix, const TString& name) {
     log << "\n"
 	 << "     |";
     for (Int_t iCol = iSheet; iCol < nCols; iCol++) {
-      if (iCol < iSheet+colsPerSheet) log << std::setw(8) << iCol << "    |";
-      log << "\n"
-	   << topbar << " \n";
-    }
+      if (iCol < iSheet+colsPerSheet) log << std::setw(8) << iCol << "    |";}
+    log << "\n" 
+	 << topbar << " \n";
     for(Int_t iRow = 0; iRow < nRows; iRow++) {
       log << std::setw(4) << iRow << " |";
       for (Int_t iCol = iSheet; iCol < nCols; iCol++) {
-          if (iCol < iSheet+colsPerSheet ) log << std::setw(12) << matrix(iRow, iCol) << " ";
-          log << "\n";
-      }
+          if (iCol < iSheet+colsPerSheet ) log << std::setw(12) << matrix(iRow, iCol) << " "; }
+      log << "\n";
     }
   }
 

--- a/PhysicsTools/KinFitter/src/TKinFitter.cc
+++ b/PhysicsTools/KinFitter/src/TKinFitter.cc
@@ -1283,13 +1283,15 @@ void TKinFitter::printMatrix(const TMatrixD &matrix, const TString& name) {
   for (Int_t iSheet = 0; iSheet < nCols; iSheet += colsPerSheet) {
     log << "\n"
 	<< "     |";
-    for (Int_t iCol = iSheet; iCol < iSheet+colsPerSheet && iCol < nCols; iCol++)
+    for (Int_t iCol = iSheet; iCol < nCols; iCol++)
+      if (iCol < iSheet+colsPerSheet) 
       log << std::setw(8) << iCol << "    |";
     log << "\n"
 	<< topbar << " \n";
     for(Int_t iRow = 0; iRow < nRows; iRow++) {
       log << std::setw(4) << iRow << " |";
-      for (Int_t iCol = iSheet; iCol < iSheet+colsPerSheet && iCol < nCols; iCol++)
+      for (Int_t iCol = iSheet; iCol < nCols; iCol++)
+          if (iCol < iSheet+colsPerSheet ) 
 	log << std::setw(12) << matrix(iRow, iCol) << " ";
       log << "\n";
     }


### PR DESCRIPTION
Move conditional out of for statement so that compiler does not attempt to optimize out for loop.

This fixes the gcc5 warning:

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/7339d4514f5638002b3a1b1f515c3f0b/opt/cmssw/slc6_amd64_gcc530/cms/cmssw/CMSSW_9_1_X_2017-03-16-1100/src/PhysicsTools/KinFitter/src/TKinFitter.cc:1256:6: warning: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Wstrict-overflow]
  void TKinFitter::printMatrix(const TMatrixD &matrix, const TString& name) {
      ^