### PR TITLE
Resolve segfault in L1TMuonProducer::sortMuons

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -385,13 +385,7 @@ L1TMuonProducer::sortMuons(MicroGMTConfiguration::InterMuonList& muons, unsigned
 
   // remove all muons that were cancelled or that do not have sufficient rank
   // (reduces the container size to nSurvivors)
-  mu1 = muons.begin();
-  while (mu1 != muons.end()) {
-    if ((*mu1)->hwWins() < minWins || (*mu1)->hwCancelBit() == 1) {
-      muons.erase(mu1);
-    }
-    ++mu1;
-  }
+  muons.remove_if([&minWins](auto muon) { return ((muon->hwWins() < minWins) || (muon->hwCancelBit() == 1)); });
   muons.sort(L1TMuonProducer::compareMuons);
 }
 


### PR DESCRIPTION
It's not safe to iterate over std::list and remove elements at the same
time. Especially the iterator of removed element will be invalidated.
This segfaults once we use `cmsRunGlibC` (i.e. system default memory allocator
from glibc).

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>