### PR TITLE
Send printouts to stderr, not stdout

### DIFF
--- a/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
+++ b/L1Trigger/Configuration/python/L1TDigiToRaw_cff.py
@@ -6,6 +6,7 @@
 # which contains all L1 trigger packers needed for the current era.
 #
 import FWCore.ParameterSet.Config as cms
+import sys
 
 # Modify the Raw Data Collection Raw collection List to include upgrade collections where appropriate:
 from EventFilter.RawDataCollector.rawDataCollector_cfi import *
@@ -20,7 +21,7 @@ stage2L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list
 # Legacy Trigger:
 #
 if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-    print "L1TDigiToRaw Sequence configured for Run1 (Legacy) trigger. "
+    sys.stderr.write("L1TDigiToRaw Sequence configured for Run1 (Legacy) trigger. \n")
     # legacy L1 packages:
     from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
     from EventFilter.DTTFRawToDigi.dttfpacker_cfi import *
@@ -41,7 +42,7 @@ if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 # Stage-1 Trigger
 #
 if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    print "L1TDigiToRaw Sequence configured for Stage-1 (2015) trigger. "    
+    sys.stderr.write("L1TDigiToRaw Sequence configured for Stage-1 (2015) trigger. \n")
     # legacy L1 packers, still in use for 2015:
     from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
     from EventFilter.DTTFRawToDigi.dttfpacker_cfi import *
@@ -66,7 +67,7 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 # Stage-2 Trigger
 #
 if stage2L1Trigger.isChosen():
-    print "L1TDigiToRaw Sequence configured for Stage-2 (2016) trigger. "
+    sys.stderr.write("L1TDigiToRaw Sequence configured for Stage-2 (2016) trigger. \n")
     from EventFilter.L1TRawToDigi.caloStage2Raw_cfi import *
     from EventFilter.L1TRawToDigi.gmtStage2Raw_cfi import *
     from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import *

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -7,7 +7,7 @@
 #
 
 import FWCore.ParameterSet.Config as cms
-
+import sys
 
 def unpack_legacy():
     global L1TRawToDigi_Legacy
@@ -70,7 +70,7 @@ def unpack_stage2():
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-    print "L1TRawToDigi Sequence configured for Run1 (Legacy) trigger. "
+    sys.stderr.write("L1TRawToDigi Sequence configured for Run1 (Legacy) trigger. \n")
     unpack_legacy()
     L1TRawToDigi = cms.Sequence(L1TRawToDigi_Legacy);
 
@@ -78,7 +78,7 @@ if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 # Stage-1 Trigger
 #
 if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    print "L1TRawToDigi Sequence configured for Stage-1 (2015) trigger. "    
+    sys.stderr.write("L1TRawToDigi Sequence configured for Stage-1 (2015) trigger. \n")
     unpack_stage1()
     L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1)
 
@@ -86,7 +86,7 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 # Stage-2 Trigger:  fow now, unpack Stage 1 and Stage 2 (in case both available)
 #
 if stage2L1Trigger.isChosen():
-    print "L1TRawToDigi Sequence configured for Stage-2 (2016) trigger. "    
+    sys.stderr.write("L1TRawToDigi Sequence configured for Stage-2 (2016) trigger. \n")
     unpack_stage1()
     unpack_stage2()
     L1TRawToDigi = cms.Sequence(L1TRawToDigi_Stage1+L1TRawToDigi_Stage2)

--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -5,6 +5,7 @@
 #
 
 import FWCore.ParameterSet.Config as cms
+import sys
 from Configuration.Eras.Modifier_run2_HI_specific_cff import run2_HI_specific
 #from Configuration.Eras.Era_Run2_2016_pA_cff import Run2_2016_pA
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
@@ -16,14 +17,14 @@ from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-#    print "L1TCalorimeter conditions configured for Run1 (Legacy) trigger. "
+#    sys.stderr.write("L1TCalorimeter conditions configured for Run1 (Legacy) trigger. \n")
 # 
 
 #
 # Stage-1 Trigger
 #
 if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    print "L1TCalorimeter Conditions configured for Stage-1 (2015) trigger. "    
+    sys.stderr.write("L1TCalorimeter Conditions configured for Stage-1 (2015) trigger. \n")
     # Switch between HI and PP calo configuration:
     if (run2_HI_specific.isChosen()):
         from L1Trigger.L1TCalorimeter.caloConfigStage1HI_cfi import *
@@ -38,10 +39,10 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 #
 if stage2L1Trigger.isChosen():
     if pA_2016.isChosen():
-        print "L1TCalorimeter Conditions configured for Stage-2 (2016 pA) trigger. "
+        sys.stderr.write("L1TCalorimeter Conditions configured for Stage-2 (2016 pA) trigger. \n")
         from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_1_HI_cfi import *    
     else:
-        print "L1TCalorimeter Conditions configured for Stage-2 (2016) trigger. "
+        sys.stderr.write("L1TCalorimeter Conditions configured for Stage-2 (2016) trigger. \n")
         from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_1_cfi import *    
     
     # What about CaloConfig?  Related:  How will we switch PP/HH?

--- a/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
 #
 # Legacy Trigger:
@@ -6,7 +7,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-    print "L1TCalorimeter Sequence configured for Run1 (Legacy) trigger. "
+    sys.stderr.write("L1TCalorimeter Sequence configured for Run1 (Legacy) trigger. \n")
 # -  RCT (Regional Calorimeter Trigger) emulator
     import L1Trigger.RegionalCaloTrigger.rctDigis_cfi
     simRctDigis = L1Trigger.RegionalCaloTrigger.rctDigis_cfi.rctDigis.clone()
@@ -22,7 +23,7 @@ if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
 # Stage-1 Trigger
 #
 if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-    print "L1TCalorimeter Sequence configured for Stage-1 (2015) trigger. "    
+    sys.stderr.write("L1TCalorimeter Sequence configured for Stage-1 (2015) trigger. \n")
 #
 # -  RCT (Regional Calorimeter Trigger) emulator
 #
@@ -42,7 +43,7 @@ if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
 # Stage-2 Trigger
 #
 if stage2L1Trigger.isChosen():
-    print "L1TCalorimeter Sequence configured for Stage-2 (2016) trigger. "
+    sys.stderr.write("L1TCalorimeter Sequence configured for Stage-2 (2016) trigger. \n")
     # select one of the following two options:
     # - layer1 from L1Trigger/L1TCalorimeter package
     #from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis

--- a/L1Trigger/L1TCommon/python/caloStage1LegacyFormatDigis_cfi.py
+++ b/L1Trigger/L1TCommon/python/caloStage1LegacyFormatDigis_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+import sys
 
-print "WARNING:  L1Trigger/L1TCommon/python/caloStage1LegacyFormatDigis_cfi.py has been deprecated..."
-print "WARNING:  please use L1Trigger/L1TCalorimeter/python/caloStage1LegacyFormatDigis_cfi.py"
+sys.stderr.write("WARNING:  L1Trigger/L1TCommon/python/caloStage1LegacyFormatDigis_cfi.py has been deprecated...\n")
+sys.stderr.write("WARNING:  please use L1Trigger/L1TCalorimeter/python/caloStage1LegacyFormatDigis_cfi.py\n")
 
 from L1Trigger.L1TCalorimeter.caloStage1LegacyFormatDigis_cfi import caloStage1LegacyFormatDigis
 

--- a/L1Trigger/L1TGlobal/python/hackConditions_cff.py
+++ b/L1Trigger/L1TGlobal/python/hackConditions_cff.py
@@ -9,6 +9,7 @@
 #
 
 import FWCore.ParameterSet.Config as cms
+import sys
 
 #
 # Legacy Trigger:  No Hacks Needed
@@ -16,20 +17,20 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-#    print "L1TGlobal conditions configured for Run1 (Legacy) trigger. "
+#    sys.stderr.write("L1TGlobal conditions configured for Run1 (Legacy) trigger. \n")
 # 
 
 #
 # Stage-1 Trigger:  No Hacks Needed
 #
 #if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-#    print "L1TGlobal Conditions configured for Stage-1 (2015) trigger. "    
+#    sys.stderr.write("L1TGlobal Conditions configured for Stage-1 (2015) trigger. \n")
 
 #
 # Stage-2 Trigger
 #
 if stage2L1Trigger.isChosen():
-    print "L1TGlobal Conditions configured for Stage-2 (2016) trigger. "
+    sys.stderr.write("L1TGlobal Conditions configured for Stage-2 (2016) trigger. \n")
     from L1Trigger.L1TGlobal.StableParameters_cff import *
 #    from L1Trigger.L1TGlobal.GlobalParameters_cff import *
     from L1Trigger.L1TGlobal.PrescalesVetos_cff import *

--- a/L1Trigger/L1TGlobal/python/simDigis_cff.py
+++ b/L1Trigger/L1TGlobal/python/simDigis_cff.py
@@ -4,12 +4,13 @@
 # All changes must be explicitly discussed with the L1T offline coordinator.
 #
 import FWCore.ParameterSet.Config as cms
+import sys
 #
 # Legacy Trigger:
 #
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 if not (stage2L1Trigger.isChosen()):
-    print "L1TGlobal Sequence configured for Legacy trigger (Run1 and Run 2015). "
+    sys.stderr.write("L1TGlobal Sequence configured for Legacy trigger (Run1 and Run 2015). \n")
 #
 # -  Global Trigger emulator
 #
@@ -32,6 +33,6 @@ if stage2L1Trigger.isChosen():
 #
 # -  Global Trigger emulator
 #
-    print "L1TGlobal Sequence configured for Stage-2 (2016) trigger. "
+    sys.stderr.write("L1TGlobal Sequence configured for Stage-2 (2016) trigger. \n")
     from L1Trigger.L1TGlobal.simGtStage2Digis_cfi import *
     SimL1TGlobal = cms.Sequence(simGtStage2Digis)

--- a/L1Trigger/L1TMuon/python/hackConditions_cff.py
+++ b/L1Trigger/L1TMuon/python/hackConditions_cff.py
@@ -5,27 +5,27 @@
 #
 
 import FWCore.ParameterSet.Config as cms
-
+import sys
 #
 # Legacy Trigger:  No Hacks Needed
 #
 from Configuration.Eras.Modifier_stage1L1Trigger_cff import stage1L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #if not (stage1L1Trigger.isChosen() or stage2L1Trigger.isChosen()):
-#    print "L1TMuon conditions configured for Run1 (Legacy) trigger. "
+#    sys.stderr.write("L1TMuon conditions configured for Run1 (Legacy) trigger. \n")
 # 
 
 #
 # Stage-1 Trigger:  No Hacks Needed
 #
 #if stage1L1Trigger.isChosen() and not stage2L1Trigger.isChosen():
-#    print "L1TMuon Conditions configured for Stage-1 (2015) trigger. "    
+#    sys.stderr.write("L1TMuon Conditions configured for Stage-1 (2015) trigger. \n")
 
 #
 # Stage-2 Trigger
 #
 if stage2L1Trigger.isChosen():
-    print "L1TMuon Conditions configured for Stage-2 (2016) trigger. "
+    sys.stderr.write("L1TMuon Conditions configured for Stage-2 (2016) trigger. \n")
     from L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff import *
     from L1Trigger.L1TMuonOverlap.fakeOmtfParams_cff import *
     from L1Trigger.L1TMuonEndCap.fakeEmtfParams_cff import *

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+import sys
 #
 # Legacy L1 Muon modules still running in 2016 trigger:
 #
@@ -26,7 +26,7 @@ SimL1TMuonCommon = cms.Sequence(simDtTriggerPrimitiveDigis + simCscTriggerPrimit
 #
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 if not (stage2L1Trigger.isChosen()):
-    print "L1TMuon Sequence configured for Legacy trigger (Run1 and Run 2015). "
+    sys.stderr.write("L1TMuon Sequence configured for Legacy trigger (Run1 and Run 2015). \n")
 #
 # - CSC Track Finder emulator
 #
@@ -69,7 +69,7 @@ if not (stage2L1Trigger.isChosen()):
 # Stage-2 Trigger
 #
 if stage2L1Trigger.isChosen():
-    print "L1TMuon Sequence configured for Stage-2 (2016) trigger. "
+    sys.stderr.write("L1TMuon Sequence configured for Stage-2 (2016) trigger. \n")
     from L1Trigger.L1TMuonBarrel.simTwinMuxDigis_cfi import *
     from L1Trigger.L1TMuonBarrel.simBmtfDigis_cfi import *
     from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -273,17 +273,17 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
 
     if tightBTagNTkHits:
         if not runIVF:
-            print "-------------------------------------------------------------------"
-            print " Warning: For a complete switch to the legacy tight b-tag track"
-            print "          selection, please also enable the \'runIVF\' switch."
-            print "-------------------------------------------------------------------"
+            sys.stderr.write("-------------------------------------------------------------------\n")
+            sys.stderr.write(" Warning: For a complete switch to the legacy tight b-tag track\n")
+            sys.stderr.write("          selection, please also enable the \'runIVF\' switch.\n")
+            sys.stderr.write("-------------------------------------------------------------------\n")
         if btagPrefix == '':
-            print "-------------------------------------------------------------------"
-            print " Warning: With the tight b-tag track selection enabled, it is"
-            print "          advisable to set \'btagPrefix\' to a non-empty string to"
-            print "          avoid unintentional modifications to the default"
-            print "          b tagging setup that might be loaded in the same job."
-            print "-------------------------------------------------------------------"
+            sys.stderr.write("-------------------------------------------------------------------\n")
+            sys.stderr.write(" Warning: With the tight b-tag track selection enabled, it is\n")
+            sys.stderr.write("          advisable to set \'btagPrefix\' to a non-empty string to\n")
+            sys.stderr.write("          avoid unintentional modifications to the default\n")
+            sys.stderr.write("          b tagging setup that might be loaded in the same job.\n")
+            sys.stderr.write("-------------------------------------------------------------------\n")
 
     ## define c tagging CvsL SV source (for now tied to the default SV source
     ## in the first part of the module label, product instance label and process name)
@@ -297,10 +297,10 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
     if pvSource.getModuleLabel() == 'offlineSlimmedPrimaryVertices' and any(i in requiredTagInfos for i in ivfcTagInfos) and not runIVF:
         runIVFforCTagOnly = True
         runIVF = True
-        print "-------------------------------------------------------------------"
-        print " Info: To run c tagging on MiniAOD, c-tag-specific IVF secondary"
-        print "       vertices will be remade."
-        print "-------------------------------------------------------------------"
+        sys.stderr.write("-------------------------------------------------------------------\n")
+        sys.stderr.write(" Info: To run c tagging on MiniAOD, c-tag-specific IVF secondary\n")
+        sys.stderr.write("       vertices will be remade.\n")
+        sys.stderr.write("-------------------------------------------------------------------\n")
     ## adjust svSources
     if runIVF and btagPrefix != '':
         if runIVFforCTagOnly:
@@ -1494,11 +1494,11 @@ class UpdateJetCollection(ConfigToolBase):
 
         ## run btagging if required by user
         if (bTagging):
-            print "**************************************************************"
-            print "b tagging needs to be run on uncorrected jets. Hence, the JECs"
-            print "will first be undone for 'updatedPatJets%s' and then applied to"%(_labelName+postfix)
-            print "'updatedPatJetsTransientCorrected%s'."%(_labelName+postfix)
-            print "**************************************************************"
+            sys.stderr.write("**************************************************************\n")
+            sys.stderr.write("b tagging needs to be run on uncorrected jets. Hence, the JECs\n")
+            sys.stderr.write("will first be undone for 'updatedPatJets%s' and then applied to\n" % (_labelName+postfix) )
+            sys.stderr.write("'updatedPatJetsTransientCorrected%s'.\n" % (_labelName+postfix) )
+            sys.stderr.write("**************************************************************\n")
             _jetSource = cms.InputTag('updatedPatJets'+_labelName+postfix)
             ## insert new jet collection with jet corrections applied and btag info added
             self(
@@ -1542,11 +1542,11 @@ class UpdateJetCollection(ConfigToolBase):
             checkJetCorrectionsFormat(jetCorrections)
             ## reset MET corrrection
             if jetCorrections[2].lower() != 'none' and jetCorrections[2] != '':
-                print "-------------------------------------------------------------------"
-                print " Warning: MET correction was set to " + jetCorrections[2] + " but"
-                print "          will be ignored. Please set it to \"None\" to avoid"
-                print "          getting this warning."
-                print "-------------------------------------------------------------------"
+                sys.stderr.write("-------------------------------------------------------------------\n")
+                sys.stderr.write(" Warning: MET correction was set to " + jetCorrections[2] + " but\n")
+                sys.stderr.write("          will be ignored. Please set it to \"None\" to avoid\n")
+                sys.stderr.write("          getting this warning.\n")
+                sys.stderr.write("-------------------------------------------------------------------\n")
                 jetCorrectionsList = list(jetCorrections)
                 jetCorrectionsList[2] = 'None'
                 jetCorrections = tuple(jetCorrectionsList)
@@ -1594,7 +1594,7 @@ class AddJetID(ConfigToolBase):
         jetIdTag=self._parameters['jetIdTag'].value
 
         jetIdLabel = jetIdTag + 'JetID'
-        print "Making new jet ID label with label " + jetIdTag
+        sys.stderr.write("Making new jet ID label with label " + jetIdTag + "\n")
 
         ## replace jet id sequence
         task = getPatAlgosToolsTask(process)
@@ -1657,44 +1657,44 @@ class SetTagInfos(ConfigToolBase):
 setTagInfos=SetTagInfos()
 
 def deprecatedOptionOutputModule(obj):
-    print "-------------------------------------------------------"
-    print " Error: the option 'outputModule' is not supported"
-    print "        anymore by:"
-    print "                   ", obj._label
-    print "        please use 'outputModules' now and specify the"
-    print "        names of all needed OutModules in there"
-    print "        (default: ['out'])"
-    print "-------------------------------------------------------"
+    sys.stderr.write("-------------------------------------------------------\n")
+    sys.stderr.write(" Error: the option 'outputModule' is not supported\n")
+    sys.stderr.write("        anymore by:\n")
+    sys.stderr.write("                     " + obj._label + "\n")
+    sys.stderr.write("        please use 'outputModules' now and specify the\n")
+    sys.stderr.write("        names of all needed OutModules in there\n")
+    sys.stderr.write("        (default: ['out'])\n")
+    sys.stderr.write("-------------------------------------------------------\n")
     raise KeyError("Unsupported option 'outputModule' used in '"+obj._label+"'")
 
 def undefinedLabelName(obj):
-    print "-------------------------------------------------------"
-    print " Error: the jet 'labelName' is not defined."
-    print "        All added jets must have 'labelName' defined."
-    print "-------------------------------------------------------"
+    sys.stderr.write("-------------------------------------------------------\n")
+    sys.stderr.write(" Error: the jet 'labelName' is not defined.\n")
+    sys.stderr.write("        All added jets must have 'labelName' defined.\n")
+    sys.stderr.write("-------------------------------------------------------\n")
     raise KeyError("Undefined jet 'labelName' used in '"+obj._label+"'")
 
 def unsupportedJetAlgorithm(obj):
-    print "-------------------------------------------------------"
-    print " Error: Unsupported jet algorithm detected."
-    print "        The supported algorithms are:"
+    sys.stderr.write("-------------------------------------------------------\n")
+    sys.stderr.write(" Error: Unsupported jet algorithm detected.\n")
+    sys.stderr.write("        The supported algorithms are:\n")
     for key in supportedJetAlgos.keys():
-        print "        " + key.upper() + ", " + key.lower() + ": " + supportedJetAlgos[key]
-    print "-------------------------------------------------------"
+        sys.stderr.write("        " + key.upper() + ", " + key.lower() + ": " + supportedJetAlgos[key] + "\n")
+    sys.stderr.write("-------------------------------------------------------\n")
     raise KeyError("Unsupported jet algorithm used in '"+obj._label+"'")
 
 def rerunningIVF():
-    print "-------------------------------------------------------------------"
-    print " Warning: You are attempting to remake the IVF secondary vertices"
-    print "          already produced by the standard reconstruction. This"
-    print "          option is not enabled by default so please use it only if"
-    print "          you know what you are doing."
-    print "-------------------------------------------------------------------"
+    sys.stderr.write("-------------------------------------------------------------------\n")
+    sys.stderr.write(" Warning: You are attempting to remake the IVF secondary vertices\n")
+    sys.stderr.write("          already produced by the standard reconstruction. This\n")
+    sys.stderr.write("          option is not enabled by default so please use it only if\n")
+    sys.stderr.write("          you know what you are doing.\n")
+    sys.stderr.write("-------------------------------------------------------------------\n")
 
 def rerunningIVFMiniAOD():
-    print "-------------------------------------------------------------------"
-    print " Warning: You are attempting to remake IVF secondary vertices from"
-    print "          MiniAOD. If that was your intention, note that secondary"
-    print "          vertices remade from MiniAOD will have somewhat degraded"
-    print "          performance compared to those remade from RECO/AOD."
-    print "-------------------------------------------------------------------"
+    sys.stderr.write("-------------------------------------------------------------------\n")
+    sys.stderr.write(" Warning: You are attempting to remake IVF secondary vertices from\n")
+    sys.stderr.write("          MiniAOD. If that was your intention, note that secondary\n")
+    sys.stderr.write("          vertices remade from MiniAOD will have somewhat degraded\n")
+    sys.stderr.write("          performance compared to those remade from RECO/AOD.\n")
+    sys.stderr.write("-------------------------------------------------------------------\n")


### PR DESCRIPTION
Usually, those printouts are in the way while using, e.g., ```edmConfigDump```. Sending them to the standard error allows to have a working and clean python.