### PR TITLE
Tuned daclusterizer for 2017

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -151,6 +151,7 @@ if isDA:
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5  
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)     
                                                                          minPt = cms.double(0.0),                                    # better for softish events                        
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
@@ -191,6 +192,7 @@ else:
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5                   
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)
                                                                          minPt = cms.double(0.0),                                    # better for softish events     
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                         

--- a/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
@@ -223,6 +223,7 @@ if isDA:
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5  
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)     
                                                                          minPt = cms.double(0.0),                                    # better for softish events                        
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
@@ -259,6 +260,7 @@ else:
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5                   
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)
                                                                          minPt = cms.double(0.0),                                    # better for softish events     
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                         

--- a/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
@@ -229,6 +229,7 @@ if isDA:
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5  
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)     
                                                                          minPt = cms.double(0.0),                                    # better for softish events                        
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
@@ -265,6 +266,7 @@ else:
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5                   
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)
                                                                          minPt = cms.double(0.0),                                    # better for softish events     
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                         

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -215,7 +215,8 @@ if isDA:
                                                                          minPixelLayersWithHits = cms.int32(2),                      # PX hits > 2                       
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5  
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)     
-                                                                         minPt = cms.double(0.0),                                    # better for softish events                        
+                                                                         minPt = cms.double(0.0),                                    # better for softish events
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
@@ -251,7 +252,8 @@ else:
                                                                          minPixelLayersWithHits=cms.int32(2),                        # PX hits > 2                   
                                                                          minSiliconLayersWithHits = cms.int32(5),                    # TK hits > 5                   
                                                                          maxD0Significance = cms.double(5.0),                        # fake cut (requiring 1 PXB hit)
-                                                                         minPt = cms.double(0.0),                                    # better for softish events     
+                                                                         minPt = cms.double(0.0),                                    # better for softish events    
+                                                                         maxEta = cms.double(5.0),                                   # as per recommendation in PR #18330 
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                         

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -49,6 +49,31 @@ def customiseFor17792(process):
             producer.produceSeedStopReasons = cms.bool(False)
     return process
 
+# DA clusterizer tuning
+def customiseFor18330(process):
+     for producer in producers_by_type(process, "PrimaryVertexProducer"):
+          if producer.TkFilterParameters.algorithm.value() == "filter" and not hasattr(producer.TkFilterParameters, "maxEta"):
+               producer.TkFilterParameters.maxEta = cms.double(100.0)
+
+          if producer.TkClusParameters.algorithm.value() == "DA_vect":
+               if abs(producer.TkClusParameters.TkDAClusParameters.Tmin.value() - 4.0) < 1e-3:
+                    # default value was changed, going from 4.0 -> 2.4 should give no change in results
+                    producer.TkClusParameters.TkDAClusParameters.Tmin = 2.4
+               if not hasattr(producer.TkClusParameters.TkDAClusParameters, "Tpurge"):
+                    producer.TkClusParameters.TkDAClusParameters.Tpurge = cms.double(2.0)
+               if not hasattr(producer.TkClusParameters.TkDAClusParameters, "Tstop"):
+                    producer.TkClusParameters.TkDAClusParameters.Tstop = cms.double(0.5)
+               if not hasattr(producer.TkClusParameters.TkDAClusParameters, "zmerge"):
+                    producer.TkClusParameters.TkDAClusParameters.zmerge = cms.double(1e-2)
+               if not hasattr(producer.TkClusParameters.TkDAClusParameters, "uniquetrkweight"):
+                    producer.TkClusParameters.TkDAClusParameters.uniquetrkweight = cms.double(0.9)
+
+          for pset in producer.vertexCollections:
+               if pset.algorithm.value() == "AdaptiveVertexFitter" and not hasattr(pset, "chi2cutoff"):
+                    pset.chi2cutoff = cms.double(3.0)
+
+     return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
@@ -56,5 +81,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor17771(process)
     process = customiseFor17792(process)
     process = customiseFor17794(process)
+    process = customiseFor18330(process)
 
     return process

--- a/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
@@ -9,6 +9,7 @@ hiPixelAdaptiveVertex = cms.EDProducer("PrimaryVertexProducer",
         minPixelLayersWithHits = cms.int32(2),   ## >=2 (was 2 for generalTracks)
         maxD0Significance = cms.double(3.0),     ## keep most primary tracks (was 5.0)
         minPt = cms.double(0.0),                 ## better for softish events
+        maxEta = cms.double(100.),
         trackQuality = cms.string("any"),
         numTracksThreshold = cms.int32(2)
     ),
@@ -25,6 +26,7 @@ hiPixelAdaptiveVertex = cms.EDProducer("PrimaryVertexProducer",
     vertexCollections = cms.VPSet(
       cms.PSet(
         label = cms.string(''),
+        chi2cutoff = cms.double(3.0),
         algorithm = cms.string('AdaptiveVertexFitter'),
         useBeamConstraint = cms.bool(False),
         maxDistanceToBeam = cms.double(0.1),

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -168,18 +168,10 @@ initialStepTracksPreSplitting = RecoTracker.TrackProducer.TrackProducer_cfi.Trac
 initialStepTracksPreSplitting.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
 
 #vertices
-import RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi
-firstStepPrimaryVerticesPreSplitting = RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi.offlinePrimaryVertices.clone()
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices as _offlinePrimaryVertices
+firstStepPrimaryVerticesPreSplitting = _offlinePrimaryVertices.clone()
 firstStepPrimaryVerticesPreSplitting.TrackLabel = cms.InputTag("initialStepTracksPreSplitting")
-firstStepPrimaryVerticesPreSplitting.vertexCollections = cms.VPSet(
-     [cms.PSet(label=cms.string(""),
-               algorithm=cms.string("AdaptiveVertexFitter"),
-               minNdof=cms.double(0.0),
-               useBeamConstraint = cms.bool(False),
-               maxDistanceToBeam = cms.double(1.0)
-               )
-      ]
-    )
+firstStepPrimaryVerticesPreSplitting.vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
 
 #Jet Core emulation to identify jet-tracks
 from RecoTracker.IterativeTracking.JetCoreRegionalStep_cff import initialStepTrackRefsForJets, caloTowerForTrk, ak4CaloJetsForTrk, jetsForCoreTracking

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -245,18 +245,10 @@ initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.cl
 
 
 #vertices
-import RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi
-firstStepPrimaryVertices=RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi.offlinePrimaryVertices.clone()
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices as _offlinePrimaryVertices
+firstStepPrimaryVertices = _offlinePrimaryVertices.clone()
 firstStepPrimaryVertices.TrackLabel = cms.InputTag("initialStepTracks")
-firstStepPrimaryVertices.vertexCollections = cms.VPSet(
-     [cms.PSet(label=cms.string(""),
-               algorithm=cms.string("AdaptiveVertexFitter"),
-               minNdof=cms.double(0.0),
-               useBeamConstraint = cms.bool(False),
-               maxDistanceToBeam = cms.double(1.0)
-               )
-      ]
-    )
+firstStepPrimaryVertices.vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
  
 
 # Final selection

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -183,7 +183,6 @@ public:
 
   void dump(const double beta, const vertex_t & y,
 	    const track_t & tks, const int verbosity = 0) const;
-  bool merge(vertex_t &) const;
   bool merge(vertex_t & y, double & beta)const;
   bool purge(vertex_t &, track_t &, double &,
 	     const double) const;
@@ -209,7 +208,6 @@ private:
 
   double mintrkweight_;
   double uniquetrkweight_;
-  bool oldbehavior_;
   double zmerge_;
   double betapurge_;
 

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -179,31 +179,40 @@ public:
   track_t	fill(const std::vector<reco::TransientTrack> & tracks) const;
   
   double update(double beta, track_t & gtracks,
-		vertex_t & gvertices, bool useRho0, double & rho0) const;
-  
+		vertex_t & gvertices, bool useRho0, const double & rho0) const;
+
   void dump(const double beta, const vertex_t & y,
 	    const track_t & tks, const int verbosity = 0) const;
   bool merge(vertex_t &) const;
   bool merge(vertex_t & y, double & beta)const;
   bool purge(vertex_t &, track_t &, double &,
 	     const double) const;
-  
   void splitAll( vertex_t & y) const;
-  bool split(const double beta,  track_t &t, vertex_t & y ) const;
+  bool split(const double beta,  track_t &t, vertex_t & y, double threshold = 1. ) const;
   
   double beta0(const double betamax, track_t const & tks, vertex_t const & y) const;
     
   
 private:
   bool verbose_;
-  float vertexSize_;
+  double zdumpcenter_;
+  double zdumpwidth_;
+
+  double vertexSize_;
   int maxIterations_;
   double coolingFactor_;
-  float betamax_;
-  float betastop_;
+  double betamax_;
+  double betastop_;
   double dzCutOff_;
   double d0CutOff_;
   bool useTc_;
+
+  double mintrkweight_;
+  double uniquetrkweight_;
+  bool oldbehavior_;
+  double zmerge_;
+  double betapurge_;
+
 };
 
 

--- a/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
@@ -21,7 +21,7 @@ public:
 
 private:
 
-  float maxD0Sig_, minPt_;
+  float maxD0Sig_, minPt_, maxEta_;
   int minSiLayers_, minPxLayers_;
   float maxNormChi2_;
   reco::TrackBase::TrackQuality quality_;

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -16,6 +16,7 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
+#include "RecoVertex/VertexTools/interface/GeometricAnnealing.h"
 
 PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
   :theConfig(conf)
@@ -75,7 +76,7 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
       if (fitterAlgorithm=="KalmanVertexFitter") {
 	algorithm.fitter= new KalmanVertexFitter();
       } else if( fitterAlgorithm=="AdaptiveVertexFitter") {
-	algorithm.fitter= new AdaptiveVertexFitter();
+	algorithm.fitter= new AdaptiveVertexFitter( GeometricAnnealing( algoconf->getParameter<double>("chi2cutoff")));
       } else {
 	throw VertexException("PrimaryVertexProducerAlgorithm: unknown algorithm: " + fitterAlgorithm);  
       }
@@ -244,9 +245,11 @@ PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
           if (f4D) std::cout << ",t";
           std::cout << "=" << v.position().x() <<" " << v.position().y() << " " <<  v.position().z();
           if (f4D) std::cout << " " << v.time();
-          std::cout << std::endl;
+          std::cout  << " cluster size = " << (*iclus).size() << std::endl;
         }
-	else std::cout <<"Invalid fitted vertex\n";
+	else{
+	  std::cout <<"Invalid fitted vertex,  cluster size=" << (*iclus).size() << std::endl;
+	}
       }
 
       if ( v.isValid() 

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
@@ -27,6 +27,7 @@ pixelVertices = cms.EDProducer("PrimaryVertexProducer",
             Tstop = cms.double(0.5),
             coolingFactor = cms.double(0.6),
             vertexSize = cms.double(0.01),
+            zmerge = cms.double(0.01),
             uniquetrkweight = cms.double(0.9)
         )
     ),

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
@@ -13,6 +13,7 @@ pixelVertices = cms.EDProducer("PrimaryVertexProducer",
         minSiliconLayersWithHits = cms.int32(3),
         maxD0Significance = cms.double(100.0), 
         minPt = cms.double(0.0),
+        maxEta = cms.double(100.),
         trackQuality = cms.string("any")
     ),
 
@@ -21,7 +22,9 @@ pixelVertices = cms.EDProducer("PrimaryVertexProducer",
         TkDAClusParameters = cms.PSet(
             dzCutOff = cms.double(4.0),
             d0CutOff = cms.double(3.0),
-            Tmin = cms.double(4.0),
+            Tmin = cms.double(2.4),
+            Tpurge = cms.double(2.0),
+            Tstop = cms.double(0.5),
             coolingFactor = cms.double(0.6),
             vertexSize = cms.double(0.01),
             use_vdt = cms.untracked.bool(True)
@@ -31,6 +34,7 @@ pixelVertices = cms.EDProducer("PrimaryVertexProducer",
     vertexCollections = cms.VPSet(
      [cms.PSet(label=cms.string(""),
                algorithm=cms.string("AdaptiveVertexFitter"),
+               chi2cutoff = cms.double(3.0),
                minNdof=cms.double(2.0),
                useBeamConstraint = cms.bool(False),
                maxDistanceToBeam = cms.double(2.0)

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
@@ -27,7 +27,7 @@ pixelVertices = cms.EDProducer("PrimaryVertexProducer",
             Tstop = cms.double(0.5),
             coolingFactor = cms.double(0.6),
             vertexSize = cms.double(0.01),
-            use_vdt = cms.untracked.bool(True)
+            uniquetrkweight = cms.double(0.9)
         )
     ),
 

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
@@ -12,6 +12,7 @@ offlinePrimaryVerticesFromCosmicTracks = cms.EDProducer("PrimaryVertexProducer",
         minSiliconLayersWithHits = cms.int32(7), ## hits > 7
         maxD0Significance = cms.double(5.0), ## keep most primary tracks
         minPt = cms.double(0.0), ## better for softish events
+        maxEta = cms.double(5.0), 
         minPixelLayersWithHits = cms.int32(2), ## hits > 2
         trackQuality = cms.string("any")
     ),
@@ -26,6 +27,7 @@ offlinePrimaryVerticesFromCosmicTracks = cms.EDProducer("PrimaryVertexProducer",
     vertexCollections = cms.VPSet(
      [cms.PSet(label=cms.string(""),
                algorithm=cms.string("AdaptiveVertexFitter"),
+               chi2cutoff = cms.double(3.0),
                minNdof=cms.double(0.0),
                useBeamConstraint = cms.bool(False),
                maxDistanceToBeam = cms.double(1.0)

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -16,6 +16,7 @@ offlinePrimaryVertices = cms.EDProducer(
         minSiliconLayersWithHits = cms.int32(5),
         maxD0Significance = cms.double(5.0), 
         minPt = cms.double(0.0),
+        maxEta = cms.double(2.4),
         trackQuality = cms.string("any")
     ),
 
@@ -24,12 +25,14 @@ offlinePrimaryVertices = cms.EDProducer(
     vertexCollections = cms.VPSet(
      [cms.PSet(label=cms.string(""),
                algorithm=cms.string("AdaptiveVertexFitter"),
+               chi2cutoff = cms.double(2.5),
                minNdof=cms.double(0.0),
                useBeamConstraint = cms.bool(False),
                maxDistanceToBeam = cms.double(1.0)
                ),
       cms.PSet(label=cms.string("WithBS"),
                algorithm = cms.string('AdaptiveVertexFitter'),
+               chi2cutoff = cms.double(2.5),
                minNdof=cms.double(2.0),
                useBeamConstraint = cms.bool(True),
                maxDistanceToBeam = cms.double(1.0)

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -11,12 +11,12 @@ offlinePrimaryVertices = cms.EDProducer(
     
     TkFilterParameters = cms.PSet(
         algorithm=cms.string('filter'),
-        maxNormalizedChi2 = cms.double(10.0),
+        maxNormalizedChi2 = cms.double(20.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
         maxD0Significance = cms.double(5.0), 
         minPt = cms.double(0.0),
-        maxEta = cms.double(2.4),
+        maxEta = cms.double(5.0),
         trackQuality = cms.string("any")
     ),
 
@@ -25,14 +25,14 @@ offlinePrimaryVertices = cms.EDProducer(
     vertexCollections = cms.VPSet(
      [cms.PSet(label=cms.string(""),
                algorithm=cms.string("AdaptiveVertexFitter"),
-               chi2cutoff = cms.double(2.5),
+               chi2cutoff = cms.double(3.0),
                minNdof=cms.double(0.0),
                useBeamConstraint = cms.bool(False),
                maxDistanceToBeam = cms.double(1.0)
                ),
       cms.PSet(label=cms.string("WithBS"),
                algorithm = cms.string('AdaptiveVertexFitter'),
-               chi2cutoff = cms.double(2.5),
+               chi2cutoff = cms.double(3.0),
                minNdof=cms.double(2.0),
                useBeamConstraint = cms.bool(True),
                maxDistanceToBeam = cms.double(1.0)

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -11,7 +11,7 @@ offlinePrimaryVertices = cms.EDProducer(
     
     TkFilterParameters = cms.PSet(
         algorithm=cms.string('filter'),
-        maxNormalizedChi2 = cms.double(20.0),
+        maxNormalizedChi2 = cms.double(10.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
         maxD0Significance = cms.double(5.0), 

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -52,3 +52,9 @@ offlinePrimaryVertices = cms.EDProducer(
 from Configuration.Eras.Modifier_trackingLowPU_cff import trackingLowPU
 trackingLowPU.toModify(offlinePrimaryVertices,
                             TkFilterParameters = dict(minPixelLayersWithHits = 0))
+
+
+# higher eta cut for the phase 2 tracker
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker 
+phase2_tracker.toModify(offlinePrimaryVertices, 
+                        TkFilterParameters = dict(maxEta = 4.0))

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -11,12 +11,12 @@ offlinePrimaryVertices = cms.EDProducer(
     
     TkFilterParameters = cms.PSet(
         algorithm=cms.string('filter'),
-        maxNormalizedChi2 = cms.double(20.0),
+        maxNormalizedChi2 = cms.double(10.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
-        maxD0Significance = cms.double(5.0), 
+        maxD0Significance = cms.double(4.0), 
         minPt = cms.double(0.0),
-        maxEta = cms.double(5.0),
+        maxEta = cms.double(2.4),
         trackQuality = cms.string("any")
     ),
 
@@ -25,14 +25,14 @@ offlinePrimaryVertices = cms.EDProducer(
     vertexCollections = cms.VPSet(
      [cms.PSet(label=cms.string(""),
                algorithm=cms.string("AdaptiveVertexFitter"),
-               chi2cutoff = cms.double(3.0),
+               chi2cutoff = cms.double(2.5),
                minNdof=cms.double(0.0),
                useBeamConstraint = cms.bool(False),
                maxDistanceToBeam = cms.double(1.0)
                ),
       cms.PSet(label=cms.string("WithBS"),
                algorithm = cms.string('AdaptiveVertexFitter'),
-               chi2cutoff = cms.double(3.0),
+               chi2cutoff = cms.double(2.5),
                minNdof=cms.double(2.0),
                useBeamConstraint = cms.bool(True),
                maxDistanceToBeam = cms.double(1.0)

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -15,13 +15,13 @@ DA_vectParameters = cms.PSet(
     algorithm   = cms.string("DA_vect"),
     TkDAClusParameters = cms.PSet(
         coolingFactor = cms.double(0.6),  # moderate annealing speed
-        Tmin = cms.double(2.0),           # end of vertex splitting
+        Tmin = cms.double(2.4),           # end of vertex splitting
         Tpurge = cms.double(2.0),         # cleaning 
         Tstop = cms.double(0.5),          # end of annealing 
-        vertexSize = cms.double(0.005),   # added in quadrature to track-z resolutions
+        vertexSize = cms.double(0.01),    # added in quadrature to track-z resolutions
         d0CutOff = cms.double(3.),        # downweight high IP tracks 
-        dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
+        dzCutOff = cms.double(4.),        # outlier rejection after freeze-out (T<Tmin)
         zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
-        uniquetrkweight = cms.double(0.8) # require at least two tracks with this weight at T=Tpurge
+        uniquetrkweight = cms.double(0.9) # require at least two tracks with this weight at T=Tpurge
         )
 )

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -15,13 +15,13 @@ DA_vectParameters = cms.PSet(
     algorithm   = cms.string("DA_vect"),
     TkDAClusParameters = cms.PSet(
         coolingFactor = cms.double(0.6),  # moderate annealing speed
-        Tmin = cms.double(2.4),           # end of vertex splitting
+        Tmin = cms.double(2.0),           # end of vertex splitting
         Tpurge = cms.double(2.0),         # cleaning 
         Tstop = cms.double(0.5),          # end of annealing 
-        vertexSize = cms.double(0.01),    # added in quadrature to track-z resolutions
+        vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
         d0CutOff = cms.double(3.),        # downweight high IP tracks 
-        dzCutOff = cms.double(4.),        # outlier rejection after freeze-out (T<Tmin)
+        dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
         zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
-        uniquetrkweight = cms.double(0.9) # require at least two tracks with this weight at T=Tpurge
+        uniquetrkweight = cms.double(0.8) # require at least two tracks with this weight at T=Tpurge
         )
 )

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -14,10 +14,14 @@ DA2DParameters = cms.PSet(
 DA_vectParameters = cms.PSet(
     algorithm   = cms.string("DA_vect"),
     TkDAClusParameters = cms.PSet(
-        coolingFactor = cms.double(0.6),  #  moderate annealing speed
-        Tmin = cms.double(4.),            #  end of annealing
-        vertexSize = cms.double(0.01),    #  ~ resolution / sqrt(Tmin)
+        coolingFactor = cms.double(0.6),  # moderate annealing speed
+        Tmin = cms.double(2.0),           # end of vertex splitting
+        Tpurge = cms.double(2.0),         # cleaning 
+        Tstop = cms.double(0.5),          # end of annealing 
+        vertexSize = cms.double(0.005),   # added in quadrature to track-z resolutions
         d0CutOff = cms.double(3.),        # downweight high IP tracks 
-        dzCutOff = cms.double(4.)         # outlier rejection after freeze-out (T<Tmin)
+        dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
+        zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
+        uniquetrkweight = cms.double(0.8) # require at least two tracks with this weight at T=Tpurge
         )
 )

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -72,8 +72,8 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 
   if ((Tstop > Tpurge) || (Tstop == 0)) {
     std::cout  << "DAClusterizerInZ: invalid Tstop" << Tstop
-	       << "  set to  " << min(1., Tpurge) << endl;
-    Tstop = min(1., Tpurge) ;
+	       << "  set to  " << max(1., Tpurge) << endl;
+    Tstop = max(1., Tpurge) ;
   }
   betastop_ = 1./Tstop;
   
@@ -486,11 +486,6 @@ DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y, dou
 
     if(w1>0){z1 = z1/w1;} else {z1=y._z[k]-epsilon;}
     if(w2>0){z2 = z2/w2;} else {z2=y._z[k]+epsilon;}
-
-    if(verbose_){
-      std::cout << "split test " << setw(10) << setprecision(4) << y._z[k] << " z -> " << setw(10) << z1 << "," << z2 <<  "   p1,p2=" << p1<< "," << p2 << std::endl;
-    }
-
 
     // reduce split size if there is not enough room
     if( ( k   > 0 ) && ( z1 < (0.6*y._z[k] + 0.4*y._z[k-1])) ){ z1 = 0.6*y._z[k] + 0.4*y._z[k-1]; }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -334,32 +334,21 @@ DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const d
     int nUnique = 0;
     double sump = 0;
 
-    if (uniquetrkweight_<0){
-    
-      sumpmin = -uniquetrkweight_;
-      double sump = y._pk[k]*nt;
-      if( sump < sumpmin){ sumpmin = sump; k0 = k; }
-
-    }else{
-
-      double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_* dzCutOff_));
-      for (unsigned int i = 0; i < nt; i++) {
-	if (tks._Z_sum[i] > 1.e-100) {
-	  double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
-	  sump += p;
-	  if ((p > uniquetrkweight_ * pmax) && (tks._pi[i] > 0)) {
-	    nUnique++;
-	  }
+    double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_* dzCutOff_));
+    for (unsigned int i = 0; i < nt; i++) {
+      if (tks._Z_sum[i] > 1.e-100) {
+	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
+	sump += p;
+	if ((p > uniquetrkweight_ * pmax) && (tks._pi[i] > 0)) {
+	  nUnique++;
 	}
       }
-
-      if ((nUnique < 2) && (sump < sumpmin)) {
-	sumpmin = sump;
-	k0 = k;
-      }
-
     }
 
+    if ((nUnique < 2) && (sump < sumpmin)) {
+      sumpmin = sump;
+      k0 = k;
+    }
 
   }
   
@@ -700,7 +689,7 @@ DAClusterizerInZ_vect::vertices(const vector<reco::TransientTrack> & tracks, con
     dump(beta, y, tks, 2);
   }
 
-  // optionally cool some more without doing anything, to make the asignment harder
+  // optionally cool some more without doing anything, to make the assignment harder
   while( beta < betastop_ ){
     beta = min( beta/coolingFactor_, betastop_);
     niter =0;
@@ -716,7 +705,7 @@ DAClusterizerInZ_vect::vertices(const vector<reco::TransientTrack> & tracks, con
   // select significant tracks and use a TransientVertex as a container
   GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
   
-  // ensure correct normalization of probabilities, should makes double assginment reasonably impossible
+  // ensure correct normalization of probabilities, should makes double assignment reasonably impossible
   const unsigned int nv = y.GetSize();
   for (unsigned int k = 0; k < nv; k++)
      if ( edm::isNotFinite(y._pk[k]) || edm::isNotFinite(y._z[k]) ) { y._pk[k]=0; y._z[k]=0;}

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -344,7 +344,7 @@ DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const d
 
       double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_* dzCutOff_));
       for (unsigned int i = 0; i < nt; i++) {
-	if (tks._Z_sum[i] > 0) {
+	if (tks._Z_sum[i] > 1.e-100) {
 	  double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
 	  sump += p;
 	  if ((p > uniquetrkweight_ * pmax) && (tks._pi[i] > 0)) {

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -14,20 +14,20 @@ using namespace std;
 
 DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 
-  // some defaults to avoid uninitialized variables
-  verbose_ = conf.getUntrackedParameter<bool> ("verbose", false);
-  
-  betamax_ = 0.1;
-  betastop_ = 1.0;
-  /*
-  coolingFactor_ = 0.6;
+  // hardcoded parameters
   maxIterations_ = 100;
-  vertexSize_ = 0.01; // 0.1 mm
-  dzCutOff_ = 4.0;  
-  */
-	// configure
+  mintrkweight_ = 0.5; // conf.getParameter<double>("mintrkweight");
 
+
+  // configurable debug outptut debug output
+  verbose_ = conf.getUntrackedParameter<bool> ("verbose", false);
+  zdumpcenter_ = conf.getUntrackedParameter<double> ("zdumpcenter", 0.);
+  zdumpwidth_ = conf.getUntrackedParameter<double> ("zdumpwidth", 20.);
+  
+  // configurable parameters
   double Tmin = conf.getParameter<double> ("Tmin");
+  double Tpurge = conf.getParameter<double> ("Tpurge");
+  double Tstop = conf.getParameter<double> ("Tstop");
   vertexSize_ = conf.getParameter<double> ("vertexSize");
   coolingFactor_ = conf.getParameter<double> ("coolingFactor");
   useTc_=true;
@@ -37,15 +37,48 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
   }
   d0CutOff_ = conf.getParameter<double> ("d0CutOff");
   dzCutOff_ = conf.getParameter<double> ("dzCutOff");
-  maxIterations_ = 100;
+  uniquetrkweight_ = conf.getParameter<double>("uniquetrkweight");
+  zmerge_ = conf.getParameter<double>("zmerge");
+
+  if(verbose_){
+    std::cout << "DAClusterizerinZ_vect: mintrkweight = " << mintrkweight_ << std::endl;
+    std::cout << "DAClusterizerinZ_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
+    std::cout << "DAClusterizerinZ_vect: zmerge = " << zmerge_ << std::endl;
+    std::cout << "DAClusterizerinZ_vect: Tmin = " << Tmin << std::endl;
+    std::cout << "DAClusterizerinZ_vect: Tpurge = " << Tpurge << std::endl;
+    std::cout << "DAClusterizerinZ_vect: Tstop = " << Tstop << std::endl;
+    std::cout << "DAClusterizerinZ_vect: vertexSize = " << vertexSize_ << std::endl;
+    std::cout << "DAClusterizerinZ_vect: coolingFactor = " << coolingFactor_ << std::endl;
+    std::cout << "DAClusterizerinZ_vect: d0CutOff = " << d0CutOff_ << std::endl;
+    std::cout << "DAClusterizerinZ_vect: dzCutOff = " << dzCutOff_ << std::endl;
+  }
+
+
   if (Tmin == 0) {
-    LogDebug("DAClusterizerinZ_vectorized")  << "DAClusterizerInZ: invalid Tmin" << Tmin
-					     << "  reset do default " << 1. / betamax_ << endl;
+    std::cout  << "DAClusterizerInZ: invalid Tmin" << Tmin
+	       << "  reset do default " << 1. / betamax_ << endl;
   } else {
     betamax_ = 1. / Tmin;
   }
 
+
+  if ((Tpurge > Tmin) || (Tpurge == 0)) {
+    std::cout  << "DAClusterizerInZ: invalid Tpurge" << Tpurge
+	       << "  set to " << Tmin << endl;
+    Tpurge =  Tmin;
+  }
+  betapurge_ = 1./Tpurge;
+  
+
+  if ((Tstop > Tpurge) || (Tstop == 0)) {
+    std::cout  << "DAClusterizerInZ: invalid Tstop" << Tstop
+	       << "  set to  " << min(1., Tpurge) << endl;
+    Tstop = min(1., Tpurge) ;
+  }
+  betapurge_ = 1./Tpurge;
+  
 }
+
 
 namespace {
   inline double local_exp( double const& inp) {
@@ -63,13 +96,12 @@ DAClusterizerInZ_vect::track_t
 DAClusterizerInZ_vect::fill(const vector<reco::TransientTrack> & tracks) const {
 
   // prepare track data for clustering
-  LogDebug("DAClusterizerinZ_vectorized") << "input values"; 
   track_t tks;
   for (auto it = tracks.begin(); it!= tracks.end(); it++){
     if (!(*it).isValid()) continue;
     double t_pi=1.;
     double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
-    if (std::abs(t_z) > 1000.) continue;
+    if (std::fabs(t_z) > 1000.) continue;
     auto const & t_mom = (*it).stateAtBeamLine().trackStateAtPCA().momentum();
     //  get the beam-spot
     reco::BeamSpot beamspot = (it->stateAtBeamLine()).beamSpot();
@@ -81,7 +113,7 @@ DAClusterizerInZ_vect::fill(const vector<reco::TransientTrack> & tracks) const {
     if (edm::isNotFinite(t_dz2) || t_dz2 < std::numeric_limits<double>::min() ) continue;
     if (d0CutOff_ > 0) {
       Measurement1D atIP =
-	(*it).stateAtBeamLine().transverseImpactParameter();// error constains beamspot
+	(*it).stateAtBeamLine().transverseImpactParameter();// error contains beamspot
       t_pi = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) - std::pow(d0CutOff_, 2))); // reduce weight for high ip tracks
       if (edm::isNotFinite(t_pi) ||  t_pi < std::numeric_limits<double>::epsilon())  continue; // usually is > 0.99
     }
@@ -91,7 +123,7 @@ DAClusterizerInZ_vect::fill(const vector<reco::TransientTrack> & tracks) const {
   tks.ExtractRaw();
   
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized") << "Track count " << tks.GetSize() << std::endl;
+    std::cout << "Track count " << tks.GetSize() << std::endl;
   }
   
   return tks;
@@ -106,7 +138,7 @@ namespace {
 }
 
 double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
-				     vertex_t & gvertices, bool useRho0, double & rho0) const {
+				     vertex_t & gvertices, bool useRho0, const double & rho0) const {
 
   //update weights and vertex positions
   // mass constrained annealing without noise
@@ -124,6 +156,11 @@ double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
 
   // intial value of a sum
   double Z_init = 0;
+  // independpent of loop
+  if ( useRho0 )
+    {
+      Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_); // cut-off
+    }
   
   // define kernels
   auto kernel_calc_exp_arg = [ beta, nv ] ( const unsigned int itrack,
@@ -176,11 +213,6 @@ double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
   }
   
   
-  // independpent of loop
-  if ( useRho0 )
-    {
-      Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_); // cut-off
-    }
   
   // loop over tracks
   for (auto itrack = 0U; itrack < nt; ++itrack) {
@@ -190,10 +222,9 @@ double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
     gtracks._Z_sum[itrack] = kernel_add_Z(gvertices);
     if (edm::isNotFinite(gtracks._Z_sum[itrack])) gtracks._Z_sum[itrack] = 0.0;
     // used in the next major loop to follow
-    if (!useRho0)
-      sumpi += gtracks._pi[itrack];
+    sumpi += gtracks._pi[itrack];
     
-    if (gtracks._Z_sum[itrack] > 1.e-100) {
+    if (gtracks._Z_sum[itrack] > 1.e-100){
       kernel_calc_normalization(itrack, gtracks, gvertices);
     }
   }
@@ -214,18 +245,17 @@ double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
       else {
 	edm::LogInfo("sumw") << "invalid sum of weights in fit: " << vertices._sw[ivertex] << endl;
 	if (this->verbose_) {
-	  LogDebug("DAClusterizerinZ_vectorized")  << " a cluster melted away ?  pk=" << vertices._pk[ ivertex ] << " sumw="
+	  std::cout  << " a cluster melted away ?  pk=" << vertices._pk[ ivertex ] << " sumw="
 						   << vertices._sw[ivertex] << endl;
 	}
       }
 #endif
     }
-    // dont do, if rho cut
-    if ( ! useRho0 ){
-      auto osumpi = 1./sumpi;
-      for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
-	vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] * osumpi;
-    }
+
+    auto osumpi = 1./sumpi;
+    for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex )
+      vertices._pk[ ivertex ] = vertices._pk[ ivertex ] * vertices._se[ ivertex ] * osumpi;
+
     return delta;
   };
   
@@ -234,6 +264,8 @@ double DAClusterizerInZ_vect::update(double beta, track_t & gtracks,
   // return how much the prototypes moved
   return delta;
 }
+
+
 
 
 
@@ -246,61 +278,44 @@ bool DAClusterizerInZ_vect::merge(vertex_t & y, double & beta)const{
   if (nv < 2)
     return false;
 
-
+  // merge the smallest distance clusters first
+  std::vector<std::pair<double, unsigned int> > critical;
   for (unsigned int k = 0; (k + 1) < nv; k++) {
-    if (fabs(y._z[k + 1] - y._z[k]) < 2.e-2) {
-      double rho=y._pk[k] + y._pk[k+1];
-      double swE=y._swE[k]+y._swE[k+1] - y._pk[k]*y._pk[k+1] /rho *std::pow(y._z[k+1]-y._z[k],2);
-      double Tc=2*swE/(y._sw[k]+y._sw[k+1]);
-
-      if(Tc*beta<1){
-        if(rho>0){
-	  y._z[k] = (y._pk[k]*y._z[k] + y._pk[k+1]*y._z[k + 1])/rho;
-        }else{
-	  y._z[k] = 0.5 * (y._z[k] + y._z[k + 1]);
-        }
-        y._pk[k] = rho;
-        y._sw[k]+=y._sw[k+1];
-        y._swE[k]=swE;
-        y.RemoveItem(k+1);
-        return true;
-      }
+    if (std::fabs(y._z[k + 1] - y._z[k]) < zmerge_) {
+      critical.push_back( make_pair( std::fabs(y._z[k + 1] - y._z[k]), k) );
     }
   }
+  if (critical.size() == 0) return false;
 
-  return false;
-}
-
-
+  std::stable_sort(critical.begin(), critical.end(), std::less<std::pair<double, unsigned int> >() );
 
 
+  for (unsigned int ik=0; ik < critical.size(); ik++){
+    unsigned int k = critical[ik].second;
+    double rho = y._pk[k]+y._pk[k+1];
+    double swE = y._swE[k]+y._swE[k+1]-y._pk[k]*y._pk[k+1] / rho*std::pow(y._z[k+1]-y._z[k],2);
+    double Tc = 2*swE / (y._sw[k]+y._sw[k+1]);
 
-bool DAClusterizerInZ_vect::merge(vertex_t & y) const {
-  // merge clusters that collapsed or never separated, return true if vertices were merged, false otherwise
-  
-  const unsigned int nv = y.GetSize();
-  
-  if (nv < 2) return false;
-
-  for (unsigned int k = 0; (k + 1) < nv; k++) {
-    //if ((k+1)->z - k->z<1.e-2){  // note, no fabs here, maintains z-ordering  (with split()+merge() at every temperature)
-    if (std::abs(y._z[k + 1] - y._z[k]) < 1.e-2) { // with fabs if only called after freeze-out (splitAll() at highter T)
-      y._pk[k] += y._pk[k + 1];
-      y._z[k] = 0.5 * (y._z[k] + y._z[k + 1]);
-      
-      y.RemoveItem(k + 1);
-      
-      if ( verbose_)
-	{
-	  LogDebug("DAClusterizerinZ_vectorized") << "Merging vertices k = " << k << std::endl;
-	}
-      
+    if(Tc*beta < 1){
+      if(verbose_){ std::cout << "merging " << y._z[k + 1] << " and " <<  y._z[k] << "  Tc = " << Tc <<  "  sw = "  << y._sw[k]+y._sw[k+1]  <<std::endl;}
+      if(rho > 0){
+	y._z[k] = (y._pk[k]*y._z[k] + y._pk[k+1]*y._z[k + 1])/rho;
+      }else{
+	y._z[k] = 0.5 * (y._z[k] + y._z[k + 1]);
+      }
+      y._pk[k] = rho;
+      y._sw[k] += y._sw[k+1];
+      y._swE[k] = swE;
+      y.RemoveItem(k+1);
       return true;
     }
   }
-  
+
   return false;
 }
+
+
+
 
 bool 
 DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const double beta) const {
@@ -318,38 +333,52 @@ DAClusterizerInZ_vect::purge(vertex_t & y, track_t & tks, double & rho0, const d
     
     int nUnique = 0;
     double sump = 0;
-    double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_* dzCutOff_));
+
+    if (uniquetrkweight_<0){
     
-    for (unsigned int i = 0; i < nt; i++) {
-      
-      if (tks._Z_sum[i] > 0) {
-	//double p=pik(beta,tks[i],*k);
-	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
-	sump += p;
-	if ((p > 0.9 * pmax) && (tks._pi[i] > 0)) {
-	  nUnique++;
+      sumpmin = -uniquetrkweight_;
+      double sump = y._pk[k]*nt;
+      if( sump < sumpmin){ sumpmin = sump; k0 = k; }
+
+    }else{
+
+      double pmax = y._pk[k] / (y._pk[k] + rho0 * local_exp(-beta * dzCutOff_* dzCutOff_));
+      for (unsigned int i = 0; i < nt; i++) {
+	if (tks._Z_sum[i] > 0) {
+	  double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
+	  sump += p;
+	  if ((p > uniquetrkweight_ * pmax) && (tks._pi[i] > 0)) {
+	    nUnique++;
+	  }
 	}
-			}
+      }
+
+      if ((nUnique < 2) && (sump < sumpmin)) {
+	sumpmin = sump;
+	k0 = k;
+      }
+
     }
-    
-    if ((nUnique < 2) && (sump < sumpmin)) {
-      sumpmin = sump;
-      k0 = k;
-    }
+
+
   }
   
   if (k0 != nv) {
     if (verbose_) {
-      LogDebug("DAClusterizerinZ_vectorized")  << "eliminating prototype at " << y._z[k0] << " with sump="
-					       << sumpmin << endl;
+      std::cout  << "eliminating prototype at " << std::setw(10) << std::setprecision(4) << y._z[k0] 
+		 << " with sump=" << sumpmin
+		 << "  rho*nt =" << y._pk[k0]*nt
+		 << endl;
     }
-    //rho0+=k0->pk;
     y.RemoveItem(k0);
     return true;
   } else {
     return false;
   }
 }
+
+
+
 
 double 
 DAClusterizerInZ_vect::beta0(double betamax, track_t const  & tks, vertex_t const & y) const {
@@ -383,22 +412,30 @@ DAClusterizerInZ_vect::beta0(double betamax, track_t const  & tks, vertex_t cons
     if (Tc > T0) T0 = Tc;
   }// vertex loop (normally there should be only one vertex at beta=0)
   
+  if(verbose_){
+    std::cout << "DAClustrizerInZ_vect.beta0:   Tc = " << T0 << std::endl;
+    int coolingsteps =  1 - int(std::log(T0 * betamax) / std::log(coolingFactor_));
+    std::cout << "DAClustrizerInZ_vect.beta0:   nstep = " << coolingsteps << std::endl;
+  }
+
+
   if (T0 > 1. / betamax) {
     return betamax / std::pow(coolingFactor_, int(std::log(T0 * betamax) / std::log(coolingFactor_)) - 1);
   } else {
     // ensure at least one annealing step
-    return betamax / coolingFactor_;
+    return betamax * coolingFactor_;
   }
 }
 
 
+  
 bool 
-DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y ) const{
+DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y, double threshold ) const{
   // split only critical vertices (Tc >~ T=1/beta   <==>   beta*Tc>~1)
   // an update must have been made just before doing this (same beta, no merging)
   // returns true if at least one cluster was split
   
-  double epsilon=1e-3;      // split all single vertices by 10 um
+  double epsilon=1e-3;      // minimum split size
   unsigned int nv = y.GetSize();
   
   // avoid left-right biases by splitting highest Tc first
@@ -406,11 +443,13 @@ DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y ) co
   std::vector<std::pair<double, unsigned int> > critical;
   for(unsigned int k=0; k<nv; k++){
     double Tc= 2*y._swE[k]/y._sw[k];
-    if (beta*Tc > 1.){
+    if (beta*Tc > threshold){
       critical.push_back( make_pair(Tc, k));
     }
   }
   if (critical.size()==0) return false;
+
+
   std::stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int> >() );
   
   
@@ -419,40 +458,72 @@ DAClusterizerInZ_vect::split(const double beta,  track_t &tks, vertex_t & y ) co
 
   for(unsigned int ic=0; ic<critical.size(); ic++){
     unsigned int k=critical[ic].second;
+
     // estimate subcluster positions and weight
     double p1=0, z1=0, w1=0;
     double p2=0, z2=0, w2=0;
     for(unsigned int i=0; i<nt; i++){
-      if (tks._Z_sum[i] > 0) {
-	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
-        double w=p*tks._dz2[i];
-        if(tks._z[i]<y._z[k]){
-          p1+=p; z1+=w*tks._z[i]; w1+=w;
-        }else{
-          p2+=p; z2+=w*tks._z[i]; w2+=w;
-        }
+      if (tks._Z_sum[i] > 1.e-100) {
+
+	// winner-takes-all, usually overestimates splitting
+	double tl = tks._z[i] < y._z[k] ? 1.: 0.;
+	double tr = 1. - tl;
+
+	 // soften it, especially at low T
+	double arg = (tks._z[i] - y._z[k]) * sqrt(beta * tks._dz2[i]);
+	if(std::fabs(arg) < 20){
+	  double t = local_exp(-arg);
+	  tl = t/(t+1.);
+	  tr = 1/(t+1.);
+	}
+
+	double p = y._pk[k] * tks._pi[i] * local_exp(-beta * Eik(tks._z[i], y._z[k], tks._dz2[i])) / tks._Z_sum[i];
+	double w = p*tks._dz2[i];
+	p1 += p*tl ; z1 += w*tl*tks._z[i]; w1 += w*tl;
+	p2 += p*tr;  z2 += w*tr*tks._z[i]; w2 += w*tr;
       }
     }
-    if(w1>0){  z1=z1/w1;} else{z1=y._z[k]-epsilon;}
-    if(w2>0){  z2=z2/w2;} else{z2=y._z[k]+epsilon;}
+
+    if(w1>0){z1 = z1/w1;} else {z1=y._z[k]-epsilon;}
+    if(w2>0){z2 = z2/w2;} else {z2=y._z[k]+epsilon;}
+
+    if(verbose_){
+      std::cout << "split test " << setw(10) << setprecision(4) << y._z[k] << " z -> " << setw(10) << z1 << "," << z2 <<  "   p1,p2=" << p1<< "," << p2 << std::endl;
+    }
+
 
     // reduce split size if there is not enough room
-    if( ( k   > 0 ) && ( y._z[k-1]>=z1 ) ){ z1=0.5*(y._z[k]+y._z[k-1]); }
-    if( ( k+1 < nv) && ( y._z[k+1]<=z2 ) ){ z2=0.5*(y._z[k]+y._z[k+1]); }
+    if( ( k   > 0 ) && ( z1 < (0.6*y._z[k] + 0.4*y._z[k-1])) ){ z1 = 0.6*y._z[k] + 0.4*y._z[k-1]; }
+    if( ( k+1 < nv) && ( z2 > (0.6*y._z[k] + 0.4*y._z[k+1])) ){ z2 = 0.6*y._z[k] + 0.4*y._z[k+1]; }
+
+    if(verbose_){
+      if (std::fabs(y._z[k] - zdumpcenter_) < zdumpwidth_){
+	std::cout << " T= " << std::setw(8) << 1./beta 
+		  << " Tc= " << critical[ic].first 
+		  << "    splitting " << std::fixed << std::setprecision(4) << y._z[k] 
+		  << " --> " << z1 << "," << z2 
+		  << "     [" << p1 << "," << p2 << "]" ;
+	if (std::fabs(z2-z1)>epsilon){
+	  std::cout << std::endl;
+	}else{
+	  std::cout <<  "  rejected " << std::endl;
+	}
+      }
+    }
 
     // split if the new subclusters are significantly separated
-    if( (z2-z1)>epsilon){
-      split=true;
-      double pk1=p1*y._pk[k]/(p1+p2);
-      double pk2=p2*y._pk[k]/(p1+p2);
+    if( (z2-z1) > epsilon){
+      split = true;
+      double pk1 = p1*y._pk[k]/(p1+p2);
+      double pk2 = p2*y._pk[k]/(p1+p2);
       y._z[k]  =  z2;
       y._pk[k] = pk2;
       y.InsertItem(k, z1, pk1);
       nv++;
 
      // adjust remaining pointers
-      for(unsigned int jc=ic; jc<critical.size(); jc++){
-        if (critical[jc].second>k) {critical[jc].second++;}
+      for(unsigned int jc=ic; jc < critical.size(); jc++){
+        if (critical[jc].second > k) {critical[jc].second++;}
       }
     }
   }
@@ -470,7 +541,7 @@ void DAClusterizerInZ_vect::splitAll( vertex_t & y) const {
   vertex_t y1;
   
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized") << "Before Split "<< std::endl;
+    std::cout << "Before Split "<< std::endl;
     y.DebugOut();
   }
 
@@ -506,7 +577,7 @@ void DAClusterizerInZ_vect::splitAll( vertex_t & y) const {
   y.ExtractRaw();
   
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized") << "After split " << std::endl;
+    std::cout << "After split " << std::endl;
     y.DebugOut();
   }
 }
@@ -534,18 +605,21 @@ DAClusterizerInZ_vect::vertices(const vector<reco::TransientTrack> & tracks, con
   
   // estimate first critical temperature
   double beta = beta0(betamax_, tks, y);
-  if ( verbose_) LogDebug("DAClusterizerinZ_vectorized") << "Beta0 is " << beta << std::endl;
+  if ( verbose_) std::cout << "Beta0 is " << beta << std::endl;
   
   niter = 0;
   while ((update(beta, tks, y, false, rho0) > 1.e-6) && 
 	 (niter++ < maxIterations_)) {}
 
   // annealing loop, stop when T<Tmin  (i.e. beta>1/Tmin)
-  while (beta < betamax_) {
+
+  double betafreeze = betamax_ * sqrt(coolingFactor_);
+
+  while (beta < betafreeze) {
     if(useTc_){
       update(beta, tks,y, false, rho0);
-      while(merge(y,beta)){update(beta, tks,y, false, rho0);}
-      split(beta, tks,y);
+      while(merge(y, beta)){update(beta, tks, y, false, rho0);}
+      split(beta, tks, y);
       beta=beta/coolingFactor_;
     }else{
       beta=beta/coolingFactor_;
@@ -556,68 +630,93 @@ DAClusterizerInZ_vect::vertices(const vector<reco::TransientTrack> & tracks, con
     niter = 0;
     while ((update(beta, tks, y, false, rho0) > 1.e-6) && 
 	   (niter++ < maxIterations_)) {}
+
+    if(verbose_){ dump( beta, y, tks, 0); }
   }
   
 
   if(useTc_){
-    // last round of splitting, make sure no critical clusters are left
+    //last round of splitting, make sure no critical clusters are left
+    if(verbose_){ std::cout << "last spliting at " << 1./beta << std::endl; }
     update(beta, tks,y, false, rho0);// make sure Tc is up-to-date
     while(merge(y,beta)){update(beta, tks,y, false, rho0);}
     unsigned int ntry=0;
-    while( split(beta, tks,y) && (ntry++<10) ){
+    double threshold = 1.0;
+    while( split(beta, tks, y, threshold) && (ntry++<10) ){
       niter=0; 
       while((update(beta, tks,y, false, rho0)>1.e-6)  && (niter++ < maxIterations_)){}
-      merge(y,beta);
+      merge(y, beta);
       update(beta, tks,y, false, rho0);
+      if(verbose_){ std::cout << "after final splitting,  try " <<  ntry << std::endl; dump(beta, y, tks, 2); }
+      threshold *= 1.1; // relax a bit to reduce multiple split-merge cycles of the same cluster
     }
   }else{
     // merge collapsed clusters 
     while(merge(y,beta)){update(beta, tks,y, false, rho0);}  
-    //while(merge(y)){}   original code
   }
   
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized")  << "dump after 1st merging " << endl;
+    update(beta, tks,y, false, rho0);
+    std::cout  << "dump after 1st merging " << endl;
     dump(beta, y, tks, 2);
   }
   
-  // switch on outlier rejection
-  rho0 = 1. / nt;
   
-  // auto-vectorized
-  for (unsigned int k = 0; k < y.GetSize(); k++) y._pk[k] = 1.; // democratic
-  niter = 0;
-  while ((update(beta, tks, y, true, rho0) > 1.e-8) && (niter++ < maxIterations_)) {}
+  // switch on outlier rejection at T=Tmin
+  if(dzCutOff_ > 0){
+    rho0 = 1./nt;
+    for(unsigned int a=0; a<10; a++){ update(beta, tks, y, true, a*rho0/10);} // adiabatic turn-on
+  }
+
+  niter=0;
+  while ((update(beta, tks, y, true, rho0) > 1.e-8) && (niter++ < maxIterations_)) {};
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized")  << "rho0=" << rho0 << " niter=" << niter << endl;
+    std::cout  << "dump after noise-suppression, rho0=" << rho0  << "  niter = " << niter << endl;
     dump(beta, y, tks, 2);
   }
-  
+
   // merge again  (some cluster split by outliers collapse here)
-  while (merge(y)) {}
+  while (merge(y, beta)) {update(beta, tks, y, true, rho0); }
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized")  << "dump after 2nd merging " << endl;
+    std::cout  << "dump after merging " << endl;
     dump(beta, y, tks, 2);
   }
 
-  // continue from freeze-out to Tstop (=1) without splitting, eliminate insignificant vertices
-  while (beta <= betastop_) {
-    while (purge(y, tks, rho0, beta)) {
-      niter = 0;
-      while ((update(beta, tks, y, true, rho0) > 1.e-6) && (niter++ < maxIterations_)) {}
-    }
-    beta /= coolingFactor_;
+  // go down to the purging temperature (if it is lower than tmin)
+  while( beta < betapurge_ ){
+    beta = min( beta/coolingFactor_, betapurge_);
     niter = 0;
-    while ((update(beta, tks, y, true, rho0) > 1.e-6) && (niter++< maxIterations_)) {}
+    while ((update(beta, tks, y, false, rho0) > 1.e-8) && (niter++ < maxIterations_)) {}
+  }
+
+
+  // eliminate insigificant vertices, this is more restrictive at higher T
+  while (purge(y, tks, rho0, beta)) {
+    niter = 0;
+    while ((update(beta, tks, y, true, rho0) > 1.e-6) && (niter++ < maxIterations_)) {}
   }
 
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized")  << "Final result, rho0=" << rho0 << endl;
+    update(beta, tks,y, true, rho0);
+    std::cout  << " after purging " << std:: endl;
+    dump(beta, y, tks, 2);
+  }
+
+  // optionally cool some more without doing anything, to make the asignment harder
+  while( beta < betastop_ ){
+    beta = min( beta/coolingFactor_, betastop_);
+    niter =0;
+    while ((update(beta, tks, y, true, rho0) > 1.e-8) && (niter++ < maxIterations_)) {}
+  }
+
+
+  if (verbose_) {
+    std::cout  << "Final result, rho0=" << std::scientific << rho0 << endl;
     dump(beta, y, tks, 2);
   }
 
   // select significant tracks and use a TransientVertex as a container
-  GlobalError dummyError;
+  GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
   
   // ensure correct normalization of probabilities, should makes double assginment reasonably impossible
   const unsigned int nv = y.GetSize();
@@ -643,9 +742,9 @@ DAClusterizerInZ_vect::vertices(const vector<reco::TransientTrack> & tracks, con
 	
 	double p = y._pk[k] * local_exp(-beta * Eik(tks._z[i], y._z[k],
 						    tks._dz2[i])) / tks._Z_sum[i];
-	if ((tks._pi[i] > 0) && (p > 0.5)) {
+	if ((tks._pi[i] > 0) && (p > mintrkweight_)) {
 	  vertexTracks.push_back(*(tks.tt[i]));
-	  tks._Z_sum[i] = 0;
+	  if ( mintrkweight_>0.49 ){ tks._Z_sum[i] = 0; }
 	} // setting Z=0 excludes double assignment
       }
     }
@@ -670,7 +769,7 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
   vector<TransientVertex> && pv = vertices(tracks);
   
   if (verbose_) {
-    LogDebug("DAClusterizerinZ_vectorized")  << "# DAClusterizerInZ::clusterize   pv.size=" << pv.size()
+    std::cout  << "# DAClusterizerInZ::clusterize   pv.size=" << pv.size()
 					     << endl;
   }
   if (pv.size() == 0) {
@@ -683,7 +782,13 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
   for (auto k = pv.begin() + 1; k != pv.end(); k++) {
     if ( std::abs(k->position().z() - (k - 1)->position().z()) > (2 * vertexSize_)) {
       // close a cluster
-      clusters.push_back(aCluster);
+      if (aCluster.size()>1){
+	clusters.push_back(aCluster);
+      }else{
+	if(verbose_){
+	  std::cout << " one track cluster at " << k->position().z() << "  suppressed" << std::endl;
+	}
+      }
       aCluster.clear();
     }
     for (unsigned int i = 0; i < k->originalTracks().size(); i++) {
@@ -699,97 +804,122 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
 
 
 
-
-
 void DAClusterizerInZ_vect::dump(const double beta, const vertex_t & y,
 		const track_t & tks, int verbosity) const {
 
 	const unsigned int nv = y.GetSize();
 	const unsigned int nt = tks.GetSize();
-
-	LogDebug("DAClusterizerinZ_vectorized")  << "-----DAClusterizerInZ::dump ----" << endl;
-	LogDebug("DAClusterizerinZ_vectorized")  << "beta=" << beta << "   betamax= " << betamax_ << endl;
-	LogDebug("DAClusterizerinZ_vectorized")  << "                                                               z= ";
-	LogDebug("DAClusterizerinZ_vectorized")  << setprecision(4);
+	
+	std::vector< unsigned int > iz;
+	for(unsigned int j=0; j<nt; j++){ iz.push_back(j); }
+	std::sort(iz.begin(), iz.end(), [tks](unsigned int a, unsigned int b){ return tks._z[a]<tks._z[b];} ); 
+	std::cout  << std::endl;
+	std::cout  << "-----DAClusterizerInZ::dump ----" <<  nv << "  clusters " << std::endl;
+	std::cout  << "                                                                z= ";
+	std::cout  << setprecision(4);
 	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
-		LogDebug("DAClusterizerinZ_vectorized")  << setw(8) << fixed << y._z[ivertex];
+	  if (std::fabs(y._z[ivertex]-zdumpcenter_) < zdumpwidth_){
+		std::cout  << setw(8) << fixed << y._z[ivertex];
+	  }
 	}
-	LogDebug("DAClusterizerinZ_vectorized")  << endl << "T=" << setw(15) << 1. / beta
-			<< "                                            Tc= ";
-	LogDebug("DAClusterizerinZ_vectorized")  << endl
-			<< "                                                               pk=";
+	std::cout  << endl << "T=" << setw(15) << 1. / beta
+		   << " Tmin =" << setw(10) << 1./betamax_
+			<< "                             Tc= ";
+	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
+	  if (std::fabs(y._z[ivertex]-zdumpcenter_) < zdumpwidth_){
+	    double Tc = 2*y._swE[ivertex]/y._sw[ivertex];
+	    std::cout  << setw(8) << fixed << setprecision(1) <<  Tc;
+	  }
+	}
+	std::cout  << endl;
+
+	std::cout  <<  "                                                               pk= ";
 	double sumpk = 0;
 	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
-		LogDebug("DAClusterizerinZ_vectorized")  << setw(8) << setprecision(3) << fixed << y._pk[ivertex];
 		sumpk += y._pk[ivertex];
+		if  (std::fabs(y._z[ivertex] - zdumpcenter_) > zdumpwidth_) continue;
+		std::cout  << setw(8) << setprecision(4) << fixed << y._pk[ivertex];
 	}
-	LogDebug("DAClusterizerinZ_vectorized")  << endl;
+	std::cout  << endl;
+
+	std::cout << "                                                               nt= ";
+	for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
+		sumpk += y._pk[ivertex];
+		if  (std::fabs(y._z[ivertex] - zdumpcenter_) > zdumpwidth_) continue;
+		std::cout  << setw(8) << setprecision(1) << fixed << y._pk[ivertex]*nt;
+	}
+	std::cout  << endl;
 
 	if (verbosity > 0) {
 		double E = 0, F = 0;
-		LogDebug("DAClusterizerinZ_vectorized")  << endl;
-		LogDebug("DAClusterizerinZ_vectorized") 
-		<< "----       z +/- dz                ip +/-dip       pt    phi  eta    weights  ----"
+		std::cout  << endl;
+		std::cout 
+		<< "----        z +/- dz                ip +/-dip       pt    phi  eta    weights  ----"
 		<< endl;
-		LogDebug("DAClusterizerinZ_vectorized")  << setprecision(4);
-		for (unsigned int i = 0; i < nt; i++) {
+		std::cout  << setprecision(4);
+		for (unsigned int i0 = 0; i0 < nt; i0++) {
+		  unsigned int i = iz[i0];
 			if (tks._Z_sum[i] > 0) {
 				F -= std::log(tks._Z_sum[i]) / beta;
 			}
 			double tz = tks._z[i];
-			LogDebug("DAClusterizerinZ_vectorized")  << setw(3) << i << ")" << setw(8) << fixed << setprecision(4)
+
+			if( std::fabs(tz - zdumpcenter_) > zdumpwidth_) continue;
+			std::cout  << setw(4) << i << ")" << setw(8) << fixed << setprecision(4)
 			 << tz << " +/-" << setw(6) << sqrt(1./tks._dz2[i]);
 
 			if (tks.tt[i]->track().quality(reco::TrackBase::highPurity)) {
-				LogDebug("DAClusterizerinZ_vectorized")  << " *";
+				std::cout  << " *";
 			} else {
-				LogDebug("DAClusterizerinZ_vectorized")  << "  ";
+				std::cout  << "  ";
 			}
 			if (tks.tt[i]->track().hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1)) {
-				LogDebug("DAClusterizerinZ_vectorized")  << "+";
+				std::cout  << "+";
 			} else {
-				LogDebug("DAClusterizerinZ_vectorized")  << "-";
+				std::cout  << "-";
 			}
-			LogDebug("DAClusterizerinZ_vectorized")  << setw(1)
+			std::cout  << setw(1)
 			 << tks.tt[i]->track().hitPattern().pixelBarrelLayersWithMeasurement(); // see DataFormats/TrackReco/interface/HitPattern.h
-			LogDebug("DAClusterizerinZ_vectorized")  << setw(1)
+			std::cout  << setw(1)
 			 << tks.tt[i]->track().hitPattern().pixelEndcapLayersWithMeasurement();
-			LogDebug("DAClusterizerinZ_vectorized")  << setw(1) << hex
+			std::cout  << setw(1) << hex
 					<< tks.tt[i]->track().hitPattern().trackerLayersWithMeasurement()
 					- tks.tt[i]->track().hitPattern().pixelLayersWithMeasurement()
 					<< dec;
-			LogDebug("DAClusterizerinZ_vectorized")  << "=" << setw(1) << hex
+			std::cout  << "=" << setw(1) << hex
 					<< tks.tt[i]->track().hitPattern().numberOfHits(reco::HitPattern::MISSING_OUTER_HITS)
 					<< dec;
 
 			Measurement1D IP =
 					tks.tt[i]->stateAtBeamLine().transverseImpactParameter();
-			LogDebug("DAClusterizerinZ_vectorized")  << setw(8) << IP.value() << "+/-" << setw(6) << IP.error();
-			LogDebug("DAClusterizerinZ_vectorized")  << " " << setw(6) << setprecision(2)
+			std::cout  << setw(8) << IP.value() << "+/-" << setw(6) << IP.error();
+			std::cout  << " " << setw(6) << setprecision(2)
 			 << tks.tt[i]->track().pt() * tks.tt[i]->track().charge();
-			LogDebug("DAClusterizerinZ_vectorized")  << " " << setw(5) << setprecision(2)
+			std::cout  << " " << setw(5) << setprecision(2)
 			 << tks.tt[i]->track().phi() << " " << setw(5)
 			 << setprecision(2) << tks.tt[i]->track().eta();
 
 			double sump = 0.;
 			for (unsigned int ivertex = 0; ivertex < nv; ++ ivertex) {
+			  if  (std::fabs(y._z[ivertex]-zdumpcenter_) > zdumpwidth_) continue;
+
 				if ((tks._pi[i] > 0) && (tks._Z_sum[i] > 0)) {
 					//double p=pik(beta,tks[i],*k);
 					double p = y._pk[ivertex]  * exp(-beta * Eik(tks._z[i], y._z[ivertex], tks._dz2[i])) / tks._Z_sum[i];
 					if (p > 0.0001) {
-						LogDebug("DAClusterizerinZ_vectorized")  << setw(8) << setprecision(3) << p;
+						std::cout  << setw(8) << setprecision(3) << p;
 					} else {
-						LogDebug("DAClusterizerinZ_vectorized")  << "    .   ";
+						std::cout  << "    .   ";
 					}
 					E += p * Eik(tks._z[i], y._z[ivertex], tks._dz2[i]);
 					sump += p;
 				} else {
-					LogDebug("DAClusterizerinZ_vectorized")  << "        ";
+					std::cout  << "        ";
 				}
 			}
-			LogDebug("DAClusterizerinZ_vectorized")  << endl;
+			std::cout  << endl;
 		}
-		LogDebug("DAClusterizerinZ_vectorized")  << endl << "T=" << 1 / beta << " E=" << E << " n=" << y.GetSize()
+		std::cout  << endl << "T=" << 1 / beta << " E=" << E << " n=" << y.GetSize()
 			 << "  F= " << F << endl << "----------" << endl;
 	}
 }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -55,24 +55,24 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
 
 
   if (Tmin == 0) {
-    std::cout  << "DAClusterizerInZ: invalid Tmin" << Tmin
-	       << "  reset do default " << 1. / betamax_ << endl;
+    edm::LogWarning("DAClusterizerinZ_vectorized") << "DAClusterizerInZ: invalid Tmin" << Tmin
+						   << "  reset do default " << 1. / betamax_;
   } else {
     betamax_ = 1. / Tmin;
   }
 
 
   if ((Tpurge > Tmin) || (Tpurge == 0)) {
-    std::cout  << "DAClusterizerInZ: invalid Tpurge" << Tpurge
-	       << "  set to " << Tmin << endl;
+    edm::LogWarning("DAClusterizerinZ_vectorized") << "DAClusterizerInZ: invalid Tpurge" << Tpurge
+						   << "  set to " << Tmin;
     Tpurge =  Tmin;
   }
   betapurge_ = 1./Tpurge;
   
 
   if ((Tstop > Tpurge) || (Tstop == 0)) {
-    std::cout  << "DAClusterizerInZ: invalid Tstop" << Tstop
-	       << "  set to  " << max(1., Tpurge) << endl;
+    edm::LogWarning("DAClusterizerinZ_vectorized") << "DAClusterizerInZ: invalid Tstop" << Tstop
+						   << "  set to  " << max(1., Tpurge);
     Tstop = max(1., Tpurge) ;
   }
   betastop_ = 1./Tstop;

--- a/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
@@ -5,6 +5,7 @@ TrackFilterForPVFinding::TrackFilterForPVFinding(const edm::ParameterSet& conf)
 {
   maxD0Sig_    = conf.getParameter<double>("maxD0Significance");
   minPt_       = conf.getParameter<double>("minPt");
+  maxEta_      = conf.getParameter<double>("maxEta");
   maxNormChi2_ = conf.getParameter<double>("maxNormalizedChi2");
   minSiLayers_    = conf.getParameter<int>("minSiliconLayersWithHits");  
   minPxLayers_    = conf.getParameter<int>("minPixelLayersWithHits");  
@@ -26,14 +27,17 @@ bool
 TrackFilterForPVFinding::operator() (const reco::TransientTrack & tk) const
 {
 	if (!tk.stateAtBeamLine().isValid()) return false;
-	bool IPSigCut = tk.stateAtBeamLine().transverseImpactParameter().significance()<maxD0Sig_;
+	bool IPSigCut = ( tk.stateAtBeamLine().transverseImpactParameter().significance() < maxD0Sig_ ) 
+	  && (tk.stateAtBeamLine().transverseImpactParameter().error() < 1.0)
+	  && (tk.track().dzError() < 1.0);
 	bool pTCut    = tk.impactPointState().globalMomentum().transverse() > minPt_;
+	bool etaCut   = std::fabs( tk.impactPointState().globalMomentum().eta() ) < maxEta_;
 	bool normChi2Cut  = tk.normalizedChi2() < maxNormChi2_;
 	bool nPxLayCut = tk.hitPattern().pixelLayersWithMeasurement() >= minPxLayers_;
 	bool nSiLayCut =  tk.hitPattern().trackerLayersWithMeasurement() >= minSiLayers_;
 	bool trackQualityCut = (quality_==reco::TrackBase::undefQuality)|| tk.track().quality(quality_);
-
-	return IPSigCut && pTCut && normChi2Cut && nPxLayCut && nSiLayCut && trackQualityCut;
+	
+	return IPSigCut && pTCut && etaCut && normChi2Cut && nPxLayCut && nSiLayCut && trackQualityCut;
 }
 
 

--- a/Validation/RecoVertex/python/pvRecoSequence_cff.py
+++ b/Validation/RecoVertex/python/pvRecoSequence_cff.py
@@ -19,6 +19,7 @@ offlinePrimaryVerticesGAP = cms.EDProducer("PrimaryVertexProducer",
                     minPixelLayersWithHits = cms.int32(2),   # >= 2
                     maxD0Significance = cms.double(100.0),     # keep most primary tracks
                     minPt = cms.double(0.0),                 # better for softish events
+                    maxEta = cms.double(5.0),
                     trackQuality = cms.string("any")
                 ),
        # clustering
@@ -30,6 +31,7 @@ offlinePrimaryVerticesGAP = cms.EDProducer("PrimaryVertexProducer",
        ),
        vertexCollections = cms.VPSet(
               [cms.PSet(label=cms.string(""),
+                        chi2cutoff = cms.double(2.5),
                         algorithm = cms.string('AdaptiveVertexFitter'),
                         minNdof=cms.double(0.0),
                         useBeamConstraint = cms.bool(False),
@@ -61,6 +63,7 @@ offlinePrimaryVerticesDA100um = cms.EDProducer("PrimaryVertexProducer",
         minSiliconLayersWithHits = cms.int32(5),
         maxD0Significance = cms.double(5.0),
         minPt = cms.double(0.0),
+        maxEta = cms.double(5.0),
         trackQuality = cms.string("any")
     ),
 
@@ -68,15 +71,19 @@ offlinePrimaryVerticesDA100um = cms.EDProducer("PrimaryVertexProducer",
         algorithm   = cms.string("DA"),
         TkDAClusParameters = cms.PSet(
             coolingFactor = cms.double(0.6),  #  moderate annealing speed
-            Tmin = cms.double(4.),            #  end of annealing
+            Tmin = cms.double(2.4),            #  end of annealing
+            Tpurge = cms.double(2.),            #  end of annealing
+            Tstop = cms.double(0.5),
             vertexSize = cms.double(0.01),    #  
             d0CutOff = cms.double(3.),        # downweight high IP tracks
-            dzCutOff = cms.double(4.)         # outlier rejection after freeze-out (T<Tmin)
+            dzCutOff = cms.double(4.),         # outlier rejection after freeze-out (T<Tmin)
+            uniquetrkweight = cms.double(0.9)
         )
     ),
 
     vertexCollections = cms.VPSet(
      [cms.PSet(label=cms.string(""),
+               chi2cutoff = cms.double(2.5),
                algorithm=cms.string("AdaptiveVertexFitter"),
                minNdof=cms.double(0.0),
                useBeamConstraint = cms.bool(False),

--- a/Validation/RecoVertex/python/pvRecoSequence_cff.py
+++ b/Validation/RecoVertex/python/pvRecoSequence_cff.py
@@ -31,7 +31,7 @@ offlinePrimaryVerticesGAP = cms.EDProducer("PrimaryVertexProducer",
        ),
        vertexCollections = cms.VPSet(
               [cms.PSet(label=cms.string(""),
-                        chi2cutoff = cms.double(2.5),
+                        chi2cutoff = cms.double(3.0),
                         algorithm = cms.string('AdaptiveVertexFitter'),
                         minNdof=cms.double(0.0),
                         useBeamConstraint = cms.bool(False),
@@ -71,19 +71,16 @@ offlinePrimaryVerticesDA100um = cms.EDProducer("PrimaryVertexProducer",
         algorithm   = cms.string("DA"),
         TkDAClusParameters = cms.PSet(
             coolingFactor = cms.double(0.6),  #  moderate annealing speed
-            Tmin = cms.double(2.4),            #  end of annealing
-            Tpurge = cms.double(2.),            #  end of annealing
-            Tstop = cms.double(0.5),
+            Tmin = cms.double(4.0),            #  end of annealing
             vertexSize = cms.double(0.01),    #  
             d0CutOff = cms.double(3.),        # downweight high IP tracks
             dzCutOff = cms.double(4.),         # outlier rejection after freeze-out (T<Tmin)
-            uniquetrkweight = cms.double(0.9)
         )
     ),
 
     vertexCollections = cms.VPSet(
      [cms.PSet(label=cms.string(""),
-               chi2cutoff = cms.double(2.5),
+               chi2cutoff = cms.double(3.0),
                algorithm=cms.string("AdaptiveVertexFitter"),
                minNdof=cms.double(0.0),
                useBeamConstraint = cms.bool(False),


### PR DESCRIPTION
Tuned clustering for offline primary vertices. 
New code allows clustering with higher resolving power for high pile-up and
additional configurable parameters have been introduced.

documented in https://indico.cern.ch/event/607511/#39-primary-vertex-tuning

The code is intended for 2017 data taking.
parameters included in this commit are chosen to resemble phase 0 behavior. 
suitable parameters for 2017 will be provide through eras (courtesy of Matti Korteleinen, Vincenzo Innocente)