### PR TITLE
Fix HCAL trigger mode in 2018 geometry

### DIFF
--- a/Geometry/HcalCommonData/data/Run2/hcalRecNumbering18.xml
+++ b/Geometry/HcalCommonData/data/Run2/hcalRecNumbering18.xml
@@ -38,7 +38,7 @@
     <PartSelector path="//HCal"/>
     <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
     <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
-    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2017" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2018" eval="false"/>
   </SpecPar>
 </SpecParSection>
 </DDDefinition>


### PR DESCRIPTION
Backport of #17953, needed for 2018 simulation to not crash. Will also need a geometry update for 90X tags.