### PR TITLE
apply HCAL layer0 weight in digi step for phase2

### DIFF
--- a/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalUnsuppressedDigis_cfi.py
@@ -50,6 +50,3 @@ run2_HCAL_2017.toModify( hcalSimBlock, TestNumbering = cms.bool(True) )
 # remove HE processing for phase 2, completely put in HGCal land
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(hcalSimBlock, killHE = cms.bool(True) )
-
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toModify(hcalSimBlock, doNeutralDensityFilter = cms.bool(False))

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -474,5 +474,3 @@ from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify( g4SimHits.ECalSD,
                              StoreLayerTimeSim = cms.untracked.bool(True),
                              TimeSliceUnit = cms.double(0.001) )
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toModify(g4SimHits.HCalSD, doNeutralDensityFilter = cms.bool(True))


### PR DESCRIPTION
In #17605, applying the HCAL layer0 weight in the DIGI step (to enable reuse of GEN-SIM) was enabled for all scenarios except for phase2. This is because it was foreseen that subsequent 90X releases could be used for re-DIGI-RECO of existing GEN-SIM samples for Phase2 TDR production.

In 91X, the phase2 geometries have changed, so 90X GEN-SIM will not be reused for TDR production with 91X releases. Therefore, we can enable this setting for HCAL GEN-SIM reusability globally.

attn: @bsunanda, @abdoulline