### PR TITLE
fix include for edm::one::EDAnalyzer as a result of #18117

### DIFF
--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -1,7 +1,7 @@
 #include <string>
 #include <iostream>
 #include <map>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"


### PR DESCRIPTION
Should fix the broken IBs (see e.g. https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc530/CMSSW_9_1_X_2017-03-30-2300/CondFormats/PCLConfig) 
@smuzaffar @davidlange6 apologies, noticed the fwk cleanup too late