### PR TITLE
add muon track validation @HLT

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -17,6 +17,7 @@ from Validation.RecoVertex.HLTpostProcessorVertex_cfi import *
 from HLTriggerOffline.Common.HLTValidationQT_cff import *
 from HLTriggerOffline.Btag.HltBtagPostValidation_cff import *
 from HLTriggerOffline.Egamma.HLTpostProcessorGsfTracker_cfi import *
+from HLTriggerOffline.Muon.HLTpostProcessorMuonTrack_cfi import *
 
 hltpostvalidation = cms.Sequence( 
     postProcessorHLTtrackingSequence
@@ -25,6 +26,7 @@ hltpostvalidation = cms.Sequence(
     +HLTTauPostVal
     +EgammaPostVal
     + postProcessorHLTgsfTrackingSequence
+    + postProcessorHLTmuonTrackingSequence
     +topHLTriggerValidationHarvest
     +heavyFlavorValidationHarvestingSequence
     +JetMETPostVal
@@ -46,6 +48,7 @@ if fastSim.isChosen():
     hltpostvalidation.remove(postProcessorHLTtrackingSequence)
     hltpostvalidation.remove(postProcessorHLTvertexing)
     hltpostvalidation.remove(postProcessorHLTgsfTrackingSequence)
+    hltpostvalidation.remove(postProcessorHLTmuonTrackingSequence)
     # remove this:     +hltvalidationqt ?
     # remove this:    +hltExoticaPostProcessors ?
     
@@ -56,6 +59,7 @@ hltpostvalidation_preprod = cms.Sequence(
     +heavyFlavorValidationHarvestingSequence
     +SusyExoPostVal
     + postProcessorHLTgsfTrackingSequence
+    + postProcessorHLTmuonTrackingSequence
    #+HLTHiggsPostVal
     )
 
@@ -63,4 +67,5 @@ hltpostvalidation_prod = cms.Sequence(
     postProcessorHLTtrackingSequence
     +postProcessorHLTvertexing
     + postProcessorHLTgsfTrackingSequence
+    + postProcessorHLTmuonTrackingSequence
     )

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -15,6 +15,7 @@ from HLTriggerOffline.Exotica.ExoticaValidation_cff import *
 from HLTriggerOffline.SMP.SMPValidation_cff import *
 from HLTriggerOffline.Btag.HltBtagValidation_cff import *
 from HLTriggerOffline.Egamma.HLTmultiTrackValidatorGsfTracks_cff import *
+from HLTriggerOffline.Muon.HLTmultiTrackValidatorMuonTracks_cff import *
 
 # offline dqm:
 # from DQMOffline.Trigger.DQMOffline_Trigger_cff.py import *
@@ -33,6 +34,7 @@ hltassociation = cms.Sequence(
     +egammaSelectors
     +ExoticaValidationProdSeq
     +hltMultiTrackValidationGsfTracks
+    +hltMultiTrackValidationMuonTracks
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
@@ -60,6 +62,7 @@ if fastSim.isChosen():
     hltassociation.remove(hltMultiTrackValidation)
     hltassociation.remove(hltMultiPVValidation)
     hltassociation.remove(hltMultiTrackValidationGsfTracks)
+    hltassociation.remove(hltMultiTrackValidationMuonTracks)
 
 hltvalidation_preprod = cms.Sequence(
   HLTTauVal

--- a/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
+++ b/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoTrack.HLTmultiTrackValidator_cfi import *
+hltMuonTrackValidator = hltMultiTrackValidator.clone(
+    label = [
+        "hltIter0HighPtTkMuMerged2016Tk",
+    ],
+    label_tp_effic           = "trackingParticlesMuon",
+    label_tp_effic_refvector = True,
+    dirName                  = 'HLT/EG/Tracking/ValidationWRTtp/',
+    ## eta range driven by ECAL acceptance
+    histoProducerAlgoBlock = dict(
+        TpSelectorForEfficiencyVsEta  = dict(ptMin = 24),
+        TpSelectorForEfficiencyVsPhi  = dict(ptMin = 24),
+        TpSelectorForEfficiencyVsVTXR = dict(ptMin = 24),
+        TpSelectorForEfficiencyVsVTXZ = dict(ptMin = 24),
+        generalTpSelector             = dict(ptMin = 24),
+    ),
+)
+
+from Validation.RecoTrack.TrackValidation_cff import trackingParticlesElectron
+trackingParticlesMuon = trackingParticlesElectron.clone(pdgId = [-13, 13])
+hltMultiTrackValidationMuonTracks = cms.Sequence(
+    hltTPClusterProducer
+    + hltTrackAssociatorByHits
+    + cms.ignore(trackingParticlesMuon)
+    + hltMuonTrackValidator
+)

--- a/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
+++ b/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
@@ -7,7 +7,7 @@ hltMuonTrackValidator = hltMultiTrackValidator.clone(
     ],
     label_tp_effic           = "trackingParticlesMuon",
     label_tp_effic_refvector = True,
-    dirName                  = 'HLT/EG/Tracking/ValidationWRTtp/',
+    dirName                  = 'HLT/Muon/Tracking/ValidationWRTtp/',
     ## eta range driven by ECAL acceptance
     histoProducerAlgoBlock = dict(
         TpSelectorForEfficiencyVsEta  = dict(ptMin = 24),

--- a/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
+++ b/HLTriggerOffline/Muon/python/HLTmultiTrackValidatorMuonTracks_cff.py
@@ -3,7 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from Validation.RecoTrack.HLTmultiTrackValidator_cfi import *
 hltMuonTrackValidator = hltMultiTrackValidator.clone(
     label = [
-        "hltIter0HighPtTkMuMerged2016Tk",
+        "hltIter0HighPtTkMuPixelTracks",
+        "hltIter0HighPtTkMuTrackSelectionHighPurity",
+        "hltIter2HighPtTkMuTrackSelectionHighPurity",
+        "hltIter2HighPtTkMuMerged",
     ],
     label_tp_effic           = "trackingParticlesMuon",
     label_tp_effic_refvector = True,

--- a/HLTriggerOffline/Muon/python/HLTpostProcessorMuonTrack_cfi.py
+++ b/HLTriggerOffline/Muon/python/HLTpostProcessorMuonTrack_cfi.py
@@ -11,6 +11,6 @@ postProcessorHLTmuonTrackingSummary = _PostProcessorTracker_cfi.postProcessorTra
 )
 
 postProcessorHLTmuonTrackingSequence = (
-    postProcessorHLTmuonTrackingSequence +
+    postProcessorHLTmuonTracking +
     postProcessorHLTmuonTrackingSummary
 )

--- a/HLTriggerOffline/Muon/python/HLTpostProcessorMuonTrack_cfi.py
+++ b/HLTriggerOffline/Muon/python/HLTpostProcessorMuonTrack_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+import Validation.RecoTrack.PostProcessorTracker_cfi as _PostProcessorTracker_cfi
+
+postProcessorHLTmuonTracking = _PostProcessorTracker_cfi.postProcessorTrack.clone(
+    subDirs = ["HLT/Muon.Tracking/ValidationWRTtp/*"]
+)
+
+postProcessorHLTmuonTrackingSummary = _PostProcessorTracker_cfi.postProcessorTrackSummary.clone(
+    subDirs = ["HLT/Muon/Tracking/ValidationWRTtp"]
+)
+
+postProcessorHLTmuonTrackingSequence = (
+    postProcessorHLTmuonTrackingSequence +
+    postProcessorHLTmuonTrackingSummary
+)


### PR DESCRIPTION
add performance plots for muon track reconstructed by the collections
- "hltIter0HighPtTkMuPixelTracks"
- "hltIter0HighPtTkMuTrackSelectionHighPurity"
- "hltIter2HighPtTkMuTrackSelectionHighPurity"
- "hltIter2HighPtTkMuMerged"

these collections have to be added to the output module
(JIRA ticket [#1225](https://its.cern.ch/jira/browse/CMSHLT-1225))