### PR TITLE
[91X] fix ShallowEventDataProducer to allow running SiStripGain PCL producers from 2016 ALCARECO  

### DIFF
--- a/CalibTracker/SiStripCommon/plugins/ShallowEventDataProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowEventDataProducer.cc
@@ -1,6 +1,7 @@
 #include "CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ShallowEventDataProducer::ShallowEventDataProducer(const edm::ParameterSet& iConfig) {
   produces <unsigned int> ( "run"      );
@@ -56,9 +57,14 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle< LumiScalersCollection > lumiScalers;
   float instLumi_=0; float PU_=0;
   iEvent.getByToken(scalerToken_, lumiScalers); 
-  if (lumiScalers->begin() != lumiScalers->end()) {
-    instLumi_ = lumiScalers->begin()->instantLumi();
-    PU_       = lumiScalers->begin()->pileup();
+  if(lumiScalers.isValid()){
+    if (lumiScalers->begin() != lumiScalers->end()) {
+      instLumi_ = lumiScalers->begin()->instantLumi();
+      PU_       = lumiScalers->begin()->pileup();
+    }
+  } else {
+    edm::LogInfo("ShallowEventDataProducer") 
+      << "LumiScalers collection not found in the event; will write dummy values";
   }
   
   auto instLumi = std::make_unique<float>(instLumi_);

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAfterAbortGap_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAfterAbortGap_Output_cff.py
@@ -12,6 +12,8 @@ OutALCARECOSiStripCalMinBiasAfterAbortGap_noDrop = cms.PSet(
         'keep DetIdedmEDCollection_siStripDigis_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep LumiScalerss_scalersRawToDigi_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_TriggerResults_*_*')
 )
 


### PR DESCRIPTION
Greetings, 
this PR fixes the problem introduced in #17570, which unfortunately breaks the mode in which `ALCA:PromptCalibProdSiStripGainsAfterAbortGap` is invoked to run on existing `ALCARECO` datasets (e.g. 2016 ones) that don't have the LumiScalers collection. At present:
```
cmsDriver.py step3 --datatier ALCARECO --conditions auto:run2_data -s ALCA:PromptCalibProdSiStripGainsAfterAbortGap --eventcontent ALCARECO --runUnscheduled --process ALCAPROMPT --data -n 100 --dasquery='file dataset=/StreamExpress/Run2016H-SiStripCalMinBiasAfterAbortGap-Express-v2/ALCARECO run=282917' --fileout file:step3.root
```
fails with: 
```
----- Begin Fatal Exception 18-Mar-2017 10:32:06 CET-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing run: 282917 lumi: 119 event: 63362406
   [1] Running path 'pathALCARECOPromptCalibProdSiStripGainsAfterAbortGap'
   [2] Prefetching for module SiStripGainFromCalibTree/'ALCARECOSiStripCalibAfterAbortGap'
   [3] Calling method for module ShallowEventDataProducer/'ALCARECOShallowEventRunAAG'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: std::vector<LumiScalers>
Looking for module label: scalersRawToDigi
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```
This running mode (which is __NOT__ the one used at Tier-0) is anyway needed for large statistics study in view of improving the monitoring for 2017. 

After internal discussions, in the same PR we propose to add `LumiScalers` and `DcsStatus` collections also in the `SiStripCalMinBiasAfterAbortGap` ALCARECO (as it was done for regular `SiStripCalMinBias` in #17419) an effective increase of ~135b/evt.
