### PR TITLE
Add histograms for nrec/nsim, and average number of pixel/strip hits to MultiTrackValidator

### DIFF
--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -1,6 +1,7 @@
 #ifndef CommonTools_RecoAlgos_RecoTrackSelectorBase_h
 #define CommonTools_RecoAlgos_RecoTrackSelectorBase_h
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 

--- a/DQMServices/ClientConfig/interface/DQMGenericClient.h
+++ b/DQMServices/ClientConfig/interface/DQMGenericClient.h
@@ -33,11 +33,17 @@ class DQMGenericClient : public DQMEDHarvester
 
   void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;
 
+  enum class EfficType {
+    none = 0,
+    efficiency,
+    fakerate
+  };
+
   struct EfficOption
   {
     std::string name, title;
     std::string numerator, denominator;
-    int type;
+    EfficType type;
     bool isProfile;
   };
 
@@ -71,7 +77,7 @@ class DQMGenericClient : public DQMEDHarvester
                          const std::string& efficMETitle,
                          const std::string& recoMEName, 
                          const std::string& simMEName, 
-                         const int type=1,
+                         const EfficType type=EfficType::efficiency,
                          const bool makeProfile = false);
   void computeResolution(DQMStore::IBooker& ibooker,
 			 DQMStore::IGetter& igetter,
@@ -112,7 +118,7 @@ class DQMGenericClient : public DQMEDHarvester
   std::vector<NormOption> normOptions_;
   std::vector<CDOption> cdOptions_;
 
-  void generic_eff (TH1 * denom, TH1 * numer, MonitorElement * efficiencyHist, const int type=1);
+  void generic_eff (TH1 * denom, TH1 * numer, MonitorElement * efficiencyHist, const EfficType type=EfficType::efficiency);
 
   void findAllSubdirectories (DQMStore::IBooker& ibooker,
 			      DQMStore::IGetter& igetter,

--- a/DQMServices/ClientConfig/interface/DQMGenericClient.h
+++ b/DQMServices/ClientConfig/interface/DQMGenericClient.h
@@ -36,7 +36,8 @@ class DQMGenericClient : public DQMEDHarvester
   enum class EfficType {
     none = 0,
     efficiency,
-    fakerate
+    fakerate,
+    simpleratio
   };
 
   struct EfficOption

--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -70,9 +70,9 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
     opt.isProfile = false;
 
     const string typeName = args.size() == 4 ? "eff" : args[4];
-    if ( typeName == "eff" ) opt.type = 1;
-    else if ( typeName == "fake" ) opt.type = 2;
-    else opt.type = 0;
+    if ( typeName == "eff" ) opt.type = EfficType::efficiency;
+    else if ( typeName == "fake" ) opt.type = EfficType::fakerate;
+    else opt.type = EfficType::none;
  
     efficOptions_.push_back(opt);
   }
@@ -89,9 +89,9 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
     opt.isProfile = false;
 
     const string typeName = efficSet->getUntrackedParameter<string>("typeName", "eff");
-    if ( typeName == "eff" ) opt.type = 1;
-    else if ( typeName == "fake" ) opt.type = 2;
-    else opt.type = 0;
+    if ( typeName == "eff" ) opt.type = EfficType::efficiency;
+    else if ( typeName == "fake" ) opt.type = EfficType::fakerate;
+    else opt.type = EfficType::none;
 
     efficOptions_.push_back(opt);
   }
@@ -125,9 +125,9 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
     opt.isProfile = true;
 
     const string typeName = args.size() == 4 ? "eff" : args[4];
-    if ( typeName == "eff" ) opt.type = 1;
-    else if ( typeName == "fake" ) opt.type = 2;
-    else opt.type = 0;
+    if ( typeName == "eff" ) opt.type = EfficType::efficiency;
+    else if ( typeName == "fake" ) opt.type = EfficType::fakerate;
+    else opt.type = EfficType::none;
  
     efficOptions_.push_back(opt);
   }
@@ -144,9 +144,9 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
     opt.isProfile = true;
 
     const string typeName = effProfileSet->getUntrackedParameter<string>("typeName", "eff");
-    if ( typeName == "eff" ) opt.type = 1;
-    else if ( typeName == "fake" ) opt.type = 2;
-    else opt.type = 0;
+    if ( typeName == "eff" ) opt.type = EfficType::efficiency;
+    else if ( typeName == "fake" ) opt.type = EfficType::fakerate;
+    else opt.type = EfficType::none;
 
     efficOptions_.push_back(opt);
   }
@@ -399,7 +399,7 @@ void DQMGenericClient::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter 
 }
 
 void DQMGenericClient::computeEfficiency (DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, const string& startDir, const string& efficMEName,
-					 const string& efficMETitle, const string& recoMEName, const string& simMEName, const int type, const bool makeProfile)
+					 const string& efficMETitle, const string& recoMEName, const string& simMEName, const EfficType type, const bool makeProfile)
 {
   if ( ! igetter.dirExists(startDir) ) {
     if ( verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_) ) {
@@ -595,8 +595,8 @@ void DQMGenericClient::computeEfficiency (DQMStore::IBooker& ibooker, DQMStore::
   const float nSimAll = hSim->GetEntries();
   const float nRecoAll = hReco->GetEntries();
   float efficAll=0; 
-  if ( type == 1 ) efficAll = nSimAll ? nRecoAll/nSimAll : 0;
-  else if ( type == 2 ) efficAll = nSimAll ? 1-nRecoAll/nSimAll : 0;
+  if ( type == EfficType::efficiency ) efficAll = nSimAll ? nRecoAll/nSimAll : 0;
+  else if ( type == EfficType::fakerate ) efficAll = nSimAll ? 1-nRecoAll/nSimAll : 0;
   const float errorAll = nSimAll && efficAll < 1 ? sqrt(efficAll*(1-efficAll)/nSimAll) : 0;
 
   const int iBin = hGlobalEffic->Fill(newEfficMEName.c_str(), 0);
@@ -927,7 +927,7 @@ void DQMGenericClient::findAllSubdirectories (DQMStore::IBooker& ibooker, DQMSto
 }
 
 
-void DQMGenericClient::generic_eff (TH1* denom, TH1* numer, MonitorElement* efficiencyHist, const int type) {
+void DQMGenericClient::generic_eff (TH1* denom, TH1* numer, MonitorElement* efficiencyHist, const EfficType type) {
   for (int iBinX = 1; iBinX < denom->GetNbinsX()+1; iBinX++){
     for (int iBinY = 1; iBinY < denom->GetNbinsY()+1; iBinY++){
       for (int iBinZ = 1; iBinZ < denom->GetNbinsZ()+1; iBinZ++){
@@ -940,7 +940,7 @@ void DQMGenericClient::generic_eff (TH1* denom, TH1* numer, MonitorElement* effi
         float effVal = 0;
 
         // fake eff is in use
-        if (type == 2 ) {          
+        if (type == EfficType::fakerate) {
           effVal = denomVal ? (1 - numerVal / denomVal) : 0;
         } else {
           effVal = denomVal ? numerVal / denomVal : 0;

--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -248,9 +248,9 @@ class MTVHistoProducerAlgoForTracker {
 
   //#hit vs eta: to be used with doProfileX
   std::vector<MonitorElement*> nhits_vs_eta,
-    nPXBhits_vs_eta, nPXFhits_vs_eta,
+    nPXBhits_vs_eta, nPXFhits_vs_eta, nPXLhits_vs_eta,
     nTIBhits_vs_eta,nTIDhits_vs_eta,
-    nTOBhits_vs_eta,nTEChits_vs_eta,
+    nTOBhits_vs_eta,nTEChits_vs_eta, nSTRIPhits_vs_eta,
     nLayersWithMeas_vs_eta, nPXLlayersWithMeas_vs_eta,
     nSTRIPlayersWithMeas_vs_eta, nSTRIPlayersWith1dMeas_vs_eta, nSTRIPlayersWith2dMeas_vs_eta;
 

--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -22,16 +22,24 @@
 
 #include "SimTracker/Common/interface/TrackingParticleSelector.h"
 #include "CommonTools/CandAlgos/interface/GenParticleCustomSelector.h"
+#include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
 
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
+namespace edm { class Event; class EventSetup; }
+
 class MTVHistoProducerAlgoForTracker {
  public:
-  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, const bool doSeedPlots, edm::ConsumesCollector && iC) :
-    MTVHistoProducerAlgoForTracker(pset, doSeedPlots, iC) {}
-  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, const bool doSeedPlots, edm::ConsumesCollector & iC) ;
+  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, const edm::InputTag& beamSpotTag, const bool doSeedPlots, edm::ConsumesCollector && iC) :
+    MTVHistoProducerAlgoForTracker(pset, beamSpotTag, doSeedPlots, iC) {}
+  MTVHistoProducerAlgoForTracker(const edm::ParameterSet& pset, const edm::InputTag& beamSpotTag, const bool doSeedPlots, edm::ConsumesCollector & iC) ;
   ~MTVHistoProducerAlgoForTracker();
+
+  static std::unique_ptr<RecoTrackSelectorBase> makeRecoTrackSelectorFromTPSelectorParameters(const edm::ParameterSet& pset, const edm::InputTag& beamSpotTag, edm::ConsumesCollector& iC);
+  static std::unique_ptr<RecoTrackSelectorBase> makeRecoTrackSelectorFromTPSelectorParameters(const edm::ParameterSet& pset, const edm::InputTag& beamSpotTag, edm::ConsumesCollector&& iC) { return makeRecoTrackSelectorFromTPSelectorParameters(pset, beamSpotTag, iC); }
+
+  void init(const edm::Event& event, const edm::EventSetup& setup);
 
   void bookSimHistos(DQMStore::IBooker& ibook);
   void bookSimTrackHistos(DQMStore::IBooker& ibook);
@@ -94,7 +102,8 @@ class MTVHistoProducerAlgoForTracker {
   void fill_trackBased_histos(int count,
 		 	      int assTracks,
 			      int numRecoTracks,
-			      int numSimTracks);
+			      int numRecoTracksSelected,
+			      int numSimTracksSelected);
 
 
   void fill_ResoAndPull_recoTrack_histos(int count,
@@ -130,6 +139,10 @@ class MTVHistoProducerAlgoForTracker {
   std::unique_ptr<TrackingParticleSelector> TpSelectorForEfficiencyVsPt;
   std::unique_ptr<TrackingParticleSelector> TpSelectorForEfficiencyVsVTXR;
   std::unique_ptr<TrackingParticleSelector> TpSelectorForEfficiencyVsVTXZ;
+
+  std::unique_ptr<RecoTrackSelectorBase> trackSelectorVsEta;
+  std::unique_ptr<RecoTrackSelectorBase> trackSelectorVsPhi;
+  std::unique_ptr<RecoTrackSelectorBase> trackSelectorVsPt;
 
   std::unique_ptr<GenParticleCustomSelector> generalGpSelector;
   std::unique_ptr<GenParticleCustomSelector> GpSelectorForEfficiencyVsEta;
@@ -179,13 +192,13 @@ class MTVHistoProducerAlgoForTracker {
 
   //1D
   std::vector<MonitorElement*> h_tracks, h_fakes, h_hits, h_charge, h_algo, h_seedsFitFailed, h_seedsFitFailedFraction;
-  std::vector<MonitorElement*> h_recoeta, h_assoceta, h_assoc2eta, h_simuleta, h_loopereta, h_misideta, h_pileupeta;
-  std::vector<MonitorElement*> h_recopT, h_assocpT, h_assoc2pT, h_simulpT, h_looperpT, h_misidpT, h_pileuppT;
+  std::vector<MonitorElement*> h_recoeta, h_reco2eta, h_assoceta, h_assoc2eta, h_simuleta, h_loopereta, h_misideta, h_pileupeta;
+  std::vector<MonitorElement*> h_recopT, h_reco2pT, h_assocpT, h_assoc2pT, h_simulpT, h_looperpT, h_misidpT, h_pileuppT;
   std::vector<MonitorElement*> h_recohit, h_assochit, h_assoc2hit, h_simulhit, h_looperhit, h_misidhit, h_pileuphit;
   std::vector<MonitorElement*> h_recolayer, h_assoclayer, h_assoc2layer, h_simullayer, h_looperlayer, h_misidlayer, h_pileuplayer;
   std::vector<MonitorElement*> h_recopixellayer, h_assocpixellayer, h_assoc2pixellayer, h_simulpixellayer, h_looperpixellayer, h_misidpixellayer, h_pileuppixellayer;
   std::vector<MonitorElement*> h_reco3Dlayer, h_assoc3Dlayer, h_assoc23Dlayer, h_simul3Dlayer, h_looper3Dlayer, h_misid3Dlayer, h_pileup3Dlayer;
-  std::vector<MonitorElement*> h_recopu, h_assocpu, h_assoc2pu, h_simulpu, h_looperpu, h_misidpu, h_pileuppu;
+  std::vector<MonitorElement*> h_recopu, h_reco2pu, h_assocpu, h_assoc2pu, h_simulpu, h_looperpu, h_misidpu, h_pileuppu;
   std::vector<MonitorElement*> h_recophi, h_assocphi, h_assoc2phi, h_simulphi, h_looperphi, h_misidphi, h_pileupphi;
   std::vector<MonitorElement*> h_recodxy, h_assocdxy, h_assoc2dxy, h_simuldxy, h_looperdxy, h_misiddxy, h_pileupdxy;
   std::vector<MonitorElement*> h_recodz, h_assocdz, h_assoc2dz, h_simuldz, h_looperdz, h_misiddz, h_pileupdz;

--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -11,6 +11,7 @@
 #include "Validation/RecoTrack/interface/MultiTrackValidatorBase.h"
 #include "Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h"
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
+#include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
 
 class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorBase {
  public:
@@ -67,6 +68,7 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
   CosmicTrackingParticleSelector cosmictpSelector;
   TrackingParticleSelector dRtpSelector;				      
   TrackingParticleSelector dRtpSelectorNoPtCut;
+  std::unique_ptr<RecoTrackSelectorBase> dRTrackSelector;
 
   edm::EDGetTokenT<SimHitTPAssociationProducer::SimHitTPAssociationList> _simHitTpMapTag;
   edm::EDGetTokenT<edm::View<reco::Track> > labelTokenForDrCalculation;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -530,23 +530,22 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
       etaL[iTP] = etaFromXYZ(p.x(),p.y(),p.z());
       phiL[iTP] = atan2f(p.y(),p.x());
     }
-    auto i=0U;
-    for(size_t iTP: selected_tPCeff) {
-      auto const& tp = *(tPCeff[iTP]);
+    for(size_t iTP1: selected_tPCeff) {
+      auto const& tp = *(tPCeff[iTP1]);
       double dR = std::numeric_limits<double>::max();
       if(dRtpSelector(tp)) {//only for those needed for efficiency!
         ++n_selTP_dr;
         auto  && p = tp.momentum();
         float eta = etaFromXYZ(p.x(),p.y(),p.z());
         float phi = atan2f(p.y(),p.x());
-        for(size_t iTP: selected_tPCeff) {
+        for(size_t iTP2: selected_tPCeff) {
           //calculare dR wrt inclusive collection (also with PU, low pT, displaced)
-	  if (i==iTP) {continue;}
-          auto dR_tmp = reco::deltaR2(eta, phi, etaL[iTP], phiL[iTP]);
+	  if (iTP1==iTP2) {continue;}
+          auto dR_tmp = reco::deltaR2(eta, phi, etaL[iTP2], phiL[iTP2]);
           if (dR_tmp<dR) dR=dR_tmp;
         }  // ttp2 (iTP)
       }
-      dR_tPCeff[i++] = std::sqrt(dR);
+      dR_tPCeff[iTP1] = std::sqrt(dR);
     }  // tp
   }
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -661,8 +661,6 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
       LogTrace("TrackValidator") << "\n# of TrackingParticles: " << tPCeff.size() << "\n";
       int ats(0);  	  //This counter counts the number of simTracks that are "associated" to recoTracks
       int st(0);    	  //This counter counts the number of simulated tracks passing the MTV selection (i.e. tpSelector(tp) )
-      unsigned sts(0);   //This counter counts the number of simTracks surviving the bunchcrossing cut
-      unsigned asts(0);  //This counter counts the number of simTracks that are "associated" to recoTracks surviving the bunchcrossing cut
 
       //loop over already-selected TPs for tracking efficiency
       for(size_t i=0; i<selected_tPCeff.size(); ++i) {
@@ -783,9 +781,6 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
         int nSimStripMonoAndStereoLayers = nStripMonoAndStereoLayers_tPCeff[tpr];
         histoProducerAlgo_->fill_recoAssociated_simTrack_histos(w,tp,momentumTP,vertexTP,dxySim,dzSim,dxyPVSim,dzPVSim,nSimHits,nSimLayers,nSimPixelLayers,nSimStripMonoAndStereoLayers,matchedTrackPointer,puinfo.getPU_NumInteractions(), dR, thePVposition, theSimPVPosition, mvaValues, selectsLoose, selectsHP);
         mvaValues.clear();
-          sts++;
-          if(matchedTrackPointer)
-            asts++;
           if(doSummaryPlots_) {
             if(dRtpSelectorNoPtCut(tp)) {
               h_simul_coll_allPt[ww]->Fill(www);

--- a/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
@@ -402,7 +402,7 @@ void MultiTrackValidatorGenPs::analyze(const edm::Event& event, const edm::Event
       
     } // End of for(View<Track>::size_type i=0; i<trackCollection->size(); ++i){
     
-    histoProducerAlgo_->fill_trackBased_histos(w,at,rT,st);
+    histoProducerAlgo_->fill_trackBased_histos(w,at,rT,rT,st);
     
     edm::LogVerbatim("TrackValidator") << "Total Simulated: " << st << "\n"
                                        << "Total Associated (genToReco): " << ats << "\n"

--- a/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
+++ b/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
@@ -38,8 +38,8 @@ MTVHistoProducerAlgoForTrackerBlock = cms.PSet(
     nintHit = cms.int32(81),
     #                               
     minPu = cms.double(-0.5),                            
-    maxPu = cms.double(199.5),
-    nintPu = cms.int32(100),
+    maxPu = cms.double(259.5),
+    nintPu = cms.int32(130),
     #
     minLayers = cms.double(-0.5),                            
     maxLayers = cms.double(25.5),
@@ -91,7 +91,7 @@ MTVHistoProducerAlgoForTrackerBlock = cms.PSet(
 
     minTracks = cms.double(0),
     maxTracks = cms.double(2000),
-    nintTracks = cms.int32(100),
+    nintTracks = cms.int32(200),
 
     # PV z coordinate (to be kept in synch with PrimaryVertexAnalyzer4PUSlimmed)
     minPVz = cms.double(-60),

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -217,6 +217,19 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
     outputFileName = cms.untracked.string("")
 )
 
+# nrec/nsim makes sense only for
+# - all tracks vs. all in-time TrackingParticles
+# - PV tracks vs. signal TrackingParticles
+postProcessorTrackNrecVsNsim = cms.EDAnalyzer("DQMGenericClient",
+    subDirs = cms.untracked.vstring("Tracking/TrackFromPV/*", "Tracking/TrackAllTPEffic/*"),
+    efficiency = cms.vstring(
+        "nrecPerNsim 'Tracks/TrackingParticles vs #eta' num_reco2_eta num_simul_eta simpleratio",
+        "nrecPerNsimPt 'Tracks/TrackingParticles vs p_{T}' num_reco2_pT num_simul_pT simpleratio",
+        "nrecPerNsim_vs_pu 'Tracks/TrackingParticles vs pu' num_reco2_pu num_simul_pu simpleratio",
+    ),
+    resolution = cms.vstring()
+)
+
 postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackConversion", "Tracking/TrackGsf", "Tracking/TrackBHadron"),
     efficiency = cms.vstring(
@@ -229,11 +242,19 @@ postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
     resolution = cms.vstring()
 )
 
-postProcessorTrackSequence = cms.Sequence(postProcessorTrack+postProcessorTrackSummary)
+postProcessorTrackSequence = cms.Sequence(
+    postProcessorTrack+
+    postProcessorTrackNrecVsNsim+
+    postProcessorTrackSummary
+)
 
 postProcessorTrackTrackingOnly = postProcessorTrack.clone()
 postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackSeeding/*", "Tracking/TrackBuilding/*"])
 postProcessorTrackSummaryTrackingOnly = postProcessorTrackSummary.clone()
 postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackSeeding", "Tracking/TrackBuilding"])
 
-postProcessorTrackSequenceTrackingOnly = cms.Sequence(postProcessorTrackTrackingOnly+postProcessorTrackSummaryTrackingOnly)
+postProcessorTrackSequenceTrackingOnly = cms.Sequence(
+    postProcessorTrackTrackingOnly+
+    postProcessorTrackNrecVsNsim+
+    postProcessorTrackSummaryTrackingOnly
+)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -392,7 +392,7 @@ trackValidatorAllTPEffic = trackValidator.clone(
     dirName = "Tracking/TrackAllTPEffic/",
     label = [x for x in trackValidator.label.value() if "Pt09" not in x],
     doSimPlots = False,
-    doRecoTrackPlots = False, # Fake rate of all tracks vs. all TPs is already included in trackValidator
+    doRecoTrackPlots = True, # Fake rate of all tracks vs. all TPs is already included in trackValidator, but we want the reco plots for other reasons
     doPVAssociationPlots = False,
 )
 trackValidatorAllTPEffic.histoProducerAlgoBlock.generalTpSelector.signalOnly = False

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -365,23 +365,31 @@ def _getXmax(obj, limitToNonZeroContent=False):
         return m*1.1 if m > 0 else m*0.9
     raise Exception("Unsupported type %s" % str(obj))
 
-def _getYmin(obj):
+def _getYmin(obj, limitToNonZeroContent=False):
     if isinstance(obj, ROOT.TH2):
         yaxis = obj.GetYaxis()
         return yaxis.GetBinLowEdge(yaxis.GetFirst())
     elif isinstance(obj, ROOT.TH1):
-        return obj.GetMinimum()
+        if limitToNonZeroContent:
+            lst = [obj.GetBinContent(i) for i in xrange(1, obj.GetNbinsX()+1) if obj.GetBinContent(i) != 0 ]
+            return min(lst) if len(lst) != 0 else 0
+        else:
+            return obj.GetMinimum()
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
         m = min([obj.GetY()[i] for i in xrange(0, obj.GetN())])
         return m*0.9 if m > 0 else m*1.1
     raise Exception("Unsupported type %s" % str(obj))
 
-def _getYmax(obj):
+def _getYmax(obj, limitToNonZeroContent=False):
     if isinstance(obj, ROOT.TH2):
         yaxis = obj.GetYaxis()
         return yaxis.GetBinUpEdge(yaxis.GetLast())
     elif isinstance(obj, ROOT.TH1):
-        return obj.GetMaximum()
+        if limitToNonZeroContent:
+            lst = [obj.GetBinContent(i) for i in xrange(1, obj.GetNbinsX()+1) if obj.GetBinContent(i) != 0 ]
+            return max(lst) if len(lst) != 0 else 0
+        else:
+            return obj.GetMaximum()
     elif isinstance(obj, ROOT.TGraph) or isinstance(obj, ROOT.TGraph2D):
         m = max([obj.GetY()[i] for i in xrange(0, obj.GetN())])
         return m*1.1 if m > 0 else m*0.9
@@ -547,8 +555,8 @@ def _findBoundsY(th1s, ylog, ymin=None, ymax=None, coverage=None, coverageRange=
                 if ylog and isinstance(ymin, list):
                     _ymin = _getYminIgnoreOutlier(th1)
                 else:
-                    _ymin = _getYmin(th1)
-                _ymax = _getYmax(th1)
+                    _ymin = _getYmin(th1, limitToNonZeroContent=isinstance(ymin, list))
+                _ymax = _getYmax(th1, limitToNonZeroContent=isinstance(ymax, list))
 #                _ymax = _getYmaxWithError(th1)
 
             ymins.append(_ymin)

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -16,7 +16,7 @@ from html import PlotPurpose
 #
 ########################################
 
-_maxEff = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025]
+_maxEff = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025, 1.2, 1.5, 2]
 _maxFake = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025]
 
 #_minMaxResol = [1e-5, 2e-5, 5e-5, 1e-4, 2e-4, 5e-4, 1e-3, 2e-3, 5e-3, 1e-2, 2e-2, 5e-2, 0.1, 0.2, 0.5, 1]
@@ -32,6 +32,7 @@ _min3DLayers = [0, 5, 10]
 _max3DLayers = [5, 10, 20]
 _minPU = [0, 10, 20, 50, 100, 150]
 _maxPU = [20, 50, 65, 80, 100, 150, 200, 250]
+_minMaxTracks = [0, 200, 500, 1000, 1500, 2000]
 
 _legendDy_1row = 0.46
 _legendDy_2rows = -0.025
@@ -371,6 +372,20 @@ _extDist5 = PlotGroup("dist5",
                       _makeDistPlots("seedingLayerSet", "seeding layers", common=dict(xtitle="", **_seedingLayerSet_common)),
                       ncols=4, legendDy=_legendDy_2rows_3cols
 )
+_common = dict(title="", ytitle="Selected tracks/TrackingParticles", ymax=_maxEff)
+_extNrecVsNsim = PlotGroup("nrecVsNsim", [
+    Plot("nrec_vs_nsim", title="", xtitle="TrackingParticles", ytitle="Tracks", profileX=True, xmin=_minMaxTracks, xmax=_minMaxTracks, ymin=_minMaxTracks, ymax=_minMaxTracks),
+    Plot("nrecPerNsim_vs_pu", xtitle="Pileup", xmin=_minPU, xmax=_maxPU, **_common),
+    Plot("nrecPerNsimPt", xtitle="p_{T} (GeV)", xlog=True, **_common),
+    Plot("nrecPerNsim", xtitle="#eta", **_common)
+], legendDy=_legendDy_2rows)
+_extHitsLayers = PlotGroup("hitsLayers", [
+    Plot("PXLhits_vs_eta", xtitle="#eta", ytitle="<pixel hits>"),
+    Plot("PXLlayersWithMeas_vs_eta", xtitle="#eta", ytitle="<pixel layers>"),
+    Plot("STRIPhits_vs_eta", xtitle="#eta", ytitle="<strip hits>"),
+    Plot("STRIPlayersWithMeas_vs_eta", xtitle="#eta", ytitle="<strip layers>"),
+], legendDy=_legendDy_2rows)
+
 
 ## Extended set of plots also for simulation
 _extDistSim1 = PlotGroup("distsim1",
@@ -966,6 +981,8 @@ _extendedPlots = [
     _extDist3,
     _extDist4,
     _extDist5,
+    _extNrecVsNsim,
+    _extHitsLayers,
     _extDistSim1,
     _extDistSim2,
     _extDistSim3,

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -574,10 +574,12 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook) {
   nhits_vs_eta.push_back( ibook.bookProfile("hits_eta","mean hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
   nPXBhits_vs_eta.push_back( ibook.bookProfile("PXBhits_vs_eta","mean # PXB its vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
   nPXFhits_vs_eta.push_back( ibook.bookProfile("PXFhits_vs_eta","mean # PXF hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nPXLhits_vs_eta.push_back( ibook.bookProfile("PXLhits_vs_eta","mean # PXL hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
   nTIBhits_vs_eta.push_back( ibook.bookProfile("TIBhits_vs_eta","mean # TIB hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
   nTIDhits_vs_eta.push_back( ibook.bookProfile("TIDhits_vs_eta","mean # TID hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
   nTOBhits_vs_eta.push_back( ibook.bookProfile("TOBhits_vs_eta","mean # TOB hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
   nTEChits_vs_eta.push_back( ibook.bookProfile("TEChits_vs_eta","mean # TEC hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nSTRIPhits_vs_eta.push_back( ibook.bookProfile("STRIPhits_vs_eta","mean # STRIP hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
 
   nLayersWithMeas_vs_eta.push_back( ibook.bookProfile("LayersWithMeas_eta","mean # Layers with measurement vs eta",
                                                       nintEta,minEta,maxEta,nintLayers,minLayers,maxLayers, " ") );
@@ -1189,12 +1191,20 @@ void MTVHistoProducerAlgoForTracker::fill_simAssociated_recoTrack_histos(int cou
     const auto eta = getEta(track.eta());
     chi2_vs_eta[count]->Fill(eta, track.normalizedChi2());
     nhits_vs_eta[count]->Fill(eta, track.numberOfValidHits());
-    nPXBhits_vs_eta[count]->Fill(eta, track.hitPattern().numberOfValidPixelBarrelHits());
-    nPXFhits_vs_eta[count]->Fill(eta, track.hitPattern().numberOfValidPixelEndcapHits());
-    nTIBhits_vs_eta[count]->Fill(eta, track.hitPattern().numberOfValidStripTIBHits());
-    nTIDhits_vs_eta[count]->Fill(eta, track.hitPattern().numberOfValidStripTIDHits());
-    nTOBhits_vs_eta[count]->Fill(eta, track.hitPattern().numberOfValidStripTOBHits());
-    nTEChits_vs_eta[count]->Fill(eta, track.hitPattern().numberOfValidStripTECHits());
+    const auto pxbHits = track.hitPattern().numberOfValidPixelBarrelHits();
+    const auto pxfHits = track.hitPattern().numberOfValidPixelEndcapHits();
+    const auto tibHits = track.hitPattern().numberOfValidStripTIBHits();
+    const auto tidHits = track.hitPattern().numberOfValidStripTIDHits();
+    const auto tobHits = track.hitPattern().numberOfValidStripTOBHits();
+    const auto tecHits = track.hitPattern().numberOfValidStripTECHits();
+    nPXBhits_vs_eta[count]->Fill(eta, pxbHits);
+    nPXFhits_vs_eta[count]->Fill(eta, pxfHits);
+    nPXLhits_vs_eta[count]->Fill(eta, pxbHits+pxfHits);
+    nTIBhits_vs_eta[count]->Fill(eta, tibHits);
+    nTIDhits_vs_eta[count]->Fill(eta, tidHits);
+    nTOBhits_vs_eta[count]->Fill(eta, tobHits);
+    nTEChits_vs_eta[count]->Fill(eta, tecHits);
+    nSTRIPhits_vs_eta[count]->Fill(eta, tibHits+tidHits+tobHits+tecHits);
     nLayersWithMeas_vs_eta[count]->Fill(eta, track.hitPattern().trackerLayersWithMeasurement());
     nPXLlayersWithMeas_vs_eta[count]->Fill(eta, track.hitPattern().pixelLayersWithMeasurement());
     int LayersAll = track.hitPattern().stripLayersWithMeasurement();


### PR DESCRIPTION
This PR adds the following histograms to MultiTrackValidator
* nrec/sim vs. pT, eta, PU
  * as a prerequisite, `num_reco2_{pT,eta,pu}` histograms are added to have distributions of tracks passing the same selection as TrackingParticles in corresponding `num_simul_{pT,eta,pu}` histograms
* average number of pixel or strip hits vs. eta

and the `nrec_vs_nsim` histogram is modified to show the numbers of selected tracks vs. selected TrackingParticles (selection as for phi etc. histograms).

In addition
* a missing include to `Event.h` is added to `RecoTrackSelectorBase.h`
* A new option "simpleratio" is added to `DQMGenericClient` efficiency calculation
  * also some magic numbers are replaced with `enum class`

Tested in 9_1_0_pre1, in addition to new histograms expecting changes in `tracks`, `fakes`, and `{num,effic,...}_*_pu` histograms because of modified axis limits.

@rovere @VinInn @ebrondol 