### PR TITLE
[cxxmodules] Added missing CMS headers in FWCore.

### DIFF
--- a/FWCore/Framework/interface/eventSetupGetImplementation.h
+++ b/FWCore/Framework/interface/eventSetupGetImplementation.h
@@ -23,6 +23,7 @@
 // user include files
 #include "FWCore/Framework/interface/HCMethods.h"
 #include "FWCore/Framework/interface/NoRecordException.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
 
 namespace edm {
   class EventSetup;


### PR DESCRIPTION
C++ modules require that headers include all necessary headers to
parse them. This patch adds those missing CMS-related includes for all
headers in FWCore:

We include EventSetupRecordKey.h in eventSetupGetImplementation.h
because we call EventSetupRecordKey::makeKey in the function
eventsetup::eventSetupGetImplementation.