### PR TITLE
[91X] Modernize configuration of SiStripDetVOffReader and add SiStripApvGainReader

### DIFF
--- a/CondTools/SiStrip/test/SiStripApvGainReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainReader_cfg.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SiStripApvGainReader")
+
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    debugModules = cms.untracked.vstring(''),
+    threshold = cms.untracked.string('INFO'),
+    destinations = cms.untracked.vstring('SiStripApvGainReader.log')
+    )
+
+##
+## Empty events source
+## (specify the run number to pick correct IOV) 
+##
+process.source = cms.Source("EmptySource",
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            firstRun = cms.untracked.uint32(1)
+                            )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+##
+## To Correctly build the SiStripGainRcd in the ES
+## we need all the dependent records => specify a Global Tag  
+##
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+##
+## Prefer the SiStripApvGainRcd or SiStripApvGain2Rcd
+## under test  
+##
+process.poolDBESSource = cms.ESSource("PoolDBESSource",
+                                      connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'), 
+                                      toGet = cms.VPSet(cms.PSet(record = cms.string('SiStripApvGainRcd'),
+                                                                 tag = cms.string('SiStripApvGain_GR10_v1_hlt')
+                                                                 )
+                                                        )
+                                      )
+process.prefer_poolDBESSource = cms.ESPrefer("PoolDBESSource","poolDBESSource")
+
+##
+## Dump the Gain payload. It will be in the format
+## DetId APV1 APV2 APV3 APV4 (APV5) (APV6) 
+##
+process.gainreader = cms.EDAnalyzer("SiStripApvGainReader",
+                                    printDebug = cms.untracked.bool(True),
+                                    outputFile = cms.untracked.string("SiStripApvGains_dump.txt"),
+                                    gainType   = cms.untracked.uint32(0)    #0 for G1, 1 for G2
+                                    )
+
+process.p1 = cms.Path(process.gainreader)
+
+

--- a/CondTools/SiStrip/test/SiStripDetVOffReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripDetVOffReader_cfg.py
@@ -9,31 +9,30 @@ process.MessageLogger = cms.Service(
     destinations = cms.untracked.vstring('SiStripDetVOffReader.log')
 )
 
-process.source = cms.Source("EmptySource",
-    numberEventsInRun = cms.untracked.uint32(1),
-    firstRun = cms.untracked.uint32(1)
-)
+process.source = cms.Source("EmptyIOVSource",
+                            timetype = cms.string('timestamp'),
+                            firstValue = cms.uint64(6318323863869830144),
+                            lastValue = cms.uint64(6318587115701303296),
+                            interval = cms.uint64(1)
+                            )
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
-)
+    )
 
-process.poolDBESSource = cms.ESSource("PoolDBESSource",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-    DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(2),
-        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
-    ),
-    timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:dbfile.db'),
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('SiStripDetVOffRcd'),
-        tag = cms.string('SiStripDetVOff_v1')
-    ))
-)
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.TrackerDigiGeometryESModule.applyAlignment = False
+from CondCore.CondDB.CondDB_cfi import *
+CondDBDetVOff = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
+process.dbInput = cms.ESSource("PoolDBESSource",
+                               CondDBDetVOff,
+                               toGet = cms.VPSet(cms.PSet(record = cms.string('SiStripDetVOffRcd'),
+                                                          tag = cms.string('SiStripDetVOff_1hourDelay_v1_Validation') #choose your own favourite
+                                                          )
+                                                 )
+                               )
 
 process.fedcablingreader = cms.EDAnalyzer("SiStripDetVOffReader")
 


### PR DESCRIPTION
Title says it all:
   * Strip DCS payloads are of `timetype=timestamp`, adjust reader accordingly (modernizing configuration file).
   * Add a reader the python configuration file to dump payloads of type `SiStripApvGain`

No effect on any production workflow is expected