### PR TITLE
Fix bug in  L1TMuonProducer

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -385,13 +385,7 @@ L1TMuonProducer::sortMuons(MicroGMTConfiguration::InterMuonList& muons, unsigned
 
   // remove all muons that were cancelled or that do not have sufficient rank
   // (reduces the container size to nSurvivors)
-  mu1 = muons.begin();
-  while (mu1 != muons.end()) {
-    if ((*mu1)->hwWins() < minWins || (*mu1)->hwCancelBit() == 1) {
-      muons.erase(mu1);
-    }
-    ++mu1;
-  }
+  muons.erase(std::remove_if(muons.begin(),muons.end(),[=](auto mu1){ return (mu1)->hwWins() < minWins || (mu1)->hwCancelBit() == 1;}),muons.end()) ;
   muons.sort(L1TMuonProducer::compareMuons);
 }
 


### PR DESCRIPTION
typical bug by C++ illiterate
see
https://en.wikipedia.org/wiki/Erase–remove_idiom


how to trigger it
```
cmsrel CMSSW_9_0_0_pre6
cd CMSSW_9_0_0_pre6/src/
cmsenv
git cms-addpkg L1Trigger/L1TMuon
cmsDriver.py test -s RAW2DIGI --era=Run2_2016 --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW --conditions=81X_upgrade2017_realistic_v26 -n -1 --mc --no_exec --no_output --filein=root://cms-xrd-global.cern.ch//store/mc/PhaseIFall16DR/BuToJpsiK_BFilter_TuneCUEP8M1_13TeV-pythia8-evtgen/GEN-SIM-RAW/FlatPU28to62HcalNZSRAW_81X_upgrade2017_realistic_v26-v1/110000/B0C8B5E9-D6F0-E611-A443-001517FB141C.root

add the following to test_RAW2DIGI.py

process.simEmtfDigis.CSCInput = cms.InputTag("simCscTriggerPrimitiveDigis","MPCSORTED")
process.simBmtfDigis.DTDigi_Source = cms.InputTag("simTwinMuxDigis")
process.simBmtfDigis.DTDigi_Theta_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
process.simOmtfDigis.srcCSC = cms.InputTag("simCscTriggerPrimitiveDigis","MPCSORTED")
process.simOmtfDigis.srcDTPh = cms.InputTag("simDtTriggerPrimitiveDigis")
process.simOmtfDigis.srcDTTh = cms.InputTag("simDtTriggerPrimitiveDigis")
process.simTwinMuxDigis.DTDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
process.simTwinMuxDigis.DTThetaDigi_Source = cms.InputTag("simDtTriggerPrimitiveDigis")
process.simDtTriggerPrimitiveDigis.digiTag = cms.InputTag("muonDTDigis")


setenv XRD_NETWORKSTACK IPv4 (perché i file sono in US e se no non li apre)
voms-proxy-init -voms cms
cmsRunGlibC test_RAW2DIGI.py

compile with -g and you get
Thread 1 "cmsRunGlibC" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fedc4de4c80 (LWP 15407)]
0x00007fedb1350607 in L1TMuonProducer::sortMuons (this=this@entry=0x15b4a9c0, muons=..., nSurvivors=nSurvivors@entry=4) at /home/vin/ori/CMSSW_9_0_0/src/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc:389
389	  while (mu1 != muons.end()) {
(gdb) where
#0  0x00007fedb1350607 in L1TMuonProducer::sortMuons (this=this@entry=0x15b4a9c0, muons=..., nSurvivors=nSurvivors@entry=4)
   at /home/vin/ori/CMSSW_9_0_0/src/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc:389
#1  0x00007fedb1355307 in L1TMuonProducer::produce (this=0x15b4a9c0, iEvent=..., iSetup=...) at /home/vin/ori/CMSSW_9_0_0/src/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc:303
```