### PR TITLE
Add customization to enable ROOT IMT

### DIFF
--- a/FWCore/Concurrency/python/enableIMT.py
+++ b/FWCore/Concurrency/python/enableIMT.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+def enableIMT(process):
+  process.InitRootHandlers = cms.Service("InitRootHandlers",
+      EnableIMT = cms.untracked.bool(True)
+  )
+  return process


### PR DESCRIPTION
It can be used like this:

    --customise FWCore/Concurrency/enableIMT.enableIMT

in cmsDriver.

This enables ROOT IMT (Implicit Multi-Threading) which by default
enabled in CMake starting 6.10.00

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>