### PR TITLE
Speed up newCell() in HcalGeometry

### DIFF
--- a/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
@@ -12,9 +12,13 @@
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include <atomic>
 
+class HcalDDDGeometryLoader;
+
 class HcalDDDGeometry : public CaloSubdetectorGeometry {
 
 public:
+
+  friend class HcalDDDGeometryLoader;
 
   typedef std::vector<IdealObliquePrism> HBCellVec ;
   typedef std::vector<IdealObliquePrism> HECellVec ;
@@ -43,6 +47,22 @@ protected:
   virtual const CaloCellGeometry* cellGeomPtr( uint32_t index ) const ;
 
 private:
+
+  void newCellImpl( const GlobalPoint& f1 ,
+			const GlobalPoint& f2 ,
+			const GlobalPoint& f3 ,
+			const CCGFloat*    parm,
+			const DetId&       detId     ) ;
+
+  //can only be used by friend classes, to ensure sorting is done at the end					
+  void newCellFast( const GlobalPoint& f1 ,
+			const GlobalPoint& f2 ,
+			const GlobalPoint& f3 ,
+			const CCGFloat*    parm,
+			const DetId&       detId     ) ;
+
+  void increaseReserve(unsigned int extra);
+  void sortValidIds();
 
   void fillDetIds() const ;
 

--- a/Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h
@@ -8,6 +8,7 @@
 
 class CaloCellGeometry;
 class HcalDetId;
+class HcalDDDGeometry;
 
 /** \class HcalDDDGeometryLoader
  *
@@ -35,11 +36,11 @@ private:
 
   /// helper functions to make all the ids and cells, and put them into the
   /// vectors and mpas passed in.
-  void fill(HcalSubdetector, HcalDDDGeometry*, CaloSubdetectorGeometry*);
+  void fill(HcalSubdetector, HcalDDDGeometry*);
   
   void makeCell( const HcalDetId &, 
 		 const HcalCellType& , double, 
-		 double, CaloSubdetectorGeometry* geom) const;
+		 double, HcalDDDGeometry* geom) const;
   
   const HcalDDDRecConstants* hcalConstants;
 

--- a/Geometry/HcalTowerAlgo/interface/HcalFlexiHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalFlexiHardcodeGeometryLoader.h
@@ -13,6 +13,7 @@
 
 class HcalTopology;
 class HcalDDDRecConstants;
+class HcalGeometry;
 
 class HcalFlexiHardcodeGeometryLoader {
 
@@ -78,9 +79,9 @@ private:
   std::vector <HECellParameters> makeHECells_H2 ();
   std::vector <HFCellParameters> makeHFCells (const HcalDDDRecConstants& hcons);
 
-  void fillHBHO (CaloSubdetectorGeometry* fGeometry, const std::vector <HBHOCellParameters>& fCells, bool fHB);
-  void fillHE (CaloSubdetectorGeometry* fGeometry, const std::vector <HECellParameters>& fCells);
-  void fillHF (CaloSubdetectorGeometry* fGeometry, const std::vector <HFCellParameters>& fCells);
+  void fillHBHO (HcalGeometry* fGeometry, const std::vector <HBHOCellParameters>& fCells, bool fHB);
+  void fillHE (HcalGeometry* fGeometry, const std::vector <HECellParameters>& fCells);
+  void fillHF (HcalGeometry* fGeometry, const std::vector <HFCellParameters>& fCells);
 
   int    MAX_HCAL_PHI;
   double DEGREE2RAD;

--- a/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
@@ -11,9 +11,15 @@
 #include "CondFormats/AlignmentRecord/interface/HcalAlignmentRcd.h"
 #include "Geometry/Records/interface/HcalGeometryRecord.h"
 
+class HcalFlexiHardcodeGeometryLoader;
+class HcalHardcodeGeometryLoader;
+
 class HcalGeometry : public CaloSubdetectorGeometry {
 
 public:
+
+  friend class HcalFlexiHardcodeGeometryLoader;
+  friend class HcalHardcodeGeometryLoader;
   
   typedef std::vector<IdealObliquePrism> HBCellVec ;
   typedef std::vector<IdealObliquePrism> HECellVec ;
@@ -118,6 +124,23 @@ protected:
   virtual unsigned int sizeForDenseIndex(const DetId& id) const { return m_topology.ncells(); }
 
 private:
+
+  //returns din
+  unsigned int newCellImpl( const GlobalPoint& f1 ,
+			const GlobalPoint& f2 ,
+			const GlobalPoint& f3 ,
+			const CCGFloat*    parm,
+			const DetId&       detId     ) ;
+
+  //can only be used by friend classes, to ensure sorting is done at the end
+  void newCellFast( const GlobalPoint& f1 ,
+			const GlobalPoint& f2 ,
+			const GlobalPoint& f3 ,
+			const CCGFloat*    parm,
+			const DetId&       detId     ) ;
+
+  void increaseReserve(unsigned int extra);
+  void sortValidIds();
 
   void fillDetIds() const ;
 

--- a/Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 class HcalTopology;
+class HcalGeometry;
 
 class HcalHardcodeGeometryLoader {
 
@@ -76,9 +77,9 @@ private:
   std::vector <HECellParameters> makeHECells_H2 ();
   std::vector <HFCellParameters> makeHFCells ();
 
-  void fillHBHO (CaloSubdetectorGeometry* fGeometry, const std::vector <HBHOCellParameters>& fCells, bool fHB);
-  void fillHE (CaloSubdetectorGeometry* fGeometry, const std::vector <HECellParameters>& fCells);
-  void fillHF (CaloSubdetectorGeometry* fGeometry, const std::vector <HFCellParameters>& fCells);
+  void fillHBHO (HcalGeometry* fGeometry, const std::vector <HBHOCellParameters>& fCells, bool fHB);
+  void fillHE (HcalGeometry* fGeometry, const std::vector <HECellParameters>& fCells);
+  void fillHF (HcalGeometry* fGeometry, const std::vector <HFCellParameters>& fCells);
 
   int    MAX_HCAL_PHI;
   double DEGREE2RAD;

--- a/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
@@ -162,7 +162,7 @@ HcalDDDGeometry::insertCell(std::vector<HcalCellType> const & cells){
 }
 
 void
-HcalDDDGeometry::newCell( const GlobalPoint& f1 ,
+HcalDDDGeometry::newCellImpl( const GlobalPoint& f1 ,
 			  const GlobalPoint& f2 ,
 			  const GlobalPoint& f3 ,
 			  const CCGFloat*    parm ,
@@ -196,7 +196,28 @@ HcalDDDGeometry::newCell( const GlobalPoint& f1 ,
       }
     }
   }
-  addValidID( detId ) ;
+}
+
+void
+HcalDDDGeometry::newCell( const GlobalPoint& f1 ,
+              const GlobalPoint& f2 ,
+              const GlobalPoint& f3 ,
+              const CCGFloat*    parm ,
+              const DetId&       detId   )
+{
+  newCellImpl(f1,f2,f3,parm,detId);
+  addValidID( detId );
+}
+
+void
+HcalDDDGeometry::newCellFast( const GlobalPoint& f1 ,
+              const GlobalPoint& f2 ,
+              const GlobalPoint& f3 ,
+              const CCGFloat*    parm ,
+              const DetId&       detId   )
+{
+  newCellImpl(f1,f2,f3,parm,detId);
+  m_validIds.push_back(detId);
 }
 
 const CaloCellGeometry* 
@@ -243,4 +264,12 @@ HcalDDDGeometry::cellGeomPtr( uint32_t din ) const
     }
   }
   return ( 0 == cell || 0 == cell->param() ? 0 : cell ) ;
+}
+
+void HcalDDDGeometry::increaseReserve(unsigned int extra) {
+  m_validIds.reserve(m_validIds.size()+extra);
+}
+
+void HcalDDDGeometry::sortValidIds() {
+  std::sort(m_validIds.begin(),m_validIds.end());
 }

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -380,7 +380,7 @@ void HcalGeometry::localCorners(Pt3DVec&        lc,
    }
 }
 
-void HcalGeometry::newCell(const GlobalPoint& f1 ,
+unsigned int HcalGeometry::newCellImpl(const GlobalPoint& f1 ,
 			   const GlobalPoint& f2 ,
 			   const GlobalPoint& f3 ,
 			   const CCGFloat*    parm ,
@@ -414,7 +414,30 @@ void HcalGeometry::newCell(const GlobalPoint& f1 ,
     m_hfCellVec.at( index ) = IdealZPrism( f1, cornersMgr(), parm,  hid.depth()==1 ? IdealZPrism::EM : IdealZPrism::HADR ) ;
   }
 
+  return din;
+}
+
+void HcalGeometry::newCell(const GlobalPoint& f1 ,
+               const GlobalPoint& f2 ,
+               const GlobalPoint& f3 ,
+               const CCGFloat*    parm ,
+               const DetId&       detId) {
+
+  unsigned int din = newCellImpl(f1,f2,f3,parm,detId);
+
   addValidID( detId ) ;
+  m_dins.push_back( din );
+}
+
+void HcalGeometry::newCellFast(const GlobalPoint& f1 ,
+               const GlobalPoint& f2 ,
+               const GlobalPoint& f3 ,
+               const CCGFloat*    parm ,
+               const DetId&       detId) {
+
+  unsigned int din = newCellImpl(f1,f2,f3,parm,detId);
+
+  m_validIds.push_back( detId ) ;
   m_dins.push_back( din );
 }
 
@@ -520,3 +543,12 @@ DetId HcalGeometry::correctId(const DetId& id) const {
     return id;
   }
 }
+
+void HcalGeometry::increaseReserve(unsigned int extra) {
+  m_validIds.reserve(m_validIds.size()+extra);
+}
+
+void HcalGeometry::sortValidIds() {
+  std::sort(m_validIds.begin(),m_validIds.end());
+}
+

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -1,7 +1,7 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <algorithm>
+#include <iostream>
 
 #include <Math/Transform3D.h>
 #include <Math/EulerAngles.h>
@@ -10,6 +10,8 @@ typedef CaloCellGeometry::CCGFloat CCGFloat ;
 typedef CaloCellGeometry::Pt3D     Pt3D     ;
 typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
 typedef CaloCellGeometry::Tr3D     Tr3D     ;
+
+//#define EDM_ML_DEBUG
 
 HcalGeometry::HcalGeometry(const HcalTopology& topology) :
   m_topology(topology), m_mergePosition(topology.getMergePositionFlag()) {
@@ -20,12 +22,14 @@ HcalGeometry::~HcalGeometry() {}
 
 void HcalGeometry::init() {
   if (!m_topology.withSpecialRBXHBHE()) m_mergePosition = false;
-  edm::LogInfo("HcalGeometry") << "HcalGeometry::init() "
+#ifdef EDM_ML_DEBUG
+  std::cout << "HcalGeometry: " << "HcalGeometry::init() "
 			       << " HBSize " << m_topology.getHBSize() 
 			       << " HESize " << m_topology.getHESize() 
 			       << " HOSize " << m_topology.getHOSize() 
-			       << " HFSize " << m_topology.getHFSize();
-    
+			       << " HFSize " << m_topology.getHFSize() << std::endl;
+#endif
+
   m_hbCellVec = HBCellVec( m_topology.getHBSize() ) ;
   m_heCellVec = HECellVec( m_topology.getHESize() ) ;
   m_hoCellVec = HOCellVec( m_topology.getHOSize() ) ;
@@ -391,11 +395,13 @@ unsigned int HcalGeometry::newCellImpl(const GlobalPoint& f1 ,
   const HcalDetId hid ( detId ) ;
   unsigned int din=m_topology.detId2denseId(detId);
 
-  edm::LogInfo("HcalGeometry") << " newCell subdet "
+#ifdef EDM_ML_DEBUG
+  std::cout << "HcalGeometry: " << " newCell subdet "
  	    << detId.subdetId() << ", raw ID " 
  	    << detId.rawId() << ", hid " << hid << ", din " 
- 	    << din << ", index ";
-  
+ 	    << din << ", index " << std::endl;
+#endif
+
   if (hid.subdet()==HcalBarrel) {
     m_hbCellVec.at( din ) = IdealObliquePrism( f1, cornersMgr(), parm ) ;
   } else if (hid.subdet()==HcalEndcap) {

--- a/Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryLoader.cc
@@ -6,6 +6,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>
+#include <algorithm>
 
 typedef CaloCellGeometry::CCGFloat CCGFloat ;
 //#define DebugLog
@@ -34,7 +35,7 @@ CaloSubdetectorGeometry* HcalHardcodeGeometryLoader::load(const HcalTopology& fT
     std::cout << std::endl;
 #endif
   }
-  CaloSubdetectorGeometry* hcalGeometry = new HcalGeometry (fTopology);
+  HcalGeometry* hcalGeometry = new HcalGeometry (fTopology);
   if( 0 == hcalGeometry->cornersMgr() ) hcalGeometry->allocateCorners ( fTopology.ncells()+fTopology.getHFSize() );
   if( 0 == hcalGeometry->parMgr() ) hcalGeometry->allocatePar (hcalGeometry->numberOfShapes(),
 							       HcalGeometry::k_NumberOfParametersPerShape ) ;
@@ -48,6 +49,8 @@ CaloSubdetectorGeometry* HcalHardcodeGeometryLoader::load(const HcalTopology& fT
     fillHF (hcalGeometry, makeHFCells());
     fillHE (hcalGeometry, makeHECells(fTopology));
   }
+  //fast insertion of valid ids requires sort at end
+  hcalGeometry->sortValidIds();
   return hcalGeometry;
 }
 
@@ -161,8 +164,9 @@ std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters> HcalHardcodeGeometr
 //
 // Convert constants to appropriate cells
 //
-void HcalHardcodeGeometryLoader::fillHBHO (CaloSubdetectorGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters>& fCells, bool fHB) {
+void HcalHardcodeGeometryLoader::fillHBHO (HcalGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters>& fCells, bool fHB) {
 
+  fGeometry->increaseReserve(fCells.size());
   for (size_t iCell = 0; iCell < fCells.size(); ++iCell) {
     const HcalHardcodeGeometryLoader::HBHOCellParameters& param = fCells[iCell];
     for (int iPhi = param.phiFirst; iPhi <= MAX_HCAL_PHI; iPhi += param.phiStep) {
@@ -185,7 +189,7 @@ void HcalHardcodeGeometryLoader::fillHBHO (CaloSubdetectorGeometry* fGeometry, c
 #ifdef DebugLog
 	std::cout << "HcalHardcodeGeometryLoader::fillHBHO-> " << hid << hid.ieta() << '/' << hid.iphi() << '/' << hid.depth() << refPoint << '/' << cellParams [0] << '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
 #endif
-	fGeometry->newCell(refPoint,  refPoint,  refPoint, 
+	fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
 			   CaloCellGeometry::getParmPtr(cellParams, 
 							fGeometry->parMgr(), 
 							fGeometry->parVecVec()),
@@ -386,8 +390,9 @@ std::vector <HcalHardcodeGeometryLoader::HFCellParameters> HcalHardcodeGeometryL
   return result;
 }
   
-void HcalHardcodeGeometryLoader::fillHE (CaloSubdetectorGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HECellParameters>& fCells) {
+void HcalHardcodeGeometryLoader::fillHE (HcalGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HECellParameters>& fCells) {
 
+  fGeometry->increaseReserve(fCells.size());
   for (size_t iCell = 0; iCell < fCells.size(); ++iCell) {
     const HcalHardcodeGeometryLoader::HECellParameters& param = fCells[iCell];
     for (int iPhi = param.phiFirst; iPhi <= MAX_HCAL_PHI; iPhi += param.phiStep) {
@@ -412,7 +417,7 @@ void HcalHardcodeGeometryLoader::fillHE (CaloSubdetectorGeometry* fGeometry, con
 #ifdef DebugLog
 	std::cout << "HcalHardcodeGeometryLoader::fillHE-> " << hid << refPoint << '/' << cellParams [0] << '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
 #endif
-	fGeometry->newCell(refPoint,  refPoint,  refPoint, 
+	fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
 			   CaloCellGeometry::getParmPtr(cellParams, 
 							fGeometry->parMgr(), 
 							fGeometry->parVecVec()),
@@ -422,8 +427,9 @@ void HcalHardcodeGeometryLoader::fillHE (CaloSubdetectorGeometry* fGeometry, con
   }
 }
 
-void HcalHardcodeGeometryLoader::fillHF (CaloSubdetectorGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HFCellParameters>& fCells) {
+void HcalHardcodeGeometryLoader::fillHF (HcalGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HFCellParameters>& fCells) {
 
+  fGeometry->increaseReserve(fCells.size());
   for (size_t iCell = 0; iCell < fCells.size(); ++iCell) {
     const HcalHardcodeGeometryLoader::HFCellParameters& param = fCells[iCell];
     for (int iPhi = param.phiFirst; iPhi <= MAX_HCAL_PHI; iPhi += param.phiStep) {
@@ -452,7 +458,7 @@ void HcalHardcodeGeometryLoader::fillHF (CaloSubdetectorGeometry* fGeometry, con
 #ifdef DebugLog
 	std::cout << "HcalHardcodeGeometryLoader::fillHF-> " << hid << refPoint << '/' << cellParams [0] << '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
 #endif	
-	fGeometry->newCell(refPoint,  refPoint,  refPoint, 
+	fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
 			   CaloCellGeometry::getParmPtr(cellParams, 
 							fGeometry->parMgr(), 
 							fGeometry->parVecVec()),


### PR DESCRIPTION
@Dr15Jones profiled the `beginRun` step for a phase2 configuration and found that 200s was spent initializing the HCAL geometry (using FlexiHardcodeLoader). This is because each new cell addition triggered a sorted `insert()` into a vector of valid DetIds.

Since the geometry is filled all at once by the loader, I was able to modify this setup to use regular `push_back()` when adding valid DetIds, and then sort the vector at the end. Intelligent `reserve()`s are also used where possible. This "fast" alternative uses private functions of the geometry, so only friend classes (loaders) can use it. If for some reason, a new cell is added by other code that doesn't guarantee sorting at the end, it will still use the regular sorted insert from `CaloSubdetectorGeometry`.

This changed reduced the 200s setup time to 10s. Much of the remaining time was due to the use of `LogInfo`, which is now replaced by `EDM_ML_DEBUG` preprocessor flags, so messages are only printed in debug mode.

attn: @ianna, @bsunanda 