### PR TITLE
Add isolated charged hadron flag to RECO+AOD+MiniAOD 

### DIFF
--- a/CommonTools/ParticleFlow/plugins/ChargedHadronIsolationProducer.cc
+++ b/CommonTools/ParticleFlow/plugins/ChargedHadronIsolationProducer.cc
@@ -33,7 +33,8 @@ private:
   // input collection
   edm::InputTag srcCandidates_;
   edm::EDGetTokenT<edm::View<reco::PFCandidate> > Candidates_token;
-  double minPt_;
+  double minTrackPt_;
+  double minRawCaloEnergy_;
 
 };
 
@@ -41,7 +42,8 @@ ChargedHadronIsolationProducer::ChargedHadronIsolationProducer(const edm::Parame
 {
   srcCandidates_ = cfg.getParameter<edm::InputTag>("src");
   Candidates_token = consumes<edm::View<reco::PFCandidate> >(srcCandidates_);
-  minPt_ = ( cfg.exists("minPt") ) ? cfg.getParameter<double>("minPt") : -1.0;
+  minTrackPt_ = ( cfg.exists("minTrackPt") ) ? cfg.getParameter<double>("minTrackPt") : -1.0;
+  minRawCaloEnergy_ = ( cfg.exists("minRawCaloEnergy") ) ? cfg.getParameter<double>("minRawCaloEnergy") : -1.0;
   
   produces<edm::ValueMap<bool> >();
 }
@@ -58,7 +60,7 @@ void ChargedHadronIsolationProducer::produce(edm::Event& evt, const edm::EventSe
   for( PFCandidateView::const_iterator c = Candidates->begin(); c!=Candidates->end(); ++c) {
     // Check that there is only one track in the block.
     unsigned int nTracks = 0;
-    if ((c->particleId()==1) && (c->pt()>minPt_)) {
+    if ((c->particleId()==1) && (c->pt()>minTrackPt_) && ((c->rawEcalEnergy()+c->rawHcalEnergy())>minRawCaloEnergy_)) {
       const reco::PFCandidate::ElementsInBlocks& theElements = c->elementsInBlocks();
       if( theElements.empty() ) continue;
       const reco::PFBlockRef blockRef = theElements[0].first;

--- a/CommonTools/ParticleFlow/plugins/ChargedHadronIsolationProducer.cc
+++ b/CommonTools/ParticleFlow/plugins/ChargedHadronIsolationProducer.cc
@@ -1,0 +1,84 @@
+/*
+ * ChargedHadronIsolationProducer
+ *
+ * Author: Andreas Hinzmann
+ *
+ * Associates PF isolation flag to charged hadron candidates
+ *
+ */
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
+
+class ChargedHadronIsolationProducer : public edm::stream::EDProducer<> 
+{
+public:
+
+  explicit ChargedHadronIsolationProducer(const edm::ParameterSet& cfg);
+  ~ChargedHadronIsolationProducer() {}
+  void produce(edm::Event& evt, const edm::EventSetup& es);
+
+private:
+  // input collection
+  edm::InputTag srcCandidates_;
+  edm::EDGetTokenT<edm::View<reco::PFCandidate> > Candidates_token;
+  double minPt_;
+
+};
+
+ChargedHadronIsolationProducer::ChargedHadronIsolationProducer(const edm::ParameterSet& cfg)
+{
+  srcCandidates_ = cfg.getParameter<edm::InputTag>("src");
+  Candidates_token = consumes<edm::View<reco::PFCandidate> >(srcCandidates_);
+  minPt_ = ( cfg.exists("minPt") ) ? cfg.getParameter<double>("minPt") : -1.0;
+  
+  produces<edm::ValueMap<bool> >();
+}
+
+void ChargedHadronIsolationProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
+{
+  // get a view of our Candidates via the base candidates
+  typedef edm::View<reco::PFCandidate> PFCandidateView;
+  edm::Handle<PFCandidateView> Candidates;
+  evt.getByToken(Candidates_token, Candidates);
+  
+  std::vector<bool> values;
+
+  for( PFCandidateView::const_iterator c = Candidates->begin(); c!=Candidates->end(); ++c) {
+    // Check that there is only one track in the block.
+    unsigned int nTracks = 0;
+    if ((c->particleId()==1) && (c->pt()>minPt_)) {
+      const reco::PFCandidate::ElementsInBlocks& theElements = c->elementsInBlocks();
+      if( theElements.empty() ) continue;
+      const reco::PFBlockRef blockRef = theElements[0].first;
+      const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
+      for(unsigned int iEle=0; iEle<elements.size(); iEle++) {	         	 // Find the tracks in the block
+         reco::PFBlockElement::Type type = elements[iEle].type();
+         if( type== reco::PFBlockElement::TRACK)
+           nTracks++;
+      }
+    }
+    values.push_back((nTracks==1));
+  }
+
+  std::unique_ptr<edm::ValueMap<bool> > out(new edm::ValueMap<bool>());
+  edm::ValueMap<bool>::Filler filler(*out);
+  filler.insert(Candidates,values.begin(),values.end());
+  filler.fill();
+  evt.put(std::move(out));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(ChargedHadronIsolationProducer);

--- a/CommonTools/ParticleFlow/python/chargedHadronIsolation_cfi.py
+++ b/CommonTools/ParticleFlow/python/chargedHadronIsolation_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+
+chargedHadronIsolation = cms.EDProducer(
+    "ChargedHadronIsolationProducer",
+    src = cms.InputTag("particleFlow"),
+    minPt = cms.double(1),
+    )

--- a/CommonTools/ParticleFlow/python/chargedHadronIsolation_cfi.py
+++ b/CommonTools/ParticleFlow/python/chargedHadronIsolation_cfi.py
@@ -4,5 +4,6 @@ import FWCore.ParameterSet.Config as cms
 chargedHadronIsolation = cms.EDProducer(
     "ChargedHadronIsolationProducer",
     src = cms.InputTag("particleFlow"),
-    minPt = cms.double(1),
+    minTrackPt = cms.double(1),
+    minRawCaloEnergy = cms.double(0.5),
     )

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -46,7 +46,7 @@ namespace pat {
       packedCovarianceDphiDphi_(0),
       packedPuppiweight_(0),
       packedPuppiweightNoLepDiff_(0),
-      ecalFraction_(0),
+      rawCaloFraction_(0),
       hcalFraction_(0),
       isIsolatedChargedHadron_(0),
       p4_(new PolarLorentzVector(0,0,0,0)), p4c_( new LorentzVector(0,0,0,0)), 
@@ -59,7 +59,7 @@ namespace pat {
     explicit PackedCandidate( const reco::Candidate & c,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), ecalFraction_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
       isIsolatedChargedHadron_(0),
       p4_( new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), 
       p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), 
@@ -75,7 +75,7 @@ namespace pat {
                               float trkPt,float etaAtVtx,float phiAtVtx,int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), ecalFraction_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
       isIsolatedChargedHadron_(0),
       p4_( new PolarLorentzVector(p4) ), p4c_( new LorentzVector(*p4_)), 
       vertex_( new Point(vtx) ), 
@@ -93,7 +93,7 @@ namespace pat {
                               float trkPt, float etaAtVtx, float phiAtVtx, int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), ecalFraction_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
       isIsolatedChargedHadron_(0),
       p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())), 
       p4c_( new LorentzVector(p4)), vertex_( new Point(vtx) ) ,
@@ -122,7 +122,7 @@ namespace pat {
       packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
-      ecalFraction_(iOther.ecalFraction_),
+      rawCaloFraction_(iOther.rawCaloFraction_),
       hcalFraction_(iOther.hcalFraction_),
       isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
       //Need to trigger unpacking in iOther
@@ -152,7 +152,7 @@ namespace pat {
       packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
-      ecalFraction_(iOther.ecalFraction_),
+      rawCaloFraction_(iOther.rawCaloFraction_),
       hcalFraction_(iOther.hcalFraction_),
       isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
       p4_( iOther.p4_.exchange(nullptr) ) ,
@@ -191,7 +191,7 @@ namespace pat {
       packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
-      ecalFraction_=iOther.ecalFraction_;
+      rawCaloFraction_=iOther.rawCaloFraction_;
       hcalFraction_=iOther.hcalFraction_;
       isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
       //Need to trigger unpacking in iOther
@@ -267,7 +267,7 @@ namespace pat {
       packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
-      ecalFraction_=iOther.ecalFraction_;
+      rawCaloFraction_=iOther.rawCaloFraction_;
       hcalFraction_=iOther.hcalFraction_;
       isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
       delete p4_.exchange(iOther.p4_.exchange(nullptr));
@@ -634,8 +634,8 @@ namespace pat {
     float puppiWeightNoLep() const;                     /// Weight from PUPPI removing leptons
     
     // for the neutral fractions
-    void setEcalFraction(float p);                      /// Set the fraction of Ecal needed for isolated charged hadrons
-    float ecalFraction() const { return (ecalFraction_>0.)?(ecalFraction_/100.):(1.-(hcalFraction_/100.)); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
+    void setRawCaloFraction(float p);                      /// Set the fraction of Ecal needed for HF and neutral isolated charged hadrons
+    float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
     void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
     float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
 
@@ -664,7 +664,7 @@ namespace pat {
 
     int8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
-    int8_t ecalFraction_;
+    int8_t rawCaloFraction_;
     int8_t hcalFraction_;
 
     bool isIsolatedChargedHadron_;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -46,7 +46,9 @@ namespace pat {
       packedCovarianceDphiDphi_(0),
       packedPuppiweight_(0),
       packedPuppiweightNoLepDiff_(0),
+      ecalFraction_(0),
       hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_(new PolarLorentzVector(0,0,0,0)), p4c_( new LorentzVector(0,0,0,0)), 
       vertex_(new Point(0,0,0)), dphi_(0), deta_(0), dtrkpt_(0),track_(nullptr), pdgId_(0),
       qualityFlags_(0), pvRefKey_(reco::VertexRef::invalidKey()),
@@ -57,7 +59,8 @@ namespace pat {
     explicit PackedCandidate( const reco::Candidate & c,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), ecalFraction_(0), hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_( new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), 
       p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), 
       dphi_(0), deta_(0), dtrkpt_(0),
@@ -72,7 +75,8 @@ namespace pat {
                               float trkPt,float etaAtVtx,float phiAtVtx,int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), ecalFraction_(0), hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_( new PolarLorentzVector(p4) ), p4c_( new LorentzVector(*p4_)), 
       vertex_( new Point(vtx) ), 
       dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
@@ -89,7 +93,8 @@ namespace pat {
                               float trkPt, float etaAtVtx, float phiAtVtx, int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), ecalFraction_(0), hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())), 
       p4c_( new LorentzVector(p4)), vertex_( new Point(vtx) ) ,
       dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
@@ -117,7 +122,9 @@ namespace pat {
       packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      ecalFraction_(iOther.ecalFraction_),
       hcalFraction_(iOther.hcalFraction_),
+      isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
       //Need to trigger unpacking in iOther
       p4_( new PolarLorentzVector(iOther.polarP4() ) ),
       p4c_( new LorentzVector(iOther.p4())), vertex_( new Point(iOther.vertex())),
@@ -145,7 +152,9 @@ namespace pat {
       packedCovarianceDphiDphi_(iOther.packedCovarianceDphiDphi_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      ecalFraction_(iOther.ecalFraction_),
       hcalFraction_(iOther.hcalFraction_),
+      isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
       p4_( iOther.p4_.exchange(nullptr) ) ,
       p4c_( iOther.p4c_.exchange(nullptr)), vertex_(iOther.vertex_.exchange(nullptr)),
       dxy_(iOther.dxy_), dz_(iOther.dz_),
@@ -182,7 +191,9 @@ namespace pat {
       packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      ecalFraction_=iOther.ecalFraction_;
       hcalFraction_=iOther.hcalFraction_;
+      isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
       //Need to trigger unpacking in iOther
       if(p4_) {
         *p4_ = iOther.polarP4();
@@ -256,7 +267,9 @@ namespace pat {
       packedCovarianceDphiDphi_=iOther.packedCovarianceDphiDphi_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      ecalFraction_=iOther.ecalFraction_;
       hcalFraction_=iOther.hcalFraction_;
+      isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
       delete p4_.exchange(iOther.p4_.exchange(nullptr));
       delete p4c_.exchange(iOther.p4c_.exchange(nullptr));
       delete vertex_.exchange(iOther.vertex_.exchange(nullptr));
@@ -620,10 +633,15 @@ namespace pat {
     float puppiWeight() const;                          /// Weight from full PUPPI
     float puppiWeightNoLep() const;                     /// Weight from PUPPI removing leptons
     
-    // for teh neutral fraction
-    void setHcalFraction(float p);                      /// Set the fraction of Ecal and Hcal needed for HF and neutral hadrons
-    float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons
+    // for the neutral fractions
+    void setEcalFraction(float p);                      /// Set the fraction of Ecal needed for isolated charged hadrons
+    float ecalFraction() const { return (ecalFraction_>0.)?(ecalFraction_/100.):(1.-(hcalFraction_/100.)); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
+    void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
+    float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
 
+     // isolated charged hadrons
+    void setIsIsolatedChargedHadron(bool p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
+    bool isIsolatedChargedHadron() const { return isIsolatedChargedHadron_; }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
 
   protected:
     friend class ::testPackedCandidate;
@@ -646,7 +664,10 @@ namespace pat {
 
     int8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
+    int8_t ecalFraction_;
     int8_t hcalFraction_;
+
+    bool isIsolatedChargedHadron_;
 
     /// the four vector                                                 
     mutable std::atomic<PolarLorentzVector*> p4_;

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -351,8 +351,8 @@ float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packed
 
 float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
 
-void pat::PackedCandidate::setEcalFraction(float p) {
-  ecalFraction_ = 100*p;
+void pat::PackedCandidate::setRawCaloFraction(float p) {
+  rawCaloFraction_ = 100*p;
 }
 
 void pat::PackedCandidate::setHcalFraction(float p) {

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -351,6 +351,14 @@ float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packed
 
 float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
 
+void pat::PackedCandidate::setEcalFraction(float p) {
+  ecalFraction_ = 100*p;
+}
+
 void pat::PackedCandidate::setHcalFraction(float p) {
   hcalFraction_ = 100*p;
+}
+
+void pat::PackedCandidate::setIsIsolatedChargedHadron(bool p) {
+  isIsolatedChargedHadron_ = p;
 }

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -288,7 +288,7 @@
   </class>
 
   <class name="pat::PackedCandidate" ClassVersion="28">
-    <version ClassVersion="28" checksum="1956349111"/>  
+    <version ClassVersion="28" checksum="2646473453"/>
     <version ClassVersion="27" checksum="2418936168"/>
     <version ClassVersion="26" checksum="2986327792"/>
     <version ClassVersion="25" checksum="3654469025"/>

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -79,6 +79,7 @@ namespace pat {
             const edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr> >    PuppiCandsMap_;
             const edm::EDGetTokenT<std::vector< reco::PFCandidate >  >    PuppiCands_;
             const edm::EDGetTokenT<std::vector< reco::PFCandidate >  >    PuppiCandsNoLep_;
+            const edm::EDGetTokenT<edm::ValueMap<bool> >            ChargedHadronIsolation_;
             std::vector< edm::EDGetTokenT<edm::View<reco::CompositePtrCandidate> > > SVWhiteLists_;
 
             const double minPtForTrackProperties_;
@@ -107,6 +108,7 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   PuppiCandsMap_(usePuppi_ ? consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc")) : edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr> >() ),
   PuppiCands_(usePuppi_ ? consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiSrc")) : edm::EDGetTokenT<std::vector< reco::PFCandidate > >() ),
   PuppiCandsNoLep_(usePuppi_ ? consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc")) : edm::EDGetTokenT<std::vector< reco::PFCandidate > >()),
+  ChargedHadronIsolation_(consumes<edm::ValueMap<bool> >(iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
   minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
@@ -159,6 +161,9 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
     const edm::Association<reco::VertexCollection> &  associatedPV=*(assoHandle.product());
     const edm::ValueMap<int>  &  associationQuality=*(assoQualityHandle.product());
            
+    edm::Handle<edm::ValueMap<bool> > chargedHadronIsolationHandle;
+    iEvent.getByToken(ChargedHadronIsolation_,chargedHadronIsolationHandle);
+    const edm::ValueMap<bool>  &  chargedHadronIsolation=*(chargedHadronIsolationHandle.product());
 
     std::set<unsigned int> whiteList;
     for(auto itoken : SVWhiteLists_) {
@@ -258,10 +263,16 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
         }
 
-	// neutrals
+	// neutrals and isolated charged hadrons
+
+        bool isIsolatedChargedHadron = chargedHadronIsolation[reco::PFCandidateRef(cands,ic)];
+        outPtrP->back().setIsIsolatedChargedHadron(isIsolatedChargedHadron);
 
 	if(abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 130) {
 	  outPtrP->back().setHcalFraction(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy()));
+        } else if(isIsolatedChargedHadron) {
+          outPtrP->back().setEcalFraction(cand.ecalEnergy()/cand.energy());
+          outPtrP->back().setHcalFraction(cand.hcalEnergy()/cand.energy());
 	} else {
 	  outPtrP->back().setHcalFraction(0);
 	}

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -271,8 +271,8 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
 	if(abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 130) {
 	  outPtrP->back().setHcalFraction(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy()));
         } else if(isIsolatedChargedHadron) {
-          outPtrP->back().setEcalFraction(cand.ecalEnergy()/cand.energy());
-          outPtrP->back().setHcalFraction(cand.hcalEnergy()/cand.energy());
+          outPtrP->back().setRawCaloFraction((cand.rawEcalEnergy()+cand.rawHcalEnergy())/cand.energy());
+          outPtrP->back().setHcalFraction(cand.rawHcalEnergy()/(cand.rawEcalEnergy()+cand.rawHcalEnergy()));
 	} else {
 	  outPtrP->back().setHcalFraction(0);
 	}

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -8,6 +8,7 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     vertexAssociator = cms.InputTag("primaryVertexAssociation","original"),
     PuppiSrc = cms.InputTag("puppi"),
     PuppiNoLepSrc = cms.InputTag("puppiNoLep"),    
+    chargedHadronIsolation = cms.InputTag("chargedHadronIsolation"),
     secondaryVerticesForWhiteList = cms.VInputTag(
       cms.InputTag("inclusiveCandidateSecondaryVertices"),
       cms.InputTag("inclusiveCandidateSecondaryVerticesCvsL"),

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
@@ -1,0 +1,89 @@
+# import ROOT in batch mode
+import sys
+oldargv = sys.argv[:]
+sys.argv = [ '-b-' ]
+import ROOT
+ROOT.gROOT.SetBatch(True)
+sys.argv = oldargv
+
+# load FWLite C++ libraries
+ROOT.gSystem.Load("libFWCoreFWLite.so");
+ROOT.gSystem.Load("libDataFormatsFWLite.so");
+ROOT.FWLiteEnabler.enable()
+
+# load FWlite python libraries
+from DataFormats.FWLite import Handle, Events
+
+# define deltaR
+from math import hypot, pi
+def deltaR(a,b):
+    dphi = abs(a.phi()-b.phi());
+    if dphi < pi: dphi = 2*pi-dphi
+    return hypot(a.eta()-b.eta(),dphi)
+
+muons, muonLabel = Handle("std::vector<pat::Muon>"), "slimmedMuons"
+electrons, electronLabel = Handle("std::vector<pat::Electron>"), "slimmedElectrons"
+jets, jetLabel = Handle("std::vector<pat::Jet>"), "slimmedJets"
+pfs, pfLabel = Handle("std::vector<pat::PackedCandidate>"), "packedPFCandidates"
+
+# open file (you can use 'edmFileUtil -d /store/whatever.root' to get the physical file name)
+events = Events("/tmp/hinzmann/10024.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017_GenSimFull+DigiFull_2017+RecoFull_2017+ALCAFull_2017+HARVESTFull_2017/step3_inMINIAODSIM.root")
+
+for iev,event in enumerate(events):
+    event.getByLabel(muonLabel, muons)
+    event.getByLabel(electronLabel, electrons)
+    event.getByLabel(pfLabel, pfs)
+    event.getByLabel(jetLabel, jets)
+
+    print "\nEvent %d: run %6d, lumi %4d, event %12d" % (iev,event.eventAuxiliary().run(), event.eventAuxiliary().luminosityBlock(),event.eventAuxiliary().event())
+
+    # Let's compute lepton PF Isolation with R=0.2, 0.5 GeV threshold on neutrals, and deltaBeta corrections
+    leps  = [ p for p in muons.product() ] + [ p for p in electrons.product() ]
+    for lep in leps:
+        # skip those below 5 GeV, which we don't care about
+        if lep.pt() < 5: continue
+        # initialize sums
+        charged = 0
+        neutral = 0
+        pileup  = 0
+        # now get a list of the PF candidates used to build this lepton, so to exclude them
+        footprint = set()
+        for i in xrange(lep.numberOfSourceCandidatePtrs()):
+            footprint.add(lep.sourceCandidatePtr(i).key()) # the key is the index in the pf collection
+        # now loop on pf candidates
+        for ipf,pf in enumerate(pfs.product()):
+            if deltaR(pf,lep) < 0.2:
+                # pfcandidate-based footprint removal
+                if ipf in footprint: continue
+                # add up
+                if (pf.charge() == 0):
+                    if pf.pt() > 0.5: neutral += pf.pt()
+                elif pf.fromPV() >= 2:
+                    charged += pf.pt()
+                else:
+                    if pf.pt() > 0.5: pileup += pf.pt()
+        # do deltaBeta
+        iso = charged + max(0, neutral-0.5*pileup)
+        print "%-8s of pt %6.1f, eta %+4.2f: relIso = %5.2f" % (
+                    "muon" if abs(lep.pdgId())==13 else "electron",
+                    lep.pt(), lep.eta(), iso/lep.pt())
+
+    # Let's compute the fraction of charged pt from particles with dz < 0.1 cm
+    for i,j in enumerate(jets.product()):
+        if j.pt() < 40 or abs(j.eta()) > 2.4: continue
+        sums = [0,0]
+        for id in xrange(j.numberOfDaughters()):
+            dau = j.daughter(id)
+            if (dau.charge() == 0): continue
+            sums[ abs(dau.dz())<0.1 ] += dau.pt()
+        sum = sums[0]+sums[1]
+        print "Jet with pt %6.1f, eta %+4.2f, beta(0.1) = %+5.3f, pileup mva disc %+.2f" % (
+                j.pt(),j.eta(), sums[1]/sum if sum else 0, j.userFloat("pileupJetId:fullDiscriminant"))
+
+    # Let's check the calorimeter response for hadrons (after PF hadron calibration)
+    for i,j in enumerate(pfs.product()):
+        if not j.isIsolatedChargedHadron(): continue
+        print "Isolated charged hadron candidate with pt %6.1f, eta %+4.2f, cand/track energy = %+5.3f, calo/track energy = %+5.3f, hcal/track energy %+5.3f" % (
+                j.pt(),j.eta(), j.pt()/j.pseudoTrack().pt(), j.ecalFraction()+j.hcalFraction(), j.hcalFraction())
+    
+    if iev > 10: break

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
@@ -83,7 +83,7 @@ for iev,event in enumerate(events):
     # Let's check the calorimeter response for hadrons (after PF hadron calibration)
     for i,j in enumerate(pfs.product()):
         if not j.isIsolatedChargedHadron(): continue
-        print "Isolated charged hadron candidate with pt %6.1f, eta %+4.2f, cand/track energy = %+5.3f, calo/track energy = %+5.3f, hcal/track energy %+5.3f" % (
-                j.pt(),j.eta(), j.pt()/j.pseudoTrack().pt(), j.ecalFraction()+j.hcalFraction(), j.hcalFraction())
+        print "Isolated charged hadron candidate with pt %6.1f, eta %+4.2f, calo/track energy = %+5.3f, hcal/calo energy %+5.3f" % (
+                j.pt(),j.eta(), j.rawCaloFraction(), j.hcalFraction())
     
     if iev > 10: break

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
@@ -44,7 +44,8 @@ RecoParticleFlowFEVT = cms.PSet(
     'keep *_particleFlow_photons_*',
     'keep *_trackerDrivenElectronSeeds_preid_*',
     'keep *_particleFlowPtrs_*_*',
-    'keep *_particleFlowTmpPtrs_*_*'
+    'keep *_particleFlowTmpPtrs_*_*',
+    'keep *_chargedHadronIsolation_*_*'
         )
     )
 # RECO content
@@ -88,7 +89,8 @@ RecoParticleFlowRECO = cms.PSet(
     'keep *_particleFlow_muons_*',
     'keep *_trackerDrivenElectronSeeds_preid_*',
     'keep *_particleFlowPtrs_*_*',
-    'keep *_particleFlowTmpPtrs_*_*'
+    'keep *_particleFlowTmpPtrs_*_*',
+    'keep *_chargedHadronIsolation_*_*'
         )
 )    
     
@@ -130,7 +132,8 @@ RecoParticleFlowAOD = cms.PSet(
     'keep recoPhotonCores_pfPhotonTranslator_*_*',
     'keep recoConversions_pfPhotonTranslator_*_*',
     'keep *_particleFlowPtrs_*_*',
-    'keep *_particleFlowTmpPtrs_*_*'
+    'keep *_particleFlowTmpPtrs_*_*',
+    'keep *_chargedHadronIsolation_*_*'
         )
 )
 

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
@@ -18,6 +18,7 @@ from RecoParticleFlow.PFProducer.pfLinker_cff import *
 
 from CommonTools.ParticleFlow.pfParticleSelection_cff import *
 
+from CommonTools.ParticleFlow.chargedHadronIsolation_cfi import *
 from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cff import *
 
 from RecoJets.JetProducers.fixedGridRhoProducerFastjet_cfi import *
@@ -36,7 +37,7 @@ particleFlowReco = cms.Sequence( particleFlowTrackWithDisplacedVertex*
                                  particleFlowEGammaFinal*
                                  pfParticleSelectionSequence )
 
-particleFlowLinks = cms.Sequence( particleFlow*particleFlowPtrs*particleBasedIsolationSequence)
+particleFlowLinks = cms.Sequence( particleFlow*particleFlowPtrs*chargedHadronIsolation*particleBasedIsolationSequence)
 
 from RecoParticleFlow.PFTracking.hgcalTrackCollection_cfi import *
 from RecoParticleFlow.PFProducer.simPFProducer_cfi import *


### PR DESCRIPTION
This PR adds a valueMap "chargedHadronIsolation" for the PFCandisdates to RECO+AOD and "isIsolatedChargedHadron", "rawCaloFraction" and "hcalFraction" to the packedCandidates which are isolated charged hadrons in MiniAOD.
Charged hadrons with track pT > 1 GeV and rawCaloEnergy > 0.5 GeV are tagged on RECO and saved in MiniAOD. (Those cuts can be tuned for MiniAOD output size)
With these variables for isolated charged hadrons, calorimeter response can be measured in data and simulation with fine granularity, enabling PF hadron calibration at AOD+MiniAOD level.

runTheMatrix -l limited works.

It was checked that the variables in RECO+AOD+MiniAOD are filled correctly with reasonable values. A test config for the MiniAOD content was added here:
PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py

Size with/without this change based on workflow 10024.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017_GenSimFull+DigiFull_2017+RecoFull_2017+ALCAFull_2017+HARVESTFull_2017 is summarized below:

New collection in RECO+AOD:
booledmValueMap_chargedHadronIsolation__RECO. 278.9 250.1

MiniAOD WITHOUT isolated charged hadrons
patPackedCandidates_packedPFCandidates__RECO. 21783.5 6757.4

MiniAOD WITH isolated charged hadrons
patPackedCandidates_packedPFCandidates__RECO. 22794.5 7010.8