### PR TITLE
fix histogram HLT_Higgs_PhotonJet_trigvsnvtx

### DIFF
--- a/DQMOffline/Trigger/src/HigPhotonJetHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/src/HigPhotonJetHLTOfflineSource.cc
@@ -322,7 +322,8 @@ HigPhotonJetHLTOfflineSource::endRun(const edm::Run & iRun,
 {
   // Normalize to the total number of events in the run
   TH2F* h = trigvsnvtx_->getTH2F();
-  double norm = evtsrun_*hltPathsToCheck_.size()/h->Integral(); 
+  double integral = h->Integral();
+  double norm = (integral > 0.) ? evtsrun_*hltPathsToCheck_.size()/integral : 1.;
   h->Scale(norm);
   if (verbose_) {
     std::cout << "xshi:: endRun total number of events: " << evtsrun_


### PR DESCRIPTION
There was a divide by zero problem in this histogram, which caused the PR comparisons to report it as a failure.