### PR TITLE
allow processingMode RunsAndLumis for ALCAHARVEST when using DAS queries

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -439,7 +439,10 @@ class ConfigBuilder(object):
 	if self._options.dasquery!='':
                self.process.source=cms.Source("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
 	       filesFromDASQuery(self._options.dasquery,self._options.dasoption,self.process.source)
-
+	       
+	       if ('HARVESTING' in self.stepMap.keys() or 'ALCAHARVEST' in self.stepMap.keys()) and (not self._options.filetype == "DQM"):
+		       self.process.source.processingMode = cms.untracked.string("RunsAndLumis")
+		       
 	##drop LHEXMLStringProduct on input to save memory if appropriate
 	if 'GEN' in self.stepMap.keys():
         	if self._options.inputCommands:


### PR DESCRIPTION
E.g.:

`cmsDriver.py step7 --data --conditions auto:run1_data --scenario pp -s ALCAHARVEST:SiPixelAli --dasquery='file dataset=/StreamExpress/Run2016H-PromptCalibProdSiPixelAli-Express-v2/ALCAPROMPT run=283407' -n -1`

won't run correctly. Is there any reason not to support this mode? Might come in handy for certain performance checks. 