### PR TITLE
Flexible SOI config for HF

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
@@ -1,8 +1,41 @@
 import FWCore.ParameterSet.Config as cms
 
+#
+# During its "normal" (i.e., non-cosmic) operation, the HFPreReconstructor
+# module constructs HFPreRecHit objects using a single time slice called
+# "sample of interest" (SOI). This time slice can be chosen in three
+# different ways:
+#    I. Take it from the data frame. This is the "standard" configuration.
+#   II. Take it from the database.
+#  III. Take is from a cfi parameter.
+#
+# HFPreReconstructor configurations corresponding to these SOI choices are:
+#    I. forceSOI < 0 and tsFromDB is False.
+#   II. forceSOI < 0 and tsFromDB is True.
+#  III. forceSOI >= 0 (the SOI is then defined by the forceSOI value).
+#
+# For configuration III, the SOI value will be the same for all channels.
+# For I and II, SOIs can differ from channel to channel, depending on DAQ
+# or database settings, respectively.
+#
+# After the time slice selection outlined above, the value of parameter
+# "soiShift" is added to this selection. "soiShift" can be positive,
+# negative, or zero.
+#
+# Note that, at the time of this writing, we read out only 3 time slices
+# in HF, so that meaningful non-negative values of "forceSOI" parameter
+# (assuming "soiShift" value of zero) are 0, 1, and 2. In all cases (I, II,
+# and III), channels for which the SOI is misconfigured will be discarded.
+#
+# For cosmic operation, the parameter "sumAllTimeSlices" should be set
+# to "True". In this case the SOI configuration is ignored, and the energy
+# is accumulated using all time slices in the data frame.
+#
 hfprereco = cms.EDProducer("HFPreReconstructor",
     digiLabel = cms.InputTag("hcalDigis"),
     dropZSmarkedPassed = cms.bool(True),
     tsFromDB = cms.bool(False),
-    sumAllTimeSlices = cms.bool(False)
+    sumAllTimeSlices = cms.bool(False),
+    forceSOI = cms.int32(-1),
+    soiShift = cms.int32(0)
 )

--- a/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
@@ -17,7 +17,6 @@
 //
 
 // system include files
-#include <iostream>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -174,7 +173,6 @@ void
 HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
 {
     using namespace edm;
-    using namespace std;
 
     // Fetch the calibrations
     ESHandle<HcalDbService> conditions;
@@ -192,8 +190,6 @@ HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
     Handle<HFPreRecHitCollection> preRecHits;
     e.getByToken(tok_PreRecHit_, preRecHits);
 
-    cout << "HFPhase1Reconstructor::produce: going over " << preRecHits->size() << " prerechits" << endl;
-    
     // Create a new output collection
     std::unique_ptr<HFRecHitCollection> rec(std::make_unique<HFRecHitCollection>());
     rec->reserve(preRecHits->size());
@@ -282,7 +278,6 @@ HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
     }
 
     // Add the output collection to the event record
-    cout << "HFPhase1Reconstructor::produce: made " << rec->size() << " rechits" << endl;
     e.put(std::move(rec));
 }
 

--- a/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPhase1Reconstructor.cc
@@ -17,6 +17,7 @@
 //
 
 // system include files
+#include <iostream>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -173,6 +174,7 @@ void
 HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
 {
     using namespace edm;
+    using namespace std;
 
     // Fetch the calibrations
     ESHandle<HcalDbService> conditions;
@@ -190,6 +192,8 @@ HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
     Handle<HFPreRecHitCollection> preRecHits;
     e.getByToken(tok_PreRecHit_, preRecHits);
 
+    cout << "HFPhase1Reconstructor::produce: going over " << preRecHits->size() << " prerechits" << endl;
+    
     // Create a new output collection
     std::unique_ptr<HFRecHitCollection> rec(std::make_unique<HFRecHitCollection>());
     rec->reserve(preRecHits->size());
@@ -278,6 +282,7 @@ HFPhase1Reconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup)
     }
 
     // Add the output collection to the event record
+    cout << "HFPhase1Reconstructor::produce: made " << rec->size() << " rechits" << endl;
     e.put(std::move(rec));
 }
 

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -62,6 +62,8 @@ private:
 
     // Module configuration parameters
     edm::InputTag inputLabel_;
+    int forceSOI_;
+    int soiShift_;
     bool dropZSmarkedPassed_;
     bool tsFromDB_;
 
@@ -84,6 +86,8 @@ private:
 //
 HFPreReconstructor::HFPreReconstructor(const edm::ParameterSet& conf)
     : inputLabel_(conf.getParameter<edm::InputTag>("digiLabel")),
+      forceSOI_(conf.getParameter<int>("forceSOI")),
+      soiShift_(conf.getParameter<int>("soiShift")),
       dropZSmarkedPassed_(conf.getParameter<bool>("dropZSmarkedPassed")),
       tsFromDB_(conf.getParameter<bool>("tsFromDB")),
       reco_(conf.getParameter<bool>("sumAllTimeSlices"))
@@ -194,16 +198,21 @@ HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& eventS
             const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
             const HcalCoderDb coder(*channelCoder, *shape);
 
-            // Get the "sample of interest" from the data frame itself
-            int tsToUse = frame.presamples();
-            if (tsFromDB_)
+            int tsToUse = forceSOI_;
+            if (tsToUse < 0)
             {
-                const HcalRecoParam* param_ts = paramTS_->getValues(cell.rawId());
-                tsToUse = param_ts->firstSample();
+                if (tsFromDB_)
+                {
+                    const HcalRecoParam* param_ts = paramTS_->getValues(cell.rawId());
+                    tsToUse = param_ts->firstSample();
+                }
+                else
+                    // Get the "sample of interest" from the data frame itself
+                    tsToUse = frame.presamples();
             }
 
             // Reconstruct the charge, energy, etc
-            qie10Infos_.push_back(reco_.reconstruct(frame, tsToUse, coder, calibrations));
+            qie10Infos_.push_back(reco_.reconstruct(frame, tsToUse+soiShift_, coder, calibrations));
         }
     }
 }
@@ -295,6 +304,8 @@ HFPreReconstructor::fillDescriptions(edm::ConfigurationDescriptions& description
     edm::ParameterSetDescription desc;
 
     desc.add<edm::InputTag>("digiLabel");
+    desc.add<int>("forceSOI", -1);
+    desc.add<int>("soiShift", 0);
     desc.add<bool>("dropZSmarkedPassed");
     desc.add<bool>("tsFromDB");
     desc.add<bool>("sumAllTimeSlices");

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -212,7 +212,9 @@ HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& eventS
             }
 
             // Reconstruct the charge, energy, etc
-            qie10Infos_.push_back(reco_.reconstruct(frame, tsToUse+soiShift_, coder, calibrations));
+            const HFQIE10Info& info = reco_.reconstruct(frame, tsToUse+soiShift_, coder, calibrations);
+            if (info.id().rawId())
+                qie10Infos_.push_back(info);
         }
     }
 }


### PR DESCRIPTION
Introducing flexible sample of interest configuration for HF (to have the capability to reconstruct pre- and post-samples). The mode of operation is described in the cfi comments.

This PR will not modify any existing relval results.
