### PR TITLE
Fix the handling of ALCARECO output for steps which don't require the creation of a combined stream (i.e. all cases but the Tier0 one)

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -606,6 +606,7 @@ class ConfigBuilder(object):
 
         for i,(streamType,tier) in enumerate(zip(streamTypes,tiers)):
 		if streamType=='': continue
+		if streamType == 'ALCARECO' and not 'ALCAPRODUCER' in self._options.step: continue
 		if streamType=='DQMIO': streamType='DQM'
                 theEventContent = getattr(self.process, streamType+"EventContent")
                 if i==0:


### PR DESCRIPTION
The inclusion of the ALCARECO datatier and event content would trigger the addition of an output module. This is not needed for the ALCARECO and ALCAOUTPUT steps since a dedicated stream is already created for each ALCARECO. Only in presence of the ALCAPRODUCER step this should happen.

This is the 91X equivalent of #17941