### PR TITLE
default resolution parameters for iRPCs

### DIFF
--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -76,9 +76,9 @@ if phase2_muon.isChosen():
             averageEfficiency = cms.double(0.95),
             Nbxing = cms.int32(9),
             timeJitter = cms.double(1.0),
-            IRPC_time_resolution = cms.double(0.1),
-            IRPC_electronics_jitter = cms.double(0.025),
-            sigmaY = cms.double(1.), #math.sqrt((0.025)*(0.025)+(0.025)*(0.025))*0.66*299792458*1e+2*1e-9 = 0.7
+            IRPC_time_resolution = cms.double(1),# resolution of 1 ns
+            IRPC_electronics_jitter = cms.double(0.1),# resolution of 100 ps
+            sigmaY = cms.double(2.), # resolution of 2 cm
             do_Y_coordinate = cms.bool(True)
             ),       
                                      digiIRPCModel = cms.string('RPCSimModelTiming')

--- a/SimMuon/RPCDigitizer/src/RPCSimModelTiming.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimModelTiming.cc
@@ -150,44 +150,28 @@ void RPCSimModelTiming::simulate(const RPCRoll* roll,
 	  }
 	}
       }
-      
+ 
+      //digitize all the strips in the cluster
+      //in the previuos version some strips were dropped 
+      //leading to un-physical "shift" of the cluster
       for (std::vector<int>::iterator i=cls.begin(); i!=cls.end();i++){
-	// Check the timing of the adjacent strip
-	if(*i != centralStrip){
-	  if(CLHEP::RandFlat::shoot(engine) < veff[*i-1]){
-	    std::pair<int, int> digi(*i,time_hit);
-            RPCDigi adigi(*i,time_hit);
-            adigi.hasTime(true);
-            adigi.setTime(precise_time);
- 	    if(do_Y)
-	      {
-	  	adigi.hasY(true);
-	  	adigi.setY(smearedPositionY);
-		adigi.setDeltaY(sigmaY);
-	      }
-            irpc_digis.insert(adigi);
-	    
-	    theDetectorHitMap.insert(DetectorHitMap::value_type(digi,&(*_hit)));
+	std::pair<int, int> digi(*i,time_hit);
+	RPCDigi adigi(*i,time_hit);
+	adigi.hasTime(true);
+	adigi.setTime(precise_time);
+	if(do_Y)
+	  {
+	    adigi.hasY(true);
+	    adigi.setY(smearedPositionY);
+	    adigi.setDeltaY(sigmaY);
 	  }
-	} 
-	else {
-	  std::pair<int, int> digi(*i,time_hit);
-	  RPCDigi adigi(*i,time_hit);
-          adigi.hasTime(true);
-          adigi.setTime(precise_time);
-          if(do_Y)
-	    {
-	      adigi.hasY(true);
-	      adigi.setY(smearedPositionY);
-	      adigi.setDeltaY(sigmaY);
-	    }
-          irpc_digis.insert(adigi);
-          theDetectorHitMap.insert(DetectorHitMap::value_type(digi,&(*_hit)));
-	}
+	irpc_digis.insert(adigi);
+	theDetectorHitMap.insert(DetectorHitMap::value_type(digi,&(*_hit)));
       }
     }
   }
 }
+
 
 void RPCSimModelTiming::simulateNoise(const RPCRoll* roll,
 				      CLHEP::HepRandomEngine* engine) 


### PR DESCRIPTION
Set the default intrinsic timing resolution to the one specified by the iRPC hardware experts (~ 1ns).
Slight change in the digitizer - all the strips in a cluster are digitized now. Before we drop some of the strips, but this leads to unphysical "shift" of the cluster. 