### PR TITLE
Adding Timing vs BX plots, and modifying thresholds for laser quality

### DIFF
--- a/DQM/EcalMonitorClient/python/LaserClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/LaserClient_cfi.py
@@ -13,8 +13,8 @@ toleranceAmpRMSRatio = 0.3
 expectedPNAmplitude = [800.0, 800.0, 800.0, 800.0]
 tolerancePNAmp = 0.1
 tolerancePNRMSRatio = 1.
-expectedTiming = [4.2, 4.2, 4.2, 4.2]
-toleranceTiming = 0.5
+expectedTiming = [4.2, 3.7, 4.2, 4.2]
+toleranceTiming = 1.0
 toleranceTimRMS = 0.4
 
 ecalLaserClient = cms.untracked.PSet(
@@ -63,9 +63,9 @@ ecalLaserClient = cms.untracked.PSet(
             ),
             otype = cms.untracked.string('SM'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(5.5),
+                high = cms.untracked.double(5.0),
                 nbins = cms.untracked.int32(100),
-                low = cms.untracked.double(3.5),
+                low = cms.untracked.double(3.0),
                 title = cms.untracked.string('time (clock)')
             ),
             btype = cms.untracked.string('User'),

--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -19,9 +19,17 @@ namespace ecaldqm {
     void runOnRecHits(EcalRecHitCollection const&, Collections);
     void runOnUncalibRecHits(EcalUncalibratedRecHitCollection const&);
 
+    enum Constants {
+      nBXBins = 15
+    };
+
   private:
     void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
     void setParams(edm::ParameterSet const&) override;
+
+    int bxBinEdges_[nBXBins + 1];
+    double bxBin_;
 
     float chi2ThresholdEB_;
     float chi2ThresholdEE_;

--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -28,7 +28,7 @@ namespace ecaldqm {
     void beginEvent(edm::Event const&, edm::EventSetup const&) override;
     void setParams(edm::ParameterSet const&) override;
 
-    int bxBinEdges_[nBXBins + 1];
+    std::array<int,nBXBins+1> bxBinEdges_;
     double bxBin_;
 
     float chi2ThresholdEB_;

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -45,7 +45,7 @@ namespace ecaldqm {
 /*     bool HLTCaloBit_; */
 /*     bool HLTMuonBit_; */
 
-    int bxBinEdges_[nBXBins + 1];
+    std::array<int,nBXBins+1> bxBinEdges_;
     double bxBin_;
 
     std::map<uint32_t, unsigned> towerReadouts_;

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -1,5 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
+bxBins = [
+    "1",
+    "271",
+    "541",
+    "892",
+    "1162",
+    "1432",
+    "1783",
+    "2053",
+    "2323",
+    "2674",
+    "2944",
+    "3214",
+    "3446",
+    "3490",
+    "3491",
+    "3565"
+]
+
 EaxisEdges = []
 for i in range(50) :
     EaxisEdges.append(pow(10., -0.5 + 2.5 / 50. * i))
@@ -101,6 +120,23 @@ ecalTimingTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT timing vs amplitude %(sm)s'),
             description = cms.untracked.string('Correlation between hit timing and energy. Only hits with GOOD or OUT_OF_TIME reconstruction flags are used.')
+        ),
+        TimingVsBX = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sTimingTask/%(prefix)sTMT Timing vs BX%(suffix)s'),
+            kind = cms.untracked.string('TProfile'),
+            otype = cms.untracked.string('Ecal3P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(16.0),
+                nbins = cms.untracked.int32(16),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('bunch crossing'),
+                labels = cms.untracked.vstring(bxBins)
+            ),
+            yaxis = cms.untracked.PSet(
+                title = cms.untracked.string('Timing (ns)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Average hit timing in the partition as a function of BX number.')
         ),
         TimeAmpBXm = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -1,6 +1,9 @@
 #include "../interface/TimingTask.h"
 
 #include "DQM/EcalCommon/interface/EcalDQMCommonUtils.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h"
 
@@ -10,6 +13,8 @@ namespace ecaldqm
 {
   TimingTask::TimingTask() :
     DQWorkerTask(),
+    bxBinEdges_{1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565},
+    bxBin_(0.),
     chi2ThresholdEB_(0.),
     chi2ThresholdEE_(0.),
     energyThresholdEB_(0.),
@@ -53,11 +58,20 @@ namespace ecaldqm
       meTimeMapByLS->reset();
   }
 
+  void
+  TimingTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&  _es)
+  {
+    using namespace std;
+    int* pBin(std::upper_bound(bxBinEdges_, bxBinEdges_ + nBXBins + 1, _evt.bunchCrossing()));
+    bxBin_ = static_cast<int>(pBin - bxBinEdges_) - 0.5;
+  }
+
   void 
   TimingTask::runOnRecHits(EcalRecHitCollection const& _hits, Collections _collection)
   {
     MESet& meTimeAmp(MEs_.at("TimeAmp"));
     MESet& meTimeAmpAll(MEs_.at("TimeAmpAll"));
+    MESet& meTimingVsBX(MEs_.at("TimingVsBX"));
     MESet& meTimeAll(MEs_.at("TimeAll"));
     MESet& meTimeAllMap(MEs_.at("TimeAllMap"));
     MESet& meTimeMap(MEs_.at("TimeMap")); // contains cumulative run stats => not suitable for Trend plots
@@ -93,6 +107,8 @@ namespace ecaldqm
 
                     meTimeAmp.fill(id, energy, time);
                     meTimeAmpAll.fill(id, energy, time);
+
+                    meTimingVsBX.fill(signedSubdet, bxBin_, time);
 
                     if(energy > threshold){
                       meTimeAll.fill(id, time);

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -13,7 +13,7 @@ namespace ecaldqm
 {
   TimingTask::TimingTask() :
     DQWorkerTask(),
-    bxBinEdges_{1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565},
+    bxBinEdges_{ {1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565} },
     bxBin_(0.),
     chi2ThresholdEB_(0.),
     chi2ThresholdEE_(0.),
@@ -62,8 +62,8 @@ namespace ecaldqm
   TimingTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&  _es)
   {
     using namespace std;
-    int* pBin(std::upper_bound(bxBinEdges_, bxBinEdges_ + nBXBins + 1, _evt.bunchCrossing()));
-    bxBin_ = static_cast<int>(pBin - bxBinEdges_) - 0.5;
+    int* pBin(std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing()));
+    bxBin_ = static_cast<int>(pBin - bxBinEdges_.begin()) - 0.5;
   }
 
   void 

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -22,7 +22,7 @@ namespace ecaldqm
     //     HLTMuonPath_(""),
     //     HLTCaloBit_(false),
     //     HLTMuonBit_(false),
-    bxBinEdges_{1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565},
+    bxBinEdges_{ {1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565} },
     bxBin_(0.),
     towerReadouts_()
   {
@@ -76,8 +76,8 @@ namespace ecaldqm
     //     HLTCaloBit_ = false;
     //     HLTMuonBit_ = false;
 
-    int* pBin(std::upper_bound(bxBinEdges_, bxBinEdges_ + nBXBins + 1, _evt.bunchCrossing()));
-    bxBin_ = static_cast<int>(pBin - bxBinEdges_) - 0.5;
+    int* pBin(std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing()));
+    bxBin_ = static_cast<int>(pBin - bxBinEdges_.begin()) - 0.5;
 
     edm::ESHandle<EcalTPGTowerStatus> TTStatusRcd_;
     _es.get<EcalTPGTowerStatusRcd>().get(TTStatusRcd_);


### PR DESCRIPTION
Companion to Deployment PR#455: https://github.com/dmwm/deployment/pull/455

PR to CMSSW master: https://github.com/cms-sw/cmssw/pull/18067

- Added new plots for the average partition timing v/s BX number.
- Changed expected values of laser timing from 4.2 clocks to 3.7 clocks for Laser 2. Also changed (the value of the deviation from the expected timing above which bad quality is triggered) to 1.0.