### PR TITLE
Fix circular dependency between FWCore/Framework and FWCore/ParameterSet

### DIFF
--- a/Alignment/CommonAlignment/plugins/APVModeFilter.cc
+++ b/Alignment/CommonAlignment/plugins/APVModeFilter.cc
@@ -44,6 +44,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLatency.h"

--- a/Alignment/CommonAlignment/plugins/FilterOutLowPt.cc
+++ b/Alignment/CommonAlignment/plugins/FilterOutLowPt.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"

--- a/Alignment/CommonAlignment/plugins/MagneticFieldFilter.cc
+++ b/Alignment/CommonAlignment/plugins/MagneticFieldFilter.cc
@@ -29,6 +29,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 #include "CondFormats/DataRecord/interface/RunSummaryRcd.h"

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
@@ -2,6 +2,7 @@
 //         Created:  Thu, 19 Mar 2015 18:12:35 GMT
 
 #include "Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/Common/interface/FileBlobCollection.h"

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.cc
@@ -2,6 +2,7 @@
 //         Created:  Mon, 23 Mar 2015 14:56:15 GMT
 
 #include "Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileExtractor.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include <zlib.h>
 

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -32,7 +32,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h" 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/Alignment/OfflineValidation/plugins/ValidationMisalignedTracker.cc
+++ b/Alignment/OfflineValidation/plugins/ValidationMisalignedTracker.cc
@@ -30,6 +30,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -30,6 +30,7 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.h
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.h
@@ -10,7 +10,7 @@
 #include <sstream>
 
 // core framework functionality
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CommonTools/Utils/plugins/CPUSpender.cc
+++ b/CommonTools/Utils/plugins/CPUSpender.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/DQM/CastorMonitor/interface/CastorLEDMonitor.h
+++ b/DQM/CastorMonitor/interface/CastorLEDMonitor.h
@@ -7,7 +7,7 @@
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbService.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
-
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 
 static const float LedMonAdc2fc[128]=
      { -0.5, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5,

--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
@@ -1,5 +1,6 @@
 #include "DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "DQMOffline/RecoB/interface/TagInfoPlotterFactory.h"
 
 using namespace reco;

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -27,6 +27,7 @@
 #include "TProfile.h"
 
 // user include files
+#include "FWCore/Framework/interface/OutputModule.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/Schedule.h"
 #include "FWCore/Framework/interface/ScheduleInfo.h"
 #include "FWCore/Framework/interface/SubProcess.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/src/Breakpoints.h"
 #include "FWCore/Framework/src/EPStates.h"
 #include "FWCore/Framework/src/EventSetupsController.h"

--- a/FWCore/Framework/test/stubs/TestFilterModule.cc
+++ b/FWCore/Framework/test/stubs/TestFilterModule.cc
@@ -2,6 +2,8 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
+#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -18,6 +18,8 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -18,6 +18,8 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -18,6 +18,8 @@ for testing purposes only.
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -12,6 +12,7 @@ Toy EDAnalyzers for testing purposes only.
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/FWCore/MessageService/test/UnitTestClient_S.cc
+++ b/FWCore/MessageService/test/UnitTestClient_S.cc
@@ -1,6 +1,7 @@
 #include "FWCore/MessageLogger/interface/LoggedErrorsSummary.h"
 #include "FWCore/MessageService/test/UnitTestClient_S.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
 
 #include <iostream>
 #include <string>

--- a/FWCore/MessageService/test/UnitTestClient_SLumi.cc
+++ b/FWCore/MessageService/test/UnitTestClient_SLumi.cc
@@ -1,6 +1,7 @@
 #include "FWCore/MessageLogger/interface/LoggedErrorsSummary.h"
 #include "FWCore/MessageService/test/UnitTestClient_SLumi.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
 
 #include <iostream>
 #include <string>

--- a/FWCore/MessageService/test/UnitTestClient_T.cc
+++ b/FWCore/MessageService/test/UnitTestClient_T.cc
@@ -1,6 +1,7 @@
 #include "FWCore/MessageService/test/UnitTestClient_T.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/Event.h"
 
 #include <iostream>
 #include <string>

--- a/FWCore/Modules/src/ModuloEventIDFilter.cc
+++ b/FWCore/Modules/src/ModuloEventIDFilter.cc
@@ -1,6 +1,7 @@
 
 #include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
@@ -28,21 +28,6 @@ method of the templated argument.  This allows the ParameterSetDescriptionFiller
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
-#include "FWCore/Framework/interface/OutputModule.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
-#include "FWCore/Framework/interface/one/EDFilter.h"
-#include "FWCore/Framework/interface/one/OutputModule.h"
-#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/stream/EDFilter.h"
-#include "FWCore/Framework/interface/global/EDAnalyzer.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
-#include "FWCore/Framework/interface/global/EDFilter.h"
-#include "FWCore/Framework/interface/global/OutputModule.h"
 
 namespace edm {
   template< typename T>
@@ -61,43 +46,14 @@ namespace edm {
     }
 
     virtual const std::string& extendedBaseType() const {
-      if (std::is_base_of<edm::EDAnalyzer, T>::value)
-        return kExtendedBaseForEDAnalyzer;
-      if (std::is_base_of<edm::EDProducer, T>::value)
-        return kExtendedBaseForEDProducer;
-      if (std::is_base_of<edm::EDFilter, T>::value)
-        return kExtendedBaseForEDFilter;
-      if (std::is_base_of<edm::OutputModule, T>::value)
-        return kExtendedBaseForOutputModule;
-      if (std::is_base_of<edm::one::EDAnalyzerBase, T>::value)
-        return kExtendedBaseForOneEDAnalyzer;
-      if (std::is_base_of<edm::one::EDProducerBase, T>::value)
-        return kExtendedBaseForOneEDProducer;
-      if (std::is_base_of<edm::one::EDFilterBase, T>::value)
-        return kExtendedBaseForOneEDFilter;
-      if (std::is_base_of<edm::one::OutputModuleBase, T>::value)
-        return kExtendedBaseForOneOutputModule;
-      if (std::is_base_of<edm::stream::EDAnalyzerBase, T>::value)
-        return kExtendedBaseForStreamEDAnalyzer;
-      if (std::is_base_of<edm::stream::EDProducerBase, T>::value)
-        return kExtendedBaseForStreamEDProducer;
-      if (std::is_base_of<edm::stream::EDFilterBase, T>::value)
-        return kExtendedBaseForStreamEDFilter;
-      if (std::is_base_of<edm::global::EDAnalyzerBase, T>::value)
-        return kExtendedBaseForGlobalEDAnalyzer;
-      if (std::is_base_of<edm::global::EDProducerBase, T>::value)
-        return kExtendedBaseForGlobalEDProducer;
-      if (std::is_base_of<edm::global::EDFilterBase, T>::value)
-        return kExtendedBaseForGlobalEDFilter;
-      if (std::is_base_of<edm::global::OutputModuleBase, T>::value)
-        return kExtendedBaseForGlobalOutputModule;
-
-      return kEmpty;
+      const T* type = nullptr;
+      return ParameterSetDescriptionFillerBase::extendedBaseType(type);
     }
 
   private:
     ParameterSetDescriptionFiller(const ParameterSetDescriptionFiller&); // stop default
     const ParameterSetDescriptionFiller& operator=(const ParameterSetDescriptionFiller&); // stop default
+    
   };
 
   // We need a special version of this class for Services because there is

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
@@ -30,6 +30,31 @@ and query the component for its allowed ParameterSetDescription.
 #include <string>
 
 namespace edm {
+   class EDProducer;
+   class EDFilter;
+   class EDAnalyzer;
+   class OutputModule;
+
+   namespace one {
+      class EDProducerBase;
+      class EDFilterBase;
+      class EDAnalyzerBase;
+      class OutputModuleBase;
+   }
+
+   namespace stream {
+    class EDProducerBase;
+    class EDFilterBase;
+    class EDAnalyzerBase;
+   }
+
+   namespace global {
+    class EDProducerBase;
+    class EDFilterBase;
+    class EDAnalyzerBase;
+    class OutputModuleBase;
+   }
+
 class ParameterSetDescriptionFillerBase
 {
 
@@ -46,27 +71,76 @@ class ParameterSetDescriptionFillerBase
 
       // ---------- member functions ---------------------------
 
-protected:
-     static const std::string kEmpty;
-     static const std::string kBaseForService;
-     static const std::string kBaseForESSource;
-     static const std::string kBaseForESProducer;
-     static const std::string kExtendedBaseForEDAnalyzer;
-     static const std::string kExtendedBaseForEDProducer;
-     static const std::string kExtendedBaseForEDFilter;
-     static const std::string kExtendedBaseForOutputModule;
-     static const std::string kExtendedBaseForOneEDAnalyzer;
-     static const std::string kExtendedBaseForOneEDProducer;
-     static const std::string kExtendedBaseForOneEDFilter;
-     static const std::string kExtendedBaseForOneOutputModule;
-     static const std::string kExtendedBaseForStreamEDAnalyzer;
-     static const std::string kExtendedBaseForStreamEDProducer;
-     static const std::string kExtendedBaseForStreamEDFilter;
-     static const std::string kExtendedBaseForGlobalEDAnalyzer;
-     static const std::string kExtendedBaseForGlobalEDProducer;
-     static const std::string kExtendedBaseForGlobalEDFilter;
-     static const std::string kExtendedBaseForGlobalOutputModule;
+   protected:
+      static const std::string kEmpty;
+      static const std::string kBaseForService;
+      static const std::string kBaseForESSource;
+      static const std::string kBaseForESProducer;
+      static const std::string kExtendedBaseForEDAnalyzer;
+      static const std::string kExtendedBaseForEDProducer;
+      static const std::string kExtendedBaseForEDFilter;
+      static const std::string kExtendedBaseForOutputModule;
+      static const std::string kExtendedBaseForOneEDAnalyzer;
+      static const std::string kExtendedBaseForOneEDProducer;
+      static const std::string kExtendedBaseForOneEDFilter;
+      static const std::string kExtendedBaseForOneOutputModule;
+      static const std::string kExtendedBaseForStreamEDAnalyzer;
+      static const std::string kExtendedBaseForStreamEDProducer;
+      static const std::string kExtendedBaseForStreamEDFilter;
+      static const std::string kExtendedBaseForGlobalEDAnalyzer;
+      static const std::string kExtendedBaseForGlobalEDProducer;
+      static const std::string kExtendedBaseForGlobalEDFilter;
+      static const std::string kExtendedBaseForGlobalOutputModule;
 
+      static const std::string& extendedBaseType(EDAnalyzer const*) {
+         return kExtendedBaseForEDAnalyzer;
+      }
+      static const std::string& extendedBaseType(EDProducer const*)  {
+       return kExtendedBaseForEDProducer;
+      }
+      static const std::string& extendedBaseType(EDFilter const*)  {
+         return kExtendedBaseForEDFilter;
+      }
+      static const std::string& extendedBaseType(OutputModule const*)  {
+         return kExtendedBaseForOutputModule;
+      }
+      static const std::string& extendedBaseType(one::EDAnalyzerBase const*)  {
+         return kExtendedBaseForOneEDAnalyzer;
+      }
+      static const std::string& extendedBaseType(one::EDProducerBase const*)  {
+         return kExtendedBaseForOneEDProducer;
+      }
+      static const std::string& extendedBaseType(one::EDFilterBase const*)  {
+         return kExtendedBaseForOneEDFilter;
+      }
+      static const std::string& extendedBaseType(one::OutputModuleBase const*)  {
+         return kExtendedBaseForOneOutputModule;
+      }
+      static const std::string& extendedBaseType(stream::EDAnalyzerBase const*) {
+         return kExtendedBaseForStreamEDAnalyzer;
+      }
+      static const std::string& extendedBaseType(stream::EDProducerBase const*) {
+         return kExtendedBaseForStreamEDProducer;
+      }
+      static const std::string& extendedBaseType(stream::EDFilterBase const*) {
+         return kExtendedBaseForStreamEDFilter;
+      }
+      static const std::string& extendedBaseType(global::EDAnalyzerBase const*) {
+         return kExtendedBaseForGlobalEDAnalyzer;
+      }
+      static const std::string& extendedBaseType(global::EDProducerBase const*) {
+         return kExtendedBaseForGlobalEDProducer;
+      }
+      static const std::string& extendedBaseType(global::EDFilterBase const*) {
+         return kExtendedBaseForGlobalEDFilter;
+      }
+      static const std::string& extendedBaseType(global::OutputModuleBase const*) {
+         return kExtendedBaseForGlobalOutputModule;
+      }
+      static const std::string& extendedBaseType(void const *) {
+         return kEmpty;
+      }
+  
    private:
       ParameterSetDescriptionFillerBase(const ParameterSetDescriptionFillerBase&); // stop default
 

--- a/FWCore/Services/plugins/ConcurrentModuleTimer.cc
+++ b/FWCore/Services/plugins/ConcurrentModuleTimer.cc
@@ -21,6 +21,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
 
 
 namespace edm {

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -5,6 +5,7 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/FastSimulation/CaloGeometryTools/test/testCaloGeometryTools.cc
+++ b/FastSimulation/CaloGeometryTools/test/testCaloGeometryTools.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/FastSimulation/CaloHitMakers/test/testEcalHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/test/testEcalHitMaker.cc
@@ -22,6 +22,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"

--- a/Geometry/CSCGeometry/test/stubs/CSCGACwithB.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGACwithB.cc
@@ -2,7 +2,7 @@
 // at centre of each CSC (Nikolai Terentiev needed the values for CSC gain studies.)
 // Tim Cox 11.03.2011 - drop ME1/A 
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/JetMETCorrections/Modules/plugins/METCorrectorDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/METCorrectorDBReader.cc
@@ -18,7 +18,7 @@
 // user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/JetMETCorrections/Modules/plugins/METCorrectorDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/METCorrectorDBWriter.cc
@@ -5,7 +5,7 @@
 #include <iostream>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiFEReproducer.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"

--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerDigiProducer.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigi.h"
 #include "DataFormats/L1THGCal/interface/HGCFETriggerDigiFwd.h"

--- a/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
+++ b/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/OnlineDB/SiStripO2O/plugins/SiStripPayloadMapTableCreator.cc
+++ b/OnlineDB/SiStripO2O/plugins/SiStripPayloadMapTableCreator.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
@@ -10,7 +10,7 @@
 */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
@@ -25,7 +25,7 @@
 #include <utility>//pair
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -10,7 +10,7 @@
  **
  ***/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/UETableProducer.cc
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -24,6 +24,7 @@
 // user include files
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/BTauReco/interface/CATopJetTagInfo.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripBaselineAnalyzer.cc
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/plugins/SiStripMeanCMExtractor.cc
@@ -32,7 +32,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
+++ b/RecoParticleFlow/PFSimProducer/plugins/PFSimParticleProducer.h
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauTransverseImpactParameters.cc
@@ -14,7 +14,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
+++ b/SimG4CMS/ShowerLibraryProducer/interface/HcalForwardLibWriter.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimMuon/CSCDigitizer/test/CSCNoiseMatrixTest.cc
+++ b/SimMuon/CSCDigitizer/test/CSCNoiseMatrixTest.cc
@@ -6,6 +6,7 @@
 #include "SimMuon/CSCDigitizer/src/CSCDbStripConditions.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.h
@@ -19,7 +19,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/SimTransport/HectorProducer/interface/HectorProducer.h
+++ b/SimTransport/HectorProducer/interface/HectorProducer.h
@@ -1,7 +1,7 @@
 #ifndef SimTransport_HectorProducer_H
 #define SimTransport_HectorProducer_H
  
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CaloCleaner.h
@@ -13,7 +13,7 @@
 #ifndef TauAnalysis_MCEmbeddingTools_CaloCleaner_H
 #define TauAnalysis_MCEmbeddingTools_CaloCleaner_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CollectionMerger.h
@@ -12,7 +12,7 @@
 #ifndef TauAnalysis_MCEmbeddingTools_CollectionMerger_H
 #define TauAnalysis_MCEmbeddingTools_CollectionMerger_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
@@ -28,9 +28,10 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuonDetCleaner.h
@@ -16,7 +16,7 @@
 #define TauAnalysis_MCEmbeddingTools_MuonDetCleaner_H
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackMergeremb.h
@@ -13,7 +13,7 @@
 #define TauAnalysis_MCEmbeddingTools_TrackMergeremb_H
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"

--- a/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/TrackerCleaner.h
@@ -13,7 +13,7 @@
 #ifndef TauAnalysis_MCEmbeddingTools_TrackerCleaner_H
 #define TauAnalysis_MCEmbeddingTools_TrackerCleaner_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"


### PR DESCRIPTION
Removed the unnecessary dependency of FWCore/ParameterSet on FWCore/Framework. No functionality was lost due to this change.