### PR TITLE
Fix for JPTFastjet correction chains

### DIFF
--- a/JetMETCorrections/Configuration/python/CorrectedJetProducers_cff.py
+++ b/JetMETCorrections/Configuration/python/CorrectedJetProducers_cff.py
@@ -22,7 +22,7 @@ ak4PFCHSJetsL1 = cms.EDProducer(
 ak4JPTJetsL1 = cms.EDProducer(
     'CorrectedJPTJetProducer',
     src        = cms.InputTag('JetPlusTrackZSPCorJetAntiKt4'),
-    correctors = cms.VInputTag('ak4JPTL1FastjetCorrector')
+    correctors = cms.VInputTag('ak4L1JPTFastjetCorrector')
     )
 ak4TrackJetsL1 = cms.EDProducer(
     'CorrectedTrackJetProducer',

--- a/JetMETCorrections/Configuration/python/JetCorrectionProducers_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectionProducers_cff.py
@@ -22,7 +22,7 @@ ak4PFCHSJetsL1 = cms.EDProducer(
 ak4JPTJetsL1 = cms.EDProducer(
     'JPTJetCorrectionProducer',
     src        = cms.InputTag('JetPlusTrackZSPCorJetAntiKt4'),
-    correctors = cms.vstring('L1Fastjet')
+    correctors = cms.vstring('ak4L1JPTFastjet')
     )
 ak4TrackJetsL1 = cms.EDProducer(
     'TrackJetCorrectionProducer',

--- a/JetMETCorrections/Configuration/python/JetCorrectionServicesAllAlgos_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectionServicesAllAlgos_cff.py
@@ -37,13 +37,27 @@ kt4PFL1Offset   = ak4PFL1Offset.clone(algorithm='KT4PF')
 kt6PFL1Offset   = ak4PFL1Offset.clone(algorithm='KT6PF')
 ic5PFL1Offset   = ak4PFL1Offset.clone(algorithm='IC5PF')
 
-ak7JPTL1Offset  = ak4CaloL1Offset.clone(algorithm='AK7JPT')
+ak7L1JPTOffset = cms.ESProducer(
+    'L1JPTOffsetCorrectionESProducer',
+    level = cms.string('L1JPTOffset'),
+    algorithm = cms.string('AK7JPT'),
+    offsetService = cms.string('ak7CaloL1Offset')
+    )
+
 
 # L1 (fastjet) Correction Services
 ak7CaloL1Fastjet = ak4CaloL1Fastjet.clone(algorithm = 'AK7Calo')
 kt4CaloL1Fastjet = ak4CaloL1Fastjet.clone(algorithm = 'KT4Calo')
 kt6CaloL1Fastjet = ak4CaloL1Fastjet.clone(algorithm = 'KT6Calo')
 ic5CaloL1Fastjet = ak4CaloL1Fastjet.clone(algorithm = 'IC5Calo')
+
+ak7L1JPTFastjet = cms.ESProducer(
+    'L1JPTOffsetCorrectionESProducer',
+    level = cms.string('L1JPTOffset'),
+    algorithm = cms.string('AK7JPT'),
+    offsetService = cms.string('ak7CaloL1Fastjet')
+    )
+
 
 ak1PFL1Fastjet   = ak4PFL1Fastjet.clone(algorithm='AK1PF')
 ak1PFCHSL1Fastjet   = ak4PFCHSL1Fastjet.clone(algorithm='AK1PFchs')
@@ -66,11 +80,6 @@ ak10PFCHSL1Fastjet   = ak4PFCHSL1Fastjet.clone(algorithm='AK10PFchs')
 kt4PFL1Fastjet   = ak4PFL1Fastjet.clone(algorithm='KT4PF')
 kt6PFL1Fastjet   = ak4PFL1Fastjet.clone(algorithm='KT6PF')
 ic5PFL1Fastjet   = ak4PFL1Fastjet.clone(algorithm='IC5PF')
-
-ak7JPTL1Fastjet  = ak4CaloL1Fastjet.clone(algorithm='AK7JPT')
-
-# SPECIAL L1JPTOffset
-ak7L1JPTOffset = ak4L1JPTOffset.clone(algorithm='AK7JPT')
 
 # L2 (relative eta-conformity) Correction Services
 ak7CaloL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK7Calo' )
@@ -365,7 +374,7 @@ ic5PFL1L2L3 = cms.ESProducer(
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak7JPTL1L2L3 = cms.ESProducer(
     'JetCorrectionESChain',
-    correctors = cms.vstring('ak7JPTL1Offset','ak7L1JPTOffset','ak7JPTL2Relative','ak7JPTL3Absolute')
+    correctors = cms.vstring('ak7L1JPTOffset','ak7JPTL2Relative','ak7JPTL3Absolute')
     )
 
 # L2L3Residual CORRECTION SERVICES
@@ -583,7 +592,7 @@ ic5PFL1L2L3Residual = cms.ESProducer(
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak7JPTL1L2L3Residual = cms.ESProducer(
     'JetCorrectionESChain',
-    correctors = cms.vstring('ak7JPTL1Offset','ak7L1JPTOffset','ak7JPTL2Relative','ak7JPTL3Absolute','ak7JPTResidual')
+    correctors = cms.vstring('ak7L1JPTOffset','ak7JPTL2Relative','ak7JPTL3Absolute','ak7JPTResidual')
     )
 
 # L1FastL2L3 CORRECTION SERVICES
@@ -609,6 +618,11 @@ ic5PFL1FastL2L3.correctors.insert(0,'ak4PFL1Fastjet')
 
 ak4TrackL1FastL2L3 = ak4TrackL2L3.clone()
 ak4TrackL1FastL2L3.correctors.insert(0,'ak4CaloL1Fastjet')
+
+ak7JPTL1FastL2L3 = cms.ESProducer(
+    'JetCorrectionESChain',
+    correctors = cms.vstring('ak7L1JPTFastjet','ak7JPTL2Relative','ak7JPTL3Absolute')
+    )
 
 # L1FastL2L3Residual CORRECTION SERVICES
 ak7CaloL1FastL2L3Residual = cms.ESProducer(
@@ -719,7 +733,7 @@ ic5PFL1FastL2L3Residual = cms.ESProducer(
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak7JPTL1FastL2L3Residual = cms.ESProducer(
     'JetCorrectionESChain',
-    correctors = cms.vstring('ak7JPTL1Fastjet','ak7L1JPTOffset','ak7JPTL2Relative','ak7JPTL3Absolute','ak7JPTResidual')
+    correctors = cms.vstring('ak7L1JPTFastjet','ak7JPTL2Relative','ak7JPTL3Absolute','ak7JPTResidual')
     )
 
 # L2L3L6 CORRECTION SERVICES

--- a/JetMETCorrections/Configuration/python/JetCorrectionServices_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectionServices_cff.py
@@ -22,7 +22,7 @@ import FWCore.ParameterSet.Config as cms
 ak4CaloL1Offset = cms.ESProducer(
     'L1OffsetCorrectionESProducer',
     level = cms.string('L1Offset'),
-    algorithm = cms.string('AK4Calo'),
+    algorithm = cms.string('AK5Calo'),
     vertexCollection = cms.string('offlinePrimaryVertices'),
     minVtxNdof = cms.int32(4)
     )
@@ -43,7 +43,7 @@ ak4L1JPTOffset = cms.ESProducer(
 ak4CaloL1Fastjet = cms.ESProducer(
     'L1FastjetCorrectionESProducer',
     level       = cms.string('L1FastJet'),
-    algorithm   = cms.string('AK4Calo'),
+    algorithm   = cms.string('AK5Calo'),
     srcRho      = cms.InputTag( 'fixedGridRhoFastjetAllCalo'  )
     )
 ak4PFL1Fastjet = cms.ESProducer(
@@ -71,7 +71,7 @@ ak4L1JPTFastjet = cms.ESProducer(
 ak4CaloL2Relative = cms.ESProducer(
     'LXXXCorrectionESProducer',
     level     = cms.string('L2Relative'),
-    algorithm = cms.string('AK4Calo')
+    algorithm = cms.string('AK5Calo')
     )
 ak4PFL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK4PF' )
 ak4PFCHSL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK4PFchs' )
@@ -82,7 +82,7 @@ ak4TrackL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK5TRK' )
 ak4CaloL3Absolute = cms.ESProducer(
     'LXXXCorrectionESProducer',
     level     = cms.string('L3Absolute'),
-    algorithm = cms.string('AK4Calo')
+    algorithm = cms.string('AK5Calo')
     )
 ak4PFL3Absolute     = ak4CaloL3Absolute.clone( algorithm = 'AK4PF' )
 ak4PFCHSL3Absolute     = ak4CaloL3Absolute.clone( algorithm = 'AK4PFchs' )
@@ -93,7 +93,7 @@ ak4TrackL3Absolute  = ak4CaloL3Absolute.clone( algorithm = 'AK5TRK' )
 ak4CaloResidual = cms.ESProducer(
     'LXXXCorrectionESProducer',
     level     = cms.string('L2L3Residual'),
-    algorithm = cms.string('AK4Calo')
+    algorithm = cms.string('AK5Calo')
     )
 ak4PFResidual  = ak4CaloResidual.clone( algorithm = 'AK4PF' )
 ak4PFCHSResidual  = ak4CaloResidual.clone( algorithm = 'AK4PFchs' )

--- a/JetMETCorrections/Configuration/python/JetCorrectionServices_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectionServices_cff.py
@@ -22,20 +22,20 @@ import FWCore.ParameterSet.Config as cms
 ak4CaloL1Offset = cms.ESProducer(
     'L1OffsetCorrectionESProducer',
     level = cms.string('L1Offset'),
-    algorithm = cms.string('AK5Calo'),
+    algorithm = cms.string('AK4Calo'),
     vertexCollection = cms.string('offlinePrimaryVertices'),
     minVtxNdof = cms.int32(4)
     )
 
 ak4PFL1Offset = ak4CaloL1Offset.clone(algorithm = 'AK4PF')
 ak4PFCHSL1Offset = ak4CaloL1Offset.clone(algorithm = 'AK4PFchs')
-ak4JPTL1Offset = ak4CaloL1Offset.clone(algorithm = 'AK5JPT')
+ak4JPTL1Offset = ak4CaloL1Offset.clone(algorithm = 'AK4JPT')
 
 # L1 (JPT Offset) Correction Service
 ak4L1JPTOffset = cms.ESProducer(
     'L1JPTOffsetCorrectionESProducer',
     level = cms.string('L1JPTOffset'),
-    algorithm = cms.string('AK5JPT'),
+    algorithm = cms.string('AK4JPT'),
     offsetService = cms.string('ak4CaloL1Offset')
     )
 
@@ -43,7 +43,7 @@ ak4L1JPTOffset = cms.ESProducer(
 ak4CaloL1Fastjet = cms.ESProducer(
     'L1FastjetCorrectionESProducer',
     level       = cms.string('L1FastJet'),
-    algorithm   = cms.string('AK5Calo'),
+    algorithm   = cms.string('AK4Calo'),
     srcRho      = cms.InputTag( 'fixedGridRhoFastjetAllCalo'  )
     )
 ak4PFL1Fastjet = cms.ESProducer(
@@ -58,39 +58,46 @@ ak4PFCHSL1Fastjet = cms.ESProducer(
     algorithm   = cms.string('AK4PFchs'),
     srcRho      = cms.InputTag( 'fixedGridRhoFastjetAll' )
     )
-ak4JPTL1Fastjet = ak4CaloL1Fastjet.clone()
+
+ak4L1JPTFastjet = cms.ESProducer(
+    'L1JPTOffsetCorrectionESProducer',
+    level = cms.string('L1JPTOffset'),
+    algorithm = cms.string('AK4JPT'),
+    offsetService = cms.string('ak4CaloL1Fastjet')
+    )
+
 
 # L2 (relative eta-conformity) Correction Services
 ak4CaloL2Relative = cms.ESProducer(
     'LXXXCorrectionESProducer',
     level     = cms.string('L2Relative'),
-    algorithm = cms.string('AK5Calo')
+    algorithm = cms.string('AK4Calo')
     )
 ak4PFL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK4PF' )
 ak4PFCHSL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK4PFchs' )
-ak4JPTL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK5JPT' )
+ak4JPTL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK4JPT' )
 ak4TrackL2Relative = ak4CaloL2Relative.clone( algorithm = 'AK5TRK' )
 
 # L3 (absolute) Correction Services
 ak4CaloL3Absolute = cms.ESProducer(
     'LXXXCorrectionESProducer',
     level     = cms.string('L3Absolute'),
-    algorithm = cms.string('AK5Calo')
+    algorithm = cms.string('AK4Calo')
     )
 ak4PFL3Absolute     = ak4CaloL3Absolute.clone( algorithm = 'AK4PF' )
 ak4PFCHSL3Absolute     = ak4CaloL3Absolute.clone( algorithm = 'AK4PFchs' )
-ak4JPTL3Absolute    = ak4CaloL3Absolute.clone( algorithm = 'AK5JPT' )
+ak4JPTL3Absolute    = ak4CaloL3Absolute.clone( algorithm = 'AK4JPT' )
 ak4TrackL3Absolute  = ak4CaloL3Absolute.clone( algorithm = 'AK5TRK' )
 
 # Residual Correction Services
 ak4CaloResidual = cms.ESProducer(
     'LXXXCorrectionESProducer',
     level     = cms.string('L2L3Residual'),
-    algorithm = cms.string('AK5Calo')
+    algorithm = cms.string('AK4Calo')
     )
 ak4PFResidual  = ak4CaloResidual.clone( algorithm = 'AK4PF' )
 ak4PFCHSResidual  = ak4CaloResidual.clone( algorithm = 'AK4PFchs' )
-ak4JPTResidual = ak4CaloResidual.clone( algorithm = 'AK5JPT' )
+ak4JPTResidual = ak4CaloResidual.clone( algorithm = 'AK4JPT' )
 
 # L6 (semileptonically decaying b-jet) Correction Services
 ak4CaloL6SLB = cms.ESProducer(
@@ -210,7 +217,7 @@ ak4PFCHSL1FastL2L3.correctors.insert(0,'ak4PFCHSL1Fastjet')
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak4JPTL1FastL2L3 = cms.ESProducer(
     'JetCorrectionESChain',
-    correctors = cms.vstring('ak4JPTL1Fastjet','ak4JPTL2Relative','ak4JPTL3Absolute')
+    correctors = cms.vstring('ak4L1JPTFastjet','ak4JPTL2Relative','ak4JPTL3Absolute')
     )
 
 # L1L2L3Residual CORRECTION SERVICES WITH FASTJET
@@ -230,7 +237,7 @@ ak4PFCHSL1FastL2L3Residual = cms.ESProducer(
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak4JPTL1FastL2L3Residual = cms.ESProducer(
     'JetCorrectionESChain',
-    correctors = cms.vstring('ak4JPTL1Fastjet','ak4JPTL2Relative','ak4JPTL3Absolute','ak4JPTResidual')
+    correctors = cms.vstring('ak4L1JPTFastjet','ak4JPTL2Relative','ak4JPTL3Absolute','ak4JPTResidual')
     )
 
 # L2L3L6 CORRECTION SERVICES

--- a/JetMETCorrections/Configuration/python/JetCorrectorsAllAlgos_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectorsAllAlgos_cff.py
@@ -37,8 +37,6 @@ kt4PFL1OffsetCorrector   = ak4PFL1OffsetCorrector.clone()
 kt6PFL1OffsetCorrector   = ak4PFL1OffsetCorrector.clone()
 ic5PFL1OffsetCorrector   = ak4PFL1OffsetCorrector.clone()
 
-ak7JPTL1OffsetCorrector  = ak4CaloL1OffsetCorrector.clone()
-
 # L1 (fastjet) Correctors
 ak7CaloL1FastjetCorrector = ak4CaloL1FastjetCorrector.clone()
 kt4CaloL1FastjetCorrector = ak4CaloL1FastjetCorrector.clone()
@@ -67,14 +65,19 @@ kt4PFL1FastjetCorrector   = ak4PFL1FastjetCorrector.clone()
 kt6PFL1FastjetCorrector   = ak4PFL1FastjetCorrector.clone()
 ic5PFL1FastjetCorrector   = ak4PFL1FastjetCorrector.clone()
 
-ak7JPTL1FastjetCorrector  = ak4JPTL1FastjetCorrector.clone()
-
 # SPECIAL L1JPTOffset
-ak7L1JPTOffsetCorrector = ak4L1JPTOffsetCorrector.clone( offsetService = 'ak7CaloL1OffsetCorrector' )
+ak7L1JPTOffsetCorrector = ak4L1JPTOffsetCorrector.clone( offsetService = 'ak7CaloL1OffsetCorrector', algorithm = 'AK7JPT' )
 ak7L1JPTOffsetCorrectorTask = cms.Task(
     ak7CaloL1OffsetCorrector, ak7L1JPTOffsetCorrector
 )
 ak7L1JPTOffsetCorrectorChain = cms.Sequence(ak7L1JPTOffsetCorrectorTask)
+
+ak7L1JPTFastjetCorrector = ak4L1JPTFastjetCorrector.clone( offsetService = 'ak7CaloL1FastjetCorrector', algorithm = 'AK7JPT' )
+ak7L1JPTFastjetCorrectorTask = cms.Task(
+    ak7CaloL1FastjetCorrector, ak7L1JPTFastjetCorrector
+)
+ak7L1JPTFastjetCorrectorChain = cms.Sequence(ak7L1JPTFastjetCorrectorTask)
+
 
 # L2 (relative eta-conformity) Correctors
 ak7CaloL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK7Calo' )
@@ -434,7 +437,7 @@ ic5PFL2L3CorrectorChain = cms.Sequence(ic5PFL2L3CorrectorTask)
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak7JPTL2L3Corrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak7L1JPTOffsetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector')
+    correctors = cms.VInputTag('ak7CaloL1OffsetCorrector','ak7L1JPTOffsetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector')
     )
 ak7JPTL2L3CorrectorTask = cms.Task(
     ak7L1JPTOffsetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTL2L3Corrector
@@ -511,10 +514,10 @@ ic5PFL1L2L3CorrectorChain = cms.Sequence(ic5PFL1L2L3CorrectorTask)
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak7JPTL1L2L3Corrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak7JPTL1OffsetCorrector','ak7L1JPTOffsetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector')
+    correctors = cms.VInputTag('ak7CaloL1OffsetCorrector','ak7L1JPTOffsetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector')
     )
 ak7JPTL1L2L3CorrectorTask = cms.Task(
-    ak7JPTL1OffsetCorrector, ak7L1JPTOffsetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTL1L2L3Corrector
+    ak7L1JPTOffsetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTL1L2L3Corrector
 )
 ak7JPTL1L2L3CorrectorChain = cms.Sequence(ak7JPTL1L2L3CorrectorTask)
 
@@ -933,10 +936,10 @@ ic5PFL1L2L3ResidualCorrectorChain = cms.Sequence(ic5PFL1L2L3ResidualCorrectorTas
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak7JPTL1L2L3ResidualCorrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak7JPTL1OffsetCorrector','ak7L1JPTOffsetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector','ak7JPTResidualCorrector')
+    correctors = cms.VInputTag('ak7CaloL1OffsetCorrector','ak7L1JPTOffsetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector','ak7JPTResidualCorrector')
     )
 ak7JPTL1L2L3ResidualCorrectorTask = cms.Task(
-    ak7JPTL1OffsetCorrector, ak7L1JPTOffsetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTResidualCorrector, ak7JPTL1L2L3ResidualCorrector
+    ak7L1JPTOffsetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTResidualCorrector, ak7JPTL1L2L3ResidualCorrector
 )
 ak7JPTL1L2L3ResidualCorrectorChain = cms.Sequence(ak7JPTL1L2L3ResidualCorrectorTask)
 
@@ -1003,6 +1006,15 @@ ak4TrackL1FastL2L3CorrectorTask = cms.Task(
     ak4CaloL1FastjetCorrector, ak4TrackL2RelativeCorrector, ak4TrackL3AbsoluteCorrector, ak4TrackL1FastL2L3Corrector
 )
 ak4TrackL1FastL2L3CorrectorChain = cms.Sequence(ak4TrackL1FastL2L3CorrectorTask)
+
+ak7JPTL1FastL2L3Corrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak7CaloL1FastjetCorrector','ak7L1JPTFastjetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector')
+    )
+ak7JPTL1FastL2L3CorrectorTask = cms.Task(
+    ak7L1JPTFastjetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTL1FastL2L3Corrector
+)
+ak7JPTL1FastL2L3CorrectorChain = cms.Sequence(ak7JPTL1FastL2L3CorrectorTask)
 
 # L1FastL2L3Residual CORRECTORS
 ak7CaloL1FastL2L3ResidualCorrector = cms.EDProducer(
@@ -1213,10 +1225,10 @@ ic5PFL1FastL2L3ResidualCorrectorChain = cms.Sequence(ic5PFL1FastL2L3ResidualCorr
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak7JPTL1FastL2L3ResidualCorrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak7JPTL1FastjetCorrector','ak7L1JPTOffsetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector','ak7JPTResidualCorrector')
+    correctors = cms.VInputTag('ak7CaloL1FastjetCorrector','ak7L1JPTFastjetCorrector','ak7JPTL2RelativeCorrector','ak7JPTL3AbsoluteCorrector','ak7JPTResidualCorrector')
     )
 ak7JPTL1FastL2L3ResidualCorrectorTask = cms.Task(
-    ak7JPTL1FastjetCorrector, ak7L1JPTOffsetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTResidualCorrector,  ak7JPTL1FastL2L3ResidualCorrector
+    ak7L1JPTFastjetCorrectorTask, ak7JPTL2RelativeCorrector, ak7JPTL3AbsoluteCorrector, ak7JPTResidualCorrector,  ak7JPTL1FastL2L3ResidualCorrector
 )
 ak7JPTL1FastL2L3ResidualCorrectorChain = cms.Sequence(ak7JPTL1FastL2L3ResidualCorrectorTask)
 
@@ -1412,6 +1424,7 @@ jetCorrectorsAllAlgosTask = cms.Task(
     kt6PFL1L2L3ResidualCorrectorTask,
     ic5PFL1L2L3ResidualCorrectorTask,
     ak7JPTL1L2L3ResidualCorrectorTask,
+    ak7L1JPTFastjetCorrectorTask,
     ak7CaloL1FastL2L3CorrectorTask,
     kt4CaloL1FastL2L3CorrectorTask,
     kt6CaloL1FastL2L3CorrectorTask,

--- a/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
@@ -8,7 +8,7 @@ import FWCore.ParameterSet.Config as cms
 ak4CaloL1OffsetCorrector = cms.EDProducer(
     'L1OffsetCorrectorProducer',
     level = cms.string('L1Offset'),
-    algorithm = cms.string('AK5Calo'),
+    algorithm = cms.string('AK4Calo'),
     vertexCollection = cms.InputTag('offlinePrimaryVertices'),
     minVtxNdof = cms.int32(4)
     )
@@ -21,7 +21,7 @@ ak4PFPuppiL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4PFP
 ak4L1JPTOffsetCorrector = cms.EDProducer(
     'L1JPTOffsetCorrectorProducer',
     level = cms.string('L1JPTOffset'),
-    algorithm = cms.string('AK5JPT'),
+    algorithm = cms.string('AK4JPT'),
     offsetService = cms.InputTag('ak4CaloL1OffsetCorrector')
     )
 ak4L1JPTOffsetCorrectorTask = cms.Task(
@@ -33,7 +33,7 @@ ak4L1JPTOffsetCorrectorChain = cms.Sequence(ak4L1JPTOffsetCorrectorTask)
 ak4CaloL1FastjetCorrector = cms.EDProducer(
     'L1FastjetCorrectorProducer',
     level       = cms.string('L1FastJet'),
-    algorithm   = cms.string('AK5Calo'),
+    algorithm   = cms.string('AK4Calo'),
     srcRho      = cms.InputTag( 'fixedGridRhoFastjetAllCalo'  )
     )
 ak4PFL1FastjetCorrector = cms.EDProducer(
@@ -52,7 +52,7 @@ ak4PFCHSL1FastjetCorrector = cms.EDProducer(
 ak4L1JPTFastjetCorrector = cms.EDProducer(
     'L1JPTOffsetCorrectorProducer',
     level = cms.string('L1JPTOffset'),
-    algorithm = cms.string('AK5JPT'),
+    algorithm = cms.string('AK4JPT'),
     offsetService = cms.InputTag('ak4CaloL1FastjetCorrector')
     )
 ak4L1JPTFastjetCorrectorTask = cms.Task(
@@ -71,7 +71,7 @@ ak4PFPuppiL1FastjetCorrector = cms.EDProducer(
 ak4CaloL2RelativeCorrector = cms.EDProducer(
     'LXXXCorrectorProducer',
     level     = cms.string('L2Relative'),
-    algorithm = cms.string('AK5Calo')
+    algorithm = cms.string('AK4Calo')
     )
 ak4PFL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4PF' )
 ak4PFCHSL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4PFchs' )
@@ -83,7 +83,7 @@ ak4PFPuppiL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'A
 ak4CaloL3AbsoluteCorrector = cms.EDProducer(
     'LXXXCorrectorProducer',
     level     = cms.string('L3Absolute'),
-    algorithm = cms.string('AK5Calo')
+    algorithm = cms.string('AK4Calo')
     )
 ak4PFL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4PF' )
 ak4PFCHSL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4PFchs' )
@@ -95,7 +95,7 @@ ak4PFPuppiL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm 
 ak4CaloResidualCorrector = cms.EDProducer(
     'LXXXCorrectorProducer',
     level     = cms.string('L2L3Residual'),
-    algorithm = cms.string('AK5Calo')
+    algorithm = cms.string('AK4Calo')
     )
 ak4PFResidualCorrector  = ak4CaloResidualCorrector.clone( algorithm = 'AK4PF' )
 ak4PFCHSResidualCorrector  = ak4CaloResidualCorrector.clone( algorithm = 'AK4PFchs' )

--- a/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
@@ -8,7 +8,7 @@ import FWCore.ParameterSet.Config as cms
 ak4CaloL1OffsetCorrector = cms.EDProducer(
     'L1OffsetCorrectorProducer',
     level = cms.string('L1Offset'),
-    algorithm = cms.string('AK4Calo'),
+    algorithm = cms.string('AK5Calo'),
     vertexCollection = cms.InputTag('offlinePrimaryVertices'),
     minVtxNdof = cms.int32(4)
     )
@@ -33,7 +33,7 @@ ak4L1JPTOffsetCorrectorChain = cms.Sequence(ak4L1JPTOffsetCorrectorTask)
 ak4CaloL1FastjetCorrector = cms.EDProducer(
     'L1FastjetCorrectorProducer',
     level       = cms.string('L1FastJet'),
-    algorithm   = cms.string('AK4Calo'),
+    algorithm   = cms.string('AK5Calo'),
     srcRho      = cms.InputTag( 'fixedGridRhoFastjetAllCalo'  )
     )
 ak4PFL1FastjetCorrector = cms.EDProducer(
@@ -71,7 +71,7 @@ ak4PFPuppiL1FastjetCorrector = cms.EDProducer(
 ak4CaloL2RelativeCorrector = cms.EDProducer(
     'LXXXCorrectorProducer',
     level     = cms.string('L2Relative'),
-    algorithm = cms.string('AK4Calo')
+    algorithm = cms.string('AK5Calo')
     )
 ak4PFL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4PF' )
 ak4PFCHSL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'AK4PFchs' )
@@ -83,7 +83,7 @@ ak4PFPuppiL2RelativeCorrector = ak4CaloL2RelativeCorrector.clone( algorithm = 'A
 ak4CaloL3AbsoluteCorrector = cms.EDProducer(
     'LXXXCorrectorProducer',
     level     = cms.string('L3Absolute'),
-    algorithm = cms.string('AK4Calo')
+    algorithm = cms.string('AK5Calo')
     )
 ak4PFL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4PF' )
 ak4PFCHSL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm = 'AK4PFchs' )
@@ -95,7 +95,7 @@ ak4PFPuppiL3AbsoluteCorrector     = ak4CaloL3AbsoluteCorrector.clone( algorithm 
 ak4CaloResidualCorrector = cms.EDProducer(
     'LXXXCorrectorProducer',
     level     = cms.string('L2L3Residual'),
-    algorithm = cms.string('AK4Calo')
+    algorithm = cms.string('AK5Calo')
     )
 ak4PFResidualCorrector  = ak4CaloResidualCorrector.clone( algorithm = 'AK4PF' )
 ak4PFCHSResidualCorrector  = ak4CaloResidualCorrector.clone( algorithm = 'AK4PFchs' )

--- a/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
+++ b/JetMETCorrections/Configuration/python/JetCorrectors_cff.py
@@ -15,7 +15,6 @@ ak4CaloL1OffsetCorrector = cms.EDProducer(
 
 ak4PFL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4PF')
 ak4PFCHSL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4PFchs')
-ak4JPTL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4JPT')
 ak4PFPuppiL1OffsetCorrector = ak4CaloL1OffsetCorrector.clone(algorithm = 'AK4PFPuppi')
 
 # L1 (JPT Offset) CORRECTOR
@@ -49,7 +48,18 @@ ak4PFCHSL1FastjetCorrector = cms.EDProducer(
     algorithm   = cms.string('AK4PFchs'),
     srcRho      = cms.InputTag( 'fixedGridRhoFastjetAll' )
     )
-ak4JPTL1FastjetCorrector = ak4CaloL1FastjetCorrector.clone()
+
+ak4L1JPTFastjetCorrector = cms.EDProducer(
+    'L1JPTOffsetCorrectorProducer',
+    level = cms.string('L1JPTOffset'),
+    algorithm = cms.string('AK5JPT'),
+    offsetService = cms.InputTag('ak4CaloL1FastjetCorrector')
+    )
+ak4L1JPTFastjetCorrectorTask = cms.Task(
+    ak4CaloL1FastjetCorrector, ak4L1JPTFastjetCorrector
+)
+ak4L1JPTFastjetCorrectorChain = cms.Sequence(ak4L1JPTFastjetCorrectorTask)
+
 ak4PFPuppiL1FastjetCorrector = cms.EDProducer(
     'L1FastjetCorrectorProducer',
     level       = cms.string('L1FastJet'),
@@ -144,7 +154,7 @@ ak4PFCHSL2L3CorrectorChain = cms.Sequence(ak4PFCHSL2L3CorrectorTask)
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak4JPTL2L3Corrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector')
+    correctors = cms.VInputTag('ak4CaloL1OffsetCorrector','ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector')
     )
 ak4JPTL2L3CorrectorTask = cms.Task(
     ak4L1JPTOffsetCorrectorTask, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTL2L3Corrector
@@ -196,7 +206,7 @@ ak4PFCHSL2L3ResidualCorrectorChain = cms.Sequence(ak4PFCHSL2L3ResidualCorrectorT
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak4JPTL2L3ResidualCorrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector','ak4JPTResidualCorrector')
+    correctors = cms.VInputTag('ak4CaloL1OffsetCorrector','ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector','ak4JPTResidualCorrector')
     )
 ak4JPTL2L3ResidualCorrectorTask = cms.Task(
     ak4L1JPTOffsetCorrectorTask, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTResidualCorrector, ak4JPTL2L3ResidualCorrector
@@ -240,7 +250,7 @@ ak4PFCHSL1L2L3CorrectorChain = cms.Sequence(ak4PFCHSL1L2L3CorrectorTask)
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak4JPTL1L2L3Corrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector')
+    correctors = cms.VInputTag('ak4CaloL1OffsetCorrector','ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector')
     )
 ak4JPTL1L2L3CorrectorTask = cms.Task(
     ak4L1JPTOffsetCorrectorTask, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTL1L2L3Corrector
@@ -284,7 +294,7 @@ ak4PFCHSL1L2L3ResidualCorrectorChain = cms.Sequence(ak4PFCHSL1L2L3ResidualCorrec
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak4JPTL1L2L3ResidualCorrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector','ak4JPTResidualCorrector')
+    correctors = cms.VInputTag('ak4CaloL1OffsetCorrector','ak4L1JPTOffsetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector','ak4JPTResidualCorrector')
     )
 ak4JPTL1L2L3ResidualCorrectorTask = cms.Task(
     ak4L1JPTOffsetCorrectorTask, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTResidualCorrector, ak4JPTL1L2L3ResidualCorrector
@@ -318,16 +328,20 @@ ak4PFCHSL1FastL2L3CorrectorTask = cms.Task(
     ak4PFCHSL1FastjetCorrector, ak4PFCHSL2RelativeCorrector, ak4PFCHSL3AbsoluteCorrector, ak4PFCHSL1FastL2L3Corrector
 )
 ak4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(ak4PFCHSL1FastL2L3CorrectorTask)
+
 #--- JPT needs the L1JPTOffset to account for the ZSP changes.
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
+
 ak4JPTL1FastL2L3Corrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak4JPTL1FastjetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector')
+    correctors = cms.VInputTag('ak4CaloL1FastjetCorrector','ak4L1JPTFastjetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector')
     )
 ak4JPTL1FastL2L3CorrectorTask = cms.Task(
-    ak4JPTL1FastjetCorrector, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTL1FastL2L3Corrector
+    ak4L1JPTFastjetCorrectorTask, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTL1FastL2L3Corrector
 )
+
 ak4JPTL1FastL2L3CorrectorChain = cms.Sequence(ak4JPTL1FastL2L3CorrectorTask)
+
 ak4PFPuppiL1FastL2L3Corrector = ak4PFPuppiL2L3Corrector.clone()
 ak4PFPuppiL1FastL2L3Corrector.correctors.insert(0,'ak4PFPuppiL1FastjetCorrector')
 ak4PFPuppiL1FastL2L3CorrectorTask = cms.Task(
@@ -364,10 +378,10 @@ ak4PFCHSL1FastL2L3ResidualCorrectorChain = cms.Sequence(ak4PFCHSL1FastL2L3Residu
 #--- L1JPTOffset is NOT the same as L1Offset !!!!!
 ak4JPTL1FastL2L3ResidualCorrector = cms.EDProducer(
     'ChainedJetCorrectorProducer',
-    correctors = cms.VInputTag('ak4JPTL1FastjetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector','ak4JPTResidualCorrector')
+    correctors = cms.VInputTag('ak4CaloL1FastjetCorrector','ak4L1JPTFastjetCorrector','ak4JPTL2RelativeCorrector','ak4JPTL3AbsoluteCorrector','ak4JPTResidualCorrector')
     )
 ak4JPTL1FastL2L3ResidualCorrectorTask = cms.Task(
-    ak4JPTL1FastjetCorrector, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTResidualCorrector, ak4JPTL1FastL2L3ResidualCorrector
+    ak4L1JPTFastjetCorrectorTask, ak4JPTL2RelativeCorrector, ak4JPTL3AbsoluteCorrector, ak4JPTResidualCorrector, ak4JPTL1FastL2L3ResidualCorrector
 )
 ak4JPTL1FastL2L3ResidualCorrectorChain = cms.Sequence(ak4JPTL1FastL2L3ResidualCorrectorTask)
 ak4PFPuppiL1FastL2L3ResidualCorrector = cms.EDProducer(
@@ -409,6 +423,7 @@ ak4PFL1FastL2L3L6CorrectorChain = cms.Sequence(ak4PFL1FastL2L3L6CorrectorTask)
 
 jetCorrectorsTask = cms.Task(
     ak4L1JPTOffsetCorrectorTask,
+    ak4L1JPTFastjetCorrectorTask,
     ak4CaloL2L3CorrectorTask,
     ak4PFL2L3CorrectorTask,
     ak4PFCHSL2L3CorrectorTask,
@@ -443,6 +458,5 @@ jetCorrectorsTask = cms.Task(
     ak4CaloL2L3L6CorrectorTask,
     ak4PFL2L3L6CorrectorTask,
     ak4CaloL1FastL2L3L6CorrectorTask,
-    ak4PFL1FastL2L3L6CorrectorTask,
-    ak4JPTL1OffsetCorrector
+    ak4PFL1FastL2L3L6CorrectorTask
 )


### PR DESCRIPTION
This request follows PR17900 for changes with Task
The reason of change is that JPTjets have the L1 corrections in two steps: firstly Calojets (part of JPTjet) are corrected for L1Offset or L1Fastjet and then corrections for zero suppression is done. Currently it is correctily implemented only for L1Offset. For chains that includes CaloL1Fastjet, zsp corrections are missed and this is 20% of jet energy scale.
Concerning rebase/update, I see that Configuration is completely changed. Thus, this is not a matter of rebase. I sent message to JetMET conveners and ask how to proceed.