### PR TITLE
Changing the number of ME0 phi-strips and adding the displaced muon validation

### DIFF
--- a/Geometry/GEMGeometryBuilder/data/v7/GEMSpecs.xml
+++ b/Geometry/GEMGeometryBuilder/data/v7/GEMSpecs.xml
@@ -3,7 +3,7 @@
   <SpecParSection label="GEMSpecs.xml">
     <SpecPar name="nStripsME0" eval="true">
       <PartSelector path="//GHA0.."/>
-      <Parameter name="nStrips" value="512"/>
+      <Parameter name="nStrips" value="384"/>
     </SpecPar>
     <SpecPar name="nStripsGE11" eval="true">
       <PartSelector path="//GHA1.."/>

--- a/Validation/RecoMuon/python/muonValidation_cff.py
+++ b/Validation/RecoMuon/python/muonValidation_cff.py
@@ -411,6 +411,10 @@ muonValidation_reduced_seq = cms.Sequence(
 #    +muonAssociatorByHitsNoSimHitsHelperStandalone +recoMuonVMuAssoc_sta
 #    +muonAssociatorByHitsNoSimHitsHelperGlobal +recoMuonVMuAssoc_glb
 #    +muonAssociatorByHitsNoSimHitsHelperTight +recoMuonVMuAssoc_tgt
+#    +seedsOfDisplacedSTAmuons_seq + tpToDisplacedStaSeedAssociation + displacedStaSeedTrackVMuonAssoc
+    +tpToDisplacedStaMuonAssociation + displacedStaMuonTrackVMuonAssoc
+    +tpToDisplacedTrkMuonAssociation + displacedTrackVMuonAssoc
+    +tpToDisplacedGlbMuonAssociation + displacedGlbMuonTrackVMuonAssoc
 )
 
 muonValidationTEV_seq = cms.Sequence(


### PR DESCRIPTION
With this PR we are changing the number of ME0 phi-strips from 512 to 384, given the latest simulation results presented during the Muon Workshop last week:

https://indico.cern.ch/event/614702/contributions/2519760/attachments/1432877/2201719/nmccoll_3_24_17_MuUpgWkshp.pdf

Moreover we need to restore the validation of the displaced muon reconstructions, to spot issues like the one that came out recently (slide 13):

https://indico.cern.ch/event/623423/contributions/2514930/subcontributions/222604/attachments/1428355/2192582/Upgrade_Performance_14032017.pdf

@pietverwilligen @jshlee @kpedro88 