### PR TITLE
pixel DQM@HLT

### DIFF
--- a/DQM/HLTEvF/plugins/DQMCorrelationClient.cc
+++ b/DQM/HLTEvF/plugins/DQMCorrelationClient.cc
@@ -100,10 +100,6 @@ void DQMCorrelationClient::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGet
 {
   std::string hname = "";
 
-  // create and cd into new folder
-  std::string currentFolder = mepset_.folder;
-  ibooker_.setCurrentFolder(currentFolder.c_str());
-
   //get available histograms
   hname = meXpset_.folder + "/" + meXpset_.name;
   MonitorElement* meX = igetter_.get( hname.c_str() );
@@ -125,6 +121,10 @@ void DQMCorrelationClient::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGet
   int    nbinsY = ( mepset_.doYaxis ? mepset_.nbinsY : meY->getNbinsY() );
   double xminY  = ( mepset_.doYaxis ? mepset_.xminY  : meY->getTH1()->GetYaxis()->GetXmin() );
   double xmaxY  = ( mepset_.doYaxis ? mepset_.xmaxY  : meY->getTH1()->GetYaxis()->GetXmax() );
+
+  // create and cd into new folder
+  std::string currentFolder = mepset_.folder;
+  ibooker_.setCurrentFolder(currentFolder.c_str());
 
   //book new histogram
   hname = mepset_.name;

--- a/DQM/HLTEvF/python/HLTLumiMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTLumiMonitoring_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.DQMOffline_LumiMontiroring_cff import *
+
+lumiOnlineMonitorHLTsequence = cms.Sequence(
+    lumiMonitorHLTsequence
+)

--- a/DQM/HLTEvF/python/HLTObjectMonitor_Client_cff.py
+++ b/DQM/HLTEvF/python/HLTObjectMonitor_Client_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.HLTEvF.HLTTrackingMonitoring_Client_cff import *
+from DQM.HLTEvF.HLTSiPixelMonitoring_Client_cff import *
+
+client = cms.EndPath(
+    trackingMonitorClientHLT
+    + trackingForElectronsMonitorClientHLT
+    + pixelOnlineHarvesterHLTsequence
+)

--- a/DQM/HLTEvF/python/HLTObjectMonitor_cff.py
+++ b/DQM/HLTEvF/python/HLTObjectMonitor_cff.py
@@ -5,20 +5,20 @@ import FWCore.ParameterSet.Config as cms
 #from DQM.HLTEvF.OccupancyPlotter_cfi import *
 
 from DQM.HLTEvF.HLTObjectMonitor_cfi import *
+from DQM.HLTEvF.HLTLumiMonitoring_cff import *
 # strip monitoring@HLT needs track re-fitting (estimation of the crossing angle through the sensor)
 # => some ESProducer modules have to be run
-# one of those (hltESPStripCPEfromTrackAngle) depends on the strip APV gain
-# and therefore it has different setting in 25ns and 50ns HLT menu
-# current setting is coherent w/ 50ns menu
-# DQM.HLTEvF.HLTSiStripMonitoring_cff has to be updated as soon as the 25ns menu will be in production
+from DQM.HLTEvF.HLTSiPixelMonitoring_cff import *
 from DQM.HLTEvF.HLTSiStripMonitoring_cff import *
 from DQM.HLTEvF.HLTTrackingMonitoring_cff import *
 from DQM.HLTEvF.HLTPrimaryVertexMonitoring_cff import *
 
 
 hlt4vector = cms.Path(
-    hltObjectMonitor
-#    * sistripOnlineMonitorHLTsequence # strip cluster monitoring
+    lumiOnlineMonitorHLTsequence # lumi
+    * hltObjectMonitor
+    * pixelOnlineMonitorHLTsequence # pixel cluster monitoring
+    * sistripOnlineMonitorHLTsequence # strip cluster monitoring
     * trackingMonitoringHLTsequence # tracking monitoring
     * egmTrackingMonitorHLTsequence # EGM tracking monitoring
     * vertexingMonitorHLTsequence # vertexing

--- a/DQM/HLTEvF/python/HLTSiPixelMonitoring_Client_cff.py
+++ b/DQM/HLTEvF/python/HLTSiPixelMonitoring_Client_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_Client_cff import *
+
+pixelOnlineHarvesterHLTsequence = cms.Sequence(
+    sipixelHarvesterHLTsequence
+)

--- a/DQM/HLTEvF/python/HLTSiPixelMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTSiPixelMonitoring_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_cff import *
+
+pixelOnlineMonitorHLTsequence = cms.Sequence(
+    sipixelMonitorHLTsequence
+)

--- a/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from TrackingTools.RecoGeometry.RecoGeometries_cff import *
 hltESPDummyDetLayerGeometry = DummyDetLayerGeometry.clone(
-#hltESPDummyDetLayerGeometry = GlobalDetLayerGeometry.clone(
     ComponentName = cms.string( "hltESPDummyDetLayerGeometry" )
 )
 
@@ -11,13 +10,9 @@ hltESPDummyDetLayerGeometry = DummyDetLayerGeometry.clone(
 # the track trajectory is needed
 # => the track re-fit has to be performed
 # => some ESProducer have to be defined
-# hltESPStripCPEfromTrackAngle depends on APV gain
-# => it has different setting in 25ns and 50ns HLT menu
-# please, make sure it has the setting in synch w/ HLT menu
-# current setting is for 50ns menu
 
 ## NB: the following ESProducer should be the same used in the HLT menu
-##     make sure they are not already defined somewhereelse inthe final configuration
+##     make sure they are not already defined somewhereelse in the final configuration
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import templates
 hltESPPixelCPETemplateReco = templates.clone(
   DoCosmics = cms.bool( False ),
@@ -61,7 +56,6 @@ hltESPTTRHBuilderAngleAndTemplate = TTRHBuilderAngleAndTemplate.clone(
   PixelCPE = cms.string( "hltESPPixelCPETemplateReco" ),
   ComponentName = cms.string( "hltESPTTRHBuilderAngleAndTemplate" )
 )
-
 hltESPTTRHBWithTrackAngle = TTRHBuilderAngleAndTemplate.clone(
   StripCPE = cms.string( "hltESPStripCPEfromTrackAngle" ),
   Matcher = cms.string( "StandardMatcher" ),
@@ -78,10 +72,10 @@ hltESPStripCPEfromTrackAngle = stripCPEESProducer.clone(
     mLC_P2 = cms.double( 0.3 ),
     mLC_P1 = cms.double( 0.618 ),
     mLC_P0 = cms.double( -0.326 ),
-    useLegacyError = cms.bool( True ), # 50ns menu
-    maxChgOneMIP = cms.double( -6000.0 ), # 50ns menu
-#    useLegacyError = cms.bool( False ), # 25ns menu
-#    maxChgOneMIP = cms.double( 6000.0 ), #25ns menu
+#    useLegacyError = cms.bool( True ), # 50ns menu
+#    maxChgOneMIP = cms.double( -6000.0 ), # 50ns menu
+    useLegacyError = cms.bool( False ), # 25ns menu
+    maxChgOneMIP = cms.double( 6000.0 ), #25ns menu
     mTEC_P1 = cms.double( 0.471 ),
     mTEC_P0 = cms.double( -1.885 ),
     mTOB_P0 = cms.double( -1.026 ),
@@ -153,9 +147,14 @@ hltESPKFUpdator = KFUpdatorESProducer.clone(
 )
 
 hltESPChi2MeasurementEstimator30 = cms.ESProducer( "Chi2MeasurementEstimatorESProducer",
-  MaxChi2 = cms.double( 30.0 ),
+  appendToDataLabel = cms.string( "" ),
+  MinimalTolerance = cms.double( 10.0 ),
+  MaxDisplacement = cms.double( 100.0 ),
+  ComponentName = cms.string( "hltESPChi2MeasurementEstimator30" ),
   nSigma = cms.double( 3.0 ),
-  ComponentName = cms.string( "hltESPChi2MeasurementEstimator30" )
+  MaxSagitta = cms.double( -1.0 ),
+  MaxChi2 = cms.double( 30.0 ),
+  MinPtForHitRecoveryInGluedDet = cms.double( 1000000.0 )
 )
 
 from TrackingTools.TrackFitters.KFTrajectoryFitter_cfi import KFTrajectoryFitter
@@ -165,8 +164,11 @@ hltESPTrajectoryFitterRK = KFTrajectoryFitter.clone(
   Estimator = cms.string( "hltESPChi2MeasurementEstimator30" ),
   Updator = cms.string( "hltESPKFUpdator" ),
   Propagator = cms.string( "hltESPRungeKuttaTrackerPropagator" ),
-#  RecoGeometry = cms.string( "hltESPDummyDetLayerGeometry" )
   RecoGeometry = cms.string( "hltESPDummyDetLayerGeometry" )
+)
+
+hltSiStripExcludedFEDListProducer = cms.EDProducer( "SiStripExcludedFEDListProducer",
+    ProductLabel = cms.InputTag( "rawDataCollector" )
 )
 
 hltMeasurementTrackerEvent = cms.EDProducer( "MeasurementTrackerEventProducer",
@@ -179,13 +181,52 @@ hltMeasurementTrackerEvent = cms.EDProducer( "MeasurementTrackerEventProducer",
     measurementTracker = cms.string( "hltESPMeasurementTracker" )
 )
 
+#####
+hltESPTrajectoryFitterRK = cms.ESProducer( "KFTrajectoryFitterESProducer",
+  appendToDataLabel = cms.string( "" ),
+  minHits = cms.int32( 3 ),
+  ComponentName = cms.string( "hltESPTrajectoryFitterRK" ),
+  Estimator = cms.string( "hltESPChi2MeasurementEstimator30" ),
+  Updator = cms.string( "hltESPKFUpdator" ),
+  Propagator = cms.string( "hltESPRungeKuttaTrackerPropagator" ),
+  RecoGeometry = cms.string( "hltESPDummyDetLayerGeometry" )
+)
+hltESPTrajectorySmootherRK = cms.ESProducer( "KFTrajectorySmootherESProducer",
+  errorRescaling = cms.double( 100.0 ),
+  minHits = cms.int32( 3 ),
+  ComponentName = cms.string( "hltESPTrajectorySmootherRK" ),
+  appendToDataLabel = cms.string( "" ),
+  Estimator = cms.string( "hltESPChi2MeasurementEstimator30" ),
+  Updator = cms.string( "hltESPKFUpdator" ),
+  Propagator = cms.string( "hltESPRungeKuttaTrackerPropagator" ),
+  RecoGeometry = cms.string( "hltESPDummyDetLayerGeometry" )
+)
+hltESPFittingSmootherIT = cms.ESProducer( "KFFittingSmootherESProducer",
+  EstimateCut = cms.double( -1.0 ),
+  appendToDataLabel = cms.string( "" ),
+  LogPixelProbabilityCut = cms.double( -16.0 ),
+  MinDof = cms.int32( 2 ),
+  NoOutliersBeginEnd = cms.bool( False ),
+  Fitter = cms.string( "hltESPTrajectoryFitterRK" ),
+  MinNumberOfHits = cms.int32( 3 ),
+  Smoother = cms.string( "hltESPTrajectorySmootherRK" ),
+  MaxNumberOfOutliers = cms.int32( 3 ),
+  BreakTrajWith2ConsecutiveMissing = cms.bool( True ),
+  MaxFractionOutliers = cms.double( 0.3 ),
+  NoInvalidHitsBeginEnd = cms.bool( True ),
+  ComponentName = cms.string( "hltESPFittingSmootherIT" ),
+  RejectTracks = cms.bool( True )
+)
+
+
+
 from DQMOffline.Trigger.SiStrip_OfflineMonitoring_cff import *
 hltTrackRefitterForSiStripMonitorTrack.TTRHBuilder             = cms.string('hltESPTTRHBWithTrackAngle')
 hltTrackRefitterForSiStripMonitorTrack.Propagator              = cms.string('hltESPRungeKuttaTrackerPropagator')
-hltTrackRefitterForSiStripMonitorTrack.Fitter                  = cms.string('hltESPTrajectoryFitterRK')
-hltTrackRefitterForSiStripMonitorTrack.MeasurementTracker      = cms.string('hltESPMeasurementTracker')
+hltTrackRefitterForSiStripMonitorTrack.Fitter                  = cms.string('hltESPFittingSmootherIT')
 hltTrackRefitterForSiStripMonitorTrack.MeasurementTrackerEvent = cms.InputTag('hltMeasurementTrackerEvent')
-hltTrackRefitterForSiStripMonitorTrack.NavigationSchool        = cms.string('')
+hltTrackRefitterForSiStripMonitorTrack.NavigationSchool        = cms.string('navigationSchoolESProducer')
+hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltIter2Merged")
 
 HLTSiStripMonitorTrack.TopFolderName = cms.string('HLT/SiStrip')
 HLTSiStripMonitorTrack.TrackProducer = 'hltTrackRefitterForSiStripMonitorTrack'
@@ -198,7 +239,34 @@ HLTSiStripMonitorTrack.OffHisto_On   = cms.bool(True)
 HLTSiStripMonitorTrack.HistoFlag_On  = cms.bool(False)
 HLTSiStripMonitorTrack.TkHistoMap_On = cms.bool(False)
 
+HLTSiStripMonitorClusterAPVgainCalibration = HLTSiStripMonitorCluster.clone()
+from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *
+#HLTSiStripMonitorClusterAPVgainCalibration.BPTXfilter = genericTriggerEventFlag4fullTrackerAndHLTnoHIPnoOOTdb # HLT_ZeroBias_FirstCollisionAfterAbortGap_*
+HLTSiStripMonitorClusterAPVgainCalibration.BPTXfilter = cms.PSet(
+   andOr         = cms.bool( False ),
+### DCS selection
+   dcsInputTag   = cms.InputTag( "scalersRawToDigi" ),
+   dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ),
+   andOrDcs      = cms.bool( False ),
+   errorReplyDcs = cms.bool( True ),
+### HLT selection
+   andOrHlt      = cms.bool(True),# True:=OR; False:=AND
+   hltInputTag   = cms.InputTag( "TriggerResults::HLT" ),
+   hltPaths      = cms.vstring("HLT_ZeroBias_FirstCollisionAfterAbortGap_v*"),
+   errorReplyHlt = cms.bool( False ),
+#   errorReplyHlt = cms.bool( True ),
+### L1 selection
+#   andOrL1       = cms.bool( True ),
+#   l1Algorithms  = cms.vstring("L1_ZeroBias_FirstCollidingBunch"),
+##   l1BeforeMask  = cms.bool( True ), # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
+#   l1BeforeMask  = cms.bool( False ), # specifies, if the L1 algorithm decision should be read as before (true) or after (false) masking is applied.
+#   errorReplyL1  = cms.bool( False ),   
+   verbosityLevel = cms.uint32(1)
+)
+HLTSiStripMonitorClusterAPVgainCalibration.TopFolderName = cms.string('HLT/SiStrip/ZeroBias_FirstCollisionAfterAbortGap')
+
 sistripOnlineMonitorHLTsequence = cms.Sequence(
     hltMeasurementTrackerEvent
     * sistripMonitorHLTsequence # strip cluster monitoring
+    * HLTSiStripMonitorClusterAPVgainCalibration
 )

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -29,15 +29,18 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 ### for pp collisions
-#process.load("DQM.HLTEvF.HLTObjectMonitor_cff")
+process.load("DQM.HLTEvF.HLTObjectMonitor_cff")
+
 ### for Proton-Lead collisions only (2016 Proton-Lead Era)
-process.load("DQM.HLTEvF.HLTObjectMonitorProtonLead_cff")
+#process.load("DQM.HLTEvF.HLTObjectMonitorProtonLead_cff")
 
 # added for hlt scalars
 process.load("DQM.TrigXMonitor.HLTSeedL1LogicScalers_cfi")
 # added for hlt scalars
 process.hltSeedL1Logic.l1GtData = cms.InputTag("l1GtUnpack","","DQM")
 process.hltSeedL1Logic.dqmFolder =    cms.untracked.string("HLT/HLTSeedL1LogicScalers_SM")
+
+process.load("DQM.HLTEvF.HLTObjectMonitor_Client_cff")
 
 #process.p = cms.EndPath(process.hlts+process.hltsClient)
 process.p = cms.EndPath(process.hltSeedL1Logic)

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -150,7 +150,10 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker & iBooker, DQMStore::
 	//	std::cout << histName << std::endl;
 	MonitorElement * me = iGetter.get(histName);
 	
-	if (!me) continue; //Ignore non-existant MEs
+	if (!me) {
+	  edm::LogWarning("SiPixelPhase1Summary") << "ME " << histName << " is not available !!";
+	  continue; //Ignore non-existant MEs
+	}
 	      
 	if (me->hasError()) {
 	  //If there is an error, fill with 0

--- a/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1TrackClusters/src/SiPixelPhase1TrackClusters.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
@@ -39,10 +40,18 @@ void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::Ev
   //get the map
   edm::Handle<reco::TrackCollection> tracks;
   iEvent.getByToken( tracksToken_, tracks);
+  if ( !tracks.isValid() ) {
+    edm::LogWarning("SiPixelPhase1TrackClusters")  << "track collection is not valid";
+    return;
+  }
   
   // get clusters
   edm::Handle< edmNew::DetSetVector<SiPixelCluster> >  clusterColl;
   iEvent.getByToken( clustersToken_, clusterColl );
+  if ( !clusterColl.isValid() ) {
+    edm::LogWarning("SiPixelPhase1TrackClusters")  << "pixel cluster collection is not valid";
+    return;
+  }
   
   // we need to store some per-cluster data. Instead of a map, we use a vector,
   // exploiting the fact that all custers live in the DetSetVector and we can 

--- a/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
@@ -16,6 +16,7 @@ from DQMOffline.Trigger.HILowLumiHLTOfflineClient_cfi import  *
 
 from DQMOffline.Trigger.TrackingMonitoring_Client_cff import *
 from DQMOffline.Trigger.TrackingMonitoringPA_Client_cff import *
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_Client_cff import *
 
 from DQMOffline.Trigger.ExoticaMonitoring_Client_cff import *
 from DQMOffline.Trigger.SusyMonitoring_Client_cff import *
@@ -29,6 +30,7 @@ from DQMOffline.Trigger.BTaggingMonitoring_Client_cff import *
 
 hltOfflineDQMClient = cms.Sequence(
 #    hltGeneralSeqClient *
+    sipixelHarvesterHLTsequence *
     egHLTOffDQMClient *
     hltMuonPostVal *
     jetMETHLTOfflineClient *

--- a/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+# lumi from scalers
+hltScalersRawToDigi = cms.EDProducer( "ScalersRawToDigi",
+    scalersInputTag = cms.InputTag( "rawDataCollector" )
+)
+hltLumiMonitor = cms.EDAnalyzer( "LumiMonitor",
+    useBPixLayer1 = cms.bool( False ),
+    minPixelClusterCharge = cms.double( 15000.0 ),
+    histoPSet = cms.PSet(
+      lsPSet = cms.PSet(  nbins = cms.int32( 2500 ) ),
+      pixelClusterPSet = cms.PSet(
+        nbins = cms.int32( 200 ),
+        xmin = cms.double( -0.5 ),
+        xmax = cms.double( 19999.5 )
+      ),
+      lumiPSet = cms.PSet(
+        nbins = cms.int32( 5000 ),
+        xmin = cms.double( 0.0 ),
+        xmax = cms.double( 20000.0 )
+      ),
+      pixellumiPSet = cms.PSet(
+        nbins = cms.int32( 300 ),
+        xmin = cms.double( 0.0 ),
+        xmax = cms.double( 3.0 )
+      )
+    ),
+    minNumberOfPixelsPerCluster = cms.int32( 2 ),
+    FolderName = cms.string( "HLT/LumiMonitoring" ),
+    scalers = cms.InputTag( "hltScalersRawToDigi" ),
+    pixelClusters = cms.InputTag( "hltSiPixelClusters" ),
+    doPixelLumi = cms.bool( False )
+)
+
+lumiMonitorHLTsequence = cms.Sequence(
+    hltScalersRawToDigi +
+    hltLumiMonitor
+)

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+# lumi
+from DQMOffline.Trigger.DQMOffline_LumiMontiroring_cff import *
 # Egamma
 from DQMOffline.Trigger.HLTGeneralOffline_cfi import *
 
@@ -33,6 +35,9 @@ from DQMOffline.Trigger.TrackingMonitoringPA_cff import*
 
 # strip
 from DQMOffline.Trigger.SiStrip_OfflineMonitoring_cff import *
+
+# pixel
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_cff import *
 
 # photon jet
 from DQMOffline.Trigger.HigPhotonJetHLTOfflineSource_cfi import * 
@@ -72,6 +77,7 @@ from DQMOffline.Trigger.BTaggingMonitoring_cff import *
 from DQMOffline.Trigger.topHLTOfflineDQM_cff import *
 offlineHLTSource = cms.Sequence(
     hltResults *
+    lumiMonitorHLTsequence *
     egHLTOffDQMSource *
     muonFullOfflineDQM *
     HLTTauDQMOffline *
@@ -103,6 +109,7 @@ dqmInfoHLTMon = cms.EDAnalyzer("DQMEventInfo",
 OfflineHLTMonitoring = cms.Sequence(
     dqmInfoHLTMon *
     sistripMonitorHLTsequence * # strip
+    sipixelMonitorHLTsequence * # pixel
     BTVHLTOfflineSource *
     trackingMonitorHLT * # tracking
     egmTrackingMonitorHLT * # egm tracking

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -108,6 +108,7 @@ dqmInfoHLTMon = cms.EDAnalyzer("DQMEventInfo",
 
 OfflineHLTMonitoring = cms.Sequence(
     dqmInfoHLTMon *
+    lumiMonitorHLTsequence * # lumi
     sistripMonitorHLTsequence * # strip
     sipixelMonitorHLTsequence * # pixel
     BTVHLTOfflineSource *

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Client_cff.py
@@ -1,0 +1,60 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_Cluster_cff import *
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_TrackCluster_cff import *
+
+from DQM.HLTEvF.dqmCorrelationClient_cfi import *
+pixelClusterVsLumi = dqmCorrelationClient.clone(
+   me = cms.PSet(
+      folder = cms.string("HLT/Pixel/"),
+      name   = cms.string("num_clusters_per_instLumi"),
+      doXaxis = cms.bool( True ),
+      nbinsX = cms.int32( 5000),
+      xminX  = cms.double(    0.),
+      xmaxX  = cms.double(20000.),
+#      doYaxis = cms.bool( False ),
+      doYaxis = cms.bool( True ),
+      nbinsY = cms.int32 (   4000 ),
+      xminY  = cms.double(      0.),
+      xmaxY  = cms.double( 400000.),
+   ),
+   me1 = cms.PSet(
+      folder   = cms.string("HLT/LumiMonitoring"),
+      name     = cms.string("lumiVsLS"),
+      profileX = cms.bool(True)
+   ),
+   me2 = cms.PSet(
+      folder   = cms.string("HLT/Pixel"),
+      name     = cms.string("num_clusters_per_Lumisection_PXBarrel"),
+      profileX = cms.bool(True)
+   ),
+)
+
+pixelClusterVsLumiPXBarrel = pixelClusterVsLumi.clone()
+pixelClusterVsLumiPXBarrel.me.name  = "num_clusters_per_instLumi_PXBarrel" 
+pixelClusterVsLumiPXBarrel.me2.name = "num_clusters_per_Lumisection_PXBarrel"
+
+pixelClusterVsLumiPXForward = pixelClusterVsLumi.clone()
+pixelClusterVsLumiPXForward.me.name  = "num_clusters_per_instLumi_PXForward" 
+pixelClusterVsLumiPXForward.me2.name = "num_clusters_per_Lumisection_PXForward"
+
+pixelTrackClusterVsLumiPXBarrel = pixelClusterVsLumi.clone()
+pixelTrackClusterVsLumiPXBarrel.me.folder  = "HLT/Pixel/TrackClusters/"
+pixelTrackClusterVsLumiPXBarrel.me.name    = "num_clusters_ontrack_per_instLumi_PXBarrel" 
+pixelTrackClusterVsLumiPXBarrel.me2.folder = "HLT/Pixel/TrackClusters"
+pixelTrackClusterVsLumiPXBarrel.me2.name   = "num_clusters_ontrack_per_Lumisection_PXBarrel"
+
+pixelTrackClusterVsLumiPXForward = pixelClusterVsLumi.clone()
+pixelTrackClusterVsLumiPXForward.me.folder  = "HLT/Pixel/TrackClusters/"
+pixelTrackClusterVsLumiPXForward.me.name    = "num_clusters_ontrack_per_instLumi_PXForward" 
+pixelTrackClusterVsLumiPXForward.me2.folder = "HLT/Pixel/TrackClusters"
+pixelTrackClusterVsLumiPXForward.me2.name   = "num_clusters_ontrack_per_Lumisection_PXForward"
+
+sipixelHarvesterHLTsequence = cms.Sequence(
+#    hltSiPixelPhase1ClustersHarvester
+#    + hltSiPixelPhase1TrackClustersHarvester
+    pixelClusterVsLumiPXBarrel
+    + pixelClusterVsLumiPXForward
+    + pixelTrackClusterVsLumiPXBarrel
+    + pixelTrackClusterVsLumiPXForward
+)    

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
@@ -1,0 +1,245 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_HistogramManager_cfi import *
+
+# order is important and it should follow ordering in .h !!!
+hltSiPixelPhase1ClustersCharge = hltDefaultHistoDigiCluster.clone(
+  name = "charge",
+  title = "Cluster Charge",
+  range_min = 0, range_max = 200e3, range_nbins = 200,
+  xlabel = "Charge (electrons)",
+  
+  specs = VPSet(
+    #StandardSpecification2DProfile,
+    hltStandardSpecificationPixelmapProfile,
+    StandardSpecificationTrend,
+#    StandardSpecifications1D,
+    hltStandardSpecifications1D,
+    StandardSpecificationTrend2D
+  )
+)
+
+hltSiPixelPhase1ClustersSize = hltDefaultHistoDigiCluster.clone(
+  enabled = cms.bool(False), # TO BE CHECKED IF NEEDED
+  name = "size",
+  title = "Total Cluster Size",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "size[pixels]",
+  specs = VPSet(
+    #StandardSpecification2DProfile,
+    hltStandardSpecificationPixelmapProfile,
+    StandardSpecificationTrend,
+#    StandardSpecifications1D,
+    hltStandardSpecifications1D,
+    StandardSpecificationTrend2D
+  )
+)
+
+hltSiPixelPhase1ClustersSizeX = hltDefaultHistoDigiCluster.clone(
+  enabled = cms.bool(False), # TO BE CHECKED IF NEEDED
+  name = "sizeX",
+  title = "Cluster Size in X",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "size[pixels]",
+  specs = VPSet(
+    #StandardSpecification2DProfile,
+    #StandardSpecificationPixelmapProfile,
+    #StandardSpecificationTrend,
+#    StandardSpecifications1D,
+    hltStandardSpecifications1D,
+    #StandardSpecificationTrend2D
+  )
+)
+
+hltSiPixelPhase1ClustersSizeY = hltDefaultHistoDigiCluster.clone(
+  enabled = cms.bool(False), # TO BE CHECKED IF NEEDED
+  name = "sizeY",
+  title = "Cluster Size in Y",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "size[pixels]",
+  specs = VPSet(
+    #StandardSpecification2DProfile,
+    #StandardSpecificationPixelmapProfile,
+    #StandardSpecificationTrend,
+#    StandardSpecifications1D,
+    hltStandardSpecifications1D,
+    #StandardSpecificationTrend2D
+  )
+)
+
+
+hltSiPixelPhase1ClustersNClusters = hltDefaultHistoDigiCluster.clone(
+  name = "clusters",
+  title = "Clusters",
+#  range_min = 0, range_max = 40000, range_nbins = 2000,
+  range_min = 0, range_max = 40000, range_nbins = 40000,
+  xlabel = "clusters",
+  dimensions = 0,
+  specs = VPSet(
+#    StandardSpecificationOccupancy,
+#    StandardSpecification2DProfile_Num,
+    StandardSpecificationTrend_Num,
+    hltStandardSpecifications1D_Num,
+
+  )
+)
+
+
+hltSiPixelPhase1ClustersNClustersInclusive = hltDefaultHistoDigiCluster.clone(
+  name = "clusters",
+  title = "Clusters",
+#  range_min = 0, range_max = 40000, range_nbins = 2000,
+  range_min = 0, range_max = 40000, range_nbins = 40000,
+  xlabel = "clusters",
+  dimensions = 0,
+  specs = VPSet(
+    StandardSpecificationInclusive_Num
+  )
+)
+
+
+hltSiPixelPhase1ClustersEventrate = hltDefaultHistoDigiCluster.clone(
+  name = "clustereventrate",
+  title = "Number of Events with clusters",
+  ylabel = "#Events",
+  dimensions = 0,
+  specs = VPSet(
+    Specification().groupBy("Lumisection")
+                   .groupBy("", "EXTEND_X").save(),
+    Specification().groupBy("BX")
+                   .groupBy("", "EXTEND_X").save()
+    )
+
+)
+
+
+hltSiPixelPhase1ClustersPositionB = hltDefaultHistoDigiCluster.clone(
+  name = "clusterposition_zphi",
+  title = "Cluster Positions",
+  range_min   =  -60, range_max   =  60, range_nbins   = 600,
+  range_y_min = -3.2, range_y_max = 3.2, range_y_nbins = 200,
+  xlabel = "Global Z", ylabel = "Global \phi",
+  dimensions = 2,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+#    Specification().groupBy("PXBarrel").save(),
+  )
+)
+
+hltSiPixelPhase1ClustersPositionF = hltDefaultHistoDigiCluster.clone(
+  name = "clusterposition_xy",
+  title = "Cluster Positions",
+  xlabel = "Global X", ylabel = "Global Y",
+  range_min   = -20, range_max   = 20, range_nbins   = 200,
+  range_y_min = -20, range_y_max = 20, range_y_nbins = 200,
+  dimensions = 2,
+  specs = VPSet(
+    Specification().groupBy("PXForward/PXDisk").save(),
+#    Specification().groupBy("PXForward").save(),
+  )
+)
+
+hltSiPixelPhase1ClustersPositionXZ = hltDefaultHistoDigiCluster.clone(
+  enabled = False, # only for debugging geometry
+  name = "clusterposition_xz",
+  title = "Cluster Positions",
+  xlabel = "Global X", ylabel = "Global Z",
+  range_min   = -20, range_max   = 20, range_nbins   = 200,
+  range_y_min = -60, range_y_max = 60, range_y_nbins = 1200,
+  dimensions = 2,
+  specs = VPSet(
+  )
+)
+
+hltSiPixelPhase1ClustersPositionYZ = hltDefaultHistoDigiCluster.clone(
+  enabled = False, # only for debugging geometry
+  name = "clusterposition_yz",
+  title = "Cluster Positions",
+  xlabel = "Global Y", ylabel = "Global Z",
+  range_min   = -20, range_max   = 20, range_nbins   = 200,
+  range_y_min = -60, range_y_max = 60, range_y_nbins = 1200,
+  dimensions = 2,
+  specs = VPSet(
+  )
+)
+
+hltSiPixelPhase1ClustersSizeVsEta = hltDefaultHistoDigiCluster.clone(
+  name = "sizeyvseta",
+  title = "Cluster Size along Beamline vs. Cluster position #eta",
+  xlabel = "Cluster #eta",
+  ylabel = "length [pixels]",
+  range_min = -3.2, range_max  = 3.2, range_nbins   = 40,
+  range_y_min =  0, range_y_max = 40, range_y_nbins = 40,
+  dimensions = 2,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save()
+  )
+)
+
+hltSiPixelPhase1ClustersReadoutCharge = hltDefaultHistoReadout.clone(
+  enabled = cms.bool(False),
+  name = "charge",
+  title = "Cluster Charge",
+  range_min = 0, range_max = 200e3, range_nbins = 200, ## e-
+  xlabel = "Charge (electrons)",
+  specs = VPSet(
+    Specification(PerReadout).groupBy("PXBarrel/Shell/Sector").save(),
+    Specification(PerReadout).groupBy("PXForward/HalfCylinder").save(),
+
+    Specification(PerReadout).groupBy("PXBarrel/Shell/Sector/OnlineBlock")
+                             .groupBy("PXBarrel/Shell/Sector", "EXTEND_Y").save(),
+    Specification(PerReadout).groupBy("PXForward/HalfCylinder/OnlineBlock")
+                             .groupBy("PXForward/HalfCylinder", "EXTEND_Y").save(),
+  )
+)
+
+hltSiPixelPhase1ClustersReadoutNClusters = hltDefaultHistoReadout.clone(
+  enabled = cms.bool(False),
+  name = "clusters",
+  title = "Clusters",
+  range_min = 0, range_max = 40000, range_nbins = 40000,
+  xlabel = "clusters",
+  dimensions = 0,
+  specs = VPSet(
+    Specification(PerReadout).groupBy("PXBarrel/Shell/Sector/DetId/Event").reduce("COUNT")
+                             .groupBy("PXBarrel/Shell/Sector").save(),
+    Specification(PerReadout).groupBy("PXForward/HalfCylinder/DetId/Event").reduce("COUNT")
+                             .groupBy("PXForward/HalfCylinder").save(),
+
+    Specification(PerReadout).groupBy("PXBarrel/Shell/Sector/DetId/Event").reduce("COUNT")
+                             .groupBy("PXBarrel/Shell/Sector/Lumisection").reduce("MEAN")
+                             .groupBy("PXBarrel/Shell/Sector", "EXTEND_X").save(),
+    Specification(PerReadout).groupBy("PXForward/HalfCylinder/DetId/Event").reduce("COUNT")
+                             .groupBy("PXForward/HalfCylinder/Lumisection").reduce("MEAN")
+                             .groupBy("PXForward/HalfCylinder", "EXTEND_X").save(),
+  )
+)
+
+hltSiPixelPhase1ClustersConf = cms.VPSet(
+  hltSiPixelPhase1ClustersCharge,
+  hltSiPixelPhase1ClustersSize,
+  hltSiPixelPhase1ClustersSizeX,
+  hltSiPixelPhase1ClustersSizeY,
+  hltSiPixelPhase1ClustersNClusters,
+  hltSiPixelPhase1ClustersNClustersInclusive,
+  hltSiPixelPhase1ClustersEventrate,
+  hltSiPixelPhase1ClustersPositionB,
+  hltSiPixelPhase1ClustersPositionF,
+  hltSiPixelPhase1ClustersPositionXZ,
+  hltSiPixelPhase1ClustersPositionYZ,
+  hltSiPixelPhase1ClustersSizeVsEta,
+  hltSiPixelPhase1ClustersReadoutCharge,
+  hltSiPixelPhase1ClustersReadoutNClusters
+)
+
+hltSiPixelPhase1ClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1Clusters",
+        src = cms.InputTag("hltSiPixelClusters"),
+        histograms = hltSiPixelPhase1ClustersConf,
+        geometry   = hltSiPixelPhase1Geometry
+)
+
+hltSiPixelPhase1ClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+        histograms = hltSiPixelPhase1ClustersConf,
+        geometry   = hltSiPixelPhase1Geometry
+)
+

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_HistogramManager_cfi.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_HistogramManager_cfi.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+OverlayCurvesForTiming.enabled = False #switch to overlay digi/clusters curves for timing scan 
+PerModule.enabled              = False 
+PerLadder.enabled              = False
+PerLayer2D.enabled             = True # 2D maps/profiles of layers
+PerLayer1D.enabled             = True # normal histos per layer
+
+hltSiPixelPhase1Geometry = SiPixelPhase1Geometry.clone()
+hltSiPixelPhase1Geometry.max_lumisection   = 2500
+hltSiPixelPhase1Geometry.max_bunchcrossing = 3600
+# online-specific things
+hltSiPixelPhase1Geometry.onlineblock    =  20 # #LS after which histograms are reset
+hltSiPixelPhase1Geometry.n_onlineblocks = 100 # #blocks to keep for histograms with history
+
+hltDefaultHistoDigiCluster = DefaultHistoDigiCluster.clone()
+hltDefaultHistoDigiCluster.topFolderName = cms.string("HLT/Pixel")
+
+hltDefaultHistoReadout = DefaultHistoReadout.clone()
+hltDefaultHistoReadout.topFolderName = cms.string("HLT/Pixel")
+
+hltDefaultHistoTrack = DefaultHistoTrack.clone()
+hltDefaultHistoTrack.topFolderName= cms.string("HLT/Pixel/TrackClusters")
+
+hltStandardSpecificationPixelmapProfile = [#produces pixel map with the mean (TProfile)
+    Specification(PerLayer2D)
+       .groupBy("PXBarrel/PXLayer/SignedLadderCoord/SignedModuleCoord")
+       .groupBy("PXBarrel/PXLayer/SignedLadderCoord", "EXTEND_X")
+       .groupBy("PXBarrel/PXLayer", "EXTEND_Y")
+       .reduce("MEAN")
+       .save(),
+    Specification(PerLayer2D)
+       .groupBy("PXForward/PXRing/SignedBladePanelCoord/SignedDiskCoord")
+       .groupBy("PXForward/PXRing/SignedBladePanelCoord", "EXTEND_X")
+       .groupBy("PXForward/PXRing", "EXTEND_Y")
+       .reduce("MEAN")
+       .save(),
+]
+
+hltStandardSpecifications1D = [
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(), # 91x nbins=100, xmin=0, xmax=3000,
+]
+
+hltStandardSpecifications1D_Num = [
+    Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
+    .reduce("COUNT")    
+    .groupBy("PXBarrel/PXLayer")
+#    .groupBy("PXBarrel")
+    .save(),
+    Specification().groupBy("PXForward/PXDisk/Event")
+    .reduce("COUNT")    
+    .groupBy("PXForward/PXDisk/")
+#    .groupBy("PXForward")
+    .save()
+]

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -1,0 +1,149 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_HistogramManager_cfi import *
+
+# order is important and it should follow ordering in .h !!!
+hltSiPixelPhase1TrackClustersOnTrackCharge = hltDefaultHistoTrack.clone(
+  name = "charge",
+  title = "Corrected Cluster Charge (OnTrack)",
+  range_min = 0, range_max = 200e3, range_nbins = 200,
+  xlabel = "Charge (electrons)",
+  specs = VPSet(
+    hltStandardSpecifications1D,
+    StandardSpecification2DProfile
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackSize = hltDefaultHistoTrack.clone(
+  name = "size",
+  title = "Total Cluster Size (OnTrack)",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "size[pixels]",
+
+  specs = VPSet(
+    hltStandardSpecifications1D    
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackNClusters = hltDefaultHistoTrack.clone(
+  name = "clusters_ontrack",
+  title = "Clusters_onTrack",
+  range_min = 0, range_max = 40000, range_nbins = 4000,
+  xlabel = "clusters",
+  dimensions = 0,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer" + "/DetId/Event") 
+                   .reduce("COUNT") 
+                   .groupBy("PXBarrel/PXLayer")
+                   .saveAll(),
+    Specification().groupBy("PXForward/PXDisk" + "/DetId/Event") 
+                   .reduce("COUNT") 
+                   .groupBy("PXForward/PXDisk")
+                   .saveAll(),
+    StandardSpecificationInclusive_Num,
+    StandardSpecificationTrend_Num
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackPositionB = hltDefaultHistoTrack.clone(
+  name = "clusterposition_zphi_ontrack",
+  title = "Cluster_onTrack Positions",
+  range_min   =  -60, range_max   =  60, range_nbins   = 600,
+  range_y_min = -3.2, range_y_max = 3.2, range_y_nbins = 200,
+  xlabel = "Global Z", ylabel = "Global \phi",
+  dimensions = 2,
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+#    Specification().groupBy("").save(),
+  )
+)
+
+hltSiPixelPhase1TrackClustersOnTrackPositionF = hltDefaultHistoTrack.clone(
+  name = "clusterposition_xy_ontrack",
+  title = "Cluster_onTrack Positions",
+  xlabel = "Global X", ylabel = "Global Y",
+  range_min   = -20, range_max   = 20, range_nbins   = 200,
+  range_y_min = -20, range_y_max = 20, range_y_nbins = 200,
+  dimensions = 2,
+  specs = VPSet(
+    Specification().groupBy("PXForward/PXDisk").save(),
+  )
+)
+
+hltSiPixelPhase1TrackClustersOffTrackCharge = hltSiPixelPhase1TrackClustersOnTrackCharge.clone(
+    topFolderName = "HLT/Pixel/TrackClusters/OffTrack", 
+    enabled = False,
+    title = "Cluster Charge"
+)
+hltSiPixelPhase1TrackClustersOffTrackSize = hltSiPixelPhase1TrackClustersOnTrackSize.clone(
+    topFolderName = "HLT/Pixel/TrackClusters/OffTrack",
+    enabled = False
+)
+
+hltSiPixelPhase1TrackClustersOffTrackNClusters = hltSiPixelPhase1TrackClustersOnTrackNClusters.clone(
+    topFolderName = "HLT/Pixel/TrackClusters/OffTrack",
+    enabled = False
+)
+
+hltSiPixelPhase1TrackClustersOffTrackPositionB = hltSiPixelPhase1TrackClustersOnTrackPositionB.clone(
+    topFolderName = "HLT/Pixel/TrackClusters/OffTrack",
+    enabled = False
+)
+
+hltSiPixelPhase1TrackClustersOffTrackPositionF = hltSiPixelPhase1TrackClustersOnTrackPositionF.clone(
+    topFolderName = "HLT/Pixel/TrackClusters/OffTrack",
+    enabled = False
+)
+
+hltSiPixelPhase1TrackClustersNTracks = hltDefaultHistoTrack.clone(
+  name = "ntracks",
+  title = "Number of Tracks",
+  xlabel = "All - Pixel - BPIX - FPIX",
+  range_min = 1, range_max = 5, range_nbins = 4,
+  dimensions = 1,
+  specs = VPSet(
+    Specification().groupBy("").save()
+  )
+)
+
+hltSiPixelPhase1TrackClustersNTracksInVolume = hltDefaultHistoTrack.clone(
+  name = "ntracksinpixvolume",
+  title = "Number of Tracks in Pixel fiducial Volume",
+  xlabel = "without hits - with hits",
+  range_min = 0, range_max = 2, range_nbins = 2,
+  dimensions = 1,
+  specs = VPSet(
+    Specification().groupBy("").save()
+  )
+
+)
+
+hltSiPixelPhase1TrackClustersConf = cms.VPSet(
+  hltSiPixelPhase1TrackClustersOnTrackCharge,
+  hltSiPixelPhase1TrackClustersOnTrackSize,
+  hltSiPixelPhase1TrackClustersOnTrackNClusters,
+  hltSiPixelPhase1TrackClustersOnTrackPositionB,
+  hltSiPixelPhase1TrackClustersOnTrackPositionF,
+
+  hltSiPixelPhase1TrackClustersOffTrackCharge,
+  hltSiPixelPhase1TrackClustersOffTrackSize,
+  hltSiPixelPhase1TrackClustersOffTrackNClusters,
+  hltSiPixelPhase1TrackClustersOffTrackPositionB,
+  hltSiPixelPhase1TrackClustersOffTrackPositionF,
+
+  hltSiPixelPhase1TrackClustersNTracks,
+  hltSiPixelPhase1TrackClustersNTracksInVolume,
+)
+
+hltSiPixelPhase1TrackClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackClusters",
+        clusters   = cms.InputTag("hltSiPixelClusters"),
+        tracks     = cms.InputTag("hltIter2Merged"),
+        histograms = hltSiPixelPhase1TrackClustersConf,
+        geometry   = hltSiPixelPhase1Geometry
+)
+
+hltSiPixelPhase1TrackClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+        histograms = hltSiPixelPhase1TrackClustersConf,
+        geometry   = hltSiPixelPhase1Geometry
+)
+

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_Cluster_cff import *
+from DQMOffline.Trigger.SiPixel_OfflineMonitoring_TrackCluster_cff import *
+
+sipixelMonitorHLTsequence = cms.Sequence(
+    hltSiPixelPhase1ClustersAnalyzer
+    + hltSiPixelPhase1TrackClustersAnalyzer
+)    

--- a/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
@@ -44,7 +44,25 @@ HLTSiStripMonitorCluster.StripDCSfilter = cms.PSet(
             andOrDcs      = cms.bool( False ),
             errorReplyDcs = cms.bool( True ),
         )
-
+HLTSiStripMonitorCluster.TH2CStripVsCpixel = cms.PSet(
+        Nbinsx = cms.int32(200),
+        xmin   = cms.double(-0.5),
+        xmax   = cms.double(99999.5),
+        Nbinsy = cms.int32(170),
+        ymin   = cms.double(-0.5),
+        ymax   = cms.double(50999.5),
+        globalswitchon = cms.bool(True)
+        )
+HLTSiStripMonitorCluster.TH1NClusPx = cms.PSet(
+        Nbinsx = cms.int32(170),
+        xmax = cms.double(50999.5),
+        xmin = cms.double(-0.5)
+        )
+HLTSiStripMonitorCluster.TH1NClusStrip = cms.PSet(
+        Nbinsx = cms.int32(200),
+        xmax = cms.double(99999.5),
+        xmin = cms.double(-0.5)
+    )
 hltESPPixelCPETemplateReco = cms.ESProducer( "PixelCPETemplateRecoESProducer",
   DoCosmics = cms.bool( False ),
   LoadTemplatesFromDB = cms.bool( True ),

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -192,35 +192,38 @@ MeasurementTrackerEventProducer::updateStrips( const edm::Event& event, StMeasur
   //=========  actually load cluster =============
   {
     edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusterHandle;
-    event.getByToken(theStripClusterLabel, clusterHandle);
-    const edmNew::DetSetVector<SiStripCluster>* clusterCollection = clusterHandle.product();
+    if (event.getByToken(theStripClusterLabel, clusterHandle)) {
+      const edmNew::DetSetVector<SiStripCluster>* clusterCollection = clusterHandle.product();
     
     
-    if (selfUpdateSkipClusters_){
-      edm::Handle<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > > stripClusterMask;
-      //and get the collection of pixel ref to skip
-      LogDebug("MeasurementTracker")<<"getting strp refs to skip";
-      event.getByToken(theStripClusterMask,stripClusterMask);
-      if (stripClusterMask.failedToGet())  edm::LogError("MeasurementTracker")<<"not getting the strip clusters to skip";
-      if (stripClusterMask->refProd().id()!=clusterHandle.id()){
-	edm::LogError("ProductIdMismatch")<<"The strip masking does not point to the proper collection of clusters: "<<stripClusterMask->refProd().id()<<"!="<<clusterHandle.id();
+      if (selfUpdateSkipClusters_){
+	edm::Handle<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > > stripClusterMask;
+	//and get the collection of pixel ref to skip
+	LogDebug("MeasurementTracker")<<"getting strp refs to skip";
+	event.getByToken(theStripClusterMask,stripClusterMask);
+	if (stripClusterMask.failedToGet())  edm::LogError("MeasurementTracker")<<"not getting the strip clusters to skip";
+	if (stripClusterMask->refProd().id()!=clusterHandle.id()){
+	  edm::LogError("ProductIdMismatch")<<"The strip masking does not point to the proper collection of clusters: "<<stripClusterMask->refProd().id()<<"!="<<clusterHandle.id();
+	}
+	stripClusterMask->copyMaskTo(stripClustersToSkip);
       }
-      stripClusterMask->copyMaskTo(stripClustersToSkip);
-    }
     
-    theStDets.handle() = clusterHandle;
-    int i=0;
-    // cluster and det and in order (both) and unique so let's use set intersection
-    for ( auto j = 0U; j< (*clusterCollection).size(); ++j) {
-      unsigned int id = (*clusterCollection).id(j);
-      while ( id != theStDets.id(i)) { // eventually change to lower_bound
-	++i;
-	if (endDet==i) throw "we have a problem in strips!!!!";
-      }
+      theStDets.handle() = clusterHandle;
+      int i=0;
+      // cluster and det and in order (both) and unique so let's use set intersection
+      for ( auto j = 0U; j< (*clusterCollection).size(); ++j) {
+	unsigned int id = (*clusterCollection).id(j);
+	while ( id != theStDets.id(i)) { // eventually change to lower_bound
+	  ++i;
+	  if (endDet==i) throw "we have a problem in strips!!!!";
+	}
       
-      // push cluster range in det
-      if ( theStDets.isActive(i) )
-	theStDets.update(i,j);
+	// push cluster range in det
+	if ( theStDets.isActive(i) )
+	  theStDets.update(i,j);
+      }
+    } else {
+      edm::LogWarning("MeasurementTrackerEventProducer") << "input strip cluster collection " << pset_.getParameter<std::string>("stripClusterProducer") << " is not valid";
     }
   }
 }
@@ -239,22 +242,25 @@ MeasurementTrackerEventProducer::updatePhase2OT( const edm::Event& event, Phase2
     } else {
   
       edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D> > & phase2OTClusters = thePh2OTDets.handle();
-      event.getByToken(thePh2OTClusterLabel, phase2OTClusters);
-      const edmNew::DetSetVector<Phase2TrackerCluster1D>* phase2OTCollection = phase2OTClusters.product();
+      if (event.getByToken(thePh2OTClusterLabel, phase2OTClusters)) {
+	const edmNew::DetSetVector<Phase2TrackerCluster1D>* phase2OTCollection = phase2OTClusters.product();
   
-      int i = 0, endDet = thePh2OTDets.size();
-      for (edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator it = phase2OTCollection->begin(), ed = phase2OTCollection->end(); it != ed; ++it) {
-  
-        edmNew::DetSet<Phase2TrackerCluster1D> set(*it);
-        unsigned int id = set.id();
-        while ( id != thePh2OTDets.id(i)) {
+	int i = 0, endDet = thePh2OTDets.size();
+	for (edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator it = phase2OTCollection->begin(), ed = phase2OTCollection->end(); it != ed; ++it) {
+	  
+	  edmNew::DetSet<Phase2TrackerCluster1D> set(*it);
+	  unsigned int id = set.id();
+	  while ( id != thePh2OTDets.id(i)) {
             ++i;
             if (endDet==i) throw "we have a problem!!!!";
-        }
-        // push cluster range in det
-        if ( thePh2OTDets.isActive(i) ) {
+	  }
+	  // push cluster range in det
+	  if ( thePh2OTDets.isActive(i) ) {
             thePh2OTDets.update(i,set);
-        }
+	  }
+	}
+      } else {
+	edm::LogWarning("MeasurementTrackerEventProducer") << "input Phase2TrackerCluster1D collection " << pset_.getParameter<std::string>("Phase2TrackerCluster1DProducer") << " is not valid";
       }
     }
 


### PR DESCRIPTION
--finally--
we have the pixel@HLT DQM
this PR add the pixel@HLT DQM on both online and offline workflow

@fioriNTU 
while testing this w/ runTheMatrix.py --limited
I saw that SiPixelPhase1TrackCluster was not checking the validity of the input collections,
not it is fixed

I also add the lumiMonitoring to the HLT offline DQM
(even if this module makes use of the lumi measurement from the scaler)

in addition, I fixed the strip DQM in the HLT online DQM as well
and add the monitoring of the HLT_ZeroBias_FirstCollisionAfterAbortGap
which is one of the calibration triggers for the tracker DPG (used for the strip APV gain)

finally, I add the client in the online DQM,
as now for both the tracking (iterative and GSF) and pixel