### PR TITLE
Move sortByStringFunction to StringObjectFunction.h.

### DIFF
--- a/CommonTools/UtilAlgos/interface/StringCutEventSelector.h
+++ b/CommonTools/UtilAlgos/interface/StringCutEventSelector.h
@@ -7,7 +7,6 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "PhysicsTools/UtilAlgos/interface/CachingVariable.h"
 
 template<typename Object, bool any=false>
 class  StringCutEventSelector : public EventSelector {

--- a/CommonTools/Utils/interface/StringObjectFunction.h
+++ b/CommonTools/Utils/interface/StringObjectFunction.h
@@ -35,4 +35,16 @@ private:
   edm::TypeWithDict type_;
 };
 
+template <typename Object> class sortByStringFunction  {
+ public:
+  sortByStringFunction(StringObjectFunction<Object> * f) : f_(f){}
+  ~sortByStringFunction(){}
+
+  bool operator() (const Object * o1, const Object * o2) {
+    return (*f_)(*o1) > (*f_)(*o2);
+  }
+ private:
+  StringObjectFunction<Object> * f_;
+};
+
 #endif

--- a/PhysicsTools/UtilAlgos/interface/CachingVariable.h
+++ b/PhysicsTools/UtilAlgos/interface/CachingVariable.h
@@ -260,18 +260,6 @@ class VarSplitter : public Splitter{
   std::vector<double> slots_;
 };
 
-template <typename Object> class sortByStringFunction  {
- public:
-  sortByStringFunction(StringObjectFunction<Object> * f) : f_(f){}
-  ~sortByStringFunction(){}
-
-  bool operator() (const Object * o1, const Object * o2) {
-    return (*f_)(*o1) > (*f_)(*o2);
-  }
- private:
-  StringObjectFunction<Object> * f_;
-};
-
 template <typename Object, const char * label>
 class ExpressionVariable : public CachingVariable {
  public:

--- a/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
@@ -25,7 +25,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "PhysicsTools/UtilAlgos/interface/InputTagDistributor.h"
-#include "PhysicsTools/UtilAlgos/interface/CachingVariable.h"
 
 #include "DataFormats/PatCandidates/interface/PFParticle.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"


### PR DESCRIPTION
PhysicsTools/UtilAlgos/interface/CachingVariable.h is sometimes only
included because of the sortByStringFunction template. This include
however is causing a layering violation because for example
CommonTools/UtilAlgos and PhysicsTools/UtilAlgos now include each
other.

This patch moves the sortByStringFunction template into the
StringObjectFunction.h and removes the now unnecessary includes
to CachingVariable.h