### PR TITLE
Add quark gluon likelihood to MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -194,6 +194,10 @@ def miniAOD_customizeCommon(process):
     process.patJets.userData.userFloats.src = [ cms.InputTag("pileupJetId:fullDiscriminant"), ]
     process.patJets.userData.userInts.src = [ cms.InputTag("pileupJetId:fullId"), ]
 
+    ## Quark Gluon Likelihood
+    process.load('RecoJets.JetProducers.QGTagger_cfi')
+    process.patJets.userData.userFloats.src += ['QGTagger:qgLikelihood']
+
     ## CaloJets
     process.caloJetMap = cms.EDProducer("RecoJetDeltaRValueMapProducer",
          src = process.patJets.jetSource,


### PR DESCRIPTION
This PR adds the userFloat "QGTagger:qgLikelihood" to slimmedJets, a variable to distinguish quark and gluon jets described in JME-16-003.
It was checked that userFloat is filled correctly with reasonable values, when running the MiniAOD sequence.
Size and timing with/without this change is summarized below

WITHOUT QGTagger:qgLikelihood:
patJets_slimmedJets__PAT. 27740.8 2602.11
TimeReport> Time report complete in 2488.15 seconds
 Time Summary: 
 - Min event:   0.646415
 - Max event:   30.6585
 - Avg event:   2.42614
 - Total loop:  2454.44
 - Total job:   2488.15
 Event Throughput: 0.407426 ev/s
 CPU Summary: 
 - Total loop:  1875.75
 - Total job:   1898.77

WITH QGTagger:qgLikelihood:
patJets_slimmedJets__PAT. 28162.9 2653.54
TimeReport> Time report complete in 2502.59 seconds
 Time Summary: 
 - Min event:   0.658903
 - Max event:   29.1476
 - Avg event:   2.44299
 - Total loop:  2471.61
 - Total job:   2502.59
 Event Throughput: 0.404595 ev/s
 CPU Summary: 
 - Total loop:  1873.68
 - Total job:   1897.58
TimeReport ---------- Module Summary ---[Real sec]----
TimeReport  per event     per exec    per visit  Name
TimeReport   0.001683     0.001683     0.001683  QGTagger

 91X PR #18303