### PR TITLE
Ignoring calibration channels for HF

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -176,13 +176,15 @@ HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& eventS
              it != digi->end(); ++it)
         {
             const QIE10DataFrame& frame(*it);
+            const HcalDetId cell(frame.id());
+            if (cell.subdet() != HcalSubdetector::HcalForward)
+                continue;
 
             // Check zero suppression
             if (dropZSmarkedPassed_)
                 if (frame.zsMarkAndPass())
                     continue;
 
-            const HcalDetId cell(it->id());
             const HcalCalibrations& calibrations(conditions->getHcalCalibrations(cell));
             const HcalQIECoder* channelCoder = conditions->getHcalCoder(cell);
             const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -177,6 +177,10 @@ HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& eventS
         {
             const QIE10DataFrame& frame(*it);
             const HcalDetId cell(frame.id());
+
+            // Protection against calibration channels which are not
+            // in the database but can still come in the QIE10DataFrame
+            // in the laser calibs, etc.
             if (cell.subdet() != HcalSubdetector::HcalForward)
                 continue;
 


### PR DESCRIPTION
It looks like we have calibration channels coming in the QIE10 data frames:
https://its.cern.ch/jira/projects/CMSTZ/issues/CMSTZ-155

This issue appears to be very similar to the issue we had with QIE11
data frames that was fixed by PR #17777 

To be backported  to 9_0 and 8_4.

This PR will not modify any relval results.
