### PR TITLE
Fix 2 bugs related to Parentage and Streamer IO

### DIFF
--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -159,7 +159,7 @@ namespace edm {
     void putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) const;
+        ProductProvenance const* productProvenance) const;
 
     virtual WrapperBase const* getIt(ProductID const& pid) const override;
     virtual WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -176,10 +176,12 @@ namespace edm {
   EventPrincipal::putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) const {
+        ProductProvenance const* productProvenance) const {
 
     assert(!bd.produced());
-    productProvenanceRetrieverPtr()->insertIntoSet(productProvenance);
+    if (productProvenance) {
+      productProvenanceRetrieverPtr()->insertIntoSet(*productProvenance);
+    }
     auto phb = getExistingProduct(bd.branchID());
     assert(phb);
     // ProductResolver assumes ownership

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -45,6 +45,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_SeriesOfProcesses.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestParentageWithStreamerIO">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_ParentageWithStreamerIO.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="TestIntegration.cpp" name="TestIntegrationThinningTests">
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_ThinningTests.sh"/>
     <use   name="FWCore/Utilities"/>

--- a/FWCore/Integration/test/TestParentage.cc
+++ b/FWCore/Integration/test/TestParentage.cc
@@ -26,9 +26,11 @@ namespace {
                     edm::BranchID const& branchID,
                     std::set<edm::BranchID>& ancestors) {
     edm::Provenance prov = e.getProvenance(branchID);
-    for (auto const& parent : prov.productProvenance()->parentage().parents()) {
-      ancestors.insert(parent);
-      getAncestors(e, parent, ancestors);
+    if (prov.productProvenance()) {
+      for (auto const& parent : prov.productProvenance()->parentage().parents()) {
+        ancestors.insert(parent);
+        getAncestors(e, parent, ancestors);
+      }
     }
   }
 

--- a/FWCore/Integration/test/run_ParentageWithStreamerIO.sh
+++ b/FWCore/Integration/test/run_ParentageWithStreamerIO.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+test=testParentageWithStreamerIO
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  echo ${test}_1_cfg.py
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}_1_cfg.py || die "cmsRun ${test}_1_cfg.py" $?
+
+  echo ${test}_2_cfg.py
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}_2_cfg.py || die "cmsRun ${test}_2_cfg.py" $?
+
+  echo ${test}_3_cfg.py
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}_3_cfg.py || die "cmsRun ${test}_3_cfg.py" $?
+
+popd
+
+exit 0

--- a/FWCore/Integration/test/testParentageWithStreamerIO_1_cfg.py
+++ b/FWCore/Integration/test/testParentageWithStreamerIO_1_cfg.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST1")
+
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.prod1 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring()
+)
+
+process.prod2 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring("prod1")
+)
+
+process.test1 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod2"),
+    expectedAncestors = cms.vstring("prod1")
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testParentageWithStreamerIO1.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *'
+    ),
+    dropMetaData = cms.untracked.string('ALL')
+)
+
+process.path1 = cms.Path(process.prod1 + process.prod2 + process.test1)
+
+process.endpath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testParentageWithStreamerIO_2_cfg.py
+++ b/FWCore/Integration/test/testParentageWithStreamerIO_2_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testParentageWithStreamerIO1.root'
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.prod11 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring()
+)
+
+process.prod12 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring("prod11")
+)
+
+process.test1 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod2"),
+    expectedAncestors = cms.vstring()
+)
+
+process.test2 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod12"),
+    expectedAncestors = cms.vstring("prod11")
+)
+
+process.out = cms.OutputModule("EventStreamFileWriter",
+    fileName = cms.untracked.string('testParentageWithStreamerIO2.dat'),
+    compression_level = cms.untracked.int32(1),
+    use_compression = cms.untracked.bool(True),
+    max_event_size = cms.untracked.int32(7000000)
+)
+
+process.path1 = cms.Path(process.prod11 + process.prod12 + process.test1 + process.test2)
+
+process.endpath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testParentageWithStreamerIO_3_cfg.py
+++ b/FWCore/Integration/test/testParentageWithStreamerIO_3_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3")
+
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring('file:testParentageWithStreamerIO2.dat')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.test1 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod2"),
+    expectedAncestors = cms.vstring()
+)
+
+process.test2 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod12"),
+    expectedAncestors = cms.vstring("prod11")
+)
+
+process.path1 = cms.Path(process.test1 + process.test2)

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -315,16 +315,28 @@ namespace edm {
 
         BranchDescription const branchDesc(*spitem.desc());
         // This ProductProvenance constructor inserts into the entry description registry
-        ProductProvenance productProvenance(spitem.branchID(), *spitem.parents());
-
-        if(spitem.prod() != nullptr) {
-          FDEBUG(10) << "addproduct next " << spitem.branchID() << std::endl;
-          eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())), productProvenance);
-          FDEBUG(10) << "addproduct done" << std::endl;
-        } else {
-          FDEBUG(10) << "addproduct empty next " << spitem.branchID() << std::endl;
-          eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), productProvenance);
-          FDEBUG(10) << "addproduct empty done" << std::endl;
+        if (spitem.parents()) {
+          ProductProvenance productProvenance(spitem.branchID(), *spitem.parents());
+          if(spitem.prod() != nullptr) {
+            FDEBUG(10) << "addproduct next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())), &productProvenance);
+            FDEBUG(10) << "addproduct done" << std::endl;
+          } else {
+            FDEBUG(10) << "addproduct empty next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), &productProvenance);
+            FDEBUG(10) << "addproduct empty done" << std::endl;
+          }
+	} else {
+          ProductProvenance const* productProvenance = nullptr;
+          if(spitem.prod() != nullptr) {
+            FDEBUG(10) << "addproduct next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())), productProvenance);
+            FDEBUG(10) << "addproduct done" << std::endl;
+          } else {
+            FDEBUG(10) << "addproduct empty next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), productProvenance);
+            FDEBUG(10) << "addproduct empty done" << std::endl;
+          }
         }
         spitem.clear();
     }


### PR DESCRIPTION
1 bug will cause a seg fault if Parentage has been
dropped or is missing for a product. In the most
common use case for Streamer IO this never happens.
It could happen when there are a series of processes
and streamer output is used not on the first process
but some later one.

The second bug causes the Parentage information
output by the streamer output module to be incorrect.

Added a new unit test for Parentage in Streamer IO.