### PR TITLE
adding decays and first daugthers for bph studies

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -5,13 +5,17 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
     select = cms.vstring(
         "drop  *", # this is the default
         "++keep abs(pdgId) == 11 || abs(pdgId) == 13 || abs(pdgId) == 15", # keep leptons, with history
-        "keep abs(pdgId) == 12 || abs(pdgId) == 14 || abs(pdgId) == 16",   # keep neutrinos
         "drop   status == 2",                                              # drop the shower part of the history
+        "keep++ (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)",   # keep decays for BPH studies
+        "drop status == 1",                                                # drop the status=1 from BPH
+        "keep+ (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)",    # but keep first daughter, to allow lifetime determinations
+        "keep abs(pdgId) == 11 || abs(pdgId) == 13 || abs(pdgId) == 15",   # keep leptons (also status1)
+        "keep abs(pdgId) == 12 || abs(pdgId) == 14 || abs(pdgId) == 16",   # keep neutrinos
         "+keep pdgId == 22 && status == 1 && (pt > 10 || isPromptFinalState())", # keep gamma above 10 GeV (or all prompt) and its first parent
         "+keep abs(pdgId) == 11 && status == 1 && (pt > 3 || isPromptFinalState())", # keep first parent of electrons above 3 GeV (or prompt)
         "keep++ abs(pdgId) == 15",                                         # but keep keep taus with decays
-	"drop  status > 30 && status < 70 ", 				   #remove pythia8 garbage
-	"drop  pdgId == 21 && pt < 5",                                    #remove pythia8 garbage
+	"drop  status > 30 && status < 70 ", 				   # remove pythia8 garbage
+	"drop  pdgId == 21 && pt < 5",                                     # remove pythia8 garbage
         "drop   status == 2 && abs(pdgId) == 21",                          # but remove again gluons in the inheritance chain
         "keep abs(pdgId) == 23 || abs(pdgId) == 24 || abs(pdgId) == 25 || abs(pdgId) == 6 || abs(pdgId) == 37 ",   # keep VIP(articles)s
         "keep abs(pdgId) == 310 && abs(eta) < 2.5 && pt > 1 ",                                                     # keep K0
@@ -20,8 +24,6 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
 	"keep (4 <= abs(pdgId) <= 5)",
 # keep light-flavour quarks and gluons for parton-based jet flavour
 	"keep (1 <= abs(pdgId) <= 3 || pdgId = 21) & (status = 2 || status = 11 || status = 71 || status = 72) && pt>5", 
-# keep b and c hadrons for hadron-based jet flavour, and decays for BPH studies
-	"keep++ (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)",
 # keep onia states, phi, X(3872), Z(4430)+ and psi(4040)
         "keep+ abs(pdgId) == 333",
         "keep+ abs(pdgId) == 9920443 || abs(pdgId) == 9042413 || abs(pdgId) == 9000443",

--- a/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/prunedGenParticles_cfi.py
@@ -20,12 +20,13 @@ prunedGenParticles = cms.EDProducer("GenParticlePruner",
 	"keep (4 <= abs(pdgId) <= 5)",
 # keep light-flavour quarks and gluons for parton-based jet flavour
 	"keep (1 <= abs(pdgId) <= 3 || pdgId = 21) & (status = 2 || status = 11 || status = 71 || status = 72) && pt>5", 
-# keep b and c hadrons for hadron-based jet flavour
-	"keep (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)",
-# keep onia states
-        "keep abs(pdgId) == 333",
-        "keep abs(pdgId) == 443 || abs(pdgId) == 100443 || abs(pdgId) == 10441 || abs(pdgId) == 20443 || abs(pdgId) == 445 || abs(pdgId) == 30443",
-        "keep abs(pdgId) == 553 || abs(pdgId) == 100553 || abs(pdgId) == 200553 || abs(pdgId) == 10551 || abs(pdgId) == 20553 || abs(pdgId) == 555",
+# keep b and c hadrons for hadron-based jet flavour, and decays for BPH studies
+	"keep++ (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)",
+# keep onia states, phi, X(3872), Z(4430)+ and psi(4040)
+        "keep+ abs(pdgId) == 333",
+        "keep+ abs(pdgId) == 9920443 || abs(pdgId) == 9042413 || abs(pdgId) == 9000443",
+        "keep+ abs(pdgId) == 443 || abs(pdgId) == 100443 || abs(pdgId) == 10441 || abs(pdgId) == 20443 || abs(pdgId) == 445 || abs(pdgId) == 30443",
+        "keep+ abs(pdgId) == 553 || abs(pdgId) == 100553 || abs(pdgId) == 200553 || abs(pdgId) == 10551 || abs(pdgId) == 20553 || abs(pdgId) == 555",
 # additional c hadrons for jet fragmentation studies
 	"keep abs(pdgId) = 10411 || abs(pdgId) = 10421 || abs(pdgId) = 10413 || abs(pdgId) = 10423 || abs(pdgId) = 20413 || abs(pdgId) = 20423 || abs(pdgId) = 10431 || abs(pdgId) = 10433 || abs(pdgId) = 20433", 
 # additional b hadrons for jet fragmentation studies


### PR DESCRIPTION
This will allow to store b-hadron decays and first daugthers of onia-like states, needed for BPH studies (signal or background). This will increase the size of the pruner list, which contains all important information for about 466 Bytes/Event (after the last modification), when measured with the ttbar relval sample

/RelValTTbar_13/CMSSW_9_0_0_pre4-PU25ns_90X_upgrade2017_realistic_v6-v1/GEN-SIM-RECO

this represent about 0.9% of the current MINIAODSIM size.  Details of this addition/validation were shown in the xPOG forum:  https://indico.cern.ch/event/626270/
