### PR TITLE
adding fast and parallel-friendly kdtree implementation

### DIFF
--- a/CommonTools/RecoAlgos/interface/FKDPoint.h
+++ b/CommonTools/RecoAlgos/interface/FKDPoint.h
@@ -1,0 +1,80 @@
+#ifndef COMMONTOOLS_RECOALGOS_FKDPOINT_H
+#define COMMONTOOLS_RECOALGOS_FKDPOINT_H
+#include <array>
+#include <utility>
+
+template<class TYPE, int numberOfDimensions>
+class FKDPoint
+{
+
+public:
+	FKDPoint() :
+			theElements(), theId(0)
+	{
+	}
+
+
+	FKDPoint(TYPE x, TYPE y, unsigned int id=0)
+	{
+    	static_assert(numberOfDimensions==2,"FKDPoint number of arguments does not match the number of dimensions");
+      	
+		theId = id;
+		theElements[0] = x;
+		theElements[1] = y;
+	}
+
+	FKDPoint(TYPE x, TYPE y, TYPE z, unsigned int id=0)
+	{
+      	static_assert(numberOfDimensions==3,"FKDPoint number of arguments does not match the number of dimensions");
+      	
+		theId = id;
+		theElements[0] = x;
+		theElements[1] = y;
+		theElements[2] = z;
+	}
+
+	FKDPoint(TYPE x, TYPE y, TYPE z, TYPE w, unsigned int id=0)
+	{
+      	static_assert(numberOfDimensions==4,"FKDPoint number of arguments does not match the number of dimensions");
+		theId = id;
+		theElements[0] = x;
+		theElements[1] = y;
+		theElements[2] = z;
+		theElements[3] = w;
+	}
+
+// the user should check that i < numberOfDimensions
+	TYPE& operator[](unsigned int const i)
+	{
+		return theElements[i];
+	}
+
+	TYPE const& operator[](unsigned int const i) const
+	{
+		return theElements[i];
+	}
+
+	void setDimension(unsigned int i, const TYPE& value)
+	{
+		theElements[i] = value;
+	}
+
+	void setId(const unsigned int id)
+	{
+		theId = id;
+	}
+
+	unsigned int getId() const
+	{
+		return theId;
+	}
+
+
+private:
+	std::array<TYPE, numberOfDimensions> theElements;
+	unsigned int theId;
+};
+
+
+
+#endif 

--- a/CommonTools/RecoAlgos/interface/FKDPoint.h
+++ b/CommonTools/RecoAlgos/interface/FKDPoint.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <utility>
 
+//a K-dimensional point to interface with the FKDTree class
 template<class TYPE, int numberOfDimensions>
 class FKDPoint
 {

--- a/CommonTools/RecoAlgos/interface/FKDPoint.h
+++ b/CommonTools/RecoAlgos/interface/FKDPoint.h
@@ -43,7 +43,7 @@ class FKDPoint
             theElements[3] = w;
         }
 
-// the user should check that i < numberOfDimensions
+        // the user should check that i < numberOfDimensions
         TYPE& operator[](unsigned int const i)
         {
             return theElements[i];

--- a/CommonTools/RecoAlgos/interface/FKDPoint.h
+++ b/CommonTools/RecoAlgos/interface/FKDPoint.h
@@ -7,74 +7,70 @@ template<class TYPE, int numberOfDimensions>
 class FKDPoint
 {
 
-public:
-	FKDPoint() :
-			theElements(), theId(0)
-	{
-	}
+    public:
+        FKDPoint() :
+                theElements(), theId(0)
+        {
+        }
 
+        FKDPoint(TYPE x, TYPE y, unsigned int id = 0)
+        {
+            static_assert(numberOfDimensions==2,"FKDPoint number of arguments does not match the number of dimensions");
 
-	FKDPoint(TYPE x, TYPE y, unsigned int id=0)
-	{
-    	static_assert(numberOfDimensions==2,"FKDPoint number of arguments does not match the number of dimensions");
-      	
-		theId = id;
-		theElements[0] = x;
-		theElements[1] = y;
-	}
+            theId = id;
+            theElements[0] = x;
+            theElements[1] = y;
+        }
 
-	FKDPoint(TYPE x, TYPE y, TYPE z, unsigned int id=0)
-	{
-      	static_assert(numberOfDimensions==3,"FKDPoint number of arguments does not match the number of dimensions");
-      	
-		theId = id;
-		theElements[0] = x;
-		theElements[1] = y;
-		theElements[2] = z;
-	}
+        FKDPoint(TYPE x, TYPE y, TYPE z, unsigned int id = 0)
+        {
+            static_assert(numberOfDimensions==3,"FKDPoint number of arguments does not match the number of dimensions");
 
-	FKDPoint(TYPE x, TYPE y, TYPE z, TYPE w, unsigned int id=0)
-	{
-      	static_assert(numberOfDimensions==4,"FKDPoint number of arguments does not match the number of dimensions");
-		theId = id;
-		theElements[0] = x;
-		theElements[1] = y;
-		theElements[2] = z;
-		theElements[3] = w;
-	}
+            theId = id;
+            theElements[0] = x;
+            theElements[1] = y;
+            theElements[2] = z;
+        }
+
+        FKDPoint(TYPE x, TYPE y, TYPE z, TYPE w, unsigned int id = 0)
+        {
+            static_assert(numberOfDimensions==4,"FKDPoint number of arguments does not match the number of dimensions");
+            theId = id;
+            theElements[0] = x;
+            theElements[1] = y;
+            theElements[2] = z;
+            theElements[3] = w;
+        }
 
 // the user should check that i < numberOfDimensions
-	TYPE& operator[](unsigned int const i)
-	{
-		return theElements[i];
-	}
+        TYPE& operator[](unsigned int const i)
+        {
+            return theElements[i];
+        }
 
-	TYPE const& operator[](unsigned int const i) const
-	{
-		return theElements[i];
-	}
+        TYPE const& operator[](unsigned int const i) const
+        {
+            return theElements[i];
+        }
 
-	void setDimension(unsigned int i, const TYPE& value)
-	{
-		theElements[i] = value;
-	}
+        void setDimension(unsigned int i, const TYPE& value)
+        {
+            theElements[i] = value;
+        }
 
-	void setId(const unsigned int id)
-	{
-		theId = id;
-	}
+        void setId(const unsigned int id)
+        {
+            theId = id;
+        }
 
-	unsigned int getId() const
-	{
-		return theId;
-	}
+        unsigned int getId() const
+        {
+            return theId;
+        }
 
-
-private:
-	std::array<TYPE, numberOfDimensions> theElements;
-	unsigned int theId;
+    private:
+        std::array<TYPE, numberOfDimensions> theElements;
+        unsigned int theId;
 };
-
-
 
 #endif 

--- a/CommonTools/RecoAlgos/interface/FKDTree.h
+++ b/CommonTools/RecoAlgos/interface/FKDTree.h
@@ -1,0 +1,386 @@
+#ifndef COMMONTOOLS_RECOALGOS_FKDTREE_H
+#define COMMONTOOLS_RECOALGOS_FKDTREE_H
+
+#include <vector>
+#include <array>
+#include <algorithm>
+#include <cmath>
+#include <utility>
+#include "FKDPoint.h"
+#include "FQueue.h"
+
+
+namespace{
+    const std::array<unsigned int,32> MultiplyDeBruijnBitPosition{{0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30,
+  8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31}};
+    unsigned int ilog2 (unsigned int v)
+	    {
+	    v |= v >> 1; // first round down to one less than a power of 2 
+	    v |= v >> 2;
+	    v |= v >> 4;
+	    v |= v >> 8;
+	    v |= v >> 16;
+	    return MultiplyDeBruijnBitPosition[(unsigned int)(v * 0x07C4ACDDU) >> 27];
+
+	    }
+
+
+
+}
+
+
+
+
+template<class TYPE, unsigned int numberOfDimensions>
+class FKDTree
+{
+
+public:
+
+
+FKDTree()
+	{
+		theNumberOfPoints = 0;
+		theDepth = 0;
+
+	}
+
+
+
+	void push_back(const FKDPoint<TYPE, numberOfDimensions>& point)
+	{
+
+		thePoints.push_back(point);
+
+
+	
+	}
+
+	void push_back(FKDPoint<TYPE, numberOfDimensions> && point)
+	{
+
+		thePoints.emplace_back(point);
+
+
+	}
+
+	template <typename ... Args>
+	void emplace_back(Args&&... args) {
+	   push_back(FKDPoint<TYPE, numberOfDimensions>(std::forward<Args>(args)...));
+	}
+
+	bool empty()
+	{
+		return theNumberOfPoints==0;
+	}
+
+
+	void search(
+			const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+			const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
+			std::vector<unsigned int>& foundPoints)
+	{
+		FQueue<unsigned int> indicesToVisit(16);
+		indicesToVisit.push_back(0);
+		unsigned int index;
+		bool intersection;
+		int dimension;
+		unsigned int numberOfindicesToVisitThisDepth;
+		int numberOfSonsToVisitNext;
+		unsigned int firstSonToVisitNext;
+
+		for (unsigned int depth = 0; depth < theDepth + 1; ++depth)
+		{
+
+			dimension = depth % numberOfDimensions;
+			numberOfindicesToVisitThisDepth = indicesToVisit.size();
+			for (unsigned int visitedindicesThisDepth = 0;
+					visitedindicesThisDepth < numberOfindicesToVisitThisDepth;
+					visitedindicesThisDepth++)
+			{
+
+				index = indicesToVisit[visitedindicesThisDepth];
+				intersection = intersects(index, minPoint, maxPoint, dimension);
+				firstSonToVisitNext = leftSonIndex(index);
+            
+
+				if (intersection)
+				{
+					if (is_in_the_box(index, minPoint, maxPoint))
+					{
+										
+						foundPoints.emplace_back(theIds[index]);
+					}
+					numberOfSonsToVisitNext = (firstSonToVisitNext < theNumberOfPoints)
+                 		 + ((firstSonToVisitNext + 1) < theNumberOfPoints);
+				}
+				else
+				{
+
+
+					firstSonToVisitNext += (theDimensions[dimension][index]
+							< minPoint[dimension]);
+
+              		numberOfSonsToVisitNext = std::min((firstSonToVisitNext< theNumberOfPoints)
+                  		+ ((firstSonToVisitNext + 1) < theNumberOfPoints) , 1);
+				}
+
+				for (int whichSon = 0; whichSon < numberOfSonsToVisitNext;
+						++whichSon){
+               
+					indicesToVisit.push_back(firstSonToVisitNext + whichSon);
+			      }
+			}
+
+			indicesToVisit.pop_front(numberOfindicesToVisitThisDepth);
+		}
+	}
+
+
+	void build()
+	{
+
+		theNumberOfPoints =thePoints.size();
+		theDepth = ilog2(theNumberOfPoints);
+		theIntervalLength.resize(theNumberOfPoints, 0);
+		theIntervalMin.resize(theNumberOfPoints, 0);
+      for (unsigned int i = 0; i < numberOfDimensions; ++i)  theDimensions[i].resize(theNumberOfPoints);
+      theIds.resize(theNumberOfPoints);	
+
+		//gather kdtree building
+		int dimension;
+		theIntervalMin[0] = 0;
+		theIntervalLength[0] = theNumberOfPoints;
+
+		for (unsigned int depth = 0; depth < theDepth; ++depth)
+		{
+
+			dimension = depth % numberOfDimensions;
+			unsigned int firstIndexInDepth = (1 << depth) - 1;
+			unsigned int maxDepth = (1 << depth);
+			for (unsigned int indexInDepth = 0; indexInDepth < maxDepth;
+					++indexInDepth)
+			{
+				unsigned int indexInArray = firstIndexInDepth + indexInDepth;
+				unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
+				unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
+
+				unsigned int whichElementInInterval = partition_complete_kdtree(
+						theIntervalLength[indexInArray]);
+				std::nth_element(
+						thePoints.begin() + theIntervalMin[indexInArray],
+						thePoints.begin() + theIntervalMin[indexInArray]
+								+ whichElementInInterval,
+						thePoints.begin() + theIntervalMin[indexInArray]
+								+ theIntervalLength[indexInArray],
+						[dimension](const FKDPoint<TYPE,numberOfDimensions> & a, const FKDPoint<TYPE,numberOfDimensions> & b) -> bool
+						{
+							if(a[dimension] == b[dimension])
+							return a.getId() < b.getId();
+							else
+							return a[dimension] < b[dimension];
+						});
+				add_at_position(
+						thePoints[theIntervalMin[indexInArray]
+								+ whichElementInInterval], indexInArray);
+
+				if (leftSonIndexInArray < theNumberOfPoints)
+				{
+					theIntervalMin[leftSonIndexInArray] =
+							theIntervalMin[indexInArray];
+					theIntervalLength[leftSonIndexInArray] =
+							whichElementInInterval;
+				}
+
+				if (rightSonIndexInArray < theNumberOfPoints)
+				{
+					theIntervalMin[rightSonIndexInArray] =
+							theIntervalMin[indexInArray]
+									+ whichElementInInterval + 1;
+					theIntervalLength[rightSonIndexInArray] =
+							(theIntervalLength[indexInArray] - 1
+									- whichElementInInterval);
+				}
+			}
+		}
+
+		dimension = theDepth % numberOfDimensions;
+		unsigned int firstIndexInDepth = (1 << theDepth) - 1;
+		for (unsigned int indexInArray = firstIndexInDepth;
+				indexInArray < theNumberOfPoints; ++indexInArray)
+		{
+			add_at_position(thePoints[theIntervalMin[indexInArray]],
+					indexInArray);
+
+		}
+
+	}
+
+
+
+
+
+
+
+	void build(std::vector<FKDPoint<TYPE, numberOfDimensions> >& points)
+	{
+
+		theNumberOfPoints = points.size();
+		theDepth = ilog2(theNumberOfPoints);
+		theIntervalLength.resize(theNumberOfPoints, 0);
+		theIntervalMin.resize(theNumberOfPoints, 0);
+		for (unsigned int i = 0; i < numberOfDimensions; ++i)  theDimensions[i].resize(theNumberOfPoints);
+      theIds.resize(theNumberOfPoints);
+
+
+		//gather kdtree building
+		int dimension;
+		theIntervalMin[0] = 0;
+		theIntervalLength[0] = theNumberOfPoints;
+
+		for (unsigned int depth = 0; depth < theDepth; ++depth)
+		{
+
+			dimension = depth % numberOfDimensions;
+			unsigned int firstIndexInDepth = (1 << depth) - 1;
+			unsigned int maxDepth = (1 << depth);
+			for (unsigned int indexInDepth = 0; indexInDepth < maxDepth;
+					++indexInDepth)
+			{
+				unsigned int indexInArray = firstIndexInDepth + indexInDepth;
+				unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
+				unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
+
+				unsigned int whichElementInInterval = partition_complete_kdtree(
+						theIntervalLength[indexInArray]);
+				std::nth_element(
+						points.begin() + theIntervalMin[indexInArray],
+						points.begin() + theIntervalMin[indexInArray]
+								+ whichElementInInterval,
+						points.begin() + theIntervalMin[indexInArray]
+								+ theIntervalLength[indexInArray],
+						[dimension](const FKDPoint<TYPE,numberOfDimensions> & a, const FKDPoint<TYPE,numberOfDimensions> & b) -> bool
+						{
+							if(a[dimension] == b[dimension])
+							return a.getId() < b.getId();
+							else
+							return a[dimension] < b[dimension];
+						});
+				add_at_position(
+						points[theIntervalMin[indexInArray]
+								+ whichElementInInterval], indexInArray);
+
+				if (leftSonIndexInArray < theNumberOfPoints)
+				{
+					theIntervalMin[leftSonIndexInArray] =
+							theIntervalMin[indexInArray];
+					theIntervalLength[leftSonIndexInArray] =
+							whichElementInInterval;
+				}
+
+				if (rightSonIndexInArray < theNumberOfPoints)
+				{
+					theIntervalMin[rightSonIndexInArray] =
+							theIntervalMin[indexInArray]
+									+ whichElementInInterval + 1;
+					theIntervalLength[rightSonIndexInArray] =
+							(theIntervalLength[indexInArray] - 1
+									- whichElementInInterval);
+				}
+			}
+		}
+
+		dimension = theDepth % numberOfDimensions;
+		unsigned int firstIndexInDepth = (1 << theDepth) - 1;
+		for (unsigned int indexInArray = firstIndexInDepth;
+				indexInArray < theNumberOfPoints; ++indexInArray)
+		{
+			add_at_position(points[theIntervalMin[indexInArray]],
+					indexInArray);
+
+		}
+
+	}
+
+	std::size_t size() const
+	{
+		return theNumberOfPoints;
+	}
+
+private:
+
+	unsigned int partition_complete_kdtree(unsigned int length)
+	{
+		if (length == 1)
+			return 0;
+		unsigned int index = 1 << (ilog2(length));
+
+
+		if ((index / 2) - 1 <= length - index)
+			return index - 1;
+		else
+			return length - index / 2;
+
+	}
+
+	unsigned int leftSonIndex(unsigned int index) const
+	{
+		return 2 * index + 1;
+	}
+
+	unsigned int rightSonIndex(unsigned int index) const
+	{
+		return 2 * index + 2;
+	}
+
+	bool intersects(unsigned int index,
+			const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+			const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
+			int dimension) const
+	{
+		return (theDimensions[dimension][index] <= maxPoint[dimension]
+				&& theDimensions[dimension][index] >= minPoint[dimension]);
+	}
+
+	bool is_in_the_box(unsigned int index,
+			const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+			const FKDPoint<TYPE, numberOfDimensions>& maxPoint) const
+	{
+		for (unsigned int i = 0; i < numberOfDimensions; ++i)
+		{
+			if ((theDimensions[i][index] <= maxPoint[i]
+					&& theDimensions[i][index] >= minPoint[i]) == false)
+				return false;
+		}
+
+		return true;
+	}
+	
+	void add_at_position(const FKDPoint<TYPE, numberOfDimensions>& point,
+			const unsigned int position)
+	{
+		for (unsigned int i = 0; i < numberOfDimensions; ++i)
+			theDimensions[i][position] = point[i];
+		theIds[position] = point.getId();
+
+	}
+
+	void add_at_position(FKDPoint<TYPE, numberOfDimensions> && point,
+			const unsigned int position)
+	{
+		for (unsigned int i = 0; i < numberOfDimensions; ++i)
+			theDimensions[i][position] = point[i];
+		theIds[position] = point.getId();
+
+	}
+
+	unsigned int theNumberOfPoints;
+	unsigned int theDepth;
+	std::vector<FKDPoint<TYPE, numberOfDimensions> > thePoints;
+	std::array<std::vector<TYPE>, numberOfDimensions> theDimensions;
+	std::vector<unsigned int> theIntervalLength;
+	std::vector<unsigned int> theIntervalMin;
+	std::vector<unsigned int> theIds;
+};
+
+#endif 

--- a/CommonTools/RecoAlgos/interface/FKDTree.h
+++ b/CommonTools/RecoAlgos/interface/FKDTree.h
@@ -9,6 +9,14 @@
 #include "FKDPoint.h"
 #include "FQueue.h"
 
+// Author: Felice Pantaleo
+// email: felice.pantaleo@cern.ch
+// date: 08/05/2017
+// Description: This class provides a k-d tree implementation targeting modern architectures.
+// Building each level of the FKDTree can be done in parallel by different threads.
+// It produces a compact array of nodes in memory thanks to the different space partitioning method used.
+
+// Fast version of the integer logarithm
 namespace
 {
 const std::array<unsigned int, 32> MultiplyDeBruijnBitPosition
@@ -43,11 +51,23 @@ class FKDTree
             return theNumberOfPoints == 0;
         }
 
+        // One can search for all the points which are contained in a k-dimensional box.
+        // Searching is done by providing the two k-dimensional points in the minimum and maximum corners.
+        // The vector that will contain the indices of the points that lay inside the box is also needed.
+        // Indices are pushed into foundPoints, which is not checked for emptiness at the beginning,
+        // nor memory is reserved for it.
+        // Searching is done using a Breadth-first search, level after level.
         void search(const FKDPoint<TYPE, numberOfDimensions>& minPoint,
                 const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
                 std::vector<unsigned int>& foundPoints)
         {
+            //going down the FKDTree, one needs track which indices have to be visited in the following level.
+            //a custom queue is created, since std::queue is based on lists which are sometimes not performing
+            // well on computing accelerators
+            // The initial size of the queue has to be a power of two for allowing fast modulo  % operation.
             FQueue<unsigned int> indicesToVisit(16);
+
+            //The root element is pushed first
             indicesToVisit.push_back(0);
             unsigned int index;
             bool intersection;
@@ -56,30 +76,38 @@ class FKDTree
             unsigned int numberOfSonsToVisitNext;
             unsigned int firstSonToVisitNext;
 
+            //The loop over levels of the FKDTree starts here
             for (unsigned int depth = 0; depth < theDepth + 1; ++depth)
             {
+                // At each level, comparisons are performed for a different dimension in round robin.
                 dimension = depth % numberOfDimensions;
                 numberOfindicesToVisitThisDepth = indicesToVisit.size();
+                // Loop over the nodes to be visit at this level
                 for (unsigned int visitedindicesThisDepth = 0;
                         visitedindicesThisDepth < numberOfindicesToVisitThisDepth;
                         visitedindicesThisDepth++)
                 {
 
                     index = indicesToVisit[visitedindicesThisDepth];
+                    // check if the element's dimension lays between the two box borders
                     intersection = intersects(index, minPoint, maxPoint, dimension);
                     firstSonToVisitNext = leftSonIndex(index);
 
+
                     if (intersection)
                     {
+                        // Check if the element is contained in the box and push it to the result
                         if (is_in_the_box(index, minPoint, maxPoint))
                         {
                             foundPoints.emplace_back(theIds[index]);
                         }
+                        //if the element is between the box borders, both the its sons have to be visited
                         numberOfSonsToVisitNext = (firstSonToVisitNext < theNumberOfPoints)
                                 + ((firstSonToVisitNext + 1) < theNumberOfPoints);
                     }
                     else
                     {
+                        // depending on the position of the element wrt the box, one son will be visited (if it exists)
                         firstSonToVisitNext += (theDimensions[dimension][index]
                                 < minPoint[dimension]);
 
@@ -88,18 +116,23 @@ class FKDTree
                                         + ((firstSonToVisitNext + 1) < theNumberOfPoints), 1);
                     }
 
+                    // the indices of the sons to be visited in the next iteration are pushed in the queue
                     for (unsigned int whichSon = 0; whichSon < numberOfSonsToVisitNext; ++whichSon)
                     {
                         indicesToVisit.push_back(firstSonToVisitNext + whichSon);
                     }
                 }
+                // a new element is popped from the queue
                 indicesToVisit.pop_front(numberOfindicesToVisitThisDepth);
             }
 
         }
 
+        // A vector of K-dimensional points needs to be passed in order to build the kdtree.
+        // The order of the elements in the vector will be modified.
         void build(std::vector<FKDPoint<TYPE, numberOfDimensions> >& points)
         {
+            // initialization of the data members
             theNumberOfPoints = points.size();
             theDepth = ilog2(theNumberOfPoints);
             theIntervalLength.resize(theNumberOfPoints, 0);
@@ -108,13 +141,17 @@ class FKDTree
                 theDimensions[i].resize(theNumberOfPoints);
             theIds.resize(theNumberOfPoints);
 
-            //gather kdtree building
+            // building is done by reordering elements in a partition starting at theIntervalMin
+            // for a number of elements theIntervalLength
             unsigned int dimension;
             theIntervalMin[0] = 0;
             theIntervalLength[0] = theNumberOfPoints;
 
+            // building for each level starts here
             for (unsigned int depth = 0; depth < theDepth; ++depth)
             {
+                // A heapified left-balanced tree can be represented in memory as an array.
+                // Each level contains a power of two number of elements and starts from element 2^depth -1
                 dimension = depth % numberOfDimensions;
                 unsigned int firstIndexInDepth = (1 << depth) - 1;
                 unsigned int maxDepth = (1 << depth);
@@ -124,8 +161,12 @@ class FKDTree
                     unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
                     unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
 
+                    // partitioning is done by choosing the pivotal element that keeps the tree heapified
+                    // and left-balanced
                     unsigned int whichElementInInterval = partition_complete_kdtree(
                             theIntervalLength[indexInArray]);
+                    // the elements have been partitioned in two unsorted subspaces (one containing the elements
+                    // smaller than the pivot, the other containing those greater than the pivot)
                     std::nth_element(points.begin() + theIntervalMin[indexInArray],
                             points.begin() + theIntervalMin[indexInArray] + whichElementInInterval,
                             points.begin() + theIntervalMin[indexInArray]
@@ -138,9 +179,10 @@ class FKDTree
                                 else
                                 return a[dimension] < b[dimension];
                             });
+                    // the element is placed in its final position in the internal array representation
+                    // of the tree
                     add_at_position(points[theIntervalMin[indexInArray] + whichElementInInterval],
                             indexInArray);
-
                     if (leftSonIndexInArray < theNumberOfPoints)
                     {
                         theIntervalMin[leftSonIndexInArray] = theIntervalMin[indexInArray];
@@ -156,7 +198,7 @@ class FKDTree
                     }
                 }
             }
-
+            // the last level of the tree may not be complete and needs special treatment
             dimension = theDepth % numberOfDimensions;
             unsigned int firstIndexInDepth = (1 << theDepth) - 1;
             for (unsigned int indexInArray = firstIndexInDepth; indexInArray < theNumberOfPoints;
@@ -166,14 +208,23 @@ class FKDTree
             }
 
         }
-
+        // returns the number of points in the FKDTree
         std::size_t size() const
         {
             return theNumberOfPoints;
         }
 
     private:
-
+        // returns the index of the element which makes the FKDtree a left-complete heap
+        // e.g.: if we have 6 elements, the tree will be shaped like
+        //                 O
+        //                / \
+        //               O   O
+        //              / \ /
+        //             O  O O
+        //
+        // This will return for a length of 6 the 4th element, which will partition the tree so that
+        // 3 elements are on its left and 2 elements are on its right
         unsigned int partition_complete_kdtree(unsigned int length)
         {
             if (length == 1)
@@ -186,16 +237,18 @@ class FKDTree
                 return length - index / 2;
         }
 
+        // returns the index of an element left son in the array representation
         unsigned int leftSonIndex(unsigned int index) const
         {
             return 2 * index + 1;
         }
-
+        // returns the index of an element right son in the array representation
         unsigned int rightSonIndex(unsigned int index) const
         {
             return 2 * index + 2;
         }
 
+        //check if one element's dimension is between minPoint's and maxPoint's dimension
         bool intersects(unsigned int index, const FKDPoint<TYPE, numberOfDimensions>& minPoint,
                 const FKDPoint<TYPE, numberOfDimensions>& maxPoint, int dimension) const
         {
@@ -203,6 +256,7 @@ class FKDTree
                     && theDimensions[dimension][index] >= minPoint[dimension]);
         }
 
+        // check if an element is completely in the box
         bool is_in_the_box(unsigned int index, const FKDPoint<TYPE, numberOfDimensions>& minPoint,
                 const FKDPoint<TYPE, numberOfDimensions>& maxPoint) const
         {
@@ -215,6 +269,7 @@ class FKDTree
             return true;
         }
 
+        // places an element at the specified position in the internal data structure
         void add_at_position(const FKDPoint<TYPE, numberOfDimensions>& point,
                 const unsigned int position)
         {
@@ -233,6 +288,8 @@ class FKDTree
 
         unsigned int theNumberOfPoints;
         unsigned int theDepth;
+
+        // a SoA containing all the dimensions for each point
         std::array<std::vector<TYPE>, numberOfDimensions> theDimensions;
         std::vector<unsigned int> theIntervalLength;
         std::vector<unsigned int> theIntervalMin;

--- a/CommonTools/RecoAlgos/interface/FKDTree.h
+++ b/CommonTools/RecoAlgos/interface/FKDTree.h
@@ -38,7 +38,6 @@ class FKDTree
             theDepth = 0;
         }
 
-
         bool empty()
         {
             return theNumberOfPoints == 0;
@@ -52,9 +51,9 @@ class FKDTree
             indicesToVisit.push_back(0);
             unsigned int index;
             bool intersection;
-            int dimension;
+            unsigned int dimension;
             unsigned int numberOfindicesToVisitThisDepth;
-            int numberOfSonsToVisitNext;
+            unsigned int numberOfSonsToVisitNext;
             unsigned int firstSonToVisitNext;
 
             for (unsigned int depth = 0; depth < theDepth + 1; ++depth)
@@ -74,7 +73,6 @@ class FKDTree
                     {
                         if (is_in_the_box(index, minPoint, maxPoint))
                         {
-
                             foundPoints.emplace_back(theIds[index]);
                         }
                         numberOfSonsToVisitNext = (firstSonToVisitNext < theNumberOfPoints)
@@ -90,7 +88,7 @@ class FKDTree
                                         + ((firstSonToVisitNext + 1) < theNumberOfPoints), 1);
                     }
 
-                    for (int whichSon = 0; whichSon < numberOfSonsToVisitNext; ++whichSon)
+                    for (unsigned int whichSon = 0; whichSon < numberOfSonsToVisitNext; ++whichSon)
                     {
                         indicesToVisit.push_back(firstSonToVisitNext + whichSon);
                     }
@@ -100,10 +98,8 @@ class FKDTree
 
         }
 
-
         void build(std::vector<FKDPoint<TYPE, numberOfDimensions> >& points)
         {
-
             theNumberOfPoints = points.size();
             theDepth = ilog2(theNumberOfPoints);
             theIntervalLength.resize(theNumberOfPoints, 0);
@@ -113,13 +109,12 @@ class FKDTree
             theIds.resize(theNumberOfPoints);
 
             //gather kdtree building
-            int dimension;
+            unsigned int dimension;
             theIntervalMin[0] = 0;
             theIntervalLength[0] = theNumberOfPoints;
 
             for (unsigned int depth = 0; depth < theDepth; ++depth)
             {
-
                 dimension = depth % numberOfDimensions;
                 unsigned int firstIndexInDepth = (1 << depth) - 1;
                 unsigned int maxDepth = (1 << depth);
@@ -168,7 +163,6 @@ class FKDTree
                     ++indexInArray)
             {
                 add_at_position(points[theIntervalMin[indexInArray]], indexInArray);
-
             }
 
         }
@@ -190,7 +184,6 @@ class FKDTree
                 return index - 1;
             else
                 return length - index / 2;
-
         }
 
         unsigned int leftSonIndex(unsigned int index) const
@@ -219,7 +212,6 @@ class FKDTree
                         && theDimensions[i][index] >= minPoint[i]) == false)
                     return false;
             }
-
             return true;
         }
 
@@ -229,7 +221,6 @@ class FKDTree
             for (unsigned int i = 0; i < numberOfDimensions; ++i)
                 theDimensions[i][position] = point[i];
             theIds[position] = point.getId();
-
         }
 
         void add_at_position(FKDPoint<TYPE, numberOfDimensions> && point,
@@ -238,7 +229,6 @@ class FKDTree
             for (unsigned int i = 0; i < numberOfDimensions; ++i)
                 theDimensions[i][position] = point[i];
             theIds[position] = point.getId();
-
         }
 
         unsigned int theNumberOfPoints;

--- a/CommonTools/RecoAlgos/interface/FKDTree.h
+++ b/CommonTools/RecoAlgos/interface/FKDTree.h
@@ -218,10 +218,10 @@ class FKDTree
         // returns the index of the element which makes the FKDtree a left-complete heap
         // e.g.: if we have 6 elements, the tree will be shaped like
         //                 O
-        //                / \
-        //               O   O
-        //              / \ /
-        //             O  O O
+        //                / '\'
+        //               O    O
+        //              /'\' /
+        //             O   OO
         //
         // This will return for a length of 6 the 4th element, which will partition the tree so that
         // 3 elements are on its left and 2 elements are on its right

--- a/CommonTools/RecoAlgos/interface/FKDTree.h
+++ b/CommonTools/RecoAlgos/interface/FKDTree.h
@@ -9,378 +9,245 @@
 #include "FKDPoint.h"
 #include "FQueue.h"
 
-
-namespace{
-    const std::array<unsigned int,32> MultiplyDeBruijnBitPosition{{0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30,
-  8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31}};
-    unsigned int ilog2 (unsigned int v)
-	    {
-	    v |= v >> 1; // first round down to one less than a power of 2 
-	    v |= v >> 2;
-	    v |= v >> 4;
-	    v |= v >> 8;
-	    v |= v >> 16;
-	    return MultiplyDeBruijnBitPosition[(unsigned int)(v * 0x07C4ACDDU) >> 27];
-
-	    }
-
-
-
+namespace
+{
+const std::array<unsigned int, 32> MultiplyDeBruijnBitPosition
+{
+{ 0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30, 8, 12, 20, 28, 15, 17, 24, 7, 19, 27,
+        23, 6, 26, 5, 4, 31 } };
+unsigned int ilog2(unsigned int v)
+{
+    v |= v >> 1; // first round down to one less than a power of 2
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    return MultiplyDeBruijnBitPosition[(unsigned int) (v * 0x07C4ACDDU) >> 27];
 }
-
-
-
+}
 
 template<class TYPE, unsigned int numberOfDimensions>
 class FKDTree
 {
 
-public:
+    public:
+
+        FKDTree()
+        {
+            theNumberOfPoints = 0;
+            theDepth = 0;
+        }
+
+
+        bool empty()
+        {
+            return theNumberOfPoints == 0;
+        }
+
+        void search(const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+                const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
+                std::vector<unsigned int>& foundPoints)
+        {
+            FQueue<unsigned int> indicesToVisit(16);
+            indicesToVisit.push_back(0);
+            unsigned int index;
+            bool intersection;
+            int dimension;
+            unsigned int numberOfindicesToVisitThisDepth;
+            int numberOfSonsToVisitNext;
+            unsigned int firstSonToVisitNext;
+
+            for (unsigned int depth = 0; depth < theDepth + 1; ++depth)
+            {
+                dimension = depth % numberOfDimensions;
+                numberOfindicesToVisitThisDepth = indicesToVisit.size();
+                for (unsigned int visitedindicesThisDepth = 0;
+                        visitedindicesThisDepth < numberOfindicesToVisitThisDepth;
+                        visitedindicesThisDepth++)
+                {
+
+                    index = indicesToVisit[visitedindicesThisDepth];
+                    intersection = intersects(index, minPoint, maxPoint, dimension);
+                    firstSonToVisitNext = leftSonIndex(index);
+
+                    if (intersection)
+                    {
+                        if (is_in_the_box(index, minPoint, maxPoint))
+                        {
+
+                            foundPoints.emplace_back(theIds[index]);
+                        }
+                        numberOfSonsToVisitNext = (firstSonToVisitNext < theNumberOfPoints)
+                                + ((firstSonToVisitNext + 1) < theNumberOfPoints);
+                    }
+                    else
+                    {
+                        firstSonToVisitNext += (theDimensions[dimension][index]
+                                < minPoint[dimension]);
+
+                        numberOfSonsToVisitNext = std::min(
+                                (firstSonToVisitNext < theNumberOfPoints)
+                                        + ((firstSonToVisitNext + 1) < theNumberOfPoints), 1);
+                    }
+
+                    for (int whichSon = 0; whichSon < numberOfSonsToVisitNext; ++whichSon)
+                    {
+                        indicesToVisit.push_back(firstSonToVisitNext + whichSon);
+                    }
+                }
+                indicesToVisit.pop_front(numberOfindicesToVisitThisDepth);
+            }
+
+        }
+
+
+        void build(std::vector<FKDPoint<TYPE, numberOfDimensions> >& points)
+        {
+
+            theNumberOfPoints = points.size();
+            theDepth = ilog2(theNumberOfPoints);
+            theIntervalLength.resize(theNumberOfPoints, 0);
+            theIntervalMin.resize(theNumberOfPoints, 0);
+            for (unsigned int i = 0; i < numberOfDimensions; ++i)
+                theDimensions[i].resize(theNumberOfPoints);
+            theIds.resize(theNumberOfPoints);
+
+            //gather kdtree building
+            int dimension;
+            theIntervalMin[0] = 0;
+            theIntervalLength[0] = theNumberOfPoints;
+
+            for (unsigned int depth = 0; depth < theDepth; ++depth)
+            {
+
+                dimension = depth % numberOfDimensions;
+                unsigned int firstIndexInDepth = (1 << depth) - 1;
+                unsigned int maxDepth = (1 << depth);
+                for (unsigned int indexInDepth = 0; indexInDepth < maxDepth; ++indexInDepth)
+                {
+                    unsigned int indexInArray = firstIndexInDepth + indexInDepth;
+                    unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
+                    unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
+
+                    unsigned int whichElementInInterval = partition_complete_kdtree(
+                            theIntervalLength[indexInArray]);
+                    std::nth_element(points.begin() + theIntervalMin[indexInArray],
+                            points.begin() + theIntervalMin[indexInArray] + whichElementInInterval,
+                            points.begin() + theIntervalMin[indexInArray]
+                                    + theIntervalLength[indexInArray],
+                            [dimension](const FKDPoint<TYPE,numberOfDimensions> & a,
+                                    const FKDPoint<TYPE,numberOfDimensions> & b) -> bool
+                            {
+                                if(a[dimension] == b[dimension])
+                                return a.getId() < b.getId();
+                                else
+                                return a[dimension] < b[dimension];
+                            });
+                    add_at_position(points[theIntervalMin[indexInArray] + whichElementInInterval],
+                            indexInArray);
+
+                    if (leftSonIndexInArray < theNumberOfPoints)
+                    {
+                        theIntervalMin[leftSonIndexInArray] = theIntervalMin[indexInArray];
+                        theIntervalLength[leftSonIndexInArray] = whichElementInInterval;
+                    }
+
+                    if (rightSonIndexInArray < theNumberOfPoints)
+                    {
+                        theIntervalMin[rightSonIndexInArray] = theIntervalMin[indexInArray]
+                                + whichElementInInterval + 1;
+                        theIntervalLength[rightSonIndexInArray] = (theIntervalLength[indexInArray]
+                                - 1 - whichElementInInterval);
+                    }
+                }
+            }
+
+            dimension = theDepth % numberOfDimensions;
+            unsigned int firstIndexInDepth = (1 << theDepth) - 1;
+            for (unsigned int indexInArray = firstIndexInDepth; indexInArray < theNumberOfPoints;
+                    ++indexInArray)
+            {
+                add_at_position(points[theIntervalMin[indexInArray]], indexInArray);
+
+            }
+
+        }
+
+        std::size_t size() const
+        {
+            return theNumberOfPoints;
+        }
+
+    private:
+
+        unsigned int partition_complete_kdtree(unsigned int length)
+        {
+            if (length == 1)
+                return 0;
+            unsigned int index = 1 << (ilog2(length));
+
+            if ((index / 2) - 1 <= length - index)
+                return index - 1;
+            else
+                return length - index / 2;
+
+        }
+
+        unsigned int leftSonIndex(unsigned int index) const
+        {
+            return 2 * index + 1;
+        }
+
+        unsigned int rightSonIndex(unsigned int index) const
+        {
+            return 2 * index + 2;
+        }
+
+        bool intersects(unsigned int index, const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+                const FKDPoint<TYPE, numberOfDimensions>& maxPoint, int dimension) const
+        {
+            return (theDimensions[dimension][index] <= maxPoint[dimension]
+                    && theDimensions[dimension][index] >= minPoint[dimension]);
+        }
+
+        bool is_in_the_box(unsigned int index, const FKDPoint<TYPE, numberOfDimensions>& minPoint,
+                const FKDPoint<TYPE, numberOfDimensions>& maxPoint) const
+        {
+            for (unsigned int i = 0; i < numberOfDimensions; ++i)
+            {
+                if ((theDimensions[i][index] <= maxPoint[i]
+                        && theDimensions[i][index] >= minPoint[i]) == false)
+                    return false;
+            }
+
+            return true;
+        }
+
+        void add_at_position(const FKDPoint<TYPE, numberOfDimensions>& point,
+                const unsigned int position)
+        {
+            for (unsigned int i = 0; i < numberOfDimensions; ++i)
+                theDimensions[i][position] = point[i];
+            theIds[position] = point.getId();
+
+        }
+
+        void add_at_position(FKDPoint<TYPE, numberOfDimensions> && point,
+                const unsigned int position)
+        {
+            for (unsigned int i = 0; i < numberOfDimensions; ++i)
+                theDimensions[i][position] = point[i];
+            theIds[position] = point.getId();
+
+        }
+
+        unsigned int theNumberOfPoints;
+        unsigned int theDepth;
+        std::array<std::vector<TYPE>, numberOfDimensions> theDimensions;
+        std::vector<unsigned int> theIntervalLength;
+        std::vector<unsigned int> theIntervalMin;
+        std::vector<unsigned int> theIds;
 
-
-FKDTree()
-	{
-		theNumberOfPoints = 0;
-		theDepth = 0;
-
-	}
-
-
-
-	void push_back(const FKDPoint<TYPE, numberOfDimensions>& point)
-	{
-
-		thePoints.push_back(point);
-
-
-	
-	}
-
-	void push_back(FKDPoint<TYPE, numberOfDimensions> && point)
-	{
-
-		thePoints.emplace_back(point);
-
-
-	}
-
-	template <typename ... Args>
-	void emplace_back(Args&&... args) {
-	   push_back(FKDPoint<TYPE, numberOfDimensions>(std::forward<Args>(args)...));
-	}
-
-	bool empty()
-	{
-		return theNumberOfPoints==0;
-	}
-
-
-	void search(
-			const FKDPoint<TYPE, numberOfDimensions>& minPoint,
-			const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
-			std::vector<unsigned int>& foundPoints)
-	{
-		FQueue<unsigned int> indicesToVisit(16);
-		indicesToVisit.push_back(0);
-		unsigned int index;
-		bool intersection;
-		int dimension;
-		unsigned int numberOfindicesToVisitThisDepth;
-		int numberOfSonsToVisitNext;
-		unsigned int firstSonToVisitNext;
-
-		for (unsigned int depth = 0; depth < theDepth + 1; ++depth)
-		{
-
-			dimension = depth % numberOfDimensions;
-			numberOfindicesToVisitThisDepth = indicesToVisit.size();
-			for (unsigned int visitedindicesThisDepth = 0;
-					visitedindicesThisDepth < numberOfindicesToVisitThisDepth;
-					visitedindicesThisDepth++)
-			{
-
-				index = indicesToVisit[visitedindicesThisDepth];
-				intersection = intersects(index, minPoint, maxPoint, dimension);
-				firstSonToVisitNext = leftSonIndex(index);
-            
-
-				if (intersection)
-				{
-					if (is_in_the_box(index, minPoint, maxPoint))
-					{
-										
-						foundPoints.emplace_back(theIds[index]);
-					}
-					numberOfSonsToVisitNext = (firstSonToVisitNext < theNumberOfPoints)
-                 		 + ((firstSonToVisitNext + 1) < theNumberOfPoints);
-				}
-				else
-				{
-
-
-					firstSonToVisitNext += (theDimensions[dimension][index]
-							< minPoint[dimension]);
-
-              		numberOfSonsToVisitNext = std::min((firstSonToVisitNext< theNumberOfPoints)
-                  		+ ((firstSonToVisitNext + 1) < theNumberOfPoints) , 1);
-				}
-
-				for (int whichSon = 0; whichSon < numberOfSonsToVisitNext;
-						++whichSon){
-               
-					indicesToVisit.push_back(firstSonToVisitNext + whichSon);
-			      }
-			}
-
-			indicesToVisit.pop_front(numberOfindicesToVisitThisDepth);
-		}
-	}
-
-
-	void build()
-	{
-
-		theNumberOfPoints =thePoints.size();
-		theDepth = ilog2(theNumberOfPoints);
-		theIntervalLength.resize(theNumberOfPoints, 0);
-		theIntervalMin.resize(theNumberOfPoints, 0);
-      for (unsigned int i = 0; i < numberOfDimensions; ++i)  theDimensions[i].resize(theNumberOfPoints);
-      theIds.resize(theNumberOfPoints);	
-
-		//gather kdtree building
-		int dimension;
-		theIntervalMin[0] = 0;
-		theIntervalLength[0] = theNumberOfPoints;
-
-		for (unsigned int depth = 0; depth < theDepth; ++depth)
-		{
-
-			dimension = depth % numberOfDimensions;
-			unsigned int firstIndexInDepth = (1 << depth) - 1;
-			unsigned int maxDepth = (1 << depth);
-			for (unsigned int indexInDepth = 0; indexInDepth < maxDepth;
-					++indexInDepth)
-			{
-				unsigned int indexInArray = firstIndexInDepth + indexInDepth;
-				unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
-				unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
-
-				unsigned int whichElementInInterval = partition_complete_kdtree(
-						theIntervalLength[indexInArray]);
-				std::nth_element(
-						thePoints.begin() + theIntervalMin[indexInArray],
-						thePoints.begin() + theIntervalMin[indexInArray]
-								+ whichElementInInterval,
-						thePoints.begin() + theIntervalMin[indexInArray]
-								+ theIntervalLength[indexInArray],
-						[dimension](const FKDPoint<TYPE,numberOfDimensions> & a, const FKDPoint<TYPE,numberOfDimensions> & b) -> bool
-						{
-							if(a[dimension] == b[dimension])
-							return a.getId() < b.getId();
-							else
-							return a[dimension] < b[dimension];
-						});
-				add_at_position(
-						thePoints[theIntervalMin[indexInArray]
-								+ whichElementInInterval], indexInArray);
-
-				if (leftSonIndexInArray < theNumberOfPoints)
-				{
-					theIntervalMin[leftSonIndexInArray] =
-							theIntervalMin[indexInArray];
-					theIntervalLength[leftSonIndexInArray] =
-							whichElementInInterval;
-				}
-
-				if (rightSonIndexInArray < theNumberOfPoints)
-				{
-					theIntervalMin[rightSonIndexInArray] =
-							theIntervalMin[indexInArray]
-									+ whichElementInInterval + 1;
-					theIntervalLength[rightSonIndexInArray] =
-							(theIntervalLength[indexInArray] - 1
-									- whichElementInInterval);
-				}
-			}
-		}
-
-		dimension = theDepth % numberOfDimensions;
-		unsigned int firstIndexInDepth = (1 << theDepth) - 1;
-		for (unsigned int indexInArray = firstIndexInDepth;
-				indexInArray < theNumberOfPoints; ++indexInArray)
-		{
-			add_at_position(thePoints[theIntervalMin[indexInArray]],
-					indexInArray);
-
-		}
-
-	}
-
-
-
-
-
-
-
-	void build(std::vector<FKDPoint<TYPE, numberOfDimensions> >& points)
-	{
-
-		theNumberOfPoints = points.size();
-		theDepth = ilog2(theNumberOfPoints);
-		theIntervalLength.resize(theNumberOfPoints, 0);
-		theIntervalMin.resize(theNumberOfPoints, 0);
-		for (unsigned int i = 0; i < numberOfDimensions; ++i)  theDimensions[i].resize(theNumberOfPoints);
-      theIds.resize(theNumberOfPoints);
-
-
-		//gather kdtree building
-		int dimension;
-		theIntervalMin[0] = 0;
-		theIntervalLength[0] = theNumberOfPoints;
-
-		for (unsigned int depth = 0; depth < theDepth; ++depth)
-		{
-
-			dimension = depth % numberOfDimensions;
-			unsigned int firstIndexInDepth = (1 << depth) - 1;
-			unsigned int maxDepth = (1 << depth);
-			for (unsigned int indexInDepth = 0; indexInDepth < maxDepth;
-					++indexInDepth)
-			{
-				unsigned int indexInArray = firstIndexInDepth + indexInDepth;
-				unsigned int leftSonIndexInArray = 2 * indexInArray + 1;
-				unsigned int rightSonIndexInArray = leftSonIndexInArray + 1;
-
-				unsigned int whichElementInInterval = partition_complete_kdtree(
-						theIntervalLength[indexInArray]);
-				std::nth_element(
-						points.begin() + theIntervalMin[indexInArray],
-						points.begin() + theIntervalMin[indexInArray]
-								+ whichElementInInterval,
-						points.begin() + theIntervalMin[indexInArray]
-								+ theIntervalLength[indexInArray],
-						[dimension](const FKDPoint<TYPE,numberOfDimensions> & a, const FKDPoint<TYPE,numberOfDimensions> & b) -> bool
-						{
-							if(a[dimension] == b[dimension])
-							return a.getId() < b.getId();
-							else
-							return a[dimension] < b[dimension];
-						});
-				add_at_position(
-						points[theIntervalMin[indexInArray]
-								+ whichElementInInterval], indexInArray);
-
-				if (leftSonIndexInArray < theNumberOfPoints)
-				{
-					theIntervalMin[leftSonIndexInArray] =
-							theIntervalMin[indexInArray];
-					theIntervalLength[leftSonIndexInArray] =
-							whichElementInInterval;
-				}
-
-				if (rightSonIndexInArray < theNumberOfPoints)
-				{
-					theIntervalMin[rightSonIndexInArray] =
-							theIntervalMin[indexInArray]
-									+ whichElementInInterval + 1;
-					theIntervalLength[rightSonIndexInArray] =
-							(theIntervalLength[indexInArray] - 1
-									- whichElementInInterval);
-				}
-			}
-		}
-
-		dimension = theDepth % numberOfDimensions;
-		unsigned int firstIndexInDepth = (1 << theDepth) - 1;
-		for (unsigned int indexInArray = firstIndexInDepth;
-				indexInArray < theNumberOfPoints; ++indexInArray)
-		{
-			add_at_position(points[theIntervalMin[indexInArray]],
-					indexInArray);
-
-		}
-
-	}
-
-	std::size_t size() const
-	{
-		return theNumberOfPoints;
-	}
-
-private:
-
-	unsigned int partition_complete_kdtree(unsigned int length)
-	{
-		if (length == 1)
-			return 0;
-		unsigned int index = 1 << (ilog2(length));
-
-
-		if ((index / 2) - 1 <= length - index)
-			return index - 1;
-		else
-			return length - index / 2;
-
-	}
-
-	unsigned int leftSonIndex(unsigned int index) const
-	{
-		return 2 * index + 1;
-	}
-
-	unsigned int rightSonIndex(unsigned int index) const
-	{
-		return 2 * index + 2;
-	}
-
-	bool intersects(unsigned int index,
-			const FKDPoint<TYPE, numberOfDimensions>& minPoint,
-			const FKDPoint<TYPE, numberOfDimensions>& maxPoint,
-			int dimension) const
-	{
-		return (theDimensions[dimension][index] <= maxPoint[dimension]
-				&& theDimensions[dimension][index] >= minPoint[dimension]);
-	}
-
-	bool is_in_the_box(unsigned int index,
-			const FKDPoint<TYPE, numberOfDimensions>& minPoint,
-			const FKDPoint<TYPE, numberOfDimensions>& maxPoint) const
-	{
-		for (unsigned int i = 0; i < numberOfDimensions; ++i)
-		{
-			if ((theDimensions[i][index] <= maxPoint[i]
-					&& theDimensions[i][index] >= minPoint[i]) == false)
-				return false;
-		}
-
-		return true;
-	}
-	
-	void add_at_position(const FKDPoint<TYPE, numberOfDimensions>& point,
-			const unsigned int position)
-	{
-		for (unsigned int i = 0; i < numberOfDimensions; ++i)
-			theDimensions[i][position] = point[i];
-		theIds[position] = point.getId();
-
-	}
-
-	void add_at_position(FKDPoint<TYPE, numberOfDimensions> && point,
-			const unsigned int position)
-	{
-		for (unsigned int i = 0; i < numberOfDimensions; ++i)
-			theDimensions[i][position] = point[i];
-		theIds[position] = point.getId();
-
-	}
-
-	unsigned int theNumberOfPoints;
-	unsigned int theDepth;
-	std::vector<FKDPoint<TYPE, numberOfDimensions> > thePoints;
-	std::array<std::vector<TYPE>, numberOfDimensions> theDimensions;
-	std::vector<unsigned int> theIntervalLength;
-	std::vector<unsigned int> theIntervalMin;
-	std::vector<unsigned int> theIds;
 };
 
 #endif 

--- a/CommonTools/RecoAlgos/interface/FQueue.h
+++ b/CommonTools/RecoAlgos/interface/FQueue.h
@@ -1,0 +1,151 @@
+#ifndef COMMONTOOLS_RECOALGOS_FQUEUE_H
+#define COMMONTOOLS_RECOALGOS_FQUEUE_H
+
+#include <vector>
+
+
+template<class T>
+
+class FQueue
+{
+public:
+	FQueue()
+	{
+		theSize = 0;
+		theFront = 0;
+		theTail = 0;
+		theCapacity = 0;
+
+	}
+
+	FQueue(unsigned int initialCapacity)
+	{
+
+		theBuffer.resize(initialCapacity);
+
+		theSize = 0;
+		theFront = 0;
+		theTail = 0;
+
+		theCapacity = initialCapacity;
+	}
+
+
+
+	unsigned int size() const
+	{
+		return theSize;
+	}
+
+
+	bool empty() const
+	{
+		return theSize == 0;
+	}
+
+
+	T front() const
+	{
+
+		return theBuffer[theFront];
+
+	}
+	T & tail()
+	{
+		return theBuffer[theTail];
+	}
+
+  	constexpr unsigned int wrapIndex(unsigned int i) {
+    	return i & (theBuffer.size()-1);
+ 	}
+
+
+	void push_back(const T & value)
+	{
+
+		if (theSize >= theCapacity)
+		{
+			theBuffer.resize(theCapacity *2);
+			if (theFront != 0)
+			{
+				std::copy(theBuffer.begin(), theBuffer.begin() + theTail, theBuffer.begin() + theCapacity);
+
+				theTail += theSize;
+
+
+			}
+			else
+			{
+
+				theTail += theCapacity;
+
+			}
+			theCapacity *=2;
+
+		}
+
+
+		theBuffer[theTail] = value;
+		theTail = wrapIndex(theTail + 1);
+
+		theSize++;
+
+
+	}
+
+
+
+	void pop_front()
+	{
+
+		if (theSize > 0)
+		{
+			theFront = wrapIndex(theFront + 1);
+			theSize--;
+
+
+		}
+	}
+
+	void pop_front(const unsigned int numberOfElementsToPop)
+	{
+		unsigned int elementsToErase =
+				theSize > numberOfElementsToPop ?
+						numberOfElementsToPop : theSize;
+		theSize -= elementsToErase;
+		theFront = wrapIndex(theFront + elementsToErase);
+	}
+
+	void reserve(unsigned int capacity)
+	{
+
+		theBuffer.reserve(capacity);
+
+	}
+
+	T & operator[](unsigned int index)
+	{
+		return theBuffer[wrapIndex(theFront + index)];
+	}
+
+	void clear()
+	{
+
+		theBuffer.clear();
+
+		theSize = 0;
+		theFront = 0;
+		theTail = 0;
+	}
+private:
+	unsigned int theSize;
+	unsigned int theFront;
+	unsigned int theTail;
+
+	std::vector<T> theBuffer;
+
+	unsigned int theCapacity;
+
+};
+
+#endif

--- a/CommonTools/RecoAlgos/interface/FQueue.h
+++ b/CommonTools/RecoAlgos/interface/FQueue.h
@@ -3,148 +3,119 @@
 
 #include <vector>
 
-
 template<class T>
 
 class FQueue
 {
-public:
-	FQueue()
-	{
-		theSize = 0;
-		theFront = 0;
-		theTail = 0;
-		theCapacity = 0;
+    public:
+        FQueue()
+        {
+            theSize = 0;
+            theFront = 0;
+            theTail = 0;
+            theCapacity = 0;
+        }
 
-	}
+        FQueue(unsigned int initialCapacity)
+        {
+            theBuffer.resize(initialCapacity);
+            theSize = 0;
+            theFront = 0;
+            theTail = 0;
+            theCapacity = initialCapacity;
+        }
 
-	FQueue(unsigned int initialCapacity)
-	{
+        unsigned int size() const
+        {
+            return theSize;
+        }
 
-		theBuffer.resize(initialCapacity);
+        bool empty() const
+        {
+            return theSize == 0;
+        }
 
-		theSize = 0;
-		theFront = 0;
-		theTail = 0;
+        T front() const
+        {
+            return theBuffer[theFront];
+        }
 
-		theCapacity = initialCapacity;
-	}
+        T & tail()
+        {
+            return theBuffer[theTail];
+        }
 
+        constexpr unsigned int wrapIndex(unsigned int i)
+        {
+            return i & (theBuffer.size() - 1);
+        }
 
+        void push_back(const T & value)
+        {
+            if (theSize >= theCapacity)
+            {
+                theBuffer.resize(theCapacity * 2);
+                if (theFront != 0)
+                {
+                    std::copy(theBuffer.begin(), theBuffer.begin() + theTail,
+                            theBuffer.begin() + theCapacity);
 
-	unsigned int size() const
-	{
-		return theSize;
-	}
+                    theTail += theSize;
 
+                }
+                else
+                {
+                    theTail += theCapacity;
+                }
+                theCapacity *= 2;
+            }
+            theBuffer[theTail] = value;
+            theTail = wrapIndex(theTail + 1);
+            theSize++;
 
-	bool empty() const
-	{
-		return theSize == 0;
-	}
+        }
 
+        void pop_front()
+        {
+            if (theSize > 0)
+            {
+                theFront = wrapIndex(theFront + 1);
+                theSize--;
+            }
+        }
 
-	T front() const
-	{
+        void pop_front(const unsigned int numberOfElementsToPop)
+        {
+            unsigned int elementsToErase =
+                    theSize > numberOfElementsToPop ? numberOfElementsToPop : theSize;
+            theSize -= elementsToErase;
+            theFront = wrapIndex(theFront + elementsToErase);
+        }
 
-		return theBuffer[theFront];
+        void reserve(unsigned int capacity)
+        {
+            theBuffer.reserve(capacity);
+        }
 
-	}
-	T & tail()
-	{
-		return theBuffer[theTail];
-	}
+        T & operator[](unsigned int index)
+        {
+            return theBuffer[wrapIndex(theFront + index)];
+        }
 
-  	constexpr unsigned int wrapIndex(unsigned int i) {
-    	return i & (theBuffer.size()-1);
- 	}
+        void clear()
+        {
+            theBuffer.clear();
+            theSize = 0;
+            theFront = 0;
+            theTail = 0;
+        }
 
-
-	void push_back(const T & value)
-	{
-
-		if (theSize >= theCapacity)
-		{
-			theBuffer.resize(theCapacity *2);
-			if (theFront != 0)
-			{
-				std::copy(theBuffer.begin(), theBuffer.begin() + theTail, theBuffer.begin() + theCapacity);
-
-				theTail += theSize;
-
-
-			}
-			else
-			{
-
-				theTail += theCapacity;
-
-			}
-			theCapacity *=2;
-
-		}
-
-
-		theBuffer[theTail] = value;
-		theTail = wrapIndex(theTail + 1);
-
-		theSize++;
-
-
-	}
-
-
-
-	void pop_front()
-	{
-
-		if (theSize > 0)
-		{
-			theFront = wrapIndex(theFront + 1);
-			theSize--;
-
-
-		}
-	}
-
-	void pop_front(const unsigned int numberOfElementsToPop)
-	{
-		unsigned int elementsToErase =
-				theSize > numberOfElementsToPop ?
-						numberOfElementsToPop : theSize;
-		theSize -= elementsToErase;
-		theFront = wrapIndex(theFront + elementsToErase);
-	}
-
-	void reserve(unsigned int capacity)
-	{
-
-		theBuffer.reserve(capacity);
-
-	}
-
-	T & operator[](unsigned int index)
-	{
-		return theBuffer[wrapIndex(theFront + index)];
-	}
-
-	void clear()
-	{
-
-		theBuffer.clear();
-
-		theSize = 0;
-		theFront = 0;
-		theTail = 0;
-	}
-private:
-	unsigned int theSize;
-	unsigned int theFront;
-	unsigned int theTail;
-
-	std::vector<T> theBuffer;
-
-	unsigned int theCapacity;
+    private:
+        unsigned int theSize;
+        unsigned int theFront;
+        unsigned int theTail;
+        std::vector<T> theBuffer;
+        unsigned int theCapacity;
 
 };
 

--- a/CommonTools/RecoAlgos/interface/FQueue.h
+++ b/CommonTools/RecoAlgos/interface/FQueue.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 template<class T>
-
 class FQueue
 {
     public:

--- a/CommonTools/RecoAlgos/test/BuildFile.xml
+++ b/CommonTools/RecoAlgos/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<use   name="cppunit"/>
+<use   name="CommonTools/RecoAlgos"/>
+<bin   file="FKDTree_t.cpp">
+
+</bin>

--- a/CommonTools/RecoAlgos/test/FKDTree_t.cpp
+++ b/CommonTools/RecoAlgos/test/FKDTree_t.cpp
@@ -1,0 +1,142 @@
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
+
+class TestFKDTree: public CppUnit::TestFixture
+{
+        CPPUNIT_TEST_SUITE (TestFKDTree);
+        CPPUNIT_TEST (test2D);
+        CPPUNIT_TEST (test3D);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        /// run all test tokenizer
+        void test2D();
+        void test3D();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION (TestFKDTree);
+
+#include "CommonTools/RecoAlgos/interface/FKDTree.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+void TestFKDTree::test2D()
+{
+    try
+    {
+        FKDTree<float, 2> tree;
+        float minX = 0.2;
+        float minY = 0.1;
+        float maxX = 0.7;
+        float maxY = 0.9;
+        unsigned int numberOfPointsInTheBox = 1000;
+        unsigned int numberOfPointsOutsideTheBox = 5000;
+        std::vector<FKDPoint<float, 2> > points;
+        std::vector<unsigned int> result;
+
+        FKDPoint<float, 2> minPoint(minX, minY);
+        FKDPoint<float, 2> maxPoint(maxX, maxY);
+        unsigned int id = 0;
+
+        for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i)
+        {
+            float x = minX
+                    + static_cast<float>(rand())
+                            / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
+
+            float y = minY
+                    + static_cast<float>(rand())
+                            / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
+
+            points.emplace_back(x, y, id);
+            id++;
+        }
+
+        for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i)
+        {
+            float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
+            float y;
+            if (x <= maxX && x >= minX)
+                y = maxY
+                        + static_cast<float>(rand())
+                                / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
+
+            points.emplace_back(x, y, id);
+            id++;
+
+        }
+        tree.build(points);
+        tree.search(minPoint,maxPoint,result);
+        CPPUNIT_ASSERT_EQUAL((unsigned int)tree.size(), numberOfPointsInTheBox+numberOfPointsOutsideTheBox);
+
+        CPPUNIT_ASSERT_EQUAL((unsigned int)result.size(), numberOfPointsInTheBox);
+    } catch (cms::Exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        CPPUNIT_ASSERT(false);
+    }
+}
+void TestFKDTree::test3D()
+{
+    try
+    {
+        FKDTree<float, 3> tree;
+        float minX = 0.2;
+        float minY = 0.1;
+        float minZ = 0.1;
+        float maxX = 0.7;
+        float maxY = 0.9;
+        float maxZ = 0.3;
+
+        unsigned int numberOfPointsInTheBox = 1000;
+        unsigned int numberOfPointsOutsideTheBox = 5000;
+        std::vector<FKDPoint<float, 3> > points;
+        std::vector<unsigned int> result;
+
+        FKDPoint<float, 3> minPoint(minX, minY, minZ);
+        FKDPoint<float, 3> maxPoint(maxX, maxY, maxZ);
+        unsigned int id = 0;
+
+        for (unsigned int i = 0; i < numberOfPointsInTheBox; ++i)
+        {
+            float x = minX
+                    + static_cast<float>(rand())
+                            / (static_cast<float>(RAND_MAX / std::fabs(maxX - minX)));
+
+            float y = minY
+                    + static_cast<float>(rand())
+                            / (static_cast<float>(RAND_MAX / std::fabs(maxY - minY)));
+            float z = minZ
+                    + static_cast<float>(rand())
+                            / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
+
+            points.emplace_back(x, y, z, id);
+            id++;
+        }
+
+        for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i)
+        {
+            float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
+            float y;
+            if (x <= maxX && x >= minX)
+                y = maxY
+                        + static_cast<float>(rand())
+                                / (static_cast<float>(RAND_MAX / std::fabs(1.f - maxY)));
+            float z = minZ
+                    + static_cast<float>(rand())
+                            / (static_cast<float>(RAND_MAX / std::fabs(maxZ - minZ)));
+
+            points.emplace_back(x, y, z, id);
+            id++;
+
+        }
+        tree.build(points);
+        tree.search(minPoint,maxPoint,result);
+        CPPUNIT_ASSERT_EQUAL((unsigned int)tree.size(), numberOfPointsInTheBox+numberOfPointsOutsideTheBox);
+        CPPUNIT_ASSERT_EQUAL((unsigned int)result.size(), numberOfPointsInTheBox);
+
+    } catch (cms::Exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        CPPUNIT_ASSERT(false);
+    }
+}


### PR DESCRIPTION
This PR adds a fast/parallel-friendly kd-tree implementation in CommonTools. 
The plan is to replace the existing PF KDtree (based on lists) with this one which is based on vectors and SoA in HGCal wfs, making it friendly for accelerators. 
Searching and building produces exactly the same results, searching with 3D point cloud of about 100k points makes it ~3x faster than the existing implementation.

@rovere @malgeri @VinInn @makortel 