### PR TITLE
Backport to 9_0_X, Fix 2 bugs related to Parentage and Streamer IO

### DIFF
--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -158,7 +158,7 @@ namespace edm {
     void putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) const;
+        ProductProvenance const* productProvenance) const;
 
     virtual WrapperBase const* getIt(ProductID const& pid) const override;
     virtual WrapperBase const* getThinnedProduct(ProductID const& pid, unsigned int& key) const override;

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -171,10 +171,12 @@ namespace edm {
   EventPrincipal::putOnRead(
         BranchDescription const& bd,
         std::unique_ptr<WrapperBase> edp,
-        ProductProvenance const& productProvenance) const {
+        ProductProvenance const* productProvenance) const {
 
     assert(!bd.produced());
-    productProvenanceRetrieverPtr()->insertIntoSet(productProvenance);
+    if (productProvenance) {
+      productProvenanceRetrieverPtr()->insertIntoSet(*productProvenance);
+    }
     auto phb = getExistingProduct(bd.branchID());
     assert(phb);
     // ProductResolver assumes ownership

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -45,6 +45,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_SeriesOfProcesses.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestParentageWithStreamerIO">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_ParentageWithStreamerIO.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="TestIntegration.cpp" name="TestIntegrationThinningTests">
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_ThinningTests.sh"/>
     <use   name="FWCore/Utilities"/>
@@ -188,7 +192,7 @@
     <use   name="FWCore/Framework"/>
     <use   name="FWCore/MessageLogger"/>
   </library>
-  <library   file="TestFindProduct.cc,ManyProductProducer.cc" name="FWCoreIntegrationTestFindProduct">
+  <library   file="TestFindProduct.cc,ManyProductProducer.cc,TestParentage.cc" name="FWCoreIntegrationTestFindProduct">
     <flags   EDM_PLUGIN="1"/>
     <use   name="FWCore/Framework"/>
     <use   name="FWCore/ParameterSet"/>

--- a/FWCore/Integration/test/TestParentage.cc
+++ b/FWCore/Integration/test/TestParentage.cc
@@ -1,0 +1,134 @@
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/Parentage.h"
+#include "DataFormats/Provenance/interface/ProductProvenance.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
+#include "DataFormats/Provenance/interface/Provenance.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/ConstProductRegistry.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+  void getAncestors(edm::Event const& e,
+                    edm::BranchID const& branchID,
+                    std::set<edm::BranchID>& ancestors) {
+    edm::Provenance prov = e.getProvenance(branchID);
+    if (prov.productProvenance()) {
+      for (auto const& parent : prov.productProvenance()->parentage().parents()) {
+        ancestors.insert(parent);
+        getAncestors(e, parent, ancestors);
+      }
+    }
+  }
+
+  // Does the same thing as the previous function in a different
+  // way. The previous function goes through the links in the
+  // ProductsResolver which for SubProcesses could lead to a different
+  // retriever. In SubProcesses, the following function follows the
+  // links in the retrievers themselves. Both should give the same answer.
+  void getAncestorsFromRetriever(edm::ProductProvenanceRetriever const* retriever,
+                                 edm::BranchID const& branchID,
+                                 std::set<edm::BranchID>& ancestors) {
+    edm::ProductProvenance const* productProvenance = retriever->branchIDToProvenance(branchID);
+    if (productProvenance) {
+      for (auto const& parent : productProvenance->parentage().parents()) {
+        ancestors.insert(parent);
+        getAncestorsFromRetriever(retriever, parent, ancestors);
+      }
+    }
+  }
+}
+
+namespace edmtest {
+
+  class TestParentage : public edm::EDAnalyzer { 
+  public:
+
+    explicit TestParentage(edm::ParameterSet const& pset);
+    virtual ~TestParentage();
+
+    virtual void analyze(edm::Event const& e, edm::EventSetup const& es) override;
+
+  private:
+
+    edm::InputTag inputTag_;
+    edm::EDGetTokenT<IntProduct> token_;
+    std::vector<std::string> expectedAncestors_;
+    bool callGetProvenance_;
+  };
+
+  TestParentage::TestParentage(edm::ParameterSet const& pset) :
+    inputTag_(pset.getParameter<edm::InputTag>("inputTag")),
+    expectedAncestors_(pset.getParameter<std::vector<std::string> >("expectedAncestors")),
+    callGetProvenance_(pset.getUntrackedParameter<bool>("callGetProvenance", true)) {
+
+    token_ = consumes<IntProduct>(inputTag_);
+  }
+
+  TestParentage::~TestParentage() {}
+
+  void
+  TestParentage::analyze(edm::Event const& e, edm::EventSetup const&) {
+
+    edm::Handle<IntProduct> h;
+    e.getByToken(token_, h);
+
+    edm::Provenance const* prov = h.provenance();
+
+    std::set<std::string> expectedAncestors(expectedAncestors_.begin(), expectedAncestors_.end());
+
+    std::map<edm::BranchID, std::string> branchIDToLabel;
+    edm::Service<edm::ConstProductRegistry> reg;
+    for(auto const& prod : reg->productList()) {
+      branchIDToLabel[prod.second.branchID()] = prod.second.moduleLabel();
+    }
+
+    // Currently we need to turn off this part of the test of when calling
+    // from a SubProcess and the parentage includes a product not kept
+    // in the SubProcess. This might get fixed someday ...
+    if (callGetProvenance_) {
+
+      std::set<edm::BranchID> ancestors;
+      getAncestors(e, prov->branchID(), ancestors);
+
+
+      std::set<std::string> ancestorLabels;
+      for (edm::BranchID const& ancestor : ancestors) {
+        ancestorLabels.insert(branchIDToLabel[ancestor]);
+      }
+      if (ancestorLabels != expectedAncestors) {
+        std::cerr << "TestParentage::analyze: ancestors do not match expected ancestors" << std::endl;
+        abort();
+      }
+    }
+
+    edm::ProductProvenanceRetriever const* retriever = prov->store();
+    std::set<edm::BranchID> ancestorsFromRetriever;
+    getAncestorsFromRetriever(retriever, prov->branchDescription().originalBranchID(), ancestorsFromRetriever);
+
+    std::set<std::string> ancestorLabels2;
+    for (edm::BranchID const& ancestor : ancestorsFromRetriever) {
+      ancestorLabels2.insert(branchIDToLabel[ancestor]);
+    }
+    if (ancestorLabels2 != expectedAncestors) {
+      std::cerr << "TestParentage::analyze: ancestors do not match expected ancestors (parentage from retriever)" << std::endl;
+      abort();
+    }
+  }
+} // namespace edmtest
+
+using edmtest::TestParentage;
+DEFINE_FWK_MODULE(TestParentage);

--- a/FWCore/Integration/test/run_ParentageWithStreamerIO.sh
+++ b/FWCore/Integration/test/run_ParentageWithStreamerIO.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+test=testParentageWithStreamerIO
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  echo ${test}_1_cfg.py
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}_1_cfg.py || die "cmsRun ${test}_1_cfg.py" $?
+
+  echo ${test}_2_cfg.py
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}_2_cfg.py || die "cmsRun ${test}_2_cfg.py" $?
+
+  echo ${test}_3_cfg.py
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}_3_cfg.py || die "cmsRun ${test}_3_cfg.py" $?
+
+popd
+
+exit 0

--- a/FWCore/Integration/test/testParentageWithStreamerIO_1_cfg.py
+++ b/FWCore/Integration/test/testParentageWithStreamerIO_1_cfg.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST1")
+
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.prod1 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring()
+)
+
+process.prod2 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring("prod1")
+)
+
+process.test1 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod2"),
+    expectedAncestors = cms.vstring("prod1")
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testParentageWithStreamerIO1.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *'
+    ),
+    dropMetaData = cms.untracked.string('ALL')
+)
+
+process.path1 = cms.Path(process.prod1 + process.prod2 + process.test1)
+
+process.endpath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testParentageWithStreamerIO_2_cfg.py
+++ b/FWCore/Integration/test/testParentageWithStreamerIO_2_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST2")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testParentageWithStreamerIO1.root'
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.prod11 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring()
+)
+
+process.prod12 = cms.EDProducer("AddIntsProducer",
+    labels = cms.vstring("prod11")
+)
+
+process.test1 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod2"),
+    expectedAncestors = cms.vstring()
+)
+
+process.test2 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod12"),
+    expectedAncestors = cms.vstring("prod11")
+)
+
+process.out = cms.OutputModule("EventStreamFileWriter",
+    fileName = cms.untracked.string('testParentageWithStreamerIO2.dat'),
+    compression_level = cms.untracked.int32(1),
+    use_compression = cms.untracked.bool(True),
+    max_event_size = cms.untracked.int32(7000000)
+)
+
+process.path1 = cms.Path(process.prod11 + process.prod12 + process.test1 + process.test2)
+
+process.endpath = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testParentageWithStreamerIO_3_cfg.py
+++ b/FWCore/Integration/test/testParentageWithStreamerIO_3_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST3")
+
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring('file:testParentageWithStreamerIO2.dat')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.test1 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod2"),
+    expectedAncestors = cms.vstring()
+)
+
+process.test2 = cms.EDAnalyzer("TestParentage",
+    inputTag = cms.InputTag("prod12"),
+    expectedAncestors = cms.vstring("prod11")
+)
+
+process.path1 = cms.Path(process.test1 + process.test2)

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -315,16 +315,28 @@ namespace edm {
 
         BranchDescription const branchDesc(*spitem.desc());
         // This ProductProvenance constructor inserts into the entry description registry
-        ProductProvenance productProvenance(spitem.branchID(), *spitem.parents());
-
-        if(spitem.prod() != nullptr) {
-          FDEBUG(10) << "addproduct next " << spitem.branchID() << std::endl;
-          eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())), productProvenance);
-          FDEBUG(10) << "addproduct done" << std::endl;
-        } else {
-          FDEBUG(10) << "addproduct empty next " << spitem.branchID() << std::endl;
-          eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), productProvenance);
-          FDEBUG(10) << "addproduct empty done" << std::endl;
+        if (spitem.parents()) {
+          ProductProvenance productProvenance(spitem.branchID(), *spitem.parents());
+          if(spitem.prod() != nullptr) {
+            FDEBUG(10) << "addproduct next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())), &productProvenance);
+            FDEBUG(10) << "addproduct done" << std::endl;
+          } else {
+            FDEBUG(10) << "addproduct empty next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), &productProvenance);
+            FDEBUG(10) << "addproduct empty done" << std::endl;
+          }
+	} else {
+          ProductProvenance const* productProvenance = nullptr;
+          if(spitem.prod() != nullptr) {
+            FDEBUG(10) << "addproduct next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(const_cast<WrapperBase*>(spitem.prod())), productProvenance);
+            FDEBUG(10) << "addproduct done" << std::endl;
+          } else {
+            FDEBUG(10) << "addproduct empty next " << spitem.branchID() << std::endl;
+            eventPrincipal.putOnRead(branchDesc, std::unique_ptr<WrapperBase>(), productProvenance);
+            FDEBUG(10) << "addproduct empty done" << std::endl;
+          }
         }
         spitem.clear();
     }


### PR DESCRIPTION
1 bug will cause a seg fault if Parentage has been
dropped or is missing for a product. In the most
common use case for Streamer IO this never happens.
It could happen when there are a series of processes
and streamer output is used not on the first process
but some later one.

The second bug causes the Parentage information
output by the streamer output module to be incorrect.

Added a new unit test for Parentage in Streamer IO.