### PR TITLE
Speed Up Cellular Automaton implementation

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -12,344 +12,301 @@
 
 class CACell {
 public:
-    using Hit = RecHitsSortedInPhi::Hit;
-    using CAntuplet = std::vector<CACell*>;
-
-    CACell(const HitDoublets* doublets, int doubletId, const unsigned int cellId, const int innerHitId, const int outerHitId) :
+  using Hit = RecHitsSortedInPhi::Hit;
+  using CAntuple = std::vector<unsigned int>;
+  using CAntuplet = std::vector<unsigned int>;
+  using CAColl = std::vector<CACell>;
+  
+  
+  CACell(const HitDoublets* doublets, int doubletId, const unsigned int cellId, const int innerHitId, const int outerHitId) :
     theCAState(0),hasSameStateNeighbors(0),
-    theDoublets(doublets), theDoubletId(doubletId),
-    theCellId(cellId)
-    ,theInnerR(doublets->rv(doubletId, HitDoublets::inner)), theOuterR(doublets->rv(doubletId, HitDoublets::outer))
-    ,theInnerZ(doublets->z(doubletId, HitDoublets::inner)), theOuterZ(doublets->z(doubletId, HitDoublets::outer)) 
-    {}
+    theDoublets(doublets), theDoubletId(doubletId)
+    ,theInnerR(doublets->rv(doubletId, HitDoublets::inner)) //, theOuterR(doublets->rv(doubletId, HitDoublets::outer))
+    ,theInnerZ(doublets->z(doubletId, HitDoublets::inner)) // , theOuterZ(doublets->z(doubletId, HitDoublets::outer)) 
+  {}
 
-    unsigned int getCellId() const {
-        return theCellId;
-    }
-
+   
+  
+  Hit const & getInnerHit() const {
+    return theDoublets->hit(theDoubletId, HitDoublets::inner);
+  }
+  
+  Hit const & getOuterHit() const {
+    return theDoublets->hit(theDoubletId, HitDoublets::outer);
+  }
+  
+  
+  float getInnerX() const {
+    return theDoublets->x(theDoubletId, HitDoublets::inner);
+  }
+  
+  float getOuterX() const {
+    return theDoublets->x(theDoubletId, HitDoublets::outer);
+  }
+  
+  float getInnerY() const {
+    return theDoublets->y(theDoubletId, HitDoublets::inner);
+  }
+  
+  float getOuterY() const {
+    return theDoublets->y(theDoubletId, HitDoublets::outer);
+  }
+  
+  float getInnerZ() const {
+    //    return theDoublets->z(theDoubletId, HitDoublets::inner);
+    return theInnerZ;
+  }
+  
+  float getOuterZ() const {
+    return theDoublets->z(theDoubletId, HitDoublets::outer);
+    // return theOuterZ;
+  }
+  
+  float getInnerR() const {
+    //      return theDoublets->rv(theDoubletId, HitDoublets::inner);
+    return theInnerR;
+  }
+  
+  float getOuterR() const {
+    return theDoublets->rv(theDoubletId, HitDoublets::outer);
+    // return theOuterR;
+  }
+  
+  float getInnerPhi() const {
+    return theDoublets->phi(theDoubletId, HitDoublets::inner);
+  }
+  
+  float getOuterPhi() const {
+    return theDoublets->phi(theDoubletId, HitDoublets::outer);
+  }
+  
+  void evolve(CAColl& allCells) {
     
-    Hit const & getInnerHit() const {
-        return theDoublets->hit(theDoubletId, HitDoublets::inner);
-    }
-
-    Hit const & getOuterHit() const {
-        return theDoublets->hit(theDoubletId, HitDoublets::outer);
-    }
+    hasSameStateNeighbors = 0;
+    unsigned int numberOfNeighbors = theOuterNeighbors.size();
     
-
-    float getInnerX() const {
-        return theDoublets->x(theDoubletId, HitDoublets::inner);
-    }
-
-    float getOuterX() const {
-        return theDoublets->x(theDoubletId, HitDoublets::outer);
-    }
-
-    float getInnerY() const {
-        return theDoublets->y(theDoubletId, HitDoublets::inner);
-    }
-
-    float getOuterY() const {
-        return theDoublets->y(theDoubletId, HitDoublets::outer);
-    }
-
-    float getInnerZ() const {
-  //    return theDoublets->z(theDoubletId, HitDoublets::inner);
-        return theInnerZ;
-    }
-
-    float getOuterZ() const {
-//      return theDoublets->z(theDoubletId, HitDoublets::outer);
-        return theOuterZ;
-    }
-
-    float getInnerR() const {
-//      return theDoublets->r(theDoubletId, HitDoublets::inner);
-      return theInnerR;
-    }
-
-    float getOuterR() const {
-//      return theDoublets->r(theDoubletId, HitDoublets::outer);
-      return theOuterR;
-    }
-
-    float getInnerPhi() const {
-        return theDoublets->phi(theDoubletId, HitDoublets::inner);
-    }
-
-    float getOuterPhi() const {
-        return theDoublets->phi(theDoubletId, HitDoublets::outer);
-    }
-
-    void evolve() {
-
-        hasSameStateNeighbors = 0;
-        unsigned int numberOfNeighbors = theOuterNeighbors.size();
-
-        for (unsigned int i = 0; i < numberOfNeighbors; ++i) {
-
-            if (theOuterNeighbors[i]->getCAState() == theCAState) {
-
-                hasSameStateNeighbors = 1;
-
-                break;
-            }
-        }
-
-    }
-
-
-    void checkAlignmentAndAct(CAntuplet & innerCells, const float ptmin, const float region_origin_x,
-                const float region_origin_y, const float region_origin_radius, const float thetaCut,
-                        const float phiCut, const float hardPtCut, std::vector<CACell::CAntuplet> * foundTriplets) {
-         int ncells = innerCells.size();
-         int constexpr VSIZE = 16;
-         int ok[VSIZE];
-         float r1[VSIZE];
-         float z1[VSIZE];
-          
-         auto loop = [&](int i, int vs) {
-            for (int j=0;j<vs; ++j) {
-                auto oc = innerCells[i+j];
-                r1[j] = oc->getInnerR();
-                z1[j] = oc->getInnerZ();
-            }
-            for	(int j=0;j<vs; ++j) ok[j] = areAlignedRZ(r1[j], z1[j], ptmin, thetaCut);
-            for (int j=0;j<vs; ++j) {
-             auto oc	= innerCells[i+j]; 
-               if (ok[j]&&haveSimilarCurvature(oc,ptmin, region_origin_x, region_origin_y,
-                                        region_origin_radius, phiCut, hardPtCut)) {
-                  if (foundTriplets) foundTriplets->emplace_back(CACell::CAntuplet{oc,this});
-                  else {
-                    tagAsInnerNeighbor(oc);
-                    oc->tagAsOuterNeighbor(this);
-                  }
-               } }
-        };
-        auto lim = VSIZE*(ncells/VSIZE);
-        for (int i=0; i<lim; i+=VSIZE) loop(i, VSIZE); 
-        loop(lim, ncells-lim);
-
-    }
-
-    void checkAlignmentAndTag(CAntuplet & innerCells, const float ptmin, const float region_origin_x,
-                const float region_origin_y, const float region_origin_radius, const float thetaCut,
-                        const float phiCut, const float hardPtCut) {
-         checkAlignmentAndAct(innerCells, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut,                                                    
-                              phiCut, hardPtCut, nullptr);
-
-    }
-    void checkAlignmentAndPushTriplet(CAntuplet & innerCells, std::vector<CACell::CAntuplet>& foundTriplets,
-                const float ptmin, const float region_origin_x, const float region_origin_y,
-                        const float region_origin_radius, const float thetaCut, const float phiCut,
-                        const float hardPtCut) {
-         checkAlignmentAndAct(innerCells, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut,
-	        	      phiCut, hardPtCut, &foundTriplets);
-    }
-
-
-    void checkAlignmentAndTag(CACell* innerCell, const float ptmin, const float region_origin_x,
-    		const float region_origin_y, const float region_origin_radius, const float thetaCut,
-			const float phiCut, const float hardPtCut) {
-
-        if (areAlignedRZ(innerCell, ptmin, thetaCut) &&
-        		haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y,
-        				region_origin_radius, phiCut, hardPtCut)) {
-            tagAsInnerNeighbor(innerCell);
-            innerCell->tagAsOuterNeighbor(this);
-        }
-    }
-
-    void checkAlignmentAndPushTriplet(CACell* innerCell, std::vector<CACell::CAntuplet>& foundTriplets,
-    		const float ptmin, const float region_origin_x, const float region_origin_y,
-			const float region_origin_radius, const float thetaCut, const float phiCut,
-			const float hardPtCut) {
-
-        if (areAlignedRZ(innerCell, ptmin, thetaCut) &&
-        		haveSimilarCurvature(innerCell,ptmin, region_origin_x, region_origin_y,
-        				region_origin_radius, phiCut, hardPtCut)) {
-        	foundTriplets.emplace_back(CACell::CAntuplet{innerCell,this});
-
-        }
-    }
-
-
-
-    bool areAlignedRZ(const CACell* otherCell, const float ptmin, const float thetaCut) const
-    {
-
-        float r1 = otherCell->getInnerR();
-        float z1 = otherCell->getInnerZ();
-        float radius_diff = std::abs(r1 - getOuterR());
-        float distance_13_squared = radius_diff*radius_diff + (z1 - getOuterZ())*(z1 - getOuterZ());
-
-        float pMin = ptmin*std::sqrt(distance_13_squared); //this needs to be divided by radius_diff later
-
-        float tan_12_13_half_mul_distance_13_squared = fabs(z1 * (getInnerR() - getOuterR()) + getInnerZ() * (getOuterR() - r1) + getOuterZ() * (r1 - getInnerR())) ;
-        return tan_12_13_half_mul_distance_13_squared * pMin <= thetaCut * distance_13_squared * radius_diff;
-    }
-
-    int areAlignedRZ(float r1, float z1, const float ptmin, const float thetaCut) const
-    {
-        float radius_diff = std::abs(r1 - getOuterR());
-        float distance_13_squared = radius_diff*radius_diff + (z1 - getOuterZ())*(z1 - getOuterZ());
-
-        float pMin = ptmin*std::sqrt(distance_13_squared); //this needs to be divided by radius_diff later
-
-        float tan_12_13_half_mul_distance_13_squared = fabs(z1 * (getInnerR() - getOuterR()) + getInnerZ() * (getOuterR() - r1) + getOuterZ() * (r1 - getInnerR())) ;
-        return tan_12_13_half_mul_distance_13_squared * pMin <= thetaCut * distance_13_squared * radius_diff;
-    }
-
-
-    void tagAsOuterNeighbor(CACell* otherCell)
-    {
-        theOuterNeighbors.push_back(otherCell);
-    }
-
-    void tagAsInnerNeighbor(CACell* otherCell)
-    {
-        theInnerNeighbors.push_back(otherCell);
-    }
-
-    bool haveSimilarCurvature(const CACell* otherCell, const float ptmin,
-            const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float phiCut, const float hardPtCut) const
-    {
-
-
-        auto x1 = otherCell->getInnerX();
-        auto y1 = otherCell->getInnerY();
-
-        auto x2 = getInnerX();
-        auto y2 = getInnerY();
-
-        auto x3 = getOuterX();
-        auto y3 = getOuterY();
-
-        float distance_13_squared = (x1 - x3)*(x1 - x3) + (y1 - y3)*(y1 - y3);
-        float tan_12_13_half_mul_distance_13_squared = std::abs(y1 * (x2 - x3) + y2 * (x3 - x1) + y3 * (x1 - x2)) ;
-        if(tan_12_13_half_mul_distance_13_squared * ptmin <= 1.0e-4f*distance_13_squared)
-        {
-
-            float distance_3_beamspot_squared = (x3-region_origin_x) * (x3-region_origin_x) + (y3-region_origin_y) * (y3-region_origin_y);
-
-            float dot_bs3_13 = ((x1 - x3)*( region_origin_x - x3) + (y1 - y3) * (region_origin_y-y3));
-            float proj_bs3_on_13_squared = dot_bs3_13*dot_bs3_13/distance_13_squared;
-
-            float distance_13_beamspot_squared  = distance_3_beamspot_squared -  proj_bs3_on_13_squared;
-
-            if(distance_13_beamspot_squared > (region_origin_radius+phiCut)*(region_origin_radius+phiCut) )
-            { 
-                return false;
-            }
-            return true;
-        }
-
-        //87 cm/GeV = 1/(3.8T * 0.3)
-
-        //take less than radius given by the hardPtCut and reject everything below
-        float minRadius = hardPtCut*87.f;
-
-        auto det = (x1 - x2) * (y2 - y3) - (x2 - x3) * (y1 - y2);
-
-
-        auto offset = x2 * x2 + y2*y2;
-
-        auto bc = (x1 * x1 + y1 * y1 - offset)*0.5f;
-
-        auto cd = (offset - x3 * x3 - y3 * y3)*0.5f;
-
-
-
-        auto idet = 1.f / det;
-
-        auto x_center = (bc * (y2 - y3) - cd * (y1 - y2)) * idet;
-        auto y_center = (cd * (x1 - x2) - bc * (x2 - x3)) * idet;
-
-        auto radius = std::sqrt((x2 - x_center)*(x2 - x_center) + (y2 - y_center)*(y2 - y_center));
-
-        if(radius < minRadius)
-        	return false;
-        auto centers_distance_squared = (x_center - region_origin_x)*(x_center - region_origin_x) + (y_center - region_origin_y)*(y_center - region_origin_y);
-        auto region_origin_radius_plus_tolerance = region_origin_radius + phiCut;
-        auto minimumOfIntersectionRange = (radius - region_origin_radius_plus_tolerance)*(radius - region_origin_radius_plus_tolerance);
-
-        if (centers_distance_squared >= minimumOfIntersectionRange) {
-            auto maximumOfIntersectionRange = (radius + region_origin_radius_plus_tolerance)*(radius + region_origin_radius_plus_tolerance);
-            return centers_distance_squared <= maximumOfIntersectionRange;
-        } 
-
-        return false;
-        
-
-
-    }
-
-    unsigned int getCAState() const {
-        return theCAState;
-    }
-    // if there is at least one left neighbor with the same state (friend), the state has to be increased by 1.
-
-    void updateState() {
-        theCAState += hasSameStateNeighbors;
-    }
-
-    bool isRootCell(const unsigned int minimumCAState) const {
-        return (theCAState >= minimumCAState);
-    }
-
-    // trying to free the track building process from hardcoded layers, leaving the visit of the graph
-    // based on the neighborhood connections between cells.
-
-    void findNtuplets(std::vector<CAntuplet>& foundNtuplets, CAntuplet& tmpNtuplet, const unsigned int minHitsPerNtuplet) const {
-
-        // the building process for a track ends if:
-        // it has no outer neighbor
-        // it has no compatible neighbor
-        // the ntuplets is then saved if the number of hits it contains is greater than a threshold
-
-        if (tmpNtuplet.size() == minHitsPerNtuplet - 1)
-        {
-            foundNtuplets.push_back(tmpNtuplet);
-        }
-        else
-        {
-        	if(theOuterNeighbors.size() == 0)
-        	{
-        		return;
-        	}
-        	else
-        	{
-                unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
-                for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
-                    tmpNtuplet.push_back((theOuterNeighbors[i]));
-                    theOuterNeighbors[i]->findNtuplets(foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
-                    tmpNtuplet.pop_back();
-                }
-        	}
-
-        }
-
+    for (unsigned int i = 0; i < numberOfNeighbors; ++i) {
+      
+      if (allCells[theOuterNeighbors[i]].getCAState() == theCAState) {
+	
+	hasSameStateNeighbors = 1;
+	
+	break;
+      }
     }
     
+  }
+  
+
+  void checkAlignmentAndAct(CAColl& allCells, CAntuple & innerCells, const float ptmin, const float region_origin_x,
+			    const float region_origin_y, const float region_origin_radius, const float thetaCut,
+			    const float phiCut, const float hardPtCut, std::vector<CACell::CAntuplet> * foundTriplets) {
+    int ncells = innerCells.size();
+    int constexpr VSIZE = 16;
+    int ok[VSIZE];
+    float r1[VSIZE];
+    float z1[VSIZE];
+    auto ro = getOuterR();
+    auto zo = getOuterZ();
+    unsigned int cellId = this - &allCells.front();
+    auto loop = [&](int i, int vs) {
+      for (int j=0;j<vs; ++j) {
+	auto koc = innerCells[i+j];
+	auto & oc =  allCells[koc];
+	r1[j] = oc.getInnerR();
+	z1[j] = oc.getInnerZ();
+      }
+      for	(int j=0;j<vs; ++j) ok[j] = areAlignedRZ(r1[j], z1[j], ro, zo, ptmin, thetaCut);
+      for (int j=0;j<vs; ++j) {
+	auto koc = innerCells[i+j];
+	auto & oc =  allCells[koc]; 
+	if (ok[j]&&haveSimilarCurvature(oc,ptmin, region_origin_x, region_origin_y,
+					region_origin_radius, phiCut, hardPtCut)) {
+	  if (foundTriplets) foundTriplets->emplace_back(CACell::CAntuplet{koc,cellId});
+	  else {
+	    oc.tagAsOuterNeighbor(cellId);
+	  }
+	} }
+    };
+    auto lim = VSIZE*(ncells/VSIZE);
+    for (int i=0; i<lim; i+=VSIZE) loop(i, VSIZE); 
+    loop(lim, ncells-lim);
     
+  }
+  
+  void checkAlignmentAndTag(CAColl& allCells, CAntuple & innerCells, const float ptmin, const float region_origin_x,
+			    const float region_origin_y, const float region_origin_radius, const float thetaCut,
+			    const float phiCut, const float hardPtCut) {
+    checkAlignmentAndAct(allCells, innerCells, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut,
+			 phiCut, hardPtCut, nullptr);
+    
+  }
+  void checkAlignmentAndPushTriplet(CAColl& allCells, CAntuple & innerCells, std::vector<CACell::CAntuplet>& foundTriplets,
+				    const float ptmin, const float region_origin_x, const float region_origin_y,
+				    const float region_origin_radius, const float thetaCut, const float phiCut,
+				    const float hardPtCut) {
+    checkAlignmentAndAct(allCells, innerCells, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut,
+			 phiCut, hardPtCut, &foundTriplets);
+  }
+  
+  
+  int areAlignedRZ(float r1, float z1, float ro, float zo, const float ptmin, const float thetaCut) const
+  {
+    float radius_diff = std::abs(r1 - ro);
+    float distance_13_squared = radius_diff*radius_diff + (z1 - zo)*(z1 - zo);
+    
+    float pMin = ptmin*std::sqrt(distance_13_squared); //this needs to be divided by radius_diff later
+    
+    float tan_12_13_half_mul_distance_13_squared = fabs(z1 * (getInnerR() - ro) + getInnerZ() * (ro - r1) + zo * (r1 - getInnerR())) ;
+    return tan_12_13_half_mul_distance_13_squared * pMin <= thetaCut * distance_13_squared * radius_diff;
+  }
+  
+  
+  void tagAsOuterNeighbor(unsigned int otherCell)
+  {
+    theOuterNeighbors.push_back(otherCell);
+  }
+  
+  void tagAsInnerNeighbor(unsigned int otherCell)
+  {
+    //  theInnerNeighbors.push_back(otherCell);
+  }
+  
+  bool haveSimilarCurvature(const CACell & otherCell, const float ptmin,
+			    const float region_origin_x, const float region_origin_y, const float region_origin_radius, const float phiCut, const float hardPtCut) const
+  {
+    
+    
+    auto x1 = otherCell.getInnerX();
+    auto y1 = otherCell.getInnerY();
+    
+    auto x2 = getInnerX();
+    auto y2 = getInnerY();
+    
+    auto x3 = getOuterX();
+    auto y3 = getOuterY();
+    
+    float distance_13_squared = (x1 - x3)*(x1 - x3) + (y1 - y3)*(y1 - y3);
+    float tan_12_13_half_mul_distance_13_squared = std::abs(y1 * (x2 - x3) + y2 * (x3 - x1) + y3 * (x1 - x2)) ;
+    if(tan_12_13_half_mul_distance_13_squared * ptmin <= 1.0e-4f*distance_13_squared)
+      {
+	
+	float distance_3_beamspot_squared = (x3-region_origin_x) * (x3-region_origin_x) + (y3-region_origin_y) * (y3-region_origin_y);
+	
+	float dot_bs3_13 = ((x1 - x3)*( region_origin_x - x3) + (y1 - y3) * (region_origin_y-y3));
+	float proj_bs3_on_13_squared = dot_bs3_13*dot_bs3_13/distance_13_squared;
+	
+	float distance_13_beamspot_squared  = distance_3_beamspot_squared -  proj_bs3_on_13_squared;
+	
+	if(distance_13_beamspot_squared > (region_origin_radius+phiCut)*(region_origin_radius+phiCut) )
+	  { 
+	    return false;
+	  }
+	return true;
+      }
+    
+    //87 cm/GeV = 1/(3.8T * 0.3)
+    
+    //take less than radius given by the hardPtCut and reject everything below
+    float minRadius = hardPtCut*87.f;
+    
+    auto det = (x1 - x2) * (y2 - y3) - (x2 - x3) * (y1 - y2);
+    
+    
+    auto offset = x2 * x2 + y2*y2;
+    
+    auto bc = (x1 * x1 + y1 * y1 - offset)*0.5f;
+    
+    auto cd = (offset - x3 * x3 - y3 * y3)*0.5f;
+    
+    
+    
+    auto idet = 1.f / det;
+    
+    auto x_center = (bc * (y2 - y3) - cd * (y1 - y2)) * idet;
+    auto y_center = (cd * (x1 - x2) - bc * (x2 - x3)) * idet;
+    
+    auto radius = std::sqrt((x2 - x_center)*(x2 - x_center) + (y2 - y_center)*(y2 - y_center));
+    
+    if(radius < minRadius)
+      return false;
+    auto centers_distance_squared = (x_center - region_origin_x)*(x_center - region_origin_x) + (y_center - region_origin_y)*(y_center - region_origin_y);
+    auto region_origin_radius_plus_tolerance = region_origin_radius + phiCut;
+    auto minimumOfIntersectionRange = (radius - region_origin_radius_plus_tolerance)*(radius - region_origin_radius_plus_tolerance);
+    
+    if (centers_distance_squared >= minimumOfIntersectionRange) {
+      auto maximumOfIntersectionRange = (radius + region_origin_radius_plus_tolerance)*(radius + region_origin_radius_plus_tolerance);
+      return centers_distance_squared <= maximumOfIntersectionRange;
+    } 
+    
+    return false;
+    
+  }
+  
+  unsigned int getCAState() const {
+    return theCAState;
+  }
+  
+  // if there is at least one left neighbor with the same state (friend), the state has to be increased by 1.
+  void updateState() {
+    theCAState += hasSameStateNeighbors;
+  }
+  
+  bool isRootCell(const unsigned int minimumCAState) const {
+    return (theCAState >= minimumCAState);
+  }
+  
+  // trying to free the track building process from hardcoded layers, leaving the visit of the graph
+  // based on the neighborhood connections between cells.
+  
+  void findNtuplets(CAColl& allCells, std::vector<CAntuplet>& foundNtuplets, CAntuplet& tmpNtuplet, const unsigned int minHitsPerNtuplet) const {
+    
+    // the building process for a track ends if:
+    // it has no outer neighbor
+    // it has no compatible neighbor
+    // the ntuplets is then saved if the number of hits it contains is greater than a threshold
+    
+    if (tmpNtuplet.size() == minHitsPerNtuplet - 1)
+      {
+	foundNtuplets.push_back(tmpNtuplet);
+      }
+    else
+      {
+	if(theOuterNeighbors.size() == 0)
+	  {
+	    return;
+	  }
+	else
+	  {
+	    unsigned int numberOfOuterNeighbors = theOuterNeighbors.size();
+	    for (unsigned int i = 0; i < numberOfOuterNeighbors; ++i) {
+	      tmpNtuplet.push_back((theOuterNeighbors[i]));
+	      allCells[theOuterNeighbors[i]].findNtuplets(allCells,foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+	      tmpNtuplet.pop_back();
+	    }
+	  }
+	
+      }
+    
+  }
+  
+  
 private:
-    unsigned int theCAState;
-    unsigned int hasSameStateNeighbors;
+  unsigned char theCAState;
+  unsigned char hasSameStateNeighbors;
+  
+  CAntuple theOuterNeighbors;
 
-    std::vector<CACell*> theInnerNeighbors;
-    std::vector<CACell*> theOuterNeighbors;
-
-    const HitDoublets* theDoublets;  
-    const int theDoubletId;
-
-    const unsigned int theCellId;
-
-    
-    const float theInnerR;
-    const float theOuterR;
-    const float theInnerZ;
-    const float theOuterZ;
-    
+  // CAntuple theInnerNeighbors;
+  
+  const HitDoublets* theDoublets;  
+  const int theDoubletId;
+  
+  const float theInnerR;
+  // const float theOuterR;
+  const float theInnerZ;
+  // const float theOuterZ;
+  
 };
 
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -19,7 +19,7 @@ public:
     theCAState(0),hasSameStateNeighbors(0),
     theDoublets(doublets), theDoubletId(doubletId),
     theCellId(cellId)
-    ,theInnerR(doublets->r(doubletId, HitDoublets::inner)), theOuterR(doublets->r(doubletId, HitDoublets::outer))
+    ,theInnerR(doublets->rv(doubletId, HitDoublets::inner)), theOuterR(doublets->rv(doubletId, HitDoublets::outer))
     ,theInnerZ(doublets->z(doubletId, HitDoublets::inner)), theOuterZ(doublets->z(doubletId, HitDoublets::outer)) 
     {}
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CACell.h
@@ -99,9 +99,9 @@ public:
     }
 
 
-    void checkAlignmentAndTag(CAntuplet & innerCells, const float ptmin, const float region_origin_x,
+    void checkAlignmentAndAct(CAntuplet & innerCells, const float ptmin, const float region_origin_x,
                 const float region_origin_y, const float region_origin_radius, const float thetaCut,
-                        const float phiCut, const float hardPtCut) {
+                        const float phiCut, const float hardPtCut, std::vector<CACell::CAntuplet> * foundTriplets) {
          int ncells = innerCells.size();
          int constexpr VSIZE = 16;
          int ok[VSIZE];
@@ -119,8 +119,11 @@ public:
              auto oc	= innerCells[i+j]; 
                if (ok[j]&&haveSimilarCurvature(oc,ptmin, region_origin_x, region_origin_y,
                                         region_origin_radius, phiCut, hardPtCut)) {
-                  tagAsInnerNeighbor(oc);
-                  oc->tagAsOuterNeighbor(this);
+                  if (foundTriplets) foundTriplets->emplace_back(CACell::CAntuplet{oc,this});
+                  else {
+                    tagAsInnerNeighbor(oc);
+                    oc->tagAsOuterNeighbor(this);
+                  }
                } }
         };
         auto lim = VSIZE*(ncells/VSIZE);
@@ -128,6 +131,23 @@ public:
         loop(lim, ncells-lim);
 
     }
+
+    void checkAlignmentAndTag(CAntuplet & innerCells, const float ptmin, const float region_origin_x,
+                const float region_origin_y, const float region_origin_radius, const float thetaCut,
+                        const float phiCut, const float hardPtCut) {
+         checkAlignmentAndAct(innerCells, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut,                                                    
+                              phiCut, hardPtCut, nullptr);
+
+    }
+    void checkAlignmentAndPushTriplet(CAntuplet & innerCells, std::vector<CACell::CAntuplet>& foundTriplets,
+                const float ptmin, const float region_origin_x, const float region_origin_y,
+                        const float region_origin_radius, const float thetaCut, const float phiCut,
+                        const float hardPtCut) {
+         checkAlignmentAndAct(innerCells, ptmin, region_origin_x, region_origin_y, region_origin_radius, thetaCut,
+	        	      phiCut, hardPtCut, &foundTriplets);
+    }
+
+
     void checkAlignmentAndTag(CACell* innerCell, const float ptmin, const float region_origin_x,
     		const float region_origin_y, const float region_origin_radius, const float thetaCut,
 			const float phiCut, const float hardPtCut) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include <array>
 #include <string>
-#include <queue>
-#include <functional>
-#include "CACell.h"
 
 struct CALayer
 {
@@ -58,8 +55,7 @@ struct CALayerPair
 	}
 
 	std::array<int, 2> theLayers;
-	std::array<unsigned int, 2> theFoundCells;
-
+	std::array<unsigned int, 2> theFoundCells= {{0,0}};
 };
 
 struct CAGraph
@@ -67,7 +63,6 @@ struct CAGraph
 	std::vector<CALayer> theLayers;
 	std::vector<CALayerPair> theLayerPairs;
 	std::vector<int> theRootLayers;
-
 };
 
 #endif /* CAGRAPH_H_ */

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAGraph.h
@@ -31,7 +31,7 @@ struct CALayer
 
 	std::vector<int> theOuterLayers;
 	std::vector<int> theInnerLayers;
-	std::vector< std::vector<CACell*> >  isOuterHitOfCell;
+	std::vector< std::vector<unsigned int> >  isOuterHitOfCell;
 
 
 private:
@@ -58,7 +58,7 @@ struct CALayerPair
 	}
 
 	std::array<int, 2> theLayers;
-	std::vector<CACell> theFoundCells;
+	std::array<unsigned int, 2> theFoundCells;
 
 };
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -138,7 +138,7 @@ namespace {
 		g.theLayers[i].theInnerLayerPairs.clear();
 		g.theLayers[i].theOuterLayers.clear();
 		g.theLayers[i].theOuterLayerPairs.clear();
-
+		for (auto & v : g.theLayers[i].isOuterHitOfCell) v.clear();
 	}
 
   }
@@ -443,7 +443,7 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
 
 void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
                                               OrderedHitSeeds & result,
-                                              std::vector<const HitDoublets *>& hitDoublets, const CAGraph& g,
+                                              std::vector<const HitDoublets *>& hitDoublets, CAGraph& g,
                                               const edm::EventSetup& es) {
 	//Retrieve tracker topology from geometry
 	edm::ESHandle<TrackerTopology> tTopoHand;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.cc
@@ -234,6 +234,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
         hitQuadruplets(region, result, hitDoubletsPtr, g, es);
         theLayerCache.clear();
 }
+
 void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDoublets,
                                               std::vector<OrderedHitSeeds>& result,
                                               const edm::EventSetup& es,
@@ -292,7 +293,8 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
 
 	ca.findNtuplets(foundQuadruplets, numberOfHitsInNtuplet);
 
-
+	auto & allCells = ca.getAllCells();
+	
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
  	// re-used thoughout
@@ -321,13 +323,13 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
     		};
     		for(unsigned int i = 0; i< 3; ++i)
     		{
-        		auto const& ahit = foundQuadruplets[quadId][i]->getInnerHit();
+        		auto const& ahit = allCells[foundQuadruplets[quadId][i]].getInnerHit();
         		gps[i] = ahit->globalPosition();
         		ges[i] = ahit->globalPositionError();
         		barrels[i] = isBarrel(ahit->geographicalId().subdetId());
     		}
 
-    		auto const& ahit = foundQuadruplets[quadId][2]->getOuterHit();
+    		auto const& ahit = allCells[foundQuadruplets[quadId][2]].getOuterHit();
     		gps[3] = ahit->globalPosition();
     		ges[3] = ahit->globalPositionError();
     		barrels[3] = isBarrel(ahit->geographicalId().subdetId());
@@ -336,10 +338,10 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
  	     		const auto fourthLayerId = tTopo->layer(ahit->geographicalId());
             		const auto sideId = tTopo->side(ahit->geographicalId());
             		const auto subDetId = ahit->geographicalId().subdetId();
-    			const auto isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
+    			const auto isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0] ==  previousCellIds[0]) && (foundQuadruplets[quadId][1] ==  previousCellIds[1]);
    			const auto isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
 
-    			previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
+    			previousCellIds = {{foundQuadruplets[quadId][0], foundQuadruplets[quadId][1]}};
     			previousfourthLayerId = fourthLayerId;
 
 
@@ -362,7 +364,9 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
     		const float thisMaxChi2 = maxChi2Eval.value(abscurv);
     		if (theComparitor)
     		{
-      			SeedingHitSet tmpTriplet(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+      			SeedingHitSet tmpTriplet(allCells[foundQuadruplets[quadId][0]].getInnerHit(),
+						 allCells[foundQuadruplets[quadId][2]].getInnerHit(),
+						 allCells[foundQuadruplets[quadId][2]].getOuterHit());
 
 
       			if (!theComparitor->compatible(tmpTriplet) )
@@ -417,13 +421,19 @@ void CAHitQuadrupletGenerator::hitNtuplets(const IntermediateHitDoublets& region
     				{
     					result[index].pop_back();
     				}
-	    			result[index].emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+	    			result[index].emplace_back(allCells[foundQuadruplets[quadId][0]].getInnerHit(),
+							   allCells[foundQuadruplets[quadId][1]].getInnerHit(),
+							   allCells[foundQuadruplets[quadId][2]].getInnerHit(),
+							   allCells[foundQuadruplets[quadId][2]].getOuterHit());
 	    			hasAlreadyPushedACandidate = true;
     			}
    		}
     		else
     		{
-	       		result[index].emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+		  result[index].emplace_back(allCells[foundQuadruplets[quadId][0]].getInnerHit(),
+					     allCells[foundQuadruplets[quadId][1]].getInnerHit(),
+					     allCells[foundQuadruplets[quadId][2]].getInnerHit(),
+					     allCells[foundQuadruplets[quadId][2]].getOuterHit());
     		}
         }
 	index++;
@@ -452,6 +462,7 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
 	ca.findNtuplets(foundQuadruplets, numberOfHitsInNtuplet);
 
+	auto & allCells = ca.getAllCells();
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
@@ -481,13 +492,13 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
     };
     for(unsigned int i = 0; i< 3; ++i)
     {
-        auto const& ahit = foundQuadruplets[quadId][i]->getInnerHit();
+        auto const& ahit = allCells[foundQuadruplets[quadId][i]].getInnerHit();
         gps[i] = ahit->globalPosition();
         ges[i] = ahit->globalPositionError();
         barrels[i] = isBarrel(ahit->geographicalId().subdetId());
     }
 
-    auto const& ahit = foundQuadruplets[quadId][2]->getOuterHit();
+    auto const& ahit = allCells[foundQuadruplets[quadId][2]].getOuterHit();
     gps[3] = ahit->globalPosition();
     ges[3] = ahit->globalPositionError();
     barrels[3] = isBarrel(ahit->geographicalId().subdetId());
@@ -497,10 +508,10 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 	    const auto fourthLayerId = tTopo->layer(ahit->geographicalId());
             const auto sideId = tTopo->side(ahit->geographicalId());
             const auto subDetId = ahit->geographicalId().subdetId();
-    	    const auto isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0]->getCellId() ==  previousCellIds[0]) && (foundQuadruplets[quadId][1]->getCellId() ==  previousCellIds[1]);
+    	    const auto isTheSameTriplet = (quadId != 0) && (foundQuadruplets[quadId][0] ==  previousCellIds[0]) && (foundQuadruplets[quadId][1] ==  previousCellIds[1]);
             const auto isTheSameFourthLayer = (quadId != 0) &&  (fourthLayerId == previousfourthLayerId) && (subDetId == previousSubDetId) && (sideId == previousSideId);
 
-	    previousCellIds = {{foundQuadruplets[quadId][0]->getCellId(), foundQuadruplets[quadId][1]->getCellId()}};
+	    previousCellIds = {{foundQuadruplets[quadId][0], foundQuadruplets[quadId][1]}};
 	    previousfourthLayerId = fourthLayerId;
 
 
@@ -526,7 +537,9 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 
     if (theComparitor)
     {
-      SeedingHitSet tmpTriplet(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+      SeedingHitSet tmpTriplet(allCells[foundQuadruplets[quadId][0]].getInnerHit(),
+			       allCells[foundQuadruplets[quadId][2]].getInnerHit(),
+			       allCells[foundQuadruplets[quadId][2]].getOuterHit());
 
 
       if (!theComparitor->compatible(tmpTriplet) )
@@ -587,16 +600,21 @@ void CAHitQuadrupletGenerator::hitQuadruplets(const TrackingRegion& region,
 			result.pop_back();
 
 		}
-		result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(),
-				foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+   
+		result.emplace_back(allCells[foundQuadruplets[quadId][0]].getInnerHit(),
+				    allCells[foundQuadruplets[quadId][1]].getInnerHit(),
+				    allCells[foundQuadruplets[quadId][2]].getInnerHit(),
+				    allCells[foundQuadruplets[quadId][2]].getOuterHit());
 		hasAlreadyPushedACandidate = true;
-
+		
 	    }
     }
     else
     {
-
-       result.emplace_back(foundQuadruplets[quadId][0]->getInnerHit(), foundQuadruplets[quadId][1]->getInnerHit(), foundQuadruplets[quadId][2]->getInnerHit(), foundQuadruplets[quadId][2]->getOuterHit());
+      result.emplace_back(allCells[foundQuadruplets[quadId][0]].getInnerHit(),
+			  allCells[foundQuadruplets[quadId][1]].getInnerHit(),
+			  allCells[foundQuadruplets[quadId][2]].getInnerHit(),
+			  allCells[foundQuadruplets[quadId][2]].getOuterHit());
     }
      
   }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGenerator.h
@@ -63,7 +63,7 @@ private:
     // actual work
     void hitQuadruplets(const TrackingRegion& reg, OrderedHitSeeds& result,
                         std::vector<const HitDoublets *>& hitDoublets,
-                        const CAGraph& g,
+                        CAGraph& g,
                         const edm::EventSetup& es);
 
     edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -132,7 +132,7 @@ namespace {
 		g.theLayers[i].theInnerLayerPairs.clear();
 		g.theLayers[i].theOuterLayers.clear();
 		g.theLayers[i].theOuterLayerPairs.clear();
-
+		for (auto & v : g.theLayers[i].isOuterHitOfCell) v.clear();
 	}
 
   }
@@ -374,7 +374,7 @@ void CAHitTripletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDou
 
 void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
                                         OrderedHitTriplets & result,
-                                        std::vector<const HitDoublets *>& hitDoublets, const CAGraph& g,
+                                        std::vector<const HitDoublets *>& hitDoublets, CAGraph& g,
                                         const edm::EventSetup& es) {
 	std::vector<CACell::CAntuplet> foundTriplets;
 	CellularAutomaton ca(g);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.cc
@@ -273,7 +273,7 @@ void CAHitTripletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDou
 	ca.findTriplets(hitDoublets, foundTriplets, region, caThetaCut, caPhiCut,
                         caHardPtCut);
 
-
+	auto & allCells = ca.getAllCells();
 
 	const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
@@ -290,9 +290,9 @@ void CAHitTripletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDou
 			++tripletId)
 	{
 
-		OrderedHitTriplet tmpTriplet(foundTriplets[tripletId][0]->getInnerHit(),
-				foundTriplets[tripletId][0]->getOuterHit(),
-				foundTriplets[tripletId][1]->getOuterHit());
+		OrderedHitTriplet tmpTriplet(allCells[foundTriplets[tripletId][0]].getInnerHit(),
+				allCells[foundTriplets[tripletId][0]].getOuterHit(),
+				allCells[foundTriplets[tripletId][1]].getOuterHit());
 
 		auto isBarrel = [](const unsigned id) -> bool
 		{
@@ -300,13 +300,13 @@ void CAHitTripletGenerator::hitNtuplets(const IntermediateHitDoublets& regionDou
 		};
 		for (unsigned int i = 0; i < 2; ++i)
 		{
-			auto const& ahit = foundTriplets[tripletId][i]->getInnerHit();
+			auto const& ahit = allCells[foundTriplets[tripletId][i]].getInnerHit();
 			gps[i] = ahit->globalPosition();
 			ges[i] = ahit->globalPositionError();
 			barrels[i] = isBarrel(ahit->geographicalId().subdetId());
 		}
 
-		auto const& ahit = foundTriplets[tripletId][1]->getOuterHit();
+		auto const& ahit = allCells[foundTriplets[tripletId][1]].getOuterHit();
 		gps[2] = ahit->globalPosition();
 		ges[2] = ahit->globalPositionError();
 		barrels[2] = isBarrel(ahit->geographicalId().subdetId());
@@ -381,6 +381,8 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 
 	ca.findTriplets(hitDoublets, foundTriplets, region, caThetaCut, caPhiCut,
 			caHardPtCut);
+	
+	auto & allCells = ca.getAllCells();
 
 	unsigned int numberOfFoundTriplets = foundTriplets.size();
 
@@ -398,9 +400,9 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 			++tripletId)
 	{
 
-		OrderedHitTriplet tmpTriplet(foundTriplets[tripletId][0]->getInnerHit(),
-				foundTriplets[tripletId][0]->getOuterHit(),
-				foundTriplets[tripletId][1]->getOuterHit());
+		OrderedHitTriplet tmpTriplet(allCells[foundTriplets[tripletId][0]].getInnerHit(),
+					     allCells[foundTriplets[tripletId][0]].getOuterHit(),
+					     allCells[foundTriplets[tripletId][1]].getOuterHit());
 
 		auto isBarrel = [](const unsigned id) -> bool
 		{
@@ -408,13 +410,13 @@ void CAHitTripletGenerator::hitTriplets(const TrackingRegion& region,
 		};
 		for (unsigned int i = 0; i < 2; ++i)
 		{
-			auto const& ahit = foundTriplets[tripletId][i]->getInnerHit();
+			auto const& ahit = allCells[foundTriplets[tripletId][i]].getInnerHit();
 			gps[i] = ahit->globalPosition();
 			ges[i] = ahit->globalPositionError();
 			barrels[i] = isBarrel(ahit->geographicalId().subdetId());
 		}
 
-		auto const& ahit = foundTriplets[tripletId][1]->getOuterHit();
+		auto const& ahit = allCells[foundTriplets[tripletId][1]].getOuterHit();
 		gps[2] = ahit->globalPosition();
 		ges[2] = ahit->globalPositionError();
 		barrels[2] = isBarrel(ahit->geographicalId().subdetId());

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitTripletGenerator.h
@@ -60,7 +60,7 @@ private:
     // actual work
     void hitTriplets(const TrackingRegion& reg, OrderedHitTriplets& result,
                      std::vector<const HitDoublets *>& hitDoublets,
-                     const CAGraph& g,
+                     CAGraph& g,
                      const edm::EventSetup& es);
 
     edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -61,10 +61,10 @@ void CellularAutomaton::createAndConnectCells(const std::vector<const HitDoublet
 							&(currentLayerPairRef.theFoundCells[i]));
 					cellId++;
 
-					for (auto neigCell : currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)])
+					auto & neigCells = currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)];
 					{
 						currentLayerPairRef.theFoundCells[i].checkAlignmentAndTag(
-								neigCell, ptmin, region_origin_x,
+								neigCells, ptmin, region_origin_x,
 								region_origin_y, region_origin_radius, thetaCut,
 								phiCut, hardPtCut);
 					}

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -6,7 +6,7 @@ void CellularAutomaton::createAndConnectCells(const std::vector<const HitDoublet
   int tsize=0;
   for ( auto hd :  hitDoublets) tsize+=hd->size();
   allCells.reserve(tsize);
-
+  allStatus.resize(tsize);
   unsigned int cellId = 0;
 	float ptmin = region.ptMin();
 	float region_origin_x = region.origin().x();
@@ -109,7 +109,7 @@ void CellularAutomaton::evolve(const unsigned int minHitsPerNtuplet)
 		{
 		  for (auto i =layerPair.theFoundCells[0]; i<layerPair.theFoundCells[1]; ++i)
 			{
-				allCells[i].evolve(allCells);
+			  allCells[i].evolve(i,allStatus);
 			}
 		}
 
@@ -117,7 +117,7 @@ void CellularAutomaton::evolve(const unsigned int minHitsPerNtuplet)
 		{
 		  for (auto i =layerPair.theFoundCells[0]; i<layerPair.theFoundCells[1]; ++i)
 			{
-			  allCells[i].updateState();
+			  allStatus[i].updateState();
 			}
 		}
 
@@ -133,12 +133,12 @@ void CellularAutomaton::evolve(const unsigned int minHitsPerNtuplet)
 		  auto foundCells = theLayerGraph.theLayerPairs[rootLayerPair].theFoundCells;
 		  for (auto i =foundCells[0]; i<foundCells[1]; ++i)
 			{
-			  auto & cell =  allCells[i];
-			  cell.evolve(allCells);
+			  auto & cell =  allStatus[i];
+			  allCells[i].evolve(i,allStatus);
 			  cell.updateState();
 			  if (cell.isRootCell(minHitsPerNtuplet - 2))
 			    {
-			      theRootCells.push_back(&cell);
+			      theRootCells.push_back(i);
 			    }
 			}
 		}
@@ -153,11 +153,11 @@ void CellularAutomaton::findNtuplets(
 	CACell::CAntuple tmpNtuplet;
 	tmpNtuplet.reserve(minHitsPerNtuplet);
 
-	for (CACell* root_cell : theRootCells)
+	for (auto root_cell : theRootCells)
 	{
-		tmpNtuplet.clear();
-		tmpNtuplet.push_back(root_cell-&allCells.front());
-		root_cell->findNtuplets(allCells,foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
+	  tmpNtuplet.clear();
+	  tmpNtuplet.push_back(root_cell);
+	  allCells[root_cell].findNtuplets(allCells,foundNtuplets, tmpNtuplet, minHitsPerNtuplet);
 	}
 
 }
@@ -169,6 +169,7 @@ void CellularAutomaton::findTriplets(const std::vector<const HitDoublets*>& hitD
   int tsize=0;
   for ( auto hd :  hitDoublets) tsize+=hd->size();
   allCells.reserve(tsize);
+  allStatus.resize(tsize);
 
   unsigned int cellId = 0;
 	float ptmin = region.ptMin();

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -3,11 +3,11 @@
 void CellularAutomaton::createAndConnectCells(const std::vector<const HitDoublets *>& hitDoublets, const TrackingRegion& region,
 		const float thetaCut, const float phiCut, const float hardPtCut)
 {
-  int tsize=0;
-  for ( auto hd :  hitDoublets) tsize+=hd->size();
-  allCells.reserve(tsize);
-  allStatus.resize(tsize);
-  unsigned int cellId = 0;
+        int tsize=0;
+        for ( auto hd :  hitDoublets) tsize+=hd->size();
+        allCells.reserve(tsize);
+        allStatus.resize(tsize);
+        unsigned int cellId = 0;
 	float ptmin = region.ptMin();
 	float region_origin_x = region.origin().x();
 	float region_origin_y = region.origin().y();
@@ -58,8 +58,7 @@ void CellularAutomaton::createAndConnectCells(const std::vector<const HitDoublet
 				currentLayerPairRef.theFoundCells[1] = cellId+numberOfDoublets;
 				for (unsigned int i = 0; i < numberOfDoublets; ++i)
 				{
-				  allCells.emplace_back(
-							doubletLayerPairId, i, cellId,
+				  allCells.emplace_back(doubletLayerPairId, i,
 							doubletLayerPairId->innerHitId(i),
 							doubletLayerPairId->outerHitId(i));
 				  
@@ -166,12 +165,12 @@ void CellularAutomaton::findNtuplets(
 void CellularAutomaton::findTriplets(const std::vector<const HitDoublets*>& hitDoublets,std::vector<CACell::CAntuplet>& foundTriplets, const TrackingRegion& region,
 		const float thetaCut, const float phiCut, const float hardPtCut)
 {
-  int tsize=0;
-  for ( auto hd :  hitDoublets) tsize+=hd->size();
-  allCells.reserve(tsize);
-  allStatus.resize(tsize);
+        int tsize=0;
+        for ( auto hd :  hitDoublets) tsize+=hd->size();
+        allCells.reserve(tsize);
+        allStatus.resize(tsize);
 
-  unsigned int cellId = 0;
+        unsigned int cellId = 0;
 	float ptmin = region.ptMin();
 	float region_origin_x = region.origin().x();
 	float region_origin_y = region.origin().y();
@@ -222,8 +221,7 @@ void CellularAutomaton::findTriplets(const std::vector<const HitDoublets*>& hitD
 				currentLayerPairRef.theFoundCells[1] = cellId+numberOfDoublets;
 				for (unsigned int i = 0; i < numberOfDoublets; ++i)
 				{
-				  allCells.emplace_back(
-							doubletLayerPairId, i, cellId,
+				  allCells.emplace_back(doubletLayerPairId, i,
 							doubletLayerPairId->innerHitId(i),
 							doubletLayerPairId->outerHitId(i));
 				  

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.cc
@@ -215,13 +215,11 @@ void CellularAutomaton::findTriplets(const std::vector<const HitDoublets*>& hitD
 							&(currentLayerPairRef.theFoundCells[i]));
 					cellId++;
 
-					for (auto neigCell : currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)])
-					{
-						currentLayerPairRef.theFoundCells[i].checkAlignmentAndPushTriplet(
-								neigCell, foundTriplets, ptmin, region_origin_x,
+                                        auto & neigCells = currentInnerLayerRef.isOuterHitOfCell[doubletLayerPairId->innerHitId(i)];
+					currentLayerPairRef.theFoundCells[i].checkAlignmentAndPushTriplet(
+								neigCells, foundTriplets, ptmin, region_origin_x,
 								region_origin_y, region_origin_radius, thetaCut,
 								phiCut, hardPtCut);
-					}
 
 				}
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
@@ -8,7 +8,7 @@
 class CellularAutomaton
 {
 public:
-  CellularAutomaton(const CAGraph& graph)
+  CellularAutomaton(CAGraph& graph)
     : theLayerGraph(graph)
   {
     
@@ -25,9 +25,11 @@ public:
 		    const float thetaCut, const float phiCut, const float hardPtCut);
   
 private:
+  CAGraph & theLayerGraph;
+
   std::vector<CACell> allCells;
   std::vector<CACellStatus> allStatus;
-  CAGraph theLayerGraph;
+
   std::vector<unsigned int> theRootCells;
   std::vector<std::vector<CACell*> > theNtuplets;
   

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
@@ -26,8 +26,9 @@ public:
   
 private:
   std::vector<CACell> allCells;
+  std::vector<CACellStatus> allStatus;
   CAGraph theLayerGraph;
-  std::vector<CACell*> theRootCells;
+  std::vector<unsigned int> theRootCells;
   std::vector<std::vector<CACell*> > theNtuplets;
   
 };

--- a/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CellularAutomaton.h
@@ -8,25 +8,28 @@
 class CellularAutomaton
 {
 public:
-	CellularAutomaton(const CAGraph& graph)
-	: theLayerGraph(graph)
-	{
-
-	}
-
-	void createAndConnectCells(const std::vector<const HitDoublets *>&,
-			const TrackingRegion&, const float, const float, const float);
-
-	void evolve(const unsigned int);
-	void findNtuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
-	void findTriplets(const std::vector<const HitDoublets*>& hitDoublets,std::vector<CACell::CAntuplet>& foundTriplets, const TrackingRegion& region,
-			const float thetaCut, const float phiCut, const float hardPtCut);
-
+  CellularAutomaton(const CAGraph& graph)
+    : theLayerGraph(graph)
+  {
+    
+  }
+  
+  std::vector<CACell> & getAllCells() { return allCells;}
+  
+  void createAndConnectCells(const std::vector<const HitDoublets *>&,
+			     const TrackingRegion&, const float, const float, const float);
+  
+  void evolve(const unsigned int);
+  void findNtuplets(std::vector<CACell::CAntuplet>&, const unsigned int);
+  void findTriplets(const std::vector<const HitDoublets*>& hitDoublets,std::vector<CACell::CAntuplet>& foundTriplets, const TrackingRegion& region,
+		    const float thetaCut, const float phiCut, const float hardPtCut);
+  
 private:
-	CAGraph theLayerGraph;
-	std::vector<CACell*> theRootCells;
-	std::vector<std::vector<CACell*> > theNtuplets;
-
+  std::vector<CACell> allCells;
+  CAGraph theLayerGraph;
+  std::vector<CACell*> theRootCells;
+  std::vector<std::vector<CACell*> > theNtuplets;
+  
 };
 
 #endif 

--- a/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
+++ b/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include<array>
 
+#include<cassert>
+
 /** A RecHit container sorted in phi.
  *  Provides fast access for hits in a given phi window
  *  using binary search.
@@ -85,8 +87,8 @@ public:
 
 public:
   float       phi(int i) const { return theHits[i].phi();}
-  float        gv(int i) const { return isBarrel ? z[i] : gp(i).perp();}  // global v
-  float        rv(int i) const { return isBarrel ? u[i] : v[i];}  // dispaced r
+  float       gv(int i) const { return isBarrel ? z[i] : gp(i).perp();}  // global v
+  float       rv(int i) const { return isBarrel ? u[i] : v[i];}  // dispaced r
   GlobalPoint gp(int i) const { return GlobalPoint(x[i],y[i],z[i]);}
 
 public:
@@ -128,33 +130,41 @@ class HitDoublets {
 public:
   enum layer { inner=0, outer=1};
 
+  using HitLayer = RecHitsSortedInPhi;
   using Hit=RecHitsSortedInPhi::Hit;
-
-
+  using ADoublet = std::pair<int,int>;
+  
   HitDoublets(  RecHitsSortedInPhi const & in,
 		RecHitsSortedInPhi const & out) :
     layers{{&in,&out}}{}
   
   HitDoublets(HitDoublets && rh) : layers(std::move(rh.layers)), indeces(std::move(rh.indeces)){}
-
-  void reserve(std::size_t s) { indeces.reserve(2*s);}
-  std::size_t size() const { return indeces.size()/2;}
+  
+  void reserve(std::size_t s) { indeces.reserve(s);}
+  std::size_t size() const { return indeces.size();}
   bool empty() const { return indeces.empty();}
   void clear() { indeces.clear();}
-  void shrink_to_fit() { indeces.shrink_to_fit();}
+  void shrink_to_fit() {
+    indeces.shrink_to_fit();
+  }
+  
+  void add (int il, int ol) {
+    indeces.emplace_back(il,ol);
+  }
 
-  void add (int il, int ol) { indeces.push_back(il);indeces.push_back(ol);}
-
+  int index(int i, layer l) const { return l==inner ? innerHitId(i) : outerHitId(i);}
   DetLayer const * detLayer(layer l) const { return layers[l]->layer; }
-  int innerHitId(int i) const {return indeces[2*i];}
-  int outerHitId(int i) const {return indeces[2*i+1];}
-  Hit const & hit(int i, layer l) const { return layers[l]->theHits[indeces[2*i+l]].hit();}
-  float       phi(int i, layer l) const { return layers[l]->phi(indeces[2*i+l]);}
-  float       rv(int i, layer l) const { return layers[l]->rv(indeces[2*i+l]);}
-  float       r(int i, layer l) const { float xp = x(i,l); float yp = y(i,l);  return sqrt (xp*xp + yp*yp);}
-  float        z(int i, layer l) const { return layers[l]->z[indeces[2*i+l]];}
-  float        x(int i, layer l) const { return layers[l]->x[indeces[2*i+l]];}
-  float        y(int i, layer l) const { return layers[l]->y[indeces[2*i+l]];}
+  HitLayer const & innerLayer() const { return *layers[inner];}
+  HitLayer const & outerLayer() const { return *layers[outer];}
+  int innerHitId(int i) const {return indeces[i].first;}
+  int outerHitId(int i) const {return indeces[i].second;}
+  Hit const & hit(int i, layer l) const { return layers[l]->theHits[index(i,l)].hit();}
+  float       phi(int i, layer l) const { return layers[l]->phi(index(i,l));}
+  float       rv(int i, layer l) const { return layers[l]->rv(index(i,l));}
+  float       r(int i, layer l) const { float xp = x(i,l); float yp = y(i,l);  return std::sqrt (xp*xp + yp*yp);}
+  float        z(int i, layer l) const { return layers[l]->z[index(i,l)];}
+  float        x(int i, layer l) const { return layers[l]->x[index(i,l)];}
+  float        y(int i, layer l) const { return layers[l]->y[index(i,l)];}
   GlobalPoint gp(int i, layer l) const { return GlobalPoint(x(i,l),y(i,l),z(i,l));}
 
 private:
@@ -162,7 +172,7 @@ private:
   std::array<RecHitsSortedInPhi const *,2> layers;
 
 
-  std::vector<int> indeces;
+  std::vector<ADoublet> indeces; // naturally sorted by outerId
 
 };
 


### PR DESCRIPTION
Most purely technical changes that produces no regression and speedup CA by about a factor 2
We took the opportunity to fix a small imperfection in the use of the radius the now is w/r/t the beam spot.  The effect is mostly to sharpen the pt cut. This change produces minor regressions.

Timing for PU200 ttbar  phase2
```
900
grep TimeRe seedCA.log | cut -c 35-120 | sort -n -r | grep StepHit | head -n2
     0.363026  initialStepHitQuadruplets
     0.067059  initialStepHitDoublets
this PR
grep TimeRe seedCAVN7.log | cut -c 35-120 | sort -n -r | grep StepHit | head -n2
     0.199053  initialStepHitQuadruplets
     0.058190  initialStepHitDoublets
```
Timing at PU50 PhaseI
```
900
grep TimeRe caOri.log | cut -c 35-120 | sort -n -r | grep QuadStepHit | head -n4
     0.139890  lowPtQuadStepHitQuadruplets
     0.072600  detachedQuadStepHitQuadruplets
     0.012884  lowPtQuadStepHitDoublets
     0.009104  detachedQuadStepHitDoublets

This PR
grep TimeRe caVecet3.log  | cut -c 35-120 | sort -n -r | grep QuadStepHit | head -n4
     0.094063  lowPtQuadStepHitQuadruplets
     0.045189  detachedQuadStepHitQuadruplets
     0.012195  lowPtQuadStepHitDoublets
     0.008520  detachedQuadStepHitDoublets
```

MTV for ttbar PU0
http://innocent.home.cern.ch/innocent/RelVal/vectCA3/plots_highPurity/effandfake1.pdf
where blue is 900, red is technical only and black is this PR