### PR TITLE
Excluding QTest and summary by the timing client

### DIFF
--- a/DQM/Integration/python/clients/pixel_timingScan_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_timingScan_dqm_sourceclient-live_cfg.py
@@ -180,7 +180,7 @@ process.p = cms.Path(
 # *process.SiPixelClusterSource
 # *process.PixelP5DQMClientWithDataCertification
  *process.siPixelPhase1OnlineDQM_source
- *process.siPixelPhase1OnlineDQM_harvesting
+ *process.siPixelPhase1OnlineDQM_timing_harvesting
 )
     
 ### process customizations included here

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -110,3 +110,8 @@ siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
  + SiPixelPhase1Summary_Online
 # + SiPixelPhase1GeometryDebugHarvester
 )
+
+siPixelPhase1OnlineDQM_timing_harvesting = siPixelPhase1OnlineDQM_harvesting.copyAndExclude([
+ RunQTests_online,
+ SiPixelPhase1Summary_Online,
+])


### PR DESCRIPTION
change the timing client config to avoid QTests and Summary production (completely unuseful for the purpose of pixel timing)