### PR TITLE
fix root Draw option for Strip monitoring tool [90X]

### DIFF
--- a/DQM/SiStripMonitorSummary/bin/makeModulePlots.cc
+++ b/DQM/SiStripMonitorSummary/bin/makeModulePlots.cc
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
 void printPlot(TH1D* hist, char* prefix, char* postfix) {
 
   TCanvas* cc= new TCanvas;
-  hist->Draw();
+  hist->Draw("hist");
   std::stringstream filename;
   filename << prefix << hist->GetName() << postfix << ".png";
   cc->Print(filename.str().c_str());


### PR DESCRIPTION
putting the right Draw Option for monitoring tools used by the tracker shifters 
Backport of the master PR #18281