### PR TITLE
Phase 1 training for BoostedDoubleSV tagger for AK8 jets

### DIFF
--- a/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
@@ -8,3 +8,6 @@ candidateBoostedDoubleSecondaryVertexAK8Computer = cms.ESProducer("CandidateBoos
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(False)
 )
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(candidateBoostedDoubleSecondaryVertexAK8Computer, weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_PhaseI_v1.weights.xml.gz'))


### PR DESCRIPTION
New Phase 1 training for BoostedDoubleSV tagger for AK8 jets.

Request to add new training to externals is here cms-sw/cmsdist#2951

@cvernier 