### PR TITLE
Fixes for Muon Alignment

### DIFF
--- a/Alignment/CommonAlignmentMonitor/python/AlignmentMonitorMuonSystemMap1D_cfi.py
+++ b/Alignment/CommonAlignmentMonitor/python/AlignmentMonitorMuonSystemMap1D_cfi.py
@@ -18,5 +18,7 @@ AlignmentMonitorMuonSystemMap1D = cms.untracked.PSet(
     doDT = cms.bool(True),
     doCSC = cms.bool(True),
     useStubPosition = cms.bool(False),
-    createNtuple = cms.bool(False)
+    createNtuple = cms.bool(False),
+    createLayerNtupleDT = cms.bool(False),
+    createLayerNtupleCSC = cms.bool(False)
 )

--- a/Alignment/CommonAlignmentMonitor/python/AlignmentMonitorMuonVsCurvature_cfi.py
+++ b/Alignment/CommonAlignmentMonitor/python/AlignmentMonitorMuonVsCurvature_cfi.py
@@ -16,5 +16,7 @@ AlignmentMonitorMuonVsCurvature = cms.untracked.PSet(
     layer = cms.int32(2),
     propagator = cms.string("SmartPropagatorAnyRK"),
     doDT = cms.bool(True),
-    doCSC = cms.bool(True)
+    doCSC = cms.bool(True),
+    createLayerNtupleDT = cms.bool(False),
+    createLayerNtupleCSC = cms.bool(False)
 )

--- a/Alignment/CommonAlignmentMonitor/python/AlignmentMonitorSegmentDifferences_cfi.py
+++ b/Alignment/CommonAlignmentMonitor/python/AlignmentMonitorSegmentDifferences_cfi.py
@@ -14,5 +14,7 @@ AlignmentMonitorSegmentDifferences = cms.untracked.PSet(
     minDT2Hits = cms.int32(4),
     minCSCHits = cms.int32(6),
     doDT = cms.bool(True),
-    doCSC = cms.bool(True)
+    doCSC = cms.bool(True),
+    createLayerNtupleDT = cms.bool(False),
+    createLayerNtupleCSC = cms.bool(False)
 )


### PR DESCRIPTION
Added 2 parameters for Muon alignemnt:
   createLayerNtupleDT = cms.bool(False),
   createLayerNtupleCSC = cms.bool(False)

In 3 files:
Alignment/CommonAlignmentMonitor/python/AlignmentMonitorMuonSystemMap1D_cfi.py
Alignment/CommonAlignmentMonitor/python/AlignmentMonitorMuonVsCurvature_cfi.py
Alignment/CommonAlignmentMonitor/python/AlignmentMonitorSegmentDifferences_cfi.py