### PR TITLE
Enable ROOT ImplicitMT through config

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -875,6 +875,10 @@ namespace edm {
       if(debugLevel >0) {
 	gDebug = debugLevel;
       }
+
+      // Enable Root implicit multi-threading
+      bool imt = pset.getUntrackedParameter<bool>("EnableIMT");
+      if (imt) ROOT::EnableImplicitMT(4);
     }
 
     InitRootHandlers::~InitRootHandlers () {
@@ -917,6 +921,8 @@ namespace edm {
           ->setComment("If True, enables automatic loading of data dictionaries.");
       desc.addUntracked<bool>("LoadAllDictionaries",false)
           ->setComment("If True, loads all ROOT dictionaries.");
+      desc.addUntracked<bool>("EnableIMT",false)
+          ->setComment("If True, calls ROOT::EnableImplicitMT().");
       desc.addUntracked<bool>("AbortOnSignal",true)
           ->setComment("If True, do an abort when a signal occurs that causes a crash. If False, ROOT will do an exit which attempts to do a clean shutdown.");
       desc.addUntracked<int>("DebugLevel",0)

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -878,7 +878,7 @@ namespace edm {
 
       // Enable Root implicit multi-threading
       bool imt = pset.getUntrackedParameter<bool>("EnableIMT");
-      if (imt) ROOT::EnableImplicitMT(4);
+      if (imt) ROOT::EnableImplicitMT();
     }
 
     InitRootHandlers::~InitRootHandlers () {

--- a/FWCore/Services/python/InitRootHandlers_cfi.py
+++ b/FWCore/Services/python/InitRootHandlers_cfi.py
@@ -6,6 +6,6 @@ InitRootHandlers = cms.Service("InitRootHandlers",
     UnloadRootSigHandler = cms.untracked.bool(False),
     ResetRootErrHandler = cms.untracked.bool(True),
     AutoLibraryLoader = cms.untracked.bool(True),
-    EnableIMT = cms.untracked.bool(True),
+    EnableIMT = cms.untracked.bool(False),
     AbortOnSignal = cms.untracked.bool(True)
 )

--- a/FWCore/Services/python/InitRootHandlers_cfi.py
+++ b/FWCore/Services/python/InitRootHandlers_cfi.py
@@ -6,5 +6,6 @@ InitRootHandlers = cms.Service("InitRootHandlers",
     UnloadRootSigHandler = cms.untracked.bool(False),
     ResetRootErrHandler = cms.untracked.bool(True),
     AutoLibraryLoader = cms.untracked.bool(True),
+    EnableIMT = cms.untracked.bool(True),
     AbortOnSignal = cms.untracked.bool(True)
 )


### PR DESCRIPTION
This enables ROOT IMT in CMSSW. It must be used with a build of ROOT with IMT enabled.