### PR TITLE
Avoid unnecessary provenance reading

### DIFF
--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -63,6 +63,8 @@ namespace edm {
 
     ProductProvenance const* branchIDToProvenance(BranchID const& bid) const;
 
+    ProductProvenance const* branchIDToProvenanceForProducedOnly(BranchID const& bid) const;
+    
     void insertIntoSet(ProductProvenance const& provenanceProduct) const;
 
     void mergeProvenanceRetrievers(std::shared_ptr<ProductProvenanceRetriever> other);

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -135,6 +135,22 @@ namespace edm {
     return &*it;
   }
 
+  ProductProvenance const*
+  ProductProvenanceRetriever::branchIDToProvenanceForProducedOnly(BranchID const& bid) const {
+    ProductProvenance ei(bid);
+    auto it = entryInfoSet_.find(ei);
+    if(it == entryInfoSet_.end()) {
+      if (parentProcessRetriever_) {
+        return parentProcessRetriever_->branchIDToProvenanceForProducedOnly(bid);
+      }
+      if(nextRetriever_) {
+        return nextRetriever_->branchIDToProvenanceForProducedOnly(bid);
+      }
+      return nullptr;
+    }
+    return &*it;
+  }
+
   ProvenanceReaderBase::~ProvenanceReaderBase() {
   }
 }

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -351,7 +351,7 @@ namespace edm {
     ProductProvenanceRetriever const* provRetriever,
     BranchID const& branchID) {
 
-    ProductProvenance const* provenance = provRetriever->branchIDToProvenance(branchID);
+    ProductProvenance const* provenance = provRetriever->branchIDToProvenanceForProducedOnly(branchID);
     if (provenance != nullptr) {
       BranchParents::iterator it = branchParents_.find(branchID);
       if (it == branchParents_.end()) {


### PR DESCRIPTION
Fix the case where a module is not run, it's provenance is requested and because there is no provenance the code attempts to find the provenance from the input. Now there is a special interface that only queries provenance for code that is produced.