### PR TITLE
Minor bug fix in hltGetConfiguration (91X)

### DIFF
--- a/HLTrigger/Configuration/scripts/hltGetConfiguration
+++ b/HLTrigger/Configuration/scripts/hltGetConfiguration
@@ -155,7 +155,7 @@ parser.add_argument('--max-events',
                     default = defaults.events,
                     metavar = 'EVENTS',
                     help    = 'Run on EVENTS events (-1 for unlimited)' )
-group.add_argument('--setup',
+parser.add_argument('--setup',
                     dest    = 'setup',
                     action  = 'store',
                     type    = str,


### PR DESCRIPTION
Allow to use --setup and --unprescale options at the same time.