### PR TITLE
Remove foward declaration for Plane3D

### DIFF
--- a/FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h
+++ b/FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h
@@ -29,6 +29,7 @@
 #include "Math/GenVector/RotationXfwd.h"
 #include "Math/GenVector/RotationYfwd.h"
 #include "Math/GenVector/RotationZfwd.h"
+#include "Math/GenVector/Plane3D.h"
 
 #include <iostream>
 
@@ -40,7 +41,7 @@ namespace ROOT {
 
   namespace Math { 
 
-    class Plane3D; 
+    using ROOT::Math::Plane3D;
 
 
 

--- a/FastSimulation/CaloGeometryTools/src/Transform3DPJ.cc
+++ b/FastSimulation/CaloGeometryTools/src/Transform3DPJ.cc
@@ -15,7 +15,6 @@
 //
 
 #include "FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h"
-#include "Math/GenVector/Plane3D.h"
 
 #include <cmath>
 #include <algorithm>


### PR DESCRIPTION
Looks this package is mostly 9-10 years old. A piece was copies from
ROOT, but my guess the changes were never integrated back into ROOT.

Plane3D is forward declaration here, but ROOT master (6.10.00) changed
namespaces holding it. Instead forward declaration lets use a complete
type ROOT::Math::Plane3D from ROOT (which is a typedef). Should work
with any ROOT version (6.08.XX, 6.10.XX).

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>