### PR TITLE
Global tag updates for legacy reprocessing 2016

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,9 +22,9 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '80X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_2016LegacyRepro_v1',
+    'run1_data'         :   '80X_dataRun2_2016LegacyRepro_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_2016LegacyRepro_v1',
+    'run2_data'         :   '80X_dataRun2_2016LegacyRepro_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '80X_dataRun2_relval_v18',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,9 +22,9 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '80X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_v19',
+    'run1_data'         :   '80X_dataRun2_2016LegacyRepro_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_v19',
+    'run2_data'         :   '80X_dataRun2_2016LegacyRepro_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '80X_dataRun2_relval_v18',
     # GlobalTag for Run1 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -22,11 +22,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '80X_mcRun2_pA_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '80X_dataRun2_2016LegacyRepro_v2',
+    'run1_data'         :   '80X_dataRun2_2016LegacyRepro_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '80X_dataRun2_2016LegacyRepro_v2',
+    'run2_data'         :   '80X_dataRun2_2016LegacyRepro_v3',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '80X_dataRun2_relval_v18',
+    'run2_data_relval'  :   '80X_dataRun2_relval_v19',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '80X_dataRun2_HLT_frozen_v14',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of changes in Global Tags

Changes are same in both RunI data and RunII data
## RunII data & RunI data

   * **RunI & RunII Offline processing** : [80X_dataRun2_2016LegacyRepro_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_2016LegacyRepro_v3) as [80X_dataRun2_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_v19) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_2016LegacyRepro_v3/80X_dataRun2_v19):
      * Change in SiPixel Templates, GenError and Lorentz Angle. [Sign-off talk](https://indico.cern.ch/event/586735/contributions/2364051/attachments/1374680/2087542/20161121_AlCaDB_EOYRECO.pdf).

      * Change in SiStrip Gain2 calibration, mostly adjustment of IOVs and a new IOV added. [Announced here](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2825.html) [signed-off talk](https://indico.cern.ch/event/586738/contributions/2397203/) 

      * Tracker alignment, APEs and surface deformations updated. [signed-off talk](https://indico.cern.ch/event/586738/contributions/2387635)

      * Update of BeamSpot corresponding to the changes in tracker alignment package. [signed-off talk](https://indico.cern.ch/event/592611/contributions/2435744)

      * Update of muon alignment and APEs. [announcement](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2884/1/1/1.html)

      * Update of DtTrig. [Announced here](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2731/1.html)

      * Update of whole ECAL package. [signed-off talk](https://indico.cern.ch/event/626460/contributions/2529699/). Changes includes update of ECAL pedestals, ADCtoGeV, ECAL alpha values, pulse shapes, time calibrations, channel status of both ECAL and ES, ECAL Laser corrections, ECAL and ES Channel quality, ECAL intercalibration and ES intercalibration.

      * Update of HCAL gains and response corrections. [announced here](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2836.html)

     * Update of global alignment

     * Update of L1 caloParam tag and addition of L1 muon param tags. [announced here](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2878/1/1/3/1/1/1/1/1/1.html)

* **RunII Offline relval processing** : [80X_dataRun2_relval_v19](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v19) as [80X_dataRun2_relval_v18](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/80X_dataRun2_relval_v18) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/80X_dataRun2_relval_v19/80X_dataRun2_relval_v18):
      * all the legacy conditions mentioned above has been updated here as well.
