### PR TITLE
Fix gcc6 misleading-indentation warning

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
@@ -303,29 +303,27 @@ void ClusterShapeExtractor::processPixelRecHits
 
   for(  SiPixelRecHitCollection::DataContainer::const_iterator
         recHit = recHits->begin(); recHit!= recHits->end(); recHit++)
-  if(checkSimHits(*recHit, simHit, key))
-    {
-      // Fill map
-      if(simHitMap.count(key) == 0)
-          { simHitMap[key] = &(*recHit); }
-      else {
-            if(        recHit->cluster()->size() >
-               simHitMap[key]->cluster()->size())
-                 { simHitMap[key] = &(*recHit);}
-           }
-      ++counter_2;
-    }
+      if(checkSimHits(*recHit, simHit, key))
+        {
+          // Fill map
+          if(simHitMap.count(key) == 0)
+              { simHitMap[key] = &(*recHit); }
+          else if(        recHit->cluster()->size() >
+                   simHitMap[key]->cluster()->size())
+                   simHitMap[key] = &(*recHit);
+          ++counter_2;
+        }
 
   for(  SiPixelRecHitCollection::DataContainer::const_iterator
         recHit = recHits->begin(); recHit!= recHits->end(); recHit++)
-  if(checkSimHits(*recHit, simHit, key))
-    {
-      // Check whether the present rechit is the largest
-        if(&(*recHit) == simHitMap[key]) {
-            processSim(*recHit, simHit, clusterShapeCache, hspc);
-            ++counter;
+      if(checkSimHits(*recHit, simHit, key))
+        {
+          // Check whether the present rechit is the largest
+            if(&(*recHit) == simHitMap[key]) {
+                processSim(*recHit, simHit, clusterShapeCache, hspc);
+                ++counter;
+            }
         }
-    }
 //    std::cout << "recHits->size() = " << recHits->size() << ", counter = " << counter
 //              << ", counter_2 = " << counter_2 << std::endl;
 }

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
@@ -304,27 +304,28 @@ void ClusterShapeExtractor::processPixelRecHits
   for(  SiPixelRecHitCollection::DataContainer::const_iterator
         recHit = recHits->begin(); recHit!= recHits->end(); recHit++)
   if(checkSimHits(*recHit, simHit, key))
-  {
-    // Fill map
-    if(simHitMap.count(key) == 0)
-       simHitMap[key] = &(*recHit);
-    else
-      if(        recHit->cluster()->size() >
-         simHitMap[key]->cluster()->size())
-         simHitMap[key] = &(*recHit);
+    {
+      // Fill map
+      if(simHitMap.count(key) == 0)
+          { simHitMap[key] = &(*recHit); }
+      else {
+            if(        recHit->cluster()->size() >
+               simHitMap[key]->cluster()->size())
+                 { simHitMap[key] = &(*recHit);}
+           }
       ++counter_2;
-  }
+    }
 
   for(  SiPixelRecHitCollection::DataContainer::const_iterator
         recHit = recHits->begin(); recHit!= recHits->end(); recHit++)
   if(checkSimHits(*recHit, simHit, key))
-  {
-    // Check whether the present rechit is the largest
-      if(&(*recHit) == simHitMap[key]) {
-      processSim(*recHit, simHit, clusterShapeCache, hspc);
-          ++counter;
-      }
-  }
+    {
+      // Check whether the present rechit is the largest
+        if(&(*recHit) == simHitMap[key]) {
+            processSim(*recHit, simHit, clusterShapeCache, hspc);
+            ++counter;
+        }
+    }
 //    std::cout << "recHits->size() = " << recHits->size() << ", counter = " << counter
 //              << ", counter_2 = " << counter_2 << std::endl;
 }


### PR DESCRIPTION
The compiler warning that else statement does not guard ++counter_2. Curly braces added for clarity. If the author intended to increment counter_2 only if the conditional was met, then the statement should be moved inside the curly braces. Original warning below.

src/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc: In member function 'void ClusterShapeExtractor::processPixelRecHits(const DataContainer*, const SiPixelClusterShapeCache&)':
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/54b89c3742bdc0e83cafdee1c8da2d62/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_1_X_2017-03-19-0000/src/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc:311:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
      else
     ^~~~
/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/54b89c3742bdc0e83cafdee1c8da2d62/opt/cmssw/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_1_X_2017-03-19-0000/src/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc:315:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
       ++counter_2;
       ^~
