### PR TITLE
CTPPS: diamond miniAOD

### DIFF
--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -3,6 +3,7 @@
 * This is a part of TOTEM offline software.
 * Authors:
 *   Jan Kašpar (jan.kaspar@gmail.com)
+*   Laurent Forthomme
 *
 ****************************************************************************/
 
@@ -14,6 +15,8 @@
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/CTPPSReco/interface/TotemRPLocalTrack.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSDiamondLocalTrack.h"
+
 #include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
 
 //----------------------------------------------------------------------------------------------------
@@ -24,69 +27,85 @@
 class CTPPSLocalTrackLiteProducer : public edm::stream::EDProducer<>
 {
   public:
-    explicit CTPPSLocalTrackLiteProducer(const edm::ParameterSet& conf);
-  
+    explicit CTPPSLocalTrackLiteProducer( const edm::ParameterSet& );
     virtual ~CTPPSLocalTrackLiteProducer() {}
-  
-    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
-  
+
+    virtual void produce( edm::Event&, const edm::EventSetup& ) override;
+
   private:
-    edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> siStripTrackToken;
+    edm::EDGetTokenT< edm::DetSetVector<TotemRPLocalTrack> > siStripTrackToken_;
+    edm::EDGetTokenT< edm::DetSetVector<CTPPSDiamondLocalTrack> > diamondTrackToken_;
 
     /// if true, this module will do nothing
     /// needed for consistency with CTPPS-less workflows
-    bool doNothing;
+    bool doNothing_;
 };
 
 //----------------------------------------------------------------------------------------------------
-//----------------------------------------------------------------------------------------------------
 
-using namespace std;
-using namespace edm;
-
-//----------------------------------------------------------------------------------------------------
-
-CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(edm::ParameterSet const& conf) :
-  doNothing(conf.getParameter<bool>("doNothing"))
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer( const edm::ParameterSet& iConfig ) :
+  siStripTrackToken_( consumes< edm::DetSetVector<TotemRPLocalTrack> >     ( iConfig.getParameter<edm::InputTag>("tagSiStripTrack") ) ),
+  diamondTrackToken_( consumes< edm::DetSetVector<CTPPSDiamondLocalTrack> >( iConfig.getParameter<edm::InputTag>("tagDiamondTrack") ) ),
+  doNothing_( iConfig.getParameter<bool>( "doNothing" ) )
 {
-  if (doNothing)
+  if ( doNothing_ )
     return;
 
-  siStripTrackToken = consumes<DetSetVector<TotemRPLocalTrack>>(conf.getParameter<edm::InputTag>("tagSiStripTrack"));
-
-  produces<vector<CTPPSLocalTrackLite>>();
+  produces< std::vector<CTPPSLocalTrackLite> >( "TrackingStrip" );
+  produces< std::vector<CTPPSLocalTrackLite> >( "TimingDiamond" );
 }
 
 //----------------------------------------------------------------------------------------------------
  
-void CTPPSLocalTrackLiteProducer::produce(edm::Event& e, const edm::EventSetup& es)
+void
+CTPPSLocalTrackLiteProducer::produce( edm::Event& iEvent, const edm::EventSetup& )
 {
-  if (doNothing)
+  if ( doNothing_ )
     return;
 
+  //----- TOTEM strips
+
   // get input from Si strips
-  edm::Handle< DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
-  e.getByToken(siStripTrackToken, inputSiStripTracks);
+  edm::Handle< edm::DetSetVector<TotemRPLocalTrack> > inputSiStripTracks;
+  iEvent.getByToken( siStripTrackToken_, inputSiStripTracks );
 
   // prepare output
-  vector<CTPPSLocalTrackLite> output;
+  std::unique_ptr< std::vector<CTPPSLocalTrackLite> > pSiStripOut( new std::vector<CTPPSLocalTrackLite>() );
   
   // process tracks from Si strips
-  for (const auto rpv : *inputSiStripTracks)
-  {
+  for ( const auto rpv : *inputSiStripTracks ) {
     const uint32_t rpId = rpv.detId();
-
-    for (const auto t : rpv)
-    {
-      if (t.isValid())
-        output.push_back(CTPPSLocalTrackLite(rpId, t.getX0(), t.getX0Sigma(), t.getY0(), t.getY0Sigma()));
+    for ( const auto t : rpv ) {
+      if ( !t.isValid() ) continue;
+      pSiStripOut->emplace_back( rpId, t.getX0(), t.getX0Sigma(), t.getY0(), t.getY0Sigma() );
     }
   }
 
   // save output to event
-  e.put(make_unique<vector<CTPPSLocalTrackLite>>(output));
+  iEvent.put( std::move( pSiStripOut ), "TrackingStrip" );
+
+  //----- diamond detectors
+
+  // get input from diamond detectors
+  edm::Handle< edm::DetSetVector<CTPPSDiamondLocalTrack> > inputDiamondTracks;
+  iEvent.getByToken( diamondTrackToken_, inputDiamondTracks );
+
+  // prepare output
+  std::unique_ptr< std::vector<CTPPSLocalTrackLite> > pDiamondOut( new std::vector<CTPPSLocalTrackLite>() );
+
+  // process tracks from diamond detectors
+  for ( const auto rpv : *inputDiamondTracks ) {
+    const unsigned int rpId = rpv.detId();
+    for ( const auto t : rpv ) {
+      if ( !t.isValid() ) continue;
+      pDiamondOut->emplace_back( rpId, t.getX0(), t.getX0Sigma(), t.getY0(), t.getY0Sigma(), t.getT() );
+    }
+  }
+
+  // save output to event
+  iEvent.put( std::move( pDiamondOut ), "TimingDiamond" );
 }
 
 //----------------------------------------------------------------------------------------------------
 
-DEFINE_FWK_MODULE(CTPPSLocalTrackLiteProducer);
+DEFINE_FWK_MODULE( CTPPSLocalTrackLiteProducer );

--- a/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
+++ b/RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cfi.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 ctppsLocalTrackLiteProducer = cms.EDProducer("CTPPSLocalTrackLiteProducer",
-  tagSiStripTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagSiStripTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagDiamondTrack = cms.InputTag("ctppsDiamondLocalTracks"),
 
-  # disable the module by default
-  doNothing = cms.bool(True)
+    # disable the module by default
+    doNothing = cms.bool(True)
 )
 
 # enable the module for CTPPS era(s)

--- a/RecoCTPPS/TotemRPLocal/test/ctpps_reco_cfg.py
+++ b/RecoCTPPS/TotemRPLocal/test/ctpps_reco_cfg.py
@@ -5,7 +5,6 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
 process.source = cms.Source('PoolSource',
     fileNames = cms.untracked.vstring(
-#        'root://eoscms.cern.ch:1094//eos/totem/data/ctpps/run284036.root',
         '/store/data/Run2016H/ZeroBias/RAW/v1/000/281/010/00000/20B9B8C4-6F7E-E611-8B60-02163E013864.root'
     ),
 )
@@ -14,25 +13,6 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1000)
 )
 
-# diamonds mapping
-#process.totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
-#    verbosity = cms.untracked.uint32(0),
-#    subSystem = cms.untracked.string("TimingDiamond"),
-#    configuration = cms.VPSet(
-#        # before diamonds inserted in DAQ
-#        cms.PSet(
-#            validityRange = cms.EventRange("1:min - 283819:max"),
-#            mappingFileNames = cms.vstring(),
-#            maskFileNames = cms.vstring()
-#        ),
-#        # after diamonds inserted in DAQ
-#        cms.PSet(
-#            validityRange = cms.EventRange("283820:min - 999999999:max"),
-#            mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond.xml"),
-#            maskFileNames = cms.vstring()
-#        )
-#    )
-#)
 process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
 
 process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')

--- a/RecoCTPPS/TotemRPLocal/test/ctpps_reco_cfg.py
+++ b/RecoCTPPS/TotemRPLocal/test/ctpps_reco_cfg.py
@@ -1,0 +1,71 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("CTPPS")
+
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(
+#        'root://eoscms.cern.ch:1094//eos/totem/data/ctpps/run284036.root',
+        '/store/data/Run2016H/ZeroBias/RAW/v1/000/281/010/00000/20B9B8C4-6F7E-E611-8B60-02163E013864.root'
+    ),
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+# diamonds mapping
+#process.totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
+#    verbosity = cms.untracked.uint32(0),
+#    subSystem = cms.untracked.string("TimingDiamond"),
+#    configuration = cms.VPSet(
+#        # before diamonds inserted in DAQ
+#        cms.PSet(
+#            validityRange = cms.EventRange("1:min - 283819:max"),
+#            mappingFileNames = cms.vstring(),
+#            maskFileNames = cms.vstring()
+#        ),
+#        # after diamonds inserted in DAQ
+#        cms.PSet(
+#            validityRange = cms.EventRange("283820:min - 999999999:max"),
+#            mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond.xml"),
+#            maskFileNames = cms.vstring()
+#        )
+#    )
+#)
+process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
+
+process.load('Geometry.VeryForwardGeometry.geometryRP_cfi')
+
+process.load('RecoCTPPS.TotemRPLocal.totemRPLocalReconstruction_cff')
+process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondLocalReconstruction_cff')
+
+process.load('RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi')
+process.ctppsLocalTrackLiteProducer.doNothing = cms.bool(False)
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("file:miniAOD.root"),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_totemRP*_*_*',
+        'keep *_ctpps*_*_*',
+    ),
+)
+
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.output_step = cms.EndPath(process.output)
+
+# execution configuration
+process.ctpps_reco_step = cms.Path(
+    process.totemRPRawToDigi *
+    process.totemRPLocalReconstruction *
+    process.ctppsDiamondRawToDigi *
+    process.ctppsDiamondLocalReconstruction
+)
+process.ctpps_miniaod_step = cms.Path(process.ctppsLocalTrackLiteProducer)
+process.schedule = cms.Schedule(process.ctpps_reco_step, process.ctpps_miniaod_step, process.endjob_step, process.output_step)
+
+from FWCore.ParameterSet.Utilities import convertToUnscheduled
+process = convertToUnscheduled(process)
+from FWCore.ParameterSet.Utilities import cleanUnscheduled
+process = cleanUnscheduled(process)

--- a/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
+++ b/RecoCTPPS/TotemRPLocal/test/diamonds_reco_cfg.py
@@ -61,6 +61,9 @@ process.load('RecoCTPPS.TotemRPLocal.ctppsDiamondLocalTracks_cfi')
 #process.ctppsDiamondLocalTracks.trackingAlgorithmParams.resolution = cms.double(0.025) # in mm
 #process.ctppsDiamondLocalTracks.trackingAlgorithmParams.pixel_efficiency_function = cms.string("(TMath::Erf((x-[0]+0.5*[1])/([2]/4)+2)+1)*TMath::Erfc((x-[0]-0.5*[1])/([2]/4)-2)/4")
 
+#process.load('RecoCTPPS.TotemRPLocal.ctppsLocalTrackLiteProducer_cfi')
+#process.ctppsLocalTrackLiteProducer.doNothing = cms.bool(False)
+
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string("file:AOD.root"),
     outputCommands = cms.untracked.vstring(
@@ -73,7 +76,8 @@ process.output = cms.OutputModule("PoolOutputModule",
 process.p = cms.Path(
     process.ctppsDiamondRawToDigi *
     process.ctppsDiamondRecHits *
-    process.ctppsDiamondLocalTracks
+    process.ctppsDiamondLocalTracks *
+    #process.ctppsLocalTrackLiteProducer
 )
 
 process.outpath = cms.EndPath(process.output) 


### PR DESCRIPTION
This PR builds an extra `CTPPSLocalTrackLite` collection to include the diamond information up to the `miniAOD` output format.
Modifies the producer developed by @jan-kaspar and pushed to the `9_1_X` through #17701 to add this new collection:
* strips information can be retrieved using the `TrackingStrip` selector
* diamond detectors information can be retrieved using the `TimindDiamond` selector