### PR TITLE
Made global Json::ValueAllocator const

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -29,8 +29,8 @@ class SystemBounds;
 class GlobalContext;
 class StreamID;
 
-class InputFile;
-class InputChunk;
+struct InputFile;
+struct InputChunk;
 
 namespace edm {
   class PathsAndConsumesOfModulesBase;

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -28,8 +28,8 @@ class FEDRawDataCollection;
 class InputSourceDescription;
 class ParameterSet;
 
-class InputFile;
-class InputChunk;
+struct InputFile;
+struct  InputChunk;
 
 namespace evf {
 class FastMonitoringService;
@@ -42,8 +42,8 @@ class DataPointDefinition;
 
 class FedRawDataInputSource: public edm::RawInputSource {
 
-friend class InputFile;
-friend class InputChunk;
+friend struct InputFile;
+friend struct InputChunk;
 
 public:
   explicit FedRawDataInputSource(edm::ParameterSet const&,edm::InputSourceDescription const&);

--- a/EventFilter/Utilities/interface/value.h
+++ b/EventFilter/Utilities/interface/value.h
@@ -527,11 +527,11 @@ namespace Json {
 
       virtual ~ValueAllocator();
 
-      virtual char *makeMemberName( const char *memberName ) = 0;
-      virtual void releaseMemberName( char *memberName ) = 0;
+      virtual char *makeMemberName( const char *memberName ) const = 0;
+      virtual void releaseMemberName( char *memberName ) const = 0;
       virtual char *duplicateStringValue( const char *value, 
-                                          unsigned int length = unknown ) = 0;
-      virtual void releaseStringValue( char *value ) = 0;
+                                          unsigned int length = unknown ) const = 0;
+      virtual void releaseStringValue( char *value ) const = 0;
    };
 
 #ifdef JSON_VALUE_USE_INTERNAL_MAP

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -137,7 +137,7 @@ namespace evf{
     timingHisto_->SetEntries(24934);
   }
 
-  void ExceptionGenerator::beginRun(edm::Run& r, const edm::EventSetup& iSetup)
+  void ExceptionGenerator::beginRun(const edm::Run& r, const edm::EventSetup& iSetup)
   {
 
     gettimeofday(&tv_start_,0);

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.h
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.h
@@ -19,9 +19,9 @@ namespace evf{
 						   
       explicit ExceptionGenerator( const edm::ParameterSet&);
       ~ExceptionGenerator(){};
-      void beginRun(edm::Run& r, const edm::EventSetup& iSetup);
-      void analyze(const edm::Event & e, const edm::EventSetup& c);
-      void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+      void beginRun(const edm::Run& r, const edm::EventSetup& iSetup) override;
+      void analyze(const edm::Event & e, const edm::EventSetup& c) override;
+      void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
     private:
       int actionId_;

--- a/EventFilter/Utilities/src/json_value.cpp
+++ b/EventFilter/Utilities/src/json_value.cpp
@@ -59,6 +59,8 @@ ValueAllocator::~ValueAllocator()
 class DefaultValueAllocator : public ValueAllocator
 {
 public:
+   DefaultValueAllocator() = default;
+
    virtual ~DefaultValueAllocator()
    {
    }

--- a/EventFilter/Utilities/src/json_value.cpp
+++ b/EventFilter/Utilities/src/json_value.cpp
@@ -59,7 +59,7 @@ ValueAllocator::~ValueAllocator()
 class DefaultValueAllocator : public ValueAllocator
 {
 public:
-   DefaultValueAllocator() = default;
+   DefaultValueAllocator() {}
 
    virtual ~DefaultValueAllocator()
    {

--- a/EventFilter/Utilities/src/json_value.cpp
+++ b/EventFilter/Utilities/src/json_value.cpp
@@ -63,18 +63,18 @@ public:
    {
    }
 
-   virtual char *makeMemberName( const char *memberName )
+   virtual char *makeMemberName( const char *memberName ) const
    {
       return duplicateStringValue( memberName );
    }
 
-   virtual void releaseMemberName( char *memberName )
+   virtual void releaseMemberName( char *memberName ) const 
    {
       releaseStringValue( memberName );
    }
 
    virtual char *duplicateStringValue( const char *value, 
-                                       unsigned int length = unknown )
+                                       unsigned int length = unknown ) const
    {
       // invesgate this old optimization
       //if ( !value  ||  value[0] == 0 )
@@ -88,17 +88,17 @@ public:
       return newString;
    }
 
-   virtual void releaseStringValue( char *value )
+   virtual void releaseStringValue( char *value ) const
    {
       if ( value )
          free( value );
    }
 };
 
-static ValueAllocator *&valueAllocator()
+static ValueAllocator const* valueAllocator()
 {
-   static DefaultValueAllocator defaultAllocator;
-   static ValueAllocator *valueAllocator = &defaultAllocator;
+   static const DefaultValueAllocator defaultAllocator;
+   static ValueAllocator const *valueAllocator = &defaultAllocator;
    return valueAllocator;
 }
 


### PR DESCRIPTION
The static analyzer was complaining about the global object which implemented
the Json::ValueAllocator interface. Since the implementation was not changing
any internal state, it was trivial to change the interface to be const and then
make the global const as well.