### PR TITLE
TkHistoMaps with TH2F

### DIFF
--- a/DQM/SiStripCommon/interface/TkHistoMap.h
+++ b/DQM/SiStripCommon/interface/TkHistoMap.h
@@ -15,10 +15,12 @@ class TkHistoMap{
   typedef std::vector<MonitorElement*> tkHistoMapVect;
 
  public:
+  TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::string MapName, float baseline, bool mechanicalView, bool isTH2F);
   TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::string MapName, float baseline=0, bool mechanicalView=false);
   TkHistoMap(std::string path, std::string MapName, float baseline=0, bool mechanicalView=false);
   TkHistoMap();
   ~TkHistoMap(){};
+
 
   void loadServices();
 
@@ -46,6 +48,7 @@ class TkHistoMap{
 
  private:
 
+  void init();
   //fixme: keep single method
   void createTkHistoMap(std::string& path, std::string& MapName, float& baseline, bool mechanicalView);
   void createTkHistoMap(DQMStore::IBooker & ibooker , std::string& path, std::string& MapName, float& baseline, bool mechanicalView);
@@ -60,6 +63,7 @@ class TkHistoMap{
   std::vector<MonitorElement*> tkHistoMap_;
   int HistoNumber;
   std::string MapName_;
+  bool isTH2F_;
 };
 
 #endif

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -3,41 +3,48 @@
 
 //#define debug_TkHistoMap
 
-TkHistoMap::TkHistoMap():
-  HistoNumber(35){
-  cached_detid=0;
-  cached_layer=0;
-  
-  LogTrace("TkHistoMap") <<"TkHistoMap::constructor without parameters"; 
-  loadServices();
+TkHistoMap::TkHistoMap()
+{
+  LogTrace("TkHistoMap") <<"TkHistoMap::constructor without parameters";
+  init();
 }
 
-
-TkHistoMap::TkHistoMap(std::string path, std::string MapName,float baseline, bool mechanicalView): 
-  HistoNumber(35),
+TkHistoMap::TkHistoMap(std::string path, std::string MapName,float baseline, bool mechanicalView):
   MapName_(MapName)
 {
-  cached_detid=0;
-  cached_layer=0;
-  LogTrace("TkHistoMap") <<"TkHistoMap::constructor with parameters"; 
-  loadServices();
+  LogTrace("TkHistoMap") <<"TkHistoMap::constructor with parameters";
+  init();
   createTkHistoMap(path,MapName_, baseline, mechanicalView);
 }
 
-TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::string MapName,float baseline, bool mechanicalView): 
-  HistoNumber(35),
+TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::string MapName,float baseline, bool mechanicalView):
   MapName_(MapName)
 {
-  cached_detid=0;
-  cached_layer=0;
-  LogTrace("TkHistoMap") <<"TkHistoMap::constructor with parameters"; 
-  loadServices();
+  LogTrace("TkHistoMap") <<"TkHistoMap::constructor without parameters";
+  init();
   createTkHistoMap(ibooker , path,MapName_, baseline, mechanicalView);
+}
+
+TkHistoMap::TkHistoMap(DQMStore::IBooker & ibooker , std::string path, std::string MapName, float baseline, bool mechanicalView, bool isTH2F):
+  MapName_(MapName)
+{
+  LogTrace("TkHistoMap") <<"TkHistoMap::constructor without parameters";
+  init();
+  isTH2F_ = true;
+  createTkHistoMap(ibooker , path,MapName_, baseline, mechanicalView);
+}
+
+void TkHistoMap::init(){
+    HistoNumber = 35;
+    cached_detid=0;
+    cached_layer=0;
+    isTH2F_ = false;
+    loadServices();
 }
 
 void TkHistoMap::loadServices(){
   if(!edm::Service<DQMStore>().isAvailable()){
-    edm::LogError("TkHistoMap") << 
+    edm::LogError("TkHistoMap") <<
       "\n------------------------------------------"
       "\nUnAvailable Service DQMStore: please insert in the configuration file an instance like"
       "\n\tprocess.load(\"DQMServices.Core.DQMStore_cfg\")"
@@ -45,7 +52,7 @@ void TkHistoMap::loadServices(){
   }
   dqmStore_=edm::Service<DQMStore>().operator->();
   if(!edm::Service<TkDetMap>().isAvailable()){
-    edm::LogError("TkHistoMap") << 
+    edm::LogError("TkHistoMap") <<
       "\n------------------------------------------"
       "\nUnAvailable Service TkHistoMap: please insert in the configuration file an instance like"
       "\n\tprocess.TkDetMap = cms.Service(\"TkDetMap\")"
@@ -61,7 +68,7 @@ void TkHistoMap::save(std::string filename){
 void TkHistoMap::loadTkHistoMap(std::string path, std::string MapName, bool mechanicalView){
   MapName_=MapName;
   std::string fullName, folder;
-  tkHistoMap_.resize(HistoNumber);    
+  tkHistoMap_.resize(HistoNumber);
   for(int layer=1;layer<HistoNumber;++layer){
     folder=folderDefinition(path,MapName_,layer,mechanicalView,fullName);
 
@@ -78,27 +85,43 @@ void TkHistoMap::loadTkHistoMap(std::string path, std::string MapName, bool mech
 }
 
 void TkHistoMap::createTkHistoMap(std::string& path, std::string& MapName, float& baseline, bool mechanicalView){
-  
+
   int nchX;
   int nchY;
   double lowX,highX;
   double lowY, highY;
   std::string fullName, folder;
 
-  tkHistoMap_.resize(HistoNumber);    
+  const bool bookTH2F = isTH2F_;
+  tkHistoMap_.resize(HistoNumber);
   for(int layer=1;layer<HistoNumber;++layer){
     folder=folderDefinition(path,MapName,layer,mechanicalView,fullName);
     tkdetmap_->getComponents(layer,nchX,lowX,highX,nchY,lowY,highY);
-    MonitorElement* me  = dqmStore_->bookProfile2D(fullName.c_str(),fullName.c_str(),
+    MonitorElement* me;
+
+    if(bookTH2F==false){
+
+    me  = dqmStore_->bookProfile2D(fullName.c_str(),fullName.c_str(),
 						   nchX,lowX,highX,
 						   nchY,lowY,highY,
                                                    0.0, 0.0);
+
+
+    }
+    else if(bookTH2F==true){
+
+    me  = dqmStore_->book2D(fullName.c_str(),fullName.c_str(),
+						   nchX,lowX,highX,
+						   nchY,lowY,highY);
+
+    }
+
     //initialize bin content for the not assigned bins
     if(baseline!=0){
       for(size_t ix = 1; ix <= (unsigned int) nchX; ++ix)
 	for(size_t iy = 1;iy <= (unsigned int) nchY; ++iy)
 	  if(!tkdetmap_->getDetFromBin(layer,ix,iy))
-	    me->Fill(1.*(lowX+ix-.5),1.*(lowY+iy-.5),baseline);	  
+	    me->Fill(1.*(lowX+ix-.5),1.*(lowY+iy-.5),baseline);
     }
 
     tkHistoMap_[layer]=me;
@@ -109,27 +132,44 @@ void TkHistoMap::createTkHistoMap(std::string& path, std::string& MapName, float
 }
 
 void TkHistoMap::createTkHistoMap(DQMStore::IBooker & ibooker , std::string& path, std::string& MapName, float& baseline, bool mechanicalView){
-  
+
   int nchX;
   int nchY;
   double lowX,highX;
   double lowY, highY;
   std::string fullName, folder;
 
-  tkHistoMap_.resize(HistoNumber);    
+  tkHistoMap_.resize(HistoNumber);
+
+  const bool bookTH2F = isTH2F_;
+
+
   for(int layer=1;layer<HistoNumber;++layer){
     folder=folderDefinition(path,MapName,layer,mechanicalView,fullName);
     tkdetmap_->getComponents(layer,nchX,lowX,highX,nchY,lowY,highY);
-    MonitorElement* me  = ibooker.bookProfile2D(fullName.c_str(),fullName.c_str(),
+    MonitorElement* me;
+    if(bookTH2F==false){
+	     me  = ibooker.bookProfile2D(fullName.c_str(),fullName.c_str(),
 						nchX,lowX,highX,
 						nchY,lowY,highY,
 						0.0, 0.0);
+    }
+    if(bookTH2F==true){
+        me  = dqmStore_->book2D(fullName.c_str(),fullName.c_str(),
+                                                   nchX,lowX,highX,
+                                                   nchY,lowY,highY);
+
+    }
+
+
+
+
     //initialize bin content for the not assigned bins
     if(baseline!=0){
       for(size_t ix = 1; ix <= (unsigned int) nchX; ++ix)
 	for(size_t iy = 1;iy <= (unsigned int) nchY; ++iy)
 	  if(!tkdetmap_->getDetFromBin(layer,ix,iy))
-	    me->Fill(1.*(lowX+ix-.5),1.*(lowY+iy-.5),baseline);	  
+	    me->Fill(1.*(lowX+ix-.5),1.*(lowY+iy-.5),baseline);
     }
 
     tkHistoMap_[layer]=me;
@@ -140,7 +180,7 @@ void TkHistoMap::createTkHistoMap(DQMStore::IBooker & ibooker , std::string& pat
 }
 
 std::string TkHistoMap::folderDefinition(std::string& path, std::string& MapName, int layer , bool mechanicalView,std::string& fullName ){
-  
+
   std::string folder=path;
   std::string name=MapName+std::string("_");
   fullName=name+tkdetmap_->getLayerName(layer);
@@ -156,7 +196,7 @@ std::string TkHistoMap::folderDefinition(std::string& path, std::string& MapName
     uint32_t subdetlayer = 0, side = 0;
     tkdetmap_->getSubDetLayerSide(layer,subDet,subdetlayer,side);
     folderOrg.getSubDetLayerFolderName(ss,subDet,subdetlayer,side);
-    
+
     folder = ss.str();
     //    std::cout << "[TkHistoMap::folderDefinition] folder: " << folder << std::endl;
   }
@@ -183,21 +223,34 @@ void TkHistoMap::fill(uint32_t& detid,float value){
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::fill] Fill detid " << detid << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName();
 #endif
-  tkHistoMap_[layer]->getTProfile2D()->Fill(xybin.x,xybin.y,value);
+  if(tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TPROFILE2D)
+    tkHistoMap_[layer]->getTProfile2D()->Fill(xybin.x,xybin.y,value);
+  else if (tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TH2F)
+      tkHistoMap_[layer]->getTH2F()->Fill(xybin.x,xybin.y,value);
 
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::fill] " << tkHistoMap_[layer]->getTProfile2D()->GetBinContent(xybin.ix,xybin.iy);
   for(size_t ii=0;ii<4;ii++)
-    for(size_t jj=0;jj<11;jj++)
-      LogTrace("TkHistoMap") << "[TkHistoMap::fill] " << ii << " " << jj << " " << tkHistoMap_[layer]->getTProfile2D()->GetBinContent(ii,jj);
+    for(size_t jj=0;jj<11;jj++){
+          if(tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TPROFILE2D)
+            LogTrace("TkHistoMap") << "[TkHistoMap::fill] " << ii << " " << jj << " " << tkHistoMap_[layer]->getTProfile2D()->GetBinContent(ii,jj);
+          if(tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TPROFILE2D)
+            LogTrace("TkHistoMap") << "[TkHistoMap::fill] " << ii << " " << jj << " " << tkHistoMap_[layer]->getTH2F()->GetBinContent(ii,jj);
+    }
+    }
 #endif
 }
 
 void TkHistoMap::setBinContent(uint32_t& detid,float value){
   int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
-  tkHistoMap_[layer]->getTProfile2D()->SetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),1);
-  tkHistoMap_[layer]->getTProfile2D()->SetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),value);
+  if(tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TPROFILE2D){
+    tkHistoMap_[layer]->getTProfile2D()->SetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),1);
+    tkHistoMap_[layer]->getTProfile2D()->SetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy),value);
+  }
+  else if (tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TH2F){
+    tkHistoMap_[layer]->getTH2F()->SetBinContent(xybin.ix,xybin.iy,value);
+  }
 
 #ifdef debug_TkHistoMap
   LogTrace("TkHistoMap") << "[TkHistoMap::setbincontent]  setBinContent detid " << detid << " Layer " << layer << " value " << value << " ix,iy "  << xybin.ix << " " << xybin.iy  << " " << xybin.x << " " << xybin.y << " " << tkHistoMap_[layer]->getTProfile2D()->GetName() << " bin " << tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy);
@@ -216,19 +269,28 @@ void TkHistoMap::add(uint32_t& detid,float value){
 #endif
   int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
-  setBinContent(detid,tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy))+value);
-  
+  if(tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TPROFILE2D)
+    setBinContent(detid,tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy))+value);
+  else if (tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TH2F)
+     setBinContent(detid,tkHistoMap_[layer]->getTH2F()->GetBinContent(tkHistoMap_[layer]->getTH2F()->GetBin(xybin.ix,xybin.iy))+value);
 }
 
 float TkHistoMap::getValue(uint32_t& detid){
   int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
-  return tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
+
+  if (tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TH2F)
+    return tkHistoMap_[layer]->getTH2F()->GetBinContent(tkHistoMap_[layer]->getTH2F()->GetBin(xybin.ix,xybin.iy));
+  else
+      return tkHistoMap_[layer]->getTProfile2D()->GetBinContent(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
 float TkHistoMap::getEntries(uint32_t& detid){
   int16_t layer=tkdetmap_->FindLayer(detid , cached_detid , cached_layer , cached_XYbin);
   TkLayerMap::XYbin xybin = tkdetmap_->getXY(detid , cached_detid , cached_layer , cached_XYbin);
-  return tkHistoMap_[layer]->getTProfile2D()->GetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
+  if (tkHistoMap_[layer]->kind() == MonitorElement::DQM_KIND_TH2F)
+    return 1;
+  else
+    return tkHistoMap_[layer]->getTProfile2D()->GetBinEntries(tkHistoMap_[layer]->getTProfile2D()->GetBin(xybin.ix,xybin.iy));
 }
 
 void TkHistoMap::dumpInTkMap(TrackerMap* tkmap,bool dumpEntries){
@@ -244,7 +306,7 @@ void TkHistoMap::dumpInTkMap(TrackerMap* tkmap,bool dumpEntries){
 	}
       }
     }
-  } 
+  }
 }
 
 #include "TCanvas.h"
@@ -271,7 +333,7 @@ void TkHistoMap::saveAsCanvas(std::string filename,std::string options,std::stri
   CTIB->cd(++i);tkHistoMap_[TkLayerMap::TIB_L2]->getTProfile2D()->Draw(options.c_str());
   CTIB->cd(++i);tkHistoMap_[TkLayerMap::TIB_L3]->getTProfile2D()->Draw(options.c_str());
   CTIB->cd(++i);tkHistoMap_[TkLayerMap::TIB_L4]->getTProfile2D()->Draw(options.c_str());
-  
+
   i=0;
   CTIDP->cd(++i);tkHistoMap_[TkLayerMap::TIDP_D1]->getTProfile2D()->Draw(options.c_str());
   CTIDP->cd(++i);tkHistoMap_[TkLayerMap::TIDP_D2]->getTProfile2D()->Draw(options.c_str());
@@ -281,7 +343,7 @@ void TkHistoMap::saveAsCanvas(std::string filename,std::string options,std::stri
   CTIDM->cd(++i);tkHistoMap_[TkLayerMap::TIDM_D1]->getTProfile2D()->Draw(options.c_str());
   CTIDM->cd(++i);tkHistoMap_[TkLayerMap::TIDM_D2]->getTProfile2D()->Draw(options.c_str());
   CTIDM->cd(++i);tkHistoMap_[TkLayerMap::TIDM_D3]->getTProfile2D()->Draw(options.c_str());
- 
+
   i=0;
   CTOB->cd(++i);tkHistoMap_[TkLayerMap::TOB_L1]->getTProfile2D()->Draw(options.c_str());
   CTOB->cd(++i);tkHistoMap_[TkLayerMap::TOB_L2]->getTProfile2D()->Draw(options.c_str());
@@ -311,7 +373,7 @@ void TkHistoMap::saveAsCanvas(std::string filename,std::string options,std::stri
   CTECM->cd(++i);tkHistoMap_[TkLayerMap::TECM_W7]->getTProfile2D()->Draw(options.c_str());
   CTECM->cd(++i);tkHistoMap_[TkLayerMap::TECM_W8]->getTProfile2D()->Draw(options.c_str());
   CTECM->cd(++i);tkHistoMap_[TkLayerMap::TECM_W9]->getTProfile2D()->Draw(options.c_str());
- 
+
   TFile *f = new TFile(filename.c_str(),mode.c_str());
   CTIB->Write();
   CTIDP->Write();
@@ -322,5 +384,3 @@ void TkHistoMap::saveAsCanvas(std::string filename,std::string options,std::stri
   f->Close();
   delete f;
 }
-
-

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -155,7 +155,7 @@ void TkHistoMap::createTkHistoMap(DQMStore::IBooker & ibooker , std::string& pat
 						0.0, 0.0);
     }
     if(bookTH2F==true){
-        me  = dqmStore_->book2D(fullName.c_str(),fullName.c_str(),
+        me  = ibooker.book2D(fullName.c_str(),fullName.c_str(),
                                                    nchX,lowX,highX,
                                                    nchY,lowY,highY);
 

--- a/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripTrackerMapCreator.cc
@@ -22,7 +22,7 @@
 
 //
 // -- Constructor
-// 
+//
 /*
 SiStripTrackerMapCreator::SiStripTrackerMapCreator() {
   trackerMap_ = 0;
@@ -37,7 +37,7 @@ SiStripTrackerMapCreator::SiStripTrackerMapCreator() {
 }
 */
 SiStripTrackerMapCreator::SiStripTrackerMapCreator(const edm::EventSetup& eSetup): meanToMaxFactor_(2.5),eSetup_(eSetup)
-						  //, psumap_() 
+						  //, psumap_()
 {
   cached_detid=0;
   cached_layer=0;
@@ -63,7 +63,7 @@ SiStripTrackerMapCreator::~SiStripTrackerMapCreator() {
 //
 // -- Create Geometric and Fed Tracker Map
 //
-void SiStripTrackerMapCreator::create(const edm::ParameterSet & tkmapPset, 
+void SiStripTrackerMapCreator::create(const edm::ParameterSet & tkmapPset,
 				      DQMStore* dqm_store, std::string& map_type,
                                       const edm::EventSetup& eSetup) {
 
@@ -79,10 +79,10 @@ void SiStripTrackerMapCreator::create(const edm::ParameterSet & tkmapPset,
   trackerMap_ = new TrackerMap(tkmapPset, fedcabling,tTopo);
   std::string tmap_title = " Tracker Map from  " + map_type;
   trackerMap_->setTitle(tmap_title);
- 
+
   nDet     = 0;
-  tkMapMax_ = 0.0; 
-  tkMapMin_ = 0.0; 
+  tkMapMax_ = 0.0;
+  tkMapMin_ = 0.0;
   meanToMaxFactor_ = 2.5;
   useSSQuality_ = false;
   ssqLabel_ = "";
@@ -92,13 +92,13 @@ void SiStripTrackerMapCreator::create(const edm::ParameterSet & tkmapPset,
     setTkMapFromAlarm(dqm_store, eSetup);
     /*
     trackerMap_->fillc_all_blank();
-    const std::vector<uint16_t>& feds = fedcabling->feds(); 
+    const std::vector<uint16_t>& feds = fedcabling->feds();
     uint32_t detId_save = 0;
-    for(std::vector<unsigned short>::const_iterator ifed = feds.begin(); 
+    for(std::vector<unsigned short>::const_iterator ifed = feds.begin();
 	ifed < feds.end(); ifed++){
       const std::vector<FedChannelConnection> fedChannels = fedcabling->connections( *ifed );
       for(std::vector<FedChannelConnection>::const_iterator iconn = fedChannels.begin(); iconn < fedChannels.end(); iconn++){
-	
+
 	uint32_t detId = iconn->detId();
 	if (detId == 0 || detId == 0xFFFFFFFF)  continue;
 	if (detId_save != detId) {
@@ -106,7 +106,7 @@ void SiStripTrackerMapCreator::create(const edm::ParameterSet & tkmapPset,
           paintTkMapFromAlarm(detId, dqm_store);
 	}
       }
-    } 
+    }
     */
   } else {
     trackerMap_->fill_all_blank();
@@ -120,7 +120,7 @@ void SiStripTrackerMapCreator::create(const edm::ParameterSet & tkmapPset,
 //
 // -- Create Tracker Map for Offline process
 //
-void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapPset, 
+void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapPset,
 						DQMStore* dqm_store, std::string& map_type,
                                                 const edm::EventSetup& eSetup) {
 
@@ -133,7 +133,7 @@ void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapP
   }
   else {
     std::string mechanicalview_dir = dqm_store->pwd();
-    stripTopLevelDir_=mechanicalview_dir.substr(0,mechanicalview_dir.find_last_of("/"));    
+    stripTopLevelDir_=mechanicalview_dir.substr(0,mechanicalview_dir.find_last_of("/"));
     edm::LogInfo("SiStripTopLevelDirFound") << "SiStrip top level directory is " << stripTopLevelDir_;
   }
   dqm_store->cd();
@@ -155,13 +155,13 @@ void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapP
   ssqLabel_ = tkmapPset.getUntrackedParameter<std::string>("ssqLabel","");
   bool tkMapPSU = tkmapPset.getUntrackedParameter<bool>("psuMap",false);
   bool tkMapFED = tkmapPset.getUntrackedParameter<bool>("fedMap",false);
-  std::string namesuffix = tkmapPset.getUntrackedParameter<std::string>("mapSuffix",""); 
- 
+  std::string namesuffix = tkmapPset.getUntrackedParameter<std::string>("mapSuffix","");
+
   //  std::string tmap_title = " Tracker Map from  " + map_type;
-  unsigned int runNumber_ = tkmapPset.getUntrackedParameter<unsigned int>("RunNumber",1); //LG                                                             
+  unsigned int runNumber_ = tkmapPset.getUntrackedParameter<unsigned int>("RunNumber",1); //LG
   std::stringstream ss; //LG
   ss << runNumber_; //LG
-  sRunNumber = ss.str(); //LG 
+  sRunNumber = ss.str(); //LG
   std::cout << sRunNumber << "\n\n\n\n\n\n";
   std::string tmap_title; //LG
   if      (runNumber_>0)  { tmap_title = " Run: " + sRunNumber + ", Tracker Map from " + map_type; } //LG
@@ -177,7 +177,7 @@ void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapP
       numTopModules=tkmapPset.getUntrackedParameter<uint32_t>("numberTopModules");
   else
       numTopModules = 20;
-  
+
   if (tkmapPset.exists("topModLabel"))
         topModLabel=tkmapPset.getUntrackedParameter<int32_t>("topModLabel");
   else
@@ -193,7 +193,7 @@ void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapP
   setTkMapRangeOffline();
 
   // check manual setting
-  
+
   if(tkmapPset.exists("mapMax")) tkMapMax_ = tkmapPset.getUntrackedParameter<double>("mapMax");
   if(tkmapPset.exists("mapMin")) tkMapMin_ = tkmapPset.getUntrackedParameter<double>("mapMin");
 
@@ -201,7 +201,7 @@ void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapP
     ResidualsRMS_ = false;
     setTkMapFromHistogram(dqm_store, map_type, eSetup);
     edm::LogInfo("TkMapToBeSaved") << "Ready to save TkMap " << map_type << namesuffix << " with range set to " << tkMapMin_ << " - " << tkMapMax_;
-    trackerMap_->save(true, tkMapMin_,tkMapMax_, map_type+namesuffix+".svg");  
+    trackerMap_->save(true, tkMapMin_,tkMapMax_, map_type+namesuffix+".svg");
     trackerMap_->save(true, tkMapMin_,tkMapMax_, map_type+namesuffix+".png",4500,2400);
     ResidualsRMS_ = true;
     map_type = "ResidualsRMS";
@@ -210,11 +210,11 @@ void SiStripTrackerMapCreator::createForOffline(const edm::ParameterSet & tkmapP
     trackerMap_->setTitle(tmap_title);
     setTkMapFromHistogram(dqm_store, map_type, eSetup);
     edm::LogInfo("TkMapToBeSaved") << "Ready to save TkMap " << map_type << namesuffix << " with range set to 0.0 - 1.0";
-    trackerMap_->save(true, 0.0, 1.0, map_type+namesuffix+".svg");  
+    trackerMap_->save(true, 0.0, 1.0, map_type+namesuffix+".svg");
     trackerMap_->save(true, 0.0, 1.0, map_type+namesuffix+".png",4500,2400);
   } else {
     edm::LogInfo("TkMapToBeSaved") << "Ready to save TkMap " << map_type << namesuffix << " with range set to " << tkMapMin_ << " - " << tkMapMax_;
-    trackerMap_->save(true, tkMapMin_,tkMapMax_, map_type+namesuffix+".svg");  
+    trackerMap_->save(true, tkMapMin_,tkMapMax_, map_type+namesuffix+".svg");
     trackerMap_->save(true, tkMapMin_,tkMapMax_, map_type+namesuffix+".png",4500,2400);
   }
 
@@ -247,8 +247,8 @@ void SiStripTrackerMapCreator::setTkMapFromAlarm(DQMStore* dqm_store, const edm:
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   nDet     = 0;
-  tkMapMax_ = 0.0; 
-  tkMapMin_ = 0.0; 
+  tkMapMax_ = 0.0;
+  tkMapMin_ = 0.0;
 
   edm::ESHandle<SiStripQuality> ssq;
 
@@ -261,7 +261,7 @@ void SiStripTrackerMapCreator::setTkMapFromAlarm(DQMStore* dqm_store, const edm:
   // used to avoid multiple checks on the same detid since the loop is done on the FED channels
     uint32_t detId_save = 0;
     // example of loop using SiStripDetCabling
-    for(std::map< uint32_t, std::vector<const FedChannelConnection *> >::const_iterator module = detcabling_->getDetCabling().begin(); 
+    for(std::map< uint32_t, std::vector<const FedChannelConnection *> >::const_iterator module = detcabling_->getDetCabling().begin();
 	module!=detcabling_->getDetCabling().end();++module) {
       uint32_t detId = module->first;
       if (detId == 0 || detId == 0xFFFFFFFF)  continue;
@@ -269,7 +269,7 @@ void SiStripTrackerMapCreator::setTkMapFromAlarm(DQMStore* dqm_store, const edm:
 	detId_save = detId;
 	bool isBad = useSSQuality_ && ssq->IsModuleBad(detId);
 	paintTkMapFromAlarm(detId, tTopo, dqm_store,isBad,badmodmap);
-      } 
+      }
       else {
 	edm::LogWarning("TwiceTheSameDetId") << "The detid " << detId << " was found already in the loop on SiStripDetCabling";
       }
@@ -298,13 +298,13 @@ void SiStripTrackerMapCreator::printBadModuleList(std::map<unsigned int,std::str
     SiStripDetId ssdetid(badmod->first);
     if(ssdetid.subDetector()==SiStripDetId::TIB) ntib++;
     if(ssdetid.subDetector()==SiStripDetId::TID) {
-      
+
       if(tTopo->tidSide(ssdetid)==1) ntids1++;
       if(tTopo->tidSide(ssdetid)==2) ntids2++;
     }
     if(ssdetid.subDetector()==SiStripDetId::TOB) ntob++;
     if(ssdetid.subDetector()==SiStripDetId::TEC) {
-      
+
       if(tTopo->tecSide(ssdetid)==1) ntecs1++;
       if(tTopo->tecSide(ssdetid)==2) ntecs2++;
     }
@@ -323,7 +323,7 @@ void SiStripTrackerMapCreator::printBadModuleList(std::map<unsigned int,std::str
   edm::LogVerbatim("BadModuleList") ;
   edm::LogVerbatim("BadModuleList") << "List of bad modules per partition:";
   edm::LogVerbatim("BadModuleList") << "----------------------------------";
-  
+
   for(std::map<unsigned int,std::string>::const_iterator badmod = badmodmap->begin(); badmod!= badmodmap->end(); ++badmod) {
     if(!tibDone && badmod->first >= tibFirst) {
       tibDone = true;
@@ -366,12 +366,12 @@ void SiStripTrackerMapCreator::printBadModuleList(std::map<unsigned int,std::str
 }
 
 //
-// -- Paint Tracker Map with QTest Alarms 
+// -- Paint Tracker Map with QTest Alarms
 //
 void SiStripTrackerMapCreator::paintTkMapFromAlarm(uint32_t det_id, const TrackerTopology* tTopo,
                                                    DQMStore* dqm_store, bool isBad, std::map<unsigned int,std::string>* badmodmap) {
   std::ostringstream comment;
-  uint16_t flag = 0; 
+  uint16_t flag = 0;
   flag = getDetectorFlagAndComment(dqm_store, det_id, tTopo, comment);
 
   int rval, gval, bval;
@@ -380,9 +380,9 @@ void SiStripTrackerMapCreator::paintTkMapFromAlarm(uint32_t det_id, const Tracke
   trackerMap_->setText(det_id, comment.str());
   trackerMap_->fillc(det_id, rval, gval, bval);
 
-  if(badmodmap && (flag!=0 || isBad)){ 
+  if(badmodmap && (flag!=0 || isBad)){
     uint  lay= tTopo->layer(SiStripDetId(det_id));
-    std::string layer =" Layer "+ std::to_string(lay); 
+    std::string layer =" Layer "+ std::to_string(lay);
     (*badmodmap)[det_id] = comment.str() + layer;
   }
 
@@ -407,16 +407,16 @@ void SiStripTrackerMapCreator::setTkMapFromHistogram(DQMStore* dqm_store, std::s
   subdet_folder.push_back("TID/PLUS");
 
   nDet     = 0;
-  tkMapMax_ = 0.0; 
+  tkMapMax_ = 0.0;
   tkMapMin_ = 0.0;
-  std::vector<std::pair<float,uint32_t> >* topNmodVec = new std::vector<std::pair<float,uint32_t> >; 
+  std::vector<std::pair<float,uint32_t> >* topNmodVec = new std::vector<std::pair<float,uint32_t> >;
 
   for (std::vector<std::string>::const_iterator it = subdet_folder.begin(); it != subdet_folder.end(); it++) {
     std::string dname = mechanicalview_dir + "/" + (*it);
     if (!dqm_store->dirExists(dname)) continue;
-    dqm_store->cd(dname);  
+    dqm_store->cd(dname);
     std::vector<std::string> layerVec = dqm_store->getSubdirs();
-    for (std::vector<std::string>::const_iterator iLayer = layerVec.begin(); iLayer != layerVec.end(); iLayer++) { 
+    for (std::vector<std::string>::const_iterator iLayer = layerVec.begin(); iLayer != layerVec.end(); iLayer++) {
       if ((*iLayer).find("BadModuleList") !=std::string::npos) continue;
       std::vector<MonitorElement*> meVec = dqm_store->getContents((*iLayer));
       MonitorElement* tkhmap_me = 0;
@@ -430,15 +430,15 @@ void SiStripTrackerMapCreator::setTkMapFromHistogram(DQMStore* dqm_store, std::s
 	  break;
 	} else if (name.find(htype) != std::string::npos) {
 	  tkhmap_me = (*itkh);
-	  break; 
-	} 
+	  break;
+	}
       }
       if (tkhmap_me != 0) {
 	if (topModules){
         	paintTkMapFromHistogram(dqm_store,tkhmap_me, htype, topNmodVec);
 	}
 	else paintTkMapFromHistogram(dqm_store,tkhmap_me, htype, 0);
-      } 
+      }
     }
     dqm_store->cd(mechanicalview_dir);
   }
@@ -452,7 +452,7 @@ void SiStripTrackerMapCreator::printTopModules(std::vector<std::pair<float,uint3
    //////////////Retrieve tracker topology from geometry
    //edm::ESHandle<TrackerTopology> tTopoHandle;
    //eSetup.get<TrackerTopologyRecord>().get(tTopoHandle);
-   //const TrackerTopology* const tTopo = tTopoHandle.product();  
+   //const TrackerTopology* const tTopo = tTopoHandle.product();
    edm::ESHandle<TrackerTopology> tTopoHandle;
    eSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
    const TrackerTopology* const tTopo = tTopoHandle.product();
@@ -461,10 +461,10 @@ void SiStripTrackerMapCreator::printTopModules(std::vector<std::pair<float,uint3
 
    std::sort(topNmodVec->rbegin(), topNmodVec->rend());
    if (topNmodVec->size() > numTopModules) topNmodVec->resize(numTopModules);
-   
+
    edm::LogVerbatim("TopModules") << topModLabel;
    edm::LogVerbatim("TopModules") << "------------------------------------------------------";
-   
+
    for (std::vector<std::pair<float, uint32_t> >::const_iterator itNmod = topNmodVec->begin(); itNmod != topNmodVec->end(); itNmod++){
        std::pair<float, uint32_t> aPair=(*itNmod);
        uint32_t det_id = aPair.second;
@@ -495,7 +495,7 @@ void SiStripTrackerMapCreator::paintTkMapFromHistogram(DQMStore* dqm_store, Moni
   //  if(useSSQuality_) { eSetup_.get<SiStripQualityRcd>().get(ssqLabel_,ssq);  }
 
   std::string name  = me->getName();
-  std::string lname = name.substr(name.find("TkHMap_")+7);  
+  std::string lname = name.substr(name.find("TkHMap_")+7);
   lname = lname.substr(lname.find("_T")+1);
   std::vector<uint32_t> layer_detids;
   tkDetMap_->getDetsForLayer(tkDetMap_->getLayerNum(lname), layer_detids);
@@ -505,15 +505,9 @@ void SiStripTrackerMapCreator::paintTkMapFromHistogram(DQMStore* dqm_store, Moni
     nDet++;
     const TkLayerMap::XYbin& xyval = tkDetMap_->getXY(det_id , cached_detid , cached_layer , cached_XYbin);
     float fval = 0.0;
-    if ( (name.find("NumberOfOff") != std::string::npos) || //temporary fix 
-         (name.find("NumberOfOnTrackCluster") != std::string::npos) ) {
-      if (me->kind() == MonitorElement::DQM_KIND_TPROFILE2D) {   
-	TProfile2D* tp = me->getTProfile2D() ;
-	fval =  tp->GetBinEntries(tp->GetBin(xyval.ix, xyval.iy)) * tp->GetBinContent(xyval.ix, xyval.iy);
-      }
-    } else if(name.find("Residuals") != std::string::npos){
+    if(name.find("Residuals") != std::string::npos){
       if(ResidualsRMS_==true){
-	if (me->kind() == MonitorElement::DQM_KIND_TPROFILE2D) {  
+	if (me->kind() == MonitorElement::DQM_KIND_TPROFILE2D) {
 	  TProfile2D* tp = me->getTProfile2D() ;
 	  float fval_prov = tp->GetBinError(xyval.ix, xyval.iy) * sqrt(tp->GetBinEntries(tp->GetBin(xyval.ix, xyval.iy)));
 	  fval =  fval_prov;
@@ -536,7 +530,7 @@ void SiStripTrackerMapCreator::paintTkMapFromHistogram(DQMStore* dqm_store, Moni
       trackerMap_->setText(det_id, comment.str());
       */
     } else {
-      if (fval == 0.0) trackerMap_->fillc(det_id,255, 255, 255);  
+      if (fval == 0.0) trackerMap_->fillc(det_id,255, 255, 255);
       else {
  	trackerMap_->fill_current_val(det_id, fval);
         if(topNmodVec){
@@ -547,13 +541,13 @@ void SiStripTrackerMapCreator::paintTkMapFromHistogram(DQMStore* dqm_store, Moni
       tkMapMax_ += fval;
     }
   }
-} 
+}
 //
 // -- Get Tracker Map Fill Range
 //
 void SiStripTrackerMapCreator::setTkMapRange(std::string& map_type) {
   tkMapMin_ = 0.0;
-  if (tkMapMax_ == 0.0) { 
+  if (tkMapMax_ == 0.0) {
     if (map_type.find("FractionOfBadChannels") != std::string::npos)        tkMapMax_ = 1.0;
     else if (map_type.find("NumberOfCluster") != std::string::npos)         tkMapMax_ = 0.01;
     else if (map_type.find("NumberOfDigi") != std::string::npos)            tkMapMax_ = 0.6;
@@ -568,7 +562,7 @@ void SiStripTrackerMapCreator::setTkMapRange(std::string& map_type) {
 }
 void SiStripTrackerMapCreator::setTkMapRangeOffline() {
   tkMapMin_ = 0.0;
-  if (tkMapMax_ != 0.0) { 
+  if (tkMapMax_ != 0.0) {
     tkMapMax_ = tkMapMax_/(nDet*1.0);
     tkMapMax_ = tkMapMax_ * meanToMaxFactor_;
  }
@@ -619,11 +613,11 @@ uint16_t SiStripTrackerMapCreator::getDetectorFlagAndComment(DQMStore* dqm_store
 
   LogDebug("SearchBadModule") << det_id << " " << subdet_folder << " " << stripTopLevelDir_;
 
-  if (dqm_store->dirExists(subdet_folder)){ 
+  if (dqm_store->dirExists(subdet_folder)){
     badmodule_folder = subdet_folder + "/BadModuleList";
     LogDebug("SearchBadModule") << subdet_folder << " exists: " << badmodule_folder;
   } else {
-    //    badmodule_folder = dqm_store->pwd() + "/BadModuleList"; 
+    //    badmodule_folder = dqm_store->pwd() + "/BadModuleList";
     edm::LogError("SubDetFolderNotFound") << subdet_folder << " does not exist for detid " << det_id;
     return flag;
   }
@@ -679,7 +673,7 @@ void SiStripTrackerMapCreator::createInfoFile(std::vector<std::string> map_names
     }
     else {
       std::string mechanicalview_dir = dqm_store->pwd();
-      dirname=mechanicalview_dir.substr(0,mechanicalview_dir.find_last_of("/"));    
+      dirname=mechanicalview_dir.substr(0,mechanicalview_dir.find_last_of("/"));
       edm::LogInfo("SiStripTrackerMapCreator::createInfoFile") << "SiStrip top level directory is " << dirname;
     }
     dqm_store->cd();
@@ -694,7 +688,7 @@ void SiStripTrackerMapCreator::createInfoFile(std::vector<std::string> map_names
         std::string tkhmap_name = "TkHMap_" + map_names.at(ih);
         tkHMaps.at(ih)->loadTkHistoMap(dirname, tkhmap_name, true);
       }
-    } 
+    }
 
     for(std::vector<uint32_t>::const_iterator idet = detidList.begin(); idet != detidList.end(); ++idet) {
       det_id = (*idet);

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
@@ -127,7 +127,7 @@ process.siStripOfflineAnalyser = cms.EDAnalyzer("SiStripOfflineDQM",
     cms.PSet(mapName=cms.untracked.string('ChargePerCMfromTrack'),RunNumber=cms.untracked.uint32(options.runNumber),mapMax=cms.untracked.double(-1.)),
     cms.PSet(mapName=cms.untracked.string('NumberMissingHits'),RunNumber=cms.untracked.uint32(options.runNumber),mapMax=cms.untracked.double(-1.)),
     cms.PSet(mapName=cms.untracked.string('NumberValidHits'),RunNumber=cms.untracked.uint32(options.runNumber),mapMax=cms.untracked.double(-1.)),
-    cms.PSet(mapName=cms.untracked.string('NumberInactiveHits'),RunNumber=cms.untracked.uint32(options.runNumber)),
+    cms.PSet(mapName=cms.untracked.string('NumberInactiveHits'),RunNumber=cms.untracked.uint32(options.runNumber),mapMax=cms.untracked.double(-1.)),
     cms.PSet(mapName=cms.untracked.string('ResidualsMean'),RunNumber=cms.untracked.uint32(options.runNumber),mapMax=cms.untracked.double(-1.),TopModules=cms.untracked.bool(True))
     )
 )

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -141,9 +141,9 @@ private:
   std::string topFolderName_;
 
   //******* TkHistoMaps
-  TkHistoMap *tkhisto_StoNCorrOnTrack, *tkhisto_NumOnTrack, *tkhisto_NumOffTrack;
-  TkHistoMap *tkhisto_ClChPerCMfromOrigin, *tkhisto_ClChPerCMfromTrack;
-  TkHistoMap *tkhisto_NumMissingHits, *tkhisto_NumberInactiveHits, *tkhisto_NumberValidHits;
+  std::unique_ptr<TkHistoMap> tkhisto_StoNCorrOnTrack, tkhisto_NumOnTrack, tkhisto_NumOffTrack;
+  std::unique_ptr<TkHistoMap> tkhisto_ClChPerCMfromOrigin, tkhisto_ClChPerCMfromTrack;
+  std::unique_ptr<TkHistoMap> tkhisto_NumMissingHits, tkhisto_NumberInactiveHits, tkhisto_NumberValidHits;
   //******** TkHistoMaps
   int numTracks;
 

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -153,16 +153,16 @@ void SiStripMonitorTrack::book(DQMStore::IBooker & ibooker , const TrackerTopolo
   folder_organizer.setSiStripFolderName(topFolderName_);
   //******** TkHistoMaps
   if (TkHistoMap_On_) {
-    tkhisto_StoNCorrOnTrack = new TkHistoMap(ibooker , topFolderName_ ,"TkHMap_StoNCorrOnTrack",         0.0,true);
-    tkhisto_NumOnTrack      = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberOfOnTrackCluster",  0.0,true);
-    tkhisto_NumOffTrack     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberOfOfffTrackCluster",0.0,true);
-    tkhisto_ClChPerCMfromTrack  = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ChargePerCMfromTrack",0.0,true);
-    tkhisto_NumMissingHits      = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberMissingHits",0.0,true);
-    tkhisto_NumberInactiveHits  = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberInactiveHits",0.0,true);
-    tkhisto_NumberValidHits     = new TkHistoMap(ibooker , topFolderName_, "TkHMap_NumberValidHits",0.0,true);
+    tkhisto_StoNCorrOnTrack = std::make_unique<TkHistoMap>(ibooker , topFolderName_ ,"TkHMap_StoNCorrOnTrack",         0.0,true);
+    tkhisto_NumOnTrack      = std::make_unique<TkHistoMap>(ibooker , topFolderName_, "TkHMap_NumberOfOnTrackCluster",  0.0,true, true);
+    tkhisto_NumOffTrack     = std::make_unique<TkHistoMap>(ibooker , topFolderName_, "TkHMap_NumberOfOfffTrackCluster",0.0,true, true);
+    tkhisto_ClChPerCMfromTrack  = std::make_unique<TkHistoMap>(ibooker , topFolderName_, "TkHMap_ChargePerCMfromTrack",0.0,true);
+    tkhisto_NumMissingHits      = std::make_unique<TkHistoMap>(ibooker , topFolderName_, "TkHMap_NumberMissingHits",0.0,true, true);
+    tkhisto_NumberInactiveHits  = std::make_unique<TkHistoMap>(ibooker , topFolderName_, "TkHMap_NumberInactiveHits",0.0,true, true);
+    tkhisto_NumberValidHits     = std::make_unique<TkHistoMap>(ibooker , topFolderName_, "TkHMap_NumberValidHits",0.0,true, true);
   }
   if (clchCMoriginTkHmap_On_)
-    tkhisto_ClChPerCMfromOrigin = new TkHistoMap(ibooker , topFolderName_, "TkHMap_ChargePerCMfromOrigin",0.0,true);
+    tkhisto_ClChPerCMfromOrigin = std::make_unique<TkHistoMap>(ibooker , topFolderName_, "TkHMap_ChargePerCMfromOrigin",0.0,true);
   //******** TkHistoMaps
 
   std::vector<uint32_t> vdetId_;
@@ -704,11 +704,11 @@ void SiStripMonitorTrack::trajectoryStudy(
       uint32_t thedetid=ttrh->rawId();
       if ( SiStripDetId(thedetid).subDetector() >=3 &&  SiStripDetId(thedetid).subDetector() <=6) { //TIB/TID + TOB + TEC only
         if ( (ttrh->getType()==1) )
-          tkhisto_NumMissingHits->add(thedetid,1.);
+          tkhisto_NumMissingHits->fill(thedetid,1.);
         if ( (ttrh->getType()==2) )
-          tkhisto_NumberInactiveHits->add(thedetid,1.);
+          tkhisto_NumberInactiveHits->fill(thedetid,1.);
         if ( (ttrh->getType()==0) )
-          tkhisto_NumberValidHits->add(thedetid,1.);
+          tkhisto_NumberValidHits->fill(thedetid,1.);
       }
     }
 
@@ -903,11 +903,11 @@ void SiStripMonitorTrack::trackStudyFromTrack(
         uint32_t thedetid=(*hit)->rawId();
         if ( SiStripDetId(thedetid).subDetector() >=3 &&  SiStripDetId(thedetid).subDetector() <=6) { //TIB/TID + TOB + TEC only
           if ( ((*hit)->getType()==1) )
-            tkhisto_NumMissingHits->add(thedetid,1.);
+            tkhisto_NumMissingHits->fill(thedetid,1.);
           if ( ((*hit)->getType()==2) )
-            tkhisto_NumberInactiveHits->add(thedetid,1.);
+            tkhisto_NumberInactiveHits->fill(thedetid,1.);
           if ( ((*hit)->getType()==0) )
-            tkhisto_NumberValidHits->add(thedetid,1.);
+            tkhisto_NumberValidHits->fill(thedetid,1.);
         }
       }
 
@@ -1247,7 +1247,7 @@ bool SiStripMonitorTrack::clusterInfos(
     //******** TkHistoMaps
     if (TkHistoMap_On_) {
       uint32_t adet=cluster->detId();
-      tkhisto_NumOnTrack->add(adet,1.);
+      tkhisto_NumOnTrack->fill(adet,1.);
       if(noise > 0.0) tkhisto_StoNCorrOnTrack->fill(adet,cluster->signalOverNoise()*cosRZ);
       if(noise == 0.0)
 	LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << noise << std::endl;
@@ -1292,7 +1292,7 @@ bool SiStripMonitorTrack::clusterInfos(
       //******** TkHistoMaps
       if (TkHistoMap_On_) {
         uint32_t adet=cluster->detId();
-        tkhisto_NumOffTrack->add(adet,1.);
+        tkhisto_NumOffTrack->fill(adet,1.);
         if(charge > 250){
 	  LogDebug("SiStripMonitorTrack") << "Module firing " << detid << " in Event " << eventNb << std::endl;
         }


### PR DESCRIPTION
Overload of TkHistoMaps constructor so it can produce TH2F objects besides TProfile2D.
Changed TkHistoMaps pointers (in SiStripMonitorTrack) to unique_ptr.

Packages involved:
- DQM/SiStripCommon
- DQM/SiStripMonitorClient
- DQM/SiStripMonitorTrack

