### PR TITLE
Lock access to lumi::service::DBService

### DIFF
--- a/RecoLuminosity/LumiProducer/interface/DBService.h
+++ b/RecoLuminosity/LumiProducer/interface/DBService.h
@@ -2,25 +2,43 @@
 #define RecoLuminosity_LumiProducer_DBService_h
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "RelationalAccess/ISessionProxy.h"
+#include "RelationalAccess/ConnectionService.h"
+
 #include <string>
-namespace coral{
-  class ISessionProxy;
-  class ConnectionService;
-}
+#include <mutex>
+#include <memory>
+
 namespace lumi{
   class DBConfig;
   namespace service{
+
+    class ISessionProxyPtr {
+    public:
+      ISessionProxyPtr( std::unique_ptr<coral::ISessionProxy> iProxy,
+                        std::unique_lock<std::mutex> iLock):
+          m_lock(std::move(iLock)),
+          m_proxy(std::move(iProxy)) {}
+
+          coral::ISessionProxy* operator->() {
+            return m_proxy.get();
+          }
+    private:
+          std::unique_lock<std::mutex> m_lock;
+          std::unique_ptr<coral::ISessionProxy> m_proxy;
+   };
+
     class DBService{
     public:
       DBService(const edm::ParameterSet& iConfig);
       ~DBService();
 
-      coral::ISessionProxy* connectReadOnly( const std::string& connectstring );
-      void disconnect( coral::ISessionProxy* session );
+      ISessionProxyPtr connectReadOnly( const std::string& connectstring );
 
     private:
-      coral::ConnectionService* m_svc;
-      lumi::DBConfig* m_dbconfig;
+      std::unique_ptr<coral::ConnectionService> m_svc;
+      std::unique_ptr<lumi::DBConfig> m_dbconfig;
+      std::mutex m_mutex;
     };//cl DBService
   }//ns service
 }//ns lumi

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
@@ -159,7 +159,7 @@ DIPLumiProducer::fillsummarycache(unsigned int runnumber,unsigned int currentlsn
   if( !mydbservice.isAvailable() ){
     throw cms::Exception("Non existing service lumi::service::DBService");
   }
-  coral::ISessionProxy* session=mydbservice->connectReadOnly(m_connectStr);
+  auto session=mydbservice->connectReadOnly(m_connectStr);
   coral::ITypeConverter& tconverter=session->typeConverter();
   tconverter.setCppTypeForSqlType(std::string("float"),std::string("FLOAT(63)"));
   tconverter.setCppTypeForSqlType(std::string("unsigned int"),std::string("NUMBER(10)"));
@@ -175,7 +175,6 @@ DIPLumiProducer::fillsummarycache(unsigned int runnumber,unsigned int currentlsn
     }else if(maxavailableLS==0){
       //this run not existing (yet)
       session->transaction().commit();
-      mydbservice->disconnect(session);
       return;
     }
     if(m_cachesize!=0){
@@ -234,10 +233,8 @@ DIPLumiProducer::fillsummarycache(unsigned int runnumber,unsigned int currentlsn
     session->transaction().commit();
   }catch(const coral::Exception& er){
     session->transaction().rollback();
-    mydbservice->disconnect(session);
     throw cms::Exception("DatabaseError ")<<er.what();
   }
-  mydbservice->disconnect(session);
 }
 unsigned int
 DIPLumiProducer::maxavailableLSforRun(coral::ISchema& schema,const std::string&tablename,unsigned int runnumber){
@@ -278,7 +275,7 @@ DIPLumiProducer::filldetailcache(unsigned int runnumber,unsigned int currentlsnu
   if( !mydbservice.isAvailable() ){
     throw cms::Exception("Non existing service lumi::service::DBService");
   }
-  coral::ISessionProxy* session=mydbservice->connectReadOnly(m_connectStr);
+  auto session=mydbservice->connectReadOnly(m_connectStr);
   coral::ITypeConverter& tconverter=session->typeConverter();
   tconverter.setCppTypeForSqlType(std::string("float"),std::string("FLOAT(63)"));
   tconverter.setCppTypeForSqlType(std::string("unsigned int"),std::string("NUMBER(10)"));
@@ -293,7 +290,6 @@ DIPLumiProducer::filldetailcache(unsigned int runnumber,unsigned int currentlsnu
     }else if(maxavailableLS==0){
       //this run not existing (yet)
       session->transaction().commit();
-      mydbservice->disconnect(session);
       return;
     }
     if(m_cachesize!=0){
@@ -339,10 +335,8 @@ DIPLumiProducer::filldetailcache(unsigned int runnumber,unsigned int currentlsnu
     session->transaction().commit();
   }catch(const coral::Exception& er){
     session->transaction().rollback();
-    mydbservice->disconnect(session);
     throw cms::Exception("DatabaseError ")<<er.what();
   }
-  mydbservice->disconnect(session);
 }
 DIPLumiProducer::~DIPLumiProducer(){}
 //define this as a plug-in

--- a/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/ExpressLumiProducer.cc
@@ -204,7 +204,7 @@ ExpressLumiProducer::fillLSCache(unsigned int runnumber,unsigned int currentlsnu
   if( !mydbservice.isAvailable() ){
     throw cms::Exception("Non existing service lumi::service::DBService");
   }
-  coral::ISessionProxy* session=mydbservice->connectReadOnly(m_connectStr);
+  auto session=mydbservice->connectReadOnly(m_connectStr);
   coral::ITypeConverter& tconverter=session->typeConverter();
   tconverter.setCppTypeForSqlType(std::string("float"),std::string("FLOAT(63)"));
   tconverter.setCppTypeForSqlType(std::string("unsigned int"),std::string("NUMBER(10)"));
@@ -220,7 +220,6 @@ ExpressLumiProducer::fillLSCache(unsigned int runnumber,unsigned int currentlsnu
     }else if(maxavailableLS==0){
       //this run not existing (yet)
       session->transaction().commit();
-      mydbservice->disconnect(session);
       return;
     }
     if(m_cachesize!=0){
@@ -343,10 +342,8 @@ ExpressLumiProducer::fillLSCache(unsigned int runnumber,unsigned int currentlsnu
     session->transaction().commit();
   }catch(const coral::Exception& er){
     session->transaction().rollback();
-    mydbservice->disconnect(session);
     throw cms::Exception("DatabaseError ")<<er.what();
   }
-  mydbservice->disconnect(session);
 }
 void
 ExpressLumiProducer::writeProductsForEntry(edm::LuminosityBlock & iLBlock,unsigned int luminum){

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -420,7 +420,7 @@ LumiProducer::beginRun(edm::Run const& run,edm::EventSetup const &iSetup)
     if( !mydbservice.isAvailable() ){
       throw cms::Exception("Non existing service lumi::service::DBService");
     }
-    coral::ISessionProxy* session=mydbservice->connectReadOnly(m_connectStr);
+    auto session=mydbservice->connectReadOnly(m_connectStr);
     try{
       session->transaction().start(true);
       m_cachedlumidataid=getLumiDataId(session->nominalSchema(),runnumber);
@@ -434,10 +434,8 @@ LumiProducer::beginRun(edm::Run const& run,edm::EventSetup const &iSetup)
       session->transaction().commit();
     }catch(const coral::Exception& er){
       session->transaction().rollback();
-      mydbservice->disconnect(session);
       throw cms::Exception("DatabaseError ")<<er.what();
     }
-    mydbservice->disconnect(session);
   }
   //std::cout<<"end of beginRun "<<runnumber<<std::endl;
 }
@@ -564,7 +562,7 @@ LumiProducer::fillLSCache(unsigned int luminum){
   if( !mydbservice.isAvailable() ){
     throw cms::Exception("Non existing service lumi::service::DBService");
   }
-  coral::ISessionProxy* session=mydbservice->connectReadOnly(m_connectStr);
+  auto session=mydbservice->connectReadOnly(m_connectStr);
   try{
     session->transaction().start(true);
     coral::ISchema& schema=session->nominalSchema();
@@ -804,10 +802,8 @@ LumiProducer::fillLSCache(unsigned int luminum){
     session->transaction().commit();
   }catch(const coral::Exception& er){
     session->transaction().rollback();
-    mydbservice->disconnect(session);
     throw cms::Exception("DatabaseError ")<<er.what();
   }
-  mydbservice->disconnect(session);
 }
 void
 LumiProducer::writeProductsForEntry(edm::LuminosityBlock & iLBlock,unsigned int runnumber,unsigned int luminum){


### PR DESCRIPTION
Use a guard class to serialize access to the underlying coral
implementation of lumi::service::DBService