### PR TITLE
ME0 pseudo digitizer update

### DIFF
--- a/DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h
+++ b/DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h
@@ -11,6 +11,7 @@
 #include <DataFormats/MuonData/interface/MuonDigiCollection.h>
 
 typedef MuonDigiCollection<ME0DetId, ME0DigiPreReco> ME0DigiPreRecoCollection;
+typedef MuonDigiCollection<ME0DetId, int > ME0DigiPreRecoMap;
 
 #endif
 

--- a/DataFormats/GEMDigi/src/classes.h
+++ b/DataFormats/GEMDigi/src/classes.h
@@ -48,5 +48,7 @@ namespace DataFormats_GEMDigi {
     std::vector<std::vector<ME0DigiPreReco> >  vvm;
     ME0DigiPreRecoCollection mcol;
     edm::Wrapper<ME0DigiPreRecoCollection> wm;
+    ME0DigiPreRecoMap mmap;
+    edm::Wrapper<ME0DigiPreRecoMap> wmmap;
   };
 }

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -42,5 +42,9 @@
 <class name="std::map<ME0DetId,std::vector<ME0DigiPreReco> >"/>
 <class name="MuonDigiCollection<ME0DetId,ME0DigiPreReco>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0DigiPreReco> >" splitLevel="0"/> 
+<class name="std::vector<int>"/>
+<class name="std::map<ME0DetId,std::vector<int> >"/>
+<class name="MuonDigiCollection<ME0DetId,int>"/> 
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,int> >" splitLevel="0"/> 
 
 </lcgdict>

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -42,7 +42,6 @@
 <class name="std::map<ME0DetId,std::vector<ME0DigiPreReco> >"/>
 <class name="MuonDigiCollection<ME0DetId,ME0DigiPreReco>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0DigiPreReco> >" splitLevel="0"/> 
-<class name="std::vector<int>"/>
 <class name="std::map<ME0DetId,std::vector<int> >"/>
 <class name="MuonDigiCollection<ME0DetId,int>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<ME0DetId,int> >" splitLevel="0"/> 

--- a/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
@@ -2,7 +2,7 @@
 #define SimMuon_GEMDigitizer_ME0ReDigiProducer_h
 
 /*
- * This module smears and discretizes the timing and position of the 
+ * This module smears and discretizes the timing and position of the
  * ME0 pseudo digis.
  */
 
@@ -17,6 +17,7 @@
 
 class ME0Geometry;
 class ME0EtaPartition;
+class TrapezoidalStripTopology;
 
 namespace CLHEP {
   class HepRandomEngine;
@@ -24,6 +25,29 @@ namespace CLHEP {
 
 class ME0ReDigiProducer : public edm::stream::EDProducer<>
 {
+private:
+	//assume that all ME0 chambers have the same dimension
+	//and for the same layer have the same radial and Z position
+	//Good for now, can build in support for more varied geos later
+	//if necessary
+	class TemporaryGeometry {
+	public:
+		TemporaryGeometry(const ME0Geometry* geometry, const unsigned int numberOfStrips, const unsigned int numberOfPartitions);
+		~TemporaryGeometry();
+		unsigned int findEtaPartition(float locY) const;
+		const TrapezoidalStripTopology * getTopo(const unsigned int partIdx) const {return stripTopos[partIdx];}
+		float getPartCenter(const unsigned int partIdx) const; //position of part. in chamber
+		float getCentralTOF(const ME0DetId& me0Id, unsigned int partIdx) const {return tofs[me0Id.layer() -1 ][partIdx];} //in detId layer numbers stat at 1
+		unsigned int numLayers() const {return tofs.size();}
+	private:
+		TrapezoidalStripTopology * buildTopo(const std::vector<float>& _p) const;
+	private:
+		float middleDistanceFromBeam;                        // radiusOfMainPartitionInCenter;
+		std::vector<TrapezoidalStripTopology * > stripTopos; // vector of Topos, one for each part
+		std::vector<std::vector<double> > tofs ;             //TOF to center of the partition:  [layer][part]
+		std::vector<float> partionTops;                      //Top of each position in the chamber's local coords
+
+	};
 public:
 
   explicit ME0ReDigiProducer(const edm::ParameterSet& ps);
@@ -33,37 +57,28 @@ public:
   virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  
-  void buildDigis(const ME0DigiPreRecoCollection &, ME0DigiPreRecoCollection &, CLHEP::HepRandomEngine* engine);
-  
+
+
+  void buildDigis(const ME0DigiPreRecoCollection &,
+                  ME0DigiPreRecoCollection &,
+				  ME0DigiPreRecoMap &,
+                  CLHEP::HepRandomEngine* engine);
+
 private:
+  //paramters
+  unsigned int numberOfSrips     ; // number of strips per partition
+  unsigned int numberOfPartitions; // number of partitions per chamber
+  double       neutronAcceptance ; // fraction of neutron events to keep in event (>= 1 means no filtering)
+  double       timeResolution    ; // smear time by gaussian with this sigma (in ns)....negative for no smearing
+  int          minBXReadout      ; // Minimum BX to readout
+  int          maxBXReadout      ; // Maximum BX to readout
+  std::vector<int> layerReadout  ; // Don't readout layer if entry is 0 (Layer number 1 in the numbering scheme is idx 0)
+  bool         mergeDigis        ; // Keep only one digi at the same chamber, strip, partition, and BX
 
-  double correctSigmaU(const ME0EtaPartition* roll, double y);
 
-  edm::EDGetTokenT<ME0DigiPreRecoCollection> token_; 
-  const ME0Geometry* geometry_;
-  double timeResolution_;
-  int minBunch_;
-  int maxBunch_;
-  bool smearTiming_;
-  bool discretizeTiming_;
-  double radialResolution_;
-  bool smearRadial_;
-  double oldXResolution_;
-  double oldYResolution_;
-  double newXResolution_;
-  double newYResolution_;
-  bool discretizeX_;
-  bool discretizeY_;
-  bool verbose_;
-  bool reDigitizeOnlyMuons_;
-  bool reDigitizeNeutronBkg_;
-  double instLumiDefault_;
-  double rateFact_;
-  double instLumi_;
-  std::vector<double> centralTOF_;
-  int nPartitions_;
+  edm::EDGetTokenT<ME0DigiPreRecoCollection> token;
+  const ME0Geometry* geometry;
+  TemporaryGeometry* tempGeo;
 };
 
 #endif
-

--- a/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
@@ -73,7 +73,8 @@ private:
   void getStripProperties(const ME0EtaPartition* etaPart, const ME0DigiPreReco* inDigi, float& tof,int& strip, LocalPoint&  digiLocalPoint, LocalError&  digiLocalError) const;
   int getCustomStripProperties(const ME0DetId& detId, const ME0DigiPreReco* inDigi, float& tof,int& strip, LocalPoint&  digiLocalPoint, LocalError&  digiLocalError) const;
 
-  typedef std::map<unsigned int, std::map<unsigned int, std::map<unsigned int, unsigned int > > > ChamberDigiMap;
+  typedef std::tuple<unsigned int, unsigned int, unsigned int> DigiIndicies;
+  typedef std::map<DigiIndicies,unsigned int> ChamberDigiMap;
   //fills map...returns -1 if digi is not already in the map
   unsigned int fillDigiMap(ChamberDigiMap& chDigiMap, unsigned int bx, unsigned int part, unsigned int strip, unsigned int currentIDX) const;
 

--- a/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
@@ -12,7 +12,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h"
-//#include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include <string>
 
 class ME0Geometry;
@@ -50,7 +49,7 @@ private:
 		float middleDistanceFromBeam;                        // radiusOfMainPartitionInCenter;
 		std::vector<TrapezoidalStripTopology * > stripTopos; // vector of Topos, one for each part
 		std::vector<std::vector<double> > tofs ;             //TOF to center of the partition:  [layer][part]
-		std::vector<float> partionTops;                      //Top of each position in the chamber's local coords
+		std::vector<float> partitionTops;                    //Top of each partition in the chamber's local coords
 
 	};
 public:
@@ -79,8 +78,9 @@ private:
   unsigned int fillDigiMap(ChamberDigiMap& chDigiMap, unsigned int bx, unsigned int part, unsigned int strip, unsigned int currentIDX) const;
 
   //paramters
+  const float bxWidth;              // ns
   bool         useBuiltinGeo     ; //Use CMSSW defined geometry for digitization, not custom strips and partitions
-  unsigned int numberOfSrips     ; // Custom number of strips per partition
+  unsigned int numberOfStrips     ; // Custom number of strips per partition
   unsigned int numberOfPartitions; // Custom number of partitions per chamber
   double       neutronAcceptance ; // fraction of neutron events to keep in event (>= 1 means no filtering)
   double       timeResolution    ; // smear time by gaussian with this sigma (in ns)....negative for no smearing
@@ -94,6 +94,8 @@ private:
   const ME0Geometry* geometry;
   TemporaryGeometry* tempGeo;
   std::vector<std::vector<double> > tofs ;  //used for built in geo
+
+
 };
 
 #endif

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -3,25 +3,14 @@ import FWCore.ParameterSet.Config as cms
 from SimMuon.GEMDigitizer.muonME0DigisPreReco_cfi import me0PreRecoDigiCommonParameters
 
 # Module to create simulated ME0 Pre Reco digis.
-simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
-    inputCollection = cms.string('simMuonME0Digis'),
-    timeResolution = cms.double(5), # in ns
-    minBunch = cms.int32(-5),
-    maxBunch = cms.int32(3),
-    smearTiming = cms.bool(True),
-    discretizeTiming = cms.bool(True),
-    radialResolution = cms.double(0.02), # in cm average resolution along radial
-    smearRadial = cms.bool(True),
-    oldXResolution = cms.double(0.00),
-    oldYResolution = cms.double(0.00),
-    newXResolution = cms.double(0.03),
-    newYResolution = cms.double(2.50),
-    discretizeX = cms.bool(False),
-    discretizeY = cms.bool(True),
-    verbose = cms.bool(False),
-    reDigitizeOnlyMuons = cms.bool(False),
-    reDigitizeNeutronBkg = cms.bool(True),
-    rateFact = me0PreRecoDigiCommonParameters.rateFact, # This must be synchronized with the default digitizer
-    instLumiDefault = me0PreRecoDigiCommonParameters.instLumi, # This must be synchronized with the default digitizer
-    instLumi = cms.double(7.5), # in units of 1E34 cm^-2 s^-1
+simMuonME0NewGeoDigis = cms.EDProducer("ME0ReDigiProducer",
+    inputCollection    =cms.string('simMuonME0Digis'),
+    numberOfSrips      =cms.uint32(768), # number of strips per partition                                             
+    numberOfPartitions =cms.uint32(8),   # number of partitions per chamber                                           
+    neutronAcceptance  =cms.double(2.0),   # fraction of neutron events to keep in event (>= 1 means no filtering)      
+    timeResolution     =cms.double(5),   # smear time by gaussian with this sigma (in ns)....negative for no smearing 
+    minBXReadout       =cms.int32(-1),  # Minimum BX to readout                                                      
+    maxBXReadout       =cms.int32(1), # Maximum BX to readout
+    layerReadout       =cms.vint32(1,1,1,1,1,1), # Don't readout layer if entry is 0 (Layer number 1 (near IP) in the numbering scheme is idx 0)                                                                                                       
+    mergeDigis         =cms.bool(True),   # Keep only one digi at the same chamber, strip, partition, and BX           
 )

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     inputCollection    =cms.string('simMuonME0Digis'),
     useBuiltinGeo      =cms.bool(True),   #Use CMSSW defined geometry for digitization, not custom strips and paritions
-    numberOfSrips      =cms.uint32(384), # If use custom: number of strips per partition                                             
+    numberOfStrips     =cms.uint32(384), # If use custom: number of strips per partition                                             
     numberOfPartitions =cms.uint32(8),   # If use custom:  number of partitions per chamber                                           
     neutronAcceptance  =cms.double(2.0),   # fraction of neutron events to keep in event (>= 1 means no filtering)      
     timeResolution     =cms.double(5),   # smear time by gaussian with this sigma (in ns)....negative for no smearing 

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -1,12 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-from SimMuon.GEMDigitizer.muonME0DigisPreReco_cfi import me0PreRecoDigiCommonParameters
-
 # Module to create simulated ME0 Pre Reco digis.
-simMuonME0NewGeoDigis = cms.EDProducer("ME0ReDigiProducer",
+simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     inputCollection    =cms.string('simMuonME0Digis'),
-    numberOfSrips      =cms.uint32(768), # number of strips per partition                                             
-    numberOfPartitions =cms.uint32(8),   # number of partitions per chamber                                           
+    useBuiltinGeo      =cms.bool(True),   #Use CMSSW defined geometry for digitization, not custom strips and paritions
+    numberOfSrips      =cms.uint32(384), # If use custom: number of strips per partition                                             
+    numberOfPartitions =cms.uint32(8),   # If use custom:  number of partitions per chamber                                           
     neutronAcceptance  =cms.double(2.0),   # fraction of neutron events to keep in event (>= 1 means no filtering)      
     timeResolution     =cms.double(5),   # smear time by gaussian with this sigma (in ns)....negative for no smearing 
     minBXReadout       =cms.int32(-1),  # Minimum BX to readout                                                      

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -398,21 +398,12 @@ void ME0ReDigiProducer::getStripProperties(const ME0EtaPartition* etaPart, const
 }
 
 unsigned int ME0ReDigiProducer::fillDigiMap(ChamberDigiMap& chDigiMap, unsigned int bx, unsigned int part, unsigned int strip, unsigned int currentIDX) const {
-	auto it1 = chDigiMap.find(bx);
+	DigiIndicies newIDX(bx,part,strip);
+	auto it1 = chDigiMap.find(newIDX);
 	if (it1 == chDigiMap.end()){
-		chDigiMap[bx][part][strip] = currentIDX;
+		chDigiMap[newIDX] = currentIDX;
 		return -1;
 	}
-	auto it2 = it1->second.find(part);
-	if (it2 == it1->second.end()){
-		it1->second[part][strip] = currentIDX;
-		return -1;
-	}
-	auto it3 = it2->second.find(strip);
-	if (it3 == it2->second.end()){
-		it2->second[strip] = currentIDX;
-		return -1;
-	}
-	return it3->second;
+	return it1->second;
 }
 

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -97,7 +97,7 @@ ME0ReDigiProducer::TemporaryGeometry::TemporaryGeometry(const ME0Geometry* geome
 		for(unsigned int iP = 0; iP < numberOfPartitions; ++iP){
 			const LocalPoint partCenter(0., getPartCenter(iP), 0.);
 			const GlobalPoint centralGP(mainChamber->layers()[iL]->etaPartitions()[0]->toGlobal(partCenter));
-			tofs[iL][iP] = (centralGP.mag() / CLHEP::c_light/CLHEP::cm); //speed of light [cm/ns]
+			tofs[iL][iP] = (centralGP.mag() / (CLHEP::c_light/CLHEP::cm)); //speed of light [cm/ns]
 			LogDebug("ME0ReDigiProducer::TemporaryGeometry") << "["<<iL<<"]["<<iP<<"]="<< tofs[iL][iP] <<" "<<std::endl;
 		}
 	}
@@ -353,7 +353,7 @@ void ME0ReDigiProducer::fillCentralTOFs() {
 		for(unsigned int iP = 0; iP < nPartitions; ++iP){
 			const unsigned int mapPartIDX = layer->etaPartitions()[iP]->id().roll() -1;
 			const GlobalPoint centralGP(layer->etaPartitions()[iP]->position());
-			tofs[mapLayIDX][mapPartIDX] = (centralGP.mag() / CLHEP::c_light/CLHEP::cm); //speed of light [cm/ns]
+			tofs[mapLayIDX][mapPartIDX] = (centralGP.mag() / (CLHEP::c_light/CLHEP::cm)); //speed of light [cm/ns]
 			LogDebug("ME0ReDigiProducer::fillCentralTOFs()") << "["<<mapLayIDX<<"]["<<mapPartIDX<<"]="<< tofs[mapLayIDX][mapPartIDX] <<" "<<std::endl;
 		}
 	}

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -136,7 +136,7 @@ TrapezoidalStripTopology * ME0ReDigiProducer::TemporaryGeometry::buildTopo(const
 ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps) :
 		bxWidth            (25.0),
 		useBuiltinGeo      (ps.getParameter<bool>("useBuiltinGeo")),
-		numberOfStrips      (ps.getParameter<unsigned int>("numberOfSrips")),
+		numberOfStrips      (ps.getParameter<unsigned int>("numberOfStrips")),
 		numberOfPartitions (ps.getParameter<unsigned int>("numberOfPartitions")),
 		neutronAcceptance  (ps.getParameter<double>("neutronAcceptance")),
 		timeResolution     (ps.getParameter<double>("timeResolution")),


### PR DESCRIPTION
We will not have the realistic digitizer in time for the Muon TDR samples, so we have decided to import the pseudo digitizer (replacing the old one) used for granularity studies. Please see for a presentation on its development:

https://indico.cern.ch/event/594656/contributions/2403265/attachments/1390281/2117550/nmccoll_12_16_16_ME0Newsigis.pdf#search=Mc%20Coll

While it is useful for granularity/neutron/# of layer studies, I added in a feature to simply use the granularity as defined by the geometry. This allows for the digitization, and merging, of hits as expected for the ME0 granularity. It also adds a new collection, which is simply a map of integers...pointing from input digi index to new digi index. Since we filter and merge inputs, it is a many to one map with empty entries.

(moved from: https://github.com/cms-sw/cmssw/pull/18112)