### PR TITLE
Update legacy modules in CommonTools, RecoMET, RecoJets

### DIFF
--- a/CommonTools/CandAlgos/interface/CandCombiner.h
+++ b/CommonTools/CandAlgos/interface/CandCombiner.h
@@ -12,7 +12,7 @@
  * $Id: CandCombiner.h,v 1.2 2009/04/22 17:51:05 kaulmer Exp $
  *
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "CommonTools/CandUtils/interface/CandCombiner.h"
 #include "CommonTools/CandAlgos/interface/decayParser.h"
@@ -64,7 +64,7 @@ namespace reco {
     };
 
 
-    struct CandCombinerBase : public edm::EDProducer {
+    struct CandCombinerBase : public edm::stream::EDProducer<> {
       CandCombinerBase(const edm::ParameterSet & cfg) :
 	setLongLived_(false),
 	setMassConstraint_(false),
@@ -145,7 +145,7 @@ namespace reco {
 
     private:
       /// process an event
-      void produce(edm::Event& evt, const edm::EventSetup& es) {
+      void produce(edm::Event& evt, const edm::EventSetup& es) override {
 	using namespace std;
 	using namespace reco;
 	Init::init(combiner_.setup(), evt, es);

--- a/CommonTools/CandAlgos/interface/CandCombiner.h
+++ b/CommonTools/CandAlgos/interface/CandCombiner.h
@@ -146,15 +146,13 @@ namespace reco {
     private:
       /// process an event
       void produce(edm::Event& evt, const edm::EventSetup& es) override {
-	using namespace std;
-	using namespace reco;
 	Init::init(combiner_.setup(), evt, es);
 	int n = labels_.size();
-	vector<edm::Handle<CandidateView> > colls(n);
+	std::vector<edm::Handle<CandidateView> > colls(n);
 	for(int i = 0; i < n; ++i)
 	  evt.getByToken(tokens_[i], colls[i]);
 
-	unique_ptr<OutputCollection> out = combiner_.combine(colls, names_.roles());
+	std::unique_ptr<OutputCollection> out = combiner_.combine(colls, names_.roles());
 	if(setLongLived_ || setMassConstraint_ || setPdgId_) {
 	  typename OutputCollection::iterator i = out->begin(), e = out->end();
 	  for(; i != e; ++i) {

--- a/CommonTools/CandUtils/interface/CandCombinerBase.h
+++ b/CommonTools/CandUtils/interface/CandCombinerBase.h
@@ -27,22 +27,22 @@ public:
   /// destructor
   virtual ~CandCombinerBase();
   /// return all selected candidate pairs
-  std::auto_ptr<OutputCollection> 
+  std::unique_ptr<OutputCollection> 
   combine(const std::vector<edm::Handle<reco::CandidateView> > &, const vstring& = vstring()) const;
   /// return all selected candidate pairs
-  std::auto_ptr<OutputCollection> 
+  std::unique_ptr<OutputCollection> 
   combine(const edm::Handle<reco::CandidateView> &, const vstring& = vstring()) const;
   /// return all selected candidate pairs
-  std::auto_ptr<OutputCollection> 
+  std::unique_ptr<OutputCollection> 
   combine(const edm::Handle<reco::CandidateView> &, 
 	  const edm::Handle<reco::CandidateView> &, const vstring& = vstring()) const;
   /// return all selected candidate pairs
-  std::auto_ptr<OutputCollection> 
+  std::unique_ptr<OutputCollection> 
   combine(const edm::Handle<reco::CandidateView> &, 
 	  const edm::Handle<reco::CandidateView> &, 
 	  const edm::Handle<reco::CandidateView> &, const vstring& = vstring()) const;
   /// return all selected candidate pairs
-  std::auto_ptr<OutputCollection> 
+  std::unique_ptr<OutputCollection> 
   combine(const edm::Handle<reco::CandidateView> &, 
 	  const edm::Handle<reco::CandidateView> &, 
 	  const edm::Handle<reco::CandidateView> &, 
@@ -63,7 +63,7 @@ private:
   void combine(size_t collectionIndex, CandStack &, ChargeStack &,
 	       std::vector<edm::Handle<reco::CandidateView> >::const_iterator begin,
 	       std::vector<edm::Handle<reco::CandidateView> >::const_iterator end,
-	       std::auto_ptr<OutputCollection> & comps,
+	       OutputCollection* comps,
 	       const vstring& name = vstring()) const;
   /// select a candidate
   virtual bool select(const reco::Candidate &) const = 0;
@@ -144,7 +144,7 @@ void CandCombinerBase<OutputCollection, CandPtr>::combine(typename OutputCollect
 }
 
 template<typename OutputCollection, typename CandPtr>
-std::auto_ptr<OutputCollection> 
+std::unique_ptr<OutputCollection> 
 CandCombinerBase<OutputCollection, CandPtr>::combine(const std::vector<edm::Handle<reco::CandidateView> > & src,
 						     const vstring& names) const {
   size_t srcSize = src.size();
@@ -152,7 +152,7 @@ CandCombinerBase<OutputCollection, CandPtr>::combine(const std::vector<edm::Hand
     throw edm::Exception(edm::errors::Configuration) 
       << "CandCombiner: trying to combine " << srcSize << " collections"
       << " but configured to check against " << dauCharge_.size() << " charges.";
-  std::auto_ptr<OutputCollection> comps(new OutputCollection);
+  std::unique_ptr<OutputCollection> comps(new OutputCollection);
   size_t namesSize = names.size();
   if(srcSize == 2) {
     std::string name1="", name2="";
@@ -203,14 +203,14 @@ CandCombinerBase<OutputCollection, CandPtr>::combine(const std::vector<edm::Hand
   } else {
     CandStack stack;
     ChargeStack qStack;
-    combine(0, stack, qStack, src.begin(), src.end(), comps, names);
+    combine(0, stack, qStack, src.begin(), src.end(), comps.get(), names);
   }
 
   return comps;
 }
 
 template<typename OutputCollection, typename CandPtr>
-std::auto_ptr<OutputCollection> 
+std::unique_ptr<OutputCollection> 
 CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::CandidateView> & src,
 						     const vstring& names) const {
   if(checkCharge_ && dauCharge_.size() != 2)
@@ -218,7 +218,7 @@ CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::Can
       << "CandCombiner: trying to combine 2 collections"
       << " but configured to check against " << dauCharge_.size() << " charges.";
 
-  std::auto_ptr<OutputCollection> comps(new OutputCollection);
+  std::unique_ptr<OutputCollection> comps(new OutputCollection);
   size_t namesSize = names.size();
   std::string name1, name2;
   if(namesSize > 0) {
@@ -250,7 +250,7 @@ CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::Can
 }
 
 template<typename OutputCollection, typename CandPtr>
-std::auto_ptr<OutputCollection> 
+std::unique_ptr<OutputCollection> 
 CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::CandidateView> & src1, 
 						     const edm::Handle<reco::CandidateView> & src2,
 						     const vstring& names) const {
@@ -261,7 +261,7 @@ CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::Can
 }
 
 template<typename OutputCollection, typename CandPtr>
-std::auto_ptr<OutputCollection> 
+std::unique_ptr<OutputCollection> 
 CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::CandidateView> & src1, 
 						     const edm::Handle<reco::CandidateView> & src2, 
 						     const edm::Handle<reco::CandidateView> & src3,
@@ -274,7 +274,7 @@ CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::Can
 }
 
 template<typename OutputCollection, typename CandPtr>
-std::auto_ptr<OutputCollection> 
+std::unique_ptr<OutputCollection> 
 CandCombinerBase<OutputCollection, CandPtr>::combine(const edm::Handle<reco::CandidateView> & src1, 
 						     const edm::Handle<reco::CandidateView> & src2, 
 						     const edm::Handle<reco::CandidateView> & src3, 
@@ -292,7 +292,7 @@ template<typename OutputCollection, typename CandPtr>
 void CandCombinerBase<OutputCollection, CandPtr>::combine(size_t collectionIndex, CandStack & stack, ChargeStack & qStack,
 							  std::vector<edm::Handle<reco::CandidateView> >::const_iterator collBegin,
 							  std::vector<edm::Handle<reco::CandidateView> >::const_iterator collEnd,
-							  std::auto_ptr<OutputCollection> & comps,
+							  OutputCollection* comps,
 							  const vstring& names) const {
   if(collBegin == collEnd) {
     static const int undetermined = 0, sameDecay = 1, conjDecay = -1, wrongDecay = 2;

--- a/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,15 +33,15 @@
 // class declaration
 //
 
-class BooleanFlagFilter : public edm::EDFilter {
+class BooleanFlagFilter : public edm::global::EDFilter<> {
    public:
       explicit BooleanFlagFilter(const edm::ParameterSet&);
       ~BooleanFlagFilter();
 
    private:
-      virtual void beginJob() override;
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      //virtual void beginJob() override;
+      virtual bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+      //virtual void endJob() override;
       
       //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
@@ -87,7 +87,7 @@ BooleanFlagFilter::~BooleanFlagFilter()
 
 // ------------ method called on each new Event  ------------
 bool
-BooleanFlagFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+BooleanFlagFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
    using namespace edm;
 
@@ -107,15 +107,19 @@ BooleanFlagFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 }
 
 // ------------ method called once each job just before starting event loop  ------------
+/*
 void 
 BooleanFlagFilter::beginJob()
 {
 }
+*/
 
 // ------------ method called once each job just after ending the event loop  ------------
+/*
 void 
 BooleanFlagFilter::endJob() {
 }
+*/
 
 // ------------ method called when starting to processes a run  ------------
 /*

--- a/RecoJets/JetAlgorithms/interface/QGLikelihoodCalculator.h
+++ b/RecoJets/JetAlgorithms/interface/QGLikelihoodCalculator.h
@@ -16,13 +16,13 @@ class QGLikelihoodCalculator{
   QGLikelihoodCalculator(){};
    ~QGLikelihoodCalculator(){};
 
-  float computeQGLikelihood(edm::ESHandle<QGLikelihoodObject> &QGLParamsColl, float pt, float eta, float rho, std::vector<float> vars);
-  float systematicSmearing(edm::ESHandle<QGLikelihoodSystematicsObject> &QGLParamsColl, float pt, float eta, float rho, float qgValue, int qgIndex);
+  float computeQGLikelihood(edm::ESHandle<QGLikelihoodObject> &QGLParamsColl, float pt, float eta, float rho, std::vector<float> vars) const;
+  float systematicSmearing(edm::ESHandle<QGLikelihoodSystematicsObject> &QGLParamsColl, float pt, float eta, float rho, float qgValue, int qgIndex) const;
 
  private:
-  const QGLikelihoodObject::Entry* findEntry(std::vector<QGLikelihoodObject::Entry> const &data, float eta, float pt, float rho, int qgIndex, int varIndex);
-  bool isValidRange(float pt, float rho, float eta, const QGLikelihoodCategory &qgValidRange);
-  float smearingFunction(float x0, float a ,float b,float min,float max);
+  const QGLikelihoodObject::Entry* findEntry(std::vector<QGLikelihoodObject::Entry> const &data, float eta, float pt, float rho, int qgIndex, int varIndex) const;
+  bool isValidRange(float pt, float rho, float eta, const QGLikelihoodCategory &qgValidRange) const;
+  float smearingFunction(float x0, float a ,float b,float min,float max) const;
 };
 
 #endif

--- a/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+++ b/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
@@ -5,7 +5,7 @@
 #include <math.h>
 
 /// Compute likelihood for a jet using the QGLikelihoodObject information and a set of variables
-float QGLikelihoodCalculator::computeQGLikelihood(edm::ESHandle<QGLikelihoodObject> &QGLParamsColl, float pt, float eta, float rho, std::vector<float> vars){
+float QGLikelihoodCalculator::computeQGLikelihood(edm::ESHandle<QGLikelihoodObject> &QGLParamsColl, float pt, float eta, float rho, std::vector<float> vars) const{
   if(!isValidRange(pt, rho, eta, QGLParamsColl->qgValidRange)) return -1;
 
   float Q=1., G=1.;
@@ -31,7 +31,7 @@ float QGLikelihoodCalculator::computeQGLikelihood(edm::ESHandle<QGLikelihoodObje
 
 
 /// Find matching entry in vector for a given eta, pt, rho, qgIndex and varIndex
-const QGLikelihoodObject::Entry* QGLikelihoodCalculator::findEntry(std::vector<QGLikelihoodObject::Entry> const &data, float eta, float pt, float rho, int qgIndex, int varIndex){
+const QGLikelihoodObject::Entry* QGLikelihoodCalculator::findEntry(std::vector<QGLikelihoodObject::Entry> const &data, float eta, float pt, float rho, int qgIndex, int varIndex) const{
   QGLikelihoodParameters myParameters;
   myParameters.Rho = rho;
   myParameters.Pt = pt;
@@ -53,7 +53,7 @@ const QGLikelihoodObject::Entry* QGLikelihoodCalculator::findEntry(std::vector<Q
 
 
 /// Check the valid range of this qg tagger
-bool QGLikelihoodCalculator::isValidRange(float pt, float rho, float eta, const QGLikelihoodCategory &qgValidRange){
+bool QGLikelihoodCalculator::isValidRange(float pt, float rho, float eta, const QGLikelihoodCategory &qgValidRange) const{
   if(pt < qgValidRange.PtMin) return false;
   if(pt > qgValidRange.PtMax) return false;
   if(rho < qgValidRange.RhoMin) return false;
@@ -65,7 +65,7 @@ bool QGLikelihoodCalculator::isValidRange(float pt, float rho, float eta, const 
 
 
 /// Return the smeared qgLikelihood value, given input x0 and parameters a, b, min and max
-float QGLikelihoodCalculator::smearingFunction(float x0, float a ,float b,float min,float max){
+float QGLikelihoodCalculator::smearingFunction(float x0, float a ,float b,float min,float max) const{
   float x=(x0-min)/(max-min);
   if(x<0.) x=0.;
   if(x>1.) x=1.;
@@ -78,7 +78,7 @@ float QGLikelihoodCalculator::smearingFunction(float x0, float a ,float b,float 
 }
 
 // Get systematic smearing
-float QGLikelihoodCalculator::systematicSmearing(edm::ESHandle<QGLikelihoodSystematicsObject> &QGLSystematicsColl, float pt, float eta, float rho, float qgValue, int qgIndex){
+float QGLikelihoodCalculator::systematicSmearing(edm::ESHandle<QGLikelihoodSystematicsObject> &QGLSystematicsColl, float pt, float eta, float rho, float qgValue, int qgIndex) const{
   if(qgValue < 0 || qgValue > 1) return -1.;
 
   QGLikelihoodParameters myParameters;

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -3,7 +3,7 @@
 #include <tuple>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -11,17 +11,17 @@
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 #include "RecoJets/JetAlgorithms/interface/QGLikelihoodCalculator.h"
 
-class QGTagger : public edm::EDProducer{
+class QGTagger : public edm::global::EDProducer<>{
    public:
       explicit QGTagger(const edm::ParameterSet&);
       ~QGTagger(){ delete qgLikelihood;};
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      std::tuple<int, float, float> calcVariables(const reco::Jet*, edm::Handle<reco::VertexCollection>&);
-      template <typename T> void putInEvent(std::string, const edm::Handle<edm::View<reco::Jet>>&, std::vector<T>*, edm::Event&);
-      bool isPackedCandidate(const reco::Candidate* candidate);
+      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+      std::tuple<int, float, float> calcVariables(const reco::Jet*, edm::Handle<reco::VertexCollection>&, bool) const;
+      template <typename T> void putInEvent(const std::string&, const edm::Handle<edm::View<reco::Jet>>&, std::vector<T>*, edm::Event&) const;
+      bool isPackedCandidate(const reco::Jet* jet) const;
 
       edm::EDGetTokenT<edm::View<reco::Jet>> 	jetsToken;
       edm::EDGetTokenT<reco::JetCorrector> 	jetCorrectorToken;
@@ -29,7 +29,6 @@ class QGTagger : public edm::EDProducer{
       edm::EDGetTokenT<double> 			rhoToken;
       std::string 				jetsLabel, systLabel;
       const bool 				useQC, useJetCorr, produceSyst;
-      bool					weStillNeedToCheckJetCandidates, weAreUsingPackedCandidates;
       QGLikelihoodCalculator *			qgLikelihood;
 };
 

--- a/RecoMET/METFilters/interface/EcalBoundaryInfoCalculator.h
+++ b/RecoMET/METFilters/interface/EcalBoundaryInfoCalculator.h
@@ -15,7 +15,8 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/METReco/interface/BoundaryInformation.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 enum CdOrientation {
     north, east, south, west, none
@@ -124,7 +125,7 @@ public:
             }
 
         } else {
-            std::cout << "ERROR - RecHit belongs to wrong sub detector" << std::endl;
+            edm::LogWarning("EcalBoundaryInfoCalculator") << "ERROR - RecHit belongs to wrong sub detector";
         }
 
         if (stati.size() > 0)
@@ -190,14 +191,14 @@ public:
             }
 
         } else {
-            std::cout << "ERROR - RecHit belongs to wrong sub detector" << std::endl;
+            edm::LogWarning("EcalBoundaryInfoCalculator") << "ERROR - RecHit belongs to wrong sub detector";
         }
 
         return false;
     }
 
     void setDebugMode() {
-        std::cout << "set Debug Mode!" << std::endl;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "set Debug Mode!";
         debug = true;
     }
 
@@ -207,22 +208,18 @@ private:
         EcalDetId next;
         switch (direction) {
         case north: {
-                //std::cout<<"go north"<<std::endl;
                 next = theNavi->north();
                 break;
             }
         case east: {
-                //std::cout<<"go east"<<std::endl;
                 next = theNavi->east();
                 break;
             }
         case south: {
-                //std::cout<<"go south"<<std::endl;
                 next = theNavi->south();
                 break;
             }
         case west: {
-                //std::cout<<"go west"<<std::endl;
                 next = theNavi->west();
                 break;
             }
@@ -254,7 +251,7 @@ private:
         if (nIt != turnMap.end())
             nextDirection = (*nIt).second;
         else
-            std::cout << "ERROR - no Next Direction found!?!?" << std::endl;
+            edm::LogWarning("EcalBoundaryInfoCalculator") << "ERROR - no Next Direction found!?!?";
         return nextDirection;
     }
 
@@ -268,7 +265,7 @@ private:
         if (nIt != turnMap.end())
             nextDirection = (*nIt).second;
         else
-            std::cout << "ERROR - no Next Direction found!?!?" << std::endl;
+            edm::LogWarning("EcalBoundaryInfoCalculator") << "ERROR - no Next Direction found!?!?";
         return nextDirection;
     }
 
@@ -282,7 +279,7 @@ private:
             theEcalNav.reset(new CaloNavigator<EcalDetId> ((EEDetId) startE, (theCaloTopology->getSubdetectorTopology(
                              DetId::Ecal, ecalSubDet))));
         } else {
-            std::cout << "initializeEcalNavigator not implemented for subDet: " << ecalSubDet << std::endl;
+            edm::LogWarning("EcalBoundaryInfoCalculator") << "initializeEcalNavigator not implemented for subDet: " << ecalSubDet;
         }
         return theEcalNav;
     }
@@ -346,15 +343,12 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     boundaryET += hit->energy() / cosh(eta);
 
     if (debug) {
-        std::cout << "Find Boundary RecHits..." << std::endl;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "Find Boundary RecHits...";
 
         if (hitdetid.subdet() == EcalBarrel) {
-            std::cout << "Starting at : (" << ((EBDetId) hitdetid).ieta() << "," << ((EBDetId) hitdetid).iphi() << ")"
-            << std::endl;
-
+            edm::LogInfo("EcalBoundaryInfoCalculator") << "Starting at : (" << ((EBDetId) hitdetid).ieta() << "," << ((EBDetId) hitdetid).iphi() << ")";
         } else if (hitdetid.subdet() == EcalEndcap) {
-            std::cout << "Starting at : (" << ((EEDetId) hitdetid).ix() << "," << ((EEDetId) hitdetid).iy() << ")"
-            << std::endl;
+            edm::LogInfo("EcalBoundaryInfoCalculator") << "Starting at : (" << ((EEDetId) hitdetid).ix() << "," << ((EEDetId) hitdetid).iy() << ")";
         }
     }
 
@@ -385,10 +379,8 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
         currDirection = turnLeft(currDirection, reverseOrientation);
         ++noDirs;
         if (noDirs > 4) {
-
-            std::cout << "No starting direction can be found: This should never happen if RecHit has a dead neighbour!" << std::endl;
-            throw "ERROR";
-            break;
+            throw cms::Exception("NoStartingDirection")
+              << "EcalBoundaryInfoCalculator: No starting direction can be found: This should never happen if RecHit has a dead neighbour!";
         }
     }
 
@@ -436,9 +428,8 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
             }
             ++noDirs;
             if (noDirs > 4) {
-                std::cout << "No valid next direction can be found: This should never happen!" << std::endl;
-                throw "ERROR";
-                break;
+              throw cms::Exception("NoNextDirection")
+                << "EcalBoundaryInfoCalculator: No valid next direction can be found: This should never happen!";
             }
         }
 
@@ -448,11 +439,11 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
         if (next == start) {
             nextIsStart = true;
             if (debug)
-                std::cout << "Boundary path reached starting position!" << std::endl;
+                edm::LogInfo("EcalBoundaryInfoCalculator") << "Boundary path reached starting position!";
         }
 
         if (debug)
-            std::cout << "Next step: " << (EcalDetId) next << " Status: " << status << " Start: " << (EcalDetId) start << std::endl;
+            edm::LogInfo("EcalBoundaryInfoCalculator") << "Next step: " << (EcalDetId) next << " Status: " << status << " Start: " << (EcalDetId) start;
 
         // save recHits and add energy if on the boundary (and not inside at border)
         if ((!atBorder || status == 0) && !nextIsStart) {
@@ -493,17 +484,17 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     }
 
     if (debug) {
-        std::cout << "<<<<<<<<<<<<<<< Final Boundary object <<<<<<<<<<<<<<<" << std::endl;
-        std::cout << "no of neighbouring RecHits: " << boundaryRecHits.size() << std::endl;
-        std::cout << "no of neighbouring DetIds: " << boundaryDetIds.size() << std::endl;
-        std::cout << "boundary energy: " << boundaryEnergy << std::endl;
-        std::cout << "boundary ET: " << boundaryET << std::endl;
-        std::cout << "no of cells contributing to boundary energy: " << beCellCounter << std::endl;
-        std::cout << "Channel stati: ";
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "<<<<<<<<<<<<<<< Final Boundary object <<<<<<<<<<<<<<<";
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "no of neighbouring RecHits: " << boundaryRecHits.size();
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "no of neighbouring DetIds: " << boundaryDetIds.size();
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "boundary energy: " << boundaryEnergy;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "boundary ET: " << boundaryET;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "no of cells contributing to boundary energy: " << beCellCounter;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "Channel stati: ";
         for (std::vector<int>::iterator it = stati.begin(); it != stati.end(); ++it) {
-            std::cout << *it << " ";
+            edm::LogInfo("EcalBoundaryInfoCalculator") << *it << " ";
         }
-        std::cout << std::endl;
+        edm::LogInfo("EcalBoundaryInfoCalculator");
     }
 
     BoundaryInformation boundInfo;
@@ -542,15 +533,12 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     gapET += hit->energy() / cosh(eta);
 
     if (debug) {
-        std::cout << "Find Border RecHits..." << std::endl;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "Find Border RecHits...";
 
         if (hitdetid.subdet() == EcalBarrel) {
-            std::cout << "Starting at : (" << ((EBDetId) hitdetid).ieta() << "," << ((EBDetId) hitdetid).iphi() << ")"
-            << std::endl;
-
+            edm::LogInfo("EcalBoundaryInfoCalculator") << "Starting at : (" << ((EBDetId) hitdetid).ieta() << "," << ((EBDetId) hitdetid).iphi() << ")";
         } else if (hitdetid.subdet() == EcalEndcap) {
-            std::cout << "Starting at : (" << ((EEDetId) hitdetid).ix() << "," << ((EEDetId) hitdetid).iy() << ")"
-            << std::endl;
+            edm::LogInfo("EcalBoundaryInfoCalculator") << "Starting at : (" << ((EEDetId) hitdetid).ix() << "," << ((EEDetId) hitdetid).iy() << ")";
         }
     }
 
@@ -578,10 +566,8 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
         currDirection = turnLeft(currDirection, reverseOrientation);
         ++noDirs;
         if (noDirs > 4) {
-
-            std::cout << "No starting direction can be found: This should never happen if RecHit is at border!" << std::endl;
-            throw "ERROR";
-            break;
+            throw cms::Exception("NoStartingDirection")
+              << "EcalBoundaryInfoCalculator: No starting direction can be found: This should never happen if RecHit is at border!";
         }
     }
 
@@ -621,9 +607,8 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
             }
             ++noDirs;
             if (noDirs > 4) {
-                std::cout << "No valid next direction can be found: This should never happen!" << std::endl;
-                throw "ERROR";
-                break;
+              throw cms::Exception("NoNextDirection")
+                << "EcalBoundaryInfoCalculator: No valid next direction can be found: This should never happen!";
             }
         }
 
@@ -635,13 +620,13 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
             startIsEnd = true;
             endIsFound = true;
             if (debug)
-                std::cout << "Path along gap reached starting position!" << std::endl;
+                edm::LogInfo("EcalBoundaryInfoCalculator") << "Path along gap reached starting position!";
         }
 
         if (debug) {
-            std::cout << "Next step: " << (EcalDetId) next << " Status: " << status << " Start: " << (EcalDetId) start << std::endl;
+            edm::LogInfo("EcalBoundaryInfoCalculator") << "Next step: " << (EcalDetId) next << " Status: " << status << " Start: " << (EcalDetId) start;
             if (endIsFound)
-                std::cout << "End of gap cluster is found going left" << std::endl;
+                edm::LogInfo("EcalBoundaryInfoCalculator") << "End of gap cluster is found going left";
         }
 
         // save recHits and add energy
@@ -703,9 +688,8 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
                 }
                 ++noDirs;
                 if (noDirs > 4) {
-                    std::cout << "No valid next direction can be found: This should never happen!" << std::endl;
-                    throw "ERROR";
-                    break;
+                  throw cms::Exception("NoStartingDirection")
+                    << "EcalBoundaryInfoCalculator: No valid next direction can be found: This should never happen!";
                 }
             }
 
@@ -714,10 +698,9 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
             current = next;
 
             if (debug) {
-                std::cout << "Next step: " << (EcalDetId) next << " Status: " << status << " Start: " << (EcalDetId) start
-                << std::endl;
+                edm::LogInfo("EcalBoundaryInfoCalculator")<< "Next step: " << (EcalDetId) next << " Status: " << status << " Start: " << (EcalDetId) start;
                 if (endIsFound)
-                    std::cout << "End of gap cluster is found going right" << std::endl;
+                    edm::LogInfo("EcalBoundaryInfoCalculator") << "End of gap cluster is found going right";
             }
 
             // save recHits and add energy
@@ -741,11 +724,11 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     }
 
     if (debug) {
-        std::cout << "<<<<<<<<<<<<<<< Final Gap object <<<<<<<<<<<<<<<" << std::endl;
-        std::cout << "No of RecHits along gap: " << gapRecHits.size() << std::endl;
-        std::cout << "No of DetIds along gap: " << gapDetIds.size() << std::endl;
-        std::cout << "Gap energy: " << gapEnergy << std::endl;
-        std::cout << "Gap ET: " << gapET << std::endl;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "<<<<<<<<<<<<<<< Final Gap object <<<<<<<<<<<<<<<";
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "No of RecHits along gap: " << gapRecHits.size();
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "No of DetIds along gap: " << gapDetIds.size();
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "Gap energy: " << gapEnergy;
+        edm::LogInfo("EcalBoundaryInfoCalculator") << "Gap ET: " << gapET;
     }
 
     BoundaryInformation gapInfo;

--- a/RecoMET/METFilters/interface/EcalBoundaryInfoCalculator.h
+++ b/RecoMET/METFilters/interface/EcalBoundaryInfoCalculator.h
@@ -203,7 +203,7 @@ public:
 
 private:
 
-    EcalDetId makeStepInDirection(CdOrientation direction, CaloNavigator<EcalDetId> * theNavi) const {
+    EcalDetId makeStepInDirection(CdOrientation direction, const CaloNavigator<EcalDetId> * theNavi) const {
         EcalDetId next;
         switch (direction) {
         case north: {
@@ -272,15 +272,15 @@ private:
         return nextDirection;
     }
 
-    CaloNavigator<EcalDetId> * initializeEcalNavigator(DetId startE, const edm::ESHandle<CaloTopology> theCaloTopology,
+    std::unique_ptr<CaloNavigator<EcalDetId>> initializeEcalNavigator(DetId startE, const edm::ESHandle<CaloTopology> theCaloTopology,
                                  EcalSubdetector ecalSubDet) const {
-        CaloNavigator<EcalDetId> * theEcalNav = NULL;
+        std::unique_ptr<CaloNavigator<EcalDetId>> theEcalNav(nullptr);
         if (ecalSubDet == EcalBarrel) {
-            theEcalNav = new CaloNavigator<EcalDetId> ((EBDetId) startE, (theCaloTopology->getSubdetectorTopology(
-                             DetId::Ecal, ecalSubDet)));
+            theEcalNav.reset(new CaloNavigator<EcalDetId> ((EBDetId) startE, (theCaloTopology->getSubdetectorTopology(
+                             DetId::Ecal, ecalSubDet))));
         } else if (ecalSubDet == EcalEndcap) {
-            theEcalNav = new CaloNavigator<EcalDetId> ((EEDetId) startE, (theCaloTopology->getSubdetectorTopology(
-                             DetId::Ecal, ecalSubDet)));
+            theEcalNav.reset(new CaloNavigator<EcalDetId> ((EEDetId) startE, (theCaloTopology->getSubdetectorTopology(
+                             DetId::Ecal, ecalSubDet))));
         } else {
             std::cout << "initializeEcalNavigator not implemented for subDet: " << ecalSubDet << std::endl;
         }
@@ -372,7 +372,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     bool startAlgo = false;
     int noDirs = 0;
     while (!startAlgo) {
-        next = makeStepInDirection(currDirection, theEcalNav);
+        next = makeStepInDirection(currDirection, theEcalNav.get());
         theEcalNav->setHome(current);
         theEcalNav->home();
         EcalChannelStatus::const_iterator chit = ecalStatus->find(next);
@@ -405,7 +405,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
         int status = 0;
         noDirs = 0;
         while (!nextStepFound) {
-            next = makeStepInDirection(currDirection, theEcalNav);
+            next = makeStepInDirection(currDirection, theEcalNav.get());
             theEcalNav->setHome(current);
             theEcalNav->home();
             EcalChannelStatus::const_iterator chit = ecalStatus->find(next);
@@ -443,7 +443,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
         }
 
         // make next step
-        next = makeStepInDirection(currDirection, theEcalNav);
+        next = makeStepInDirection(currDirection, theEcalNav.get());
 
         if (next == start) {
             nextIsStart = true;
@@ -515,10 +515,6 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     boundInfo.nextToBorder = nextToBorder;
     boundInfo.channelStatus = stati;
 
-    if (theEcalNav != 0) {
-        delete theEcalNav;
-        theEcalNav = 0;
-    }
     return boundInfo;
 }
 
@@ -571,7 +567,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     bool startAlgo = false;
     int noDirs = 0;
     while (!startAlgo) {
-        next = makeStepInDirection(currDirection, theEcalNav);
+        next = makeStepInDirection(currDirection, theEcalNav.get());
         theEcalNav->setHome(start);
         theEcalNav->home();
         if (next == EcalDetId(0)) {
@@ -603,7 +599,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
         int status = 0;
         noDirs = 0;
         while (!nextStepFound) {
-            next = makeStepInDirection(currDirection, theEcalNav);
+            next = makeStepInDirection(currDirection, theEcalNav.get());
             theEcalNav->setHome(current);
             theEcalNav->home();
             EcalChannelStatus::const_iterator chit = ecalStatus->find(next);
@@ -632,7 +628,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
         }
 
         // make next step
-        next = makeStepInDirection(currDirection, theEcalNav);
+        next = makeStepInDirection(currDirection, theEcalNav.get());
         current = next;
 
         if (next == start) {
@@ -685,7 +681,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
             int status = 0;
             noDirs = 0;
             while (!nextStepFound) {
-                next = makeStepInDirection(currDirection, theEcalNav);
+                next = makeStepInDirection(currDirection, theEcalNav.get());
                 theEcalNav->setHome(current);
                 theEcalNav->home();
                 EcalChannelStatus::const_iterator chit = ecalStatus->find(next);
@@ -714,7 +710,7 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
             }
 
             // make next step
-            next = makeStepInDirection(currDirection, theEcalNav);
+            next = makeStepInDirection(currDirection, theEcalNav.get());
             current = next;
 
             if (debug) {
@@ -762,10 +758,6 @@ template<class EcalDetId> BoundaryInformation EcalBoundaryInfoCalculator<EcalDet
     std::vector<int> stati;
     gapInfo.channelStatus = stati;
 
-    if (theEcalNav != 0) {
-        delete theEcalNav;
-        theEcalNav = 0;
-    }
     return gapInfo;
 }
 

--- a/RecoMET/METFilters/plugins/EEBadScFilter.cc
+++ b/RecoMET/METFilters/plugins/EEBadScFilter.cc
@@ -14,13 +14,12 @@
 
 
 // include files
-#include <iostream>
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -193,9 +192,9 @@ bool EEBadScFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventS
     // print some debug info
 
     if (debug_) {
-      std::cout << "EEBadScFilter.cc:  SCID=" <<  *scit << std::endl;
-      std::cout << "EEBadScFilter.cc:  ix=" << ix << " iy=" << iy << " iz=" << iz << std::endl;
-      std::cout << "EEBadScFilter.cc:  Et(5x5)=" << totEt << " nbadhits=" << nhits << std::endl;
+      edm::LogInfo("EEBadScFilter") << "SCID=" <<  *scit;
+      edm::LogInfo("EEBadScFilter") << "ix=" << ix << " iy=" << iy << " iz=" << iz;
+      edm::LogInfo("EEBadScFilter") << "Et(5x5)=" << totEt << " nbadhits=" << nhits;
     }
 
 
@@ -208,7 +207,7 @@ bool EEBadScFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventS
   }
 
   // print the decision if event is bad
-  if (pass==false && debug_) std::cout << "EEBadScFilter.cc:  REJECT EVENT!!!" << std::endl;
+  if (pass==false && debug_) edm::LogInfo("EEBadScFilter") << "REJECT EVENT!!!";
 
 
   iEvent.put(std::make_unique<bool>(pass));

--- a/RecoMET/METFilters/plugins/EEBadScFilter.cc
+++ b/RecoMET/METFilters/plugins/EEBadScFilter.cc
@@ -17,7 +17,7 @@
 #include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -34,7 +34,7 @@
 
 #include "TVector3.h"
 
-class EEBadScFilter : public edm::EDFilter {
+class EEBadScFilter : public edm::global::EDFilter<> {
 
   public:
 
@@ -45,11 +45,11 @@ class EEBadScFilter : public edm::EDFilter {
 
   // main filter function
 
-  virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+  virtual bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
   // function to calculate 5x5 energy and check rechit flags
 
-  virtual void scan5x5(const DetId & det, const edm::Handle<EcalRecHitCollection> &hits, const edm::ESHandle<CaloTopology>  &caloTopo, const edm::ESHandle<CaloGeometry>  &geometry, int &nHits, float & totEt);
+  virtual void scan5x5(const DetId & det, const edm::Handle<EcalRecHitCollection> &hits, const edm::ESHandle<CaloTopology>  &caloTopo, const edm::ESHandle<CaloGeometry>  &geometry, int &nHits, float & totEt) const;
 
   // input parameters
 
@@ -83,7 +83,7 @@ EEBadScFilter::EEBadScFilter(const edm::ParameterSet & iConfig)
 }
 
 
-void EEBadScFilter::scan5x5(const DetId & det, const edm::Handle<EcalRecHitCollection> &hits, const edm::ESHandle<CaloTopology>  &caloTopo, const edm::ESHandle<CaloGeometry>  &geometry, int &nHits, float & totEt)
+void EEBadScFilter::scan5x5(const DetId & det, const edm::Handle<EcalRecHitCollection> &hits, const edm::ESHandle<CaloTopology>  &caloTopo, const edm::ESHandle<CaloGeometry>  &geometry, int &nHits, float & totEt) const
 {
 
   // function to compute:  total transverse energy in a given supercrystal (totEt)
@@ -133,7 +133,7 @@ void EEBadScFilter::scan5x5(const DetId & det, const edm::Handle<EcalRecHitColle
 
 
 
-bool EEBadScFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool EEBadScFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
 
   // load required collections

--- a/RecoMET/METFilters/plugins/EcalDeadCellBoundaryEnergyFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellBoundaryEnergyFilter.cc
@@ -128,11 +128,11 @@ EcalDeadCellBoundaryEnergyFilter::EcalDeadCellBoundaryEnergyFilter(const edm::Pa
 
    maxBoundaryEnergy_ = cutBoundEnergyDeadCellsEB;
 
-   if (skimGap_ && debug_ ) std::cout << "Skim Gap!" << std::endl;
-   if (skimDead_ && debug_ ) std::cout << "Skim Dead!" << std::endl;
+   if (skimGap_ && debug_ ) edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "Skim Gap!";
+   if (skimDead_ && debug_ ) edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "Skim Dead!";
 
    if( debug_ ) {
-      std::cout << "Constructor EcalAnomalousEvent" << std::endl;
+      edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "Constructor EcalAnomalousEvent";
       ebBoundaryCalc.setDebugMode();
       eeBoundaryCalc.setDebugMode();
    }
@@ -143,7 +143,6 @@ EcalDeadCellBoundaryEnergyFilter::EcalDeadCellBoundaryEnergyFilter(const edm::Pa
 }
 
 EcalDeadCellBoundaryEnergyFilter::~EcalDeadCellBoundaryEnergyFilter() {
-   //std::cout << "destructor Filter" << std::endl;
 }
 
 // ------------ method called on each new Event  ------------
@@ -192,7 +191,7 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
    if (!limitFilterToEE_) {
 
       if (debug_)
-         std::cout << "process EB" << std::endl;
+         edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "process EB";
 
       for (EcalRecHitCollection::const_iterator hit = EBRecHits->begin(); hit != EBRecHits->end(); ++hit) {
 
@@ -213,7 +212,6 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
             int channelAllowed = limitDeadCellToChannelStatusEB_[cs];
 
             for (std::vector<int>::iterator sit = deadNeighbourStati.begin(); sit != deadNeighbourStati.end(); ++sit) {
-               //std::cout << "Neighbouring dead channel with status: " << *sit << std::endl;
                if (channelAllowed == *sit || (channelAllowed < 0 && std::abs(channelAllowed) <= *sit)) {
                   passChannelLimitation = true;
                   break;
@@ -245,8 +243,8 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
                v_enNeighboursGap_EB.push_back(gapinfo);
 
                if (debug_)
-                  std::cout << "EB: gap cluster energy: " << gapinfo.boundaryEnergy << " deadCells: "
-                        << gapinfo.detIds.size() << std::endl;
+                  edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "EB: gap cluster energy: " << gapinfo.boundaryEnergy << " deadCells: "
+                        << gapinfo.detIds.size();
             }
          }
 
@@ -269,8 +267,8 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
                v_boundaryInfoDeadCells_EB.push_back(boundinfo);
 
                if (debug_)
-                  std::cout << "EB: boundary Energy dead RecHit: " << boundinfo.boundaryEnergy << " ET: "
-                        << boundinfo.boundaryET << " deadCells: " << boundinfo.detIds.size() << std::endl;
+                  edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "EB: boundary Energy dead RecHit: " << boundinfo.boundaryEnergy << " ET: "
+                        << boundinfo.boundaryET << " deadCells: " << boundinfo.detIds.size();
             }
 
          }
@@ -283,7 +281,7 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
    if (!limitFilterToEB_) {
 
       if (debug_)
-         std::cout << "process EE" << std::endl;
+         edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "process EE";
 
       for (EcalRecHitCollection::const_iterator hit = EERecHits->begin(); hit != EERecHits->end(); ++hit) {
 
@@ -304,7 +302,6 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
             int channelAllowed = limitDeadCellToChannelStatusEE_[cs];
 
             for (std::vector<int>::iterator sit = deadNeighbourStati.begin(); sit != deadNeighbourStati.end(); ++sit) {
-               //std::cout << "Neighbouring dead channel with status: " << *sit << std::endl;
                if (channelAllowed == *sit || (channelAllowed < 0 && std::abs(channelAllowed) <= *sit)) {
                   passChannelLimitation = true;
                   break;
@@ -340,8 +337,8 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
                v_enNeighboursGap_EE.push_back(gapinfo);
 
                if (debug_)
-                  std::cout << "EE: gap cluster energy: " << gapinfo.boundaryEnergy << " deadCells: "
-                        << gapinfo.detIds.size() << std::endl;
+                  edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "EE: gap cluster energy: " << gapinfo.boundaryEnergy << " deadCells: "
+                        << gapinfo.detIds.size();
             }
          }
 
@@ -364,12 +361,8 @@ bool EcalDeadCellBoundaryEnergyFilter::filter(edm::StreamID, edm::Event& iEvent,
                v_boundaryInfoDeadCells_EE.push_back(boundinfo);
 
                if (debug_)
-                  std::cout << "EE: boundary Energy dead RecHit: " << boundinfo.boundaryEnergy << " ET: "
-                        << boundinfo.boundaryET << " deadCells: " << boundinfo.detIds.size() << std::endl;
-
-               //               for (std::vector<DetId>::iterator it = boundinfo.detIds.begin(); it != boundinfo.detIds.end(); it++) {
-               //                  std::cout << (EEDetId) * it << std::endl;
-               //               }
+                  edm::LogInfo("EcalDeadCellBoundaryEnergyFilter") << "EE: boundary Energy dead RecHit: " << boundinfo.boundaryEnergy << " ET: "
+                        << boundinfo.boundaryET << " deadCells: " << boundinfo.detIds.size();
 
             }
 

--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -66,8 +66,6 @@
 
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
-#include "TTree.h"
-
 using namespace std;
 
 class EcalDeadCellTriggerPrimitiveFilter : public edm::stream::EDFilter<> {

--- a/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellTriggerPrimitiveFilter.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 
@@ -202,7 +203,7 @@ void EcalDeadCellTriggerPrimitiveFilter::loadEventInfoForFilter(const edm::Event
     if( hastpDigiCollection_ && hasReducedRecHits_>=2 ){ break; }
   }
 
-  if( debug_ ) std::cout<<"\nhastpDigiCollection_ : "<<hastpDigiCollection_<<"  hasReducedRecHits_ : "<<hasReducedRecHits_<<std::endl;
+  if( debug_ ) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"\nhastpDigiCollection_ : "<<hastpDigiCollection_<<"  hasReducedRecHits_ : "<<hasReducedRecHits_;
 
   const edm::ProcessHistory& history = iEvent.processHistory();
   const unsigned int nHist = history.size();
@@ -213,7 +214,7 @@ void EcalDeadCellTriggerPrimitiveFilter::loadEventInfoForFilter(const edm::Event
   int majorV = TString(split->At(1)->GetName()).Atoi();
   int minorV = TString(split->At(2)->GetName()).Atoi();
 
-  if( debug_ ) std::cout<<"processName : "<<history[nHist-2].processName().data()<<"  releaseVersion : "<<releaseVersion_<<std::endl;
+  if( debug_ ) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"processName : "<<history[nHist-2].processName().data()<<"  releaseVersion : "<<releaseVersion_;
 
 // If TP is available, always use TP.
 // In RECO file, we always have ecalTPSkim (at least from 38X for data and 39X for MC).
@@ -222,8 +223,8 @@ void EcalDeadCellTriggerPrimitiveFilter::loadEventInfoForFilter(const edm::Event
 // If they really can provide them, they must be experts to modify this code to suit their own purpose :-)
   if( !hastpDigiCollection_ && !hasReducedRecHits_ ){ useTPmethod_ = false; useHITmethod_ = false;
      if( debug_ ){
-        std::cout<<"\nWARNING ... Cannot find either tpDigiCollection_ or reducedRecHitCollecion_ ?!"<<std::endl;
-        std::cout<<"  Will NOT DO ANY FILTERING !"<<std::endl;
+        edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"\nWARNING ... Cannot find either tpDigiCollection_ or reducedRecHitCollecion_ ?!";
+        edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"  Will NOT DO ANY FILTERING !";
      }
   }
   else if( hastpDigiCollection_ ){ useTPmethod_ = true; useHITmethod_ = false; }
@@ -231,12 +232,12 @@ void EcalDeadCellTriggerPrimitiveFilter::loadEventInfoForFilter(const edm::Event
   else if( majorV >=5 || (majorV==4 && minorV >=2) ){ useTPmethod_ = false; useHITmethod_ = true; }
   else{ useTPmethod_ = false; useHITmethod_ = false;
      if( debug_ ){
-        std::cout<<"\nWARNING ... TP filter can ONLY be used in AOD after 42X"<<std::endl;
-        std::cout<<"  Will NOT DO ANY FILTERING !"<<std::endl;
+        edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"\nWARNING ... TP filter can ONLY be used in AOD after 42X";
+        edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"  Will NOT DO ANY FILTERING !";
      }
   }
 
-  if( debug_ ) std::cout<<"useTPmethod_ : "<<useTPmethod_<<"  useHITmethod_ : "<<useHITmethod_<<std::endl;
+  if( debug_ ) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"useTPmethod_ : "<<useTPmethod_<<"  useHITmethod_ : "<<useHITmethod_;
 
   getEventInfoForFilterOnce_ = true;
 
@@ -262,7 +263,7 @@ void EcalDeadCellTriggerPrimitiveFilter::loadEcalRecHits(edm::Event& iEvent, con
 
 void EcalDeadCellTriggerPrimitiveFilter::envSet(const edm::EventSetup& iSetup) {
 
-  if (debug_ && verbose_ >=2) std::cout << "***envSet***" << std::endl;
+  if (debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter") << "***envSet***";
 
   ecalScale_.setEventSetup( iSetup );
   iSetup.get<IdealGeometryRecord>().get(ttMap_);
@@ -317,13 +318,13 @@ void EcalDeadCellTriggerPrimitiveFilter::beginRun(const edm::Run &iRun, const ed
 // Event setup
   envSet(iSetup);
   getChannelStatusMaps();
-  if( debug_ && verbose_ >=2) std::cout<< "EcalAllDeadChannelsValMap.size() : "<<EcalAllDeadChannelsValMap.size()<<"  EcalAllDeadChannelsBitMap.size() : "<<EcalAllDeadChannelsBitMap.size()<<std::endl;
+  if( debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<< "EcalAllDeadChannelsValMap.size() : "<<EcalAllDeadChannelsValMap.size()<<"  EcalAllDeadChannelsBitMap.size() : "<<EcalAllDeadChannelsBitMap.size();
   return ;
 }
 
 int EcalDeadCellTriggerPrimitiveFilter::setEvtRecHitstatus(const double &tpValCut, const int &chnStatus, const int &towerTest){
 
-  if( debug_ && verbose_ >=2) std::cout<<"***begin setEvtTPstatusRecHits***"<<std::endl;
+  if( debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"***begin setEvtTPstatusRecHits***";
 
   accuTTetMap.clear(); accuTTchnMap.clear(); TTzsideMap.clear();
   accuSCetMap.clear(); accuSCchnMap.clear(); SCzsideMap.clear();
@@ -384,7 +385,7 @@ int EcalDeadCellTriggerPrimitiveFilter::setEvtRecHitstatus(const double &tpValCu
            if( towerTest <0 && bit2Itor->second.back() >= abs(towerTest) ) continue;
            towerTestCnt ++;
         }
-        if( towerTestCnt !=0 && debug_ && verbose_ >=2) std::cout<<"towerTestCnt : "<<towerTestCnt<<"  for towerTest : "<<towerTest<<std::endl;
+        if( towerTestCnt !=0 && debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"towerTestCnt : "<<towerTestCnt<<"  for towerTest : "<<towerTest;
 
         std::vector<DetId>::iterator avoidItor; avoidItor = find( avoidDuplicateVec.begin(), avoidDuplicateVec.end(), det);
         if( avoidItor == avoidDuplicateVec.end() ){
@@ -449,7 +450,7 @@ int EcalDeadCellTriggerPrimitiveFilter::setEvtRecHitstatus(const double &tpValCu
            if( towerTest <0 && bit2Itor->second.back() >= abs(towerTest) ) continue;
            towerTestCnt ++;
         }
-        if( towerTestCnt !=0 && debug_ && verbose_ >=2) std::cout<<"towerTestCnt : "<<towerTestCnt<<"  for towerTest : "<<towerTest<<std::endl;
+        if( towerTestCnt !=0 && debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"towerTestCnt : "<<towerTestCnt<<"  for towerTest : "<<towerTest;
 // ^^^^=                  END                 =^^^^
 
         EcalScDetId sc( (det.ix()-1)/5+1, (det.iy()-1)/5+1, det.zside() );
@@ -485,12 +486,12 @@ int EcalDeadCellTriggerPrimitiveFilter::setEvtRecHitstatus(const double &tpValCu
      double ttetVal = ttetItor->second;
 
      std::map<EcalTrigTowerDetId, int>::iterator ttchnItor = accuTTchnMap.find(ttDetId);
-     if( ttchnItor == accuTTchnMap.end() ){ cout<<"\nERROR  cannot find ttDetId : "<<ttDetId<<" in accuTTchnMap?!"<<endl<<endl; }
+     if( ttchnItor == accuTTchnMap.end() ){ edm::LogError("EcalDeadCellTriggerPrimitiveFilter")<<"\nERROR  cannot find ttDetId : "<<ttDetId<<" in accuTTchnMap?!"; }
 
      std::map<EcalTrigTowerDetId, int>::iterator ttzsideItor = TTzsideMap.find(ttDetId);
-     if( ttzsideItor == TTzsideMap.end() ){ cout<<"\nERROR  cannot find ttDetId : "<<ttDetId<<" in TTzsideMap?!"<<endl<<endl; }
+     if( ttzsideItor == TTzsideMap.end() ){ edm::LogError("EcalDeadCellTriggerPrimitiveFilter")<<"\nERROR  cannot find ttDetId : "<<ttDetId<<" in TTzsideMap?!"; }
 
-     if( ttchnItor->second != 25 && debug_ && verbose_ >=2) cout<<"WARNING ... ttchnCnt : "<<ttchnItor->second<<"  NOT equal  25!"<<endl;
+     if( ttchnItor->second != 25 && debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"WARNING ... ttchnCnt : "<<ttchnItor->second<<"  NOT equal  25!";
 
      if( ttetVal >= tpValCut ){ isPassCut = 1; isPassCut *= ttzsideItor->second; }
 
@@ -505,18 +506,18 @@ int EcalDeadCellTriggerPrimitiveFilter::setEvtRecHitstatus(const double &tpValCu
      double scetVal = scetItor->second;
 
      std::map<EcalScDetId, int>::iterator scchnItor = accuSCchnMap.find(scDetId);
-     if( scchnItor == accuSCchnMap.end() ){ cout<<"\nERROR  cannot find scDetId : "<<scDetId<<" in accuSCchnMap?!"<<endl<<endl; }
+     if( scchnItor == accuSCchnMap.end() ){ edm::LogError("EcalDeadCellTriggerPrimitiveFilter")<<"\nERROR  cannot find scDetId : "<<scDetId<<" in accuSCchnMap?!"; }
 
      std::map<EcalScDetId, int>::iterator sczsideItor = SCzsideMap.find(scDetId);
-     if( sczsideItor == SCzsideMap.end() ){ cout<<"\nERROR  cannot find scDetId : "<<scDetId<<" in SCzsideMap?!"<<endl<<endl; }
+     if( sczsideItor == SCzsideMap.end() ){ edm::LogError("EcalDeadCellTriggerPrimitiveFilter")<<"\nERROR  cannot find scDetId : "<<scDetId<<" in SCzsideMap?!"; }
 
-     if( scchnItor->second != 25 && debug_ && verbose_ >=2) cout<<"WARNING ... scchnCnt : "<<scchnItor->second<<"  NOT equal  25!"<<endl;
+     if( scchnItor->second != 25 && debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"WARNING ... scchnCnt : "<<scchnItor->second<<"  NOT equal  25!";
 
      if( scetVal >= tpValCut ){ isPassCut = 1; isPassCut *= sczsideItor->second; }
 
   }
 
-  if( debug_ && verbose_ >=2) std::cout<<"***end setEvtTPstatusRecHits***"<<std::endl;
+  if( debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"***end setEvtTPstatusRecHits***";
 
   return isPassCut;
 
@@ -525,7 +526,7 @@ int EcalDeadCellTriggerPrimitiveFilter::setEvtRecHitstatus(const double &tpValCu
 
 int EcalDeadCellTriggerPrimitiveFilter::setEvtTPstatus(const double &tpValCut, const int &chnStatus) {
 
-  if( debug_ && verbose_ >=2) std::cout<<"***begin setEvtTPstatus***"<<std::endl;
+  if( debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"***begin setEvtTPstatus***";
 
   int isPassCut =0;
 
@@ -560,7 +561,7 @@ int EcalDeadCellTriggerPrimitiveFilter::setEvtTPstatus(const double &tpValCut, c
      }
   } // loop over EB + EE
 
-  if( debug_ && verbose_ >=2) std::cout<<"***end setEvtTPstatus***"<<std::endl;
+  if( debug_ && verbose_ >=2) edm::LogInfo("EcalDeadCellTriggerPrimitiveFilter")<<"***end setEvtTPstatus***";
 
   return isPassCut;
 }

--- a/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include <DataFormats/EcalDetId/interface/EBDetId.h>
@@ -99,11 +100,11 @@ bool EcalLaserCorrFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::
     if( energy>EEEnegyMIN_ && (lasercalib < EELaserMIN_ || lasercalib > EELaserMAX_) ) {
       goodCalib = false;
       if(debug_) {
-	std::cout << "RecHit EE "
+         edm::LogInfo("EcalLaserCorrFilter")
+          << "RecHit EE "
 		  << iEvent.id().run()<< ":" << iEvent.luminosityBlock() <<":"<<iEvent.id().event()
 		  << " lasercalib " << lasercalib << " rechit ene " << energy << " time " << time
-		  << " ix, iy, z = " << jx << " " << jy  << " " << jz
-		  << std::endl;
+		  << " ix, iy, z = " << jx << " " << jy  << " " << jz;
       }
     }
 
@@ -128,11 +129,11 @@ bool EcalLaserCorrFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::
     if (energy>EBEnegyMIN_ && (lasercalib < EBLaserMIN_ || lasercalib > EBLaserMAX_) ) {
       goodCalib = false;
       if(debug_) {
-	std::cout << "RecHit EB "
+          edm::LogInfo("EcalLaserCorrFilter")
+          << "RecHit EB "
 		  << iEvent.id().run()<< ":" << iEvent.luminosityBlock() <<":"<<iEvent.id().event()
 		  << " lasercalib " << lasercalib << " rechit ene " << energy << " time " << time
-		  << " eta, phi, z = " << etarec << " " << phirec  << " " << zrec
-		  << std::endl;
+		  << " eta, phi, z = " << etarec << " " << phirec  << " " << zrec;
       }
     }
     //if (!goodCalib) break;
@@ -140,7 +141,6 @@ bool EcalLaserCorrFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::
 
 
   bool result = goodCalib;
-  //std::cout << " *********** Result ******** " << result << std::endl;
 
   iEvent.put(std::make_unique<bool>(result));
 

--- a/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
@@ -38,8 +38,8 @@ class EcalLaserCorrFilter : public edm::global::EDFilter<> {
 
     virtual bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
-    edm::EDGetTokenT<EcalRecHitCollection> ebRHSrcToken_;
-    edm::EDGetTokenT<EcalRecHitCollection> eeRHSrcToken_;
+    const edm::EDGetTokenT<EcalRecHitCollection> ebRHSrcToken_;
+    const edm::EDGetTokenT<EcalRecHitCollection> eeRHSrcToken_;
 
     // thresholds to laser corr to set kPoorCalib
     const double EBLaserMIN_, EELaserMIN_, EBLaserMAX_, EELaserMAX_, EBEnegyMIN_, EEEnegyMIN_;

--- a/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalLaserCorrFilter.cc
@@ -1,6 +1,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -27,7 +27,7 @@
 #include "FWCore/Utilities/interface/typelookup.h"  ///// added as a try for CaloTopology
 
 
-class EcalLaserCorrFilter : public edm::EDFilter {
+class EcalLaserCorrFilter : public edm::global::EDFilter<> {
 
   public:
 
@@ -36,7 +36,7 @@ class EcalLaserCorrFilter : public edm::EDFilter {
 
   private:
 
-    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+    virtual bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
     edm::EDGetTokenT<EcalRecHitCollection> ebRHSrcToken_;
     edm::EDGetTokenT<EcalRecHitCollection> eeRHSrcToken_;
@@ -63,7 +63,7 @@ EcalLaserCorrFilter::EcalLaserCorrFilter(const edm::ParameterSet & iConfig)
 }
 
 
-bool EcalLaserCorrFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool EcalLaserCorrFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
    using namespace edm;
    using namespace reco;

--- a/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalLaserEventFilter.cc
@@ -35,6 +35,7 @@ It also allows users to remove events in which the number of HBHE rechits exceed
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // Use for HBHERecHitCollection
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
@@ -169,7 +170,7 @@ HcalLaserEventFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Event
 
    bool filterDecision=true;
 
-   if (debug_) std::cout <<"<HcalLaserEventFilter> Run = "<<iEvent.id().run()<<" Event = "<<iEvent.id().event()<<std::endl;
+   if (debug_) edm::LogInfo("HcalLaserEventFilter") <<"<HcalLaserEventFilter> Run = "<<iEvent.id().run()<<" Event = "<<iEvent.id().event();
 
    // Veto events by run/event numbers
    if (vetoByRunEventNumber_)
@@ -179,7 +180,7 @@ HcalLaserEventFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Event
 	   if (iEvent.id().run()==RunEventData_[i].first &&
 	       iEvent.id().event()==RunEventData_[i].second)
 	     {
-	       if (debug_) std::cout<<"\t<HcalLaserEventFilter> Filtering bad event;  Run "<<iEvent.id().run()<<" Event = "<<iEvent.id().event()<<std::endl;
+	       if (debug_) edm::LogInfo("HcalLaserEventFilter")<<"\t<HcalLaserEventFilter> Filtering bad event;  Run "<<iEvent.id().run()<<" Event = "<<iEvent.id().event();
 	       filterDecision=false;
 	       break;
 	     }
@@ -206,16 +207,16 @@ HcalLaserEventFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Event
 	   edm::Handle<HBHERecHitCollection> hbheRecHits;
 	   if (iEvent.getByToken(hbheToken_,hbheRecHits))
 	     {
-	       if (debug_) std::cout <<"Rechit size = "<<hbheRecHits->size()<<"  threshold = "<<minOccupiedHBHE_<<std::endl;
+	       if (debug_) edm::LogInfo("HcalLaserEventFilter") <<"Rechit size = "<<hbheRecHits->size()<<"  threshold = "<<minOccupiedHBHE_;
 	       if (hbheRecHits->size()>=minOccupiedHBHE_)
 		 {
-		   if (debug_) std::cout <<"<HcalLaserEventFilter>  Filtering because of large HBHE rechit size; "<<hbheRecHits->size()<<" rechits is greater than or equal to the allowed maximum of "<<minOccupiedHBHE_<<std::endl;
+		   if (debug_) edm::LogInfo("HcalLaserEventFilter") <<"<HcalLaserEventFilter>  Filtering because of large HBHE rechit size; "<<hbheRecHits->size()<<" rechits is greater than or equal to the allowed maximum of "<<minOccupiedHBHE_;
 		   filterDecision=false;
 		 }
 	     }
 	   else
 	     {
-	       if (debug_) std::cout <<"<HcalLaserEventFilter::Error> No valid HBHERecHitCollection with label '"<<hbheInputLabel_<<"' found"<<std::endl;
+	       if (debug_) edm::LogInfo("HcalLaserEventFilter") <<"<HcalLaserEventFilter::Error> No valid HBHERecHitCollection with label '"<<hbheInputLabel_<<"' found";
 	     }
 	 }
 
@@ -229,16 +230,16 @@ HcalLaserEventFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Event
 	   Handle<HcalNoiseSummary> hSummary;
 	   if (iEvent.getByToken(hcalNoiseSummaryToken_,hSummary)) // get by label, usually with label 'hcalnoise'
 	     {
-	       if (debug_)  std::cout << " RECHIT SIZE (from HcalNoiseSummary) = "<<hSummary->GetRecHitCount()<<"  threshold = "<<minOccupiedHBHE_<<std::endl;
+	       if (debug_)  edm::LogInfo("HcalLaserEventFilter") << " RECHIT SIZE (from HcalNoiseSummary) = "<<hSummary->GetRecHitCount()<<"  threshold = "<<minOccupiedHBHE_;
 	       if (hSummary->GetRecHitCount() >= (int)minOccupiedHBHE_)
 		 {
-		   if (debug_) std::cout <<"<HcalLaserEventFilter>  Filtering because of large HBHE rechit size in HcalNoiseSummary; "<<hSummary->GetRecHitCount()<<" rechits is greater than or equal to the allowed maximum of "<<minOccupiedHBHE_<<std::endl;
+		   if (debug_) edm::LogInfo("HcalLaserEventFilter") <<"<HcalLaserEventFilter>  Filtering because of large HBHE rechit size in HcalNoiseSummary; "<<hSummary->GetRecHitCount()<<" rechits is greater than or equal to the allowed maximum of "<<minOccupiedHBHE_;
 		   filterDecision=false;
 		 }
 	     }
 	   else
 	     {
-	       if (debug_) std::cout <<"<HcalLaserEventFilter::Error> No valid HcalNoiseSummary with label '"<<hcalNoiseSummaryLabel_<<"' found"<<std::endl;
+	       if (debug_) edm::LogInfo("HcalLaserEventFilter") <<"<HcalLaserEventFilter::Error> No valid HcalNoiseSummary with label '"<<hcalNoiseSummaryLabel_<<"' found";
 	     }
 	 }
      }// if (vetoByHBHEOccupancy_)

--- a/RecoMET/METFilters/plugins/TrackingFailureFilter.cc
+++ b/RecoMET/METFilters/plugins/TrackingFailureFilter.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -78,11 +79,11 @@ bool TrackingFailureFilter::filter(edm::StreamID, edm::Event & iEvent, const edm
   const bool pass = (sumpt/ht) > minSumPtOverHT_;
 
   if( !pass && debug_ )
-    std::cout << "TRACKING FAILURE: "
+    edm::LogInfo("TrackingFailureFilter")
+              << "TRACKING FAILURE: "
               << iEvent.id().run() << " : " << iEvent.id().luminosityBlock() << " : " << iEvent.id().event()
               << " HT=" << ht
-              << " SumPt=" << sumpt
-              << std::endl;
+              << " SumPt=" << sumpt;
 
   iEvent.put(std::make_unique<bool>(pass));
 

--- a/RecoMET/METFilters/plugins/TrackingFailureFilter.cc
+++ b/RecoMET/METFilters/plugins/TrackingFailureFilter.cc
@@ -1,6 +1,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/View.h"
@@ -9,7 +9,7 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 
 
-class TrackingFailureFilter : public edm::EDFilter {
+class TrackingFailureFilter : public edm::global::EDFilter<> {
 
   public:
 
@@ -18,7 +18,7 @@ class TrackingFailureFilter : public edm::EDFilter {
 
   private:
 
-    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+    virtual bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
     edm::EDGetTokenT<edm::View<reco::Jet> > jetSrcToken_;
     edm::EDGetTokenT<std::vector<reco::Track> > trackSrcToken_;
@@ -45,7 +45,7 @@ TrackingFailureFilter::TrackingFailureFilter(const edm::ParameterSet & iConfig)
 }
 
 
-bool TrackingFailureFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool TrackingFailureFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
   edm::Handle<edm::View<reco::Jet> > jets;
   iEvent.getByToken(jetSrcToken_, jets);

--- a/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
+++ b/RecoMET/METFilters/python/EcalDeadCellTriggerPrimitiveFilter_cfi.py
@@ -20,9 +20,6 @@ EcalDeadCellTriggerPrimitiveFilter = cms.EDFilter(
     maskedEcalChannelStatusThreshold = cms.int32( 1 ),
     
     doEEfilter = cms.untracked.bool( True ), # turn it on by default
-    
-    makeProfileRoot = cms.untracked.bool( False ),
-    profileRootName = cms.untracked.string("deadCellFilterProfile.root" ),
 
     useTTsum = cms.bool ( True ),
     usekTPSaturated = cms.bool ( False)


### PR DESCRIPTION
In the course of testing Phase2 workflows on Knights Landing machines (with 64 threads), @Dr15Jones and @gartung found a number of legacy modules causing stalls.

In this PR, I fixed several of them. Modules were updated to global where possible (no mutable state required, or mutable state could be avoided with straightforward code changes) and stream otherwise (when a mutable state of the class was unavoidable). In some cases, code edits were necessary to remove thread-unsafe practices.