### PR TITLE
GTupdates_for_910pre3_L1O2OTags_HCAL2018Geo_PCL_TkAl_AlignableThresholds

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
@@ -11,18 +11,6 @@ ALCARECOTkAlMinBiasFilterForSiPixelAli.TriggerResultsTag = cms.InputTag("Trigger
 
 from Alignment.CommonAlignmentProducer.LSNumberFilter_cfi import *
 
-
-# Ugly as hell, but that's life
-from CondCore.CondDB.CondDB_cfi import *
-CondDB.connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')
-PoolDBESSource = cms.ESSource("PoolDBESSource",
-                              CondDB,
-                              toGet = cms.VPSet(cms.PSet(record = cms.string('AlignPCLThresholdsRcd'),
-                                                         tag = cms.string('SiPixelAliThresholds_test_v0')
-                                                         )
-                                                )
-                              )
-
 # Ingredient: offlineBeamSpot
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import offlineBeamSpot
 

--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -9,17 +9,6 @@ SiPixelAliMilleFileExtractor = cms.EDAnalyzer("MillePedeFileExtractor",
     # 0000, 0001, 0002,...
     outputBinaryFile = cms.string('pedeBinary%04d.dat'))
 
-# Ugly as hell, but that's life
-from CondCore.CondDB.CondDB_cfi import *
-CondDB.connect = cms.string('frontier://FrontierPrep/CMS_CONDITIONS')
-PoolDBESSource = cms.ESSource("PoolDBESSource",
-                              CondDB,
-                              toGet = cms.VPSet(cms.PSet(record = cms.string('AlignPCLThresholdsRcd'),
-                                                         tag = cms.string('SiPixelAliThresholds_test_v0')
-                                                         )
-                                                )
-                              )
-
 from Alignment.MillePedeAlignmentAlgorithm.MillePedeAlignmentAlgorithm_cfi import *
 from Alignment.CommonAlignmentProducer.TrackerAlignmentProducerForPCL_cff import AlignmentProducer
 SiPixelAliPedeAlignmentProducer = copy.deepcopy(AlignmentProducer)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,35 +22,35 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '91X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '91X_dataRun2_v1',
+    'run1_data'         :   '91X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '91X_dataRun2_v1',
+    'run2_data'         :   '91X_dataRun2_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '91X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '91X_dataRun2_relval_v2',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '91X_dataRun2_PromptLike_v1',
+    'run2_data_promptlike' : '91X_dataRun2_PromptLike_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '91X_dataRun2_HLT_frozen_v1',
+    'run1_hlt'          :   '91X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '91X_dataRun2_HLT_frozen_v1',
+    'run2_hlt'          :   '91X_dataRun2_HLT_frozen_v2',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '91X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'   :   '91X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '91X_dataRun2_HLTHI_frozen_v1',
+    'run2_hlt_hi'       :   '91X_dataRun2_HLTHI_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '91X_upgrade2017_design_IdealBS_v2',
+    'phase1_2017_design'       :  '91X_upgrade2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '91X_upgrade2017_realistic_v2',
+    'phase1_2017_realistic'    : '91X_upgrade2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '91X_upgrade2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      : '91X_upgrade2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '91X_upgrade2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' : '91X_upgrade2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '91X_upgrade2018_design_IdealBS_v2',
+    'phase1_2018_design'       : '91X_upgrade2018_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '91X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    : '91X_upgrade2018_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '91X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :   '91X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,21 +22,21 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '91X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '91X_dataRun2_v2',
+    'run1_data'         :   '91X_dataRun2_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '91X_dataRun2_v2',
+    'run2_data'         :   '91X_dataRun2_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '91X_dataRun2_relval_v2',
+    'run2_data_relval'  :   '91X_dataRun2_relval_v3',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike' : '91X_dataRun2_PromptLike_v2',
+    'run2_data_promptlike' : '91X_dataRun2_PromptLike_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '91X_dataRun2_HLT_frozen_v2',
+    'run1_hlt'          :   '91X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '91X_dataRun2_HLT_frozen_v2',
+    'run2_hlt'          :   '91X_dataRun2_HLT_frozen_v3',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'   :   '91X_dataRun2_HLT_relval_v2',
+    'run2_hlt_relval'   :   '91X_dataRun2_HLT_relval_v3',
     # GlobalTag for Run2 HLT for HI: it points to the online GT
-    'run2_hlt_hi'       :   '91X_dataRun2_HLTHI_frozen_v2',
+    'run2_hlt_hi'       :   '91X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '91X_upgrade2017_design_IdealBS_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
# Summary of changes in Global Tags

## RunI data

   * **RunI HLT processing** : [91X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLT_frozen_v3) as [91X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLT_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_HLT_frozen_v3/91X_dataRun2_HLT_frozen_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html

   * **RunI Offline processing** : [91X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_v3) as [91X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_v3/91X_dataRun2_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html
      * addition of new record with PCL alignable configurable thresholds for tracker alignment

## RunII data

   * **RunII HLTHI processing** : [91X_dataRun2_HLTHI_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLTHI_frozen_v3) as [91X_dataRun2_HLTHI_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLTHI_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_HLTHI_frozen_v3/91X_dataRun2_HLTHI_frozen_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html

   * **RunII HLT processing** : [91X_dataRun2_HLT_frozen_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLT_frozen_v3) as [91X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLT_frozen_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_HLT_frozen_v3/91X_dataRun2_HLT_frozen_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html

   * **RunII HLT relval processing** : [91X_dataRun2_HLT_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLT_relval_v3) as [91X_dataRun2_HLT_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_HLT_relval_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_HLT_relval_v3/91X_dataRun2_HLT_relval_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html

   * **RunII Offline processing** : [91X_dataRun2_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_v3) as [91X_dataRun2_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_v3/91X_dataRun2_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html
      * addition of new record with PCL alignable configurable thresholds for tracker alignment

   * **RunII Offline relval processing** : [91X_dataRun2_relval_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_relval_v3) as [91X_dataRun2_relval_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_relval_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_relval_v3/91X_dataRun2_relval_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html
      * addition of new record with PCL alignable configurable thresholds for tracker alignment

   * **RunII Prompt processing** : [91X_dataRun2_PromptLike_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_PromptLike_v3) as [91X_dataRun2_PromptLike_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_dataRun2_PromptLike_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_dataRun2_PromptLike_v3/91X_dataRun2_PromptLike_v1):
      * addition of L1 O2O caloParam and Muon Param tags https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878.html
      * addition of new record with PCL alignable configurable thresholds for tracker alignment
## Upgrade

   * **PhaseI 2017 cosmics peak scenario** : [91X_upgrade2017cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_peak_v3) as [91X_upgrade2017cosmics_realistic_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_peak_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017cosmics_realistic_peak_v3/91X_upgrade2017cosmics_realistic_peak_v2):
      * updates of Pixel local reco conditions : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2885.html

   * **PhaseI 2017 cosmics scenario** : [91X_upgrade2017cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_deco_v3) as [91X_upgrade2017cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017cosmics_realistic_deco_v3/91X_upgrade2017cosmics_realistic_deco_v2):
      * updates of Pixel local reco conditions : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2885.html

   * **PhaseI 2017 design scenario** : [91X_upgrade2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_design_IdealBS_v3) as [91X_upgrade2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017_design_IdealBS_v3/91X_upgrade2017_design_IdealBS_v2):
      * updates of Pixel local reco conditions : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2885.html

   * **PhaseI 2017 realistic scenario** : [91X_upgrade2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_realistic_v3) as [91X_upgrade2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017_realistic_v3/91X_upgrade2017_realistic_v2):
      * updates of Pixel local reco conditions : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2885.html

   * **PhaseI 2018 cosmics scenario** : [91X_upgrade2018cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018cosmics_realistic_deco_v3) as [91X_upgrade2018cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018cosmics_realistic_deco_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2018cosmics_realistic_deco_v3/91X_upgrade2018cosmics_realistic_deco_v2):
      * updates of Pixel local reco conditions : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2885.html
      * Update of HCAL geometry : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2859.html

   * **PhaseI 2018 design scenario** : [91X_upgrade2018_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_design_IdealBS_v3) as [91X_upgrade2018_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_design_IdealBS_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2018_design_IdealBS_v3/91X_upgrade2018_design_IdealBS_v2):
      * Update of HCAL geometry : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2859.html
      * updates of Pixel local reco conditions : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2885.html

   * **PhaseI 2018 realistic scenario** : [91X_upgrade2018_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_realistic_v3) as [91X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2018_realistic_v3/91X_upgrade2018_realistic_v2):
      * updates of Pixel local reco conditions : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2885.html
      * Update of HCAL geometry : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2859.html