### PR TITLE
Pixel Cluster Counting Automation

### DIFF
--- a/Calibration/PCCAlCaRecoProducers/interface/AlcaPCCProducer.h
+++ b/Calibration/PCCAlCaRecoProducers/interface/AlcaPCCProducer.h
@@ -1,0 +1,55 @@
+#ifndef PCCAlCaRecoProducers_AlcaPCCProducer_h
+#define PCCAlCaRecoProducers_AlcaPCCProducer_h
+
+/**_________________________________________________________________
+   class:   AlcaPCCProducer.h
+   package: Calibration/PCCAlCaRecoProducers
+   
+
+ authors:Sam Higginbotham (shigginb@cern.ch) and Chris Palmer (capalmer@cern.ch) 
+
+________________________________________________________________**/
+
+
+// C++ standard
+#include <string>
+// CMS
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "DataFormats/Luminosity/interface/PCC.h"
+
+class AlcaPCCProducer : public edm::one::EDProducer<edm::EndLuminosityBlockProducer,
+                                                             edm::one::WatchLuminosityBlocks> {
+  public:
+    explicit AlcaPCCProducer(const edm::ParameterSet&);
+    ~AlcaPCCProducer();
+
+  private:
+    virtual void beginLuminosityBlock     (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override final;
+    virtual void endLuminosityBlock       (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override final;
+    virtual void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) override final;
+    virtual void produce                  (edm::Event& iEvent, const edm::EventSetup& iSetup) override final;
+ 
+    edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> >  pixelToken;
+    edm::InputTag   fPixelClusterLabel;
+
+    std::string trigstring_;      //specifies the trigger Rand or ZeroBias 
+    int ftotalevents;
+    int resetNLumi_;
+    int countEvt_;       //counter
+    int countLumi_;      //counter
+    int beginLumiOfPCC_;
+    int endLumiOfPCC_;
+
+    std::unique_ptr<reco::PCC> thePCCob;
+
+};
+
+#endif

--- a/Calibration/PCCAlCaRecoProducers/plugins/AlcaPCCProducer.cc
+++ b/Calibration/PCCAlCaRecoProducers/plugins/AlcaPCCProducer.cc
@@ -1,0 +1,116 @@
+/**_________________________________________________________________
+class:   AlcaPCCProducer.cc
+
+
+
+authors:Sam Higginbotham (shigginb@cern.ch) and Chris Palmer (capalmer@cern.ch) 
+
+________________________________________________________________**/
+
+
+// C++ standard
+#include <string>
+// CMS
+#include "DataFormats/Luminosity/interface/PCC.h"
+#include "Calibration/PCCAlCaRecoProducers/interface/AlcaPCCProducer.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include "TMath.h"
+
+//--------------------------------------------------------------------------------------------------
+AlcaPCCProducer::AlcaPCCProducer(const edm::ParameterSet& iConfig)
+{
+    resetNLumi_ = iConfig.getParameter<edm::ParameterSet>("AlcaPCCProducerParameters").getUntrackedParameter<int>("resetEveryNLumi",-1);
+    fPixelClusterLabel = iConfig.getParameter<edm::ParameterSet>("AlcaPCCProducerParameters").getParameter<edm::InputTag>("pixelClusterLabel");
+    trigstring_ = iConfig.getParameter<edm::ParameterSet>("AlcaPCCProducerParameters").getUntrackedParameter<std::string>("trigstring","alcaPCC");
+
+    //std::cout<<"A Print Statement"<<std::endl;
+    ftotalevents = 0;
+    countLumi_ = 0;
+    beginLumiOfPCC_ = endLumiOfPCC_ = -1;
+
+    produces<reco::PCC, edm::InLumi>(trigstring_);
+    pixelToken=consumes<edmNew::DetSetVector<SiPixelCluster> >(fPixelClusterLabel);
+}
+
+//--------------------------------------------------------------------------------------------------
+AlcaPCCProducer::~AlcaPCCProducer(){
+}
+
+//--------------------------------------------------------------------------------------------------
+void AlcaPCCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+    ftotalevents++;
+
+    unsigned int bx=iEvent.bunchCrossing();
+    //std::cout<<"The Bunch Crossing"<<bx<<std::endl;
+    thePCCob->eventCounter(bx);
+
+    //Looping over the clusters and adding the counts up  
+    edm::Handle< edmNew::DetSetVector<SiPixelCluster> > hClusterColl;
+    iEvent.getByToken(pixelToken,hClusterColl);
+
+    const edmNew::DetSetVector<SiPixelCluster>& clustColl = *(hClusterColl.product()); 
+    // ----------------------------------------------------------------------
+    // -- Clusters without tracks
+    for (auto const & mod: clustColl) {
+        if(mod.empty()) { continue; }
+        DetId detId = mod.id();
+
+        // -- clusters on this det
+        edmNew::DetSet<SiPixelCluster>::const_iterator  di;
+        int nClusterCount=0;
+        for (di = mod.begin(); di != mod.end(); ++di) {
+            nClusterCount++;
+        }
+        int nCluster = mod.size();
+        if(nCluster!=nClusterCount) {
+            std::cout<<"counting yields "<<nClusterCount<<" but the size is "<<nCluster<<"; they should match."<<std::endl;
+        }
+        thePCCob->Increment(detId(), bx, nCluster);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+void AlcaPCCProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
+    //New PCC object at the beginning of each lumi section
+    thePCCob = std::make_unique<reco::PCC>();
+    
+    if ( countLumi_ == 0 || (resetNLumi_ > 0 && countLumi_%resetNLumi_ == 0) ) {
+        beginLumiOfPCC_ = lumiSeg.luminosityBlock();
+    }
+
+    countLumi_++;
+
+}
+
+//--------------------------------------------------------------------------------------------------
+void AlcaPCCProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
+    //Saving the PCC object 
+    //FIXME! The line below doesn't work but I need to save here. 
+    //lumiSeg.put(std::move(thePCCob), std::string(trigstring_)); 
+}
+
+//--------------------------------------------------------------------------------------------------
+void AlcaPCCProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup){
+
+    endLumiOfPCC_ = lumiSeg.luminosityBlock();
+
+    if (resetNLumi_ == -1) return;
+
+    if (countLumi_%resetNLumi_!=0) return;
+
+    //Saving the PCC object 
+    std::cout<<"Saving Object "<<std::endl;
+    lumiSeg.put(std::move(thePCCob), std::string(trigstring_)); 
+
+}
+
+DEFINE_FWK_MODULE(AlcaPCCProducer);

--- a/Calibration/PCCAlCaRecoProducers/test/PCC_Random_cfg.py
+++ b/Calibration/PCCAlCaRecoProducers/test/PCC_Random_cfg.py
@@ -1,0 +1,211 @@
+#########################
+#Author: Sam Higginbotham
+#Purpose: To investigate the AlCaPCCProducer input and output. 
+#########################
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ALCARECO")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:/eos/cms/store/data/Run2015D/AlCaLumiPixels/ALCARECO/LumiPixels-PromptReco-v4/000/260/039/00000/1CF2A210-5B7E-E511-8F4F-02163E014145.root','/eos/cms/store/data/Run2015D/AlCaLumiPixels/ALCARECO/LumiPixels-PromptReco-v4/000/260/039/00000/1E2B0829-707E-E511-B51B-02163E0145FE.root','/eos/cms/store/data/Run2015D/AlCaLumiPixels/ALCARECO/LumiPixels-PromptReco-v4/000/260/039/00000/2666E76A-707E-E511-92E4-02163E014689.root','/eos/cms/store/data/Run2015D/AlCaLumiPixels/ALCARECO/LumiPixels-PromptReco-v4/000/260/039/00000/2A1E3304-707E-E511-946C-02163E014241.root')
+)
+
+#Added process to select the appropriate events 
+process.OutALCARECOPromptCalibProdPCC = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdPCC')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_alcaPCCProducer_*_*', 
+        'keep *_MEtoEDMConvertSiStrip_*_*')
+)
+#Make sure that variables match in producer.cc and .h
+process.alcaPCCProducer = cms.EDProducer("AlcaPCCProducer",
+    AlcaPCCProducerParameters = cms.PSet(
+        WriteToDB = cms.bool(False),
+        pixelClusterLabel = cms.InputTag("siPixelClustersForLumi"),
+        #Mod factor to count lumi and the string to specify output 
+        resetEveryNLumi = cms.untracked.int32(100),
+        trigstring = cms.untracked.string("alcaPCCRand") 
+    ),
+)
+
+process.OutALCARECOLumiPixels = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOLumiPixels')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_siPixelClustersForLumi_*_*', 
+        'keep *_TriggerResults_*_HLT')
+)
+
+
+process.OutALCARECOLumiPixels_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOLumiPixels')
+    ),
+    outputCommands = cms.untracked.vstring('keep *_siPixelClustersForLumi_*_*', 
+        'keep *_TriggerResults_*_HLT')
+)
+
+process.siPixelClustersForLumi = cms.EDProducer("SiPixelClusterProducer",
+    ChannelThreshold = cms.int32(1000),
+    ClusterThreshold = cms.double(4000.0),
+    MissCalibrate = cms.untracked.bool(True),
+    SeedThreshold = cms.int32(1000),
+    SplitClusters = cms.bool(False),
+    VCaltoElectronGain = cms.int32(65),
+    VCaltoElectronOffset = cms.int32(-414),
+    maxNumberOfClusters = cms.int32(-1),
+    payloadType = cms.string('Offline'),
+    src = cms.InputTag("siPixelDigisForLumi")
+)
+
+
+process.siPixelDigisForLumi = cms.EDProducer("SiPixelRawToDigi",
+    CablingMapLabel = cms.string(''),
+    ErrorList = cms.vint32(29),
+    IncludeErrors = cms.bool(True),
+    InputLabel = cms.InputTag("hltFEDSelectorLumiPixels"),
+    Regions = cms.PSet(
+
+    ),
+    Timing = cms.untracked.bool(False),
+    UsePhase1 = cms.bool(False),
+    UsePilotBlade = cms.bool(False),
+    UseQualityInfo = cms.bool(False),
+    UserErrorList = cms.vint32(40)
+)
+
+
+
+
+#HLT filter for PCC
+process.ALCARECOHltFilterForPCC = cms.EDFilter("HLTHighLevel",
+    HLTPaths = cms.vstring("*Random*"),
+    eventSetupPathsKey = cms.string(""),
+    TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
+    andOr = cms.bool(True),
+    throw = cms.bool(False)
+)
+#From the end path, this is where we specify format for our output.
+process.ALCARECOStreamPromptCalibProdPCC = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdPCC')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('ALCAPROMPT'),
+        filterName = cms.untracked.string('PromptCalibProdPCC')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('ProdPCC_Random_100.root'),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_alcaPCCProducer_*_*', 
+        'keep *_MEtoEDMConvertSiStrip_*_*')
+)
+
+
+#
+process.alcaPCC = cms.Sequence(process.alcaPCCProducer)
+
+#This is the key sequence that we are adding first...
+process.seqALCARECOPromptCalibProdPCC = cms.Sequence(process.ALCARECOHltFilterForPCC+process.alcaPCCProducer)
+
+process.pathALCARECOPromptCalibProdPCC = cms.Path(process.seqALCARECOPromptCalibProdPCC)
+
+process.seqALCARECOLumiPixels = cms.Sequence(process.siPixelDigisForLumi+process.siPixelClustersForLumi)
+
+process.pathALCARECOLumiPixels = cms.Path(process.seqALCARECOLumiPixels)
+
+process.ALCARECOStreamPromptCalibProdOutPath = cms.EndPath(process.ALCARECOStreamPromptCalibProdPCC)
+
+process.MessageLogger = cms.Service("MessageLogger",
+    FrameworkJobReport = cms.untracked.PSet(
+        FwkJob = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        optionalPSet = cms.untracked.bool(True)
+    ),
+    categories = cms.untracked.vstring('FwkJob', 
+        'FwkReport', 
+        'FwkSummary', 
+        'Root_NoDictionary'),
+    cerr = cms.untracked.PSet(
+        FwkJob = cms.untracked.PSet(
+            limit = cms.untracked.int32(0),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        FwkReport = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            optionalPSet = cms.untracked.bool(True),
+            reportEvery = cms.untracked.int32(100000)
+        ),
+        FwkSummary = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            optionalPSet = cms.untracked.bool(True),
+            reportEvery = cms.untracked.int32(1)
+        ),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        Root_NoDictionary = cms.untracked.PSet(
+            limit = cms.untracked.int32(0),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000)
+        ),
+        noTimeStamps = cms.untracked.bool(False),
+        optionalPSet = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    ),
+    cerr_stats = cms.untracked.PSet(
+        optionalPSet = cms.untracked.bool(True),
+        output = cms.untracked.string('cerr'),
+        threshold = cms.untracked.string('WARNING')
+    ),
+    cout = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring(),
+    debugs = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    default = cms.untracked.PSet(
+
+    ),
+    destinations = cms.untracked.vstring('warnings', 
+        'errors', 
+        'infos', 
+        'debugs', 
+        'cout', 
+        'cerr'),
+    errors = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
+    infos = cms.untracked.PSet(
+        Root_NoDictionary = cms.untracked.PSet(
+            limit = cms.untracked.int32(0),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        optionalPSet = cms.untracked.bool(True),
+        placeholder = cms.untracked.bool(True)
+    ),
+    statistics = cms.untracked.vstring('cerr_stats'),
+    suppressDebug = cms.untracked.vstring(),
+    suppressInfo = cms.untracked.vstring(),
+    suppressWarning = cms.untracked.vstring(),
+    warnings = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    )
+)
+#added line for additional output summary `
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+
+process.schedule = cms.Schedule(*[ process.pathALCARECOPromptCalibProdPCC, process.ALCARECOStreamPromptCalibProdOutPath ])

--- a/Calibration/PCCAlCaRecoProducers/test/PCC_ZeroBias_cfg.py
+++ b/Calibration/PCCAlCaRecoProducers/test/PCC_ZeroBias_cfg.py
@@ -1,0 +1,211 @@
+#########################
+#Author: Sam Higginbotham
+#Purpose: To investigate the AlCaPCCProducer input and output. 
+#########################
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ALCARECO")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:/eos/cms/store/data/Run2015D/AlCaLumiPixels/ALCARECO/LumiPixels-PromptReco-v4/000/260/039/00000/1CF2A210-5B7E-E511-8F4F-02163E014145.root')
+)
+
+#Added process to select the appropriate events 
+process.OutALCARECOPromptCalibProdPCC = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdPCC')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_alcaPCCProducer_*_*', 
+        'keep *_MEtoEDMConvertSiStrip_*_*')
+)
+#Make sure that variables match in producer.cc and .h
+process.alcaPCCProducer = cms.EDProducer("AlcaPCCProducer",
+    AlcaPCCProducerParameters = cms.PSet(
+        WriteToDB = cms.bool(False),
+        pixelClusterLabel = cms.InputTag("siPixelClustersForLumi"), 
+        #Mod factor to count lumi and the string to specify output 
+        resetEveryNLumi = cms.untracked.int32(1),
+        trigstring = cms.untracked.string("alcaPCCZB") 
+    ),
+)
+
+process.OutALCARECOLumiPixels = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOLumiPixels')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_siPixelClustersForLumi_*_*', 
+        'keep *_TriggerResults_*_HLT')
+)
+
+
+process.OutALCARECOLumiPixels_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOLumiPixels')
+    ),
+    outputCommands = cms.untracked.vstring('keep *_siPixelClustersForLumi_*_*', 
+        'keep *_TriggerResults_*_HLT')
+)
+
+process.siPixelClustersForLumi = cms.EDProducer("SiPixelClusterProducer",
+    ChannelThreshold = cms.int32(1000),
+    ClusterThreshold = cms.double(4000.0),
+    MissCalibrate = cms.untracked.bool(True),
+    SeedThreshold = cms.int32(1000),
+    SplitClusters = cms.bool(False),
+    VCaltoElectronGain = cms.int32(65),
+    VCaltoElectronOffset = cms.int32(-414),
+    maxNumberOfClusters = cms.int32(-1),
+    payloadType = cms.string('Offline'),
+    src = cms.InputTag("siPixelDigisForLumi")
+)
+
+
+process.siPixelDigisForLumi = cms.EDProducer("SiPixelRawToDigi",
+    CablingMapLabel = cms.string(''),
+    ErrorList = cms.vint32(29),
+    IncludeErrors = cms.bool(True),
+    InputLabel = cms.InputTag("hltFEDSelectorLumiPixels"),
+    Regions = cms.PSet(
+
+    ),
+    Timing = cms.untracked.bool(False),
+    UsePhase1 = cms.bool(False),
+    UsePilotBlade = cms.bool(False),
+    UseQualityInfo = cms.bool(False),
+    UserErrorList = cms.vint32(40)
+)
+
+
+
+
+#HLT filter for PCC
+process.ALCARECOHltFilterForPCC = cms.EDFilter("HLTHighLevel",
+    HLTPaths = cms.vstring("*ZeroBias*"),
+    eventSetupPathsKey = cms.string(""),
+    TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
+    andOr = cms.bool(True),
+    throw = cms.bool(False)
+)
+#From the end path, this is where we specify format for our output.
+process.ALCARECOStreamPromptCalibProdPCC = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOPromptCalibProdPCC')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('ALCAPROMPT'),
+        filterName = cms.untracked.string('PromptCalibProdPCC')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('ProdPCC_ZeroBias_1.root'),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_alcaPCCProducer_*_*', 
+        'keep *_MEtoEDMConvertSiStrip_*_*')
+)
+
+
+#
+process.alcaPCC = cms.Sequence(process.alcaPCCProducer)
+
+#This is the key sequence that we are adding first...
+process.seqALCARECOPromptCalibProdPCC = cms.Sequence(process.ALCARECOHltFilterForPCC+process.alcaPCCProducer)
+
+process.pathALCARECOPromptCalibProdPCC = cms.Path(process.seqALCARECOPromptCalibProdPCC)
+
+process.seqALCARECOLumiPixels = cms.Sequence(process.siPixelDigisForLumi+process.siPixelClustersForLumi)
+
+process.pathALCARECOLumiPixels = cms.Path(process.seqALCARECOLumiPixels)
+
+process.ALCARECOStreamPromptCalibProdOutPath = cms.EndPath(process.ALCARECOStreamPromptCalibProdPCC)
+
+process.MessageLogger = cms.Service("MessageLogger",
+    FrameworkJobReport = cms.untracked.PSet(
+        FwkJob = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        optionalPSet = cms.untracked.bool(True)
+    ),
+    categories = cms.untracked.vstring('FwkJob', 
+        'FwkReport', 
+        'FwkSummary', 
+        'Root_NoDictionary'),
+    cerr = cms.untracked.PSet(
+        FwkJob = cms.untracked.PSet(
+            limit = cms.untracked.int32(0),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        FwkReport = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            optionalPSet = cms.untracked.bool(True),
+            reportEvery = cms.untracked.int32(10000)
+        ),
+        FwkSummary = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            optionalPSet = cms.untracked.bool(True),
+            reportEvery = cms.untracked.int32(1)
+        ),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        Root_NoDictionary = cms.untracked.PSet(
+            limit = cms.untracked.int32(0),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000)
+        ),
+        noTimeStamps = cms.untracked.bool(False),
+        optionalPSet = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    ),
+    cerr_stats = cms.untracked.PSet(
+        optionalPSet = cms.untracked.bool(True),
+        output = cms.untracked.string('cerr'),
+        threshold = cms.untracked.string('WARNING')
+    ),
+    cout = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring(),
+    debugs = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    default = cms.untracked.PSet(
+
+    ),
+    destinations = cms.untracked.vstring('warnings', 
+        'errors', 
+        'infos', 
+        'debugs', 
+        'cout', 
+        'cerr'),
+    errors = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
+    infos = cms.untracked.PSet(
+        Root_NoDictionary = cms.untracked.PSet(
+            limit = cms.untracked.int32(0),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        optionalPSet = cms.untracked.bool(True),
+        placeholder = cms.untracked.bool(True)
+    ),
+    statistics = cms.untracked.vstring('cerr_stats'),
+    suppressDebug = cms.untracked.vstring(),
+    suppressInfo = cms.untracked.vstring(),
+    suppressWarning = cms.untracked.vstring(),
+    warnings = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    )
+)
+#added line for additional output summary `
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+
+process.schedule = cms.Schedule(*[ process.pathALCARECOPromptCalibProdPCC, process.ALCARECOStreamPromptCalibProdOutPath ])

--- a/DataFormats/Luminosity/interface/PCC.h
+++ b/DataFormats/Luminosity/interface/PCC.h
@@ -1,0 +1,75 @@
+#ifndef PCC_h
+#define PCC_h
+/** \class reco::PCC
+ *  
+ * Reconstructed PCC object that will contain the moduleID, BX, and counts.
+ *
+ * \authors: Sam Higginbotham shiggib@cern.ch and Chris Palmer capalmer@cern.ch
+ * 
+ *
+ *
+ */
+#include <algorithm>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <vector>
+
+namespace reco {
+class PCC {
+static constexpr unsigned int nEmBX=3564;//Empty BX to fill with counts
+    public:
+        PCC() : m_events(nEmBX){}
+        ////////////////////////////////////////////
+        void Increment(int mD,int BXid,int count){
+            std::vector<int>::iterator it;
+            it = std::find(m_ModID.begin(), m_ModID.end(), mD);
+            size_t modIndex = it - m_ModID.begin();
+
+            if(it == m_ModID.end()){
+                std::vector<int> m_empBX(nEmBX, 0);
+                m_ModID.push_back(mD);
+                m_counts.push_back(m_empBX); 
+            }
+           m_counts[modIndex][BXid] += count; 
+        }
+        ////////////////////////////////////////////
+        void eventCounter(int BXid){
+            m_events[BXid]++;
+        }
+        ////////////////////////////////////////////
+        std::vector<std::vector<int>> const & read_counts() const {
+                return(m_counts);
+            }
+        ////////////////////////////////////////////
+        void printVector()
+        { 
+            int irow = 0;
+            std::vector< std::vector<int> >::const_iterator row; 
+            std::vector<int>::const_iterator col; 
+
+            for (row = m_counts.begin(); row != m_counts.end(); ++row)
+            { 
+            
+               std::cout << m_ModID[irow] << " :";
+               for (col = row->begin(); col != row->end(); ++col)
+               { 
+                  std::cout << *col << " "; 
+               } 
+               irow++;
+               std::cout<<std::endl;
+            } 
+
+        }
+
+      private:
+        std::vector<std::vector<int> > m_counts;
+        std::vector<int> m_events;
+        std::vector<int> m_ModID;
+        std::vector<int> m_empBX;
+            
+
+};
+
+}
+#endif

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -40,4 +40,11 @@
   </class>
   <class name="std::vector<LumiSummary::L1>"/>
   <class name="std::vector<LumiSummary::HLT>"/>
+  <class name="reco::PCC" ClassVersion="13">
+   <version ClassVersion="13" checksum="1593740538"/>
+   <version ClassVersion="12" checksum="3216246807"/>
+   <version ClassVersion="11" checksum="1497064974"/>
+   <version ClassVersion="10" checksum="915260007"/>
+  </class>
+ <class name="edm::Wrapper<reco::PCC>"/>
 </lcgdict>


### PR DESCRIPTION
Working Update to PCC Producer workflow in 9_1_X, trimmed files and added ZeroBias and Random Trigger configuration files to test run. 
The test configuration files are located here:
CMSSW_9_1_0_pre1/src/Calibration/PCCAlCaRecoProducers/test/PCC_Random_cfg.py
CMSSW_9_1_0_pre1/src/Calibration/PCCAlCaRecoProducers/test/PCC_ZeroBias_cfg.py 

The Lumisection sample rate can be changed in each of these configuration files, but the defaults are 100LS for Random and 1 for ZeroBias. 
_____________________________________________________________________________________________________________
Major Steps to Project Completion:
1. Construction of rawPCCProducer that will loop over the modules and count the pixel clusters 
2. Harvesters to save reco::PCC object (output from AlcaPCCProducer) and LumiInfo object (output from rawPCCProducer)

Other collaborators working directly on this project:
@capalmer85 

