### PR TITLE
Tracker Geometry Error Messages with More Details

### DIFF
--- a/CommonTools/RecoAlgos/BuildFile.xml
+++ b/CommonTools/RecoAlgos/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="SimGeneral/HepPDTRecord"/>
-<use   name="DataFormats/RecoCandidate"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/TrackReco"/>

--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -1,4 +1,5 @@
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 const TrackingLayer::eqfct TrackingLayer::_eqfct;
 

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -7,20 +7,6 @@
 
 class GeometricDet;
 
-#include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
-
-#include "DataFormats/Common/interface/Trie.h"
-
-// FIXME here just to allow prototyping...
-namespace trackerTrie {
-  typedef GeomDet const* PDet;
-  typedef edm::Trie<PDet> DetTrie;
-  typedef edm::TrieNode<PDet> Node;
-  typedef Node const * node_pointer; // sigh....
-  typedef edm::TrieNodeIter<PDet> node_iterator;
-}
-
-
 /**
  * A specific Tracker Builder which builds a Tracker from a list of DetUnits. 
  * Pattern recognition is used to discover layers, rings etc.

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -16,35 +16,35 @@
 #include <map>
 
 namespace {
-GeomDetEnumerators::SubDetector
-geometricDetToGeomDet(GeometricDet::GDEnumType gdenum) {
-  // provide a map between the GeometricDet enumerators and the GeomDet enumerators of the possible tracker subdetectors
-  if(gdenum == GeometricDet::GDEnumType::PixelBarrel ) return GeomDetEnumerators::SubDetector::PixelBarrel;
-  if(gdenum == GeometricDet::GDEnumType::PixelEndCap) return GeomDetEnumerators::SubDetector::PixelEndcap;
-  if(gdenum == GeometricDet::GDEnumType::TIB) return GeomDetEnumerators::SubDetector::TIB;
-  if(gdenum == GeometricDet::GDEnumType::TID) return GeomDetEnumerators::SubDetector::TID;
-  if(gdenum == GeometricDet::GDEnumType::TOB) return GeomDetEnumerators::SubDetector::TOB;
-  if(gdenum == GeometricDet::GDEnumType::TEC) return GeomDetEnumerators::SubDetector::TEC;
-  if(gdenum == GeometricDet::GDEnumType::PixelPhase1Barrel) return GeomDetEnumerators::SubDetector::P1PXB;
-  if(gdenum == GeometricDet::GDEnumType::PixelPhase1EndCap) return GeomDetEnumerators::SubDetector::P1PXEC;
-  if(gdenum == GeometricDet::GDEnumType::PixelPhase2EndCap) return GeomDetEnumerators::SubDetector::P2PXEC;
-  if(gdenum == GeometricDet::GDEnumType::OTPhase2Barrel) return GeomDetEnumerators::SubDetector::P2OTB;
-  if(gdenum == GeometricDet::GDEnumType::OTPhase2EndCap) return GeomDetEnumerators::SubDetector::P2OTEC;
-  return GeomDetEnumerators::SubDetector::invalidDet;
-}
-class DetIdComparator {
-public:
-  bool operator()(GeometricDet const* gd1, GeometricDet const * gd2) const {
-    uint32_t det1 = gd1->geographicalId();
-    uint32_t det2 = gd2->geographicalId();
-    return det1 < det2;
-  }                                      
+  GeomDetEnumerators::SubDetector
+  geometricDetToGeomDet(GeometricDet::GDEnumType gdenum) {
+    // provide a map between the GeometricDet enumerators and the GeomDet enumerators of the possible tracker subdetectors
+    if(gdenum == GeometricDet::GDEnumType::PixelBarrel ) return GeomDetEnumerators::SubDetector::PixelBarrel;
+    if(gdenum == GeometricDet::GDEnumType::PixelEndCap) return GeomDetEnumerators::SubDetector::PixelEndcap;
+    if(gdenum == GeometricDet::GDEnumType::TIB) return GeomDetEnumerators::SubDetector::TIB;
+    if(gdenum == GeometricDet::GDEnumType::TID) return GeomDetEnumerators::SubDetector::TID;
+    if(gdenum == GeometricDet::GDEnumType::TOB) return GeomDetEnumerators::SubDetector::TOB;
+    if(gdenum == GeometricDet::GDEnumType::TEC) return GeomDetEnumerators::SubDetector::TEC;
+    if(gdenum == GeometricDet::GDEnumType::PixelPhase1Barrel) return GeomDetEnumerators::SubDetector::P1PXB;
+    if(gdenum == GeometricDet::GDEnumType::PixelPhase1EndCap) return GeomDetEnumerators::SubDetector::P1PXEC;
+    if(gdenum == GeometricDet::GDEnumType::PixelPhase2EndCap) return GeomDetEnumerators::SubDetector::P2PXEC;
+    if(gdenum == GeometricDet::GDEnumType::OTPhase2Barrel) return GeomDetEnumerators::SubDetector::P2OTB;
+    if(gdenum == GeometricDet::GDEnumType::OTPhase2EndCap) return GeomDetEnumerators::SubDetector::P2OTEC;
+    return GeomDetEnumerators::SubDetector::invalidDet;
+  }
   
-};
+  class DetIdComparator {
+  public:
+    bool operator()(GeometricDet const* gd1, GeometricDet const * gd2) const {
+      uint32_t det1 = gd1->geographicalId();
+      uint32_t det2 = gd2->geographicalId();
+      return det1 < det2;
+    }  
+  };
 }
- 
 
-TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd)
+TrackerGeometry::TrackerGeometry(GeometricDet const* gd)
+   : theTrackerDet(gd)
 {
   for(unsigned int i=0;i<6;++i) {
     theSubDetTypeMap[i] = GeomDetEnumerators::invalidDet;
@@ -91,7 +91,6 @@ TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd)
   }  
 }
 
-
 TrackerGeometry::~TrackerGeometry() {
     for (auto d : theDets) delete const_cast<GeomDet*>(d);
     for (auto d : theDetTypes) delete const_cast<GeomDetType*>(d);
@@ -111,7 +110,6 @@ void TrackerGeometry::finalize() {
     theTOBDets.shrink_to_fit(); // not owned: they're also in 'theDets'
     theTECDets.shrink_to_fit(); // not owned: they're also in 'theDets'
 }
-
 
 void TrackerGeometry::addType(GeomDetType const * p) {
   theDetTypes.push_back(p);  // add to vector
@@ -156,8 +154,6 @@ void TrackerGeometry::addDet(GeomDet const * p) {
   default:
     edm::LogError("TrackerGeometry")<<"ERROR - I was expecting a Tracker Subdetector, I got a "<<id.subdetId();
   }
-
-
 }
 
 void TrackerGeometry::addDetId(DetId p){
@@ -207,7 +203,8 @@ TrackerGeometry::idToDetUnit(DetId s)const
   mapIdToDetUnit::const_iterator p=theMapUnit.find(s.rawId());
   if (p != theMapUnit.end())
     return static_cast<const TrackerGeomDet *>(p->second);
-  edm::LogError("TrackerGeometry")<<"Invalid DetID: no GeomDetUnit associated";
+  edm::LogError("TrackerGeometry") << "Invalid DetID: no GeomDetUnit associated with raw ID "
+				   << s.rawId() << " of subdet ID " << s.subdetId();
   return nullptr;
 }
 
@@ -217,7 +214,8 @@ TrackerGeometry::idToDet(DetId s)const
   mapIdToDet::const_iterator p=theMap.find(s.rawId());
   if (p != theMap.end())
     return static_cast<const TrackerGeomDet *>(p->second);
-  edm::LogError("TrackerGeometry")<<"Invalid DetID: no GeomDet associated";
+  edm::LogError("TrackerGeometry")<<"Invalid DetID: no GeomDet associated with raw ID "
+				  << s.rawId() << " of subdet ID " << s.subdetId();
   return nullptr;
 }
 
@@ -274,6 +272,7 @@ TrackerGeometry::ModuleType TrackerGeometry::getDetectorType(DetId detid) const 
   }
   return TrackerGeometry::ModuleType::UNKNOWN;
 }
+
 float TrackerGeometry::getDetectorThickness(DetId detid) const {
   for (auto iVal : theDetTypetList) {
     DetId detid_max = std::get<0>(iVal);

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -201,22 +201,24 @@ const TrackerGeomDet *
 TrackerGeometry::idToDetUnit(DetId s)const
 {
   mapIdToDetUnit::const_iterator p=theMapUnit.find(s.rawId());
-  if (p != theMapUnit.end())
+  if (p != theMapUnit.end()) {
     return static_cast<const TrackerGeomDet *>(p->second);
-  edm::LogError("TrackerGeometry") << "Invalid DetID: no GeomDetUnit associated with raw ID "
-				   << s.rawId() << " of subdet ID " << s.subdetId();
-  return nullptr;
+  } else {
+    throw cms::Exception("WrongTrackerSubDet") << "Invalid DetID: no GeomDetUnit associated with raw ID "
+					       << s.rawId() << " of subdet ID " << s.subdetId();
+  }
 }
 
 const TrackerGeomDet* 
 TrackerGeometry::idToDet(DetId s)const
 {
   mapIdToDet::const_iterator p=theMap.find(s.rawId());
-  if (p != theMap.end())
+  if (p != theMap.end()) {
     return static_cast<const TrackerGeomDet *>(p->second);
-  edm::LogError("TrackerGeometry")<<"Invalid DetID: no GeomDet associated with raw ID "
-				  << s.rawId() << " of subdet ID " << s.subdetId();
-  return nullptr;
+  } else {
+    throw cms::Exception("WrongTrackerSubDet") << "Invalid DetID: no GeomDetUnit associated with raw ID "
+					       << s.rawId() << " of subdet ID " << s.subdetId();
+  }
 }
 
 const GeomDetEnumerators::SubDetector 

--- a/RecoTracker/GeometryESProducer/test/TrackerRecoGeometryAnalyzer.cc
+++ b/RecoTracker/GeometryESProducer/test/TrackerRecoGeometryAnalyzer.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -16,44 +16,22 @@
 
 using namespace std;
 
-//
-//
-// class decleration
-//
+class TrackerRecoGeometryAnalyzer : public edm::one::EDAnalyzer<> {
+public:
+  TrackerRecoGeometryAnalyzer( const edm::ParameterSet& );
+  ~TrackerRecoGeometryAnalyzer();
 
-class TrackerRecoGeometryAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit TrackerRecoGeometryAnalyzer( const edm::ParameterSet& );
-      ~TrackerRecoGeometryAnalyzer();
-
-
-      virtual void analyze( const edm::Event&, const edm::EventSetup& );
+  void beginJob() override {}
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void endJob() override {}
 };
 
-
-// constructors and destructor
-//
 TrackerRecoGeometryAnalyzer::TrackerRecoGeometryAnalyzer( const edm::ParameterSet& iConfig )
-{
-   //now do what ever initialization is needed
-
-}
-
+{}
 
 TrackerRecoGeometryAnalyzer::~TrackerRecoGeometryAnalyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+{}
 
-}
-
-
-//
-// member functions
-//
-
-// ------------ method called to produce the data  ------------
 void
 TrackerRecoGeometryAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
@@ -67,18 +45,15 @@ TrackerRecoGeometryAnalyzer::analyze( const edm::Event& iEvent, const edm::Event
    
    //---- testing access to barrelLayers ----
    vector<const BarrelDetLayer*> theBarrelLayers = track->barrelLayers();
-   edm::LogInfo("analyzer") << "number of BarrelLayers: " << theBarrelLayers.size() ;
+   edm::LogInfo("TrackerRecoGeometryAnalyzer") << "number of BarrelLayers: " << theBarrelLayers.size() ;
 
    for(unsigned int i=0; i<3; i++){
      const BarrelDetLayer* theLayer = theBarrelLayers[i];   
-     edm::LogInfo("analyzer") << "theLayer[" << i << "]->position().perp(): " 
+     edm::LogInfo("TrackerRecoGeometryAnalyzer") << "theLayer[" << i << "]->position().perp(): " 
 	  << theLayer->components().front()->surface().position().perp() ;     
    }   
-   //--------------------------------------
-
 }
 
-//define this as a plug-in
 DEFINE_FWK_MODULE(TrackerRecoGeometryAnalyzer);
  
  

--- a/RecoTracker/GeometryESProducer/test/testTrackerRecoGeometry_cfg.py
+++ b/RecoTracker/GeometryESProducer/test/testTrackerRecoGeometry_cfg.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TrackerRecoGeometryTest")
+
+process.maxEvents = cms.untracked.PSet(  input = cms.untracked.int32(1) )
+
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
+process.MessageLogger = cms.Service("MessageLogger",
+                                    debugModules = cms.untracked.vstring('TrackerRecoGeometryAnalyzer'),
+                                    destinations = cms.untracked.vstring('TrackerRecoGeometryAnalyzer_infos'),
+                                    TrackerRecoGeometryAnalyzer_infos = cms.untracked.PSet(
+                                      threshold = cms.untracked.string('INFO') 
+                                      ),
+                                    categories = cms.untracked.vstring('TrackerRecoGeometryAnalyzer')
+                                    )
+
+process.source = cms.Source("EmptySource")
+
+process.TrackerRecoGeometryAnalyzer = cms.EDAnalyzer("TrackerRecoGeometryAnalyzer")
+process.p1 = cms.Path(process.TrackerRecoGeometryAnalyzer)
+
+

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -21,23 +21,15 @@
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "DataFormats/GeometrySurface/interface/BoundSurface.h"
 
-
 // ======= specific includes =======
-// #include "RecoTracker/TkDetLayers/interface/TOBLayerBuilder.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTrackerBuilder.h"
 
 
 // for trie
 #include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
-
 #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
-
-
 #include "DataFormats/Common/interface/Trie.h"
-#include <boost/function.hpp>
-#include <boost/bind.hpp>
-
 
 // for the test
 #include "TrackingTools/DetLayers/interface/CylinderBuilderFromDet.h"
@@ -45,6 +37,15 @@
 
 
 namespace {
+
+  // FIXME here just to allow prototyping...
+  namespace trackerTrie {
+    typedef GeomDet const* PDet;
+    typedef edm::Trie<PDet> DetTrie;
+    typedef edm::TrieNode<PDet> Node;
+    typedef Node const * node_pointer; // sigh....
+    typedef edm::TrieNodeIter<PDet> node_iterator;
+  }
 
   // Wrapper for trie call back
   template< typename F>
@@ -60,35 +61,24 @@ namespace {
 
 }
 
-
 using namespace edm;
 using namespace std;
 
+class TkDetLayersAnalyzer : public edm::one::EDAnalyzer<> {
+public:
+  TkDetLayersAnalyzer( const edm::ParameterSet& );
+  ~TkDetLayersAnalyzer();
 
-//
-//
-// class decleration
-//
-
-class TkDetLayersAnalyzer : public EDAnalyzer {
-   public:
-      explicit TkDetLayersAnalyzer( const ParameterSet& );
-      ~TkDetLayersAnalyzer();
-
-
-      virtual void analyze( const Event&, const EventSetup& );
-   private:
-      // ----------member data ---------------------------
+  void beginJob() override {}
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void endJob() override {}
 };
 
-
-//
-TkDetLayersAnalyzer::TkDetLayersAnalyzer( const ParameterSet& iConfig )
+TkDetLayersAnalyzer::TkDetLayersAnalyzer( const edm::ParameterSet& iConfig )
 {
    //now do what ever initialization is needed
 
 }
-
 
 TkDetLayersAnalyzer::~TkDetLayersAnalyzer()
 {
@@ -98,14 +88,8 @@ TkDetLayersAnalyzer::~TkDetLayersAnalyzer()
 
 }
 
-
-//
-// member functions
-//
-
-// ------------ method called to produce the data  ------------
 void
-TkDetLayersAnalyzer::analyze( const Event& iEvent, const EventSetup& iSetup )
+TkDetLayersAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
   ESHandle<TrackerGeometry> pTrackerGeometry;
   iSetup.get<TrackerDigiGeometryRecord>().get( pTrackerGeometry ); 


### PR DESCRIPTION
* Improve error message when TrackerGeometry is asked for non-existent DetId
* Move a prototype structure from TrackerGeometry to an analyzer where it is used
* Migrate to multi-threaded analyzers
* Add test python configuration
* Add missing direct dependency
* Remove extra dependency which was already declared to remove a warning

@slava77 - Should there be an Exception thrown? Most of the downstream code does not check DetId validity any more to improve performance. I'd prefer it to crashing. It's your call.