### PR TITLE
[91X] SiPixelAli PCL payload creation thresholds from db - Consumer Code

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
@@ -12,6 +12,17 @@ ALCARECOTkAlMinBiasFilterForSiPixelAli.TriggerResultsTag = cms.InputTag("Trigger
 from Alignment.CommonAlignmentProducer.LSNumberFilter_cfi import *
 
 
+# Ugly as hell, but that's life
+from CondCore.CondDB.CondDB_cfi import *
+CondDB.connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')
+PoolDBESSource = cms.ESSource("PoolDBESSource",
+                              CondDB,
+                              toGet = cms.VPSet(cms.PSet(record = cms.string('AlignPCLThresholdsRcd'),
+                                                         tag = cms.string('SiPixelAliThresholds_test_v0')
+                                                         )
+                                                )
+                              )
+
 # Ingredient: offlineBeamSpot
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import offlineBeamSpot
 

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -9,6 +9,17 @@ SiPixelAliMilleFileExtractor = cms.EDAnalyzer("MillePedeFileExtractor",
     # 0000, 0001, 0002,...
     outputBinaryFile = cms.string('pedeBinary%04d.dat'))
 
+# Ugly as hell, but that's life
+from CondCore.CondDB.CondDB_cfi import *
+CondDB.connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')
+PoolDBESSource = cms.ESSource("PoolDBESSource",
+                              CondDB,
+                              toGet = cms.VPSet(cms.PSet(record = cms.string('AlignPCLThresholdsRcd'),
+                                                         tag = cms.string('SiPixelAliThresholds_test_v0')
+                                                         )
+                                                )
+                              )
+
 from Alignment.MillePedeAlignmentAlgorithm.MillePedeAlignmentAlgorithm_cfi import *
 from Alignment.CommonAlignmentProducer.TrackerAlignmentProducerForPCL_cff import AlignmentProducer
 SiPixelAliPedeAlignmentProducer = copy.deepcopy(AlignmentProducer)
@@ -24,7 +35,6 @@ SiPixelAliPedeAlignmentProducer.ParameterBuilder.Selector = cms.PSet(
     )
 
 SiPixelAliPedeAlignmentProducer.doMisalignmentScenario = False #True
-
 
 SiPixelAliPedeAlignmentProducer.checkDbAlignmentValidity = False
 SiPixelAliPedeAlignmentProducer.applyDbAlignment = True

--- a/Alignment/MillePedeAlignmentAlgorithm/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="Alignment/MuonAlignment"/>
 <use   name="Alignment/SurveyAnalysis"/>
 <use   name="Alignment/ReferenceTrajectories"/>
+<use   name="CondFormats/PCLConfig"/> 
 <use   name="DataFormats/CLHEP"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="DataFormats/GeometryVector"/>

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -40,6 +40,9 @@ class MillePedeFileReader {
     const std::array<double, 6>& getZobsErr()  const { return ZobsErr_;  }
     const std::array<double, 6>& getTZobs()    const { return tZobs_;    }
     const std::array<double, 6>& getTZobsErr() const { return tZobsErr_; }
+  
+    const AlignPCLThresholds::threshold_map& getTheThresolds() const { return theThresholds_.get()->getThreshold_Map(); }
+
 
   private:
   //========================= PRIVATE ENUMS ====================================
@@ -99,7 +102,7 @@ class MillePedeFileReader {
     std::array<double, 6> ZobsErr_  = {{0.,0.,0.,0.,0.,0.}};
     std::array<double, 6> tZobs_    = {{0.,0.,0.,0.,0.,0.}};
     std::array<double, 6> tZobsErr_ = {{0.,0.,0.,0.,0.,0.}};
-
+  
 };
 
 #endif /* ALIGNMENT_MILLEPEDEALIGNMENTALGORITHM_INTERFACE_MILLEPEDEFILEREADER_H_ */

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -4,6 +4,7 @@
 /*** system includes ***/
 #include <array>
 #include <string>
+#include <iostream>
 
 /*** core framework functionality ***/
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -102,7 +103,6 @@ class MillePedeFileReader {
   
 };
 
-#include<iostream>
 const std::array<std::string,8> coord_str = {{"X", "Y", "Z", "theta_X", "theta_Y", "theta_Z", "extra_DOF", "none"}};
 inline std::ostream & operator<<(std::ostream & os, const AlignPCLThresholds::coordType& c) {
   if (c >= AlignPCLThresholds::endOfTypes || c < 0) return os << "unrecongnized coordinate";

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -40,9 +40,6 @@ class MillePedeFileReader {
     const std::array<double, 6>& getZobsErr()  const { return ZobsErr_;  }
     const std::array<double, 6>& getTZobs()    const { return tZobs_;    }
     const std::array<double, 6>& getTZobsErr() const { return tZobsErr_; }
-  
-    const AlignPCLThresholds::threshold_map& getTheThresolds() const { return theThresholds_.get()->getThreshold_Map(); }
-
 
   private:
   //========================= PRIVATE ENUMS ====================================

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -42,6 +42,8 @@ class MillePedeFileReader {
     const std::array<double, 6>& getTZobs()    const { return tZobs_;    }
     const std::array<double, 6>& getTZobsErr() const { return tZobsErr_; }
 
+    const AlignPCLThresholds::threshold_map getThresholdMap() const {return theThresholds_.get()->getThreshold_Map (); }   
+
   private:
   //========================= PRIVATE ENUMS ====================================
   //============================================================================

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -10,7 +10,7 @@
 
 /*** Alignment ***/
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h"
-
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h" 
 
 class MillePedeFileReader {
 
@@ -18,7 +18,9 @@ class MillePedeFileReader {
   public: //====================================================================
 
     explicit MillePedeFileReader(const edm::ParameterSet&,
-                                 const std::shared_ptr<const PedeLabelerBase>&);
+                                 const std::shared_ptr<const PedeLabelerBase>&,
+				 const std::shared_ptr<const AlignPCLThresholds>&);
+
     virtual ~MillePedeFileReader() = default;
 
     void read();
@@ -57,6 +59,7 @@ class MillePedeFileReader {
     void readMillePedeLogFile();
     void readMillePedeResultFile();
     PclHLS getHLS(const Alignable*);
+    std::string getStringFromHLS(PclHLS HLS);
 
   //========================== PRIVATE DATA ====================================
   //============================================================================
@@ -64,19 +67,13 @@ class MillePedeFileReader {
     // pede labeler plugin
     const std::shared_ptr<const PedeLabelerBase> pedeLabeler_;
 
+    // thresholds from DB
+    const std::shared_ptr<const AlignPCLThresholds> theThresholds_;
+
     // file-names
     const std::string millePedeLogFile_;
     const std::string millePedeResFile_;
-
-    // signifiance of movement must be above
-    const double sigCut_;
-    // cutoff in micro-meter & micro-rad
-    const double Xcut_, tXcut_;
-    const double Ycut_, tYcut_;
-    const double Zcut_, tZcut_;
-    // maximum movement in micro-meter/rad
-    const double maxMoveCut_, maxErrorCut_;
-
+ 
     // conversion factors: cm to um & rad to urad
     static constexpr std::array<double, 6> multiplier_ = {{ 10000.,      // X
                                                             10000.,      // Y
@@ -84,9 +81,6 @@ class MillePedeFileReader {
                                                             1000000.,    // tX
                                                             1000000.,    // tY
                                                             1000000. }}; // tZ
-
-    const std::array<double, 6> cutoffs_ = {{ Xcut_,  Ycut_,  Zcut_,
-                                              tXcut_, tYcut_, tZcut_}};
 
     bool updateDB_{false};
     int Nrec_{0};

--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -102,4 +102,11 @@ class MillePedeFileReader {
   
 };
 
+#include<iostream>
+const std::array<std::string,8> coord_str = {{"X", "Y", "Z", "theta_X", "theta_Y", "theta_Z", "extra_DOF", "none"}};
+inline std::ostream & operator<<(std::ostream & os, const AlignPCLThresholds::coordType& c) {
+  if (c >= AlignPCLThresholds::endOfTypes || c < 0) return os << "unrecongnized coordinate";
+  return os << coord_str[c];
+}
+
 #endif /* ALIGNMENT_MILLEPEDEALIGNMENTALGORITHM_INTERFACE_MILLEPEDEFILEREADER_H_ */

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -203,10 +203,7 @@ void MillePedeAlignmentAlgorithm::initialize(const edm::EventSetup &setup,
     edm::ESHandle<AlignPCLThresholds> thresholdHandle;
     setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
     theThresholds = thresholdHandle.product();
-  } else {
-    theThresholds = new AlignPCLThresholds();
-    edm::LogInfo("MillePedeAlignmentAlgorithm")<<"Creating a fake AlignPCLThresholds objects. Irrelevant since the running mode is not PCL"<<std::endl;
-  }
+  } 
 
   theAlignableNavigator = std::make_unique<AlignableNavigator>(extras, tracker, muon);
   theAlignmentParameterStore = store;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -342,12 +342,12 @@ bool MillePedeAlignmentAlgorithm::storeAlignments()
   if (isMode(myPedeRunBit)) {
     if (runAtPCL_) {
 
-      auto myThresholds = std::unique_ptr<AlignPCLThresholds>(new AlignPCLThresholds());
+      auto myThresholds = new AlignPCLThresholds();
       myThresholds->setAlignPCLThresholds(theThresholds->getNrecords(),theThresholds->getThreshold_Map());
 
       MillePedeFileReader mpReader(theConfig.getParameter<edm::ParameterSet>("MillePedeFileReader"),
 				   thePedeLabels,
-				   std::shared_ptr<const AlignPCLThresholds>(myThresholds.get()));
+				   std::shared_ptr<const AlignPCLThresholds>(myThresholds));
       mpReader.read();
       return mpReader.storeAlignments();
     } else {
@@ -356,9 +356,6 @@ bool MillePedeAlignmentAlgorithm::storeAlignments()
   } else {
     return false;
   }
-
-  delete theThresholds;
-
 }
 
 //____________________________________________________

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -129,7 +129,6 @@ MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet
 //____________________________________________________
 MillePedeAlignmentAlgorithm::~MillePedeAlignmentAlgorithm()
 {
-  delete theThresholds;
 }
 
 // Call at beginning of job ---------------------------------------------------
@@ -357,6 +356,9 @@ bool MillePedeAlignmentAlgorithm::storeAlignments()
   } else {
     return false;
   }
+
+  delete theThresholds;
+
 }
 
 //____________________________________________________

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -73,6 +73,8 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   /// Pass integrated calibrations to Millepede (they are not owned by Millepede!)
   virtual bool addCalibrations(const std::vector<IntegratedCalibrationBase*> &iCals) override;
 
+  virtual bool storeThresholds(const int & nRecords,const AlignPCLThresholds::threshold_map & thresholdMap);
+
   /// Called at end of job
   virtual void terminate(const edm::EventSetup& iSetup) override;
   /// Called at end of job
@@ -263,7 +265,7 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   std::unique_ptr<PedeSteerer>           thePedeSteer;
   std::unique_ptr<TrajectoryFactoryBase> theTrajectoryFactory;
   std::vector<IntegratedCalibrationBase*> theCalibrations;
-  const AlignPCLThresholds* theThresholds; 
+  std::shared_ptr<AlignPCLThresholds> theThresholds; 
   unsigned int              theMinNumHits;
   double                    theMaximalCor2D; /// maximal correlation allowed for 2D hit in TID/TEC.
                                              /// If larger, the 2D measurement gets diagonalized!!!

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -20,6 +20,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "Alignment/ReferenceTrajectories/interface/ReferenceTrajectoryBase.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h" 
 
 #include <vector>
 #include <string>
@@ -262,6 +263,7 @@ class MillePedeAlignmentAlgorithm : public AlignmentAlgorithmBase
   std::unique_ptr<PedeSteerer>           thePedeSteer;
   std::unique_ptr<TrajectoryFactoryBase> theTrajectoryFactory;
   std::vector<IntegratedCalibrationBase*> theCalibrations;
+  const AlignPCLThresholds* theThresholds; 
   unsigned int              theMinNumHits;
   double                    theMaximalCor2D; /// maximal correlation allowed for 2D hit in TID/TEC.
                                              /// If larger, the 2D measurement gets diagonalized!!!

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -58,12 +58,12 @@ void MillePedeDQMModule
   booker.cd();
   booker.setCurrentFolder("AlCaReco/SiPixelAli/");
 
-  h_xPos = booker.book1D("Xpos",   "#Delta X;;#mu m", 30, 0., 30.);
-  h_xRot = booker.book1D("Xrot",   "#Delta #theta_{X};;#mu rad", 30, 0., 30.);
-  h_yPos = booker.book1D("Ypos",   "#Delta Y;;#mu m", 30, 0., 30.);
-  h_yRot = booker.book1D("Yrot",   "#Delta #theta_{Y};;#mu rad", 30, 0., 30.);
-  h_zPos = booker.book1D("Zpos",   "#Delta Z;;#mu m", 30, 0., 30.);
-  h_zRot = booker.book1D("Zrot",   "#Delta #theta_{Z};;#mu rad", 30, 0., 30.);
+  h_xPos = booker.book1D("Xpos",   "Alignment fit #DeltaX;;#mum", 30, 0., 30.);
+  h_xRot = booker.book1D("Xrot",   "Alignment fit #Delta#theta_{X};;#murad", 30, 0., 30.);
+  h_yPos = booker.book1D("Ypos",   "Alignment fit #DeltaY;;#mum", 30, 0., 30.);
+  h_yRot = booker.book1D("Yrot",   "Alignment fit #Delta#theta_{Y};;#murad", 30, 0., 30.);
+  h_zPos = booker.book1D("Zpos",   "Alignment fit #DeltaZ;;#mum", 30, 0., 30.);
+  h_zRot = booker.book1D("Zrot",   "Alignment fit #Delta#theta_{Z};;#murad", 30, 0., 30.);
 
   booker.cd();
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -57,12 +57,12 @@ void MillePedeDQMModule
   booker.cd();
   booker.setCurrentFolder("AlCaReco/SiPixelAli/");
 
-  h_xPos = booker.book1D("Xpos",   "Alignment fit #DeltaX;;#mum", 30, 0., 30.);
-  h_xRot = booker.book1D("Xrot",   "Alignment fit #Delta#theta_{X};;#murad", 30, 0., 30.);
-  h_yPos = booker.book1D("Ypos",   "Alignment fit #DeltaY;;#mum", 30, 0., 30.);
-  h_yRot = booker.book1D("Yrot",   "Alignment fit #Delta#theta_{Y};;#murad", 30, 0., 30.);
-  h_zPos = booker.book1D("Zpos",   "Alignment fit #DeltaZ;;#mum", 30, 0., 30.);
-  h_zRot = booker.book1D("Zrot",   "Alignment fit #Delta#theta_{Z};;#murad", 30, 0., 30.);
+  h_xPos = booker.book1D("Xpos",   "Alignment fit #DeltaX;;#mum", 36, 0., 36.);
+  h_xRot = booker.book1D("Xrot",   "Alignment fit #Delta#theta_{X};;#murad", 36, 0., 36.);
+  h_yPos = booker.book1D("Ypos",   "Alignment fit #DeltaY;;#mum", 36, 0., 36.);
+  h_yRot = booker.book1D("Yrot",   "Alignment fit #Delta#theta_{Y};;#murad", 36, 0., 36.);
+  h_zPos = booker.book1D("Zpos",   "Alignment fit #DeltaZ;;#mum", 36, 0., 36.);
+  h_zRot = booker.book1D("Zrot",   "Alignment fit #Delta#theta_{Z};;#murad", 36, 0., 36.);
 
   booker.cd();
 }
@@ -211,37 +211,35 @@ void MillePedeDQMModule
   histo_0->SetMinimum(-(max_));
   histo_0->SetMaximum(  max_);
 
-  // first 6 bins for movements
+  //  Schematics of the bin contents
+  // 
+  //  XX XX XX XX XX XX    OO OO OO OO    II II II II 
+  // |--|--|--|--|--|--|--|--|--|--|--|--|--|--|--|--|--|
+  // | 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|13|14|15|16|17|  ...
+  //
+  // |-----------------|  |-----------|  |-----------|  
+  // |observed movement|  |thresholds1|  |thresholds2|     
 
   for (size_t i = 0; i < obs.size(); ++i) {
+    
+    // fist obs.size() bins for observed movements
     histo_0->SetBinContent(i+1, obs[i]);
     histo_0->SetBinError(i+1, obsErr[i]); 
+    
+    // then at bin 8,8+5,8+10,... for cutoffs
+    // 5 bins is the space allocated for the 4 other thresholds + 1 empty separation bin
+    histo_0->SetBinContent(8+i*5 , cut[i]);
+    
+    // then at bin 9,9+5,9+10,... for significances
+    histo_0->SetBinContent(9+i*5 , sigCut[i]);
+
+    // then at bin 10,10+5,10+10,... for maximum movements
+    histo_0->SetBinContent(10+i*5, maxMoveCut[i]);
+
+    // then at bin 11,11+5,11+10,... for maximum errors
+    histo_0->SetBinContent(11+i*5, maxErrorCut[i]);
+    
   }
-
-  // next 6 bins for cutoffs
-
-  for (size_t i = obs.size(); i < obs.size()*2; ++i) {
-    histo_0->SetBinContent(i+1, cut[i-obs.size()]); 	
-  }
-
-  // next 6 bins for significances
-
-  for (size_t i = obs.size()*2; i < obs.size()*3; ++i) {
-    histo_0->SetBinContent(i+1, sigCut[i-obs.size()*2]);
-  }
-
-  // next 6 bins for maximum movements
-
-  for (size_t i = obs.size()*3; i < obs.size()*4; ++i) {
-    histo_0->SetBinContent(i+1, maxMoveCut[i-obs.size()*3]);	
-  }
-
-  // final 6 bins for maximum errors
-
-  for (size_t i = obs.size()*4; i < obs.size()*5; ++i) {
-    histo_0->SetBinContent(i+1, maxErrorCut[i-obs.size()*4]);
-  }
-
 }
 
 bool MillePedeDQMModule

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -202,9 +202,9 @@ void MillePedeDQMModule
 
 void MillePedeDQMModule
 ::fillExpertHisto(MonitorElement* histo, 
-		  std::array<double, 6> cut, std::array<double, 6> sigCut, 
-		  std::array<double, 6> maxMoveCut, std::array<double, 6> maxErrorCut,
-                  std::array<double, 6> obs, std::array<double, 6> obsErr)
+		  const std::array<double, 6>& cut, const std::array<double, 6>& sigCut, 
+		  const std::array<double, 6>& maxMoveCut,const  std::array<double, 6>& maxErrorCut,
+                  const std::array<double, 6>& obs,const std::array<double, 6>& obsErr)
 {
   TH1F* histo_0 = histo->getTH1F();
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -101,6 +101,7 @@ void MillePedeDQMModule
   edm::ESHandle<PTrackerParameters> ptp;
   setup.get<PTrackerParametersRcd>().get(ptp);
 
+  // take the thresholds from DB
   edm::ESHandle<AlignPCLThresholds> thresholdHandle;
   setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
   theThresholds = thresholdHandle.product();
@@ -145,8 +146,6 @@ void MillePedeDQMModule
   std::array<double, 6> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
 
   auto myMap = theThresholds->getThreshold_Map(); ;
-
-  //auto myMap = mpReader_-> getTheThresolds();
   theThresholds->printAll();
 
   std::vector<std::string> alignablesList;
@@ -214,22 +213,32 @@ void MillePedeDQMModule
   histo_0->SetMinimum(-(max_));
   histo_0->SetMaximum(  max_);
 
+  // first 6 bins for movements
+
   for (size_t i = 0; i < obs.size(); ++i) {
     histo_0->SetBinContent(i+1, obs[i]);
     histo_0->SetBinError(i+1, obsErr[i]); 
   }
 
+  // next 6 bins for cutoffs
+
   for (size_t i = obs.size(); i < obs.size()*2; ++i) {
     histo_0->SetBinContent(i+1, cut[i-obs.size()]); 	
   }
+
+  // next 6 bins for significances
 
   for (size_t i = obs.size()*2; i < obs.size()*3; ++i) {
     histo_0->SetBinContent(i+1, sigCut[i-obs.size()*2]);
   }
 
+  // next 6 bins for maximum movements
+
   for (size_t i = obs.size()*3; i < obs.size()*4; ++i) {
     histo_0->SetBinContent(i+1, maxMoveCut[i-obs.size()*3]);	
   }
+
+  // final 6 bins for maximum errors
 
   for (size_t i = obs.size()*4; i < obs.size()*5; ++i) {
     histo_0->SetBinContent(i+1, maxErrorCut[i-obs.size()*4]);

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -28,7 +28,9 @@
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerPluginFactory.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 
-
+/*** Thresholds from DB ***/
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
+ 
 
 MillePedeDQMModule
 ::MillePedeDQMModule(const edm::ParameterSet& config) :
@@ -108,6 +110,13 @@ void MillePedeDQMModule
   edm::ESHandle<PTrackerParameters> ptp;
   setup.get<PTrackerParametersRcd>().get(ptp);
 
+  edm::ESHandle<AlignPCLThresholds> thresholdHandle;
+  setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
+  const AlignPCLThresholds* theThresholds = thresholdHandle.product();
+
+  auto myThresholds = new AlignPCLThresholds();
+  myThresholds->setAlignPCLThresholds(theThresholds->getNrecords(),theThresholds->getThreshold_Map());
+
   TrackerGeomBuilderFromGeometricDet builder;
 
   const auto trackerGeometry = builder.build(&(*geometricDet), *ptp, &(*tTopo));
@@ -125,7 +134,8 @@ void MillePedeDQMModule
               labelerConfig)
   };
 
-  mpReader_ = std::make_unique<MillePedeFileReader>(mpReaderConfig_, pedeLabeler);
+  mpReader_ = std::make_unique<MillePedeFileReader>(mpReaderConfig_, pedeLabeler, std::shared_ptr<const AlignPCLThresholds>(myThresholds)); 
+
 }
 
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -36,17 +36,7 @@ MillePedeDQMModule
 ::MillePedeDQMModule(const edm::ParameterSet& config) :
   mpReaderConfig_(
     config.getParameter<edm::ParameterSet>("MillePedeFileReader")
-  ),
-
-  sigCut_     (mpReaderConfig_.getParameter<double>("sigCut")),
-  Xcut_       (mpReaderConfig_.getParameter<double>("Xcut")),
-  tXcut_      (mpReaderConfig_.getParameter<double>("tXcut")),
-  Ycut_       (mpReaderConfig_.getParameter<double>("Ycut")),
-  tYcut_      (mpReaderConfig_.getParameter<double>("tYcut")),
-  Zcut_       (mpReaderConfig_.getParameter<double>("Zcut")),
-  tZcut_      (mpReaderConfig_.getParameter<double>("tZcut")),
-  maxMoveCut_ (mpReaderConfig_.getParameter<double>("maxMoveCut")),
-  maxErrorCut_ (mpReaderConfig_.getParameter<double>("maxErrorCut"))
+  )
 {
 }
 
@@ -114,7 +104,7 @@ void MillePedeDQMModule
   setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
   const AlignPCLThresholds* theThresholds = thresholdHandle.product();
 
-  auto myThresholds = new AlignPCLThresholds();
+  auto myThresholds = std::unique_ptr<AlignPCLThresholds>(new AlignPCLThresholds());
   myThresholds->setAlignPCLThresholds(theThresholds->getNrecords(),theThresholds->getThreshold_Map());
 
   TrackerGeomBuilderFromGeometricDet builder;
@@ -134,7 +124,7 @@ void MillePedeDQMModule
               labelerConfig)
   };
 
-  mpReader_ = std::make_unique<MillePedeFileReader>(mpReaderConfig_, pedeLabeler, std::shared_ptr<const AlignPCLThresholds>(myThresholds)); 
+  mpReader_ = std::make_unique<MillePedeFileReader>(mpReaderConfig_, pedeLabeler, std::shared_ptr<const AlignPCLThresholds>(myThresholds.get())); 
 
 }
 
@@ -142,35 +132,102 @@ void MillePedeDQMModule
 void MillePedeDQMModule
 ::fillExpertHistos()
 {
+  std::array<double, 6> Xcut_,  sigXcut_,  maxMoveXcut_,  maxErrorXcut_; 
+  std::array<double, 6> tXcut_, sigtXcut_, maxMovetXcut_, maxErrortXcut_;
+                                                    
+  std::array<double, 6> Ycut_,  sigYcut_,  maxMoveYcut_,  maxErrorYcut_; 
+  std::array<double, 6> tYcut_, sigtYcut_, maxMovetYcut_, maxErrortYcut_;
+                                                    
+  std::array<double, 6> Zcut_,  sigZcut_,  maxMoveZcut_,  maxErrorZcut_; 
+  std::array<double, 6> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
 
-  fillExpertHisto(h_xPos,  Xcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader_->getXobs(),  mpReader_->getXobsErr());
-  fillExpertHisto(h_xRot, tXcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader_->getTXobs(), mpReader_->getTXobsErr());
+  auto myMap = mpReader_->getTheThresolds();
 
-  fillExpertHisto(h_yPos,  Ycut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader_->getYobs(),  mpReader_->getYobsErr());
-  fillExpertHisto(h_yRot, tYcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader_->getTYobs(), mpReader_->getTYobsErr());
+  std::vector<std::string> alignablesList;
+  for(auto it = myMap.begin(); it != myMap.end() ; ++it){
+    alignablesList.push_back(it->first);
+  }
 
-  fillExpertHisto(h_zPos,  Zcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader_->getZobs(),  mpReader_->getZobsErr());
-  fillExpertHisto(h_zRot, tZcut_, sigCut_, maxMoveCut_, maxErrorCut_, mpReader_->getTZobs(), mpReader_->getTZobsErr());
+  for (auto &alignable : alignablesList){
+
+    int detIndex = getIndexFromString(alignable);
+
+    Xcut_[detIndex]          = myMap[alignable].getXcut() ;
+    sigXcut_[detIndex]       = myMap[alignable].getSigXcut() ;
+    maxMoveXcut_[detIndex]   = myMap[alignable].getMaxMoveXcut() ;
+    maxErrorXcut_[detIndex]  = myMap[alignable].getErrorXcut() ;
+
+    Ycut_[detIndex]          = myMap[alignable].getYcut() ;
+    sigYcut_[detIndex]       = myMap[alignable].getSigYcut() ;
+    maxMoveYcut_[detIndex]   = myMap[alignable].getMaxMoveYcut() ; 
+    maxErrorYcut_[detIndex]  = myMap[alignable].getErrorYcut() ;
+ 
+    Zcut_[detIndex]          = myMap[alignable].getZcut() ;
+    sigZcut_[detIndex]       = myMap[alignable].getSigZcut() ;
+    maxMoveZcut_[detIndex]   = myMap[alignable].getMaxMoveZcut() ;
+    maxErrorZcut_[detIndex]  = myMap[alignable].getErrorZcut() ;
+
+    tXcut_[detIndex]         = myMap[alignable].getThetaXcut() ;
+    sigtXcut_[detIndex]      = myMap[alignable].getSigThetaXcut() ; 
+    maxMovetXcut_[detIndex]  = myMap[alignable].getMaxMoveThetaXcut() ;
+    maxErrortXcut_[detIndex] = myMap[alignable].getErrorThetaXcut() ;
+
+    tYcut_[detIndex]         = myMap[alignable].getThetaYcut() ;
+    sigtYcut_[detIndex]      = myMap[alignable].getSigThetaYcut() ;
+    maxMovetYcut_[detIndex]  = myMap[alignable].getMaxMoveThetaYcut() ;
+    maxErrortYcut_[detIndex] = myMap[alignable].getErrorThetaYcut() ;
+ 
+    tZcut_[detIndex]         = myMap[alignable].getThetaZcut() ;
+    sigtZcut_[detIndex]      = myMap[alignable].getSigThetaYcut() ;
+    maxMovetZcut_[detIndex]  = myMap[alignable].getMaxMoveThetaYcut() ;
+    maxErrortZcut_[detIndex] = myMap[alignable].getErrorThetaYcut() ;
+
+  }
+
+  fillExpertHisto(h_xPos,  Xcut_, sigXcut_,  maxMoveXcut_,  maxErrorXcut_,  mpReader_->getXobs(),  mpReader_->getXobsErr());
+  fillExpertHisto(h_xRot, tXcut_, sigtXcut_, maxMovetXcut_, maxErrortXcut_, mpReader_->getTXobs(), mpReader_->getTXobsErr());
+
+  fillExpertHisto(h_yPos,  Ycut_, sigYcut_,  maxMoveYcut_,  maxErrorYcut_,  mpReader_->getYobs(),  mpReader_->getYobsErr());
+  fillExpertHisto(h_yRot, tYcut_, sigtYcut_, maxMovetYcut_, maxErrortYcut_, mpReader_->getTYobs(), mpReader_->getTYobsErr());
+
+  fillExpertHisto(h_zPos,  Zcut_, sigZcut_,  maxMoveZcut_,  maxErrorZcut_,  mpReader_->getZobs(),  mpReader_->getZobsErr());
+  fillExpertHisto(h_zRot, tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_, mpReader_->getTZobs(), mpReader_->getTZobsErr());
 
 }
 
 void MillePedeDQMModule
-::fillExpertHisto(MonitorElement* histo, const double cut, const double sigCut, const double maxMoveCut, const double maxErrorCut,
+::fillExpertHisto(MonitorElement* histo, 
+		  std::array<double, 6> cut, std::array<double, 6> sigCut, 
+		  std::array<double, 6> maxMoveCut, std::array<double, 6> maxErrorCut,
                   std::array<double, 6> obs, std::array<double, 6> obsErr)
 {
   TH1F* histo_0 = histo->getTH1F();
 
-  histo_0->SetMinimum(-(maxMoveCut_));
-  histo_0->SetMaximum(  maxMoveCut_);
+  double max_ = *std::max_element(maxMoveCut.begin(),maxMoveCut.end());
+
+  histo_0->SetMinimum(-(max_));
+  histo_0->SetMaximum(  max_);
 
   for (size_t i = 0; i < obs.size(); ++i) {
     histo_0->SetBinContent(i+1, obs[i]);
     histo_0->SetBinError(i+1, obsErr[i]);
   }
-  histo_0->SetBinContent(8,cut);
-  histo_0->SetBinContent(9,sigCut);
-  histo_0->SetBinContent(10,maxMoveCut);
-  histo_0->SetBinContent(11,maxErrorCut);
+
+  for (size_t i = obs.size(); i < obs.size()*2; ++i) {
+    histo_0->SetBinContent(i+1, cut[i]);
+  }
+
+  for (size_t i = obs.size()*2; i < obs.size()*3; ++i) {
+    histo_0->SetBinContent(i+1, sigCut[i]);
+  }
+
+  for (size_t i = obs.size()*3; i < obs.size()*4; ++i) {
+    histo_0->SetBinContent(i+1, maxMoveCut[i]);
+  }
+
+  for (size_t i = obs.size()*4; i < obs.size()*5; ++i) {
+    histo_0->SetBinContent(i+1, maxErrorCut[i]);
+  }
 
 }
 
@@ -184,4 +241,29 @@ bool MillePedeDQMModule
   if (watchPTrackerParametersRcd_.check(setup)) changed = true;
 
   return changed;
+}
+
+
+int MillePedeDQMModule
+::getIndexFromString(const std::string& alignableId)
+{
+  
+  if(alignableId == "TPBHalfBarrelXminus"){
+    return 3;
+  } else if(alignableId == "TPBHalfBarrelXplus"){
+    return 2;
+  } else if(alignableId == "TPEHalfCylinderXminusZminus") {
+    return 1;
+  } else if(alignableId == "TPEHalfCylinderXplusZminus") {
+    return 0;
+  } else if(alignableId == "TPEHalfCylinderXminusZplus") {
+    return 5;
+  } else if(alignableId == "TPEHalfCylinderXplusZplus") {
+    return 4;
+  } else{
+    throw cms::Exception("LogicError") 
+      << "@SUB=MillePedeDQMModule::getIndexFromString\n"
+      << "Retrieving conversion for not supported Alignable partition" 
+      << alignableId;
+  }
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -43,7 +43,6 @@ MillePedeDQMModule
 MillePedeDQMModule
 ::~MillePedeDQMModule()
 {
-  delete theThresholds;
 }
 
 //=============================================================================
@@ -104,10 +103,10 @@ void MillePedeDQMModule
   // take the thresholds from DB
   edm::ESHandle<AlignPCLThresholds> thresholdHandle;
   setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
-  theThresholds = thresholdHandle.product();
+  thresholds_ = thresholdHandle.product();
 
   auto myThresholds = new AlignPCLThresholds();
-  myThresholds->setAlignPCLThresholds(theThresholds->getNrecords(),theThresholds->getThreshold_Map());
+  myThresholds->setAlignPCLThresholds(thresholds_->getNrecords(),thresholds_->getThreshold_Map());
 
   TrackerGeomBuilderFromGeometricDet builder;
 
@@ -145,8 +144,8 @@ void MillePedeDQMModule
   std::array<double, 6> Zcut_,  sigZcut_,  maxMoveZcut_,  maxErrorZcut_; 
   std::array<double, 6> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
 
-  auto myMap = theThresholds->getThreshold_Map(); ;
-  theThresholds->printAll();
+  auto myMap = thresholds_->getThreshold_Map(); ;
+  thresholds_->printAll();
 
   std::vector<std::string> alignablesList;
   for(auto it = myMap.begin(); it != myMap.end() ; ++it){

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -103,9 +103,9 @@ void MillePedeDQMModule
   // take the thresholds from DB
   edm::ESHandle<AlignPCLThresholds> thresholdHandle;
   setup.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
-  thresholds_ = thresholdHandle.product();
+  auto thresholds_ = thresholdHandle.product();
 
-  auto myThresholds = new AlignPCLThresholds();
+  auto myThresholds = std::make_shared<AlignPCLThresholds>(); 
   myThresholds->setAlignPCLThresholds(thresholds_->getNrecords(),thresholds_->getThreshold_Map());
 
   TrackerGeomBuilderFromGeometricDet builder;
@@ -144,8 +144,7 @@ void MillePedeDQMModule
   std::array<double, 6> Zcut_,  sigZcut_,  maxMoveZcut_,  maxErrorZcut_; 
   std::array<double, 6> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
 
-  auto myMap = thresholds_->getThreshold_Map(); ;
-  thresholds_->printAll();
+  auto myMap = mpReader_->getThresholdMap();
 
   std::vector<std::string> alignablesList;
   for(auto it = myMap.begin(); it != myMap.end() ; ++it){

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -65,17 +65,18 @@ class MillePedeDQMModule : public DQMEDHarvester {
     void fillExpertHistos();
 
     void fillExpertHisto(MonitorElement* histo,
-                         const double cut,
-                         const double sigCut,
-                         const double maxMoveCut,
-                         const double maxErrorCut,
+			 std::array<double, 6> cut, 
+			 std::array<double, 6> sigCut, 
+			 std::array<double, 6> maxMoveCut, 
+			 std::array<double, 6> maxErrorCut,
                          std::array<double, 6> obs,
                          std::array<double, 6> obsErr);
 
     bool setupChanged(const edm::EventSetup&);
+    int getIndexFromString(const std::string& alignableId);
 
-  //========================== PRIVATE DATA ====================================
-  //============================================================================
+    //========================== PRIVATE DATA ====================================
+    //============================================================================
 
     const edm::ParameterSet mpReaderConfig_;
     std::unique_ptr<AlignableTracker> tracker_;
@@ -84,16 +85,6 @@ class MillePedeDQMModule : public DQMEDHarvester {
     edm::ESWatcher<TrackerTopologyRcd> watchTrackerTopologyRcd_;
     edm::ESWatcher<IdealGeometryRecord> watchIdealGeometryRcd_;
     edm::ESWatcher<PTrackerParametersRcd> watchPTrackerParametersRcd_;
-
-    // Signifiance of movement must be above
-    double sigCut_;
-    // Cutoff in micro-meter & micro-rad
-    double Xcut_, tXcut_;
-    double Ycut_, tYcut_;
-    double Zcut_, tZcut_;
-    // maximum movement in micro-meter/rad
-    double maxMoveCut_;
-    double maxErrorCut_;
 
     // Histograms
     MonitorElement* h_xPos;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -61,12 +61,12 @@ class MillePedeDQMModule : public DQMEDHarvester {
     void fillExpertHistos();
 
     void fillExpertHisto(MonitorElement* histo,
-			 std::array<double, 6> cut, 
-			 std::array<double, 6> sigCut, 
-			 std::array<double, 6> maxMoveCut, 
-			 std::array<double, 6> maxErrorCut,
-                         std::array<double, 6> obs,
-                         std::array<double, 6> obsErr);
+			 const std::array<double,6>& cut, 
+			 const std::array<double,6>& sigCut, 
+			 const std::array<double,6>& maxMoveCut, 
+			 const std::array<double,6>& maxErrorCut,
+                         const std::array<double,6>& obs,
+                         const std::array<double,6>& obsErr);
 
     bool setupChanged(const edm::EventSetup&);
     int getIndexFromString(const std::string& alignableId);

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -74,7 +74,7 @@ class MillePedeDQMModule : public DQMEDHarvester {
     //========================== PRIVATE DATA ====================================
     //============================================================================
 
-    const AlignPCLThresholds* theThresholds; 
+    const AlignPCLThresholds* thresholds_; 
     const edm::ParameterSet mpReaderConfig_;
     std::unique_ptr<AlignableTracker> tracker_;
     std::unique_ptr<MillePedeFileReader> mpReader_;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -74,7 +74,6 @@ class MillePedeDQMModule : public DQMEDHarvester {
     //========================== PRIVATE DATA ====================================
     //============================================================================
 
-    const AlignPCLThresholds* thresholds_; 
     const edm::ParameterSet mpReaderConfig_;
     std::unique_ptr<AlignableTracker> tracker_;
     std::unique_ptr<MillePedeFileReader> mpReader_;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -49,10 +49,6 @@ class MillePedeDQMModule : public DQMEDHarvester {
     MillePedeDQMModule(const edm::ParameterSet&);
     virtual ~MillePedeDQMModule();
 
-
-
-
-
     virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &)  override;
 
   //========================= PRIVATE METHODS ==================================
@@ -78,6 +74,7 @@ class MillePedeDQMModule : public DQMEDHarvester {
     //========================== PRIVATE DATA ====================================
     //============================================================================
 
+    const AlignPCLThresholds* theThresholds; 
     const edm::ParameterSet mpReaderConfig_;
     std::unique_ptr<AlignableTracker> tracker_;
     std::unique_ptr<MillePedeFileReader> mpReader_;

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
@@ -4,4 +4,4 @@ import  Alignment.MillePedeAlignmentAlgorithm.MillePedeFileReader_cfi as MillePe
 
 SiPixelAliDQMModule = cms.EDAnalyzer("MillePedeDQMModule",
                                      MillePedeFileReader = cms.PSet(MillePedeFileReader_cfi.MillePedeFileReader.clone())
-    )
+                                     )

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
@@ -3,4 +3,19 @@ import FWCore.ParameterSet.Config as cms
 MillePedeFileReader = cms.PSet(
   millePedeLogFile = cms.string('millepede.log'),
   millePedeResFile = cms.string('millepede.res'),
+ 
+  # signifiance of movement must be above
+  sigCut = cms.double(2.5),
+
+  # cutoff in micro-meter & micro-rad
+  Xcut  = cms.double( 5.0),
+  tXcut = cms.double(30.0), # thetaX
+  Ycut  = cms.double(10.0),
+  tYcut = cms.double(30.0), # thetaY
+  Zcut  = cms.double(15.0),
+  tZcut = cms.double(30.0), # thetaZ
+
+  # maximum movement in micro-meter/rad
+  maxMoveCut  = cms.double(200.0),
+  maxErrorCut = cms.double( 10.0)
 )

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
@@ -3,19 +3,4 @@ import FWCore.ParameterSet.Config as cms
 MillePedeFileReader = cms.PSet(
   millePedeLogFile = cms.string('millepede.log'),
   millePedeResFile = cms.string('millepede.res'),
-
-  # signifiance of movement must be above
-  sigCut = cms.double(2.5),
-
-  # cutoff in micro-meter & micro-rad
-  Xcut  = cms.double( 5.0),
-  tXcut = cms.double(30.0), # thetaX
-  Ycut  = cms.double(10.0),
-  tYcut = cms.double(30.0), # thetaY
-  Zcut  = cms.double(15.0),
-  tZcut = cms.double(30.0), # thetaZ
-
-  # maximum movement in micro-meter/rad
-  maxMoveCut  = cms.double(200.0),
-  maxErrorCut = cms.double( 10.0)
 )

--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeFileReader_cfi.py
@@ -3,19 +3,4 @@ import FWCore.ParameterSet.Config as cms
 MillePedeFileReader = cms.PSet(
   millePedeLogFile = cms.string('millepede.log'),
   millePedeResFile = cms.string('millepede.res'),
- 
-  # signifiance of movement must be above
-  sigCut = cms.double(2.5),
-
-  # cutoff in micro-meter & micro-rad
-  Xcut  = cms.double( 5.0),
-  tXcut = cms.double(30.0), # thetaX
-  Ycut  = cms.double(10.0),
-  tYcut = cms.double(30.0), # thetaY
-  Zcut  = cms.double(15.0),
-  tZcut = cms.double(30.0), # thetaZ
-
-  # maximum movement in micro-meter/rad
-  maxMoveCut  = cms.double(200.0),
-  maxErrorCut = cms.double( 10.0)
-)
+  )

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -125,55 +125,64 @@ void MillePedeFileReader
 
         auto det = getHLS(alignable);
 	int detIndex = static_cast<int>(det);
+	auto coord = static_cast<AlignPCLThresholds::coordType>(alignableIndex); 
 	std::string detLabel = getStringFromHLS(det);
 
         if (det != PclHLS::NotInPCL) {
-          switch (alignableIndex) {
-          case 0:
+          switch (coord) {
+          case AlignPCLThresholds::X:
             Xobs_[detIndex] = ObsMove;
             XobsErr_[detIndex] = ObsErr;
             break;
-          case 1:
+          case AlignPCLThresholds::Y:
             Yobs_[detIndex] = ObsMove;
             YobsErr_[detIndex] = ObsErr;
             break;
-          case 2:
+          case AlignPCLThresholds::Z:
             Zobs_[detIndex] = ObsMove;
             ZobsErr_[detIndex] = ObsErr;
             break;
-          case 3:
+          case AlignPCLThresholds::theta_X:
             tXobs_[detIndex] = ObsMove;
             tXobsErr_[detIndex] = ObsErr;
             break;
-          case 4:
+          case AlignPCLThresholds::theta_Y:
             tYobs_[detIndex] = ObsMove;
             tYobsErr_[detIndex] = ObsErr;
             break;
-          case 5:
+          case AlignPCLThresholds::theta_Z:
             tZobs_[detIndex] = ObsMove;
             tZobsErr_[detIndex] = ObsErr;
             break;
+	  default:
+	    edm::LogError("MillePedeFileReader") << "Currently not able to handle DOF " << coord 
+						 << std::endl;
+	    break;
           }
         } else {
           continue;
         }
 
-	edm::LogVerbatim("MillePedeFileReader")<<" alignableLabel: "<< alignableLabel <<" with index "<<alignableIndex 
-					       <<" for detLabel: "<<detLabel<<" ("<<detIndex<<")\n"
-					       <<" has movement: "<<ObsMove<<" +/- "<<ObsErr<<"\n"
-					       <<" cutoff (cutoffs_["<<detLabel<<"]["<<alignableIndex<<"]): "<<  cutoffs_[detLabel][alignableIndex] <<"\n"  
-					       <<" significance (significances_["<<detLabel<<"]["<<alignableIndex<<"]): "<<  significances_[detLabel][alignableIndex] <<"\n"
-					       <<" error thresolds (errors_["<<detLabel<<"]["<<alignableIndex<<"]): "<< errors_[detLabel][alignableIndex] <<"\n"
-					       <<" max movement (thresholds_["<<detLabel<<"]["<<alignableIndex<<"]): "<< thresholds_[detLabel][alignableIndex] <<"\n"
+	edm::LogVerbatim("MillePedeFileReader")<<" alignableLabel: "<< alignableLabel <<" with alignableIndex "<<alignableIndex <<" detIndex"<< detIndex <<"\n"
+					       <<" i.e. detLabel: "<< detLabel <<" ("<< coord <<")\n"
+					       <<" has movement: "<< ObsMove <<" +/- "<< ObsErr <<"\n"
+					       <<" cutoff (cutoffs_["<< detLabel <<"]["<< coord <<"]): "<<  cutoffs_[detLabel][alignableIndex] <<"\n"  
+					       <<" significance (significances_["<< detLabel <<"]["<< coord <<"]): "<<  significances_[detLabel][alignableIndex] <<"\n"
+					       <<" error thresolds (errors_["<< detLabel <<"]["<< coord <<"]): "<< errors_[detLabel][alignableIndex] <<"\n"
+					       <<" max movement (thresholds_["<< detLabel <<"]["<< coord <<"]): "<< thresholds_[detLabel][alignableIndex] <<"\n"
 					       <<"============="<< std::endl;
 
         if (std::abs(ObsMove) > thresholds_[detLabel][alignableIndex]) {
+	  edm::LogWarning("MillePedeFileReader")<<"Aborting payload creation."
+						<<" Exceeding maximum thresholds for movement: "<<std::abs(ObsMove)<<" for"<< detLabel <<"("<<coord<<")" ;	  
           updateDB_    = false;
           break;
 
         } else if (std::abs(ObsMove) > cutoffs_[detLabel][alignableIndex]) {
 
           if (std::abs(ObsErr) > errors_[detLabel][alignableIndex]) {
+	    edm::LogWarning("MillePedeFileReader")<<"Aborting payload creation." 
+						  <<" Exceeding maximum thresholds for error: "<<std::abs(ObsErr)<<" for"<< detLabel <<"("<<coord<<")" ;	  	  
             updateDB_    = false;
             break;
           } else {
@@ -182,6 +191,7 @@ void MillePedeFileReader
             }
           }
           updateDB_ = true;
+	  edm::LogWarning("MillePedeFileReader")<<"This correction will trigger a new payload!";
         }
       }
     }
@@ -262,3 +272,6 @@ MillePedeFileReader::getStringFromHLS(MillePedeFileReader::PclHLS HLS){
 //===   STATIC CONST MEMBER DEFINITION                                      ===
 //=============================================================================
 constexpr std::array<double, 6> MillePedeFileReader::multiplier_;
+
+
+

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -81,12 +81,11 @@ void MillePedeFileReader
 {
   
   // cutoffs by coordinate and by alignable 
-  
   std::map<std::string,std::array<float, 6 > > cutoffs_; 
   std::map<std::string,std::array<float, 6 > > significances_;
   std::map<std::string,std::array<float, 6 > > thresholds_;
   std::map<std::string,std::array<float, 6 > > errors_;
-  
+
   std::vector<std::string> alignables_ = theThresholds_->getAlignableList();
   for (auto ali : alignables_){
     cutoffs_[ali]       = theThresholds_->getCut(ali);

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -63,6 +63,7 @@ void MillePedeFileReader
         iss >> trash >> trash >> Nrec_;
 
         if (Nrec_ < theThresholds_->getNrecords() ) {
+	  edm::LogInfo("MillePedeFileReader")<<"Number of records used "<<theThresholds_->getNrecords()<<std::endl;
           updateDB_   = false;
         }
       }
@@ -156,6 +157,15 @@ void MillePedeFileReader
         } else {
           continue;
         }
+
+	edm::LogVerbatim("MillePedeFileReader")<<" alignableLabel: "<< alignableLabel <<" with index "<<alignableIndex 
+					       <<" for detLabel: "<<detLabel<<" ("<<detIndex<<")\n"
+					       <<" has movement: "<<ObsMove<<" +/- "<<ObsErr<<"\n"
+					       <<" cutoff (cutoffs_["<<detLabel<<"]["<<alignableIndex<<"]): "<<  cutoffs_[detLabel][alignableIndex] <<"\n"  
+					       <<" significance (significances_["<<detLabel<<"]["<<alignableIndex<<"]): "<<  significances_[detLabel][alignableIndex] <<"\n"
+					       <<" error thresolds (errors_["<<detLabel<<"]["<<alignableIndex<<"]): "<< errors_[detLabel][alignableIndex] <<"\n"
+					       <<" max movement (thresholds_["<<detLabel<<"]["<<alignableIndex<<"]): "<< thresholds_[detLabel][alignableIndex] <<"\n"
+					       <<"============="<< std::endl;
 
         if (std::abs(ObsMove) > thresholds_[detLabel][alignableIndex]) {
           updateDB_    = false;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -191,7 +191,7 @@ void MillePedeFileReader
             }
           }
           updateDB_ = true;
-	  edm::LogWarning("MillePedeFileReader")<<"This correction will trigger a new payload!";
+	  edm::LogWarning("MillePedeFileReader")<<"This correction: "<<ObsMove<<"+/-" <<ObsErr<<" for "<< detLabel <<"("<<coord<<") will trigger a new Tracker Alignment payload!";
         }
       }
     }

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -88,7 +88,7 @@ void MillePedeFileReader
   std::map<std::string,std::array<float, 6 > > errors_;
 
   std::vector<std::string> alignables_ = theThresholds_->getAlignableList();
-  for (auto ali : alignables_){
+  for (auto &ali : alignables_){
     cutoffs_[ali]       = theThresholds_->getCut(ali);
     significances_[ali] = theThresholds_->getSigCut(ali);
     thresholds_[ali]    = theThresholds_->getMaxMoveCut(ali);
@@ -191,7 +191,7 @@ void MillePedeFileReader
             }
           }
           updateDB_ = true;
-	  edm::LogWarning("MillePedeFileReader")<<"This correction: "<<ObsMove<<"+/-" <<ObsErr<<" for "<< detLabel <<"("<<coord<<") will trigger a new Tracker Alignment payload!";
+	  edm::LogInfo("MillePedeFileReader")<<"This correction: "<<ObsMove<<"+/-" <<ObsErr<<" for "<< detLabel <<"("<<coord<<") will trigger a new Tracker Alignment payload!";
         }
       }
     }
@@ -263,7 +263,10 @@ MillePedeFileReader::getStringFromHLS(MillePedeFileReader::PclHLS HLS){
     case PclHLS::TPEHalfCylinderXplusZminus  : return "TPEHalfCylinderXplusZminus";
     case PclHLS::TPEHalfCylinderXminusZplus  : return "TPEHalfCylinderXminusZplus";
     case PclHLS::TPEHalfCylinderXplusZplus   : return "TPEHalfCylinderXplusZplus";
-    default: return "None";
+    default: 
+      throw cms::Exception("LogicError")
+        << "@SUB=MillePedeFileReader::getStringFromHLS\n"
+        << "Found an alignable structure not possible to map in the default AlignPCLThresholds partitions";
     }
 }
 


### PR DESCRIPTION
 Greeting, 
this is a follow-up Pull Request to #18087. The Pixel Alignment Prompt Calibration Loop consumer code in `/Alignment/MillePedeAlignmentAlgorithm` is changed to use thresholds for payload creation from DataBase instead that from python configuration file.
The two main areas affected are:
   * `Alignment/MillePedeAlignmentAlgorithm/interface(src)/MillePedeFileReader.h(cc)` class that presides to the checking of the payload features. 
   * `Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h(cc)` class that provides the DQM monitoring at the `AlCaHarvesting` stage.

To let PR tests run (since the new `AlignPCLThresholds` payload is not yet integrated) I am providing the needed conditions via `ESSource` in 
   * `AlCaSkimming` (`ALCARECOPromptCalibProdSiPixelAli_cff.py`) 
   * `AlCaHarvesting` (`AlcaSiPixelAliHarvester_cff.py`)  

I will remove the external sources when the payload will be integrated in Global Tag (requests in the Conditon Data Browser are [here](https://cms-conddb.cern.ch/cmsDbBrowser/requests_management/Prod/tag/SiPixelAliThresholds_express_v0/AlignPCLThresholdsRcd) and [here](https://cms-conddb.cern.ch/cmsDbBrowser/requests_management/Prod/tag/SiPixelAliThresholds_offline_v0/AlignPCLThresholdsRcd) ).
Once merged a follow-up Pull Request to https://github.com/dmwm/deployment will be issued to fix the DQMGUI rendering plugin.

I attach here an example of how it will look like once finally integrated (using the payload at `/afs/cern.ch/user/m/musich/public/AlCa/AlignPCLThresholds_Payload/mythresholds.db`, that features thresholds dependent on the alignable partition).

![screenshot 2017-04-04 17 43 54](https://cloud.githubusercontent.com/assets/5082376/24666745/7f04e02e-1961-11e7-99ff-a011485c81ef.png)

attn: @mschrode @meng-xiao 
