### PR TITLE
Disable Xrootd's read recovery mechanism.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -151,6 +151,7 @@ RequestManager::initialize(std::weak_ptr<RequestManager> self)
   for (int idx=0; idx<retries; idx++)
   {
     file.reset(new XrdCl::File());
+    file->SetProperty("ReadRecovery", "false");
     auto opaque = prepareOpaqueString();
     std::string new_filename = m_name + (opaque.size() ? ((m_name.find("?") == m_name.npos) ? "?" : "&") + opaque : "");
     SyncHostResponseHandler handler;
@@ -1187,6 +1188,7 @@ XrdAdaptor::RequestManager::OpenHandler::open()
     std::string new_name = manager.m_name + ((manager.m_name.find("?") == manager.m_name.npos) ? "?" : "&") + opaque;
     edm::LogVerbatim("XrdAdaptorInternal") << "Trying to open URL: " << new_name;
     m_file.reset(new XrdCl::File());
+    m_file->SetProperty("ReadRecovery", "false");
     m_outstanding_open = true;
 
     // Always make sure we release m_file and set m_outstanding_open to false on error.


### PR DESCRIPTION
CMSSW and Xrootd both implement a retry mechanism, one on top of the other.  We are getting reports from the IBs that Xrootd's retry mechanism is possibly causing the file-close callbacks to be invoked twice (and the second time it is done against a deleted object, causing a `SIGSEGV`).  This work attempts to see if the problem can be avoided by relying solely on CMSSW's recovery mechanisms.