### PR TITLE
Remove redundant addition of exception context

### DIFF
--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -209,9 +209,11 @@ namespace edm {
         worker->doWork<T>(p, es,StreamID::invalidStreamID(), parentContext, context);
       }
       catch (cms::Exception & ex) {
-        std::ostringstream ost;
-        ost << "Processing " <<T::transitionName()<<" "<< p.id();
-        ex.addContext(ost.str());
+        if(ex.context().empty()) {
+          std::ostringstream ost;
+          ost << "Processing " <<T::transitionName()<<" "<< p.id();
+          ex.addContext(ost.str());
+        }
         throw;
       }
     }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -616,9 +616,11 @@ namespace edm {
         results_inserter_->doWork<Traits>(ep, es, streamID_, parentContext, &streamContext_);
       }
       catch (cms::Exception & ex) {
-        std::ostringstream ost;
-        ost << "Processing Event " << ep.id();
-        ex.addContext(ost.str());
+        if(ex.context().empty()) {
+          std::ostringstream ost;
+          ost << "Processing Event " << ep.id();
+          ex.addContext(ost.str());
+        }
         iExcept = std::current_exception();
       }
       catch(...) {


### PR DESCRIPTION
In the exception context cleanup, a few redundant cases were missed.