### PR TITLE
Small improvements for HLT tracking validation tools

### DIFF
--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from Validation.RecoTrack.HLTmultiTrackValidator_cfi import *
+from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cff import *
+
 hltTrackValidator = hltMultiTrackValidator.clone(
     label = [
         "hltPixelTracks",
@@ -18,6 +20,7 @@ hltTrackValidator = hltMultiTrackValidator.clone(
 
 hltMultiTrackValidation = cms.Sequence(
     hltTPClusterProducer
+    + trackingParticleNumberOfLayersProducer
     + hltTrackAssociatorByHits
     + hltTrackValidator
-)    
+)

--- a/Validation/RecoTrack/python/HLTpostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/HLTpostProcessorTracker_cfi.py
@@ -10,7 +10,7 @@ postProcessorHLTtrackingSummary = _PostProcessorTracker_cfi.postProcessorTrackSu
     subDirs = ["HLT/Tracking/ValidationWRTtp"]
 )
 
-postProcessorHLTtrackingSequence = (
+postProcessorHLTtrackingSequence = cms.Sequence(
     postProcessorHLTtracking +
     postProcessorHLTtrackingSummary
 )

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -140,6 +140,7 @@ _pageNameMap = {
     "v0": "V0",
     "miniaod": "MiniAOD",
     "timing": "Timing",
+    "hlt": "HLT",
 }
 
 _sectionNameMapOrder = collections.OrderedDict([
@@ -256,6 +257,7 @@ class PlotPurpose:
     class Vertexing: pass
     class MiniAOD: pass
     class Timing: pass
+    class HLT: pass
 
 class Page(object):
     def __init__(self, title, sampleName):
@@ -462,10 +464,11 @@ class Page(object):
         return ret
 
 class PageSet(object):
-    def __init__(self, title, sampleName, sample, fastVsFull, pileupComparison):
+    def __init__(self, title, sampleName, sample, fastVsFull, pileupComparison, dqmSubFolderTranslatedToSectionName=None):
         self._title = title
         self._sampleName = sampleName
         self._pages = collections.OrderedDict()
+        self._dqmSubFolderTranslatedToSectionName = dqmSubFolderTranslatedToSectionName
 
         self._prefix = ""
         if sample.fastsim():
@@ -506,7 +509,10 @@ class PageSet(object):
         sectionName = plotterFolder.getSection()
         if sectionName is None:
             if plotterFolder.getPage() is not None and dqmSubFolder is not None:
-                sectionName = dqmSubFolder.translated
+                if self._dqmSubFolderTranslatedToSectionName is not None:
+                    sectionName = self._dqmSubFolderTranslatedToSectionName(dqmSubFolder.translated)
+                else:
+                    sectionName = dqmSubFolder.translated
             else:
                 sectionName = ""
 
@@ -628,6 +634,7 @@ class IndexSection:
         self._vertexPage = PageSet(*params)
         self._miniaodPage = PageSet(*params)
         self._timingPage = PageSet(*params)
+        self._hltPages = PageSet(*params, dqmSubFolderTranslatedToSectionName=lambda algoQuality: algoQuality[0])
         self._otherPages = PageSet(*params)
 
         self._purposePageMap = {
@@ -636,6 +643,7 @@ class IndexSection:
             PlotPurpose.Vertexing: self._vertexPage,
             PlotPurpose.MiniAOD: self._miniaodPage,
             PlotPurpose.Timing: self._timingPage,
+            PlotPurpose.HLT: self._hltPages,
         }
 
     def addPlots(self, plotterFolder, dqmSubFolder, plotFiles):
@@ -657,7 +665,7 @@ class IndexSection:
             "  <ul>",
             ]
 
-        for pages in [self._summaryPage, self._iterationPages, self._vertexPage, self._miniaodPage, self._timingPage, self._otherPages]:
+        for pages in [self._summaryPage, self._iterationPages, self._vertexPage, self._miniaodPage, self._timingPage, self._hltPages, self._otherPages]:
             labelFiles = pages.write(baseDir)
             for label, fname in labelFiles:
                 ret.append('   <li><a href="%s">%s</a></li>' % (fname, label))

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -455,12 +455,13 @@ class Page(object):
         return _sectionNameMapOrder.get(section, section)
 
     def _orderSets(self, keys):
+        keys_sorted = sorted(keys)
         ret = []
         for section in _sectionNameMapOrder.keys():
-            if section in keys:
+            if section in keys_sorted:
                 ret.append(section)
                 keys.remove(section)
-        ret.extend(keys)
+        ret.extend(keys_sorted)
         return ret
 
 class PageSet(object):

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1065,6 +1065,16 @@ plotter.append("packedCandidateLostTracks", _trackingFolders("PackedCandidate/lo
                PlotFolder(*_packedCandidatePlots, loopSubFolders=False,
                           purpose=PlotPurpose.MiniAOD, page="miniaod", section="PackedCandidate (lostTracks)"))
 
+# HLT
+_hltFolder = [
+    "DQMData/Run 1/HLT/Run summary/Tracking/ValidationWRTtp",
+]
+plotterHLT = Plotter()
+plotterHLTExt = Plotter()
+_common = dict(purpose=PlotPurpose.HLT, page="hlt")
+plotterHLT.append("hlt", _hltFolder, TrackingPlotFolder(*(_simBasedPlots+_recoBasedPlots), **_common))
+plotterHLTExt.append("hlt", _hltFolder, TrackingPlotFolder(*_extendedPlots, **_common))
+
 # Timing
 class Iteration:
     def __init__(self, name, clusterMasking=None, seeding=None, building=None, fit=None, selection=None, other=[]):

--- a/Validation/RecoTrack/scripts/harvestTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/harvestTrackValidationPlots.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     os.chdir(_tempdir)
 
     # compile cmsDriver command
-    cmsDriverCommand = "cmsDriver.py harvest --scenario pp --filetype DQM --conditions auto:run2_mc --mc -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM -n -1 --filein {0}".format(filelist)
+    cmsDriverCommand = "cmsDriver.py harvest --scenario pp --filetype DQM --conditions auto:run2_mc --mc -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM+postProcessorHLTtrackingSequence -n -1 --filein {0}".format(filelist)
     print "# running cmsDriver" + "\n" + cmsDriverCommand
     
     # run it

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -61,10 +61,10 @@ def main(opts):
         }
 
     trk = [trackingPlots.plotter]
-    other = [trackingPlots.timePlotter, vertexPlots.plotter]
+    other = [trackingPlots.timePlotter, vertexPlots.plotter, trackingPlots.plotterHLT]
     if opts.extended:
         trk.append(trackingPlots.plotterExt)
-        other.append(vertexPlots.plotterExt)
+        other.extend([vertexPlots.plotterExt, trackingPlots.plotterHLTExt])
     val.doPlots(trk, plotterDrawArgs=drawArgs, **kwargs_tracking)
     val.doPlots(other, plotterDrawArgs=drawArgs)
     print


### PR DESCRIPTION
This PR makes the following improvements in MultiTrackValidator uses for HLT
* Add `trackingParticleNumberOfLayersProducer` to `hltMultiTrackValidation` sequence
  * To allow use of `hltMultiTrackValidation` sequence in standalone tests without running the offline MTV sequence
* Add HLT MTV post processing sequence to harvestTrackValidationPlots.py
  * Required transforming `postProcessorHLTtrackingSequence` to a `Sequence`
* Add initial support for HLT MTV plots to `makeTrackValidationPlots.py`

Tested in 9_0_0_pre5 (to allow private merges in 90X), no changes expected in standard workflows.

@rovere @VinInn @felicepantaleo @mtosi @JanFSchulte 