### PR TITLE
Fixes in CalibTracker/SiStripChannelGain

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.cc
@@ -78,7 +78,7 @@ SiStripApvGain * SiStripGainFromAsciiFile::getNewObject(){
     nApvPair=reader.getNumberOfApvsAndStripLength(*it).first/2;
     
     ss << "Looking at detid " << *it << " nApvPairs  " << nApvPair << std::endl;
-    __gnu_cxx::hash_map< unsigned int,ModuleGain>::const_iterator iter=GainsMap.find(*it);    
+    auto iter=GainsMap.find(*it);    
     if (iter!=GainsMap.end()){
       MG = iter->second;
       ss << " " <<  MG.apv[0] << " " <<  MG.apv[1] << " " <<  MG.apv[2] <<  " " <<  MG.apv[3] << " " <<  MG.apv[4] << " " <<  MG.apv[5] << std::endl;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.h
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromAsciiFile.h
@@ -7,7 +7,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
 #include <vector>
 
-#include <ext/hash_map>
+#include <unordered_map>
 
 class SiStripGainFromAsciiFile : public ConditionDBWriter<SiStripApvGain> {
 
@@ -34,8 +34,7 @@ private:
   float referenceValue_;
   edm::FileInPath fp_;
 
-  __gnu_cxx::hash_map< unsigned int,ModuleGain>  GainsMap;
-  //std::map< unsigned int,ModuleGain>  GainsMap;
+  std::unordered_map< unsigned int,ModuleGain>  GainsMap;
 
 };
 #endif

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -76,16 +76,13 @@
 #include "TTree.h"
 #include "TChain.h"
 
-#include <ext/hash_map>
+#include <unordered_map>
 
 
 
 using namespace edm;
 using namespace reco;
 using namespace std;
-using namespace __gnu_cxx;
-using __gnu_cxx::hash_map;
-using __gnu_cxx::hash;
 
 struct stAPVGain{
   unsigned int Index; 
@@ -261,13 +258,9 @@ private:
 	string CalibSuffix_; //("");
 
 private :
-	class isEqual{
-	public:
-		template <class T> bool operator () (const T& PseudoDetId1, const T& PseudoDetId2) { return PseudoDetId1==PseudoDetId2; }
-	};
 
 	std::vector<stAPVGain*> APVsCollOrdered;
-	__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual > APVsColl;
+        std::unordered_map<unsigned int, stAPVGain*> APVsColl;
 };
 
 inline int
@@ -1015,7 +1008,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
 	printf("Progressing Bar              :0%%       20%%       40%%       60%%       80%%       100%%\n");
 	printf("Fitting Charge Distribution  :");
 	int TreeStep = APVsColl.size()/50;
-	for(__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual >::iterator it = APVsColl.begin();it!=APVsColl.end();it++,I++){
+	for(auto it = APVsColl.begin();it!=APVsColl.end();it++,I++){
 		if(I%TreeStep==0){printf(".");fflush(stdout);}
 		stAPVGain* APV = it->second;
 		if(APV->Bin<0) APV->Bin = chvsidx->GetXaxis()->FindBin(APV->Index);
@@ -1035,8 +1028,7 @@ void SiStripGainFromCalibTree::algoComputeMPVandGain() {
 			if(Proj2){Proj->Add(Proj2,1);delete Proj2;}
 		}else if(CalibrationLevel==2){
 			for(unsigned int i=0;i<16;i++){  //loop up to 6APV for Strip and up to 16 for Pixels
-				__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual >::iterator tmpit;
-				tmpit = APVsColl.find((APV->DetId<<4) | i);
+				auto tmpit = APVsColl.find((APV->DetId<<4) | i);
 				if(tmpit==APVsColl.end())continue;
 				stAPVGain* APV2 = tmpit->second;
 				if(APV2->DetId != APV->DetId || APV2->APVId == APV->APVId)continue;            

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -193,6 +193,7 @@ private:
         enum statistic_type {None=-1, StdBunch, StdBunch0T, FaABunch, FaABunch0T, IsoBunch, IsoBunch0T, Harvest};
 
         std::vector<string>    dqm_tag_;
+        std::string booked_dir_;
 
         std::vector<MonitorElement*>  Charge_Vs_Index;
         //std::vector<MonitorElement*>  Charge_Vs_Index_Absolute;
@@ -403,13 +404,11 @@ SiStripGainFromCalibTree::SiStripGainFromCalibTree(const edm::ParameterSet& iCon
 
 void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* tag)
 {
-    static std::string booked_dir = "";
-
     edm::LogInfo("SiStripGainFromCalibTree") << "Setting " << dqm_dir << "in DQM and booking histograms for tag "
                                              << tag << std::endl;
 
-    if ( strcmp(booked_dir.c_str(),dqm_dir)!=0 ) {
-        booked_dir = dqm_dir;
+    if ( strcmp(booked_dir_.c_str(),dqm_dir)!=0 ) {
+        booked_dir_ = dqm_dir;
         dbe->setCurrentFolder(dqm_dir);
     }
 

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -66,16 +66,13 @@
 #include "TF1.h"
 #include "TROOT.h"
 
-#include <ext/hash_map>
+#include <unordered_map>
 
 
 
 using namespace edm;
 using namespace reco;
 using namespace std;
-using namespace __gnu_cxx;
-using __gnu_cxx::hash_map;
-using __gnu_cxx::hash;
 
 
 struct stAPVGain{unsigned int Index; int DetId; int APVId; int SubDet; float Eta; float R; float Phi; float Thickness; double MPV; double Gain; double PreviousGain; char Side;};
@@ -284,7 +281,7 @@ class SiStripGainFromData : public ConditionDBWriter<SiStripApvGain> {
       };
 
       std::vector<stAPVGain*> APVsCollOrdered;
-      __gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual > APVsColl;
+      std::unordered_map<unsigned int, stAPVGain*> APVsColl;
 };
 
 SiStripGainFromData::SiStripGainFromData(const edm::ParameterSet& iConfig) : ConditionDBWriter<SiStripApvGain>(iConfig)
@@ -643,7 +640,7 @@ SiStripGainFromData::algoEndJob() {
       TH1D* Proj = NULL;
       double* FitResults = new double[5];
       I=0;
-      for(__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual >::iterator it = APVsColl.begin();it!=APVsColl.end();it++){
+      for(auto it = APVsColl.begin();it!=APVsColl.end();it++){
          if( I%3650==0 ) printf("Fitting Histograms \t %6.2f%%\n",(100.0*I)/APVsColl.size());
          I++;
          stAPVGain* APV = it->second;
@@ -670,7 +667,7 @@ SiStripGainFromData::algoEndJob() {
 	    }
          }else if(CalibrationLevel>1){
 //	     printf("%8i %i--> %4.0f + %4.0f\n",APV->DetId, APV->APVId, 0.0, Proj->GetEntries());
-             for(__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual >::iterator it2 = APVsColl.begin();it2!=APVsColl.end();it2++){
+             for(auto it2 = APVsColl.begin();it2!=APVsColl.end();it2++){
                 stAPVGain* APV2 = it2->second;
              
                 if(APV2->DetId != APV->DetId)continue;
@@ -766,7 +763,7 @@ SiStripGainFromData::algoEndJob() {
       unsigned int BAD  = 0;
       double MPVmean = MPVs->GetMean();
       MPVmean = 300;
-      for(__gnu_cxx::hash_map<unsigned int, stAPVGain*,  __gnu_cxx::hash<unsigned int>, isEqual >::iterator it = APVsColl.begin();it!=APVsColl.end();it++){
+      for(auto it = APVsColl.begin();it!=APVsColl.end();it++){
 
          stAPVGain*   APV = it->second;
          if(APV->MPV>0){


### PR DESCRIPTION
replaced non-standard __gnu_cxx::hash_map with std::unordered_map
removed the use of a static variable