### PR TITLE
CSC stub central BX shift

### DIFF
--- a/L1Trigger/CSCCommonTrigger/python/CSCCommonTrigger_cfi.py
+++ b/L1Trigger/CSCCommonTrigger/python/CSCCommonTrigger_cfi.py
@@ -2,8 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 #Common Parameters for the various CSCTrigger producers
 CSCCommonTrigger = cms.PSet(
-    MaxBX = cms.int32(9),
+    #shift the readout window from [3, 9] to [5,11], make sure simulation consistent with data, by tao.huang@cern.ch
+    MaxBX = cms.int32(11),
     #minimum and maximum bx to process
-    MinBX = cms.int32(3)
+    MinBX = cms.int32(5)
 )
 

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -135,8 +135,6 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev,
     lctBuilder_->setConfigParameters(conf.product());
   }
   
-  // temporary hack to run on data
-  lctBuilder_->runOnData(ev.eventAuxiliary().isRealData());
   
   // Get the collections of comparator & wire digis from event.
   edm::Handle<CSCComparatorDigiCollection> compDigis;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -135,7 +135,7 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
   tmb_l1a_window_size = // Common to CLCT and TMB
     tmbParams.getParameter<unsigned int>("tmbL1aWindowSize");
 
-  lct_central_bx = 6;
+  lct_central_bx = 8;
 
   // configuration handle for number of early time bins
   early_tbins = tmbParams.getParameter<int>("tmbEarlyTbins");

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -620,11 +620,6 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
   // run MPC simulation
   m_muonportcard->loadDigis(oc_lct);
 
-  // temporary hack to ensure that all MPC LCTs are read out
-  if (runOnData_) {
-    m_minBX = 5;
-    m_maxBX = 11;
-  }
 
   std::vector<csctf::TrackStub> result;
   for(int bx = m_minBX; bx <= m_maxBX; ++bx)

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
@@ -89,9 +89,6 @@ class CSCTriggerPrimitivesBuilder
   static const int min_chamber;   // chambers per trigger subsector
   static const int max_chamber;
 
-  /// temporary flag to run on data
-  bool runOnData_;
-
   /// a flag whether to skip chambers from the bad chambers map
   bool checkBadChambers_;
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
@@ -53,9 +53,6 @@ class CSCTriggerPrimitivesBuilder
   void setGEMGeometry(const GEMGeometry *g) { gem_g = g; }
   void setRPCGeometry(const RPCGeometry *g) { rpc_g = g; }
 
-  /* temporary function to check if running on data */
-  void runOnData(bool runOnData) {runOnData_ = runOnData;}
-
   /** Build anode, cathode, and correlated LCTs in each chamber and fill
    *  them into output collections.  Select up to three best correlated LCTs
    *  in each (sub)sector and put them into an output collection as well. */

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -11,8 +11,9 @@ import FWCore.ParameterSet.Config as cms
 ## Two options for CSCInputBxShift
 ##   * -2 when using simCscTriggerPrimitiveDigis re-emulated from data
 ##   *  0 in all other cases (MC, csctfDigis or emtfStage2Digis input)
+##   * changed to -2 for MC because LCT central BX is shifted from 6 to 8 now in MC
 simEmtfDigis = cms.EDProducer("L1TMuonEndCapTrackProducer",
                               CSCInput = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
                               RPCInput = cms.InputTag('simMuonRPCDigis'),
-                              CSCInputBxShift = cms.untracked.int32(0),
+                              CSCInputBxShift = cms.untracked.int32(-2),
                               )

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
@@ -276,7 +276,7 @@ OMTFinput OMTFinputMaker::processCSC(const CSCCorrelatedLCTDigiCollection *cscDi
 
       ///Check Trigger primitive quality.
       ///CSC central BX is 6 for some reason.
-      if (abs(digi->getBX()- 6)>0) continue;
+      if (abs(digi->getBX()- 8)>0) continue;
       
       unsigned int hwNumber = myOmtfConfig->getLayerNumber(rawid);
       if(myOmtfConfig->getHwToLogicLayer().find(hwNumber)==myOmtfConfig->getHwToLogicLayer().end()) continue;

--- a/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
+++ b/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
@@ -5,7 +5,8 @@ import FWCore.ParameterSet.Config as cms
 simMuonCSCDigis = cms.EDProducer("CSCDigiProducer",
     strips = cms.PSet(
         peakTimeSigma = cms.double(3.0),
-        timeBitForBxZero = cms.int32(6),
+	#shift the central BX of wire digi from 6 to 7, make sure simulation consistent with data, by tao.huang@cern.ch
+        timeBitForBxZero = cms.int32(7),
         doNoise = cms.bool(True),
         nScaBins = cms.int32(8),
         doCrosstalk = cms.bool(True),
@@ -63,7 +64,9 @@ simMuonCSCDigis = cms.EDProducer("CSCDigiProducer",
         peakTimeSigma = cms.double(0.0),
         shapingTime = cms.int32(30),
         readBadChannels = cms.bool(False),
-        timeBitForBxZero = cms.int32(6),
+
+	#shift the central BX of wire digi from 6 to 8, make sure simulation consistent with data, by tao.huang@cern.ch
+        timeBitForBxZero = cms.int32(8),
         samplingTime = cms.double(5.0),
         # bunchTimingOffsets - comments for strips (above) also apply
         bunchTimingOffsets = cms.vdouble(0.00, 21.64, 21.64, 28.29, 29.36, 29.33, 28.57, 28.61, 28.83, 29.09, 28.22),


### PR DESCRIPTION
1. change the central BX in CSC digitizer, from 6 to 8 for wire digi and from 6 to 7 for strip digi
2. change the readout window for CSC common trigger, from [3,9] to [5,11]
3. change LCT central BX used in overlap muon track-finder, from 6 to 8
4. change the CSCInputBxShift in Endcap muon track-finder, from 0 to -2 