### PR TITLE
New muon validation fixes

### DIFF
--- a/Validation/RecoMuon/plugins/NewMuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/NewMuonTrackValidator.cc
@@ -14,6 +14,7 @@
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
 #include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
+#include "SimTracker/TrackAssociation/interface/TrackingParticleIP.h"
 
 #include "TMath.h"
 #include <TF1.h>
@@ -366,9 +367,8 @@ void NewMuonTrackValidator::analyze(const edm::Event& event, const edm::EventSet
 	    vertexTP = tp->vertex();
 	    TrackingParticle::Vector momentum = Lhc_parametersDefinerTP->momentum(event,setup,tpr);
 	    TrackingParticle::Point vertex = Lhc_parametersDefinerTP->vertex(event,setup,tpr);
-	    dxySim = (-vertex.x()*sin(momentum.phi())+vertex.y()*cos(momentum.phi()));
-	    dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y()) /
-	                          sqrt(momentum.perp2()) * momentum.z()/sqrt(momentum.perp2());
+	    dxySim = TrackingParticleIP::dxy(vertex, momentum, bs.position());
+	    dzSim = TrackingParticleIP::dz(vertex, momentum, bs.position());
 	  }
 	//for cosmics get the momentum and vertex at PCA
 	else if(parametersDefiner=="CosmicParametersDefinerForTP")
@@ -377,9 +377,8 @@ void NewMuonTrackValidator::analyze(const edm::Event& event, const edm::EventSet
 	    if(! cosmictpSelector(tpr,&bs,event,setup)) continue;	
 	    momentumTP = Cosmic_parametersDefinerTP->momentum(event,setup,tpr);
 	    vertexTP = Cosmic_parametersDefinerTP->vertex(event,setup,tpr);
-	    dxySim = (-vertexTP.x()*sin(momentumTP.phi())+vertexTP.y()*cos(momentumTP.phi()));
-	    dzSim = vertexTP.z() - (vertexTP.x()*momentumTP.x()+vertexTP.y()*momentumTP.y()) /
-	                            sqrt(momentumTP.perp2()) * momentumTP.z()/sqrt(momentumTP.perp2());
+	    dxySim = TrackingParticleIP::dxy(vertexTP, momentumTP, bs.position());
+	    dzSim = TrackingParticleIP::dz(vertexTP, momentumTP, bs.position());
 	  }
 	edm::LogVerbatim("NewMuonTrackValidator") <<"--------------------Selected TrackingParticle #"<<tpr.key();
 	edm::LogVerbatim("NewMuonTrackValidator") <<"momentumTP: pt = "<<sqrt(momentumTP.perp2())<<", pz = "<<momentumTP.z() 
@@ -700,9 +699,8 @@ void NewMuonTrackValidator::analyze(const edm::Event& event, const edm::EventSet
 	double etaSim = momentumTP.eta();
 	double thetaSim = momentumTP.theta();
 	double phiSim = momentumTP.phi();
-	double dxySim = (-vertexTP.x()*sin(momentumTP.phi())+vertexTP.y()*cos(momentumTP.phi()));
-	double dzSim = vertexTP.z() - (vertexTP.x()*momentumTP.x()+vertexTP.y()*momentumTP.y()) /
-	                               sqrt(momentumTP.perp2()) * momentumTP.z()/sqrt(momentumTP.perp2());
+	double dxySim = TrackingParticleIP::dxy(vertexTP, momentumTP, bs.position());
+	double dzSim = TrackingParticleIP::dz(vertexTP, momentumTP, bs.position());
 	
 	double etares = etaRec - etaSim;
 	double ptRelRes = (ptRec - ptSim) / ptSim;    // relative residual -> resolution

--- a/Validation/RecoMuon/python/NewAssociators_cff.py
+++ b/Validation/RecoMuon/python/NewAssociators_cff.py
@@ -36,7 +36,13 @@ MABH.EfficiencyCut_muon = 0.     # for high pt muons this is a better choice
 MABH.PurityCut_muon = 0.75
 MABH.includeZeroHitMuons = False
 #
+# temporary fix for Phase2
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( MABH, EfficiencyCut_track = 0. )
+phase2_tracker.toModify( MABH, PurityCut_track = 0. )
+#
 MABHhlt = MABH.clone()
+MABHhlt.EfficiencyCut_track = 0. # backup solution as UseGrouped/UseSplitting are always assumed to be true
 MABHhlt.DTrechitTag = 'hltDt1DRecHits'
 MABHhlt.ignoreMissingTrackCollection = True
 ################################################

--- a/Validation/RecoMuon/python/NewMuonValidation_cff.py
+++ b/Validation/RecoMuon/python/NewMuonValidation_cff.py
@@ -173,6 +173,9 @@ NEWmuonValidation_reduced_seq = cms.Sequence(
     NEWprobeTracks_seq + NEWtpToTkMuonAssociation + NEWtrkProbeTrackVMuonAssoc
     +NEWtpToStaUpdMuonAssociation + NEWstaUpdMuonTrackVMuonAssoc
     +NEWtpToGlbMuonAssociation + NEWglbMuonTrackVMuonAssoc
+    +NEWtpToDisplacedStaMuonAssociation + NEWdisplacedStaMuonTrackVMuonAssoc
+    +NEWtpToDisplacedTrkMuonAssociation + NEWdisplacedTrackVMuonAssoc
+    +NEWtpToDisplacedGlbMuonAssociation + NEWdisplacedGlbMuonTrackVMuonAssoc
 )
 
 NEWmuonValidationTEV_seq = cms.Sequence(

--- a/Validation/RecoMuon/python/customiseForNewMuonValidation.py
+++ b/Validation/RecoMuon/python/customiseForNewMuonValidation.py
@@ -3,8 +3,9 @@ import FWCore.ParameterSet.Config as cms
 def enableNewMuonVal(process):
     "Enable new muon validation sequence, both for sources and harvesting"    
     
-    if hasattr(process,"validation")       and \
-       not hasattr(process,"validationHI") and \
+    if hasattr(process,"validation")              and \
+       not hasattr(process,"validationHI")        and \
+       not hasattr(process,"prevalidation_step2") and \
        hasattr(process,"recoMuonValidation") :
     
         print "[enableNewMuonVal] : pp RECO"
@@ -14,6 +15,19 @@ def enableNewMuonVal(process):
         if hasattr(process,"validation") :
             process.validation.replace(process.recoMuonValidation, \
                                        process.NEWrecoMuonValidation)
+
+    if hasattr(process,"globalPrevalidationMuons") and \
+       hasattr(process,"prevalidation_step2")      and \
+       not hasattr(process,"validationHI")         and \
+       hasattr(process,"recoMuonValidation") :
+    
+        print "[enableNewMuonVal] : pp RECO Upgrades"
+    
+        process.load("Validation.RecoMuon.NewMuonValidation_cff")
+    
+        if hasattr(process,"validation") :
+            process.globalPrevalidationMuons.replace(process.recoMuonValidation, \
+                                                     process.NEWrecoMuonValidation)
 
     if hasattr(process,"hltvalidation")    and \
        not hasattr(process,"validationHI") and \
@@ -67,6 +81,15 @@ def enableNewMuonVal(process):
         if hasattr(process,"postValidation") :
             process.postValidation.replace(process.recoMuonPostProcessors, \
                                            process.NEWrecoMuonPostProcessors)
+
+    if hasattr(process,"postValidation_muons") and \
+       hasattr(process,"recoMuonPostProcessors") :
+
+        process.load("Validation.RecoMuon.NewPostProcessor_cff")
+
+        if hasattr(process,"postValidation_muons") :
+            process.postValidation_muons.replace(process.recoMuonPostProcessors, \
+                                                 process.NEWrecoMuonPostProcessors)
 
     if hasattr(process,"postValidationHI") and \
        hasattr(process,"recoMuonPostProcessors") :


### PR DESCRIPTION
These are fixes to the New muon validation, determined after checks of few relevant workflows.
Comparison plots of New vs production validation are visible here:
https://cmsdoc.cern.ch/cms/Physics/muon/CMSSW/Performance/RecoMuon/Validation/val/test_NewValidation/
All the visible features are expected, due to the new validation.
In addition it synchronizes the New validation with concurrent changes in the production version.
