### PR TITLE
Fill arbitration flags also for ME0 and GEM segments

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -713,7 +713,11 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
 
    LogTrace("MuonIdentification") << "number of muons produced: " << outputMuons->size();
-   if ( fillMatching_ ) fillArbitrationInfo( outputMuons.get() );
+   if ( fillMatching_ ) {
+       fillArbitrationInfo( outputMuons.get(), reco::Muon::TrackerMuon );
+       fillArbitrationInfo( outputMuons.get(), reco::Muon::ME0Muon );
+       fillArbitrationInfo( outputMuons.get(), reco::Muon::GEMMuon );
+   }
    edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(std::move(outputMuons));
 
    auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = ""){
@@ -968,7 +972,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
    // fillTime( iEvent, iSetup, aMuon );
 }
 
-void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons )
+void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons, unsigned int muonType )
 {
    //
    // apply segment flags
@@ -984,11 +988,17 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons )
      // chamberIter1
      for ( auto& chamber1 : muon1.matches() )
      {
-       if(chamber1.segmentMatches.empty()) continue;
+       // segmentIter1
+       std::vector<reco::MuonSegmentMatch> * segmentMatches1 = nullptr;
+       if      (muonType == reco::Muon::TrackerMuon) segmentMatches1 =  & chamber1.segmentMatches;
+       else if (muonType == reco::Muon::ME0Muon)     segmentMatches1 =  & chamber1.me0Matches;
+       else if (muonType == reco::Muon::GEMMuon)     segmentMatches1 =  & chamber1.gemMatches;
+       else throw cms::Exception("fillArbitrationInfo called with unsupported muonType");
+
+       if(segmentMatches1->empty()) continue;
        chamberPairs.clear();
 
-       // segmentIter1
-       for ( auto& segment1 : chamber1.segmentMatches )
+       for ( auto& segment1 : *segmentMatches1 )
        {
          chamberPairs.push_back(std::make_pair(&chamber1, &segment1));
          if(!segment1.isMask()) // has not yet been arbitrated
@@ -998,18 +1008,22 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons )
 
            // find identical segments with which to arbitrate
            // tracker muons only
-           if (muon1.isTrackerMuon()) {
+           if (muon1.type() & muonType) {
              // muonIndex2
              for( unsigned int muonIndex2 = muonIndex1+1; muonIndex2 < pOutputMuons->size(); ++muonIndex2 )
              {
                auto& muon2 = pOutputMuons->at(muonIndex2);
                // tracker muons only
-               if ( !muon2.isTrackerMuon() ) continue;
+               if ( !(muon2.type() & muonType) ) continue;
                // chamberIter2
                for ( auto& chamber2 : muon2.matches() )
                {
                  // segmentIter2
-                 for ( auto& segment2 : chamber2.segmentMatches )
+                 std::vector<reco::MuonSegmentMatch> * segmentMatches2 = nullptr;
+                 if      (muonType == reco::Muon::TrackerMuon) segmentMatches2 =  & chamber2.segmentMatches;
+                 else if (muonType == reco::Muon::ME0Muon)     segmentMatches2 =  & chamber2.me0Matches;
+                 else if (muonType == reco::Muon::GEMMuon)     segmentMatches2 =  & chamber2.gemMatches;
+                 for ( auto& segment2 : *segmentMatches2 )
                  {
                    if(segment2.isMask()) continue; // has already been arbitrated
                    if(approxEqual(segment2.x      , segment1.x      ) &&
@@ -1052,7 +1066,7 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons )
          }
 
          // setup me1a cleaning for later
-         if( chamber1.id.subdetId() == MuonSubdetId::CSC && arbClean_ &&
+         if( muonType == reco::Muon::TrackerMuon && chamber1.id.subdetId() == MuonSubdetId::CSC && arbClean_ &&
              CSCDetId(chamber1.id).ring() == 4) {
            for ( auto& segment2 : chamber1.segmentMatches ) {
              if( segment1.cscSegmentRef.isNull() || segment2.cscSegmentRef.isNull() ) continue;
@@ -1097,9 +1111,13 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons )
          for ( auto& chamber : muon1.matches() )
          {
            if(!(chamber.station()==stationIndex && chamber.detector()==detectorIndex)) continue;
-           if(chamber.segmentMatches.empty()) continue;
+           std::vector<reco::MuonSegmentMatch> * segmentMatches = nullptr;
+           if      (muonType == reco::Muon::TrackerMuon) segmentMatches =  & chamber.segmentMatches;
+           else if (muonType == reco::Muon::ME0Muon)     segmentMatches =  & chamber.me0Matches;
+           else if (muonType == reco::Muon::GEMMuon)     segmentMatches =  & chamber.gemMatches;
+           if (segmentMatches->empty()) continue;
 
-           for ( auto& segment : chamber.segmentMatches ) {
+           for ( auto& segment : *segmentMatches ) {
              stationPairs.push_back(std::make_pair(&chamber, &segment));
            }
          } // chamberIter

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -989,11 +989,7 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons, un
      for ( auto& chamber1 : muon1.matches() )
      {
        // segmentIter1
-       std::vector<reco::MuonSegmentMatch> * segmentMatches1 = nullptr;
-       if      (muonType == reco::Muon::TrackerMuon) segmentMatches1 =  & chamber1.segmentMatches;
-       else if (muonType == reco::Muon::ME0Muon)     segmentMatches1 =  & chamber1.me0Matches;
-       else if (muonType == reco::Muon::GEMMuon)     segmentMatches1 =  & chamber1.gemMatches;
-       else throw cms::Exception("fillArbitrationInfo called with unsupported muonType");
+       std::vector<reco::MuonSegmentMatch> * segmentMatches1 = getSegmentMatches(chamber1, muonType);
 
        if(segmentMatches1->empty()) continue;
        chamberPairs.clear();
@@ -1019,10 +1015,7 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons, un
                for ( auto& chamber2 : muon2.matches() )
                {
                  // segmentIter2
-                 std::vector<reco::MuonSegmentMatch> * segmentMatches2 = nullptr;
-                 if      (muonType == reco::Muon::TrackerMuon) segmentMatches2 =  & chamber2.segmentMatches;
-                 else if (muonType == reco::Muon::ME0Muon)     segmentMatches2 =  & chamber2.me0Matches;
-                 else if (muonType == reco::Muon::GEMMuon)     segmentMatches2 =  & chamber2.gemMatches;
+                 std::vector<reco::MuonSegmentMatch> * segmentMatches2 = getSegmentMatches(chamber2, muonType);
                  for ( auto& segment2 : *segmentMatches2 )
                  {
                    if(segment2.isMask()) continue; // has already been arbitrated
@@ -1103,7 +1096,7 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons, un
      // station segment sort
      for( int stationIndex = 1; stationIndex < 5; ++stationIndex ) 
      {
-       for( int detectorIndex = 1; detectorIndex < 4; ++detectorIndex )
+       for( int detectorIndex = 1; detectorIndex <= 5; ++detectorIndex ) // 1-5, as in DataFormats/MuonDetId/interface/MuonSubdetId.h
        {
          stationPairs.clear();
 
@@ -1111,10 +1104,7 @@ void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons, un
          for ( auto& chamber : muon1.matches() )
          {
            if(!(chamber.station()==stationIndex && chamber.detector()==detectorIndex)) continue;
-           std::vector<reco::MuonSegmentMatch> * segmentMatches = nullptr;
-           if      (muonType == reco::Muon::TrackerMuon) segmentMatches =  & chamber.segmentMatches;
-           else if (muonType == reco::Muon::ME0Muon)     segmentMatches =  & chamber.me0Matches;
-           else if (muonType == reco::Muon::GEMMuon)     segmentMatches =  & chamber.gemMatches;
+           std::vector<reco::MuonSegmentMatch> * segmentMatches = getSegmentMatches(chamber, muonType);
            if (segmentMatches->empty()) continue;
 
            for ( auto& segment : *segmentMatches ) {

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -122,6 +122,15 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    {
      return std::abs(a-b) < tol;
    }
+
+
+   /// get the segment matches of the appropriate type
+   std::vector<reco::MuonSegmentMatch> * getSegmentMatches(reco::MuonChamberMatch & chamber, unsigned int muonType) const {
+       if      (muonType == reco::Muon::TrackerMuon) return & chamber.segmentMatches;
+       else if (muonType == reco::Muon::ME0Muon)     return & chamber.me0Matches;
+       else if (muonType == reco::Muon::GEMMuon)     return & chamber.gemMatches;
+       else throw cms::Exception("getSegmentMatches called with unsupported muonType");
+   }
      
    TrackDetectorAssociator trackAssociator_;
    TrackAssociatorParameters parameters_;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -82,7 +82,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
  private:
    void          fillMuonId( edm::Event&, const edm::EventSetup&, reco::Muon&, 
 			     TrackDetectorAssociator::Direction direction = TrackDetectorAssociator::InsideOut );
-   void          fillArbitrationInfo( reco::MuonCollection* );
+   void          fillArbitrationInfo( reco::MuonCollection*, unsigned int muonType = reco::Muon::TrackerMuon );
    void          fillMuonIsolation( edm::Event&, const edm::EventSetup&, reco::Muon& aMuon,
 				    reco::IsoDeposit& trackDep, reco::IsoDeposit& ecalDep, reco::IsoDeposit& hcalDep, reco::IsoDeposit& hoDep,
 				    reco::IsoDeposit& jetDep);


### PR DESCRIPTION
Minimal PR to have the arbitration flags for muon segments saved into the `reco::Muon` object also for ME0 and GEM.