### PR TITLE
MiniAOD phase2 updates: updated PUPPI tune, removed old MET filters

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -80,3 +80,42 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
                        # )
                       )
 )
+                        
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(
+    puppi,
+    DeltaZCut = cms.double(0.1),
+    algos = cms.VPSet( 
+        cms.PSet( 
+             etaMin = cms.vdouble(0.),
+             etaMax = cms.vdouble(2.5),
+             ptMin  = cms.vdouble(0.),
+             MinNeutralPt   = cms.vdouble(0.2),
+             MinNeutralPtSlope   = cms.vdouble(0.015),
+             RMSEtaSF = cms.vdouble(1.0),
+             MedEtaSF = cms.vdouble(1.0),
+             EtaMaxExtrap = cms.double(2.0),
+             puppiAlgos = puppiCentral
+        ), cms.PSet( 
+             etaMin = cms.vdouble(2.5),
+             etaMax = cms.vdouble(3.5),
+             ptMin  = cms.vdouble(0.),#Normally 0
+             MinNeutralPt   = cms.vdouble(0.2),
+             MinNeutralPtSlope   = cms.vdouble(0.030),
+             RMSEtaSF = cms.vdouble(1.0),
+             MedEtaSF = cms.vdouble(1.0),
+             EtaMaxExtrap = cms.double(2.0),
+             puppiAlgos = puppiCentral
+        ), cms.PSet( 
+             etaMin              = cms.vdouble( 3.5),
+             etaMax              = cms.vdouble(10.0),
+             ptMin               = cms.vdouble( 0.), #Normally 0
+             MinNeutralPt        = cms.vdouble( 2.0),
+             MinNeutralPtSlope   = cms.vdouble(0.08),
+             RMSEtaSF            = cms.vdouble(1.0 ),
+             MedEtaSF            = cms.vdouble(0.75),
+             EtaMaxExtrap        = cms.double( 2.0),
+             puppiAlgos = puppiForward
+       )
+    )
+)

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -87,23 +87,13 @@ phase2_common.toModify(
     DeltaZCut = cms.double(0.1),
     algos = cms.VPSet( 
         cms.PSet( 
-             etaMin = cms.vdouble(0.),
-             etaMax = cms.vdouble(2.5),
-             ptMin  = cms.vdouble(0.),
-             MinNeutralPt   = cms.vdouble(0.2),
-             MinNeutralPtSlope   = cms.vdouble(0.015),
-             RMSEtaSF = cms.vdouble(1.0),
-             MedEtaSF = cms.vdouble(1.0),
-             EtaMaxExtrap = cms.double(2.0),
-             puppiAlgos = puppiCentral
-        ), cms.PSet( 
-             etaMin = cms.vdouble(2.5),
-             etaMax = cms.vdouble(3.5),
-             ptMin  = cms.vdouble(0.),#Normally 0
-             MinNeutralPt   = cms.vdouble(0.2),
-             MinNeutralPtSlope   = cms.vdouble(0.030),
-             RMSEtaSF = cms.vdouble(1.0),
-             MedEtaSF = cms.vdouble(1.0),
+             etaMin = cms.vdouble(0.,  2.5),
+             etaMax = cms.vdouble(2.5, 3.5),
+             ptMin  = cms.vdouble(0.,  0.), #Normally 0
+             MinNeutralPt   = cms.vdouble(0.2, 0.2),
+             MinNeutralPtSlope   = cms.vdouble(0.015, 0.030),
+             RMSEtaSF = cms.vdouble(1.0, 1.0),
+             MedEtaSF = cms.vdouble(1.0, 1.0),
              EtaMaxExtrap = cms.double(2.0),
              puppiAlgos = puppiCentral
         ), cms.PSet( 

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -50,6 +50,11 @@ def miniAOD_customizeMETFiltersFastSim(process):
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(False)))
     return process
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith( Flag_trkPOG_manystripclus53X, cms.Path() )
+phase2_common.toReplaceWith( Flag_trkPOG_toomanystripclus53X, cms.Path() )
+phase2_common.toReplaceWith( Flag_trkPOGFilters, cms.Path(~logErrorTooManyClusters) )
+
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith( Flag_HBHENoiseFilter, cms.Path() )
 phase2_hgcal.toReplaceWith( Flag_HBHENoiseIsoFilter, cms.Path() )
@@ -79,3 +84,5 @@ metFilterPathsTask = cms.Task(
     chargedHadronTrackResolutionFilter,
     muonBadTrackFilter
 )
+phase2_common.toReplaceWith( metFilterPathsTask, metFilterPathsTask.copyAndExclude( [ manystripclus53X, toomanystripclus53X ] ) )
+phase2_hgcal.toReplaceWith( metFilterPathsTask, metFilterPathsTask.copyAndExclude( [ HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, eeBadScFilter ] ) )


### PR DESCRIPTION
PUPPI tune taken from https://twiki.cern.ch/twiki/bin/view/CMS/UPGTrackerTDRStudies + some discussion with Phil to fix some odd ends.
Checked on a few H &rarr; &gamma;&gamma; events that the run 2 photon ID still makes some sense also at PU140 (i.e. the photons selected by PuppiPhoton are mostly the same between PU0, PU35 and PU140), so there is no need to switch it off.

@violatingcp @nhanvtran @kpedro88 