### PR TITLE
add plot params to individual histograms created in the geometry hierarchy

### DIFF
--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -58,18 +58,27 @@ SiPixelPhase1ClustersSizeY = DefaultHistoDigiCluster.clone(
   )
 )
 
-
 SiPixelPhase1ClustersNClusters = DefaultHistoDigiCluster.clone(
   name = "clusters",
   title = "Clusters",
   range_min = 0, range_max = 10, range_nbins = 10,
   xlabel = "clusters",
   dimensions = 0,
+
   specs = VPSet(
     StandardSpecificationOccupancy,
     StandardSpecification2DProfile_Num,
     StandardSpecificationTrend_Num,
     StandardSpecifications1D_Num,
+
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+                             .reduce("COUNT")    
+                             .groupBy("PXBarrel/PXLayer")
+                             .save(nbins=100, xmin=0, xmax=10000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                             .reduce("COUNT")    
+                             .groupBy("PXForward/PXDisk/")
+                             .save(nbins=200, xmin=0, xmax=30000),
   )
 )
 

--- a/DQM/SiPixelPhase1Common/interface/SummationSpecification.h
+++ b/DQM/SiPixelPhase1Common/interface/SummationSpecification.h
@@ -42,6 +42,10 @@ struct SummationStep {
   enum Stage {NO_STAGE, FIRST, STAGE1, STAGE2};
   Stage stage = NO_STAGE;
 
+  int nbins{-1};
+  int xmin{0};
+  int xmax{0};
+  
   std::vector<GeometryInterface::Column> columns;
   
   // more parameters. Not very elegant but good enough for step2.

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -269,14 +269,6 @@ StandardSpecifications1D_Num = [
                              .reduce("MEAN")
                              .groupBy("PXBarrel/Shell/PXLayer/SignedLadder", "EXTEND_X")
                              .save(),
-    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
-                             .reduce("COUNT")
-                             .groupBy("PXBarrel/PXLayer")
-                             .save(),
-    Specification().groupBy("PXForward/PXDisk/Event")
-                             .reduce("COUNT")
-                             .groupBy("PXForward/PXDisk/")
-                             .save()
 ]
 
 

--- a/DQM/SiPixelPhase1Common/python/SpecificationBuilder_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/SpecificationBuilder_cfi.py
@@ -145,7 +145,8 @@ class Specification(cms.PSet):
       type = t, 
       stage = self._state, 
       columns = cms.vstring(cname),
-      arg = cms.string(mode)
+      arg = cms.string(mode),
+      nbins = cms.int32(-1), xmin = cms.int32(0), xmax = cms.int32(0)
     ))
 
     # In the very beginning emit standard column assignments, they will be 
@@ -154,19 +155,22 @@ class Specification(cms.PSet):
       self._x = cms.PSet(
         type = USE_X, stage = STAGE1,
         columns = cms.vstring(),
-        arg = cms.string("")
+        arg = cms.string(""),
+        nbins = cms.int32(-1), xmin = cms.int32(0), xmax = cms.int32(0)
       )
       self.spec.append(self._x)
       self._y = cms.PSet(
         type = USE_Y, stage = STAGE1,
         columns = cms.vstring(),
-        arg = cms.string("")
+        arg = cms.string(""),
+        nbins = cms.int32(-1), xmin = cms.int32(0), xmax = cms.int32(0)
       )
       self.spec.append(self._y)
       self._z = cms.PSet(
         type = USE_Z, stage = STAGE1,
         columns = cms.vstring(),
-        arg = cms.string("")
+        arg = cms.string(""),
+        nbins = cms.int32(-1), xmin = cms.int32(0), xmax = cms.int32(0)
       )
       self.spec.append(self._z)
 
@@ -191,7 +195,8 @@ class Specification(cms.PSet):
       if sort == "MEAN":
         self.spec.append(cms.PSet(
           type = PROFILE, stage = STAGE1,
-          columns = cms.vstring(), arg = cms.string("")
+          columns = cms.vstring(), arg = cms.string(""),
+          nbins = cms.int32(-1), xmin = cms.int32(0), xmax = cms.int32(0)
         ))
       return self
 
@@ -202,31 +207,48 @@ class Specification(cms.PSet):
       type = REDUCE, 
       stage = self._state, 
       columns = cms.vstring(),
-      arg = cms.string(sort)
+      arg = cms.string(sort),
+      nbins = cms.int32(-1), xmin = cms.int32(0), xmax = cms.int32(0)
     ))
     return self
 
-  def save(self):
+  def save(self, nbins=-1, xmin=0, xmax=0):
     if self._state == FIRST:
       raise Exception("First statement must be groupBy.")
 
     if self._state == STAGE1:
       # end of STAGE1, fix the parameter assignments
       n = 1
-      if self._x.type == USE_X: self._x.arg = cms.string(str(n)); n = n+1
-      if self._y.type == USE_Y: self._y.arg = cms.string(str(n)); n = n+1
-      if self._z.type == USE_Z: self._z.arg = cms.string(str(n)); n = n+1
+      if self._x.type == USE_X: 
+        self._x.arg = cms.string(str(n))
+        n = n+1
+        self._x.nbins = cms.int32(nbins)
+        self._x.xmin = cms.int32(xmin)
+        self._x.xmax = cms.int32(xmax)
+      if self._y.type == USE_Y: 
+        self._y.arg = cms.string(str(n)) 
+        n = n+1
+        self._y.nbins = cms.int32(nbins)
+        self._y.xmin = cms.int32(xmin)
+        self._y.xmax = cms.int32(xmax)  
+      if self._z.type == USE_Z: 
+        self._z.arg = cms.string(str(n)) 
+        n = n+1
+        self._z.nbins = cms.int32(nbins)
+        self._z.xmin = cms.int32(xmin)
+        self._z.xmax = cms.int32(xmax)
       # we don't know how many parameters the user wants to pass here, but the 
       # HistogramManager knows. So we just add 3.
 
     # SAVE is implicit in step1 and ignored in harvesting, so not really needed.
-    #self.spec.append(cms.PSet(
-    #  type = SAVE, 
-    #  stage = self._state, 
-    #  columns = cms.vstring(),
-    #  arg = cms.string("")
-    #))
+    # self.spec.append(cms.PSet(
+    # type = SAVE, 
+    # stage = self._state, 
+    # columns = cms.vstring(),
+    # arg = cms.string(""),
+    # ))
     self._state = STAGE2
+
     return self
 
   def saveAll(self):

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -345,15 +345,18 @@ void HistogramManager::book(DQMStore::IBooker& iBooker,
         // refer to fillInternal() for the actual execution
         // compute labels, title, type, user-set ranges here
         int tot_parameters = n_parameters;
+								
 #define SET_AXIS(to, from) \
-                mei.to##label = from##label; \
-                mei.range_##to##_min = this->range_##from##_min; \
-                mei.range_##to##_max = this->range_##from##_max; \
-                mei.range_##to##_nbins = this->range_##from##_nbins 
+        mei.to##label = from##label; \
+				mei.range_##to##_min = ((it->nbins == -1) ? this->range_##from##_min : it->xmin); \
+        mei.range_##to##_max = ((it->nbins == -1) ? this->range_##from##_max : it->xmax); \
+        mei.range_##to##_nbins = ((it->nbins == -1) ? this->range_##from##_nbins : it->nbins)
+				
+				
         for (auto it = firststep+1; it != laststep; ++it) {
           switch (it->type) {
             case SummationStep::USE_X:
-              if (it->arg[0] == '1' && n_parameters >= 1) { SET_AXIS(x, x); }
+              if (it->arg[0] == '1' && n_parameters >= 1) { SET_AXIS(x, x); }  // TODO: make use of current nbins, xmin, xmax if set
               if (it->arg[0] == '2' && n_parameters >= 2) { SET_AXIS(x, y); }
               break;
             case SummationStep::USE_Y:

--- a/DQM/SiPixelPhase1Common/src/SummationSpecification.cc
+++ b/DQM/SiPixelPhase1Common/src/SummationSpecification.cc
@@ -20,10 +20,17 @@ SummationSpecification::parse_columns(std::string name, GeometryInterface& geome
 
 SummationSpecification::SummationSpecification(const edm::ParameterSet& config, GeometryInterface& geometryInterface) {
   auto spec = config.getParameter<edm::VParameterSet>("spec");
+
   for (auto step : spec) {
     auto s = SummationStep();
     s.type = SummationStep::Type(step.getParameter<int>("type"));
     s.stage = SummationStep::Stage(step.getParameter<int>("stage"));
+	
+    s.nbins = int(step.getParameter<int>("nbins"));
+    s.xmin = int(step.getParameter<int>("xmin"));
+    s.xmax = int(step.getParameter<int>("xmax"));
+
+	
     for (auto c : step.getParameter<std::vector<std::string>>("columns")) {
       s.columns.push_back(parse_columns(c, geometryInterface));
     }

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -27,10 +27,20 @@ SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
   range_max = 30,
   range_nbins = 30,
   dimensions = 0, # this is a count
+
   specs = VPSet(
     StandardSpecificationTrend_Num,
     StandardSpecification2DProfile_Num,
-    StandardSpecifications1D_Num
+    StandardSpecifications1D_Num,
+	
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+                             .reduce("COUNT")    
+                             .groupBy("PXBarrel/PXLayer")
+                             .save(nbins=100, xmin=0, xmax=10000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                             .reduce("COUNT")    
+                             .groupBy("PXForward/PXDisk/")
+                             .save(nbins=200, xmin=0, xmax=30000),
   )
 )
 

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -32,6 +32,7 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
   range_min = 0, range_max = 10, range_nbins = 10,
   xlabel = "clusters",
   dimensions = 0,
+
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer" + "/DetId/Event") 
                    .reduce("COUNT") 
@@ -42,7 +43,16 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
                    .groupBy("PXForward/PXDisk")
                    .saveAll(),
     StandardSpecificationInclusive_Num,
-    StandardSpecificationTrend_Num
+    StandardSpecificationTrend_Num,
+
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+                             .reduce("COUNT")    
+                             .groupBy("PXBarrel/PXLayer")
+                             .save(nbins=100, xmin=0, xmax=10000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                             .reduce("COUNT")    
+                             .groupBy("PXForward/PXDisk/")
+                             .save(nbins=200, xmin=0, xmax=30000),
   )
 )
 

--- a/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -1,14 +1,25 @@
 import FWCore.ParameterSet.Config as cms
 from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 
+
 SiPixelPhase1TrackEfficiencyValid = DefaultHistoTrack.clone(
   name = "valid",
   title = "Valid Hits",
   xlabel = "valid hits",
   dimensions = 0,
+
   specs = VPSet(
     StandardSpecifications1D_Num,
     StandardSpecification2DOccupancy,
+
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+                             .reduce("COUNT")    
+                             .groupBy("PXBarrel/PXLayer")
+                             .save(nbins=100, xmin=0, xmax=10000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                             .reduce("COUNT")    
+                             .groupBy("PXForward/PXDisk/")
+                             .save(nbins=200, xmin=0, xmax=30000),
   )
 )
 
@@ -17,9 +28,19 @@ SiPixelPhase1TrackEfficiencyMissing = DefaultHistoTrack.clone(
   title = "Missing Hits",
   xlabel = "missing hits",
   dimensions = 0,
+
   specs = VPSet(
     StandardSpecifications1D_Num,
     StandardSpecification2DOccupancy,
+
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+                             .reduce("COUNT")    
+                             .groupBy("PXBarrel/PXLayer")
+                             .save(nbins=100, xmin=0, xmax=10000),
+    Specification().groupBy("PXForward/PXDisk/Event")
+                             .reduce("COUNT")    
+                             .groupBy("PXForward/PXDisk/")
+                             .save(nbins=200, xmin=0, xmax=30000),
   )
 )
 


### PR DESCRIPTION
Updated the save function to permit setting plot ranges,#bins  for individual plots created in the geometry hierarchy without effecting the bundle settings.