### PR TITLE
Removed #includes to TrackerTopology.h in DataFormats/GeometrySurface

### DIFF
--- a/CondTools/SiPixel/test/SiPixelDynamicInefficiencyReader.cc
+++ b/CondTools/SiPixel/test/SiPixelDynamicInefficiencyReader.cc
@@ -11,6 +11,7 @@
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 

--- a/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelBarrelName.h
@@ -7,11 +7,11 @@
 
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <string>
 
-class DetId; 
+class DetId;
+class TrackerTopology;
 
 class PixelBarrelName : public PixelModuleName {
 public:

--- a/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
+++ b/DataFormats/SiPixelDetId/interface/PixelEndcapName.h
@@ -5,13 +5,13 @@
  * Endcap Module name (as in PixelDatabase) for endcaps
  */
 #include "DataFormats/SiPixelDetId/interface/PixelModuleName.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 
 #include <string>
 #include <iostream>
 
 class DetId;
+class TrackerTopology;
 
 class PixelEndcapName : public PixelModuleName {
 public:

--- a/DataFormats/SiPixelDetId/src/PixelBarrelName.cc
+++ b/DataFormats/SiPixelDetId/src/PixelBarrelName.cc
@@ -3,7 +3,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-//#include "DataFormats/TarckerCommon/interface/TarckerTopology.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <sstream>
 #include <iostream>

--- a/DataFormats/SiPixelDetId/src/PixelEndcapName.cc
+++ b/DataFormats/SiPixelDetId/src/PixelEndcapName.cc
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 using namespace std;
 


### PR DESCRIPTION
These includes cause a layering violation because GeometryCommonDetAlgo
in turn already depends on DataFormats/GeometrySurface.