### PR TITLE
[cxxmodules] Added missing system headers to FWCore.

### DIFF
--- a/FWCore/Utilities/interface/OffsetToBase.h
+++ b/FWCore/Utilities/interface/OffsetToBase.h
@@ -1,5 +1,6 @@
 #ifndef FWCore_Utilities_OffsetToBase_h
 #define FWCore_Utilities_OffsetToBase_h
+#include <cstddef>
 #include <typeinfo>
 
 /*

--- a/FWCore/Utilities/interface/make_sentry.h
+++ b/FWCore/Utilities/interface/make_sentry.h
@@ -19,7 +19,7 @@
 //
 
 // system include files
-
+#include <memory>
 // user include files
 
 // forward declarations


### PR DESCRIPTION
C++ modules require that headers include all necessary headers to
parse them. This patch adds those missing system includes for all
headers in FWCore.