### PR TITLE
bug fix : TriggerRatesMonitorClient

### DIFF
--- a/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitorClient.cc
@@ -92,7 +92,7 @@ void TriggerRatesMonitorClient::fillDescriptions(edm::ConfigurationDescriptions 
 
   edm::ParameterSetDescription desc;
   desc.addUntracked<std::string>("dqmPath","HLT/Datasets");
-  descriptions.add("dqmCorrelationClient", desc);
+  descriptions.add("triggerRatesMonitorClient", desc);
 
 }
 


### PR DESCRIPTION
as pointed out by @dmitrijus (thanks !)
there was a bug in a DQM client file,
which was preventing the HLT DQM application to run on p5