### PR TITLE
Add feature to save generator protons from pile-up for standard mixing and premixing

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/plugins/GenPUProtonProducer.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenPUProtonProducer.cc
@@ -1,0 +1,268 @@
+/* \class GenPUProtonProducer
+ *
+ * Modification of GenParticleProducer.
+ * Saves final state protons from HepMC events in Crossing Frame, in the generator-particle format.
+ *
+ * Note: Use the option USER_CXXFLAGS=-DEDM_ML_DEBUG with SCRAM in order to enable the debug messages
+ *
+ * March 9, 2017: initial version
+ * March 14, 2017: Updated debug messages
+ *
+ */
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <vector>
+#include <string>
+#include <map>
+#include <set>
+
+namespace GenPUProtonProducer_utilities {
+
+  class ConvertParticle {
+    public:
+     static const int PDGCacheMax = 32768;
+     static constexpr double mmToCm = 0.1;
+
+     ConvertParticle() :
+        abortOnUnknownPDGCode_( true ),
+        initialized_( false ),
+        chargeP_( PDGCacheMax, 0 ), chargeM_( PDGCacheMax, 0 ) {};
+
+     ConvertParticle(bool abortOnUnknownPDGCode) :
+        abortOnUnknownPDGCode_( abortOnUnknownPDGCode ),
+        initialized_( false ),
+        chargeP_( PDGCacheMax, 0 ), chargeM_( PDGCacheMax, 0 ) {};
+
+     ~ConvertParticle() {};
+
+     bool initialized() const { return initialized_; }
+
+     void init(HepPDT::ParticleDataTable const& pdt) {
+	if( !initialized_ ) {
+	   for( HepPDT::ParticleDataTable::const_iterator p = pdt.begin(); p != pdt.end(); ++p ) {
+	      HepPDT::ParticleID const& id = p->first;
+	      int pdgId = id.pid(), apdgId = std::abs( pdgId );
+	      int q3 = id.threeCharge();
+	      if ( apdgId < PDGCacheMax && pdgId > 0 ) {
+		 chargeP_[ apdgId ] = q3;
+		 chargeM_[ apdgId ] = -q3;
+	      } else if ( apdgId < PDGCacheMax ) {
+		 chargeP_[ apdgId ] = -q3;
+		 chargeM_[ apdgId ] = q3;
+	      } else {
+		 chargeMap_[ pdgId ] = q3;
+		 chargeMap_[ -pdgId ] = -q3;
+	      }
+	   }
+	   initialized_ = true;
+	}
+     }
+
+     bool operator() (reco::GenParticle& cand, HepMC::GenParticle const* part) {
+	reco::Candidate::LorentzVector p4( part->momentum() );
+	int pdgId = part->pdg_id();
+	cand.setThreeCharge( chargeTimesThree( pdgId ) );
+	cand.setPdgId( pdgId );
+	cand.setStatus( part->status() );
+	cand.setP4( p4 );
+	cand.setCollisionId(0);
+	HepMC::GenVertex const* v = part->production_vertex();
+	if ( v != 0 ) {
+	   HepMC::ThreeVector vtx = v->point3d();
+	   reco::Candidate::Point vertex( vtx.x() * mmToCm, vtx.y() * mmToCm, vtx.z() * mmToCm );
+	   cand.setVertex( vertex );
+	} else {
+	   cand.setVertex( reco::Candidate::Point( 0, 0, 0 ) );
+	}
+	return true;
+     }
+
+    private:
+     bool abortOnUnknownPDGCode_;
+     bool initialized_; 
+     std::vector<int> chargeP_, chargeM_;
+     std::map<int, int> chargeMap_;
+
+     int chargeTimesThree( int id ) const {
+	if( std::abs( id ) < PDGCacheMax )
+	   return id > 0 ? chargeP_[ id ] : chargeM_[ - id ];
+
+	std::map<int, int>::const_iterator f = chargeMap_.find( id );
+	if ( f == chargeMap_.end() )  {
+	   if ( abortOnUnknownPDGCode_ )
+	      throw edm::Exception( edm::errors::LogicError ) << "invalid PDG id: " << id << std::endl;
+	   else
+	      return HepPDT::ParticleID(id).threeCharge();
+	}
+	return f->second;
+     }
+
+  }; 
+
+  class SelectProton { 
+     public:
+        bool operator() ( HepMC::GenParticle const* part, double minPz ) const {
+           bool selection = ( ( !part->end_vertex() && part->status() == 1 ) && 
+                              ( part->pdg_id() == 2212 ) && ( TMath::Abs( part->momentum().pz() ) >= minPz ) );
+           return selection;
+        }
+  };
+
+}
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h"
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+namespace edm { class ParameterSet; }
+
+class GenPUProtonProducer : public edm::EDProducer {
+ public:
+  GenPUProtonProducer( const edm::ParameterSet & );
+  ~GenPUProtonProducer();
+
+  virtual void produce( edm::Event& e, const edm::EventSetup&) override;
+  reco::GenParticleRefProd ref_;
+
+ private:
+  edm::EDGetTokenT<CrossingFrame<edm::HepMCProduct> > mixToken_;
+
+  bool abortOnUnknownPDGCode_;
+  std::vector<int> bunchList_;
+  double minPz_; 
+  GenPUProtonProducer_utilities::ConvertParticle convertParticle_;
+  GenPUProtonProducer_utilities::SelectProton    select_;
+
+};
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+
+#include <algorithm>
+
+using namespace edm;
+using namespace reco;
+using namespace std;
+using namespace HepMC;
+
+GenPUProtonProducer::GenPUProtonProducer( const ParameterSet & cfg ) :
+  abortOnUnknownPDGCode_( cfg.getUntrackedParameter<bool>( "abortOnUnknownPDGCode", true ) ),
+  bunchList_( cfg.getParameter<vector<int> >( "bunchCrossingList" ) ),
+  minPz_( cfg.getParameter<double>( "minPz" ) ) 
+{
+  produces<GenParticleCollection>();
+  mixToken_ = consumes<CrossingFrame<HepMCProduct> >( InputTag(cfg.getParameter<std::string>( "mix" ),"generatorSmeared") );
+}
+
+GenPUProtonProducer::~GenPUProtonProducer() { }
+
+void GenPUProtonProducer::produce( Event& evt, const EventSetup& es ) {
+
+   if ( !convertParticle_.initialized() ) {
+     ESHandle<HepPDT::ParticleDataTable> pdt_handle;
+     es.getData( pdt_handle );
+     HepPDT::ParticleDataTable const& pdt = *pdt_handle.product();
+     convertParticle_.init( pdt ); 
+   }
+
+   unsigned int totalSize = 0;
+   unsigned int npiles = 1;
+
+   Handle<CrossingFrame<HepMCProduct> > cf;
+   evt.getByToken(mixToken_,cf);
+   std::auto_ptr<MixCollection<HepMCProduct> > cfhepmcprod( new MixCollection<HepMCProduct>( cf.product() ) );
+   npiles = cfhepmcprod->size();
+
+   LogDebug("GenPUProtonProducer") << " Number of pile-up events : " << npiles << endl;
+
+   for(unsigned int icf = 0; icf < npiles; ++icf){
+      LogDebug("GenPUProtonProducer") << "CF " << icf << " size : " << cfhepmcprod->getObject(icf).GetEvent()->particles_size() << endl;
+      totalSize += cfhepmcprod->getObject(icf).GetEvent()->particles_size();
+   }
+   LogDebug("GenPUProtonProducer") << "Total size : " << totalSize << endl;
+
+   // Loop over pile-up events
+   MixCollection<HepMCProduct>::MixItr mixHepMC_itr;
+   unsigned int total_number_of_protons = 0;
+   size_t idx_mix = 0;
+   for( mixHepMC_itr = cfhepmcprod->begin() ; mixHepMC_itr != cfhepmcprod->end() ; ++mixHepMC_itr, ++idx_mix ){
+      int bunch = mixHepMC_itr.bunch();
+      if( find( bunchList_.begin(), bunchList_.end(), bunch ) != bunchList_.end() ){
+	 auto event = (*mixHepMC_itr).GetEvent();
+	 // Find protons
+	 unsigned int number_of_protons = 0;
+	 for( auto p = event->particles_begin() ; p != event->particles_end() ; ++p ){
+	    if( select_(*p, minPz_) ) ++number_of_protons;
+	 }
+	 LogDebug("GenPUProtonProducer") << "Idx : " << idx_mix << " Bunch : " << bunch << " Number of protons : " << number_of_protons << endl;
+	 total_number_of_protons += number_of_protons;
+      }
+   }
+   LogDebug("GenPUProtonProducer") << "Total number of protons : " << total_number_of_protons << endl;
+
+   // Initialise containers
+   const size_t size = total_number_of_protons;
+   vector<const HepMC::GenParticle *> particles( size );
+
+   auto candsPtr = std::make_unique<GenParticleCollection>(size);
+   auto barCodeVector = std::make_unique<vector<int>>(size);
+   ref_ = evt.getRefBeforePut<GenParticleCollection>();
+   GenParticleCollection& cands = *candsPtr;
+
+   size_t idx_particle = 0;
+   idx_mix = 0;
+   // Fill collection
+   for( mixHepMC_itr = cfhepmcprod->begin() ; mixHepMC_itr != cfhepmcprod->end() ; ++mixHepMC_itr, ++idx_mix ){
+      int bunch = mixHepMC_itr.bunch();
+
+      if( find( bunchList_.begin(), bunchList_.end(), bunch ) != bunchList_.end() ){
+
+	 auto event = (*mixHepMC_itr).GetEvent();
+
+	 size_t num_particles = event->particles_size();
+
+	 // Fill output collection
+	 unsigned int number_of_protons = 0;
+	 for( auto p = event->particles_begin() ; p != event->particles_end() ; ++p ) {
+	    HepMC::GenParticle const* part = *p;  
+	    if( select_(part, minPz_) ) {
+	       reco::GenParticle& cand = cands[ idx_particle++ ];
+	       convertParticle_( cand, part);
+               ++number_of_protons;
+	    } 
+	 }
+	 LogDebug("GenPUProtonProducer") << "Idx : " << idx_mix << " Bunch : " << bunch 
+                                         << " Number of particles : " << num_particles 
+                                         << " Number of protons : " << number_of_protons 
+                                         << " Part. idx : " << idx_particle << endl;
+
+      }
+   }
+   LogDebug("GenPUProtonProducer") << "Output collection size : " << cands.size() << endl;
+
+   evt.put(std::move(candsPtr));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE( GenPUProtonProducer );
+

--- a/PhysicsTools/HepMCCandAlgos/python/addGenPUProtons.py
+++ b/PhysicsTools/HepMCCandAlgos/python/addGenPUProtons.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseGenPUProtons(process):
+
+    process.mix.mixObjects.mixHepMC.makeCrossingFrame = True
+
+    process.genPUProtons = cms.EDProducer("GenPUProtonProducer",
+	mix = cms.string("mix"),
+	bunchCrossingList = cms.vint32(),
+	minPz = cms.double( 4800. )
+    )
+    process.genPUProtonsBx0 = process.genPUProtons.clone()
+    process.genPUProtonsBx0.bunchCrossingList = [0]
+    process.genPUProtonsBxm1 = process.genPUProtons.clone()
+    process.genPUProtonsBxm1.bunchCrossingList = [-1]
+    process.genPUProtonsBxp1 = process.genPUProtons.clone()
+    process.genPUProtonsBxp1.bunchCrossingList = [1]
+    process.genPUProtons_seq = cms.Sequence(process.genPUProtonsBx0+process.genPUProtonsBxm1+process.genPUProtonsBxp1)
+
+    # Path and EndPath definitions
+    process.digitisation_step.replace( process.pdigi, process.pdigi*process.genPUProtons_seq)
+     
+    return process

--- a/PhysicsTools/HepMCCandAlgos/python/addGenPUProtonsEventContent.py
+++ b/PhysicsTools/HepMCCandAlgos/python/addGenPUProtonsEventContent.py
@@ -1,0 +1,26 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseGenPUProtonsEventContent(process):
+
+    commonOutputCommands = cms.untracked.vstring('keep *_genPUProtons*_*_*', 'keep *_*_genPUProtons*_*')
+    process.RAWSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.RAWSIMHLTEventContent.outputCommands.extend( commonOutputCommands)
+    process.GENRAWEventContent.outputCommands.extend( commonOutputCommands)
+    process.PREMIXEventContent.outputCommands.extend( commonOutputCommands)
+    process.PREMIXRAWEventContent.outputCommands.extend( commonOutputCommands)
+    process.REPACKRAWSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.RECOSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.AODSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.RAWRECOSIMHLTEventContent.outputCommands.extend( commonOutputCommands)
+    process.RAWRECODEBUGHLTEventContent.outputCommands.extend( commonOutputCommands)
+    process.FEVTSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.RAWDEBUGEventContent.outputCommands.extend( commonOutputCommands)
+    process.RAWDEBUGHLTEventContent.outputCommands.extend( commonOutputCommands)
+    process.FEVTDEBUGEventContent.outputCommands.extend( commonOutputCommands)
+    process.FEVTDEBUGHLTEventContent.outputCommands.extend( commonOutputCommands)
+    process.REPACKRAWSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.MINIAODSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.RAWMINIAODSIMEventContent.outputCommands.extend( commonOutputCommands)
+    process.RAWAODSIMEventContent.outputCommands.extend( commonOutputCommands)
+
+    return process

--- a/SimGeneral/DataMixingModule/plugins/BuildFile.xml
+++ b/SimGeneral/DataMixingModule/plugins/BuildFile.xml
@@ -17,6 +17,7 @@
 <use   name="DataFormats/SiPixelDigi"/>
 <use   name="DataFormats/SiStripDigi"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/HepMCCandidate"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -24,6 +24,7 @@
 //
 //
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataMixingModule.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
@@ -234,6 +235,13 @@ namespace edm
       produces< std::vector<PileupSummaryInfo> >();
       produces< int >("bunchSpacing");
       produces<CrossingFramePlaybackInfoNew>();
+
+      std::vector<edm::InputTag> GenPUProtonsInputTags;
+      if( ps.exists("GenPUProtonsInputTags") )
+         GenPUProtonsInputTags = ps.getParameter<std::vector<edm::InputTag> >("GenPUProtonsInputTags");
+      for(std::vector<edm::InputTag>::const_iterator it_InputTag = GenPUProtonsInputTags.begin(); 
+                                                     it_InputTag != GenPUProtonsInputTags.end(); ++it_InputTag) 
+         produces< std::vector<reco::GenParticle> >( it_InputTag->label() );
 
       PUWorker_ = new DataMixingPileupCopy(ps, consumesCollector());
     }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.h
@@ -29,6 +29,9 @@
 #include <vector>
 #include <string>
 
+namespace reco{
+  class GenParticle; 
+}
 
 namespace edm
 {
@@ -61,11 +64,15 @@ namespace edm
       edm::InputTag BunchSpacingInputTag_ ;     // InputTag for bunch spacing int
       edm::InputTag CFPlaybackInputTag_   ;   // InputTag for CrossingFrame Playback information
 
+      std::vector<edm::InputTag> GenPUProtonsInputTags_ ;
    
       CrossingFramePlaybackInfoNew CrossingFramePlaybackStorage_;
 
       std::vector<PileupSummaryInfo> PileupSummaryStorage_;
       int bsStorage_;
+
+      std::vector<std::string> GenPUProtons_labels_;
+      std::vector<std::vector<reco::GenParticle> > GenPUProtons_;
 
       //      unsigned int eventId_; //=0 for signal, from 1-n for pileup events
 

--- a/SimGeneral/DataMixingModule/python/addGenPUProtonsDataMixing.py
+++ b/SimGeneral/DataMixingModule/python/addGenPUProtonsDataMixing.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseGenPUProtonsDataMixing(process):
+
+    process.mixData.GenPUProtonsInputTags = cms.VInputTag("genPUProtonsBx0", "genPUProtonsBxm1", "genPUProtonsBxp1")
+    return process


### PR DESCRIPTION
Add feature to save generator protons from pile-up, related to simulation/analysis with proton detectors.
- In PhysicsTools/HepMCCandAlgos, add GenPUProtonProducer and customisation functions to run with cmsDriver;
- In  SimGeneral/DataMixingModule, update DataMixingModule with optional list of GenParticle collections from premixing sample, to save in the main event. Also add customisation function to run with cmsDriver.