### PR TITLE
initialize counters

### DIFF
--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -71,11 +71,11 @@ private:
 
   Worker::Worker(ModuleDescription const& iMD, 
 		 ExceptionToActionTable const* iActions) :
-    timesRun_(),
-    timesVisited_(),
-    timesPassed_(),
-    timesFailed_(),
-    timesExcept_(),
+    timesRun_(0),
+    timesVisited_(0),
+    timesPassed_(0),
+    timesFailed_(0),
+    timesExcept_(0),
     state_(Ready),
     numberOfPathsOn_(0),
     numberOfPathsLeftToRun_(0),


### PR DESCRIPTION
The default constructor for std::atomic does not initialize its value when used as member data.