### PR TITLE
By default digitize single partition ME0 geometry with custom parameters

### DIFF
--- a/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
@@ -80,7 +80,7 @@ private:
 
   //paramters
   const float bxWidth;              // ns
-  bool         useBuiltinGeo     ; //Use CMSSW defined geometry for digitization, not custom strips and partitions
+  bool         useCusGeoFor1PartGeo      ; //Use custom strips and partitions for digitization for single partition geometry
   unsigned int numberOfStrips     ; // Custom number of strips per partition
   unsigned int numberOfPartitions; // Custom number of partitions per chamber
   double       neutronAcceptance ; // fraction of neutron events to keep in event (>= 1 means no filtering)
@@ -89,9 +89,9 @@ private:
   int          maxBXReadout      ; // Maximum BX to readout
   std::vector<int> layerReadout  ; // Don't readout layer if entry is 0 (Layer number 1 in the numbering scheme is idx 0)
   bool         mergeDigis        ; // Keep only one digi at the same chamber, strip, partition, and BX
-
-
   edm::EDGetTokenT<ME0DigiPreRecoCollection> token;
+
+  bool         useBuiltinGeo     ;
   const ME0Geometry* geometry;
   TemporaryGeometry* tempGeo;
   std::vector<std::vector<double> > tofs ;  //used for built in geo

--- a/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0ReDigis_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # Module to create simulated ME0 Pre Reco digis.
 simMuonME0ReDigis = cms.EDProducer("ME0ReDigiProducer",
     inputCollection    =cms.string('simMuonME0Digis'),
-    useBuiltinGeo      =cms.bool(True),   #Use CMSSW defined geometry for digitization, not custom strips and paritions
+    useCusGeoFor1PartGeo =cms.bool(True),   #Use custom strips and partitions for digitization for single partition geometry
     numberOfStrips     =cms.uint32(384), # If use custom: number of strips per partition                                             
     numberOfPartitions =cms.uint32(8),   # If use custom:  number of partitions per chamber                                           
     neutronAcceptance  =cms.double(2.0),   # fraction of neutron events to keep in event (>= 1 means no filtering)      

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -24,7 +24,7 @@
 ME0ReDigiProducer::TemporaryGeometry::TemporaryGeometry(const ME0Geometry* geometry, const unsigned int numberOfStrips, const unsigned int numberOfPartitions) {
 	//First test geometry to make sure that it is compatible with our assumptions
 	const auto& chambers = geometry->chambers();
-	if(!chambers.size())
+	if(chambers.empty())
 		throw cms::Exception("Setup") << "ME0ReDigiProducer::TemporaryGeometry::TemporaryGeometry() - No ME0Chambers in geometry.";
 	const auto* mainChamber = chambers.front();
 	const unsigned int nLayers = chambers.front()->nLayers();
@@ -185,7 +185,7 @@ void ME0ReDigiProducer::beginRun(const edm::Run&, const edm::EventSetup& eventSe
 	geometry= &*hGeom;
 
 	const auto& chambers = geometry->chambers();
-	if(!chambers.size())
+	if(chambers.empty())
 		throw cms::Exception("Setup") << "ME0ReDigiProducer::beginRun() - No ME0Chambers in geometry.";
 
 	const unsigned int nLayers = chambers.front()->nLayers();

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -135,7 +135,7 @@ TrapezoidalStripTopology * ME0ReDigiProducer::TemporaryGeometry::buildTopo(const
 
 ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps) :
 		bxWidth            (25.0),
-		useBuiltinGeo      (ps.getParameter<bool>("useBuiltinGeo")),
+		useCusGeoFor1PartGeo(ps.getParameter<bool>("useCusGeoFor1PartGeo")),
 		numberOfStrips      (ps.getParameter<unsigned int>("numberOfStrips")),
 		numberOfPartitions (ps.getParameter<unsigned int>("numberOfPartitions")),
 		neutronAcceptance  (ps.getParameter<double>("neutronAcceptance")),
@@ -157,8 +157,9 @@ ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps) :
 	}
 	geometry = 0;
 	tempGeo = 0;
+	useBuiltinGeo = true;
 
-	if(!useBuiltinGeo){
+	if(useCusGeoFor1PartGeo){
 		if(numberOfStrips == 0)
 			throw cms::Exception("Setup") << "ME0ReDigiProducer::ME0PreRecoDigiProducer() - Must have at least one strip if using custom geometry.";
 		if(numberOfPartitions == 0)
@@ -183,11 +184,20 @@ void ME0ReDigiProducer::beginRun(const edm::Run&, const edm::EventSetup& eventSe
 	eventSetup.get<MuonGeometryRecord>().get(hGeom);
 	geometry= &*hGeom;
 
+	const auto& chambers = geometry->chambers();
+	if(!chambers.size())
+		throw cms::Exception("Setup") << "ME0ReDigiProducer::beginRun() - No ME0Chambers in geometry.";
+
+	const unsigned int nLayers = chambers.front()->nLayers();
+	if(!nLayers) throw cms::Exception("Setup") << "ME0ReDigiProducer::beginRun() - No layers in ME0 geometry.";
+
+	const unsigned int nPartitions = chambers.front()->layers()[0]->nEtaPartitions();
+
+	if(useCusGeoFor1PartGeo && nPartitions == 1){
+		useBuiltinGeo = false;
+	}
+
 	if(useBuiltinGeo){
-		const auto& chambers = geometry->chambers();
-		if(!chambers.size())
-			throw cms::Exception("Setup") << "ME0ReDigiProducer::beginRun() - No ME0Chambers in geometry.";
-		const unsigned int nLayers = chambers.front()->nLayers();
 		if(nLayers != layerReadout.size() )
 			throw cms::Exception("Configuration") << "ME0ReDigiProducer::beginRun() - The geometry has "<<nLayers
 			<< " layers, but the readout of "<<layerReadout.size() << " were specified with the layerReadout parameter."  ;


### PR DESCRIPTION
PR #18113 Updated the digitizer to use either the built-in geometry or the custom one defined in the parameter set. For single partition geometries, which will not be used in the Muon TDR, this resulted in a single partition digitization. In order to allow for better default behavior in geometries such as D4 the default is to now use the custom geometry whenever there is a single partition geometry.

The "useBuiltInGeo" parameter wasn't useful for geometries other than single partition ones. It would return an error if you tried to use it on a multi-partition one. Instead it was replaced with "useCusGeoFor1PartGeo" which is only used on single partition geometries. No change in the reconstruction for the default, D12 geometry. 

D4 geometry (1 partition) before this PR:
[hitMap_D4_beforePR.pdf](https://github.com/cms-sw/cmssw/files/911793/hitMap_D4_beforePR.pdf)

D4 geometry (1 partition) after this PR:
[hitMap_D4_afterPR.pdf](https://github.com/cms-sw/cmssw/files/911795/hitMap_D4_afterPR.pdf)

D12 geometry (8 partition) before this PR:
[hitMap_D12_beforePR.pdf](https://github.com/cms-sw/cmssw/files/911796/hitMap_D12_beforePR.pdf)

D12 geometry (8 partition) after this PR:
[hitMap_D12_afterPR.pdf](https://github.com/cms-sw/cmssw/files/911798/hitMap_D12_afterPR.pdf)


There is a displacement in local (chamber) coordinates between D4 and D12. This is due tot he placement of the eta partitions within the D4 geo. It doesn't affect segment reconstruction as it is simply a uniform displacement in Y.

