### PR TITLE
Update legacy modules in SiStripTools, L1TCalorimeter, DQM

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -55,7 +55,7 @@
 // class decleration
 //
 
-class APVCyclePhaseProducerFromL1TS : public edm::EDProducer {
+class APVCyclePhaseProducerFromL1TS : public edm::stream::EDProducer<> {
    public:
       explicit APVCyclePhaseProducerFromL1TS(const edm::ParameterSet&);
       ~APVCyclePhaseProducerFromL1TS();

--- a/DPGAnalysis/SiStripTools/plugins/EventWithHistoryProducerFromL1ABC.cc
+++ b/DPGAnalysis/SiStripTools/plugins/EventWithHistoryProducerFromL1ABC.cc
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -40,7 +40,7 @@
 // class decleration
 //
 
-class EventWithHistoryProducerFromL1ABC : public edm::EDProducer {
+class EventWithHistoryProducerFromL1ABC : public edm::stream::EDProducer<> {
    public:
       explicit EventWithHistoryProducerFromL1ABC(const edm::ParameterSet&);
       ~EventWithHistoryProducerFromL1ABC();

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -12,11 +12,11 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -25,20 +25,17 @@
 class BeamFitter;
 class PVFitter;
 
-class AlcaBeamMonitor : public edm::EDAnalyzer {
+class AlcaBeamMonitor : public DQMEDAnalyzer {
  public:
   AlcaBeamMonitor( const edm::ParameterSet& );
   ~AlcaBeamMonitor();
 
  protected:
 
-  void beginJob 	   (void) override;
-  void beginRun 	   (const edm::Run& iRun,  	       const edm::EventSetup& iSetup) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze  	   (const edm::Event& iEvent, 	       const edm::EventSetup& iSetup) override;
   void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void endLuminosityBlock  (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
-  void endRun		   (const edm::Run& iRun,              const edm::EventSetup& iSetup) override;
-  void endJob		   (const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup);
   
  private:
   //Typedefs
@@ -59,7 +56,6 @@ class AlcaBeamMonitor : public edm::EDAnalyzer {
 
   //Service variables
   int         numberOfValuesToSave_;
-  DQMStore*   dbe_;
   BeamFitter* theBeamFitter_;
   PVFitter*   thePVFitter_;
   
@@ -79,9 +75,3 @@ class AlcaBeamMonitor : public edm::EDAnalyzer {
 };
 
 #endif
-
-
-// Local Variables:
-// show-trailing-whitespace: t
-// truncate-lines: t
-// End:

--- a/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
@@ -13,7 +13,6 @@
 #include "EventFilter/DTRawToDigi/interface/DTROChainCoding.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <FWCore/Framework/interface/LuminosityBlock.h>
@@ -38,7 +37,7 @@ class DTROS25Data;
 class DTDDUData;
 class DTTimeEvolutionHisto;
 
-class DTDataIntegrityTask: public thread_unsafe::DQMEDAnalyzer {
+class DTDataIntegrityTask: public DQMEDAnalyzer {
 
 public:
 

--- a/DQMServices/Components/src/DQMMessageLogger.h
+++ b/DQMServices/Components/src/DQMMessageLogger.h
@@ -3,20 +3,20 @@
 #define DQMMESSAGELOGGER_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/FWLite/interface/Event.h"
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
 #include <vector>
 #include <string>
 #include <map>
 
-class DQMStore;
 class MonitorElement;
 
-class DQMMessageLogger : public edm::EDAnalyzer {
+class DQMMessageLogger : public DQMEDAnalyzer {
  public:
 
   /// Constructor
@@ -25,25 +25,18 @@ class DQMMessageLogger : public edm::EDAnalyzer {
   /// Destructor
   virtual ~DQMMessageLogger();
   
-  /// Inizialize parameters for histo binning
-  void beginJob();
-
   /// Get the analysis
   void analyze(const edm::Event&, const edm::EventSetup&);
 
+ protected:
 
-  /// collate categories in summary plots
-  void endRun(const edm::Run & r, const edm::EventSetup & c);
-
-  /// Save the histos
-  void endJob();
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
  private:
 
 
   // ----------member data ---------------------------
   
-  DQMStore* theDbe;
   // Switch for verbosity
   std::string metname;
   

--- a/L1Trigger/L1TCalorimeter/plugins/L1TPhysicalEtAdder.h
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TPhysicalEtAdder.h
@@ -15,7 +15,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,7 +35,7 @@
 //
 
 
-  class L1TPhysicalEtAdder : public edm::EDProducer {
+  class L1TPhysicalEtAdder : public edm::global::EDProducer<> {
   public:
     explicit L1TPhysicalEtAdder(const edm::ParameterSet& ps);
     ~L1TPhysicalEtAdder();
@@ -43,14 +43,7 @@
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
-      virtual void beginJob() override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
-
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
       // ----------member data ---------------------------
 


### PR DESCRIPTION
Followup to #18153, fixing more modules. attn: @Dr15Jones 

@dmitrijus, it seemed straightforward to move `DQMMessageLogger` and `AlcaBeamMonitor` to the `DQMEDAnalyzer` stream framework. If this is inappropriate for a non-obvious reason, please let me know and I'll remove those commits. (In that case, I suppose those modules would have to become `one` analyzers.)