### PR TITLE
Sort worker summary after all streams have been added

### DIFF
--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1109,6 +1109,7 @@ namespace edm {
     for(auto& s: streamSchedules_) {
       s->getTriggerReport(rep);
     }
+    sort_all(rep.workerSummaries);
   }
 
   void

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -857,7 +857,6 @@ namespace edm {
     fill_summary(trig_paths_,  rep.trigPathSummaries, &fillPathSummary);
     fill_summary(end_paths_,   rep.endPathSummaries,  &fillPathSummary);
     fill_summary(allWorkers(), rep.workerSummaries,   &fillWorkerSummary);
-    sort_all(rep.workerSummaries);
   }
 
   void


### PR DESCRIPTION
The worker summary was reporting incorrect values because the code assumed the ordering of modules in the list was the same from one StreamSchedule to the next. This was violated since StreamSchedules fill the container in the order from allModules() but then at the end would sort based on name. Therefore the first StreamSchedule called would reorder the list and the other StreamSchedules would assume it was the original order.
Now sorting is done only after all StreamScheduled have been called.