### PR TITLE
Changes to implement the new CTagger retraining for PhaseI

### DIFF
--- a/RecoBTag/CTagging/interface/CharmTagger.h
+++ b/RecoBTag/CTagging/interface/CharmTagger.h
@@ -46,7 +46,7 @@ private:
 	edm::FileInPath weight_file_;
   bool use_GBRForest_;
   bool use_adaBoost_;
-  bool isPhase1_;
+  bool defaultValueNoTracks_;
 };
 
 #endif

--- a/RecoBTag/CTagging/interface/CharmTagger.h
+++ b/RecoBTag/CTagging/interface/CharmTagger.h
@@ -46,6 +46,7 @@ private:
 	edm::FileInPath weight_file_;
   bool use_GBRForest_;
   bool use_adaBoost_;
+  bool isPhase1_;
 };
 
 #endif

--- a/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
+++ b/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
@@ -3,9 +3,12 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.CTagging.charmTagsComputerCvsL_cfi import *
 
 charmTagsComputerCvsB = charmTagsComputerCvsL.clone(
-   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_b_PhaseI.xml'),   
+   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_b_sklearn.weight.xml'),   
    variables = c_vs_b_vars_vpset
    )
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(charmTagsComputerCvsB, weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_b_PhaseI.xml'))
 
 #
 # Negative tagger

--- a/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
+++ b/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.CTagging.charmTagsComputerCvsL_cfi import *
 
 charmTagsComputerCvsB = charmTagsComputerCvsL.clone(
-   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_b_sklearn.weight.xml'),   
+   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_b_PhaseI.xml'),   
    variables = c_vs_b_vars_vpset
    )
 

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -14,7 +14,7 @@ charmTagsComputerCvsL = cms.ESProducer(
    slComputerCfg = cms.PSet(
       **sl_cfg.candidateCombinedSecondaryVertexSoftLeptonComputer.parameters_()
       ),
-   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_sklearn.weight.xml'),
+   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'),
    variables = c_vs_l_vars_vpset,
    computer = cms.ESInputTag('combinedSecondaryVertexSoftLeptonComputer'),
    tagInfos = cms.VInputTag(
@@ -30,4 +30,4 @@ charmTagsComputerCvsL = cms.ESProducer(
    useAdaBoost = cms.bool(False)
    )
 
-charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
+charmTagsComputerCvsL.slComputerCfg.correctVertexMass = True

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -30,7 +30,8 @@ charmTagsComputerCvsL = cms.ESProducer(
    useAdaBoost = cms.bool(False)
    )
 
-charmTagsComputerCvsL.slComputerCfg.correctVertexMass = True
+charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(charmTagsComputerCvsL, weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'))
+phase1Pixel.toModify(charmTagsComputerCvsL, slComputerCfg = dict(correctVertexMass = True))

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -28,7 +28,7 @@ charmTagsComputerCvsL = cms.ESProducer(
    gbrForestLabel = cms.string(''),
    useGBRForest = cms.bool(True),
    useAdaBoost = cms.bool(False),
-   isPhase1 = cms.bool(False)
+   defaultValueNoTracks = cmss.bool(False)
    )
 
 charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
@@ -36,4 +36,4 @@ charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(charmTagsComputerCvsL, weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'))
 phase1Pixel.toModify(charmTagsComputerCvsL, slComputerCfg = dict(correctVertexMass = True))
-phase1Pixel.toModify(charmTagsComputerCvsL, isPhase1 = cms.bool(True))
+phase1Pixel.toModify(charmTagsComputerCvsL, defaultValueNoTracks = cms.bool(True))

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -27,7 +27,8 @@ charmTagsComputerCvsL = cms.ESProducer(
    useCondDB = cms.bool(False),
    gbrForestLabel = cms.string(''),
    useGBRForest = cms.bool(True),
-   useAdaBoost = cms.bool(False)
+   useAdaBoost = cms.bool(False),
+   isPhase1 = cms.bool(False)
    )
 
 charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
@@ -35,3 +36,4 @@ charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(charmTagsComputerCvsL, weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'))
 phase1Pixel.toModify(charmTagsComputerCvsL, slComputerCfg = dict(correctVertexMass = True))
+phase1Pixel.toModify(charmTagsComputerCvsL, isPhase1 = cms.bool(True))

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -14,7 +14,7 @@ charmTagsComputerCvsL = cms.ESProducer(
    slComputerCfg = cms.PSet(
       **sl_cfg.candidateCombinedSecondaryVertexSoftLeptonComputer.parameters_()
       ),
-   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'),
+   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_sklearn.weight.xml'),
    variables = c_vs_l_vars_vpset,
    computer = cms.ESInputTag('combinedSecondaryVertexSoftLeptonComputer'),
    tagInfos = cms.VInputTag(
@@ -31,3 +31,6 @@ charmTagsComputerCvsL = cms.ESProducer(
    )
 
 charmTagsComputerCvsL.slComputerCfg.correctVertexMass = True
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(charmTagsComputerCvsL, weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'))

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -28,7 +28,7 @@ charmTagsComputerCvsL = cms.ESProducer(
    gbrForestLabel = cms.string(''),
    useGBRForest = cms.bool(True),
    useAdaBoost = cms.bool(False),
-   defaultValueNoTracks = cmss.bool(False)
+   defaultValueNoTracks = cms.bool(False)
    )
 
 charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False

--- a/RecoBTag/CTagging/src/CharmTagger.cc
+++ b/RecoBTag/CTagging/src/CharmTagger.cc
@@ -101,6 +101,7 @@ float CharmTagger::discriminator(const TagInfoHelper & tagInfo) const {
 	}
 
 	//get the MVA output
-	float tag = mvaID_->evaluate(inputs);
+	bool notracks = (vars.get(reco::btau::jetNTracks,0) == 0);	
+	float tag = !notracks ? mvaID_->evaluate(inputs) : -2; // if no tracks available, put value at -2
 	return tag;
 }

--- a/RecoBTag/CTagging/src/CharmTagger.cc
+++ b/RecoBTag/CTagging/src/CharmTagger.cc
@@ -20,7 +20,7 @@ CharmTagger::CharmTagger(const edm::ParameterSet & configuration):
   weight_file_(configuration.getParameter<edm::FileInPath>("weightFile")),
   use_GBRForest_(configuration.getParameter<bool>("useGBRForest")),
   use_adaBoost_(configuration.getParameter<bool>("useAdaBoost")),
-  isPhase1_(configuration.getParameter<bool>("isPhase1"))
+  defaultValueNoTracks_(configuration.getParameter<bool>("defaultValueNoTracks"))
 {
 	vpset vars_definition = configuration.getParameter<vpset>("variables");
 	for(auto &var : vars_definition) {
@@ -104,6 +104,6 @@ float CharmTagger::discriminator(const TagInfoHelper & tagInfo) const {
 	//get the MVA output
 	bool notracks = (vars.get(reco::btau::jetNTracks,0) == 0);
 	float tag = mvaID_->evaluate(inputs);
-	if (isPhase1_ && notracks){tag = -2;} // if no tracks available, put value at -2 (only for Phase I)
+	if (defaultValueNoTracks_ && notracks){tag = -2;} // if no tracks available, put value at -2 (only for Phase I)
 	return tag;
 }

--- a/RecoBTag/CTagging/src/CharmTagger.cc
+++ b/RecoBTag/CTagging/src/CharmTagger.cc
@@ -19,7 +19,8 @@ CharmTagger::CharmTagger(const edm::ParameterSet & configuration):
   gbrForest_label_(configuration.getParameter<std::string>("gbrForestLabel")),
   weight_file_(configuration.getParameter<edm::FileInPath>("weightFile")),
   use_GBRForest_(configuration.getParameter<bool>("useGBRForest")),
-  use_adaBoost_(configuration.getParameter<bool>("useAdaBoost"))
+  use_adaBoost_(configuration.getParameter<bool>("useAdaBoost")),
+  isPhase1_(configuration.getParameter<bool>("isPhase1"))
 {
 	vpset vars_definition = configuration.getParameter<vpset>("variables");
 	for(auto &var : vars_definition) {
@@ -101,7 +102,8 @@ float CharmTagger::discriminator(const TagInfoHelper & tagInfo) const {
 	}
 
 	//get the MVA output
-	bool notracks = (vars.get(reco::btau::jetNTracks,0) == 0);	
-	float tag = !notracks ? mvaID_->evaluate(inputs) : -2; // if no tracks available, put value at -2
+	bool notracks = (vars.get(reco::btau::jetNTracks,0) == 0);
+	float tag = mvaID_->evaluate(inputs);
+	if (isPhase1_ && notracks){tag = -2;} // if no tracks available, put value at -2 (only for Phase I)
 	return tag;
 }


### PR DESCRIPTION
This PR changes the c-tagger training files to the new re-trainings for phase I, which were added here: https://github.com/cms-data/RecoBTag-CTagging/pull/5, https://github.com/cms-sw/cmsdist/pull/2939 (currently still testing)

On top of that the training now uses the corrected secondary vertex mass (explaining the switch from False to True in charmTagsComputerCvsL.slComputerCfg.correctVertexMass)

Also jets without any tracks passing the BTV track selection are given a default discriminator value of -2, similarly to what happens for other Taggers.