### PR TITLE
JobReport now supports concurrent opening of output files

### DIFF
--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -250,7 +250,7 @@ namespace edm {
 
         std::vector<InputFile> inputFiles_;
         tbb::concurrent_vector<InputFile> inputFilesSecSource_;
-        std::vector<OutputFile> outputFiles_;
+        tbb::concurrent_vector<OutputFile> outputFiles_;
         std::map<std::string, long long> readBranches_;
         std::map<std::string, long long> readBranchesSecFile_;
         tbb::concurrent_unordered_map<std::string, AtomicLongLong> readBranchesSecSource_;


### PR DESCRIPTION
Switched to using a concurrent_vector to handle the different output file data. This allows concurrent opening of new output files.
The code still assumes that one output module will only report new lumis and runs sequentially.