### PR TITLE
fix hep17 and hf compression luts

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -34,15 +34,13 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
         throw cms::Exception("CaloTPGTranscoderULUT") << "Topology not set! Use CaloTPGTranscoderULUT::setup(...) first!";
     }
 
-    std::array<unsigned int, OUTPUT_LUT_SIZE> analytical10BITLUT;
-    std::array<unsigned int, OUTPUT_LUT_SIZE> analytical11BITLUT;
+    std::array<unsigned int, OUTPUT_LUT_SIZE> analyticalLUT;
     std::array<unsigned int, OUTPUT_LUT_SIZE> linearRctLUT;
     std::array<unsigned int, OUTPUT_LUT_SIZE> linearNctLUT;
 
     // Compute compression LUT
     for (unsigned int i=0; i < OUTPUT_LUT_SIZE; i++) {
-	analytical10BITLUT[i] = (unsigned int)(sqrt(14.94*log(1.+i/14.94)*i) + 0.5);
-	analytical11BITLUT[i] = (unsigned int)(sqrt(5.32*log(1.+i/5.32)*i) + 0.5);
+	analyticalLUT[i] = min((unsigned int)(sqrt(14.94*log(1.+i/14.94)*i) + 0.5), TPGMAX - 1);
 	linearRctLUT[i] = min((unsigned int)(i/rct_factor_), TPGMAX - 1);
 	linearNctLUT[i] = min((unsigned int)(i/nct_factor_), TPGMAX - 1);
     }
@@ -76,12 +74,9 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
         for (unsigned int i = 0; i < threshold; ++i)
            outputLUT_[index][i] = 0;
 
-        if (isHBHE and lutsize == REDUCE10BIT) {
+        if (isHBHE) {
            for (unsigned int i = threshold; i < lutsize; ++i)
-              outputLUT_[index][i] = analytical10BITLUT[i];
-        } else if (isHBHE) {
-           for (unsigned int i = threshold; i < lutsize; ++i)
-              outputLUT_[index][i] = analytical11BITLUT[i];
+              outputLUT_[index][i] = analyticalLUT[i];
         } else {
            for (unsigned int i = threshold; i < lutsize; ++i)
               outputLUT_[index][i] = version == 0 ? linearRctLUT[i] : linearNctLUT[i];

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -48,7 +48,7 @@ public:
 
   // Map different QIE to the right linearization
   static const unsigned int QIE8_OUTPUT_LUT_SIZE = REDUCE10BIT;
-  static const unsigned int QIE10_OUTPUT_LUT_SIZE = REDUCE10BIT;
+  static const unsigned int QIE10_OUTPUT_LUT_SIZE = REDUCE11BIT;
   static const unsigned int QIE11_OUTPUT_LUT_SIZE = REDUCE11BIT;
   static const unsigned int OUTPUT_LUT_SIZE = std::max({QIE8_OUTPUT_LUT_SIZE, QIE10_OUTPUT_LUT_SIZE, QIE11_OUTPUT_LUT_SIZE});
   static const unsigned int TPGMAX = 256;


### PR DESCRIPTION
This is to revert the HEP17 LUTs and make them same as for the other HE channels for the first 10 bits, as discussed in the Hcal DPG trigger meeting with @nsmith- . 
Also extending HF compression LUTs to 11 bits (this is now only important for online HCAL compression LUTs).

Would be good to have it signed off by L1. 



