### PR TITLE
Switch phase1 tracking to template pixel CPE

### DIFF
--- a/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
+++ b/RecoMuon/Configuration/python/MergeDisplacedTrackCollections_cff.py
@@ -54,10 +54,6 @@ displacedTracksSequence = cms.Sequence(
     displacedTracks
     )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(duplicateDisplacedTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -45,10 +45,6 @@ GlobalMuonRefitter = cms.PSet(
     RefitFlag = cms.bool( True )
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(GlobalMuonRefitter, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -69,14 +69,6 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         ),
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(GlobalTrajectoryBuilderCommon, # FIXME
-    TrackerRecHitBuilder = 'WithTrackAngle',
-    TrackTransformer = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
-    GlbRefitterParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle'),
-)
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
+++ b/RecoMuon/MuonIdentification/python/TrackerKinkFinder_cfi.py
@@ -18,10 +18,6 @@ TrackerKinkFinderParametersBlock = cms.PSet(
     )
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(TrackerKinkFinderParametersBlock, TrackerKinkFinderParameters = dict(TrackerRecHitBuilder = 'WithTrackAngle')) # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonTrackLoader_cff.py
@@ -84,11 +84,6 @@ MuonTrackLoaderForCosmic = cms.PSet(
     )
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-for _loader in [MuonTrackLoaderForSTA, MuonTrackLoaderForGLB, MuonTrackLoaderForL2, MuonTrackLoaderForL3, MuonTrackLoaderForCosmic]:
-    phase1Pixel.toModify(_loader, TrackLoaderParameters = dict(TTRHBuilder = 'WithTrackAngle')) # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
@@ -49,10 +49,6 @@ trackerDrivenElectronSeeds = cms.EDProducer("GoodSeedProducer",
     Min_dr = cms.double(0.2)
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(trackerDrivenElectronSeeds, TTRHBuilder  = 'WithTrackAngle') # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -30,11 +30,6 @@ duplicateTrackClassifier.mva.maxChi2n = [10.,1.0,0.4]  # [9999.,9999.,9999.]
 duplicateTrackClassifier.mva.minLayers = [0,0,0]
 duplicateTrackClassifier.mva.min3DLayers = [0,0,0]
 duplicateTrackClassifier.mva.maxLostLayers = [99,99,99]
-
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(duplicateTrackCandidates, ttrhBuilderName = "WithTrackAngle") # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/inOutSeedsFromTrackerMuons_cfi.py
@@ -21,10 +21,6 @@ inOutSeedsFromTrackerMuons = cms.EDProducer("MuonReSeeder",
     Propagator = cms.string('SmartPropagatorAnyRKOpposite'),
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(inOutSeedsFromTrackerMuons, TrackerRecHitBuilder = 'WithTrackAngle') # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
@@ -27,10 +27,6 @@ TrackProducer = cms.EDProducer("TrackProducer",
     MeasurementTrackerEvent = cms.InputTag('MeasurementTrackerEvent'),                   
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(TrackProducer, TTRHBuilder = 'WithTrackAngle') # FIXME
-
 # This customization will be removed once we get the templates for
 # phase2 pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker

--- a/RecoTracker/TrackProducer/python/TrackRefitter_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackRefitter_cfi.py
@@ -39,6 +39,4 @@ TrackRefitter = cms.EDProducer("TrackRefitter",
     #NavigationSchool = cms.string('') 
 )
 
-# Switch back to GenericCPE until bias in template CPE gets fixed
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(TrackRefitter, TTRHBuilder = 'WithTrackAngle') # FIXME
+


### PR DESCRIPTION
Following #18038 and #18269, this PR switches phase1 tracking back to template pixel CPE (by reverting #16703).

~~Needs to be merged after #18269.~~ (merged now)

Here are MTV plots for 1000 ttbar+PU35 plots in 910pre2+#18038+#18269
https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_1_0_pre2_PR18271/
Main effects are
* ~1 % reduction in generalTracks fake rate (less in HP)
   * https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_1_0_pre2_PR18271/ttbar_pu35_ootb/dupandfakePtEtaPhi.pdf
* resolutions improve
   * https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_1_0_pre2_PR18271/ttbar_pu35_highPurity/resolutionsEta.pdf
   * https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_1_0_pre2_PR18271/ttbar_pu35_highPurity/resolutionsPt.pdf
* chi2/ndof increases tiny bit
   * https://cms-tracking-validation.web.cern.ch/cms-tracking-validation/PR/CMSSW_9_1_0_pre2_PR18271/ttbar_pu35_highPurity/tuning.pdf
* Timing of iterative tracking increases by ~10 %

Tested in 9_1_0_pre2. Expecting changes in the track resolutions in 2017/2018 workflows, should have no effect in phase0/2 workflows.

@rovere @VinInn @veszpv @boudoul @jkarancs 