### PR TITLE
Made all BuildFile.xml files easier to parse.

### DIFF
--- a/Calibration/TkAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/TkAlCaRecoProducers/plugins/BuildFile.xml
@@ -27,9 +27,6 @@
 <library   file="AlcaBeamSpotFromDB.cc" name="AlcaBeamSpotFromDB">
   <flags   EDM_PLUGIN="1"/>
 </library>
-<library   file="AlcaBeamSpotFromDB.cc" name="AlcaBeamSpotFromDB">
-  <flags   EDM_PLUGIN="1"/>
-</library>
 <library   file="PCLMetadataWriter.cc" name="PCLMetadataWriter">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/CondTools/RunInfo/plugins/BuildFile.xml
+++ b/CondTools/RunInfo/plugins/BuildFile.xml
@@ -18,9 +18,6 @@
 <library   file="L1TriggerScalerPopConAnalyzer.cc" name="CondToolsL1TriggerScalerPopConAnalyzer">
   <flags   EDM_PLUGIN="1"/>
 </library>
-<library   file="L1TriggerScalerPopConAnalyzer.cc" name="CondToolsL1TriggerScalerPopConAnalyzer">
-  <flags   EDM_PLUGIN="1"/>
-</library>
 <library   file="FillInfoESAnalyzer.cc" name="CondToolsFillInfoESAnalyzer">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="cppunit"/>
 <use   name="DataFormats/Provenance"/>
-<bin   name="testDataFormatsProvenance"file="testRunner.cpp,eventid_t.cppunit.cc,timestamp_t.cppunit.cc,parametersetid_t.cppunit.cc,indexIntoFile_t.cppunit.cc,indexIntoFile1_t.cppunit.cc,indexIntoFile2_t.cppunit.cc,indexIntoFile3_t.cppunit.cc,indexIntoFile4_t.cppunit.cc,indexIntoFile5_t.cppunit.cc,lumirange_t.cppunit.cc,eventrange_t.cppunit.cc">
+<bin   name="testDataFormatsProvenance" file="testRunner.cpp,eventid_t.cppunit.cc,timestamp_t.cppunit.cc,parametersetid_t.cppunit.cc,indexIntoFile_t.cppunit.cc,indexIntoFile1_t.cppunit.cc,indexIntoFile2_t.cppunit.cc,indexIntoFile3_t.cppunit.cc,indexIntoFile4_t.cppunit.cc,indexIntoFile5_t.cppunit.cc,lumirange_t.cppunit.cc,eventrange_t.cppunit.cc">
 </bin>
 <bin   file="EntryDescription_t.cpp">
 </bin>

--- a/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
+++ b/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
@@ -1,7 +1,7 @@
-<use name=DataFormats/Common>
+<use name="DataFormats/Common"/>
 
 <export>
-  <lib name=__subsys__xxxEventHypothesis>
-  <use name=DataFormats/Common>
+  <lib name="__subsys__xxxEventHypothesis"/>
+  <use name="DataFormats/Common"/>
 
 </export>

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -1,28 +1,24 @@
-<environment>
-  <use   name="boost"/>
-  <use   name="FWCore/Utilities"/>
-  <bin   file="Exception_t.cpp">
-  </bin>
-  <bin   file="EDMException_t.cpp">
-  </bin>
-  <bin   file="TestHelper_t.cpp">
-    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Utilities/test one.sh two.sh testFriendlyNames.sh testAdler32.sh"/>
-  </bin>
-  <bin   file="value_ptr_t.cpp">
-  </bin>
-  <bin   file="atomic_value_ptr_t.cpp">
-  </bin>
-  <bin   file="Digest_t.cpp">
-  </bin>
-  <bin   file="CRC32Calculator_t.cpp">
-  </bin>
-  <bin   file="MallocOpts_t.cpp">
-  </bin>
-  <bin   file="Guid_t.cpp">
-  </bin>
-  <bin   file="typedefs_t.cpp">
-  </bin>
-</environment>
+<use   name="boost"/>
+<use   name="FWCore/Utilities"/>
+<bin   file="Exception_t.cpp">
+</bin>
+<bin   file="EDMException_t.cpp">
+</bin>
+<bin   file="TestHelper_t.cpp">
+<flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Utilities/test one.sh two.sh testFriendlyNames.sh testAdler32.sh"/>
+</bin>
+<bin   file="value_ptr_t.cpp">
+</bin>
+<bin   file="atomic_value_ptr_t.cpp">
+</bin>
+<bin   file="Digest_t.cpp">
+</bin>
+<bin   file="CRC32Calculator_t.cpp">
+</bin>
+<bin   file="Guid_t.cpp">
+</bin>
+<bin   file="typedefs_t.cpp">
+</bin>
 <bin   file="HRTime_t.cpp">
   <use   name="cppunit"/>
 </bin>

--- a/Fireworks/FWInterface/plugins/BuildFile.xml
+++ b/Fireworks/FWInterface/plugins/BuildFile.xml
@@ -7,7 +7,7 @@
  <use name="SimDataFormats/TrackingHit"/>
  <use name="SimDataFormats/CaloHit"/>
  <use name="SimDataFormats/Vertex"/>
- <use name="SimDataFormats/TrackingAnalysis"/  >
+ <use name="SimDataFormats/TrackingAnalysis"/>
  <use name="SimGeneral/TrackingAnalysis"/>
 <use name="rootcore"/>
 <lib name="Geom"/>

--- a/RecoHI/HiEgammaAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiEgammaAlgos/plugins/BuildFile.xml
@@ -14,7 +14,7 @@
   <use   name="CondFormats/DataRecord"/>
   <use   name="CondFormats/EcalObjects"/>
   <use   name="FWCore/MessageLogger"/>
-  <use   mane="DataFormats/EgammaReco"/>
+  <use   name="DataFormats/EgammaReco"/>
   <use   name="root"/>
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
This patch makes all BuildFile.xml a bit closer to valid XML and removes some duplicate build targets. This should make it easier for third-party tools to handle SCRAM based projects.