### PR TITLE
modify sequences to remove unnecessary L1Emulator modules in PreMixing 

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -948,6 +948,8 @@ class ConfigBuilder(object):
 
 	if "DIGIPREMIX" in self.stepMap.keys():
             self.DIGIDefaultCFF="Configuration/StandardSequences/Digi_PreMix_cff"
+            self.DIGI2RAWDefaultCFF="Configuration/StandardSequences/DigiToRawPreMixing_cff"
+            self.L1EMDefaultCFF="Configuration/StandardSequences/SimL1EmulatorPreMix_cff"
 
         self.ALCADefaultSeq=None
 	self.LHEDefaultSeq='externalLHEProducer'

--- a/Configuration/StandardSequences/python/DigiToRawPreMixing_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawPreMixing_cff.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+# This object is used to make changes for different running scenarios. In
+# this case for Run 2
+
+from EventFilter.SiPixelRawToDigi.SiPixelDigiToRaw_cfi import *
+from EventFilter.SiStripRawToDigi.SiStripDigiToRaw_cfi import *
+from SimCalorimetry.EcalTrigPrimProducers.ecalTriggerPrimitiveDigis_cff import *
+import EventFilter.EcalDigiToRaw.ecalDigiToRaw_cfi
+ecalPacker = EventFilter.EcalDigiToRaw.ecalDigiToRaw_cfi.ecaldigitorawzerosup.clone()
+from EventFilter.ESDigiToRaw.esDigiToRaw_cfi import *
+from EventFilter.HcalRawToDigi.HcalDigiToRaw_cfi import *
+from EventFilter.CSCRawToDigi.cscPacker_cfi import *
+from EventFilter.DTRawToDigi.dtPacker_cfi import *
+from EventFilter.RPCRawToDigi.rpcPacker_cfi import *
+from EventFilter.CastorRawToDigi.CastorDigiToRaw_cfi import *
+from EventFilter.RawDataCollector.rawDataCollector_cfi import *
+#from L1Trigger.Configuration.L1TDigiToRaw_cff import *  # no L1 DigiToRaw in first PreMixing step
+#DigiToRaw = cms.Sequence(L1TDigiToRaw*siPixelRawData*SiStripDigiToRaw*ecalPacker*esDigiToRaw*hcalRawData*cscpacker*dtpacker*rpcpacker*rawDataCollector)
+DigiToRaw = cms.Sequence(siPixelRawData*SiStripDigiToRaw*ecalPacker*esDigiToRaw*hcalRawData*cscpacker*dtpacker*rpcpacker*castorRawData*rawDataCollector)
+ecalPacker.Label = 'simEcalDigis'
+ecalPacker.InstanceEB = 'ebDigis'
+ecalPacker.InstanceEE = 'eeDigis'
+ecalPacker.labelEBSRFlags = "simEcalDigis:ebSrFlags"
+ecalPacker.labelEESRFlags = "simEcalDigis:eeSrFlags"
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([castorRawData]))
+
+#until we have hcal raw data for phase 2....
+from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
+phase2_hcal.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([hcalRawData]))
+
+# Remove siPixelRawData until we have phase1 pixel digis
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([siPixelRawData])) # FIXME
+
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+phase2_muon.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([rpcpacker]))
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+if fastSim.isChosen() :
+    for _entry in [siPixelRawData,SiStripDigiToRaw,castorRawData]:
+        DigiToRaw.remove(_entry)

--- a/Configuration/StandardSequences/python/SimL1EmulatorPreMix_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorPreMix_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.Configuration.SimL1Emulator_cff import *
+
+#If PreMixing, don't run these modules during first step
+SimL1Emulator.remove(SimL1TCalorimeter)
+SimL1Emulator.remove(SimL1TechnicalTriggers)
+SimL1Emulator.remove(SimL1TGlobal)
+
+# make trigger digis available under with the raw2digi names
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+if fastSim.isChosen():
+    # pretend these digis have been through digi2raw and to the HLT internal raw2digi, by using the approprate aliases
+    # consider moving these mods to the HLT configuration
+    from FastSimulation.Configuration.DigiAliases_cff import loadTriggerDigiAliases
+    loadTriggerDigiAliases()
+    from FastSimulation.Configuration.DigiAliases_cff import gtDigis,gmtDigis,gctDigis,caloStage1LegacyFormatDigis
+    


### PR DESCRIPTION
Remove unnecessary L1Emulator modules from the standard sequences so that they don't run in the first PreMixing step.  Note that the L1 objects produced in the first PreMixing step are useless and are deprecated when the real digis are made in the second step.