### PR TITLE
Geant4 physics lists without Geant4 particle iterator

### DIFF
--- a/SimG4Core/CustomPhysics/interface/CustomParticleFactory.h
+++ b/SimG4Core/CustomPhysics/interface/CustomParticleFactory.h
@@ -4,7 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
-#include <set>
+#include <vector>
 #include <string>
 
 class G4DecayTable;
@@ -16,7 +16,7 @@ class CustomParticleFactory {
 
  public:
   static void loadCustomParticles(const std::string & filePath);
-  static bool isCustomParticle(G4ParticleDefinition *particle);
+  static const std::vector<G4ParticleDefinition *>& GetCustomParticles();
 
  private:
 
@@ -26,7 +26,7 @@ class CustomParticleFactory {
   static G4DecayTable* getAntiDecayTable(int pdgId, G4DecayTable *theDecayTable);
 
   static bool loaded;
-  static std::set<G4ParticleDefinition *> m_particles;
+  static std::vector<G4ParticleDefinition *> m_particles;
 
   static std::string ToLower(std::string str);  
   

--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -23,12 +23,7 @@
 using namespace CLHEP;
 
 bool CustomParticleFactory::loaded = false;
-std::set<G4ParticleDefinition *> CustomParticleFactory::m_particles;
-
-bool CustomParticleFactory::isCustomParticle(G4ParticleDefinition *particle)
-{
-  return (m_particles.find(particle)!=m_particles.end());
-}
+std::vector<G4ParticleDefinition *> CustomParticleFactory::m_particles;
 
 void CustomParticleFactory::loadCustomParticles(const std::string & filePath){
   if(loaded) return;
@@ -212,7 +207,7 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const st
     particle->SetCloud(0);
     particle->SetSpectator(0);
   } 
-  m_particles.insert(particle);
+  m_particles.push_back(particle);
 }
 
 void  CustomParticleFactory::getMassTable(std::ifstream *configFile) {
@@ -386,3 +381,7 @@ std::string CustomParticleFactory::ToLower(std::string str) {
   return str; 	
 }
 
+const std::vector<G4ParticleDefinition *>& CustomParticleFactory::GetCustomParticles()
+{
+  return m_particles;
+}

--- a/SimG4Core/CustomPhysics/src/CustomPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysics.cc
@@ -1,8 +1,7 @@
 #include "SimG4Core/CustomPhysics/interface/CustomPhysics.h"
 #include "SimG4Core/CustomPhysics/interface/CustomPhysicsList.h"
 #include "SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h"
-#include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95msc93.h"
-#include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h"
+#include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4DecayPhysics.hh"
@@ -13,7 +12,7 @@
 #include "G4NeutronTrackingCut.hh"
 
 #include "G4DataQuestionaire.hh"
-#include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
+#include "G4HadronPhysicsFTFP_BERT.hh"
 #include "G4SystemOfUnits.hh"
  
 CustomPhysics::CustomPhysics(G4LogicalVolumeToDDLogicalPartMap& map, 
@@ -32,8 +31,7 @@ CustomPhysics::CustomPhysics(G4LogicalVolumeToDDLogicalPartMap& map,
 			      << "CustomPhysicsList " << ssPhys << " for exotics; "
                               << " tracking cut " << tracking << "  t(ns)= " << timeLimit/ns;
   // EM Physics
-  RegisterPhysics(new CMSEmStandardPhysics(ver));
-  //RegisterPhysics(new CMSEmStandardPhysics95msc93("EM standard msc93",ver,""));
+  RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
   // Synchroton Radiation & GN Physics
   RegisterPhysics(new G4EmExtraPhysics(ver));
@@ -45,7 +43,7 @@ CustomPhysics::CustomPhysics(G4LogicalVolumeToDDLogicalPartMap& map,
   RegisterPhysics(new G4HadronElasticPhysics(ver)); 
 
   // Hadron Physics
-  RegisterPhysics(new G4HadronPhysicsQGSP_FTFP_BERT(ver));
+  RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
   // Stopping Physics
   RegisterPhysics(new G4StoppingPhysics(ver));

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -54,19 +54,15 @@ void CustomPhysicsList::ConstructProcess() {
   
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  aParticleIterator->reset();
-  G4ParticleDefinition* particle;
-
-  while((*aParticleIterator)()) {
-    particle = aParticleIterator->value();
-    if(CustomParticleFactory::isCustomParticle(particle)) {
-      CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
+  for(auto particle : CustomParticleFactory::GetCustomParticles()) {
+    CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
+    if(cp) {
       G4ProcessManager* pmanager = particle->GetProcessManager();
       edm::LogInfo("SimG4CoreCustomPhysics") 
 	<<"CustomPhysicsList: " << particle->GetParticleName()
 	<<"  PDGcode= " << particle->GetPDGEncoding()
 	<< "  Mass= " << particle->GetPDGMass()/GeV  <<" GeV.";
-      if(cp && pmanager) {
+      if(pmanager) {
 	if(particle->GetPDGCharge() != 0.0) {
 	  ph->RegisterProcess(new G4hMultipleScattering, particle);
 	  ph->RegisterProcess(new G4hIonisation, particle);

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -50,19 +50,16 @@ void CustomPhysicsListSS::ConstructProcess() {
   fDecayProcess = new G4Decay();
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  aParticleIterator->reset();
-  G4ParticleDefinition* particle;
+  for(auto particle : CustomParticleFactory::GetCustomParticles()) {
 
-  while((*aParticleIterator)()) {
-    particle = aParticleIterator->value();
-    if(CustomParticleFactory::isCustomParticle(particle)) {
-      CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
+    CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
+    if(cp) {
       G4ProcessManager* pmanager = particle->GetProcessManager();
       edm::LogInfo("SimG4CoreCustomPhysics") 
 	<<"CustomPhysicsListSS: " << particle->GetParticleName()
 	<<" PDGcode= " << particle->GetPDGEncoding()
 	<< " Mass= " << particle->GetPDGMass()/GeV  <<" GeV.";
-      if(cp && pmanager) {
+      if(pmanager) {
 	if(particle->GetPDGCharge() != 0.0) {
 	  ph->RegisterProcess(new G4hMultipleScattering, particle);
 	  ph->RegisterProcess(new G4hIonisation, particle);

--- a/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
@@ -9,9 +9,10 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include"SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
+#include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
 #include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
 #include "SimG4Core/CustomPhysics/interface/CustomParticle.h"
+#include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
 
 using namespace CLHEP;
 
@@ -94,25 +95,15 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
 
   process_stream.close();
 
-  G4ParticleTable::G4PTblDicIterator* theParticleIterator;
-  theParticleIterator = particleTable->GetIterator();
-
-  theParticleIterator->reset();
-  while( (*theParticleIterator)() ){
-    CustomParticle* particle = dynamic_cast<CustomParticle*>(theParticleIterator->value());
-    std::string name = theParticleIterator->value()->GetParticleName();
-    G4DecayTable* table = theParticleIterator->value()->GetDecayTable();
-    if(particle!=0&&table!=0&&name.find("cloud")>name.size()&&hadronlifetime > 0)
-      {
-	particle->SetPDGLifeTime(hadronlifetime*s);
-	particle->SetPDGStable(false);
-	edm::LogInfo("SimG4CoreCustomPhysics")
-	  <<"ProcessHelper: Lifetime of "<<name<<" set to "
-	  <<particle->GetPDGLifeTime()/s<<" s;"
-	  <<" isStable: "<<particle->GetPDGStable();
-      }
+  for(auto part : CustomParticleFactory::GetCustomParticles()) {
+    CustomParticle* particle = dynamic_cast<CustomParticle*>(part);
+    if(particle) {
+      edm::LogInfo("SimG4CoreCustomPhysics")
+	<<"ProcessHelper: Lifetime of "<<part->GetParticleName()<<" set to "
+	<<particle->GetPDGLifeTime()/s<<" s;"
+	<<" isStable: "<<particle->GetPDGStable();
+    }
   }
-  theParticleIterator->reset();
 }
 
 G4bool G4ProcessHelper::ApplicabilityTester(const G4ParticleDefinition& aPart){

--- a/SimG4Core/PhysicsLists/interface/CMSParticleList.h
+++ b/SimG4Core/PhysicsLists/interface/CMSParticleList.h
@@ -5,10 +5,12 @@
 // List of Geant4 basic particle names used in SIM step 
 
 #include "globals.hh"
+#include <vector>
 
-static const G4int numParticles = 44;
-static const G4String PartNames[numParticles] = 
-{ 
+namespace cmsparticlelist {
+
+  static const std::vector<G4String> PartNames = 
+    { 
         "gamma",            "e-",           "e+",           "mu+",        "mu-",
           "pi+",           "pi-",        "kaon+",         "kaon-",     "proton",
   "anti_proton",         "alpha",          "He3",    "GenericIon",         "B+",
@@ -18,8 +20,8 @@ static const G4String PartNames[numParticles] =
    "anti_xi_c+",      "anti_xi-",     "deuteron",     "lambda_c+",     "omega-",
      "sigma_c+",     "sigma_c++",       "sigma+",        "sigma-",       "tau+",
          "tau-",        "triton",        "xi_c+",           "xi-"
+    };
 };
-
 
 #endif
 

--- a/SimG4Core/PhysicsLists/interface/CMSParticleList.h
+++ b/SimG4Core/PhysicsLists/interface/CMSParticleList.h
@@ -1,0 +1,25 @@
+#ifndef SimG4Core_PhysicsList_CMSParticleList_h
+#define SimG4Core_PhysicsList_CMSParticleList_h 1
+
+// V.Ivanchenko 6 March 2017
+// List of Geant4 basic particle names used in SIM step 
+
+#include "globals.hh"
+
+static const G4int numParticles = 44;
+static const G4String PartNames[numParticles] = 
+{ 
+        "gamma",            "e-",           "e+",           "mu+",        "mu-",
+          "pi+",           "pi-",        "kaon+",         "kaon-",     "proton",
+  "anti_proton",         "alpha",          "He3",    "GenericIon",         "B+",
+           "B-",            "D+",           "D-",           "Ds+",        "Ds-",
+     "anti_He3",    "anti_alpha","anti_deuteron","anti_lambda_c+","anti_omega-",
+"anti_sigma_c+","anti_sigma_c++",  "anti_sigma+",   "anti_sigma-","anti_triton",
+   "anti_xi_c+",      "anti_xi-",     "deuteron",     "lambda_c+",     "omega-",
+     "sigma_c+",     "sigma_c++",       "sigma+",        "sigma-",       "tau+",
+         "tau-",        "triton",        "xi_c+",           "xi-"
+};
+
+
+#endif
+

--- a/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
@@ -134,8 +134,7 @@ void CMSEmNoDeltaRay::ConstructProcess() {
   }
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-  for(G4int i=0; i<numParticles; ++i) {
-    G4String particleName = PartNames[i];
+  for(const auto& particleName : cmsparticlelist::PartNames) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
     G4ProcessManager* pmanager = particle->GetProcessManager();
     if(verbose > 1)

--- a/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
@@ -1,15 +1,17 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmNoDeltaRay.h"
-#include "SimG4Core/PhysicsLists/interface/UrbanMscModel93.h"
+#include "SimG4Core/PhysicsLists/interface/CMSParticleList.h"
+#include "G4EmParameters.hh"
+#include "G4ParticleTable.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4ProcessManager.hh"
 #include "G4LossTableManager.hh"
-#include "G4EmProcessOptions.hh"
 #include "G4RegionStore.hh"
 
 #include "G4ComptonScattering.hh"
 #include "G4GammaConversion.hh"
 #include "G4PhotoElectricEffect.hh"
+#include "G4UrbanMscModel.hh"
 
 #include "G4hMultipleScattering.hh"
 #include "G4eMultipleScattering.hh"
@@ -61,11 +63,18 @@
 #include "G4Alpha.hh"
 #include "G4GenericIon.hh"
 
+#include "G4BuilderType.hh"
 #include "G4SystemOfUnits.hh"
 
 CMSEmNoDeltaRay::CMSEmNoDeltaRay(const G4String& name, G4int ver, std::string reg):
   G4VPhysicsConstructor(name), verbose(ver), region(reg) {
-  G4LossTableManager::Instance();
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(verbose);
+  param->SetApplyCuts(true);
+  param->SetMscRangeFactor(0.2);
+  param->SetMscStepLimitType(fMinimal);
+  SetPhysicsType(bElectromagnetic);
 }
 
 CMSEmNoDeltaRay::~CMSEmNoDeltaRay() {}
@@ -124,11 +133,11 @@ void CMSEmNoDeltaRay::ConstructProcess() {
     reg = regStore->GetRegion(region, true);
   }
 
-  aParticleIterator->reset();
-  while( (*aParticleIterator)() ){
-    G4ParticleDefinition* particle = aParticleIterator->value();
+  G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+  for(G4int i=0; i<numParticles; ++i) {
+    G4String particleName = PartNames[i];
+    G4ParticleDefinition* particle = table->FindParticle(particleName);
     G4ProcessManager* pmanager = particle->GetProcessManager();
-    G4String particleName = particle->GetParticleName();
     if(verbose > 1)
       G4cout << "### " << GetPhysicsName() << " instantiates for " 
 	     << particleName << " at " << particle << G4endl;
@@ -141,12 +150,10 @@ void CMSEmNoDeltaRay::ConstructProcess() {
 
     } else if (particleName == "e-") {
 
-      //      G4eIonisation* eioni = new G4eIonisation();
-      //      eioni->SetStepFunction(0.8, 1.0*mm);
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       msc->SetStepLimitType(fMinimal);
       if (reg != 0) {
-	UrbanMscModel93* msc_el  = new UrbanMscModel93();
+	G4UrbanMscModel* msc_el  = new G4UrbanMscModel();
 	msc_el->SetRangeFactor(0.04);
 	msc->AddEmModel(0,msc_el,reg);
       }
@@ -161,7 +168,7 @@ void CMSEmNoDeltaRay::ConstructProcess() {
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       msc->SetStepLimitType(fMinimal);
       if (reg != 0) {
-	UrbanMscModel93* msc_pos  = new UrbanMscModel93();
+	G4UrbanMscModel* msc_pos  = new G4UrbanMscModel();
 	msc_pos->SetRangeFactor(0.04);
 	msc->AddEmModel(0,msc_pos,reg);
       }
@@ -228,12 +235,4 @@ void CMSEmNoDeltaRay::ConstructProcess() {
       pmanager->AddProcess(new G4hhIonisation,        -1, 2, 2);
     }
   }
-
-  // Setup options
-  //
-  G4EmProcessOptions opt;
-  opt.SetVerbose(verbose);
-  // ApplyCuts
-  //
-  opt.SetApplyCuts(true);
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -1,9 +1,11 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h"
 #include "SimG4Core/PhysicsLists/interface/UrbanMscModel93.h"
+#include "SimG4Core/PhysicsLists/interface/CMSParticleList.h"
+#include "G4EmParameters.hh"
+#include "G4ParticleTable.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4LossTableManager.hh"
-#include "G4EmProcessOptions.hh"
 
 #include "G4ComptonScattering.hh"
 #include "G4GammaConversion.hh"
@@ -71,7 +73,12 @@
 
 CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver) :
   G4VPhysicsConstructor("CMSEmStandard_opt1"), verbose(ver) {
-  G4LossTableManager::Instance();
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(verbose);
+  param->SetApplyCuts(true);
+  param->SetMscRangeFactor(0.2);
+  param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
 }
 
@@ -155,10 +162,10 @@ void CMSEmStandardPhysics::ConstructProcess() {
   // high energy limit for e+- scattering models and bremsstrahlung
   G4double highEnergyLimit = 100*MeV;
 
-  aParticleIterator->reset();
-  while( (*aParticleIterator)() ){
-    G4ParticleDefinition* particle = aParticleIterator->value();
-    G4String particleName = particle->GetParticleName();
+  G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+  for(G4int i=0; i<numParticles; ++i) {
+    G4String particleName = PartNames[i];
+    G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {
 
@@ -331,8 +338,4 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(new G4hIonisation(), particle);
     }
   }
-  G4EmProcessOptions opt;
-  opt.SetVerbose(verbose);
-  opt.SetPolarAngleLimit(CLHEP::pi);
-  opt.SetApplyCuts(true);
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -163,8 +163,7 @@ void CMSEmStandardPhysics::ConstructProcess() {
   G4double highEnergyLimit = 100*MeV;
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-  for(G4int i=0; i<numParticles; ++i) {
-    G4String particleName = PartNames[i];
+  for(const auto& particleName : cmsparticlelist::PartNames) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -149,8 +149,7 @@ void CMSEmStandardPhysics95::ConstructProcess()
 
   // Add standard EM Processes
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-  for(G4int i=0; i<numParticles; ++i) {
-    G4String particleName = PartNames[i];
+  for(const auto& particleName : cmsparticlelist::PartNames) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
     if(verbose > 1)
       G4cout << "### " << GetPhysicsName() << " instantiates for " 

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -1,9 +1,11 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95.h"
+#include "SimG4Core/PhysicsLists/interface/CMSParticleList.h"
+#include "G4EmParameters.hh"
+#include "G4ParticleTable.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4ProcessManager.hh"
 #include "G4LossTableManager.hh"
-#include "G4EmProcessOptions.hh"
 #include "G4RegionStore.hh"
 
 #include "G4ComptonScattering.hh"
@@ -70,7 +72,12 @@
 
 CMSEmStandardPhysics95::CMSEmStandardPhysics95(const G4String& name, G4int ver, std::string reg):
   G4VPhysicsConstructor(name), verbose(ver), region(reg) {
-  G4LossTableManager::Instance();
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(verbose);
+  param->SetApplyCuts(true);
+  param->SetMscRangeFactor(0.2);
+  param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
 }
 
@@ -141,10 +148,10 @@ void CMSEmStandardPhysics95::ConstructProcess()
   G4hMultipleScattering* hmsc = nullptr;
 
   // Add standard EM Processes
-  aParticleIterator->reset();
-  while( (*aParticleIterator)() ){
-    G4ParticleDefinition* particle = aParticleIterator->value();
-    G4String particleName = particle->GetParticleName();
+  G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+  for(G4int i=0; i<numParticles; ++i) {
+    G4String particleName = PartNames[i];
+    G4ParticleDefinition* particle = table->FindParticle(particleName);
     if(verbose > 1)
       G4cout << "### " << GetPhysicsName() << " instantiates for " 
 	     << particleName << G4endl;
@@ -283,12 +290,4 @@ void CMSEmStandardPhysics95::ConstructProcess()
       ph->RegisterProcess(new G4hIonisation(), particle);
     }
   }
-
-  // Setup options
-  //
-  G4EmProcessOptions opt;
-  opt.SetVerbose(verbose);
-  // ApplyCuts
-  //
-  opt.SetApplyCuts(true);
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
@@ -151,8 +151,7 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
   // except e+e- for which the Urban93 model is used
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-  for(G4int i=0; i<numParticles; ++i) {
-    G4String particleName = PartNames[i];
+  for(const auto& particleName : cmsparticlelist::PartNames) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
     G4ProcessManager* pmanager = particle->GetProcessManager();
     if(verbose > 1)

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
@@ -1,10 +1,12 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95msc93.h"
 #include "SimG4Core/PhysicsLists/interface/UrbanMscModel93.h"
+#include "SimG4Core/PhysicsLists/interface/CMSParticleList.h"
+#include "G4EmParameters.hh"
+#include "G4ParticleTable.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4ProcessManager.hh"
 #include "G4LossTableManager.hh"
-#include "G4EmProcessOptions.hh"
 #include "G4RegionStore.hh"
 
 #include "G4ComptonScattering.hh"
@@ -64,11 +66,19 @@
 #include "G4Alpha.hh"
 #include "G4GenericIon.hh"
 
+#include "G4BuilderType.hh"
 #include "G4SystemOfUnits.hh"
 
 CMSEmStandardPhysics95msc93::CMSEmStandardPhysics95msc93(const G4String& name, 
 							 G4int ver, std::string reg)
 : G4VPhysicsConstructor(name), verbose(ver), region(reg) {
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(verbose);
+  param->SetApplyCuts(true);
+  param->SetMscRangeFactor(0.2);
+  param->SetMscStepLimitType(fMinimal);
+  SetPhysicsType(bElectromagnetic);
   G4LossTableManager::Instance();
 }
 
@@ -140,11 +150,11 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
   // Multiple scattering by Urban for all particles
   // except e+e- for which the Urban93 model is used
 
-  aParticleIterator->reset();
-  while( (*aParticleIterator)() ){
-    G4ParticleDefinition* particle = aParticleIterator->value();
+  G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+  for(G4int i=0; i<numParticles; ++i) {
+    G4String particleName = PartNames[i];
+    G4ParticleDefinition* particle = table->FindParticle(particleName);
     G4ProcessManager* pmanager = particle->GetProcessManager();
-    G4String particleName = particle->GetParticleName();
     if(verbose > 1)
       G4cout << "### " << GetPhysicsName() << " instantiates for " 
 	     << particleName << " at " << particle << G4endl;
@@ -277,13 +287,4 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
       pmanager->AddProcess(new G4hIonisation,   -1, 2, 2);
     }
   }
-
-  // Setup options
-  //
-  G4EmProcessOptions opt;
-  opt.SetVerbose(verbose);
-  //  opt.SetPolarAngleLimit(CLHEP::pi);
-  // ApplyCuts
-  //
-  opt.SetApplyCuts(true);
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -171,8 +171,7 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
     G4RegionStore::GetInstance()->GetRegion("HGCalRegion",false);
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-  for(G4int i=0; i<numParticles; ++i) {
-    G4String particleName = PartNames[i];
+  for(const auto& particleName : cmsparticlelist::PartNames) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -1,8 +1,10 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h"
+#include "SimG4Core/PhysicsLists/interface/CMSParticleList.h"
+#include "G4EmParameters.hh"
+#include "G4ParticleTable.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4LossTableManager.hh"
-#include "G4EmParameters.hh"
 
 #include "G4ComptonScattering.hh"
 #include "G4GammaConversion.hh"
@@ -139,7 +141,7 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
 
   // This EM builder takes default models of Geant4 10 EMV.
   // Multiple scattering by Urban for all particles
-  // except e+e- below 100 MeV for which the Urban93 model is used
+  // except e+e- below 100 MeV for which the Urban model is used
 
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
@@ -168,10 +170,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
   G4Region* bRegion = 
     G4RegionStore::GetInstance()->GetRegion("HGCalRegion",false);
 
-  aParticleIterator->reset();
-  while( (*aParticleIterator)() ){
-    G4ParticleDefinition* particle = aParticleIterator->value();
-    G4String particleName = particle->GetParticleName();
+  G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+  for(G4int i=0; i<numParticles; ++i) {
+    G4String particleName = PartNames[i];
+    G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {
 

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -174,8 +174,7 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
     G4RegionStore::GetInstance()->GetRegion("HGCalRegion",false);
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
-  for(G4int i=0; i<numParticles; ++i) {
-    G4String particleName = PartNames[i];
+  for(const auto& particleName : cmsparticlelist::PartNames) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -1,5 +1,8 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsXS.h"
 #include "SimG4Core/PhysicsLists/interface/UrbanMscModel93.h"
+#include "SimG4Core/PhysicsLists/interface/CMSParticleList.h"
+#include "G4EmParameters.hh"
+#include "G4ParticleTable.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4LossTableManager.hh"
@@ -170,10 +173,10 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   G4Region* bRegion = 
     G4RegionStore::GetInstance()->GetRegion("HGCalRegion",false);
 
-  aParticleIterator->reset();
-  while( (*aParticleIterator)() ){
-    G4ParticleDefinition* particle = aParticleIterator->value();
-    G4String particleName = particle->GetParticleName();
+  G4ParticleTable* table = G4ParticleTable::GetParticleTable();
+  for(G4int i=0; i<numParticles; ++i) {
+    G4String particleName = PartNames[i];
+    G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {
 


### PR DESCRIPTION
Newer versions of Geant4 cannot compile with the current CMSSW due to interface to Geant4 particle. This change removes such limitation.  

This is also a first step to make custom physics be MT capable (not the case so far). In other word, make exotics simulation  multi-threaded.

For CMS alternative EM physics constructors initialisation is changed according Geant4 recommendations.

It should not affect any result of current simulation even simulation history.