### PR TITLE
skip invalid TP collection

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRaw.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRaw.cc
@@ -69,7 +69,7 @@ void HcalDigiToRaw::produce(edm::Event& e, const edm::EventSetup& es)
   edm::Handle<HcalTrigPrimDigiCollection> htp;
   if (!trigTag_.label().empty()) {
     e.getByToken(tok_htp_,htp);
-    colls.tpCont=htp.product();
+    if(htp.isValid()) colls.tpCont=htp.product();
   }
   // get the mapping
   edm::ESHandle<HcalDbService> pSetup;


### PR DESCRIPTION
Fixes premix relval failures in `CMSSW_9_1_X_2017-03-23-1100` caused by #17920 (this behavior is default for the new uHTR HcalDigiToRaw plugin, so I didn't notice it wasn't handled in the old plugin).

This fix is automatically included in the backport #17921.

Tested locally with WF 250199.0 (one of the failing ones in the IB).

attn: @Dr15Jones 