### PR TITLE
Remove deprecated call in FastjetJetProducer [to be able to update to fastjet-contrib 1.026]

### DIFF
--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -443,7 +443,7 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       bge_rho->set_particles(fjInputs_);
       fastjet::contrib::ConstituentSubtractor * constituentSubtractor = new fastjet::contrib::ConstituentSubtractor(bge_rho.get());
       // this sets the same background estimator to be used for deltaMass density, rho_m, as for pt density, rho:
-      constituentSubtractor->use_common_bge_for_rho_and_rhom(true); // for massless input particles it does not make any difference (rho_m is always zero)
+      //constituentSubtractor->use_common_bge_for_rho_and_rhom(true); // for massless input particles it does not make any difference (rho_m is always zero)
 
       transformers.push_back( transformer_ptr(constituentSubtractor) );
     };

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -442,8 +442,6 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       bge_rho = unique_ptr<fastjet::JetMedianBackgroundEstimator> (new  fastjet::JetMedianBackgroundEstimator(rho_range, fastjet::JetDefinition(fastjet::kt_algorithm, csRParam_), *fjAreaDefinition_) );
       bge_rho->set_particles(fjInputs_);
       fastjet::contrib::ConstituentSubtractor * constituentSubtractor = new fastjet::contrib::ConstituentSubtractor(bge_rho.get());
-      // this sets the same background estimator to be used for deltaMass density, rho_m, as for pt density, rho:
-      //constituentSubtractor->use_common_bge_for_rho_and_rhom(true); // for massless input particles it does not make any difference (rho_m is always zero)
 
       transformers.push_back( transformer_ptr(constituentSubtractor) );
     };


### PR DESCRIPTION
This is a trivial addition to a request for fastjet-contrib's update to 1.026. Here I turned off some deprecated code. 