### PR TITLE
Neutron background rescale for GE1/1 and GE2/1

### DIFF
--- a/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
+++ b/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
@@ -92,6 +92,8 @@ private:
     
   double instLumi_;
   double rateFact_;
+    
+  const double referenceInstLumi = 5; //In units of 10^34 Hz/cm^2. Internally the functions based on the FLUKA+GEANT simulation are normalized to 5x10^34 Hz/cm^2, this is needed to rescale them properly
 };
 #endif
 

--- a/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
+++ b/SimMuon/GEMDigitizer/interface/GEMSimpleModel.h
@@ -89,6 +89,9 @@ private:
   double GE21ModNeuBkgParam3;
   double GE21ModNeuBkgParam4;
   double GE21ModNeuBkgParam5;
+    
+  double instLumi_;
+  double rateFact_;
 };
 #endif
 

--- a/SimMuon/GEMDigitizer/python/customizeGEMDigi.py
+++ b/SimMuon/GEMDigitizer/python/customizeGEMDigi.py
@@ -463,3 +463,12 @@ def append_GEMDigi_event(process):
             # getattr(process,b).outputCommands.append('keep *_simSiStripDigis_*_*')
 
     return process
+
+# Customizations for the background
+def customize_digi_noGEMbkg(process):
+    process.simMuonGEMDigis.doBkgNoise = False
+    return process
+
+def customize_digi_noGEMsafety(process):
+    process.simMuonGEMDigis.rateFact = 1
+    return process

--- a/SimMuon/GEMDigitizer/python/customizeME0Digi.py
+++ b/SimMuon/GEMDigitizer/python/customizeME0Digi.py
@@ -162,3 +162,13 @@ def append_ME0Digi_event(process):
         if hasattr(process,b):
             getattr(process,b).outputCommands.append('keep *_simMuonME0Digis_*_*')
     return process
+
+# Customizations for the background (to be updated once the realistic digi is in place)
+def customize_digi_noME0bkg(process):
+    process.simMuonME0Digis.simulateElectronBkg = False
+    process.simMuonME0Digis.simulateNeutralBkg = False
+    return process
+
+def customize_digi_noME0safety(process):
+    process.simMuonME0Digis.rateFact = 1
+    return process

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-# Module to create simulated GEM digis.
-simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
+gemDigiCommonParameters = cms.PSet(
     signalPropagationSpeed = cms.double(0.66),
     cosmics = cms.bool(False),
     timeResolution = cms.double(5),
     timeJitter = cms.double(1.0),
     averageShapingTime = cms.double(50.0),
-# clsParametrization = cms.vdouble(0.455091, 0.865613, 0.945891, 0.973286, 0.986234, 0.991686, 0.996865, 0.998501, 1.),
+    #clsParametrization = cms.vdouble(0.455091, 0.865613, 0.945891, 0.973286, 0.986234, 0.991686, 0.996865, 0.998501, 1.),
     averageEfficiency = cms.double(0.98),
     averageNoiseRate = cms.double(0.001), #intrinsic noise
     bxwidth = cms.int32(25),
@@ -24,6 +23,11 @@ simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     simulateElectronBkg = cms.bool(True),	#False=simulate only neutral Bkg
     simulateLowNeutralRate = cms.bool(False),	#True=neutral_Bkg at L=1x10^{34}, False at L=5x10^{34}cm^{-2}s^{-1}
     instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200
-    rateFact = cms.double(2.0), # We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known)
+    rateFact = cms.double(2.0) # We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known)
+)
+
+# Module to create simulated GEM digis.
+simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
+    gemDigiCommonParameters
 )
 

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -22,7 +22,7 @@ simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     fixedRollRadius = cms.bool(True), #Uses fixed radius in the center of the roll
     simulateIntrinsicNoise = cms.bool(False),
     simulateElectronBkg = cms.bool(True),	#False=simulate only neutral Bkg
-    simulateLowNeutralRate = cms.bool(False)	#True=neutral_Bkg at L=1x10^{34}, False at L=5x10^{34}cm^{-2}s^{-1}
+    simulateLowNeutralRate = cms.bool(False),	#True=neutral_Bkg at L=1x10^{34}, False at L=5x10^{34}cm^{-2}s^{-1}
     instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200
     rateFact = cms.double(2.0), # We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known)
 )

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -23,5 +23,7 @@ simMuonGEMDigis = cms.EDProducer("GEMDigiProducer",
     simulateIntrinsicNoise = cms.bool(False),
     simulateElectronBkg = cms.bool(True),	#False=simulate only neutral Bkg
     simulateLowNeutralRate = cms.bool(False)	#True=neutral_Bkg at L=1x10^{34}, False at L=5x10^{34}cm^{-2}s^{-1}
+    instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200
+    rateFact = cms.double(2.0), # We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known)
 )
 

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from SimMuon.GEMDigitizer.muonGEMDigis_cfi import gemDigiCommonParameters
+
 me0PreRecoDigiCommonParameters = cms.PSet(
     inputCollection = cms.string('g4SimHitsMuonME0Hits'),
     digiPreRecoModelString = cms.string('PreRecoGaussian'),
@@ -20,8 +22,8 @@ me0PreRecoDigiCommonParameters = cms.PSet(
     simulateNeutralBkg  = cms.bool(True),       # True - will simulate neutral (n+g)  background
     minBunch = cms.int32(-5),                   # [x 25 ns], forms the readout window together with maxBunch,
     maxBunch = cms.int32(3),                    # we should think of shrinking this window ...
-    instLumi = cms.double(7.5),                 # in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200
-    rateFact = cms.double(2.0),                 # We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known). Hits can be thrown away later at re-digi step.
+    instLumi = gemDigiCommonParameters.instLumi,# in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200
+    rateFact = gemDigiCommonParameters.rateFact,# We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known). Hits can be thrown away later at re-digi step. Parameters are kept in sync with the ones used in the GEM digitizers
     mixLabel = cms.string('mix'),
 )
 

--- a/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0DigisPreReco_cfi.py
@@ -23,7 +23,7 @@ me0PreRecoDigiCommonParameters = cms.PSet(
     minBunch = cms.int32(-5),                   # [x 25 ns], forms the readout window together with maxBunch,
     maxBunch = cms.int32(3),                    # we should think of shrinking this window ...
     instLumi = gemDigiCommonParameters.instLumi,# in units of 1E34 cm^-2 s^-1. Internally the background is parametrized from FLUKA+GEANT results at 5x10^34 (PU140). We are adding a 1.5 factor for PU200
-    rateFact = gemDigiCommonParameters.rateFact,# We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known). Hits can be thrown away later at re-digi step. Parameters are kept in sync with the ones used in the GEM digitizers
+    rateFact = gemDigiCommonParameters.rateFact,# We are adding also a safety factor of 2 to take into account the new beam pipe effect (not yet known). Hits can be thrown away later at re-digi step. Parameters are kept in sync with the ones used in the GEM digitizer
     mixLabel = cms.string('mix'),
 )
 

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -21,7 +21,7 @@ simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     verbose = cms.bool(False),
     reDigitizeOnlyMuons = cms.bool(False),
     reDigitizeNeutronBkg = cms.bool(True),
-    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This must be synchronized with the default digitizer
-    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This must be synchronized with the default digitizer
-    instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1
+    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This must be synchronized with the default ME0 digitizer
+    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This must be synchronized with the default ME0 digitizer
+    instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1. This is the value used downstream in the ME0 simulation.
 )

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -21,7 +21,7 @@ simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     verbose = cms.bool(False),
     reDigitizeOnlyMuons = cms.bool(False),
     reDigitizeNeutronBkg = cms.bool(True),
-    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This must be synchronized with the default ME0 digitizer
-    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This must be synchronized with the default ME0 digitizer
-    instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1. This is the value used downstream in the ME0 simulation.
+    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This must be synchronized with the default digitizer
+    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This must be synchronized with the default digitizer
+    instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1
 )

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -220,9 +220,8 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
                                       + GE11ElecBkgParam3 * rollRadius * rollRadius * rollRadius;
       
     // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)
-    averageNoiseElectronRatePerRoll *= instLumi_*rateFact_*1.0/5;
-    averageNeutralNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
+    averageNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
   }
   if (gemId.station() == 2)
   {
@@ -245,9 +244,8 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
     if (simulateElectronBkg_)
       averageNoiseElectronRatePerRoll = constElecGE21 * TMath::Exp(slopeElecGE21 * rollRadius);
     // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)
-    averageNoiseElectronRatePerRoll *= instLumi_*rateFact_*1.0/5;
-    averageNeutralNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
+    averageNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
   }
 //simulate intrinsic noise
   if(simulateIntrinsicNoise_)

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -35,6 +35,8 @@ GEMDigiModel(config)
 , fixedRollRadius_(config.getParameter<bool> ("fixedRollRadius"))
 , simulateElectronBkg_(config.getParameter<bool> ("simulateElectronBkg"))
 , simulateLowNeutralRate_(config.getParameter<bool>("simulateLowNeutralRate"))
+, instLumi_(config.getParameter<double>("instLumi"))
+, rateFact_(config.getParameter<double>("rateFact"))
 {
 //initialise parameters from the fit:
 //params for pol3 model of electron bkg for GE1/1:
@@ -216,6 +218,10 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
                                       + GE11ElecBkgParam1 * rollRadius
                                       + GE11ElecBkgParam2 * rollRadius * rollRadius
                                       + GE11ElecBkgParam3 * rollRadius * rollRadius * rollRadius;
+      
+    // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)
+    averageNoiseElectronRatePerRoll *= instLumi_*rateFact_*1.0/5;
+    averageNeutralNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
   }
   if (gemId.station() == 2)
@@ -238,6 +244,9 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
 //simulate electron background for GE2/1
     if (simulateElectronBkg_)
       averageNoiseElectronRatePerRoll = constElecGE21 * TMath::Exp(slopeElecGE21 * rollRadius);
+    // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)
+    averageNoiseElectronRatePerRoll *= instLumi_*rateFact_*1.0/5;
+    averageNeutralNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
   }
 //simulate intrinsic noise

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -221,7 +221,7 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
       
     // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
-    averageNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
+    averageNoiseRatePerRoll *= instLumi_*rateFact_*1.0/referenceInstLumi;
   }
   if (gemId.station() == 2)
   {
@@ -245,7 +245,7 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
       averageNoiseElectronRatePerRoll = constElecGE21 * TMath::Exp(slopeElecGE21 * rollRadius);
     // Scale up/down for desired instantaneous lumi (reference is 5E34, double from config is in units of 1E34)
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
-    averageNoiseRatePerRoll *= instLumi_*rateFact_*1.0/5;
+    averageNoiseRatePerRoll *= instLumi_*rateFact_*1.0/referenceInstLumi;
   }
 //simulate intrinsic noise
   if(simulateIntrinsicNoise_)

--- a/SimMuon/RPCDigitizer/python/customizeRPCDigi.py
+++ b/SimMuon/RPCDigitizer/python/customizeRPCDigi.py
@@ -88,3 +88,8 @@ def customize_digi_addGEM_muon_only(process):
     )
     process = append_GEMDigi_event(process)
     return process
+
+# Customizations for the background
+def customize_digi_noRPCbkg(process):
+    process.simMuonRPCDigis.doBkgNoise = False
+    return process


### PR DESCRIPTION
This PR adds the possibility to rescale the neutron background as we do for ME0. Also in this case the same comments apply: we need to make this an automatic rescaling with PU, but as usual we are on hurry (if we have time we will do it now). We add also some customization functions to switch off the neutron background when we go with the GEANT simulation. The functions will be updated using the latest FLUKA+GEANT results soon. In that case the safetyFactor will be set to 1.

@pietverwilligen @jshlee @kpedro88 @bapavlov 