### PR TITLE
Phase1 Residuals and RecHits fix

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -38,6 +38,14 @@ siPixelPhase1OfflineDQM_source_cosmics = siPixelPhase1OfflineDQM_source.copyAndE
 SiPixelPhase1TrackResidualsAnalyzer_cosmics = SiPixelPhase1TrackResidualsAnalyzer.clone()
 SiPixelPhase1TrackResidualsAnalyzer_cosmics.Tracks = "ctfWithMaterialTracksP5"
 SiPixelPhase1TrackResidualsAnalyzer_cosmics.trajectoryInput = "ctfWithMaterialTracksP5"
+SiPixelPhase1TrackResidualsAnalyzer_cosmics.VertexCut = False # don't cuts based on the primary vertex position for cosmics
+
 
 siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1TrackResidualsAnalyzer,
                                                SiPixelPhase1TrackResidualsAnalyzer_cosmics)
+
+SiPixelPhase1RecHitsAnalyzer_cosmics = SiPixelPhase1RecHitsAnalyzer.clone()
+SiPixelPhase1RecHitsAnalyzer_cosmics.onlyValidHits = True # In Cosmics the efficiency plugin will not run, so we monitor only valid hits
+
+siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1RecHitsAnalyzer,
+                                               SiPixelPhase1RecHitsAnalyzer_cosmics)

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -46,6 +46,7 @@ siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1TrackResidualsAnalyz
 
 SiPixelPhase1RecHitsAnalyzer_cosmics = SiPixelPhase1RecHitsAnalyzer.clone()
 SiPixelPhase1RecHitsAnalyzer_cosmics.onlyValidHits = True # In Cosmics the efficiency plugin will not run, so we monitor only valid hits
+SiPixelPhase1RecHitsAnalyzer_cosmics.src = "ctfWithMaterialTracksP5"
 
 siPixelPhase1OfflineDQM_source_cosmics.replace(SiPixelPhase1RecHitsAnalyzer,
                                                SiPixelPhase1RecHitsAnalyzer_cosmics)

--- a/DQM/SiPixelPhase1RecHits/BuildFile.xml
+++ b/DQM/SiPixelPhase1RecHits/BuildFile.xml
@@ -1,3 +1,5 @@
 <use   name="DQM/SiPixelPhase1Common"/>
 <use   name="DataFormats/TrackerRecHit2D"/>
+<use   name="TrackingTools/TrackFitters"/>
+
 <flags   EDM_PLUGIN="1"/>

--- a/DQM/SiPixelPhase1RecHits/interface/SiPixelPhase1RecHits.h
+++ b/DQM/SiPixelPhase1RecHits/interface/SiPixelPhase1RecHits.h
@@ -22,6 +22,8 @@ class SiPixelPhase1RecHits : public SiPixelPhase1Base {
     CLUSTER_PROB
   };
 
+  bool onlyValid_;
+
   public:
   explicit SiPixelPhase1RecHits(const edm::ParameterSet& conf);
   void analyze(const edm::Event&, const edm::EventSetup&);

--- a/DQM/SiPixelPhase1RecHits/interface/SiPixelPhase1RecHits.h
+++ b/DQM/SiPixelPhase1RecHits/interface/SiPixelPhase1RecHits.h
@@ -9,7 +9,8 @@
 // Original Author: Marcel Schneider
 
 #include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 class SiPixelPhase1RecHits : public SiPixelPhase1Base {
   enum {
@@ -29,7 +30,7 @@ class SiPixelPhase1RecHits : public SiPixelPhase1Base {
   void analyze(const edm::Event&, const edm::EventSetup&);
 
   private:
-  edm::EDGetTokenT<SiPixelRecHitCollection> srcToken_;
+    edm::EDGetTokenT<reco::TrackCollection> srcToken_;
 };
 
 #endif

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -92,7 +92,9 @@ SiPixelPhase1RecHitsConf = cms.VPSet(
 SiPixelPhase1RecHitsAnalyzer = cms.EDAnalyzer("SiPixelPhase1RecHits",
         src = cms.InputTag("siPixelRecHits"),
         histograms = SiPixelPhase1RecHitsConf,
-        geometry = SiPixelPhase1Geometry
+        geometry = SiPixelPhase1Geometry,
+        onlyValidHits = cms.bool(False)
+
 )
 
 SiPixelPhase1RecHitsHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -90,7 +90,7 @@ SiPixelPhase1RecHitsConf = cms.VPSet(
 )
 
 SiPixelPhase1RecHitsAnalyzer = cms.EDAnalyzer("SiPixelPhase1RecHits",
-        src = cms.InputTag("siPixelRecHits"),
+        src = cms.InputTag("generalTracks"),
         histograms = SiPixelPhase1RecHitsConf,
         geometry = SiPixelPhase1Geometry,
         onlyValidHits = cms.bool(False)

--- a/DQM/SiPixelPhase1RecHits/src/SiPixelPhase1RecHits.cc
+++ b/DQM/SiPixelPhase1RecHits/src/SiPixelPhase1RecHits.cc
@@ -22,6 +22,7 @@ SiPixelPhase1RecHits::SiPixelPhase1RecHits(const edm::ParameterSet& iConfig) :
   SiPixelPhase1Base(iConfig) 
 {
   srcToken_ = consumes<SiPixelRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  onlyValid_=iConfig.getParameter<bool>("onlyValidHits");
 }
 
 void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -36,9 +37,14 @@ void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSet
 
   SiPixelRecHitCollection::const_iterator it;
   for (it = input->begin(); it != input->end(); ++it) {
+    
     auto id = DetId(it->detId());
 
     for(SiPixelRecHit const& rechit : *it) {
+      
+      bool isHitValid   = rechit.getType()==TrackingRecHit::valid;
+      if (onlyValid_ && !isHitValid) continue;
+
       SiPixelRecHit::ClusterRef const& clust = rechit.cluster();
 
       int sizeX = (*clust).sizeX();

--- a/DQM/SiPixelPhase1RecHits/src/SiPixelPhase1RecHits.cc
+++ b/DQM/SiPixelPhase1RecHits/src/SiPixelPhase1RecHits.cc
@@ -6,7 +6,6 @@
 
 // Original Author: Marcel Schneider
 
-#include "DQM/SiPixelPhase1RecHits/interface/SiPixelPhase1RecHits.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -16,12 +15,19 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+
+#include "DQM/SiPixelPhase1RecHits/interface/SiPixelPhase1RecHits.h"
 
 SiPixelPhase1RecHits::SiPixelPhase1RecHits(const edm::ParameterSet& iConfig) :
   SiPixelPhase1Base(iConfig) 
 {
-  srcToken_ = consumes<SiPixelRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  srcToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"));
   onlyValid_=iConfig.getParameter<bool>("onlyValidHits");
 }
 
@@ -31,29 +37,60 @@ void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSet
   iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
   assert(tracker.isValid());
 
-  edm::Handle<SiPixelRecHitCollection> input;
-  iEvent.getByToken(srcToken_, input);
-  if (!input.isValid()) return;
+  edm::Handle<reco::TrackCollection> tracks;
+  iEvent.getByToken( srcToken_, tracks);
+  if (!tracks.isValid()) return;
 
-  SiPixelRecHitCollection::const_iterator it;
-  for (it = input->begin(); it != input->end(); ++it) {
-    
-    auto id = DetId(it->detId());
+  for (auto const & track : *tracks) {
 
-    for(SiPixelRecHit const& rechit : *it) {
+    bool isBpixtrack = false, isFpixtrack = false;
+
+    auto const & trajParams = track.extra()->trajParams();
+    auto hb = track.recHitsBegin();
+    for(unsigned int h=0;h<track.recHitsSize();h++){
+     
+      auto hit = *(hb+h);
+      if(!hit->isValid()) continue;
       
-      bool isHitValid   = rechit.getType()==TrackingRecHit::valid;
-      if (onlyValid_ && !isHitValid) continue;
+      DetId id = hit->geographicalId();
+      uint32_t subdetid = (id.subdetId());
 
-      SiPixelRecHit::ClusterRef const& clust = rechit.cluster();
+      if (subdetid == PixelSubdetector::PixelBarrel) isBpixtrack = true;
+      if (subdetid == PixelSubdetector::PixelEndcap) isFpixtrack = true;
+    }
 
-      int sizeX = (*clust).sizeX();
-      int sizeY = (*clust).sizeY();
+    if (!isBpixtrack && !isFpixtrack) continue;
+
+    // then, look at each hit
+    for(unsigned int h=0;h<track.recHitsSize();h++){
+      auto rechit = *(hb+h);
+    
+      if(!rechit->isValid()) continue;
+
+      //continue if not a Pixel recHit
+      DetId id = rechit->geographicalId();
+      uint32_t subdetid = (id.subdetId());
+
+      if (   subdetid != PixelSubdetector::PixelBarrel 
+	     && subdetid != PixelSubdetector::PixelEndcap) continue;
+
+      bool isHitValid   = rechit->getType()==TrackingRecHit::valid;
+      if (onlyValid_ && !isHitValid) continue; //useful to run on cosmics where the TrackEfficiency plugin is not used
+
+      const SiPixelRecHit* prechit = dynamic_cast<const SiPixelRecHit*>(rechit);//to be used to get the associated cluster and the cluster probability      
+
+      int sizeX=0, sizeY=0;
+
+      if (isHitValid){
+	SiPixelRecHit::ClusterRef const& clust = prechit->cluster();
+	sizeX = (*clust).sizeX();
+	sizeY = (*clust).sizeY();
+      }
 
       const PixelGeomDetUnit* geomdetunit = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(id) );
       const PixelTopology& topol = geomdetunit->specificTopology();
 
-      LocalPoint lp = rechit.localPosition();
+      LocalPoint lp = trajParams[h].position();
       MeasurementPoint mp = topol.measurementPosition(lp);
       
       int row = (int) mp.x();
@@ -62,23 +99,27 @@ void SiPixelPhase1RecHits::analyze(const edm::Event& iEvent, const edm::EventSet
       float rechit_x = lp.x();
       float rechit_y = lp.y();
       
-      LocalError lerr = rechit.localPositionError();
+      LocalError lerr = rechit->localPositionError();
       float lerr_x = sqrt(lerr.xx());
       float lerr_y = sqrt(lerr.yy());
 
-      histo[NRECHITS].fill(id, &iEvent, col, row);
+      histo[NRECHITS].fill(id, &iEvent, col, row); //in general a inclusive counter of missing/valid/inactive hits
 
-      histo[CLUST_X].fill(sizeX, id, &iEvent, col, row);
-      histo[CLUST_Y].fill(sizeY, id, &iEvent, col, row);
+      if (isHitValid){
+	histo[CLUST_X].fill(sizeX, id, &iEvent, col, row);
+	histo[CLUST_Y].fill(sizeY, id, &iEvent, col, row);
+      }
 
       histo[ERROR_X].fill(lerr_x, id, &iEvent);
       histo[ERROR_Y].fill(lerr_y, id, &iEvent);
 
       histo[POS].fill(rechit_x, rechit_y, id, &iEvent);
-
-      double clusterProbability = rechit.clusterProbability(0);
-      if (clusterProbability > 0)
-        histo[CLUSTER_PROB].fill(log10(clusterProbability), id, &iEvent);
+      
+      if (isHitValid){
+	double clusterProbability= prechit->clusterProbability(0);
+	if (clusterProbability > 0)
+	  histo[CLUSTER_PROB].fill(log10(clusterProbability), id, &iEvent);
+      }
     }
   }
 

--- a/DQM/SiPixelPhase1TrackEfficiency/src/SiPixelPhase1TrackEfficiency.cc
+++ b/DQM/SiPixelPhase1TrackEfficiency/src/SiPixelPhase1TrackEfficiency.cc
@@ -49,6 +49,7 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
   // get the map
   edm::Handle<reco::TrackCollection> tracks;
   iEvent.getByToken( tracksToken_, tracks);
+  if (!tracks.isValid()) return;
 
   for (auto const & track : *tracks) {
 
@@ -59,7 +60,8 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
     auto const & trajParams = track.extra()->trajParams();
     auto hb = track.recHitsBegin();
     for(unsigned int h=0;h<track.recHitsSize();h++){
-       auto hit = *(hb+h);
+      
+      auto hit = *(hb+h);
       if(!hit->isValid()) continue;
 
       DetId id = hit->geographicalId();
@@ -103,7 +105,6 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
       MeasurementPoint mp = topol.measurementPosition(lp);
       int row = (int) mp.x();
       int col = (int) mp.y();
-
 
       if (isHitValid)   {
         histo[VALID].fill(id, &iEvent, col, row);

--- a/DQM/SiPixelPhase1TrackResiduals/interface/SiPixelPhase1TrackResiduals.h
+++ b/DQM/SiPixelPhase1TrackResiduals/interface/SiPixelPhase1TrackResiduals.h
@@ -18,6 +18,8 @@ class SiPixelPhase1TrackResiduals : public SiPixelPhase1Base {
     RESIDUAL_Y
   };
 
+  bool ApplyVertexCut_;
+
   public:
   explicit SiPixelPhase1TrackResiduals(const edm::ParameterSet& conf);
   void analyze(const edm::Event&, const edm::EventSetup&);

--- a/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -27,7 +27,7 @@ SiPixelPhase1TrackResidualsConf = cms.VPSet(
 SiPixelPhase1TrackResidualsAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackResiduals",
         trajectoryInput = cms.string("generalTracks"),
         Tracks        = cms.InputTag("generalTracks"),
-        VertexCut                  = cms.bool(True),
+        VertexCut                  = cms.bool(True), # Will not apply the vertex cuts on cosmics
         histograms = SiPixelPhase1TrackResidualsConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -27,6 +27,7 @@ SiPixelPhase1TrackResidualsConf = cms.VPSet(
 SiPixelPhase1TrackResidualsAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackResiduals",
         trajectoryInput = cms.string("generalTracks"),
         Tracks        = cms.InputTag("generalTracks"),
+        VertexCut                  = cms.bool(True),
         histograms = SiPixelPhase1TrackResidualsConf,
         geometry = SiPixelPhase1Geometry
 )


### PR DESCRIPTION
With this PR we fix the following

-  Residuals plot will be filled also in cosmics removing ad hoc any cut based on the primary vertices (i.e distance of closest approach)

- Fix the inclusive RecHit monitor to show only rechits attached to tracks and not all the collection of SiPixelRecHits that basically would duplicate the plots on Pixel clusters

In the case another patch release will be needed it would be great to have also this included, I will submit the same PR to 9_1_X now

