### PR TITLE
Task based stream begin transitions

### DIFF
--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -56,6 +56,10 @@ namespace edm {
     static void postPathSignal(ActivityRegistry *a, HLTPathStatus const& status, PathContext const* pathContext) {
       a->postPathEventSignal_(*pathContext->streamContext(), *pathContext, status);
     }
+    
+    static const char* transitionName() {
+      return "Event";
+    }
   };
 
   template <>
@@ -92,6 +96,9 @@ namespace edm {
     static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleGlobalBeginRunSignal_(*globalContext, *moduleCallingContext);
     }
+    static const char* transitionName() {
+      return "global begin Run";
+    }
   };
 
   template <>
@@ -127,6 +134,9 @@ namespace edm {
     static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleStreamBeginRunSignal_(*streamContext, *moduleCallingContext);
     }
+    static const char* transitionName() {
+      return "stream begin Run";
+    }
   };
 
   template <>
@@ -161,6 +171,9 @@ namespace edm {
     }
     static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleStreamEndRunSignal_(*streamContext, *moduleCallingContext);
+    }
+    static const char* transitionName() {
+      return "stream end Run";
     }
   };
 
@@ -198,6 +211,9 @@ namespace edm {
     static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleGlobalEndRunSignal_(*globalContext, *moduleCallingContext);
     }
+    static const char* transitionName() {
+      return "global end Run";
+    }
   };
 
   template <>
@@ -234,6 +250,9 @@ namespace edm {
     static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleGlobalBeginLumiSignal_(*globalContext, *moduleCallingContext);
     }
+    static const char* transitionName() {
+      return "global begin LuminosityBlock";
+    }
   };
 
   template <>
@@ -268,6 +287,9 @@ namespace edm {
     }
     static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleStreamBeginLumiSignal_(*streamContext, *moduleCallingContext);
+    }
+    static const char* transitionName() {
+      return "stream begin LuminosityBlock";
     }
   };
 
@@ -306,6 +328,9 @@ namespace edm {
     static void postModuleSignal(ActivityRegistry *a, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleStreamEndLumiSignal_(*streamContext, *moduleCallingContext);
     }
+    static const char* transitionName() {
+      return "end stream LuminosityBlock";
+    }
   };
 
   template <>
@@ -341,6 +366,9 @@ namespace edm {
     }
     static void postModuleSignal(ActivityRegistry *a, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleGlobalEndLumiSignal_(*globalContext, *moduleCallingContext);
+    }
+    static const char* transitionName() {
+      return "end global LuminosityBlock";
     }
   };
 }

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -67,32 +67,7 @@ namespace edm {
             worker->doWork<T>(p, es, streamID, parentContext, topContext);
           }
           catch (cms::Exception & ex) {
-            std::ostringstream ost;
-            if (T::isEvent_) {
-              ost << "Calling event method";
-            }
-            else if (T::begin_ && T::branchType_ == InRun) {
-              ost << "Calling beginRun";
-            }
-            else if (T::begin_ && T::branchType_ == InLumi) {
-              ost << "Calling beginLuminosityBlock";
-            }
-            else if (!T::begin_ && T::branchType_ == InLumi) {
-              ost << "Calling endLuminosityBlock";
-            }
-            else if (!T::begin_ && T::branchType_ == InRun) {
-              ost << "Calling endRun";
-            }
-            else {
-              // It should be impossible to get here ...
-              ost << "Calling unknown function";
-            }
-            ost << " for unscheduled module " << worker->description().moduleName()
-                << "/'" << worker->description().moduleLabel() << "'";
-            ex.addContext(ost.str());
-            ost.str("");
-            ost << "Processing " << p.id();
-            ex.addContext(ost.str());
+            addContextToException<T>(ex,worker,p.id());
             throw;
           }
         }
@@ -114,6 +89,12 @@ namespace edm {
 
     
   private:
+    template <typename T, typename ID>
+    void addContextToException(cms::Exception& ex, Worker const* worker, ID const& id) const {
+      std::ostringstream ost;
+      ost << "Processing " << T::transitionName()<<" "<< id;
+      ex.addContext(ost.str());
+    }
     worker_container unscheduledWorkers_;
     UnscheduledAuxiliary aux_;
   };

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -99,6 +99,20 @@ namespace edm {
       }
     }
 
+    template <typename T, typename U>
+    void runNowAsync(WaitingTask* task,
+                     typename T::MyPrincipal& p, EventSetup const& es, StreamID streamID,
+                     typename T::Context const* topContext, U const* context) const {
+      //do nothing for event since we will run when requested
+      if(!T::isEvent_) {
+        for(auto worker: unscheduledWorkers_) {
+          ParentContext parentContext(context);
+          worker->doWorkNoPrefetchingAsync<T>(task, p, es, streamID, parentContext, topContext);
+        }
+      }
+    }
+
+    
   private:
     worker_container unscheduledWorkers_;
     UnscheduledAuxiliary aux_;

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -53,7 +53,16 @@ namespace edm {
                               typename T::Context const* topContext,
                               U const* context,
                               bool cleaningUpAfterException = false);
+    template <typename T, typename U>
+    void processOneOccurrenceAsync(
+                              WaitingTask* task,
+                              typename T::MyPrincipal& principal,
+                              EventSetup const& eventSetup,
+                              StreamID streamID,
+                              typename T::Context const* topContext,
+                              U const* context);
 
+    
     void setupOnDemandSystem(EventPrincipal& principal, EventSetup const& es);
 
     void beginJob(ProductRegistry const& iRegistry);
@@ -75,9 +84,9 @@ namespace edm {
                       std::shared_ptr<ProcessConfiguration const> processConfiguration,
                       std::string const& label);
 
-  private:
-
     void resetAll();
+
+  private:
 
     WorkerRegistry      workerReg_;
     ExceptionToActionTable const*  actionTable_;
@@ -112,6 +121,19 @@ namespace edm {
       throw;
     }
   }
+  
+  template <typename T, typename U>
+  void
+  WorkerManager::processOneOccurrenceAsync(WaitingTask* task,
+                                           typename T::MyPrincipal& ep,
+                                           EventSetup const& es,
+                                           StreamID streamID,
+                                           typename T::Context const* topContext,
+                                           U const* context) {
+    //make sure the unscheduled items see this run or lumi transition
+    unscheduled_.runNowAsync<T,U>(task,ep, es,streamID, topContext, context);
+  }
+
 }
 
 #endif

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -210,27 +210,7 @@ namespace edm {
       }
       catch (cms::Exception & ex) {
         std::ostringstream ost;
-        if (T::begin_ && T::branchType_ == InRun) {
-          ost << "Calling global beginRun";
-        }
-        else if (T::begin_ && T::branchType_ == InLumi) {
-          ost << "Calling global beginLuminosityBlock";
-        }
-        else if (!T::begin_ && T::branchType_ == InLumi) {
-          ost << "Calling global endLuminosityBlock";
-        }
-        else if (!T::begin_ && T::branchType_ == InRun) {
-          ost << "Calling global endRun";
-        }
-        else {
-          // It should be impossible to get here ...
-          ost << "Calling unknown function";
-        }
-        ost << " for module " << worker->description().moduleName()
-        << "/'" << worker->description().moduleLabel() << "'";
-        ex.addContext(ost.str());
-        ost.str("");
-        ost << "Processing " << p.id();
+        ost << "Processing " <<T::transitionName()<<" "<< p.id();
         ex.addContext(ost.str());
         throw;
       }

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -115,33 +115,28 @@ namespace edm {
                          std::string const& id,
                          PathContext const& pathContext) {
     std::ostringstream ost;
-    if (not isEvent) {
-      //For the event case, the Worker has already
-      // added the necessary module context to the exception
-      if (begin && branchType == InRun) {
-        ost << "Calling beginRun";
-      }
-      else if (begin && branchType == InLumi) {
-        ost << "Calling beginLuminosityBlock";
-      }
-      else if (!begin && branchType == InLumi) {
-        ost << "Calling endLuminosityBlock";
-      }
-      else if (!begin && branchType == InRun) {
-        ost << "Calling endRun";
-      }
-      else {
-        // It should be impossible to get here ...
-        ost << "Calling unknown function";
-      }
-      ost << " for module " << desc.moduleName() << "/'" << desc.moduleLabel() << "'";
-      ex.addContext(ost.str());
-      ost.str("");
-    }
     ost << "Running path '" << pathContext.pathName() << "'";
     ex.addContext(ost.str());
     ost.str("");
     ost << "Processing ";
+    //For the event case, the Worker has already
+    // added the necessary module context to the exception
+    if (begin && branchType == InRun) {
+      ost << "stream begin Run";
+    }
+    else if (begin && branchType == InLumi) {
+      ost << "stream begin LuminosityBlock ";
+    }
+    else if (!begin && branchType == InLumi) {
+      ost << "stream end LuminosityBlock ";
+    }
+    else if (!begin && branchType == InRun) {
+      ost << "stream end Run ";
+    }
+    else if (isEvent) {
+      // It should be impossible to get here ...
+      ost << "Event ";
+    }
     ost << id;
     ex.addContext(ost.str());
   }

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -62,6 +62,13 @@ namespace edm {
     void processOneOccurrence(typename T::MyPrincipal const&, EventSetup const&,
                               StreamID const&, typename T::Context const*);
 
+    template <typename T>
+    void runAllModulesAsync(WaitingTask*,
+                            typename T::MyPrincipal const&,
+                            EventSetup  const&,
+                            StreamID const&,
+                            typename T::Context const*);
+
     void processOneOccurrenceAsync(WaitingTask*, EventPrincipal const&, EventSetup const&, StreamID const&, StreamContext const*);
     
     int bitPosition() const { return bitpos_; }
@@ -170,6 +177,17 @@ namespace edm {
       hlt::HLTState const& state_;
       PathContext const* pathContext_;
     };
+  }
+
+  template <typename T>
+  void Path::runAllModulesAsync(WaitingTask* task,
+                          typename T::MyPrincipal const& p,
+                          EventSetup  const& es,
+                          StreamID const& streamID,
+                                typename T::Context const* context) {
+    for(auto& worker: workers_) {
+      worker.runWorkerAsync<T>(task,p,es,streamID,context);
+    }
   }
 
   template <typename T>

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -623,9 +623,8 @@ namespace edm {
         results_inserter_->doWork<Traits>(ep, es, streamID_, parentContext, &streamContext_);
       }
       catch (cms::Exception & ex) {
-        ex.addContext("Calling produce method for module TriggerResultInserter");
         std::ostringstream ost;
-        ost << "Processing " << ep.id();
+        ost << "Processing Event " << ep.id();
         ex.addContext(ost.str());
         iExcept = std::current_exception();
       }

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -427,14 +427,60 @@ namespace edm {
                                              EventSetup const& es,
                                              bool cleaningUpAfterException) {
     ServiceToken token = ServiceRegistry::instance().presentToken();
-    
-    auto task = make_functor_task(tbb::task::allocate_root(), [this,iHolder,&ep,&es,cleaningUpAfterException,token] () mutable {
+
+    T::setStreamContext(streamContext_, ep);
+
+    auto id = ep.id();
+    auto doneTask = make_waiting_task(tbb::task::allocate_root(),
+                                      [this,iHolder, id,cleaningUpAfterException,token](std::exception_ptr const* iPtr) mutable
+    {
       ServiceRegistry::Operate op(token);
-      try {
-        this->processOneStream<T>(ep,es,cleaningUpAfterException);
-      } catch(...) {
-        iHolder.doneWaiting(std::current_exception());
+      std::exception_ptr excpt;
+      if(iPtr) {
+        excpt = *iPtr;
+        //add context information to the exception and print message
+        try {
+          convertException::wrap([&]() {
+            std::rethrow_exception(excpt);
+          });
+        } catch(cms::Exception& ex) {
+          //TODO: should add the transition type info
+          std::ostringstream ost;
+          ost<<"Processing "<<T::transitionName()<<" "<<id;
+          addContextAndPrintException(ost.str().c_str(), ex, cleaningUpAfterException);
+          excpt = std::current_exception();
+        }
+        
+        actReg_->preStreamEarlyTerminationSignal_(streamContext_,TerminationOrigin::ExceptionFromThisContext);
       }
+      
+      try {
+        T::postScheduleSignal(actReg_.get(), &streamContext_);
+      } catch(...) {
+        if(not excpt) {
+          excpt = std::current_exception();
+        }
+      }
+      iHolder.doneWaiting(excpt);
+      
+    });
+    
+    auto task = make_functor_task(tbb::task::allocate_root(), [this,doneTask,&ep,&es,cleaningUpAfterException,token] () mutable {
+      ServiceRegistry::Operate op(token);
+      T::preScheduleSignal(actReg_.get(), &streamContext_);
+      WaitingTaskHolder h(doneTask);
+
+      workerManager_.resetAll();
+      for(auto& p : end_paths_) {
+        p.runAllModulesAsync<T>(doneTask, ep, es, streamID_, &streamContext_);
+      }
+
+      for(auto& p : trig_paths_) {
+        p.runAllModulesAsync<T>(doneTask, ep, es, streamID_, &streamContext_);
+      }
+      
+      workerManager_.processOneOccurrenceAsync<T>(doneTask,
+                                                  ep, es, streamID_, &streamContext_, &streamContext_);
     });
     
     if(streamID_.value() == 0) {

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -127,17 +127,7 @@ private:
       imcc = imcc->moduleCallingContext();
     }
     std::ostringstream ost;
-    if (iIsEvent) {
-      ost << "Calling event method";
-    }
-    else {
-      // It should be impossible to get here, because
-      // this function only gets called when the IgnoreCompletely
-      // exception behavior is active, which can only be true
-      // for events.
-      ost << "Calling unknown function";
-    }
-    ost << " for module " << imcc->moduleDescription()->moduleName() << "/'" << imcc->moduleDescription()->moduleLabel() << "'";
+    ost << "Calling method for module " << imcc->moduleDescription()->moduleName() << "/'" << imcc->moduleDescription()->moduleLabel() << "'";
     ex.addContext(ost.str());
     
     if (imcc->type() == ParentContext::Type::kPlaceInPath) {
@@ -147,7 +137,7 @@ private:
       ex.addContext(ost.str());
     }
     ost.str("");
-    ost << "Processing ";
+    ost << "Processing Event ";
     ost << iID;
     ex.addContext(ost.str());
   }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -826,6 +826,12 @@ namespace edm {
       TransitionIDValue<typename T::MyPrincipal> idValue(ep);
       if(shouldRethrowException(ex, parentContext, T::isEvent_, idValue)) {
         assert(not cached_exception_);
+        std::ostringstream iost;
+        iost<<"Calling method for module ";
+        iost<<description().moduleName() << "/'"
+        << description().moduleLabel() << "'";
+        ex.addContext(iost.str());
+
         setException<T::isEvent_>(std::current_exception());
         waitingTasks_.doneWaiting(cached_exception_);
         std::rethrow_exception(cached_exception_);

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -39,6 +39,7 @@ the worker is reset().
 #include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueueChain.h"
+#include "FWCore/Concurrency/interface/FunctorTask.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -94,6 +95,14 @@ namespace edm {
                      StreamID stream,
                      ParentContext const& parentContext,
                      typename T::Context const* context);
+
+    template <typename T>
+    void doWorkNoPrefetchingAsync(WaitingTask* task,
+                                  typename T::MyPrincipal const&,
+                                  EventSetup const& c,
+                                  StreamID stream,
+                                  ParentContext const& parentContext,
+                                  typename T::Context const* context);
 
     void callWhenDoneAsync(WaitingTask* task) {
       waitingTasks_.add(task);
@@ -667,6 +676,56 @@ namespace edm {
       }
     }
     waitingTasks_.doneWaiting(nullptr);
+  }
+
+  template <typename T>
+  void Worker::doWorkNoPrefetchingAsync(WaitingTask* task,
+                           typename T::MyPrincipal const& principal,
+                           EventSetup const& es,
+                           StreamID streamID,
+                           ParentContext const& parentContext,
+                           typename T::Context const* context) {
+    waitingTasks_.add(task);
+    bool expected = false;
+    if(workStarted_.compare_exchange_strong(expected,true)) {
+      auto serviceToken = ServiceRegistry::instance().presentToken();
+      
+      auto toDo =[this, &principal, &es, streamID,parentContext,context, serviceToken]()
+      {
+        try {
+          //Need to make the services available
+          ServiceRegistry::Operate guard(serviceToken);
+          convertException::wrap([&]() {
+            
+            this->runModule<T>(principal,
+                                 es,
+                                 streamID,
+                                 parentContext,
+                                 context);
+          });
+        } catch( cms::Exception& iException) {
+          TransitionIDValue<typename T::MyPrincipal> idValue(principal);
+          if(shouldRethrowException(iException, parentContext, T::isEvent_, idValue)) {
+            assert(not this->cached_exception_);
+            std::ostringstream iost;
+            iost<<"Calling method for module ";
+            iost<<this->description().moduleName() << "/'"
+            << this->description().moduleLabel() << "'";
+            iException.addContext(iost.str());
+            setException<T::isEvent_>(std::current_exception());
+            this->waitingTasks_.doneWaiting(this->cached_exception_);
+            return;
+          }
+        }
+        this->waitingTasks_.doneWaiting(nullptr);
+      };
+      if(auto queue = this->serializeRunModule()) {
+        queue->push( toDo);
+      } else {
+        auto task = make_functor_task( tbb::task::allocate_root(), toDo);
+        tbb::task::spawn(*task);
+      }
+    }
   }
 
   template <typename T>

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -126,7 +126,7 @@ namespace edm {
       worker_->doWorkAsync<T>(iTask,ep, es,streamID, parentContext, context);
     } else {
       ParentContext parentContext(context);
-      worker_->doWorkAsync<T>(iTask,ep, es,streamID, parentContext, context);
+      worker_->doWorkNoPrefetchingAsync<T>(iTask,ep, es,streamID, parentContext, context);
     }
   }
   

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
@@ -104,6 +104,12 @@ ModuleCallingContext state = Running
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
+++++++ starting: begin run for module: stream = 0 label = 'result4' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'result4' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'result2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'result2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'result1' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'result1' id = 4
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -128,12 +134,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin run for module: stream = 0 label = 'result1' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'result1' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'result2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'result2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'result4' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'result4' id = 6
 ++++++ starting: begin run for module: stream = 0 label = 'get' id = 2
 ++++++ finished: begin run for module: stream = 0 label = 'get' id = 2
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
@@ -176,6 +176,12 @@ ModuleCallingContext state = Running
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
+++++++ starting: begin lumi for module: stream = 0 label = 'result4' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'result4' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'result2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'result2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'result1' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'result1' id = 4
 ++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -200,12 +206,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin lumi for module: stream = 0 label = 'result1' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'result1' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'result2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'result2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'result4' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'result4' id = 6
 ++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 2
 ++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 2
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -160,6 +160,8 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 8
 ++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -184,18 +186,16 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: begin run for module: stream = 0 label = 'a1' id = 3
 ++++++ finished: begin run for module: stream = 0 label = 'a1' id = 3
 ++++++ starting: begin run for module: stream = 0 label = 'a2' id = 4
 ++++++ finished: begin run for module: stream = 0 label = 'a2' id = 4
 ++++++ starting: begin run for module: stream = 0 label = 'a3' id = 5
 ++++++ finished: begin run for module: stream = 0 label = 'a3' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 6
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 6
 ++++ finished: begin run: stream = 0 run = 1 time = 1
@@ -292,6 +292,8 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -316,18 +318,16 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: begin lumi for module: stream = 0 label = 'a1' id = 3
 ++++++ finished: begin lumi for module: stream = 0 label = 'a1' id = 3
 ++++++ starting: begin lumi for module: stream = 0 label = 'a2' id = 4
 ++++++ finished: begin lumi for module: stream = 0 label = 'a2' id = 4
 ++++++ starting: begin lumi for module: stream = 0 label = 'a3' id = 5
 ++++++ finished: begin lumi for module: stream = 0 label = 'a3' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 6
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 6
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -115,10 +115,10 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 5
 ++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -203,10 +203,10 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 5
 ++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0


### PR DESCRIPTION
Switched to using per module tasks for stream begin Run and begin LuminosityBlock. All tasks for a transition are scheduled simultaneously thereby allowing multiple modules to run. During these stream transitions, there should be no inter-module dependencies.