### PR TITLE
[80x] Backport of lumi information in Strip ALCARECO and Shallow trees 

### DIFF
--- a/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowEventDataProducer.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+#include "DataFormats/Scalers/interface/LumiScalers.h" 
 #include <string>
 
 class ShallowEventDataProducer : public edm::EDProducer {
@@ -12,6 +13,7 @@ class ShallowEventDataProducer : public edm::EDProducer {
  private: 
   void produce( edm::Event &, const edm::EventSetup & );
 	edm::EDGetTokenT< L1GlobalTriggerReadoutRecord > trig_token_;
+	edm::EDGetTokenT< LumiScalersCollection > scalerToken_; 
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/python/ShallowEventDataProducer_cfi.py
+++ b/CalibTracker/SiStripCommon/python/ShallowEventDataProducer_cfi.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 shallowEventRun = cms.EDProducer(
    "ShallowEventDataProducer",
-   trigRecord = cms.InputTag('gtDigis')
+   trigRecord = cms.InputTag('gtDigis'),
+   lumiScalers = cms.InputTag("scalersRawToDigi") 
    )

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAfterAbortGap_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAfterAbortGap_Output_cff.py
@@ -12,6 +12,8 @@ OutALCARECOSiStripCalMinBiasAfterAbortGap_noDrop = cms.PSet(
         'keep DetIdedmEDCollection_siStripDigis_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep LumiScalerss_scalersRawToDigi_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_TriggerResults_*_*')
 )
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
@@ -12,6 +12,8 @@ OutALCARECOSiStripCalMinBias_noDrop = cms.PSet(
         'keep DetIdedmEDCollection_siStripDigis_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep LumiScalerss_scalersRawToDigi_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_TriggerResults_*_*')
 )
 


### PR DESCRIPTION
backport of #17419 #17570 and #17981

In case it is in the plans to re-run the ALCA step in the Spring17 (legacy) re-reco of 2016 data and there is still time to include changes in the release, this backport will highly simplify the workflow for producing luminosity dependent studies of the SiStrip hit efficiency.
att: @dimattia @boudoul 