### PR TITLE
Activate Max-Sample algorithm in EB by default for 80X legacy re-reco

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -26,6 +26,7 @@ class EcalUncalibRecHitMultiFitAlgo
   EcalUncalibRecHitMultiFitAlgo();
   ~EcalUncalibRecHitMultiFitAlgo() { };
   EcalUncalibratedRecHit makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrix &noisecor, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX);
+  void setGainSwitchUseMaxSample(bool b) { _gainSwitchUseMaxSample = b; }
   void disableErrorCalculation() { _computeErrors = false; }
   void setDoPrefit(bool b) { _doPrefit = b; }
   void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
@@ -36,6 +37,7 @@ class EcalUncalibRecHitMultiFitAlgo
    bool _computeErrors;
    bool _doPrefit;
    double _prefitMaxChiSq;
+   bool _gainSwitchUseMaxSample;
    BXVector _singlebx;
 
 };

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -47,6 +47,8 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
     bunchSpacingManual_ = ps.getParameter<int>("bunchSpacing");
   }
 
+  gainSwitchUseMaxSampleEB_ = ps.getParameter<bool>("gainSwitchUseMaxSampleEB");
+  gainSwitchUseMaxSampleEE_ = ps.getParameter<bool>("gainSwitchUseMaxSampleEE");
   doPrefitEB_ = ps.getParameter<bool>("doPrefitEB");
   doPrefitEE_ = ps.getParameter<bool>("doPrefitEE");
 
@@ -263,6 +265,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 aPulseCov = &pulsecovariances->endcap(hashedIndex);
                 multiFitMethod_.setDoPrefit(doPrefitEE_);
 		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEE_);
+                multiFitMethod_.setGainSwitchUseMaxSample(gainSwitchUseMaxSampleEE_);
 		offsetTime = offtime->getEEValue();
         } else {
                 unsigned int hashedIndex = EBDetId(detid).hashedIndex();
@@ -273,6 +276,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 aPulseCov = &pulsecovariances->barrel(hashedIndex);
                 multiFitMethod_.setDoPrefit(doPrefitEB_);
 		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB_);
+                multiFitMethod_.setGainSwitchUseMaxSample(gainSwitchUseMaxSampleEB_);
 		offsetTime = offtime->getEBValue();
         }
 
@@ -573,6 +577,8 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
 	      edm::ParameterDescription<bool>("ampErrorCalculation", true, true) and
 	      edm::ParameterDescription<bool>("useLumiInfoRunHeader", true, true) and
 	      edm::ParameterDescription<int>("bunchSpacing", 0, true) and
+	      edm::ParameterDescription<bool>("gainSwitchUseMaxSampleEB", false, true) and
+	      edm::ParameterDescription<bool>("gainSwitchUseMaxSampleEE", false, true) and
 	      edm::ParameterDescription<bool>("doPrefitEB", false, true) and
 	      edm::ParameterDescription<bool>("doPrefitEE", false, true) and
 	      edm::ParameterDescription<double>("prefitMaxChiSqEB", 25., true) and

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -93,6 +93,8 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
                 const EcalWeightSet::EcalWeightMatrix* weights[2];
                 EcalUncalibRecHitTimeWeightsAlgo<EBDataFrame> weightsMethod_barrel_;
                 EcalUncalibRecHitTimeWeightsAlgo<EEDataFrame> weightsMethod_endcap_;
+                bool gainSwitchUseMaxSampleEB_;
+                bool gainSwitchUseMaxSampleEE_;
                 bool doPrefitEB_;
                 bool doPrefitEE_;
 		double prefitMaxChiSqEB_;

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -15,7 +15,7 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       ampErrorCalculation = cms.bool(True),
       useLumiInfoRunHeader = cms.bool(True),
 
-      gainSwitchUseMaxSampleEB = cms.bool(False),
+      gainSwitchUseMaxSampleEB = cms.bool(True),
       gainSwitchUseMaxSampleEE = cms.bool(False),      
       doPrefitEB = cms.bool(False),
       doPrefitEE = cms.bool(False),

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -14,7 +14,9 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
       ampErrorCalculation = cms.bool(True),
       useLumiInfoRunHeader = cms.bool(True),
-  
+
+      gainSwitchUseMaxSampleEB = cms.bool(False),
+      gainSwitchUseMaxSampleEE = cms.bool(False),      
       doPrefitEB = cms.bool(False),
       doPrefitEE = cms.bool(False),
       prefitMaxChiSqEB = cms.double(25.),


### PR DESCRIPTION
This activate the code in PR #17259 for the ECAL barrel by default. 
This is the configuration that should be used for the legacy re-reco of 2016 data in 8.0.X.
Activated by default as in suggestion https://github.com/cms-sw/cmssw/pull/17259#issuecomment-292117017.

@amassiro @bendavid @paramatti @fcouderc also notice this change.