### PR TITLE
Add missing virtual dtors

### DIFF
--- a/EventFilter/L1TRawToDigi/interface/Unpacker.h
+++ b/EventFilter/L1TRawToDigi/interface/Unpacker.h
@@ -11,6 +11,7 @@ namespace l1t {
    class Unpacker {
       public:
          virtual bool unpack(const Block& block, UnpackerCollections *coll) = 0;
+         virtual ~Unpacker() = default;
    };
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -88,6 +88,7 @@ public:
       ClusterParam(const SiPixelCluster & cl) : theCluster(&cl), loc_trk_pred(0.0,0.0,0.0,0.0),
       probabilityX_(0.0), probabilityY_(0.0), probabilityQ_(0.0), qBin_(0.0),
       isOnEdge_(false), hasBadPixels_(false), spansTwoROCs_(false), hasFilledProb_(false) {}
+      virtual ~ClusterParam() = default;
       const SiPixelCluster * theCluster;
       
       //--- Cluster-level quantities (may need more)

--- a/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
@@ -17,7 +17,7 @@ class PFCPositionCalculatorBase {
   PFCPositionCalculatorBase(const edm::ParameterSet& conf) :
     _minFractionInCalc(conf.getParameter<double>("minFractionInCalc")),
     _algoName(conf.getParameter<std::string>("algoName")) { }
-  ~PFCPositionCalculatorBase() { }
+  virtual ~PFCPositionCalculatorBase() = default;
   //get rid of things we should never use
   PFCPositionCalculatorBase(const PosCalc&) = delete;
   PosCalc& operator=(const PosCalc&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -32,7 +32,7 @@ class PFClusterBuilderBase {
       _positionCalc.reset(calcp);
     }
   }
-  ~PFClusterBuilderBase() { }
+  virtual ~PFClusterBuilderBase() = default;
   // get rid of things we should never use...
   PFClusterBuilderBase(const PFCBB&) = delete;
   PFCBB& operator=(const PFCBB&) = delete;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
@@ -34,6 +34,7 @@ class PFRecHitCreatorBase {
       qualityTests_.emplace_back(PFRecHitQTestFactory::get()->create(name,qTests.at(i)));
     }
   }
+  virtual ~PFRecHitCreatorBase() = default;
 
   virtual void init(const edm::EventSetup &es) { }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
@@ -33,6 +33,7 @@ class PFRecHitQTestBase {
  public:
   PFRecHitQTestBase() {}
   PFRecHitQTestBase(const edm::ParameterSet& iConfig) {}
+  virtual ~PFRecHitQTestBase() = default;
 
   virtual void beginEvent(const edm::Event&,const edm::EventSetup&)=0;
 

--- a/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
@@ -12,6 +12,7 @@ class RecHitTopologicalCleanerBase {
  public:
   RecHitTopologicalCleanerBase(const edm::ParameterSet& conf) { }
   RecHitTopologicalCleanerBase(const RecHitTopologicalCleanerBase& ) = delete;
+  virtual ~RecHitTopologicalCleanerBase() = default;
   RecHitTopologicalCleanerBase& operator=(const RecHitTopologicalCleanerBase&) = delete;
 
   virtual void clean(const edm::Handle<reco::PFRecHitCollection>&, 

--- a/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
@@ -11,6 +11,7 @@ class SeedFinderBase {
   SeedFinderBase(const edm::ParameterSet& conf):
     _algoName(conf.getParameter<std::string>("algoName")) { }
   SeedFinderBase(const SeedFinderBase&) = delete;
+  virtual ~SeedFinderBase() = default;
   SeedFinderBase& operator=(const SeedFinderBase&) = delete;
 
   virtual void findSeeds( const edm::Handle<reco::PFRecHitCollection>& input, 

--- a/RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h
+++ b/RecoParticleFlow/PFProducer/interface/BlockElementImporterBase.h
@@ -18,6 +18,7 @@ class BlockElementImporterBase {
 			  edm::ConsumesCollector & sumes ):
   _importerName( conf.getParameter<std::string>("importerName") ) { }
   BlockElementImporterBase(const BlockElementImporterBase& ) = delete;
+  virtual ~BlockElementImporterBase() = default;
   BlockElementImporterBase& operator=(const BlockElementImporterBase&) = delete;
 
   virtual void updateEventSetup(const edm::EventSetup& ) {}

--- a/RecoParticleFlow/PFProducer/interface/BlockElementLinkerBase.h
+++ b/RecoParticleFlow/PFProducer/interface/BlockElementLinkerBase.h
@@ -12,6 +12,7 @@ class BlockElementLinkerBase {
  BlockElementLinkerBase(const edm::ParameterSet& conf):
   _linkerName( conf.getParameter<std::string>("linkerName") ) { }
   BlockElementLinkerBase(const BlockElementLinkerBase& ) = delete;
+  virtual ~BlockElementLinkerBase() = default;
   BlockElementLinkerBase& operator=(const BlockElementLinkerBase&) = delete;
 
   virtual bool linkPrefilter( const reco::PFBlockElement*,


### PR DESCRIPTION
CMSSW GCC 7.0.1 builds now follows jemalloc (dev branch) and also has a
new TCMalloc. Both of these have C++14 sized deallocation feature
enabled. This means that if possible operator delete will be called with
size argument, which will help allocator to reduce the time to free the
object. E.g. this is not possible for incomplete types which size is
unknown at a time.

GCC 7.0.1 builds contain an additional build of jemalloc
(jemalloc-debug) which contains extra asserts and checks for developers.
It helped to find two places were operate delete is called using base
class type instead of actual type. E.g., this means that wrong size (8
bytes) were passed to operator delete instead of actual type (16 bytes).

This seems to be undefined behavior in C++14. From [expr.delete] (5.3.5
Delete):

    In the first alternative (delete object), if the static type of the
    object to be deleted is different from its dynamic type, the static type
    shall be a base class of the dynamic type of the object to be deleted
    and the static type shall have a virtual destructor or the behavior is
    undefined.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>