### PR TITLE
[90X] Fix muon alignment converter

### DIFF
--- a/Alignment/CommonAlignment/src/AlignableObjectId.cc
+++ b/Alignment/CommonAlignment/src/AlignableObjectId.cc
@@ -308,6 +308,8 @@ align::StructureType AlignableObjectId::stringToId(const char *name) const
 //______________________________________________________________________________
 AlignableObjectId::Geometry AlignableObjectId
 ::trackerGeometry(const TrackerGeometry* geometry) {
+  if (!geometry) return Geometry::General;
+
   if (geometry->isThere(GeomDetEnumerators::P2PXEC)) {
     // use structure-type <-> name translation for PhaseII geometry
     return Geometry::PhaseII;

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputXML.h
@@ -33,7 +33,7 @@
 
 class MuonAlignmentInputXML: public MuonAlignmentInputMethod {
    public:
-      MuonAlignmentInputXML(std::string fileName);
+      MuonAlignmentInputXML(const std::string& fileName);
       virtual ~MuonAlignmentInputXML();
 
       // ---------- const member functions ---------------------

--- a/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
@@ -20,7 +20,7 @@
 
 // system include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -40,12 +40,14 @@
 // class decleration
 //
 
-class MuonGeometryDBConverter : public edm::EDAnalyzer {
+class MuonGeometryDBConverter : public edm::one::EDAnalyzer<> {
    public:
       explicit MuonGeometryDBConverter(const edm::ParameterSet&);
       ~MuonGeometryDBConverter();
 
       static void fillDescriptions(edm::ConfigurationDescriptions&);
+      void beginJob() override {};
+      void endJob() override {};
 
    private:
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;

--- a/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
@@ -45,6 +45,7 @@ class MuonGeometryDBConverter : public edm::EDAnalyzer {
       explicit MuonGeometryDBConverter(const edm::ParameterSet&);
       ~MuonGeometryDBConverter();
 
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
 
    private:
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -204,6 +205,42 @@ MuonGeometryDBConverter::analyze(const edm::Event &iEvent, const edm::EventSetup
    else {
       throw cms::Exception("BadConfig") << "Set maxEvents.input to 1.  (Your output is okay.)" << std::endl;
    }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+MuonGeometryDBConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.setComment("Converts muon geometry between various formats.");
+  desc.add<std::string>("input", "ideal");
+  desc.add<std::string>("dtLabel", "");
+  desc.add<std::string>("cscLabel", "");
+  desc.add<double>("shiftErr", 1000.0);
+  desc.add<double>("angleErr", 6.28);
+  desc.add<bool>("getAPEs", true);
+  desc.add<std::string>("output", "xml");
+  desc.add<std::string>("fileName", "REPLACEME.xml");
+  edm::ParameterSetDescription outputXML;
+  outputXML.add<std::string>("fileName", "REPLACEME.xml");
+  outputXML.add<std::string>("relativeto", "ideal");
+  outputXML.add<bool>("survey", false);
+  outputXML.add<bool>("rawIds", false);
+  outputXML.add<bool>("eulerAngles", false);
+  outputXML.add<int>("precision", 10);
+  outputXML.addUntracked<bool>("suppressDTBarrel",      true);
+  outputXML.addUntracked<bool>("suppressDTWheels",      true);
+  outputXML.addUntracked<bool>("suppressDTStations",    true);
+  outputXML.addUntracked<bool>("suppressDTChambers",    false);
+  outputXML.addUntracked<bool>("suppressDTSuperLayers", false);
+  outputXML.addUntracked<bool>("suppressDTLayers",      false);
+  outputXML.addUntracked<bool>("suppressCSCEndcaps",    true);
+  outputXML.addUntracked<bool>("suppressCSCStations",   true);
+  outputXML.addUntracked<bool>("suppressCSCRings",      true);
+  outputXML.addUntracked<bool>("suppressCSCChambers",   false);
+  outputXML.addUntracked<bool>("suppressCSCLayers",     false);
+  desc.add("outputXML", outputXML);
+  descriptions.add("muonGeometryDBConverter", desc);
 }
 
 //define this as a plug-in

--- a/Alignment/MuonAlignment/python/convertSQLitetoXML_cfg.py
+++ b/Alignment/MuonAlignment/python/convertSQLitetoXML_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("CONVERT")
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
-process.load("Configuration.StandardSequences.GeometryIdeal_cff")
+process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 
 process.load("CondCore.DBCommon.CondDBSetup_cfi")

--- a/Alignment/MuonAlignment/python/convertXMLtoSQLite_cfg.py
+++ b/Alignment/MuonAlignment/python/convertXMLtoSQLite_cfg.py
@@ -5,7 +5,7 @@ process = cms.Process("CONVERT")
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
-process.load("Configuration.StandardSequences.GeometryIdeal_cff")
+process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 
 process.MuonGeometryDBConverter = cms.EDAnalyzer("MuonGeometryDBConverter",

--- a/Alignment/MuonAlignment/python/download_sqlite_cfg.py
+++ b/Alignment/MuonAlignment/python/download_sqlite_cfg.py
@@ -8,7 +8,7 @@ process = cms.Process("CONVERT")
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
-process.load("Configuration.StandardSequences.GeometryIdeal_cff")
+process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = globalTag

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -44,9 +44,10 @@ XERCES_CPP_NAMESPACE_USE
 //
 // constructors and destructor
 //
-MuonAlignmentInputXML::MuonAlignmentInputXML(std::string fileName)
+MuonAlignmentInputXML::MuonAlignmentInputXML(const std::string& fileName)
    : m_fileName(fileName)
 {
+   cms::concurrency::xercesInitialize();
    str_operation = XMLString::transcode("operation");
    str_collection = XMLString::transcode("collection");
    str_name = XMLString::transcode("name");
@@ -197,6 +198,7 @@ MuonAlignmentInputXML::~MuonAlignmentInputXML() {
    XMLString::release(&str_none);
    XMLString::release(&str_ideal);
    XMLString::release(&str_container);
+   cms::concurrency::xercesTerminate();
 }
 
 //

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -288,9 +288,6 @@ AlignableMuon *MuonAlignmentInputXML::newAlignableMuon(const edm::EventSetup& iS
       char *message = XMLString::transcode(toCatch.getMessage());
       throw cms::Exception("XMLException") << "Xerces XML parser threw this exception: " << message << std::endl;
    }
-   catch (...) {
-      throw cms::Exception("XMLException") << "Xerces XML parser threw an unknown exception" << std::endl;
-   }
 
    DOMDocument *doc = parser->getDocument();
    DOMElement *node_MuonAlignment = doc->getDocumentElement();

--- a/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
@@ -130,7 +130,7 @@ void MuonAlignmentOutputXML::write(AlignableMuon *alignableMuon, const edm::Even
       DTGeometryBuilderFromDDD DTGeometryBuilder;
       CSCGeometryBuilderFromDDD CSCGeometryBuilder;
  
-      auto dtGeometry = std::shared_ptr<DTGeometry>();
+      auto dtGeometry = std::make_shared<DTGeometry>();
       DTGeometryBuilder.build(dtGeometry, &(*cpv), *mdc);
 
       auto boost_cscGeometry = std::make_shared<CSCGeometry>();

--- a/Alignment/MuonAlignment/test/BuildFile.xml
+++ b/Alignment/MuonAlignment/test/BuildFile.xml
@@ -8,3 +8,4 @@
 <library   file="*.cpp" name="AlignmentMuonAlignment_test">
   <flags   EDM_PLUGIN="1"/>
 </library>
+<test name="test_MuonGeometryDBConverter" command="test_MuonGeometryDBConverter.sh" />

--- a/Alignment/MuonAlignment/test/muonGeometryDBConverter_cfg.py
+++ b/Alignment/MuonAlignment/test/muonGeometryDBConverter_cfg.py
@@ -1,0 +1,91 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+
+################################################################################
+# command line options
+options = VarParsing.VarParsing()
+options.register('input',
+                 default = "ideal",
+                 mytype = VarParsing.VarParsing.varType.string,
+                 info = "input format")
+options.register('inputFile',
+                 default = None,
+                 mytype = VarParsing.VarParsing.varType.string,
+                 info = "input file name")
+options.register('output',
+                 default = "none",
+                 mytype = VarParsing.VarParsing.varType.string,
+                 info = "output format")
+options.register('outputFile',
+                 default = None,
+                 mytype = VarParsing.VarParsing.varType.string,
+                 info = "output file name")
+options.parseArguments()
+
+################################################################################
+# setting up the process
+process = cms.Process("CONVERT")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.Geometry.GeometryIdeal_cff")
+process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Alignment.MuonAlignment.muonGeometryDBConverter_cfi")
+
+################################################################################
+# parameters to configure:
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase1_2017_design")
+process.muonGeometryDBConverter.input = options.input
+process.muonGeometryDBConverter.output = options.output
+
+if options.input == "db":
+    process.GlobalTag.toGet.extend(
+        [cms.PSet(connect = cms.string("sqlite_file:"+options.inputFile),
+                  record = cms.string("DTAlignmentRcd"),
+                  tag = cms.string("DTAlignmentRcd")),
+         cms.PSet(connect = cms.string("sqlite_file:"+options.inputFile),
+                  record = cms.string("DTAlignmentErrorExtendedRcd"),
+                  tag = cms.string("DTAlignmentErrorExtendedRcd")),
+         cms.PSet(connect = cms.string("sqlite_file:"+options.inputFile),
+                  record = cms.string("CSCAlignmentRcd"),
+                  tag = cms.string("CSCAlignmentRcd")),
+         cms.PSet(connect = cms.string("sqlite_file:"+options.inputFile),
+                  record = cms.string("CSCAlignmentErrorExtendedRcd"),
+                  tag = cms.string("CSCAlignmentErrorExtendedRcd"))
+        ])
+elif options.input == "xml":
+    process.muonGeometryDBConverter.fileName = options.inputFile
+
+if options.output == "db":
+    from CondCore.CondDB.CondDB_cfi import CondDB
+    process.PoolDBOutputService = cms.Service(
+        "PoolDBOutputService",
+        CondDB,
+        toPut = cms.VPSet(
+            cms.PSet(record = cms.string("DTAlignmentRcd"),
+                     tag = cms.string("DTAlignmentRcd")),
+            cms.PSet(record = cms.string("DTAlignmentErrorExtendedRcd"),
+                     tag = cms.string("DTAlignmentErrorExtendedRcd")),
+            cms.PSet(record = cms.string("CSCAlignmentRcd"),
+                     tag = cms.string("CSCAlignmentRcd")),
+            cms.PSet(record = cms.string("CSCAlignmentErrorExtendedRcd"),
+                     tag = cms.string("CSCAlignmentErrorExtendedRcd")),
+        )
+    )
+    process.PoolDBOutputService.connect = "sqlite_file:"+options.outputFile
+elif options.output == "xml":
+    process.muonGeometryDBConverter.outputXML.fileName = options.outputFile
+    process.muonGeometryDBConverter.outputXML.suppressDTSuperLayers = True
+    process.muonGeometryDBConverter.outputXML.suppressDTLayers = True
+    process.muonGeometryDBConverter.outputXML.suppressCSCLayers = True
+
+
+################################################################################
+
+usedGlobalTag = process.GlobalTag.globaltag.value()
+print "Using Global Tag:", usedGlobalTag
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.source = cms.Source("EmptySource")
+process.p = cms.Path(process.muonGeometryDBConverter)

--- a/Alignment/MuonAlignment/test/test_MuonGeometryDBConverter.sh
+++ b/Alignment/MuonAlignment/test/test_MuonGeometryDBConverter.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+TEST_DIR="/tmp/MuonGeomtryDBConverter_$(date '+%G-%m-%d_%H.%M.%S.%N')_${RANDOM}"
+TEST_CFG="${CMSSW_BASE}/src/Alignment/MuonAlignment/test/muonGeometryDBConverter_cfg.py"
+
+clean_up() {
+    rm -rf ${TEST_DIR}
+}
+trap clean_up EXIT
+
+check_for_success() {
+    "${@}" && echo -e "\n ---> Passed test of '${@}'\n\n" || exit 1
+}
+
+
+rm -rf ${TEST_DIR}
+mkdir -p ${TEST_DIR}
+
+check_for_success cmsRun ${TEST_CFG} input=ideal output=db outputFile=${TEST_DIR}/ideal.db
+check_for_success cmsRun ${TEST_CFG} input=db output=xml inputFile=${TEST_DIR}/ideal.db outputFile=${TEST_DIR}/ideal.xml
+check_for_success cmsRun ${TEST_CFG} input=xml output=none inputFile=${TEST_DIR}/ideal.xml
+
+clean_up

--- a/Alignment/MuonAlignmentAlgorithms/python/align_cfg.py
+++ b/Alignment/MuonAlignmentAlgorithms/python/align_cfg.py
@@ -68,7 +68,7 @@ process.MuonNumberingRecord = cms.ESSource( "EmptyESSource",
     firstValid = cms.vuint32( 1 )
 )
 
-process.load("Configuration.StandardSequences.GeometryIdeal_cff")
+process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 process.load("Alignment.MuonAlignmentAlgorithms.MuonAlignmentFromReference_cff")

--- a/Alignment/MuonAlignmentAlgorithms/test/test_CSCOverlapsAlignmentAlgorithm_cfg.py
+++ b/Alignment/MuonAlignmentAlgorithms/test/test_CSCOverlapsAlignmentAlgorithm_cfg.py
@@ -13,7 +13,7 @@ process.MessageLogger = cms.Service("MessageLogger",
                                     cout = cms.untracked.PSet(threshold = cms.untracked.string("ERROR")))
 
 process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
-process.load("Configuration/StandardSequences/GeometryIdeal_cff")
+process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("TrackingTools.GeomPropagators.SmartPropagator_cff")
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")


### PR DESCRIPTION
backport of #18097

Fixes bugs in muon alignment code used for providing muon alignment constants.
Adds also a unit test to prevent such a silent introduction of bugs in the future.
Migrated the respective module to an edm::one module.

Attn.: @lpernie 
