### PR TITLE
Removed superfluous #include in StringCutEventSelector.h

### DIFF
--- a/CommonTools/UtilAlgos/interface/StringCutEventSelector.h
+++ b/CommonTools/UtilAlgos/interface/StringCutEventSelector.h
@@ -7,7 +7,6 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "PhysicsTools/UtilAlgos/interface/CachingVariable.h"
 
 template<typename Object, bool any=false>
 class  StringCutEventSelector : public EventSelector {


### PR DESCRIPTION
This #include is a layering violation because it creates an dependency
from PhysicsTools/UtilAlgos to CommonTools/UtilAlgos from which in turn
depends on PhysicsTools/UtilAlgos.

This patch fixes this by just removing this #include directive as
it doesn't seem to be necessary for parsing StringCutEventSelector.h.