### PR TITLE
Add virtual dtors for MakeProvenanceReader & ExpressionElementFinderBase

### DIFF
--- a/CommonTools/Utils/src/FormulaEvaluator.cc
+++ b/CommonTools/Utils/src/FormulaEvaluator.cc
@@ -46,6 +46,8 @@ namespace {
     virtual bool checkStart(char) const = 0;
 
     virtual EvaluatorInfo createEvaluator(std::string::const_iterator, std::string::const_iterator) const = 0;
+
+    virtual ~ExpressionElementFinderBase() = default;
   };
 
   std::string::const_iterator findMatchingParenthesis(std::string::const_iterator iBegin, std::string::const_iterator iEnd) {

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -55,6 +55,7 @@ namespace edm {
   class MakeProvenanceReader {
   public:
     virtual std::unique_ptr<ProvenanceReaderBase> makeReader(RootTree& eventTree, DaqProvenanceHelper const* daqProvenanceHelper) const = 0;
+    virtual ~MakeProvenanceReader() = default;
   };
 
   class RootFile {


### PR DESCRIPTION
CMSSW GCC 7.0.1 builds now follows jemalloc (dev branch) and also has a
new TCMalloc. Both of these have C++14 sized deallocation feature
enabled. This means that if possible operator delete will be called with
size argument, which will help allocator to reduce the time to free the
object. E.g. this is not possible for incomplete types which size is
unknown at a time.

GCC 7.0.1 builds contain an additional build of jemalloc
(jemalloc-debug) which contains extra asserts and checks for developers.
It helped to find two places were operate delete is called using base
class type instead of actual type. E.g., this means that wrong size (8
bytes) were passed to operator delete instead of actual type (16 bytes).

This seems to be undefined behavior in C++14. From [expr.delete] (5.3.5
Delete):

    In the first alternative (delete object), if the static type of the
    object to be deleted is different from its dynamic type, the static type
    shall be a base class of the dynamic type of the object to be deleted
    and the static type shall have a virtual destructor or the behavior is
    undefined.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>