### PR TITLE
Puppi candidates for b tagging of Puppi jets in MiniAOD for Phase 2

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -271,8 +271,15 @@ def miniAOD_customizeCommon(process):
     )
     task.add(process.patJetPuppiCharge)
 
+    ## Using Puppi candidates as input for b tagging in Phase 2
+    _pfCandidates = 'particleFlow'
+    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+    if process.isUsingModifier( phase2_common ):
+        _pfCandidates = 'puppi'
+
     addJetCollection(process, postfix   = "", labelName = 'Puppi', jetSource = cms.InputTag('ak4PFJetsPuppi'),
                     jetCorrections = ('AK4PFPuppi', ['L2Relative', 'L3Absolute'], ''),
+                    pfCandidates = cms.InputTag(_pfCandidates),
                     algo= 'AK', rParam = 0.4, btagDiscriminators = map(lambda x: x.value() ,process.patJets.discriminatorSources)
                     )
     


### PR DESCRIPTION
This PR switches the input candidate collection used in b tagging from the default Particle-flow candidates (`particleFlow`) to Puppi candidates (`pupi`) for Phase 2. These changes only affect MiniAOD, more specifically ak4 Puppi jets, for the Phase 2 era.

This is related to https://github.com/cms-sw/cmssw/pull/18260 but does not add new b-tag discriminators since they are now added in https://github.com/cms-sw/cmssw/pull/18315