### PR TITLE
Add conversions 91x

### DIFF
--- a/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
+++ b/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
@@ -9,8 +9,8 @@
 #ifndef __OniaPhotonConversionProducer_h_
 #define __OniaPhotonConversionProducer_h_
 
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -33,7 +33,7 @@
 
  */
 
-class OniaPhotonConversionProducer : public edm::EDProducer {
+class OniaPhotonConversionProducer : public edm::stream::EDProducer<> {
 
  public:
   explicit OniaPhotonConversionProducer(const edm::ParameterSet& ps);
@@ -41,7 +41,7 @@ class OniaPhotonConversionProducer : public edm::EDProducer {
  private:
 
   virtual void produce(edm::Event& event, const edm::EventSetup& esetup);
-  virtual void endJob() ;
+  virtual void endStream();
   void removeDuplicates(reco::ConversionCollection&);
   bool checkTkVtxCompatibility(const reco::Conversion&, const reco::VertexCollection&);
   bool foundCompatibleInnerHits(const reco::HitPattern& hitPatA, const reco::HitPattern& hitPatB); 
@@ -86,6 +86,7 @@ class OniaPhotonConversionProducer : public edm::EDProducer {
   int store_conversion;
 
   std::string convSelectionCuts_;
+  bool wantSummary_;
 
 };
 

--- a/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
+++ b/HeavyFlavorAnalysis/Onia2MuMu/interface/OniaPhotonConversionProducer.h
@@ -73,20 +73,7 @@ class OniaPhotonConversionProducer : public edm::stream::EDProducer<> {
   int convAlgo_;
   std::vector<int>   convQuality_;
   
-  int total_conversions;
-  int selection_fail;
-  int algo_fail;
-  int flag_fail;
-  int pizero_fail;
-  int duplicates;
-  int TkVtxC;
-  int CInnerHits;
-  int highpurity_count;
-  int final_conversion;
-  int store_conversion;
-
   std::string convSelectionCuts_;
-  bool wantSummary_;
 
 };
 

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
@@ -80,20 +80,7 @@ OniaPhotonConversionProducer:: OniaPhotonConversionProducer(const edm::Parameter
   if( qual[0] != "" ) convQuality_ =StringToEnumValue<reco::Conversion::ConversionQuality>(qual);
 
   convSelectionCuts_ = ps.getParameter<std::string>("convSelection");
-  wantSummary_ = ps.getUntrackedParameter<bool>("wantSummary", false);
   produces<pat::CompositeCandidateCollection>("conversions");
-
-  total_conversions = 0;
-  selection_fail = 0;
-  algo_fail = 0;
-  flag_fail = 0;
-  pizero_fail = 0;
-  duplicates = 0;
-  TkVtxC = 0;
-  CInnerHits = 0;
-  highpurity_count = 0;
-  final_conversion = 0;
-  store_conversion = 0;
 }
 
 void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSetup& esetup){
@@ -115,14 +102,11 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
   StringCutObjectSelector<reco::Conversion> *convSelection_ = new StringCutObjectSelector<reco::Conversion>(convSelectionCuts_);
 
   for(reco::ConversionCollection::const_iterator conv = pConv->begin(); conv != pConv->end(); ++conv){
-    total_conversions++;
 
     if (! ( *convSelection_)(*conv)){
-	selection_fail++;	
 	continue; // selection string
     }
     if (convAlgo_ != 0 && conv->algo()!= convAlgo_){
-	algo_fail++;	
 	continue; // select algorithm
     }
     if(convQuality_.size() > 0){
@@ -135,7 +119,6 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
            }
         }
 	if (!flagsok){
-	   flag_fail++;
 	   continue;
         }
     }
@@ -158,7 +141,6 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
      if (! checkTkVtxCompatibility(*conv,*priVtxs.product())) {
        flagTkVtxCompatibility = false;
        if (wantTkVtxCompatibility_) {
-          TkVtxC++;
           flag1 = false;
        }
      }
@@ -169,21 +151,18 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
        if ( foundCompatibleInnerHits(hitPatA,hitPatB) && foundCompatibleInnerHits(hitPatB,hitPatA) ) flagCompatibleInnerHits = true;
      }
      if (wantCompatibleInnerHits_ && ! flagCompatibleInnerHits) {
-       CInnerHits++;
        flag2 = false;
      }
      bool flagHighpurity = true;
      if (!HighpuritySubset(*conv,*priVtxs.product())) {
        flagHighpurity = false;
        if (wantHighpurity_) {
-          highpurity_count++;
           flag3 = false;
        }
      }
      bool pizero_rejected = false;
      bool large_pizero_window = CheckPi0(*conv, pfphotons, pizero_rejected);
      if (pi0OnlineSwitch_ && pizero_rejected) {
-       pizero_fail++;
        flag4 = false;
      }
 
@@ -193,10 +172,8 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
         pat::CompositeCandidate *pat_conv = makePhotonCandidate(*conv);
         pat_conv->addUserInt("flags",flags);
         patoutCollection->push_back(*pat_conv);
-        final_conversion++;
      }
   }
-  store_conversion += patoutCollection->size();
   event.put(std::move(patoutCollection),"conversions");
 
   delete convSelection_;
@@ -245,7 +222,6 @@ void OniaPhotonConversionProducer::removeDuplicates(reco::ConversionCollection& 
      int iter2 = iter1+1;
      while( iter2 < (int) c.size()) if(ConversionEqualByTrack( c[iter1], c[iter2] ) ){
         c.erase( c.begin() + iter2 );
-	duplicates++;
         }else{
         iter2++;	// Increment index only if this element is no duplicate. 
 			// If it is duplicate check again the same index since the vector rearranged elements index after erasing
@@ -381,24 +357,6 @@ reco::Candidate::LorentzVector OniaPhotonConversionProducer::convertVector(const
 
 
 void OniaPhotonConversionProducer::endStream() {
-  if (wantSummary_) {
-     std::cout << "############################" << std::endl;
-     std::cout << "Conversion Candidate producer report" << std::endl;
-     std::cout << "############################" << std::endl;
-     std::cout << "Total examined conversions: " << total_conversions << std::endl;
-     std::cout << "Selection fail candidates:  " << selection_fail << std::endl;
-     std::cout << "Algo fail candidates:       " << algo_fail << std::endl;
-     std::cout << "Quality fail candidates:    " << flag_fail << std::endl;
-     std::cout << "Pi0 fail:                   " << pizero_fail << std::endl;
-     std::cout << "Total duplicates found:     " << duplicates << std::endl;
-     std::cout << "Vertex compatibility fail:  " << TkVtxC << std::endl;
-     std::cout << "Compatible inner hits fail: " << CInnerHits << std::endl;
-     std::cout << "Highpurity Subset fail:     " << highpurity_count << std::endl;
-     std::cout << "############################" << std::endl;
-     std::cout << "Final number of conversions:  " << final_conversion << std::endl;
-     std::cout << "Stored number of conversions: " << store_conversion << std::endl;
-     std::cout << "############################" << std::endl;
-  }
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(OniaPhotonConversionProducer);

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
@@ -80,7 +80,7 @@ OniaPhotonConversionProducer:: OniaPhotonConversionProducer(const edm::Parameter
   if( qual[0] != "" ) convQuality_ =StringToEnumValue<reco::Conversion::ConversionQuality>(qual);
 
   convSelectionCuts_ = ps.getParameter<std::string>("convSelection");
-  
+  wantSummary_ = ps.getUntrackedParameter<bool>("wantSummary", false);
   produces<pat::CompositeCandidateCollection>("conversions");
 
   total_conversions = 0;
@@ -95,7 +95,6 @@ OniaPhotonConversionProducer:: OniaPhotonConversionProducer(const edm::Parameter
   final_conversion = 0;
   store_conversion = 0;
 }
-
 
 void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSetup& esetup){
 
@@ -381,23 +380,25 @@ reco::Candidate::LorentzVector OniaPhotonConversionProducer::convertVector(const
 }
 
 
-void OniaPhotonConversionProducer::endJob(){
-   std::cout << "############################" << std::endl;
-   std::cout << "Conversion Candidate producer report" << std::endl;
-   std::cout << "############################" << std::endl;
-   std::cout << "Total examined conversions: " << total_conversions << std::endl;
-   std::cout << "Selection fail candidates:  " << selection_fail << std::endl;
-   std::cout << "Algo fail candidates:       " << algo_fail << std::endl;
-   std::cout << "Quality fail candidates:    " << flag_fail << std::endl;
-   std::cout << "Pi0 fail:                   " << pizero_fail << std::endl;
-   std::cout << "Total duplicates found:     " << duplicates << std::endl;
-   std::cout << "Vertex compatibility fail:  " << TkVtxC << std::endl;
-   std::cout << "Compatible inner hits fail: " << CInnerHits << std::endl;
-   std::cout << "Highpurity Subset fail:     " << highpurity_count << std::endl;
-   std::cout << "############################" << std::endl;
-   std::cout << "Final number of conversions:  " << final_conversion << std::endl;
-   std::cout << "Stored number of conversions: " << store_conversion << std::endl;
-   std::cout << "############################" << std::endl;
+void OniaPhotonConversionProducer::endStream() {
+  if (wantSummary_) {
+     std::cout << "############################" << std::endl;
+     std::cout << "Conversion Candidate producer report" << std::endl;
+     std::cout << "############################" << std::endl;
+     std::cout << "Total examined conversions: " << total_conversions << std::endl;
+     std::cout << "Selection fail candidates:  " << selection_fail << std::endl;
+     std::cout << "Algo fail candidates:       " << algo_fail << std::endl;
+     std::cout << "Quality fail candidates:    " << flag_fail << std::endl;
+     std::cout << "Pi0 fail:                   " << pizero_fail << std::endl;
+     std::cout << "Total duplicates found:     " << duplicates << std::endl;
+     std::cout << "Vertex compatibility fail:  " << TkVtxC << std::endl;
+     std::cout << "Compatible inner hits fail: " << CInnerHits << std::endl;
+     std::cout << "Highpurity Subset fail:     " << highpurity_count << std::endl;
+     std::cout << "############################" << std::endl;
+     std::cout << "Final number of conversions:  " << final_conversion << std::endl;
+     std::cout << "Stored number of conversions: " << store_conversion << std::endl;
+     std::cout << "############################" << std::endl;
+  }
 }
 //define this as a plug-in
 DEFINE_FWK_MODULE(OniaPhotonConversionProducer);

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -31,6 +31,8 @@ MicroEventContent = cms.PSet(
         'keep *_offlineBeamSpot_*_*',
         'keep *_offlineSlimmedPrimaryVertices_*_*',
         'keep patPackedCandidates_packedPFCandidates_*_*',
+        # low energy conversions for BPH
+        'keep *_oniaPhotonCandidates_*_*',
 
         'keep *_bunchSpacingProducer_*_*',
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -18,6 +18,7 @@ from PhysicsTools.PatAlgos.slimming.metFilterPaths_cff   import *
 from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import *
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi  import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import bunchSpacingProducer
+from HeavyFlavorAnalysis.Onia2MuMu.OniaPhotonConversionProducer_cfi import PhotonCandidates as oniaPhotonCandidates
 
 slimmingTask = cms.Task(
     packedPFCandidatesTask,
@@ -38,5 +39,6 @@ slimmingTask = cms.Task(
     slimmedMETs,
     metFilterPathsTask,
     reducedEgamma,
-    bunchSpacingProducer
+    bunchSpacingProducer,
+    oniaPhotonCandidates
 )


### PR DESCRIPTION
This PR add low energy photon conversions. For now we are storing  the track of the electrons to avoid issues observed with the PCA/refpoints. A better solution will be worked out later. 
For testing size increase, we have used

/RelValTTbar_13/CMSSW_9_0_0_pre4-PU25ns_90X_upgrade2017_realistic_v6-v1/GEN-SIM-RECO

and observed that each event will be increased by about 561 Bytes

patCompositeCandidates_oniaPhotonCandidates_conversions_PAT. 1803.25 560.73

this represent about 1% of the current MINIAODSIM size.

This work is based on the description made at xPOG forum:

https://indico.cern.ch/event/614937/contributions/2484951/attachments/1415862/2167752/BPH-MINIAOD-Add-conversions-v3.pdf