### PR TITLE
remove unnecessary cout from RunInfoProxy.cc [backport]

### DIFF
--- a/CondCore/CondDB/src/RunInfoProxy.cc
+++ b/CondCore/CondDB/src/RunInfoProxy.cc
@@ -93,7 +93,6 @@ namespace cond {
       
        std::string dummy;
        m_session->runInfoSchema().runInfoTable().getInclusiveRunRange( low, up, m_data->runList );
-       std::cout <<"Min="<<std::get<0>(m_data->runList.front())<<" max="<<std::get<0>(m_data->runList.back())<<std::endl;
     }
 
     void RunInfoProxy::load( const boost::posix_time::ptime& low, const boost::posix_time::ptime& up ){


### PR DESCRIPTION
The title says all.
This is a back-port to 90x of https://github.com/cms-sw/cmssw/pull/18184 .
Besides not being necessary,
the extra 2 words would interfere with the shipping of histo-points for the payload inspector