### PR TITLE
L1T DQM Offline Stage 2 upgrades

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -46,6 +46,7 @@ from DQMOffline.L1Trigger.L1TRate_Offline_cfi import *
 from DQMOffline.L1Trigger.L1TSync_Offline_cfi import *
 from DQMOffline.L1Trigger.L1TEmulatorMonitorOffline_cff import *
 from DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi import *
+from DQMOffline.L1Trigger.L1TEGammaOffline_cfi import *
 l1TdeRCT.rctSourceData = 'gctDigis'
 
 # DQM Offline Step 2 cfi/cff imports
@@ -139,7 +140,8 @@ l1TriggerOnline = cms.Sequence(
 l1TriggerOffline = cms.Sequence(
     l1TriggerOnline *
     dqmEnvL1TriggerReco *
-    l1tStage2CaloLayer2OfflineDQM
+    l1tStage2CaloLayer2OfflineDQM *
+    l1tEGammaOfflineDQM
 )
 
 #
@@ -151,7 +153,8 @@ l1TriggerEmulatorOnline = cms.Sequence(
 
 l1TriggerEmulatorOffline = cms.Sequence(
     l1TriggerEmulatorOnline *
-    l1tStage2CaloLayer2OfflineDQMEmu
+    l1tStage2CaloLayer2OfflineDQMEmu *
+    l1tEGammaOfflineDQMEmu
 )
 #
 
@@ -254,3 +257,108 @@ l1TriggerStage1Clients.remove(l1tTestsSummary)
 #l1EmulatorMonitorClient.remove(l1EmulatorQualityTests)
 l1EmulatorMonitorClient.remove(l1EmulatorErrorFlagClient)
 #l1EmulatorMonitorClient.remove(l1EmulatorEventInfoClient)
+
+#stage2 
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+
+from L1Trigger.L1TGlobal.hackConditions_cff import *
+from L1Trigger.L1TMuon.hackConditions_cff import *
+from L1Trigger.L1TCalorimeter.hackConditions_cff import *
+
+from DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi import *
+l1tStage2CaloLayer2OfflineDQMEmu.stage2CaloLayer2JetSource=cms.InputTag("valCaloStage2Layer2Digis")
+l1tStage2CaloLayer2OfflineDQMEmu.stage2CaloLayer2EtSumSource=cms.InputTag("valCaloStage2Layer2Digis")
+from DQMOffline.L1Trigger.L1TEGammaOffline_cfi import *
+l1tEGammaOfflineDQMEmu.stage2CaloLayer2EGammaSource=cms.InputTag("valCaloStage2Layer2Digis")
+
+from Configuration.StandardSequences.Eras import eras
+from DQM.L1TMonitor.L1TStage2_cff import *
+
+stage2UnpackPath = cms.Sequence(
+     l1tCaloLayer1Digis +
+     caloStage2Digis +
+     bmtfDigis  +
+#     BMTFStage2Digis +
+     emtfStage2Digis +
+     gmtStage2Digis +
+     gtStage2Digis
+)
+
+##Stage 2 Emulator
+
+from DQM.L1TMonitor.L1TStage2Emulator_cff import *
+from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClient_cfi import *
+from DQM.L1TMonitorClient.L1TStage2MonitorClient_cff import *
+# L1T monitor client sequence (system clients and quality tests)
+l1TStage2EmulatorClients = cms.Sequence(
+                        l1tStage2CaloLayer2DEClient
+                        # l1tStage2EmulatorEventInfoClient 
+                        )
+
+l1tStage2EmulatorMonitorClient = cms.Sequence(
+                        # l1TStage2EmulatorQualityTests +
+                        l1TStage2EmulatorClients
+                        )
+
+#
+# define sequences
+#
+
+Stage2l1TriggerOnline = cms.Sequence(
+                               stage2UnpackPath
+                                * l1tStage2OnlineDQM
+                                * dqmEnvL1T
+                               )
+
+
+
+
+Stage2l1TriggerOffline = cms.Sequence(
+                                Stage2l1TriggerOnline *
+                                dqmEnvL1TriggerReco *
+                                l1tStage2CaloLayer2OfflineDQM *
+                                l1tEGammaOfflineDQM
+
+                                )
+
+#
+from L1Trigger.Configuration.ValL1Emulator_cff import *
+
+Stage2l1TriggerEmulatorOnline = cms.Sequence(
+                                 valHcalTriggerPrimitiveDigis +
+                                 Stage2L1HardwareValidation +
+                                 l1tStage2EmulatorOnlineDQM +
+                                 dqmEnvL1TEMU
+                                )
+
+Stage2l1TriggerEmulatorOffline = cms.Sequence(
+                                Stage2l1TriggerEmulatorOnline +
+                                l1tStage2CaloLayer2OfflineDQMEmu +
+                                l1tEGammaOfflineDQMEmu
+                                )
+
+#
+
+# DQM Offline Step 1 sequence
+Stage2l1TriggerDqmOffline = cms.Sequence(
+                                Stage2l1TriggerOffline
+ #                               * l1tRate_Offline
+  #                              * l1tSync_Offline
+                                * Stage2l1TriggerEmulatorOffline
+                                )
+
+# DQM Offline Step 2 sequence                                 
+Stage2l1TriggerDqmOfflineClient = cms.Sequence(
+                                l1tStage2EmulatorMonitorClient *
+                                l1tStage2MonitorClient
+                                )
+
+
+#replacements for stage2
+stage2L1Trigger.toReplaceWith(l1TriggerOnline, Stage2l1TriggerOnline)
+stage2L1Trigger.toReplaceWith(l1TriggerOffline, Stage2l1TriggerOffline)
+stage2L1Trigger.toReplaceWith(l1TriggerEmulatorOnline, Stage2l1TriggerEmulatorOnline)
+stage2L1Trigger.toReplaceWith(l1TriggerEmulatorOffline, Stage2l1TriggerEmulatorOffline)
+stage2L1Trigger.toReplaceWith(l1TriggerDqmOffline, Stage2l1TriggerDqmOffline)
+stage2L1Trigger.toReplaceWith(l1TriggerDqmOfflineClient, Stage2l1TriggerDqmOfflineClient)
+stage2L1Trigger.toReplaceWith(l1EmulatorMonitorClient,l1tStage2EmulatorMonitorClient)

--- a/DQMOffline/L1Trigger/test/customDQM.py
+++ b/DQMOffline/L1Trigger/test/customDQM.py
@@ -1,0 +1,49 @@
+
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+
+#    process.dtDataIntegrityUnpacker.inputLabel = cms.untracked.InputTag('rawDataCollector')
+
+#    process.DQMOfflineCosmics.remove(process.hcalOfflineDQMSource)
+
+#    process.load("FWCore.Modules.printContent_cfi")
+#    process.myPath1 = cms.Path( process.printContent )
+
+    process.options = cms.untracked.PSet(
+      wantSummary = cms.untracked.bool(True) 
+    )
+
+    #using the DQMROOT means that the reco output will be empty
+    process.DQMoutput.outputCommands.append('drop *')
+    process.DQMoutput.outputCommands.append('keep *_MEtoEDMConverter_*_*')
+
+#    process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
+#     ignoreTotal=cms.untracked.int32(1),
+#     oncePerEventMode=cms.untracked.bool(False)
+#    )
+
+    # Do not activate by default the logging of where each histogram is booked.
+    process.DQMStore.verbose = cms.untracked.int32(2)
+    process.load("DQMServices.Components.DQMStoreStats_cfi")
+    process.stats = cms.Path(process.dqmStoreStats)
+    process.schedule.insert(-1,process.stats)
+    #Run only on fat events
+    from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+    process.hltFatEventFilters = hltHighLevel.clone()
+    process.hltFatEventFilters.throw = cms.bool(False)
+    process.hltFatEventFilters.HLTPaths = cms.vstring('HLT_L1FatEvents_v*')
+    #Run L1TReemulation
+    from L1Trigger.Configuration.customiseReEmul import L1TReEmulFromRAW 
+    process = L1TReEmulFromRAW(process)
+    #Put all together into one path, so that reco does not run on non-fat events
+    process.p=cms.Path( #process.hltFatEventFilters*
+    			process.RawToDigi*
+    			process.reconstruction*
+    			process.DQMOffline*			
+    			process.L1TReEmul
+    		)
+    process.e=cms.EndPath( process.DQMoutput )
+    process.schedule=cms.Schedule(process.p,process.e)
+    return(process)
+

--- a/DQMOffline/L1Trigger/test/driver11a.sh
+++ b/DQMOffline/L1Trigger/test/driver11a.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+numev=20
+tnum=11
+DQMSEQUENCE=DQM
+step=a
+
+eval `scramv1 r -sh`
+
+#cmsDriver.py test_${tnum}_${step}_1 -s RAW2DIGI,RECO,${DQMSEQUENCE} -n ${numev} --eventcontent DQM --datatier DQMIO --conditions auto:com10  --filein  file:/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/DQMTest/MinimumBias__RAW__v1__165633__1CC420EE-B686-E011-A788-0030487CD6E8.root --data --customise DQMServices/Components/test/customDQM.py --no_exec --python_filename=test_${tnum}_${step}_1.py
+cmsDriver.py test_${tnum}_${step}_1 -s RAW2DIGI,RECO,${DQMSEQUENCE} -n ${numev} --eventcontent DQM --datatier DQMIO --conditions 91X_dataRun2_v3 --era Run2_2016 --filein file:/eos/uscms/store/user/wangz/data/RAW_singleElectron.root --data --no_exec --python_filename=test_${tnum}_${step}_1.py
+
+cmsRun -e test_${tnum}_${step}_1.py 2>&1 | tee p${tnum}.1.log 
+
+if [ $? -ne 0 ]; then
+  return 1
+fi
+
+mv FrameworkJobReport{,_${tnum}_${step}_1}.xml
+

--- a/DQMOffline/L1Trigger/test/driver11b.sh
+++ b/DQMOffline/L1Trigger/test/driver11b.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+eval `scramv1 r -sh`
+
+tnum=11
+DQMSEQUENCE=HARVESTING:dqmHarvesting
+step=b
+
+#cmsDriver.py test_${tnum}_${step}_1 -s ${DQMSEQUENCE} --conditions auto:com10 --data --filetype DQM --filein file:test_${tnum}_a_1_RAW2DIGI_RECO_DQM.root --scenario pp --customise DQMServices/Components/test/customHarvesting.py --no_exec --python_filename=test_${tnum}_${step}_1.py
+cmsDriver.py test_${tnum}_${step}_1 -s ${DQMSEQUENCE} --conditions 81X_dataRun2_v9 --data --filetype DQM --filein file:test_${tnum}_a_1_RAW2DIGI_RECO_DQM.root --scenario pp --customise DQMServices/Components/test/customHarvesting.py --no_exec --python_filename=test_${tnum}_${step}_1.py --era Run2_2016
+#cmsRun -e test_${tnum}_${step}_1.py 2>&1 | tee q${tnum}.1.log 
+
+if [ $? -ne 0 ]; then
+  return 1
+fi
+
+mv FrameworkJobReport{,_${tnum}_${step}_1}.xml
+


### PR DESCRIPTION
Changed L1T DQM Offline sequences to use L1T Stage 2 modules and to produce the same histograms as L1T DQM Online sequences.

Based on and supersedes #16095, #16639, #17739, and #18025.

Work by @cbbrainerd and @z4027163.