### PR TITLE
comment out unguarded cout in ElectronMcMiniAODSignalValidator.cc

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -350,7 +350,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
                         okGsfFound = true;
                         
                 // DEBUG LINES - KEEP IT !
-                        std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
+                //        std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
                 // DEBUG LINES - KEEP IT !  /**/ 
                     }
                 }


### PR DESCRIPTION
this was creating printouts like

```
evt ID : run: 1 lumi: 18 event: 863 - Pt : 78.4755 - eta : -0.275391 - phi : -1.01622
```

which also garble normal messages in multi-threaded running