### PR TITLE
remove duplicate def available in DataFormats/StdDictionaries/src/classes_def_pair.xml

### DIFF
--- a/DataFormats/StdDictionaries/src/classes_def_map.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_map.xml
@@ -32,7 +32,6 @@
  <class name="std::map<unsigned int,std::vector<std::pair<unsigned int,int> > >"/>
  <class name="std::map<unsigned int,std::vector<unsigned int> >"/>
  <class name="std::map<unsigned int,unsigned int>"/>
- <class name="std::pair<unsigned int,unsigned int>"/>
  <class name="std::map<unsigned long long,std::basic_string<char> >"/>
  <class name="std::map<unsigned long,std::vector<unsigned long> >"/>
  <class name="std::map<unsigned long,unsigned long>"/>


### PR DESCRIPTION

in 910pre1 ``` duplicateReflexLibrarySearch.py --dir ./ --dup ``` leads to 
```
pair< unsigned int, unsigned int >
   ./DataFormats/StdDictionaries/src/classes_def_map.xml
   ./DataFormats/StdDictionaries/src/classes_def_pair.xml
```
