### PR TITLE
BD hadron track monitoring in standard validation sequence

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -162,7 +162,7 @@ def miniAOD_customizeCommon(process):
     '?(tagInfoCandSecondaryVertex("pfSecondaryVertex").nVertices()>0)?(tagInfoCandSecondaryVertex("pfSecondaryVertex").secondaryVertex(0).vertex.z):(0)',
     )
     process.patJets.userData.userFunctionLabels = cms.vstring('vtxMass','vtxNtracks','vtx3DVal','vtx3DSig','vtxPx','vtxPy','vtxPz','vtxPosX','vtxPosY','vtxPosZ')
-    process.patJets.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfos"),cms.InputTag("pfImpactParameterTagInfos"))
+    process.patJets.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfos"))
     process.patJets.addTagInfos = cms.bool(True)
 
     ## Legacy tight b-tag track selection

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -162,7 +162,7 @@ def miniAOD_customizeCommon(process):
     '?(tagInfoCandSecondaryVertex("pfSecondaryVertex").nVertices()>0)?(tagInfoCandSecondaryVertex("pfSecondaryVertex").secondaryVertex(0).vertex.z):(0)',
     )
     process.patJets.userData.userFunctionLabels = cms.vstring('vtxMass','vtxNtracks','vtx3DVal','vtx3DSig','vtxPx','vtxPy','vtxPz','vtxPosX','vtxPosY','vtxPosZ')
-    process.patJets.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfos"))
+    process.patJets.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfos"),cms.InputTag("pfImpactParameterTagInfos"))
     process.patJets.addTagInfos = cms.bool(True)
 
     ## Legacy tight b-tag track selection

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -92,7 +92,7 @@ globalValidation = cms.Sequence(   trackerHitsValidation
                                  + pfTauRunDQMValidation
                                  + bTagPlotsMCbcl
                                  + L1Validator
-				 + bdHadronTrackValidationSeq
+                                 + bdHadronTrackValidationSeq
 )
 
 

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -38,6 +38,7 @@ from Validation.DTRecHits.DTRecHitQuality_cfi import *
 from Validation.RecoTau.DQMMCValidation_cfi import *
 from Validation.L1T.L1Validator_cfi import *
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
+from Validation.RecoB.BDHadronTrackValidation_cff import *
 
 # filter/producer "pre-" sequence for globalValidation
 globalPrevalidationTracking = cms.Sequence(
@@ -91,6 +92,7 @@ globalValidation = cms.Sequence(   trackerHitsValidation
                                  + pfTauRunDQMValidation
                                  + bTagPlotsMCbcl
                                  + L1Validator
+				 + bdHadronTrackValidationSeq
 )
 
 

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -11,6 +11,7 @@ from Validation.EventGenerator.PostProcessor_cff import *
 from Validation.RecoEgamma.photonPostProcessor_cff import *
 from Validation.RecoEgamma.electronPostValidationSequence_cff import *
 from Validation.RecoEgamma.electronPostValidationSequenceMiniAOD_cff import *
+from Validation.RecoB.BDHadronTrackValidation_cff import *
 from Validation.RecoParticleFlow.PFValidationClient_cff import *
 from Validation.RPCRecHits.postValidation_cfi import *
 from Validation.RecoTau.DQMMCValidation_cfi import *
@@ -37,6 +38,7 @@ postValidation = cms.Sequence(
     + runTauEff + makeBetterPlots
     + bTagCollectorSequenceMCbcl
     + METPostProcessor
+    + bdHadronTrackPostProcessor
 )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringAnalyzer.cc
@@ -45,6 +45,7 @@ BDHadronTrackMonitoringAnalyzer::BDHadronTrackMonitoringAnalyzer(const edm::Para
 
 void BDHadronTrackMonitoringAnalyzer::bookHistograms(DQMStore::IBooker & ibook, edm::Run const & run, edm::EventSetup const & es)
 {
+  ibook.setCurrentFolder("BDHadronTracks/JetContent");
   //
   // Book all histograms.
   //
@@ -59,6 +60,7 @@ void BDHadronTrackMonitoringAnalyzer::bookHistograms(DQMStore::IBooker & ibook, 
 
   // Loop over different Track History Categories
   for (unsigned int i = 0; i < TrkHistCat.size(); i++){
+    ibook.setCurrentFolder("BDHadronTracks/JetContent");
     // b jets
     nTrk_bjet[i] = ibook.book1D("nTrk_bjet_"+TrkHistCat[i],"Number of selected tracks in b jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
  
@@ -68,7 +70,7 @@ void BDHadronTrackMonitoringAnalyzer::bookHistograms(DQMStore::IBooker & ibook, 
     // dusg jets
     nTrk_dusgjet[i] = ibook.book1D("nTrk_dusgjet_"+TrkHistCat[i],"Number of selected tracks in dusg jets ("+TrkHistCat[i]+");number of selected tracks ("+TrkHistCat[i]+");jets",16,-0.5,15.5);
  
-
+    ibook.setCurrentFolder("BDHadronTracks/TrackInfo");
     // track properties for all flavours combined
     TrkPt_alljets[i] = ibook.book1D("TrkPt_"+TrkHistCat[i],"Track pT ("+TrkHistCat[i]+");track p_{T} ("+TrkHistCat[i]+");tracks",30,0,100);
     TrkEta_alljets[i] = ibook.book1D("TrkEta_"+TrkHistCat[i],"Track #eta ("+TrkHistCat[i]+");track #eta ("+TrkHistCat[i]+");tracks",30,-2.5,2.5);
@@ -78,6 +80,8 @@ void BDHadronTrackMonitoringAnalyzer::bookHistograms(DQMStore::IBooker & ibook, 
     TrkHitAll_alljets[i] = ibook.book1D("TrkHitAll_"+TrkHistCat[i],"Number of tracker hits ("+TrkHistCat[i]+");track number of all hits ("+TrkHistCat[i]+");tracks",31,-0.5,30.5);
     TrkHitStrip_alljets[i] = ibook.book1D("TrkHitStrip_"+TrkHistCat[i],"Number of strip hits ("+TrkHistCat[i]+");track number of strip hits ("+TrkHistCat[i]+");tracks",31,-0.5,30.5);
     TrkHitPixel_alljets[i] = ibook.book1D("TrkHitPixel_"+TrkHistCat[i],"Number of pixel hits ("+TrkHistCat[i]+");track number of pixel hits ("+TrkHistCat[i]+");tracks",9,-0.5,8.5);
+    
+    ibook.setCurrentFolder("BDHadronTracks/TrackTruthInfo");
     if (i < 5){ // Fakes (i == 5) have no truth by definition!
         TrkTruthPt_alljets[i] = ibook.book1D("TrkTruthPt_"+TrkHistCat[i],"Track pT ("+TrkHistCat[i]+" Truth);track p_{T} ("+TrkHistCat[i]+" Truth);tracks",30,0,100);
         TrkTruthEta_alljets[i] = ibook.book1D("TrkTruthEta_"+TrkHistCat[i],"Track #eta ("+TrkHistCat[i]+" Truth);track #eta ("+TrkHistCat[i]+" Truth);tracks",30,-2.5,2.5);
@@ -150,7 +154,7 @@ void BDHadronTrackMonitoringAnalyzer::analyze(const edm::Event& iEvent, const ed
 
     unsigned int flav = abs(jet->hadronFlavour());
 
-
+    //std::cout << "patJet collection has pfImpactParameterTagInfo?: " << jet->hasTagInfo("pfImpactParameter") << std::endl;
     const CandIPTagInfo *trackIpTagInfo = jet->tagInfoCandIP(ipTagInfos_.c_str());
     const std::vector<edm::Ptr<reco::Candidate> > & selectedTracks( trackIpTagInfo->selectedTracks() );
 

--- a/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
+++ b/Validation/RecoB/plugins/BDHadronTrackMonitoringHarvester.cc
@@ -27,6 +27,7 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     //
     // ***********************
     RecoBTag::setTDRStyle();
+    ibook.setCurrentFolder("BDHadronTracks/JetContent");
 
     // b jets
     // absolute average number of tracks
@@ -108,27 +109,27 @@ void BDHadronTrackMonitoringHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMS
     // get all the old histograms
     //
     // ***********************
-
+    
     // b jets
     MonitorElement *nTrk_bjet[6];
     for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
-        nTrk_bjet[i] = iget.get("nTrk_bjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
+        nTrk_bjet[i] = iget.get("BDHadronTracks/JetContent/nTrk_bjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
-    MonitorElement *nTrkAll_bjet = iget.get("nTrkAll_bjet");
-
+    MonitorElement *nTrkAll_bjet = iget.get("BDHadronTracks/JetContent/nTrkAll_bjet");
+    
     // c jets
     MonitorElement *nTrk_cjet[6];
     for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
-        nTrk_cjet[i] = iget.get("nTrk_cjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
+        nTrk_cjet[i] = iget.get("BDHadronTracks/JetContent/nTrk_cjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
-    MonitorElement *nTrkAll_cjet = iget.get("nTrkAll_cjet");
+    MonitorElement *nTrkAll_cjet = iget.get("BDHadronTracks/JetContent/nTrkAll_cjet");
 
     // dusg jets
     MonitorElement *nTrk_dusgjet[6];
     for(unsigned int i = 0; i < BDHadronTrackMonitoringAnalyzer::TrkHistCat.size(); i++) {
-        nTrk_dusgjet[i] = iget.get("nTrk_dusgjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
+        nTrk_dusgjet[i] = iget.get("BDHadronTracks/JetContent/nTrk_dusgjet_"+BDHadronTrackMonitoringAnalyzer::TrkHistCat[i]);
     }
-    MonitorElement *nTrkAll_dusgjet = iget.get("nTrkAll_dusgjet");
+    MonitorElement *nTrkAll_dusgjet = iget.get("BDHadronTracks/JetContent/nTrkAll_dusgjet");
 
 
 

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -1,9 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
+# Need to add pfImpactParameterTagInfos to the pat jets --> make personal patJet collection
+from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import _patJets as patJets
+patJetsBDHadron = patJets.clone(
+    tagInfoSources = cms.VInputTag(cms.InputTag('pfImpactParameterTagInfos')),
+    addTagInfos = cms.bool(True)
+)
+
+selectedPatJetsBDHadron = cms.EDFilter("PATJetSelector",
+    src = cms.InputTag("patJetsBDHadron"),
+    cut = cms.string("pt > 10.")
+)
+
+
 # my analyzer
 from Validation.RecoB.BDHadronTrackMonitoring_cfi import *
-BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('selectedPatJets')
+BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('selectedPatJetsBDHadron')#'selectedPatJets')
 
-bdHadronTrackValidationSeq = cms.Sequence(BDHadronTrackMonitoringAnalyze)
+
+
+bdHadronTrackValidationSeq = cms.Sequence(patJetsBDHadron * selectedPatJetsBDHadron * BDHadronTrackMonitoringAnalyze)
 
 bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -14,11 +14,14 @@ from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('patJetsBDHadron')
 
 bdHadronTrackValidationSeq = cms.Sequence(patJetCorrections
-					* patJetCharge*patJetPartonMatch
-					* patJetGenJetMatch*patJetFlavourIdLegacy
-					* patJetFlavourId*patJetsBDHadron
-					* tpClusterProducer
-					* BDHadronTrackMonitoringAnalyze
-					) 
+                                        * patJetCharge
+                                        * patJetPartonMatch
+                                        * patJetGenJetMatch
+                                        * patJetFlavourIdLegacy
+                                        * patJetFlavourId
+                                        * patJetsBDHadron
+                                        * tpClusterProducer
+                                        * BDHadronTrackMonitoringAnalyze
+) 
 					
 bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+# my analyzer
+from Validation.RecoB.BDHadronTrackMonitoring_cfi import *
+BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('selectedPatJets')
+
+bdHadronTrackValidationSeq = cms.Sequence(BDHadronTrackMonitoringAnalyze)
+
+bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -1,24 +1,31 @@
 import FWCore.ParameterSet.Config as cms
 
 # Need to add pfImpactParameterTagInfos to the pat jets --> make personal patJet collection
-from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import _patJets as patJets
+# and rerun PAT (because sometimes validation is ran without PAT sequence enables)
+from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import *
 patJetsBDHadron = patJets.clone(
     tagInfoSources = cms.VInputTag(cms.InputTag('pfImpactParameterTagInfos')),
     addTagInfos = cms.bool(True)
 )
 
-selectedPatJetsBDHadron = cms.EDFilter("PATJetSelector",
-    src = cms.InputTag("patJetsBDHadron"),
-    cut = cms.string("pt > 10.")
-)
+#selectedPatJetsBDHadron = cms.EDFilter("PATJetSelector",
+#    src = cms.InputTag("patJetsBDHadron"),
+#    cut = cms.string("pt > 10.")
+#)
 
 
 # my analyzer
 from Validation.RecoB.BDHadronTrackMonitoring_cfi import *
-BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('selectedPatJetsBDHadron')#'selectedPatJets')
+from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
+BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('patJetsBDHadron')#'selectedPatJetsBDHadron')
 
 
 
-bdHadronTrackValidationSeq = cms.Sequence(patJetsBDHadron * selectedPatJetsBDHadron * BDHadronTrackMonitoringAnalyze)
+bdHadronTrackValidationSeq = cms.Sequence(patJetCorrections
+					* patJetCharge*patJetPartonMatch
+					* patJetGenJetMatch*patJetFlavourIdLegacy
+					* patJetFlavourId*patJetsBDHadron
+					* tpClusterProducer
+					* BDHadronTrackMonitoringAnalyze) #patJetsBDHadron * selectedPatJetsBDHadron * 
 
 bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)

--- a/Validation/RecoB/python/BDHadronTrackValidation_cff.py
+++ b/Validation/RecoB/python/BDHadronTrackValidation_cff.py
@@ -8,24 +8,17 @@ patJetsBDHadron = patJets.clone(
     addTagInfos = cms.bool(True)
 )
 
-#selectedPatJetsBDHadron = cms.EDFilter("PATJetSelector",
-#    src = cms.InputTag("patJetsBDHadron"),
-#    cut = cms.string("pt > 10.")
-#)
-
-
 # my analyzer
 from Validation.RecoB.BDHadronTrackMonitoring_cfi import *
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
-BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('patJetsBDHadron')#'selectedPatJetsBDHadron')
-
-
+BDHadronTrackMonitoringAnalyze.PatJetSource = cms.InputTag('patJetsBDHadron')
 
 bdHadronTrackValidationSeq = cms.Sequence(patJetCorrections
 					* patJetCharge*patJetPartonMatch
 					* patJetGenJetMatch*patJetFlavourIdLegacy
 					* patJetFlavourId*patJetsBDHadron
 					* tpClusterProducer
-					* BDHadronTrackMonitoringAnalyze) #patJetsBDHadron * selectedPatJetsBDHadron * 
-
+					* BDHadronTrackMonitoringAnalyze
+					) 
+					
 bdHadronTrackPostProcessor = cms.Sequence(BDHadronTrackMonitoringHarvest)


### PR DESCRIPTION
This PR introduces the DQM monitoring tools for B and D Hadron Tracks (for BTV group) in the standard validation sequence. The tools were introduced in PR: https://github.com/cms-sw/cmssw/pull/17444

