### PR TITLE
HCAL DQM update for 8_4_X (fixes merge error in 17881)

### DIFF
--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -143,6 +143,12 @@ class DigiTask : public hcaldqm::DQTask
 		hcaldqm::ContainerXXX<uint32_t> _xNChs; // online only
 		hcaldqm::ContainerXXX<uint32_t> _xNChsNominal; // online only
 
+		// QIE10 TDC histograms
+		hcaldqm::ContainerSingle2D _cLETDCvsADC;
+		hcaldqm::ContainerSingle2D _cLETDCvsTS;
+		hcaldqm::ContainerSingle1D _cLETDCTime;
+
+
 		//	#events counters
 		MonitorElement *meNumEvents1LS; // to transfer the #events to harvesting
 		MonitorElement *meUnknownIds1LS;

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -44,13 +44,15 @@ class DigiTask : public hcaldqm::DQTask
 		virtual void _resetMonitors(hcaldqm::UpdateFreq);
 
 		edm::InputTag		_tagHBHE;
+		edm::InputTag		_tagHEP17;
 		edm::InputTag		_tagHO;
 		edm::InputTag		_tagHF;
 		edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
+		edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
 		edm::EDGetTokenT<HODigiCollection>	 _tokHO;
 		edm::EDGetTokenT<QIE10DigiCollection>	_tokHF;
 
-		double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
+		double _cutSumQ_HBHE, _cutSumQ_HEP17, _cutSumQ_HO, _cutSumQ_HF;
 		double _thresh_unihf;
 
 		//	flag vector

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -212,6 +212,18 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
 		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),0);
 
+	_cLETDCvsADC.initialize(_name, "LETDCvsADC",
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10TDC_64),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+	_cLETDCvsTS.initialize(_name, "LETDCvsTS", 
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE11TDC_64));
+	_cLETDCTime.initialize(_name, "LETDCTime",
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTime_ns_250),
+		new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true));
+
+
 	//	INITIALIZE HISTOGRAMS that are only for Online
 	if (_ptype==fOnline)
 	{
@@ -329,6 +341,10 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 	_cOccupancyCut_depth.book(ib, _emap, _subsystem);
 
 	_cDigiSize_FED.book(ib, _emap, _subsystem);
+
+	_cLETDCvsADC.book(ib, _subsystem);
+	_cLETDCvsTS.book(ib, _subsystem);
+	_cLETDCTime.book(ib, _subsystem);
 
 	//	BOOK HISTOGRAMS that are only for Online
 	_ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
@@ -856,6 +872,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		{
 			_cADC_SubdetPM.fill(did, digi[i].adc());
 			_cfC_SubdetPM.fill(did, constants::adc2fC[digi[i].adc()] - 2.5);
+			_cLETDCvsADC.fill(digi[i].adc(), digi[i].le_tdc());
+			_cLETDCvsTS.fill((int)i, digi[i].le_tdc());
+			if (digi[i].le_tdc() <50) {
+				_cLETDCTime.fill(i*25. + (digi[i].le_tdc() / 2.));
+			}
+
 			if (sumQ>_cutSumQ_HF)
 				_cShapeCut_FED.fill(eid, (int)i, constants::adc2fC[digi[i].adc()] - 2.5);
 		}

--- a/DQM/HcalTasks/plugins/RecHitTask.cc
+++ b/DQM/HcalTasks/plugins/RecHitTask.cc
@@ -393,8 +393,14 @@ RecHitTask::RecHitTask(edm::ParameterSet const& ps):
 		//	Explicit check on the DetIds present in the Collection
 		HcalDetId did = it->id();
 		uint32_t rawid = _ehashmap.lookup(did);
+        /*
+         * Needs to be removed as DetIds that belong to the HEP17 after combination
+         * are not present in the emap
+         * Removed until further notice!
+         *
 		if (rawid==0)
 		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
+        */
 		HcalElectronicsId const& eid(rawid);
 		rawidValid = did.rawId();
 		if (did.subdet()==HcalBarrel)

--- a/DQM/HcalTasks/plugins/RecHitTask.cc
+++ b/DQM/HcalTasks/plugins/RecHitTask.cc
@@ -398,9 +398,10 @@ RecHitTask::RecHitTask(edm::ParameterSet const& ps):
          * are not present in the emap
          * Removed until further notice!
          *
-		if (rawid==0)
-		{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
-        */
+         */
+		//if (rawid==0)
+		//{meUnknownIds1LS->Fill(1); _unknownIdsPresent=true;continue;}
+        
 		HcalElectronicsId const& eid(rawid);
 		rawidValid = did.rawId();
 		if (did.subdet()==HcalBarrel)
@@ -421,16 +422,18 @@ RecHitTask::RecHitTask(edm::ParameterSet const& ps):
 			_cOccupancyvsieta_Subdet.fill(did);
 		}
 		//	^^^ONLINE ONLY!
-
-		if (eid.isVMEid())
-		{
-			_cOccupancy_FEDVME.fill(eid);
-			_cOccupancy_ElectronicsVME.fill(eid);
-		}
-		else
-		{
-			_cOccupancy_FEDuTCA.fill(eid);
-			_cOccupancy_ElectronicsuTCA.fill(eid);
+		//	Also, for these electronics plots, require that the channel was found in the emap.
+		if (rawid != 0) {
+			if (eid.isVMEid())
+			{
+				_cOccupancy_FEDVME.fill(eid);
+				_cOccupancy_ElectronicsVME.fill(eid);
+			}
+			else if (eid.isUTCAid())
+			{
+				_cOccupancy_FEDuTCA.fill(eid);
+				_cOccupancy_ElectronicsuTCA.fill(eid);
+			}
 		}
 
 		if (energy>_cutE_HBHE)
@@ -466,40 +469,43 @@ RecHitTask::RecHitTask(edm::ParameterSet const& ps):
 				_cTimingCut_depth.fill(did, timing);
 			}
 			_cOccupancyCut_depth.fill(did);
-			if (eid.isVMEid())
-			{
 
-				//	ONLINE 
-				if (_ptype==fOnline)
+			if (rawid != 0) {
+				if (eid.isVMEid())
 				{
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-				} // ^^^ ONLINE
-				else
-				{
-					_cTimingCut_FEDVME.fill(eid, timing);
-					_cTimingCut_ElectronicsVME.fill(eid, timing);
-				}
-				//	^^^ONLINE
 
-				_cOccupancyCut_FEDVME.fill(eid);
-				_cOccupancyCut_ElectronicsVME.fill(eid);
-			}
-			else
-			{
-				if (_ptype==fOnline)
-				{
-					//	time constraints are explicit!
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
+					//	ONLINE 
+					if (_ptype==fOnline)
+					{
+						_cTimingCut_FEDVME.fill(eid, timing);
+						_cTimingCut_ElectronicsVME.fill(eid, timing);
+					} // ^^^ ONLINE
+					else
+					{
+						_cTimingCut_FEDVME.fill(eid, timing);
+						_cTimingCut_ElectronicsVME.fill(eid, timing);
+					}
+					//	^^^ONLINE
+
+					_cOccupancyCut_FEDVME.fill(eid);
+					_cOccupancyCut_ElectronicsVME.fill(eid);
 				}
-				else
+				else if (eid.isUTCAid())
 				{
-					_cTimingCut_FEDuTCA.fill(eid, timing);
-					_cTimingCut_ElectronicsuTCA.fill(eid, timing);
+					if (_ptype==fOnline)
+					{
+						//	time constraints are explicit!
+						_cTimingCut_FEDuTCA.fill(eid, timing);
+						_cTimingCut_ElectronicsuTCA.fill(eid, timing);
+					}
+					else
+					{
+						_cTimingCut_FEDuTCA.fill(eid, timing);
+						_cTimingCut_ElectronicsuTCA.fill(eid, timing);
+					}
+					_cOccupancyCut_FEDuTCA.fill(eid);
+					_cOccupancyCut_ElectronicsuTCA.fill(eid);
 				}
-				_cOccupancyCut_FEDuTCA.fill(eid);
-				_cOccupancyCut_ElectronicsuTCA.fill(eid);
 			}
 			did.subdet()==HcalBarrel?nChsHBCut++:nChsHECut++;
 		}

--- a/DQM/HcalTasks/plugins/RecHitTask.cc
+++ b/DQM/HcalTasks/plugins/RecHitTask.cc
@@ -460,12 +460,16 @@ RecHitTask::RecHitTask(edm::ParameterSet const& ps):
 			//	ONLINE 
 			if (_ptype==fOnline)
 			{
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+				if (rawid != 0) {
+					_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+				}
 				_cTimingCut_depth.fill(did, timing);
 			}//	^^^ONLINE
 			else
 			{
-				_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+				if (rawid != 0) {
+			    	_cTimingCutvsLS_FED.fill(eid, _currentLS, timing);
+				}
 				_cTimingCut_depth.fill(did, timing);
 			}
 			_cOccupancyCut_depth.fill(did);

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -98,8 +98,7 @@ process.load("DQM.HcalTasks.DigiTask")
 process.load('DQM.HcalTasks.TPTask')
 process.load('DQM.HcalTasks.RawTask')
 process.load('DQM.HcalTasks.NoCQTask')
-process.load('DQM.HcalTasks.QIE10Task')
-process.load('DQM.HcalTasks.ZDCTask')
+#process.load('DQM.HcalTasks.ZDCTask')
 process.load('DQM.HcalTasks.QIE11Task')
 process.load('DQM.HcalTasks.HcalOnlineHarvesting')
 
@@ -133,12 +132,9 @@ process.rawTask.runkeyVal = runType
 process.rawTask.runkeyName = runTypeName
 process.tpTask.runkeyVal = runType
 process.tpTask.runkeyName = runTypeName
-process.qie10Task.runkeyVal = runType
-process.qie10Task.runkeyName = runTypeName
-process.qie10Task.tagQIE10 = cms.untracked.InputTag("hcalDigis")
-process.zdcTask.runkeyVal = runType
-process.zdcTask.runkeyName = runTypeName
-process.zdcTask.tagQIE10 = cms.untracked.InputTag("castorDigis")
+#process.zdcTask.runkeyVal = runType
+#process.zdcTask.runkeyName = runTypeName
+#process.zdcTask.tagQIE10 = cms.untracked.InputTag("castorDigis")
 process.qie11Task.runkeyVal = runType
 process.qie11Task.runkeyName = runTypeName
 process.qie11Task.tagQIE11 = cms.untracked.InputTag("hcalDigis")
@@ -151,10 +147,9 @@ process.tasksPath = cms.Path(
 		+process.digiTask
 		+process.tpTask
 		+process.nocqTask
-		+process.qie10Task
 		+process.qie11Task
 		#ZDC to be removed for 2017 pp running
-		+process.zdcTask
+		#+process.zdcTask
 )
 
 process.harvestingPath = cms.Path(

--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -10,6 +10,7 @@ import os, sys, socket, string
 #-------------------------------------
 #	Standard CMSSW Imports/Definitions
 #-------------------------------------
+from Configuration.StandardSequences.Eras import eras
 import FWCore.ParameterSet.Config as cms
 process			= cms.Process('HCALDQM')
 subsystem		= 'HcalCalib'
@@ -52,7 +53,8 @@ process.source.minEventsPerLumi=100
 #-------------------------------------
 #	CMSSW/Hcal non-DQM Related Module import
 #-------------------------------------
-process.load('Configuration.Geometry.GeometryIdeal_cff')
+#process.load('Configuration.Geometry.GeometryIdeal_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.load("EventFilter.HcalRawToDigi.HcalRawToDigi_cfi")
 process.load("RecoLocalCalo.Configuration.hcalLocalReco_cff")


### PR DESCRIPTION
Retrying PR 17881 without the extra signatures due to a merge error.

This PR is for online DQM, on top of 8_4_0_patch2.

---

Some updates for HCAL DQM:

Inconsistency between emap and RecHits after collapsing resulted in missing channels in ieta-iphi plots. Removed a hard check on the channels, so missing channels should appear.
Add QIE11 digis (aka HEP17) to DigiTask.
Remove QIE10Task (redundant with DigiTask, QIE10==HF now) and ZDCTask.
Fixed crashing hcalcalib (GeometryIdeal --> GeometryRecoDB).
Reintroduced the consistency check on channels vs emap for histograms that explicitly require a valid electronics channel.


