### PR TITLE
Activate Max-Sample algorithm in EB by default for 80X legacy re-reco

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -15,7 +15,7 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       ampErrorCalculation = cms.bool(True),
       useLumiInfoRunHeader = cms.bool(True),
 
-      gainSwitchUseMaxSampleEB = cms.bool(False),
+      gainSwitchUseMaxSampleEB = cms.bool(True),
       gainSwitchUseMaxSampleEE = cms.bool(False),      
       doPrefitEB = cms.bool(False),
       doPrefitEE = cms.bool(False),


### PR DESCRIPTION
This activate the code in PR #17259 for the ECAL barrel by default.
This is the configuration that should be used for the legacy re-reco of 2016 data in 8.0.X.
Activated by default as in suggestion https://github.com/cms-sw/cmssw/pull/17259#issuecomment-292117017

@amassiro @bendavid @paramatti @fcouderc also notice this change.