### PR TITLE
Add missing virtual dtors #2

### DIFF
--- a/CalibFormats/CastorObjects/interface/CastorCoder.h
+++ b/CalibFormats/CastorObjects/interface/CastorCoder.h
@@ -14,6 +14,7 @@ class CastorCoder {
 public:
   virtual void adc2fC(const CastorDataFrame& df, CaloSamples& lf) const = 0;
   virtual void fC2adc(const CaloSamples& clf, CastorDataFrame& df, int fCapIdOffset) const = 0;
+  virtual ~CastorCoder() = default;
 };
 
 #endif

--- a/CalibFormats/HcalObjects/interface/HcalCoder.h
+++ b/CalibFormats/HcalObjects/interface/HcalCoder.h
@@ -32,6 +32,7 @@ public:
   virtual void fC2adc(const CaloSamples& clf, HcalCalibDataFrame& df, int fCapIdOffset) const = 0;
   virtual void fC2adc(const CaloSamples& clf, QIE10DataFrame& df, int fCapIdOffset) const = 0;
   virtual void fC2adc(const CaloSamples& clf, QIE11DataFrame& df, int fCapIdOffset) const = 0;
+  virtual ~HcalCoder() = default;
 };
 
 #endif

--- a/EventFilter/L1TRawToDigi/interface/Packer.h
+++ b/EventFilter/L1TRawToDigi/interface/Packer.h
@@ -14,6 +14,7 @@ namespace l1t {
    class Packer {
       public:
          virtual Blocks pack(const edm::Event&, const PackerTokens*) = 0;
+         virtual ~Packer() = default;
    };
 
    typedef std::vector<std::shared_ptr<Packer>> Packers;

--- a/EventFilter/L1TRawToDigi/interface/PackerTokens.h
+++ b/EventFilter/L1TRawToDigi/interface/PackerTokens.h
@@ -8,6 +8,8 @@ namespace edm {
 
 namespace l1t {
    class PackerTokens {
+     public:
+       virtual ~PackerTokens() = default;
    };
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -195,9 +195,6 @@ CSCMotherboard::CSCMotherboard() :
   }
 }
 
-CSCMotherboard::~CSCMotherboard() {
-}
-
 void CSCMotherboard::clear() {
   if (alct) alct->clear();
   if (clct) clct->clear();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -50,7 +50,7 @@ class CSCMotherboard
   CSCMotherboard();
 
   /** Default destructor. */
-  ~CSCMotherboard();
+  virtual ~CSCMotherboard() = default;
 
   /** Test version of run function. */
   void run(const std::vector<int> w_time[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES],

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
@@ -74,6 +74,7 @@ private:
 class EtaPhiRegionDataBase {
 public:
   EtaPhiRegionDataBase(){}
+  virtual ~EtaPhiRegionDataBase() = default;
   virtual void getEtaPhiRegions(const edm::Event&,std::vector<EtaPhiRegion>&)const=0;
 };
 


### PR DESCRIPTION
CMSSW GCC 7.0.1 builds now follows jemalloc (dev branch) and also has a
new TCMalloc. Both of these have C++14 sized deallocation feature
enabled. This means that if possible operator delete will be called with
size argument, which will help allocator to reduce the time to free the
object. E.g. this is not possible for incomplete types which size is
unknown at a time.

GCC 7.0.1 builds contain an additional build of jemalloc
(jemalloc-debug) which contains extra asserts and checks for developers.

This seems to be undefined behavior in C++14. From [expr.delete] (5.3.5
Delete):

    In the first alternative (delete object), if the static type of the
    object to be deleted is different from its dynamic type, the static type
    shall be a base class of the dynamic type of the object to be deleted
    and the static type shall have a virtual destructor or the behavior is
    undefined.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>