### PR TITLE
add ecal digi SR flags to FEVT and RECO

### DIFF
--- a/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
@@ -14,7 +14,9 @@ RecoHiEgammaFEVT = cms.PSet(
     'keep recoPhotons_gedPhotonsTmp_*_*',
     'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*',
     'keep recoElectronSeeds_ecalDrivenElectronSeeds_*_*',
-    'keep recoTrackExtras_electronGsfTracks_*_*'
+    'keep recoTrackExtras_electronGsfTracks_*_*',
+    'keep EBSrFlagsSorted_ecalDigis__*',
+    'keep EESrFlagsSorted_ecalDigis__*'
     )
     )
 
@@ -54,6 +56,8 @@ RecoHiEgammaRECO = cms.PSet(
     #'keep EcalRecHitsSorted_*_*_*',
     'keep EcalRecHitsSorted_ecalRecHit_*_*',
     'keep EcalRecHitsSorted_ecalPreshowerRecHit_*_*',
+    'keep EBSrFlagsSorted_ecalDigis__*',
+    'keep EESrFlagsSorted_ecalDigis__*'
     #'keep floatedmValueMap_*_*_*',  # isolation not created yet in RECO step, but in case it is later
     'keep floatedmValueMap_hiDetachedTripletStepQual_MVAVals_*',        
     'keep floatedmValueMap_hiDetachedTripletStepSelector_MVAVals_*',    

--- a/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
@@ -57,7 +57,7 @@ RecoHiEgammaRECO = cms.PSet(
     'keep EcalRecHitsSorted_ecalRecHit_*_*',
     'keep EcalRecHitsSorted_ecalPreshowerRecHit_*_*',
     'keep EBSrFlagsSorted_ecalDigis__*',
-    'keep EESrFlagsSorted_ecalDigis__*'
+    'keep EESrFlagsSorted_ecalDigis__*',
     #'keep floatedmValueMap_*_*_*',  # isolation not created yet in RECO step, but in case it is later
     'keep floatedmValueMap_hiDetachedTripletStepQual_MVAVals_*',        
     'keep floatedmValueMap_hiDetachedTripletStepSelector_MVAVals_*',    

--- a/RecoLocalCalo/Configuration/python/ecalLocalReco_EventContentCosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalReco_EventContentCosmics_cff.py
@@ -9,7 +9,9 @@ ecalLocalRecoFEVT = cms.PSet(
         'keep *_ecalFixedAlphaBetaFitUncalibRecHit_*_*', 
         'keep *_ecalPreshowerRecHit_*_*', 
         'keep *_ecalRecHit_*_*',
-        'keep ESDataFramesSorted_ecalPreshowerDigis_*_*'
+        'keep ESDataFramesSorted_ecalPreshowerDigis_*_*',
+        'keep EBSrFlagsSorted_ecalDigis__*',
+        'keep EESrFlagsSorted_ecalDigis__*'
         )
 )
 # RECO content
@@ -19,7 +21,9 @@ ecalLocalRecoRECO = cms.PSet(
         'keep *_ecalPreshowerRecHit_*_*', 
         'keep *_ecalRecHit_*_*',
         'keep *_ecalCompactTrigPrim_*_*',
-        'keep ESDataFramesSorted_ecalPreshowerDigis_*_*'
+        'keep ESDataFramesSorted_ecalPreshowerDigis_*_*',
+        'keep EBSrFlagsSorted_ecalDigis__*',
+        'keep EESrFlagsSorted_ecalDigis__*'
         )
 )
 # AOD content

--- a/RecoLocalCalo/Configuration/python/ecalLocalReco_EventContent_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalReco_EventContent_cff.py
@@ -13,7 +13,10 @@ ecalLocalRecoFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_ecalMultiFitUncalibRecHit_*_*', 
         'keep *_ecalPreshowerRecHit_*_*', 
-        'keep *_ecalRecHit_*_*')
+        'keep *_ecalRecHit_*_*',
+        'keep EBSrFlagsSorted_ecalDigis__*',
+        'keep EESrFlagsSorted_ecalDigis__*'
+        )
 )
 #RECO content
 ecalLocalRecoRECO = cms.PSet(
@@ -21,7 +24,9 @@ ecalLocalRecoRECO = cms.PSet(
         'keep *_ecalPreshowerRecHit_*_*', 
         'keep *_ecalRecHit_*_*',
         'keep *_ecalCompactTrigPrim_*_*',
-        'keep *_ecalTPSkim_*_*'
+        'keep *_ecalTPSkim_*_*',
+        'keep EBSrFlagsSorted_ecalDigis__*',
+        'keep EESrFlagsSorted_ecalDigis__*'
         )
 )
 #AOD content


### PR DESCRIPTION
ecal digi SR flags are needed for PF and can be useful for other studies.

This fixes a problem in RECOfromRECO workflows (or other places rerunning PF from reco) after merging #17794.

