### PR TITLE
[91X] Offline DQM modules for L1 Trigger, Stage 2 CaloLayer2 (Electrons + Photons)

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -17,39 +17,22 @@
 
 //Candidate handling
 #include "DataFormats/Candidate/interface/Candidate.h"
-#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
-// Electron
-#include "DataFormats/EgammaCandidates/interface/Electron.h"
+// Electron & photon collections
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
-
-// PFMET
-#include "DataFormats/METReco/interface/PFMET.h"
-#include "DataFormats/METReco/interface/PFMETCollection.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
 
 // Vertex utilities
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-// CaloJets
-#include "DataFormats/JetReco/interface/CaloJet.h"
-
-// Calo MET
-#include "DataFormats/METReco/interface/CaloMET.h"
-#include "DataFormats/METReco/interface/CaloMETCollection.h"
-
-// Conversions
-#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
 // Trigger
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerObject.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
-#include "FWCore/Common/interface/TriggerNames.h"
 
 // stage2 collections:
-#include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 
 class L1TEGammaOffline: public DQMEDAnalyzer {
@@ -69,10 +52,8 @@ protected:
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
 
 private:
-  bool passesSelection(edm::Handle<reco::GsfElectronCollection> const& electrons) const;
   bool passesLooseEleId(reco::GsfElectron const& electron) const;
   bool passesMediumEleId(reco::GsfElectron const& electron) const;
-  //histos booking function
   void bookElectronHistos(DQMStore::IBooker &);
   void bookPhotonHistos(DQMStore::IBooker &);
 
@@ -85,7 +66,6 @@ private:
   void fillPhotons(edm::Event const& e, const unsigned int nVertex);
   bool findTagAndProbePair(edm::Handle<reco::GsfElectronCollection> const& electrons);
 
-  //private variables
   math::XYZPoint PVPoint_;
 
   //variables from config file
@@ -108,10 +88,12 @@ private:
 
   reco::GsfElectron tagElectron_;
   reco::GsfElectron probeElectron_;
+  double tagAndProbleInvariantMass_;
 
   // TODO: add turn-on cuts (vectors of doubles)
   // Histograms
   MonitorElement* h_nVertex_;
+  MonitorElement* h_tagAndProbeMass_;
 
   // electron reco vs L1
   MonitorElement* h_L1EGammaETvsElectronET_EB_;

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -26,7 +26,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-
 // Trigger
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerObject.h"
@@ -83,8 +82,10 @@ private:
   edm::EDGetTokenT<l1t::EGammaBxCollection> stage2CaloLayer2EGammaToken_;
 
   std::vector<double> electronEfficiencyThresholds_;
-
   std::vector<double> electronEfficiencyBins_;
+
+  std::vector<double> photonEfficiencyThresholds_;
+  std::vector<double> photonEfficiencyBins_;
 
   reco::GsfElectron tagElectron_;
   reco::GsfElectron probeElectron_;
@@ -127,6 +128,39 @@ private:
   std::map<double, MonitorElement*> h_efficiencyElectronET_EB_total_;
   std::map<double, MonitorElement*> h_efficiencyElectronET_EE_total_;
   std::map<double, MonitorElement*> h_efficiencyElectronET_EB_EE_total_;
+
+  // photons
+  MonitorElement* h_L1EGammaETvsPhotonET_EB_;
+  MonitorElement* h_L1EGammaETvsPhotonET_EE_;
+  MonitorElement* h_L1EGammaETvsPhotonET_EB_EE_;
+
+  MonitorElement* h_L1EGammaPhivsPhotonPhi_EB_;
+  MonitorElement* h_L1EGammaPhivsPhotonPhi_EE_;
+  MonitorElement* h_L1EGammaPhivsPhotonPhi_EB_EE_;
+
+  MonitorElement* h_L1EGammaEtavsPhotonEta_;
+
+  // electron resolutions
+  MonitorElement* h_resolutionPhotonET_EB_;
+  MonitorElement* h_resolutionPhotonET_EE_;
+  MonitorElement* h_resolutionPhotonET_EB_EE_;
+
+  MonitorElement* h_resolutionPhotonPhi_EB_;
+  MonitorElement* h_resolutionPhotonPhi_EE_;
+  MonitorElement* h_resolutionPhotonPhi_EB_EE_;
+
+  MonitorElement* h_resolutionPhotonEta_;
+
+  // electron turn-ons
+  std::map<double, MonitorElement*> h_efficiencyPhotonET_EB_pass_;
+  std::map<double, MonitorElement*> h_efficiencyPhotonET_EE_pass_;
+  std::map<double, MonitorElement*> h_efficiencyPhotonET_EB_EE_pass_;
+
+  // we could drop the map here, but L1TEfficiency_Harvesting expects
+  // identical names except for the suffix
+  std::map<double, MonitorElement*> h_efficiencyPhotonET_EB_total_;
+  std::map<double, MonitorElement*> h_efficiencyPhotonET_EE_total_;
+  std::map<double, MonitorElement*> h_efficiencyPhotonET_EB_EE_total_;
 
 };
 

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -69,7 +69,9 @@ protected:
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
 
 private:
-  bool filter(edm::Event const& e, edm::EventSetup const& eSetup);
+  bool passesSelection(edm::Handle<reco::GsfElectronCollection> const& electrons) const;
+  bool passesLooseEleId(reco::GsfElectron const& electron) const;
+  bool passesMediumEleId(reco::GsfElectron const& electron) const;
   //histos booking function
   void bookElectronHistos(DQMStore::IBooker &);
   void bookPhotonHistos(DQMStore::IBooker &);
@@ -81,6 +83,7 @@ private:
 
   void fillElectrons(edm::Event const& e, const unsigned int nVertex);
   void fillPhotons(edm::Event const& e, const unsigned int nVertex);
+  bool findTagAndProbePair(edm::Handle<reco::GsfElectronCollection> const& electrons);
 
   //private variables
   math::XYZPoint PVPoint_;
@@ -102,6 +105,9 @@ private:
   std::vector<double> electronEfficiencyThresholds_;
 
   std::vector<double> electronEfficiencyBins_;
+
+  reco::GsfElectron tagElectron_;
+  reco::GsfElectron probeElectron_;
 
   // TODO: add turn-on cuts (vectors of doubles)
   // Histograms

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -1,0 +1,144 @@
+#ifndef L1TEGammaOffline_H
+#define L1TEGammaOffline_H
+
+//Framework
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+//event
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+//Candidate handling
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+// Electron
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+// PFMET
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+
+// Vertex utilities
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+// CaloJets
+#include "DataFormats/JetReco/interface/CaloJet.h"
+
+// Calo MET
+#include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/METReco/interface/CaloMETCollection.h"
+
+// Conversions
+#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+
+// Trigger
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+
+// stage2 collections:
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+
+class L1TEGammaOffline: public DQMEDAnalyzer {
+
+public:
+
+  L1TEGammaOffline(const edm::ParameterSet& ps);
+  virtual ~L1TEGammaOffline();
+
+protected:
+
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const& e, edm::EventSetup const& eSetup);
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
+  void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& eSetup);
+  void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
+
+private:
+  //histos booking function
+  void bookElectronHistos(DQMStore::IBooker &);
+  void bookPhotonHistos(DQMStore::IBooker &);
+
+  //other functions
+  double Distance(const reco::Candidate & c1, const reco::Candidate & c2);
+  double DistancePhi(const reco::Candidate & c1, const reco::Candidate & c2);
+  double calcDeltaPhi(double phi1, double phi2);
+
+  void fillElectrons(edm::Event const& e, const unsigned int nVertex);
+  void fillPhotons(edm::Event const& e, const unsigned int nVertex);
+
+  //private variables
+  math::XYZPoint PVPoint_;
+
+  //variables from config file
+  edm::EDGetTokenT<reco::GsfElectronCollection> theGsfElectronCollection_;
+  edm::EDGetTokenT<std::vector<reco::Photon> > thePhotonCollection_;
+  edm::EDGetTokenT<reco::VertexCollection> thePVCollection_;
+  edm::EDGetTokenT<reco::BeamSpot> theBSCollection_;
+  edm::EDGetTokenT<trigger::TriggerEvent> triggerEvent_;
+  edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
+  edm::InputTag triggerFilter_;
+  std::string triggerPath_;
+  std::string histFolder_;
+  std::string efficiencyFolder_;
+
+  edm::EDGetTokenT<l1t::EGammaBxCollection> stage2CaloLayer2EGammaToken_;
+
+  std::vector<double> electronEfficiencyThresholds_;
+
+  std::vector<double> electronEfficiencyBins_;
+
+  // TODO: add turn-on cuts (vectors of doubles)
+  // Histograms
+  MonitorElement* h_nVertex_;
+
+  // electron reco vs L1
+  MonitorElement* h_L1EGammaETvsElectronET_EB_;
+  MonitorElement* h_L1EGammaETvsElectronET_EE_;
+  MonitorElement* h_L1EGammaETvsElectronET_EB_EE_;
+
+  MonitorElement* h_L1EGammaPhivsElectronPhi_EB_;
+  MonitorElement* h_L1EGammaPhivsElectronPhi_EE_;
+  MonitorElement* h_L1EGammaPhivsElectronPhi_EB_EE_;
+
+  MonitorElement* h_L1EGammaEtavsElectronEta_;
+
+  // electron resolutions
+  MonitorElement* h_resolutionElectronET_EB_;
+  MonitorElement* h_resolutionElectronET_EE_;
+  MonitorElement* h_resolutionElectronET_EB_EE_;
+
+  MonitorElement* h_resolutionElectronPhi_EB_;
+  MonitorElement* h_resolutionElectronPhi_EE_;
+  MonitorElement* h_resolutionElectronPhi_EB_EE_;
+
+  MonitorElement* h_resolutionElectronEta_;
+
+  // electron turn-ons
+  std::map<double, MonitorElement*> h_efficiencyElectronET_EB_pass_;
+  std::map<double, MonitorElement*> h_efficiencyElectronET_EE_pass_;
+  std::map<double, MonitorElement*> h_efficiencyElectronET_EB_EE_pass_;
+
+  // we could drop the map here, but L1TEfficiency_Harvesting expects
+  // identical names except for the suffix
+  std::map<double, MonitorElement*> h_efficiencyElectronET_EB_total_;
+  std::map<double, MonitorElement*> h_efficiencyElectronET_EE_total_;
+  std::map<double, MonitorElement*> h_efficiencyElectronET_EB_EE_total_;
+
+};
+
+#endif

--- a/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TEGammaOffline.h
@@ -69,6 +69,7 @@ protected:
   void endRun(edm::Run const& run, edm::EventSetup const& eSetup);
 
 private:
+  bool filter(edm::Event const& e, edm::EventSetup const& eSetup);
   //histos booking function
   void bookElectronHistos(DQMStore::IBooker &);
   void bookPhotonHistos(DQMStore::IBooker &);

--- a/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
@@ -24,11 +24,19 @@ resolution_plots = [
     "resolutionElectronET_EB", "resolutionElectronET_EE",
     "resolutionElectronET_EB_EE", "resolutionElectronPhi_EB", "resolutionElectronPhi_EE",
     "resolutionElectronPhi_EB_EE", "resolutionElectronEta",
+    #
+    "resolutionPhotonET_EB", "resolutionPhotonET_EE",
+    "resolutionPhotonET_EB_EE", "resolutionPhotonPhi_EB", "resolutionPhotonPhi_EE",
+    "resolutionPhotonPhi_EB_EE", "resolutionPhotonEta",
 ]
 plots2D = [
     'L1EGammaETvsElectronET_EB', 'L1EGammaETvsElectronET_EE', 'L1EGammaETvsElectronET_EB_EE',
     'L1EGammaPhivsElectronPhi_EB', 'L1EGammaPhivsElectronPhi_EE', 'L1EGammaPhivsElectronPhi_EB_EE',
     'L1EGammaEtavsElectronEta',
+    #
+    'L1EGammaETvsPhotonET_EB', 'L1EGammaETvsPhotonET_EE', 'L1EGammaETvsPhotonET_EB_EE',
+    'L1EGammaPhivsPhotonPhi_EB', 'L1EGammaPhivsPhotonPhi_EE', 'L1EGammaPhivsPhotonPhi_EB_EE',
+    'L1EGammaEtavsPhotonEta',
 ]
 
 allPlots = []

--- a/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
@@ -21,14 +21,14 @@ for variable, thresholds in variables.iteritems():
             add_plot(plotName)
 
 resolution_plots = [
-    "resolutionElectronET_EB", "resolutionElectronET_EE", "resolutionElectronET_HF",
+    "resolutionElectronET_EB", "resolutionElectronET_EE",
     "resolutionElectronET_EB_EE", "resolutionElectronPhi_EB", "resolutionElectronPhi_EE",
-    "resolutionElectronPhi_HF", "resolutionElectronPhi_EB_EE", "resolutionElectronEta",
+    "resolutionElectronPhi_EB_EE", "resolutionElectronEta",
 ]
 plots2D = [
     'L1EGammaETvsElectronET_EB', 'L1EGammaETvsElectronET_EE', 'L1EGammaETvsElectronET_EB_EE',
     'L1EGammaPhivsElectronPhi_EB', 'L1EGammaPhivsElectronPhi_EE', 'L1EGammaPhivsElectronPhi_EB_EE',
-    'L1JetEtavsCaloJetEta_EB',
+    'L1EGammaEtavsElectronEta',
 ]
 
 allPlots = []

--- a/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaDiff_cfi.py
@@ -1,0 +1,50 @@
+import FWCore.ParameterSet.Config as cms
+from DQMOffline.L1Trigger import L1TEGammaOffline_cfi
+
+variables = {
+    'electron': L1TEGammaOffline_cfi.electronEfficiencyThresholds,
+}
+
+plots = {
+    'electron': [
+        "efficiencyElectronET_EB", "efficiencyElectronET_EE",
+        "efficiencyElectronET_EB_EE"
+    ],
+}
+
+allEfficiencyPlots = []
+add_plot = allEfficiencyPlots.append
+for variable, thresholds in variables.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+resolution_plots = [
+    "resolutionElectronET_EB", "resolutionElectronET_EE", "resolutionElectronET_HF",
+    "resolutionElectronET_EB_EE", "resolutionElectronPhi_EB", "resolutionElectronPhi_EE",
+    "resolutionElectronPhi_HF", "resolutionElectronPhi_EB_EE", "resolutionElectronEta",
+]
+plots2D = [
+    'L1EGammaETvsElectronET_EB', 'L1EGammaETvsElectronET_EE', 'L1EGammaETvsElectronET_EB_EE',
+    'L1EGammaPhivsElectronPhi_EB', 'L1EGammaPhivsElectronPhi_EE', 'L1EGammaPhivsElectronPhi_EB_EE',
+    'L1JetEtavsCaloJetEta_EB',
+]
+
+allPlots = []
+allPlots.extend(allEfficiencyPlots)
+allPlots.extend(resolution_plots)
+allPlots.extend(plots2D)
+
+from DQMOffline.L1Trigger.L1TDiffHarvesting_cfi import l1tDiffHarvesting
+l1tEGammaEmuDiff = l1tDiffHarvesting.clone(
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(  # EMU comparison
+            dir1=cms.untracked.string("L1T/L1TEGamma"),
+            dir2=cms.untracked.string("L1TEMU/L1TEGamma"),
+            outputDir=cms.untracked.string(
+                "L1TEMU/L1TEGamma/Comparison"),
+            plots=cms.untracked.vstring(allPlots)
+        ),
+    )
+)

--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+from DQMOffline.L1Trigger import L1TEGammaOffline_cfi
+
+variables = {
+    'electron': L1TEGammaOffline_cfi.electronEfficiencyThresholds,
+}
+
+plots = {
+    'electron': [
+        "efficiencyElectronET_EB", "efficiencyElectronET_EE",
+        "efficiencyElectronET_EB_EE"
+    ],
+}
+
+allEfficiencyPlots = []
+add_plot = allEfficiencyPlots.append
+for variable, thresholds in variables.iteritems():
+    for plot in plots[variable]:
+        for threshold in thresholds:
+            plotName = '{0}_threshold_{1}'.format(plot, threshold)
+            add_plot(plotName)
+
+from DQMOffline.L1Trigger.L1TEfficiencyHarvesting2_cfi import l1tEfficiencyHarvesting
+l1tEGammaEfficiency = l1tEfficiencyHarvesting.clone(
+    plotCfgs=cms.untracked.VPSet(
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1T/L1TEGamma/efficiency_raw"),
+            outputDir=cms.untracked.string("L1T/L1TEGamma"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots)
+        ),
+        cms.untracked.PSet(
+            numeratorDir=cms.untracked.string("L1TEMU/L1TEGamma/efficiency_raw"),
+            outputDir=cms.untracked.string("L1TEMU/L1TEGamma"),
+            numeratorSuffix=cms.untracked.string("_Num"),
+            denominatorSuffix=cms.untracked.string("_Den"),
+            plots=cms.untracked.vstring(allEfficiencyPlots)
+        ),
+    )
+)

--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -3,6 +3,7 @@ from DQMOffline.L1Trigger import L1TEGammaOffline_cfi
 
 variables = {
     'electron': L1TEGammaOffline_cfi.electronEfficiencyThresholds,
+    'photon': L1TEGammaOffline_cfi.photonEfficiencyThresholds,
 }
 
 plots = {
@@ -10,6 +11,10 @@ plots = {
         "efficiencyElectronET_EB", "efficiencyElectronET_EE",
         "efficiencyElectronET_EB_EE"
     ],
+    'photon': [
+        "efficiencyPhotonET_EB", "efficiencyPhotonET_EE",
+        "efficiencyPhotonET_EB_EE"
+    ]
 }
 
 allEfficiencyPlots = []
@@ -31,7 +36,8 @@ l1tEGammaEfficiency = l1tEfficiencyHarvesting.clone(
             plots=cms.untracked.vstring(allEfficiencyPlots)
         ),
         cms.untracked.PSet(
-            numeratorDir=cms.untracked.string("L1TEMU/L1TEGamma/efficiency_raw"),
+            numeratorDir=cms.untracked.string(
+                "L1TEMU/L1TEGamma/efficiency_raw"),
             outputDir=cms.untracked.string("L1TEMU/L1TEGamma"),
             numeratorSuffix=cms.untracked.string("_Num"),
             denominatorSuffix=cms.untracked.string("_Den"),

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -8,6 +8,10 @@ electronEfficiencyBins.extend(list(xrange(120, 180, 20)))
 electronEfficiencyBins.extend(list(xrange(180, 300, 40)))
 electronEfficiencyBins.extend(list(xrange(300, 400, 100)))
 
+# just copy for now
+photonEfficiencyThresholds = electronEfficiencyThresholds
+photonEfficiencyBins = electronEfficiencyBins
+
 l1tEGammaOfflineDQM = cms.EDAnalyzer(
     "L1TEGammaOffline",
     electronCollection=cms.InputTag("gedGsfElectrons"),
@@ -28,9 +32,12 @@ l1tEGammaOfflineDQM = cms.EDAnalyzer(
     stage2CaloLayer2EGammaSource=cms.InputTag("caloStage2Digis", "EGamma"),
 
     histFolder=cms.string('L1T/L1TEGamma'),
-    electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds),
 
+    electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds),
     electronEfficiencyBins=cms.vdouble(electronEfficiencyBins),
+    
+    photonEfficiencyThresholds=cms.vdouble(photonEfficiencyThresholds),
+    photonEfficiencyBins=cms.vdouble(photonEfficiencyBins),
 )
 
 l1tEGammaOfflineDQMEmu = l1tEGammaOfflineDQM.clone(

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+electronEfficiencyThresholds = [36, 68, 128, 176]
+
+electronEfficiencyBins = []
+electronEfficiencyBins.extend(list(xrange(0, 120, 10)))
+electronEfficiencyBins.extend(list(xrange(120, 180, 20)))
+electronEfficiencyBins.extend(list(xrange(180, 300, 40)))
+electronEfficiencyBins.extend(list(xrange(300, 400, 100)))
+
+l1tEGammaOfflineDQM = cms.EDAnalyzer(
+    "L1TEGammaOffline",
+    electronCollection=cms.InputTag("gedGsfElectrons"),
+    photonCollection=cms.InputTag("photons"),
+    caloJetCollection=cms.InputTag("ak4CaloJets"),
+    caloMETCollection=cms.InputTag("caloMet"),
+    conversionsCollection=cms.InputTag("allConversions"),
+    PVCollection=cms.InputTag("offlinePrimaryVerticesWithBS"),
+    beamSpotCollection=cms.InputTag("offlineBeamSpot"),
+
+    TriggerEvent=cms.InputTag('hltTriggerSummaryAOD', '', 'HLT'),
+    TriggerResults=cms.InputTag('TriggerResults', '', 'HLT'),
+    # last filter of HLTEle27WP80Sequence
+    TriggerFilter=cms.InputTag('hltEle27WP80TrackIsoFilter', '', 'HLT'),
+    TriggerPath=cms.string('HLT_Ele27_WP80_v13'),
+
+
+    stage2CaloLayer2EGammaSource=cms.InputTag("caloStage2Digis", "EGamma"),
+
+    histFolder=cms.string('L1T/L1TEGamma'),
+    electronEfficiencyThresholds=cms.vdouble(electronEfficiencyThresholds),
+
+    electronEfficiencyBins=cms.vdouble(electronEfficiencyBins),
+)
+
+l1tEGammaOfflineDQMEmu = l1tEGammaOfflineDQM.clone(
+    stage2CaloLayer2EGammaSource=cms.InputTag("simCaloStage2Digis"),
+
+    histFolder=cms.string('L1TEMU/L1TEGamma'),
+)

--- a/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TStage2CaloLayer2Diff_cfi.py
@@ -41,8 +41,8 @@ plots2D = [
     'L1METPhivsCaloMETPhi', 'L1MHTPhivsRecoMHTPhi',
     # jets
     'L1JetETvsCaloJetET_HB', 'L1JetETvsCaloJetET_HE', 'L1JetETvsCaloJetET_HF',
-    'L1JetETvsCaloJetET_HB_HE', 'L1JetETvsCaloJetET_HB', 'L1JetETvsCaloJetET_HE',
-    'L1JetETvsCaloJetET_HF', 'L1JetETvsCaloJetET_HB_HE', 'L1JetEtavsCaloJetEta_HB',
+    'L1JetETvsCaloJetET_HB_HE', 'L1JetPhivsCaloJetPhi_HB', 'L1JetPhivsCaloJetPhi_HE',
+    'L1JetPhivsCaloJetPhi_HF', 'L1JetPhivsCaloJetPhi_HB_HE', 'L1JetEtavsCaloJetEta_HB',
 ]
 
 allPlots = []

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_SecondStep_cff.py
@@ -3,9 +3,13 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.L1Trigger.L1TStage2CaloLayer2Efficiency_cfi import *
 from DQMOffline.L1Trigger.L1TStage2CaloLayer2Diff_cfi import *
 
+from DQMOffline.L1Trigger.L1TEGammaEfficiency_cfi import *
+from DQMOffline.L1Trigger.L1TEGammaDiff_cfi import *
+
 # l1tStage2CaloLayer2EmuDiff uses plots produced by
 # l1tStage2CaloLayer2Efficiency
 DQMHarvestL1Trigger = cms.Sequence(
-    l1tStage2CaloLayer2Efficiency * l1tStage2CaloLayer2EmuDiff
+    l1tStage2CaloLayer2Efficiency * l1tStage2CaloLayer2EmuDiff *
+    l1tEGammaEfficiency * l1tEGammaEmuDiff 
 )
 

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -46,6 +46,7 @@ from DQMOffline.L1Trigger.L1TRate_Offline_cfi import *
 from DQMOffline.L1Trigger.L1TSync_Offline_cfi import *
 from DQMOffline.L1Trigger.L1TEmulatorMonitorOffline_cff import *
 from DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi import *
+from DQMOffline.L1Trigger.L1TEGammaOffline_cfi import *
 l1TdeRCT.rctSourceData = 'gctDigis'
 
 # DQM Offline Step 2 cfi/cff imports
@@ -139,7 +140,8 @@ l1TriggerOnline = cms.Sequence(
 l1TriggerOffline = cms.Sequence(
     l1TriggerOnline *
     dqmEnvL1TriggerReco *
-    l1tStage2CaloLayer2OfflineDQM
+    l1tStage2CaloLayer2OfflineDQM *
+    l1tEGammaOfflineDQM
 )
 
 #
@@ -151,7 +153,8 @@ l1TriggerEmulatorOnline = cms.Sequence(
 
 l1TriggerEmulatorOffline = cms.Sequence(
     l1TriggerEmulatorOnline *
-    l1tStage2CaloLayer2OfflineDQMEmu
+    l1tStage2CaloLayer2OfflineDQMEmu *
+    l1tEGammaOfflineDQMEmu
 )
 #
 

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -56,6 +56,11 @@ void L1TEGammaOffline::dqmBeginRun(edm::Run const &, edm::EventSetup const &)
 {
   edm::LogInfo("L1TEGammaOffline") << "L1TEGammaOffline::beginRun" << std::endl;
 }
+
+bool L1TEGammaOffline::filter(edm::Event const& e, edm::EventSetup const& eSetup){
+  return true;
+}
+
 //
 // -------------------------------------- bookHistos --------------------------------------------
 //
@@ -265,23 +270,23 @@ void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
   ibooker.setCurrentFolder(histFolder_.c_str());
   h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
   // electron reco vs L1
-  h_L1EGammaETvsElectronET_EB_ = ibooker.book2D("L1EGammaETvsElectronET_HB",
+  h_L1EGammaETvsElectronET_EB_ = ibooker.book2D("L1EGammaETvsElectronET_EB",
       "L1 EGamma E_{T} vs GSF Electron E_{T} (HB); GSF Electron E_{T} (GeV); L1 EGamma E_{T} (GeV)", 300, 0, 300, 300,
       0, 300);
-  h_L1EGammaETvsElectronET_EE_ = ibooker.book2D("L1EGammaETvsElectronET_HE",
+  h_L1EGammaETvsElectronET_EE_ = ibooker.book2D("L1EGammaETvsElectronET_EE",
       "L1 EGamma E_{T} vs GSF Electron E_{T} (HE); GSF Electron E_{T} (GeV); L1 EGamma E_{T} (GeV)", 300, 0, 300, 300,
       0, 300);
-  h_L1EGammaETvsElectronET_EB_EE_ = ibooker.book2D("L1EGammaETvsElectronET_EB_HE",
+  h_L1EGammaETvsElectronET_EB_EE_ = ibooker.book2D("L1EGammaETvsElectronET_EB_EE",
       "L1 EGamma E_{T} vs GSF Electron E_{T} (HB+HE); GSF Electron E_{T} (GeV); L1 EGamma E_{T} (GeV)", 300, 0, 300,
       300, 0, 300);
 
-  h_L1EGammaPhivsElectronPhi_EB_ = ibooker.book2D("L1EGammaPhivsElectronET_HB",
+  h_L1EGammaPhivsElectronPhi_EB_ = ibooker.book2D("L1EGammaPhivsElectronPhi_EB",
       "#phi_{electron}^{L1} vs #phi_{electron}^{offline} (HB); #phi_{electron}^{offline}; #phi_{electron}^{L1}", 100,
       -4, 4, 100, -4, 4);
-  h_L1EGammaPhivsElectronPhi_EE_ = ibooker.book2D("L1EGammaPhivsElectronET_HE",
+  h_L1EGammaPhivsElectronPhi_EE_ = ibooker.book2D("L1EGammaPhivsElectronPhi_EE",
       "#phi_{electron}^{L1} vs #phi_{electron}^{offline} (HE); #phi_{electron}^{offline}; #phi_{electron}^{L1}", 100,
       -4, 4, 100, -4, 4);
-  h_L1EGammaPhivsElectronPhi_EB_EE_ = ibooker.book2D("L1EGammaPhivsElectronET_EB_HE",
+  h_L1EGammaPhivsElectronPhi_EB_EE_ = ibooker.book2D("L1EGammaPhivsElectronPhi_EB_EE",
       "#phi_{electron}^{L1} vs #phi_{electron}^{offline} (HB+HE); #phi_{electron}^{offline}; #phi_{electron}^{L1}", 100,
       -4, 4, 100, -4, 4);
 
@@ -289,23 +294,23 @@ void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
       "L1 EGamma #eta vs GSF Electron #eta; GSF Electron #eta; L1 EGamma #eta", 100, -10, 10, 100, -10, 10);
 
   // electron resolutions
-  h_resolutionElectronET_EB_ = ibooker.book1D("resolutionElectronET_HB",
+  h_resolutionElectronET_EB_ = ibooker.book1D("resolutionElectronET_EB",
       "electron ET resolution (HB); (L1 EGamma E_{T} - GSF Electron E_{T})/GSF Electron E_{T}; events", 50, -1, 1.5);
-  h_resolutionElectronET_EE_ = ibooker.book1D("resolutionElectronET_HE",
+  h_resolutionElectronET_EE_ = ibooker.book1D("resolutionElectronET_EE",
       "electron ET resolution (HE); (L1 EGamma E_{T} - GSF Electron E_{T})/GSF Electron E_{T}; events", 50, -1, 1.5);
-  h_resolutionElectronET_EB_EE_ = ibooker.book1D("resolutionElectronET_EB_HE",
+  h_resolutionElectronET_EB_EE_ = ibooker.book1D("resolutionElectronET_EB_EE",
       "electron ET resolution (HB+HE); (L1 EGamma E_{T} - GSF Electron E_{T})/GSF Electron E_{T}; events", 50, -1, 1.5);
 
   h_resolutionElectronPhi_EB_ =
-      ibooker.book1D("resolutionElectronPhi_HB",
+      ibooker.book1D("resolutionElectronPhi_EB",
           "#phi_{electron} resolution (HB); (#phi_{electron}^{L1} - #phi_{electron}^{offline})/#phi_{electron}^{offline}; events",
           120, -0.3, 0.3);
   h_resolutionElectronPhi_EE_ =
-      ibooker.book1D("resolutionElectronPhi_HE",
+      ibooker.book1D("resolutionElectronPhi_EE",
           "electron #phi resolution (HE); (#phi_{electron}^{L1} - #phi_{electron}^{offline})/#phi_{electron}^{offline}; events",
           120, -0.3, 0.3);
   h_resolutionElectronPhi_EB_EE_ =
-      ibooker.book1D("resolutionElectronPhi_EB_HE",
+      ibooker.book1D("resolutionElectronPhi_EB_EE",
           "electron #phi resolution (HB+HE); (#phi_{electron}^{L1} - #phi_{electron}^{offline})/#phi_{electron}^{offline}; events",
           120, -0.3, 0.3);
 

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -1,0 +1,355 @@
+#include "DQMOffline/L1Trigger/interface/L1TEGammaOffline.h"
+#include "DQMOffline/L1Trigger/interface/L1TFillWithinLimits.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+// Geometry
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "TLorentzVector.h"
+
+#include <iostream>
+#include <iomanip>
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <math.h>
+#include <algorithm>
+
+//
+// -------------------------------------- Constructor --------------------------------------------
+//
+L1TEGammaOffline::L1TEGammaOffline(const edm::ParameterSet& ps) :
+        theGsfElectronCollection_(
+            consumes < reco::GsfElectronCollection > (ps.getParameter < edm::InputTag > ("electronCollection"))),
+        thePhotonCollection_(
+            consumes < std::vector<reco::Photon> > (ps.getParameter < edm::InputTag > ("photonCollection"))),
+        thePVCollection_(consumes < reco::VertexCollection > (ps.getParameter < edm::InputTag > ("PVCollection"))),
+        theBSCollection_(consumes < reco::BeamSpot > (ps.getParameter < edm::InputTag > ("beamSpotCollection"))),
+        triggerEvent_(consumes < trigger::TriggerEvent > (ps.getParameter < edm::InputTag > ("TriggerEvent"))),
+        triggerResults_(consumes < edm::TriggerResults > (ps.getParameter < edm::InputTag > ("TriggerResults"))),
+        triggerFilter_(ps.getParameter < edm::InputTag > ("TriggerFilter")),
+        triggerPath_(ps.getParameter < std::string > ("TriggerPath")),
+        histFolder_(ps.getParameter < std::string > ("histFolder")),
+        efficiencyFolder_(histFolder_ + "/efficiency_raw"),
+        stage2CaloLayer2EGammaToken_(
+            consumes < l1t::EGammaBxCollection > (ps.getParameter < edm::InputTag > ("stage2CaloLayer2EGammaSource"))),
+        electronEfficiencyThresholds_(ps.getParameter < std::vector<double> > ("electronEfficiencyThresholds")),
+        electronEfficiencyBins_(ps.getParameter < std::vector<double> > ("electronEfficiencyBins"))
+{
+  edm::LogInfo("L1TEGammaOffline") << "Constructor " << "L1TEGammaOffline::L1TEGammaOffline " << std::endl;
+}
+
+//
+// -- Destructor
+//
+L1TEGammaOffline::~L1TEGammaOffline()
+{
+  edm::LogInfo("L1TEGammaOffline") << "Destructor L1TEGammaOffline::~L1TEGammaOffline " << std::endl;
+}
+
+//
+// -------------------------------------- beginRun --------------------------------------------
+//
+void L1TEGammaOffline::dqmBeginRun(edm::Run const &, edm::EventSetup const &)
+{
+  edm::LogInfo("L1TEGammaOffline") << "L1TEGammaOffline::beginRun" << std::endl;
+}
+//
+// -------------------------------------- bookHistos --------------------------------------------
+//
+void L1TEGammaOffline::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const &, edm::EventSetup const &)
+{
+  edm::LogInfo("L1TEGammaOffline") << "L1TEGammaOffline::bookHistograms" << std::endl;
+
+  //book at beginRun
+  bookElectronHistos(ibooker);
+  bookPhotonHistos(ibooker);
+}
+//
+// -------------------------------------- beginLuminosityBlock --------------------------------------------
+//
+void L1TEGammaOffline::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& context)
+{
+  edm::LogInfo("L1TEGammaOffline") << "L1TEGammaOffline::beginLuminosityBlock" << std::endl;
+}
+
+//
+// -------------------------------------- Analyze --------------------------------------------
+//
+void L1TEGammaOffline::analyze(edm::Event const& e, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("L1TEGammaOffline") << "L1TEGammaOffline::analyze" << std::endl;
+
+  edm::Handle<reco::VertexCollection> vertexHandle;
+  e.getByToken(thePVCollection_, vertexHandle);
+  if (!vertexHandle.isValid()) {
+    edm::LogError("L1TEGammaOffline") << "invalid collection: vertex " << std::endl;
+    return;
+  }
+
+  unsigned int nVertex = vertexHandle->size();
+  dqmoffline::l1t::fillWithinLimits(h_nVertex_, nVertex);
+
+  // L1T
+  fillElectrons(e, nVertex);
+//      fillPhotons(e, nVertex);
+}
+
+void L1TEGammaOffline::fillElectrons(edm::Event const& e, const unsigned int nVertex)
+{
+  edm::Handle<l1t::EGammaBxCollection> l1EGamma;
+  e.getByToken(stage2CaloLayer2EGammaToken_, l1EGamma);
+
+  edm::Handle<reco::GsfElectronCollection> gsfElectrons;
+  e.getByToken(theGsfElectronCollection_, gsfElectrons);
+
+  if (!gsfElectrons.isValid()) {
+    edm::LogError("L1TEGammaOffline") << "invalid collection: GSF electrons " << std::endl;
+    return;
+  }
+  if (gsfElectrons->size() == 0) {
+    edm::LogError("L1TEGammaOffline") << "empty collection: GSF electrons " << std::endl;
+    return;
+  }
+  if (!l1EGamma.isValid()) {
+    edm::LogError("L1TEGammaOffline") << "invalid collection: L1 EGamma " << std::endl;
+    return;
+  }
+
+  auto leadingGsfElectron = gsfElectrons->front();
+
+  // find corresponding L1 EG
+  double minDeltaR = 0.3;
+  l1t::EGamma closestL1EGamma;
+  bool foundMatch = false;
+
+  int bunchCrossing = 0;
+  for (auto egamma = l1EGamma->begin(bunchCrossing); egamma != l1EGamma->end(bunchCrossing); ++egamma) {
+    double currentDeltaR = deltaR(egamma->eta(), egamma->phi(), leadingGsfElectron.eta(), leadingGsfElectron.phi());
+    if (currentDeltaR > minDeltaR) {
+      continue;
+    } else {
+      minDeltaR = currentDeltaR;
+      closestL1EGamma = *egamma;
+      foundMatch = true;
+    }
+
+  }
+//  }
+
+  if (!foundMatch) {
+    edm::LogError("L1TEGammaOffline") << "Could not find a matching L1 EGamma " << std::endl;
+    return;
+  }
+
+  double recoEt = leadingGsfElectron.et();
+  double recoEta = leadingGsfElectron.eta();
+  double recoPhi = leadingGsfElectron.phi();
+
+  double l1Et = closestL1EGamma.et();
+  double l1Eta = closestL1EGamma.eta();
+  double l1Phi = closestL1EGamma.phi();
+
+  // if no reco value, relative resolution does not make sense -> sort to overflow
+  double outOfBounds = 9999;
+  double resolutionEt = recoEt > 0 ? (l1Et - recoEt) / recoEt : outOfBounds;
+  double resolutionEta = abs(recoEta) > 0 ? (l1Eta - recoEta) / recoEta : outOfBounds;
+  double resolutionPhi = abs(recoPhi) > 0 ? (l1Phi - recoPhi) / recoPhi : outOfBounds;
+
+  using namespace dqmoffline::l1t;
+  // eta
+  fill2DWithinLimits(h_L1EGammaEtavsElectronEta_, recoEta, l1Eta);
+  fillWithinLimits(h_resolutionElectronEta_, resolutionEta);
+
+  if (abs(recoEta) <= 1.479) { // barrel
+    // et
+    fill2DWithinLimits(h_L1EGammaETvsElectronET_EB_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1EGammaETvsElectronET_EB_EE_, recoEt, l1Et);
+    //resolution
+    fillWithinLimits(h_resolutionElectronET_EB_, resolutionEt);
+    fillWithinLimits(h_resolutionElectronET_EB_EE_, resolutionEt);
+    // phi
+    fill2DWithinLimits(h_L1EGammaPhivsElectronPhi_EB_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1EGammaPhivsElectronPhi_EB_EE_, recoPhi, l1Phi);
+    // resolution
+    fillWithinLimits(h_resolutionElectronPhi_EB_, resolutionPhi);
+    fillWithinLimits(h_resolutionElectronPhi_EB_EE_, resolutionPhi);
+
+    // turn-ons
+
+    for (auto threshold : electronEfficiencyThresholds_) {
+      fillWithinLimits(h_efficiencyElectronET_EB_total_[threshold], recoEt);
+      fillWithinLimits(h_efficiencyElectronET_EB_EE_total_[threshold], recoEt);
+      if (l1Et > threshold) {
+        fillWithinLimits(h_efficiencyElectronET_EB_pass_[threshold], recoEt);
+        fillWithinLimits(h_efficiencyElectronET_EB_EE_pass_[threshold], recoEt);
+      }
+    }
+
+  } else { // end-cap
+    // et
+    fill2DWithinLimits(h_L1EGammaETvsElectronET_EE_, recoEt, l1Et);
+    fill2DWithinLimits(h_L1EGammaETvsElectronET_EB_EE_, recoEt, l1Et);
+    //resolution
+    fillWithinLimits(h_resolutionElectronET_EE_, resolutionEt);
+    fillWithinLimits(h_resolutionElectronET_EB_EE_, resolutionEt);
+    // phi
+    fill2DWithinLimits(h_L1EGammaPhivsElectronPhi_EE_, recoPhi, l1Phi);
+    fill2DWithinLimits(h_L1EGammaPhivsElectronPhi_EB_EE_, recoPhi, l1Phi);
+    // resolution
+    fillWithinLimits(h_resolutionElectronPhi_EE_, resolutionPhi);
+    fillWithinLimits(h_resolutionElectronPhi_EB_EE_, resolutionPhi);
+
+    // turn-ons
+    for (auto threshold : electronEfficiencyThresholds_) {
+      fillWithinLimits(h_efficiencyElectronET_EE_total_[threshold], recoEt);
+      fillWithinLimits(h_efficiencyElectronET_EB_EE_total_[threshold], recoEt);
+      if (l1Et > threshold) {
+        fillWithinLimits(h_efficiencyElectronET_EE_pass_[threshold], recoEt);
+        fillWithinLimits(h_efficiencyElectronET_EB_EE_pass_[threshold], recoEt);
+      }
+    }
+  }
+}
+
+void L1TEGammaOffline::fillPhotons(edm::Event const& e, const unsigned int nVertex)
+{
+  edm::Handle<l1t::EGammaBxCollection> l1EGamma;
+  e.getByToken(stage2CaloLayer2EGammaToken_, l1EGamma);
+
+  edm::Handle<reco::Photon> photons;
+  e.getByToken(thePhotonCollection_, photons);
+
+  if (!photons.isValid()) {
+    edm::LogError("L1TEGammaOffline") << "invalid collection: reco::Photons " << std::endl;
+    return;
+  }
+  if (!l1EGamma.isValid()) {
+    edm::LogError("L1TEGammaOffline") << "invalid collection: L1 EGamma " << std::endl;
+    return;
+  }
+
+  int bunchCrossing = 0;
+
+  for (auto egamma = l1EGamma->begin(bunchCrossing); egamma != l1EGamma->end(bunchCrossing); ++egamma) {
+//    double et = egamma->et();
+//    double phi = egamma->phi();
+//    double eta = egamma->eta();
+  }
+}
+
+//
+// -------------------------------------- endLuminosityBlock --------------------------------------------
+//
+void L1TEGammaOffline::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("L1TEGammaOffline") << "L1TEGammaOffline::endLuminosityBlock" << std::endl;
+}
+
+//
+// -------------------------------------- endRun --------------------------------------------
+//
+void L1TEGammaOffline::endRun(edm::Run const& run, edm::EventSetup const& eSetup)
+{
+  edm::LogInfo("L1TEGammaOffline") << "L1TEGammaOffline::endRun" << std::endl;
+}
+
+//
+// -------------------------------------- book histograms --------------------------------------------
+//
+void L1TEGammaOffline::bookElectronHistos(DQMStore::IBooker & ibooker)
+{
+  ibooker.cd();
+  ibooker.setCurrentFolder(histFolder_.c_str());
+  h_nVertex_ = ibooker.book1D("nVertex", "Number of event vertices in collection", 40, -0.5, 39.5);
+  // electron reco vs L1
+  h_L1EGammaETvsElectronET_EB_ = ibooker.book2D("L1EGammaETvsElectronET_HB",
+      "L1 EGamma E_{T} vs GSF Electron E_{T} (HB); GSF Electron E_{T} (GeV); L1 EGamma E_{T} (GeV)", 300, 0, 300, 300,
+      0, 300);
+  h_L1EGammaETvsElectronET_EE_ = ibooker.book2D("L1EGammaETvsElectronET_HE",
+      "L1 EGamma E_{T} vs GSF Electron E_{T} (HE); GSF Electron E_{T} (GeV); L1 EGamma E_{T} (GeV)", 300, 0, 300, 300,
+      0, 300);
+  h_L1EGammaETvsElectronET_EB_EE_ = ibooker.book2D("L1EGammaETvsElectronET_EB_HE",
+      "L1 EGamma E_{T} vs GSF Electron E_{T} (HB+HE); GSF Electron E_{T} (GeV); L1 EGamma E_{T} (GeV)", 300, 0, 300,
+      300, 0, 300);
+
+  h_L1EGammaPhivsElectronPhi_EB_ = ibooker.book2D("L1EGammaPhivsElectronET_HB",
+      "#phi_{electron}^{L1} vs #phi_{electron}^{offline} (HB); #phi_{electron}^{offline}; #phi_{electron}^{L1}", 100,
+      -4, 4, 100, -4, 4);
+  h_L1EGammaPhivsElectronPhi_EE_ = ibooker.book2D("L1EGammaPhivsElectronET_HE",
+      "#phi_{electron}^{L1} vs #phi_{electron}^{offline} (HE); #phi_{electron}^{offline}; #phi_{electron}^{L1}", 100,
+      -4, 4, 100, -4, 4);
+  h_L1EGammaPhivsElectronPhi_EB_EE_ = ibooker.book2D("L1EGammaPhivsElectronET_EB_HE",
+      "#phi_{electron}^{L1} vs #phi_{electron}^{offline} (HB+HE); #phi_{electron}^{offline}; #phi_{electron}^{L1}", 100,
+      -4, 4, 100, -4, 4);
+
+  h_L1EGammaEtavsElectronEta_ = ibooker.book2D("L1EGammaEtavsElectronEta",
+      "L1 EGamma #eta vs GSF Electron #eta; GSF Electron #eta; L1 EGamma #eta", 100, -10, 10, 100, -10, 10);
+
+  // electron resolutions
+  h_resolutionElectronET_EB_ = ibooker.book1D("resolutionElectronET_HB",
+      "electron ET resolution (HB); (L1 EGamma E_{T} - GSF Electron E_{T})/GSF Electron E_{T}; events", 50, -1, 1.5);
+  h_resolutionElectronET_EE_ = ibooker.book1D("resolutionElectronET_HE",
+      "electron ET resolution (HE); (L1 EGamma E_{T} - GSF Electron E_{T})/GSF Electron E_{T}; events", 50, -1, 1.5);
+  h_resolutionElectronET_EB_EE_ = ibooker.book1D("resolutionElectronET_EB_HE",
+      "electron ET resolution (HB+HE); (L1 EGamma E_{T} - GSF Electron E_{T})/GSF Electron E_{T}; events", 50, -1, 1.5);
+
+  h_resolutionElectronPhi_EB_ =
+      ibooker.book1D("resolutionElectronPhi_HB",
+          "#phi_{electron} resolution (HB); (#phi_{electron}^{L1} - #phi_{electron}^{offline})/#phi_{electron}^{offline}; events",
+          120, -0.3, 0.3);
+  h_resolutionElectronPhi_EE_ =
+      ibooker.book1D("resolutionElectronPhi_HE",
+          "electron #phi resolution (HE); (#phi_{electron}^{L1} - #phi_{electron}^{offline})/#phi_{electron}^{offline}; events",
+          120, -0.3, 0.3);
+  h_resolutionElectronPhi_EB_EE_ =
+      ibooker.book1D("resolutionElectronPhi_EB_HE",
+          "electron #phi resolution (HB+HE); (#phi_{electron}^{L1} - #phi_{electron}^{offline})/#phi_{electron}^{offline}; events",
+          120, -0.3, 0.3);
+
+  h_resolutionElectronEta_ = ibooker.book1D("resolutionElectronEta",
+      "electron #eta resolution  (HB); (L1 EGamma #eta - GSF Electron #eta)/GSF Electron #eta; events", 120, -0.3, 0.3);
+
+  // electron turn-ons
+  ibooker.setCurrentFolder(efficiencyFolder_.c_str());
+  std::vector<float> electronBins(electronEfficiencyBins_.begin(), electronEfficiencyBins_.end());
+  int nBins = electronBins.size() - 1;
+  float* electronBinArray = &(electronBins[0]);
+
+  for (auto threshold : electronEfficiencyThresholds_) {
+    std::string str_threshold = std::to_string(int(threshold));
+    h_efficiencyElectronET_EB_pass_[threshold] = ibooker.book1D(
+        "efficiencyElectronET_EB_threshold_" + str_threshold + "_Num",
+        "electron efficiency (HB); GSF Electron E_{T} (GeV); events", nBins, electronBinArray);
+    h_efficiencyElectronET_EE_pass_[threshold] = ibooker.book1D(
+        "efficiencyElectronET_EE_threshold_" + str_threshold + "_Num",
+        "electron efficiency (HE); GSF Electron E_{T} (GeV); events", nBins, electronBinArray);
+    h_efficiencyElectronET_EB_EE_pass_[threshold] = ibooker.book1D(
+        "efficiencyElectronET_EB_EE_threshold_" + str_threshold + "_Num",
+        "electron efficiency (HB+HE); GSF Electron E_{T} (GeV); events", nBins, electronBinArray);
+
+    h_efficiencyElectronET_EB_total_[threshold] = ibooker.book1D(
+        "efficiencyElectronET_EB_threshold_" + str_threshold + "_Den",
+        "electron efficiency (HB); GSF Electron E_{T} (GeV); events", nBins, electronBinArray);
+    h_efficiencyElectronET_EE_total_[threshold] = ibooker.book1D(
+        "efficiencyElectronET_EE_threshold_" + str_threshold + "_Den",
+        "electron efficiency (HE); GSF Electron E_{T} (GeV); events", nBins, electronBinArray);
+    h_efficiencyElectronET_EB_EE_total_[threshold] = ibooker.book1D(
+        "efficiencyElectronET_EB_EE_threshold_" + str_threshold + "_Den",
+        "electron efficiency (HB+HE); GSF Electron E_{T} (GeV); events", nBins, electronBinArray);
+  }
+
+  ibooker.cd();
+}
+
+void L1TEGammaOffline::bookPhotonHistos(DQMStore::IBooker & ibooker)
+{
+  ibooker.cd();
+  ibooker.setCurrentFolder(histFolder_.c_str());
+  ibooker.cd();
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE (L1TEGammaOffline);

--- a/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TEGammaOffline.cc
@@ -124,7 +124,8 @@ void L1TEGammaOffline::fillElectrons(edm::Event const& e, const unsigned int nVe
     ;
   return; //continue to next event
 
-  auto probeElectron = gsfElectrons->at(1);
+  // for now without tag&probe
+  auto probeElectron = gsfElectrons->at(0);
 
   // find corresponding L1 EG
   double minDeltaR = 0.3;
@@ -384,9 +385,7 @@ void L1TEGammaOffline::fillPhotons(edm::Event const& e, const unsigned int nVert
   int bunchCrossing = 0;
 
   for (auto egamma = l1EGamma->begin(bunchCrossing); egamma != l1EGamma->end(bunchCrossing); ++egamma) {
-//    double et = egamma->et();
-//    double phi = egamma->phi();
-//    double eta = egamma->eta();
+    // fill photon histograms
   }
 }
 

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -497,13 +497,13 @@ void L1TStage2CaloLayer2Offline::bookJetHistos(DQMStore::IBooker & ibooker)
       "L1 Jet E_{T} vs Offline Jet E_{T} (HB+HE); Offline Jet E_{T} (GeV); L1 Jet E_{T} (GeV)", 300, 0, 300, 300, 0,
       300);
 
-  h_L1JetPhivsCaloJetPhi_HB_ = ibooker.book2D("L1JetETvsCaloJetET_HB",
+  h_L1JetPhivsCaloJetPhi_HB_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HB",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HB); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
-  h_L1JetPhivsCaloJetPhi_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HE",
+  h_L1JetPhivsCaloJetPhi_HE_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HE",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HE); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
-  h_L1JetPhivsCaloJetPhi_HF_ = ibooker.book2D("L1JetETvsCaloJetET_HF",
+  h_L1JetPhivsCaloJetPhi_HF_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HF",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HF); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
-  h_L1JetPhivsCaloJetPhi_HB_HE_ = ibooker.book2D("L1JetETvsCaloJetET_HB_HE",
+  h_L1JetPhivsCaloJetPhi_HB_HE_ = ibooker.book2D("L1JetPhivsCaloJetPhi_HB_HE",
       "#phi_{jet}^{L1} vs #phi_{jet}^{offline} (HB+HE); #phi_{jet}^{offline}; #phi_{jet}^{L1}", 100, -4, 4, 100, -4, 4);
 
   h_L1JetEtavsCaloJetEta_ = ibooker.book2D("L1JetEtavsCaloJetEta_HB",

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+import os
 from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('L1TStage2EmulatorDQM', eras.Run2_2016)
@@ -45,9 +45,10 @@ with open('fileListRAW.local') as f:
     fileListRAW = f.readlines()
 process.source = cms.Source(
     "PoolSource",
-    fileNames=cms.untracked.vstring('file:///vagrant/workspace/DQMOffline/src/doubleEG/009E5CBE-AE87-E611-9122-0025905A60C6.root'),
-#     secondaryFileNames=cms.untracked.vstring(
-#         fileListRAW),
+#     fileNames=cms.untracked.vstring(fileList[0]),
+#     secondaryFileNames=cms.untracked.vstring(fileListRAW),
+    fileNames=cms.untracked.vstring(
+        'file:///vagrant/workspace/DQMOffline/src/doubleEG/009E5CBE-AE87-E611-9122-0025905A60C6.root'),
 )
 
 process.options = cms.untracked.PSet(
@@ -74,17 +75,23 @@ process.raw2digi_step = cms.Path(process.RawToDigi)
 process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi')
 process.load('DQMOffline.L1Trigger.L1TEGammaOffline_cfi')
 
+if os.environ.get('DEBUG', False):
+    process.MessageLogger.cout.threshold=cms.untracked.string('DEBUG')
+    process.MessageLogger.debugModules = cms.untracked.vstring(
+        '*',
+    )
+
 process.dqmoffline_step = cms.Path(
     process.l1tStage2CaloLayer2OfflineDQMEmu +
-    process.l1tStage2CaloLayer2OfflineDQM + 
-    process.l1tEGammaOfflineDQM + 
+    process.l1tStage2CaloLayer2OfflineDQM +
+    process.l1tEGammaOfflineDQM +
     process.l1tEGammaOfflineDQMEmu
 )
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 # Schedule definition
 process.schedule = cms.Schedule(
     process.raw2digi_step,
-    )
+)
 
 # customisation of the process.
 

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -71,9 +71,12 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 process.raw2digi_step = cms.Path(process.RawToDigi)
 
 process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi')
+process.load('DQMOffline.L1Trigger.L1TEGammaOffline_cfi')
 process.dqmoffline_step = cms.Path(
     process.l1tStage2CaloLayer2OfflineDQMEmu +
-    process.l1tStage2CaloLayer2OfflineDQM
+    process.l1tStage2CaloLayer2OfflineDQM + 
+    process.l1tEGammaOfflineDQM + 
+    process.l1tEGammaOfflineDQMEmu
 )
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 # Schedule definition

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step1_L1TStage2CaloLayer2_cfg.py
@@ -45,9 +45,9 @@ with open('fileListRAW.local') as f:
     fileListRAW = f.readlines()
 process.source = cms.Source(
     "PoolSource",
-    fileNames=cms.untracked.vstring(fileList[0]),
-    secondaryFileNames=cms.untracked.vstring(
-        fileListRAW),
+    fileNames=cms.untracked.vstring('file:///vagrant/workspace/DQMOffline/src/doubleEG/009E5CBE-AE87-E611-9122-0025905A60C6.root'),
+#     secondaryFileNames=cms.untracked.vstring(
+#         fileListRAW),
 )
 
 process.options = cms.untracked.PSet(
@@ -65,13 +65,15 @@ process.DQMoutput = cms.OutputModule(
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 
 # Path and EndPath definitions
 process.raw2digi_step = cms.Path(process.RawToDigi)
 
 process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Offline_cfi')
 process.load('DQMOffline.L1Trigger.L1TEGammaOffline_cfi')
+
 process.dqmoffline_step = cms.Path(
     process.l1tStage2CaloLayer2OfflineDQMEmu +
     process.l1tStage2CaloLayer2OfflineDQM + 
@@ -81,7 +83,8 @@ process.dqmoffline_step = cms.Path(
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 # Schedule definition
 process.schedule = cms.Schedule(
-    process.raw2digi_step, process.dqmoffline_step, process.DQMoutput_step)
+    process.raw2digi_step,
+    )
 
 # customisation of the process.
 
@@ -92,3 +95,5 @@ from L1Trigger.Configuration.customiseReEmul import L1TReEmulFromRAW
 # call to customisation function L1TReEmulFromRAW imported from
 # L1Trigger.Configuration.customiseReEmul
 process = L1TReEmulFromRAW(process)
+process.schedule.append(process.dqmoffline_step)
+process.schedule.append(process.DQMoutput_step)

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
@@ -25,6 +25,8 @@ process.load('DQMServices.Examples.test.DQMExample_qTester_cfi')
 # L1T
 process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Efficiency_cfi')
 process.load('DQMOffline.L1Trigger.L1TStage2CaloLayer2Diff_cfi')
+process.load('DQMOffline.L1Trigger.L1TEGammaEfficiency_cfi')
+process.load('DQMOffline.L1Trigger.L1TEGammaDiff_cfi')
 
 
 process.maxEvents = cms.untracked.PSet(
@@ -47,7 +49,8 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  # for MC
 # Path and EndPath definitions
 process.myHarvesting = cms.Path(process.DQMExample_Step2)
 process.myEff = cms.Path(
-    process.l1tStage2CaloLayer2Efficiency * process.l1tStage2CaloLayer2EmuDiff
+    process.l1tStage2CaloLayer2Efficiency * process.l1tStage2CaloLayer2EmuDiff +
+    process. l1tEGammaEfficiency * process.l1tEGammaEmuDiff
 )
 process.myTest = cms.Path(process.DQMExample_qTester)
 process.dqmsave_step = cms.Path(process.dqmSaver)


### PR DESCRIPTION
This PR includes Offline DQM components for the Stage 2 Calo Layer 2 objects and is an extension of #16704. In particular, this DQM focuses on electrons and photons and their L1T-reco comparison including the L1T emulator.
Furthermore, it includes two fixes to #16704 where histograms were assigned the incorrect names.

This PR has been tested on the DoubleEG dataset in `CMSSW_9_1_0_pre1`.

@dmitrijus & @rekovic please review and sign off.

@bortigno This should complete the first draft for the two DQM modules.

@davidlange6 tried not to replicate mistakes from #16704, but apologies in advance if I did.
Please beware: as in the previous PR, the biggest file, `L1TEGammaOffline.cc`, is not loaded by default.