### PR TITLE
Fixes for ECAL O2O scripts

### DIFF
--- a/CondTools/Ecal/python/EcalDCS_popcon.py
+++ b/CondTools/Ecal/python/EcalDCS_popcon.py
@@ -16,7 +16,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.essource = cms.ESSource("PoolDBESSource",
                                 connect = cms.string( str(options.destinationDatabase) ),
                                 DumpStat=cms.untracked.bool(True),
-                                toGet = cms.VPSet( psetForRec )
+                                toGet = cms.VPSet( psetForRecord( recordName ) )
 )
 
 db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()

--- a/CondTools/Ecal/python/copyLin_cfg.py
+++ b/CondTools/Ecal/python/copyLin_cfg.py
@@ -4,7 +4,7 @@ import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-rocess.MessageLogger = cms.Service("MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')

--- a/CondTools/Ecal/python/copyPed_cfg.py
+++ b/CondTools/Ecal/python/copyPed_cfg.py
@@ -4,7 +4,7 @@ import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-rocess.MessageLogger = cms.Service("MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')

--- a/CondTools/Ecal/python/copyPhysConst_cfg.py
+++ b/CondTools/Ecal/python/copyPhysConst_cfg.py
@@ -4,7 +4,7 @@ import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-rocess.MessageLogger = cms.Service("MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')

--- a/CondTools/Ecal/python/copySli_cfg.py
+++ b/CondTools/Ecal/python/copySli_cfg.py
@@ -4,7 +4,7 @@ import CondTools.Ecal.db_credentials as auth
 
 process = cms.Process("ProcessOne")
 
-rocess.MessageLogger = cms.Service("MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')

--- a/CondTools/Ecal/python/updateADCToGeV_express.py
+++ b/CondTools/Ecal/python/updateADCToGeV_express.py
@@ -34,6 +34,8 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     ))
 )
 
+db_service,db_user,db_pwd = auth.get_readOnly_db_credentials()
+
 process.Test1 = cms.EDAnalyzer("ExTestEcalADCToGeVAnalyzer",
     record = cms.string('EcalADCToGeVConstantRcd'),
     loggingOn= cms.untracked.bool(True),


### PR DESCRIPTION
This PR fixes the following scripts:

- EcalDCS_popcon.py ( wrong input record list )
- copyLin_cfg.py, copyPed_cfg.py, copyPhysConst_cfg.py, copySli_cfg.py ( typos )
- updateADCToGev_express.py ( missing authentication command )