### PR TITLE
Fix phase2 tracker association

### DIFF
--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -70,8 +70,10 @@ muonAssociatorByHitsCommonParameters = cms.PSet(
     #
     associatePixel = cms.bool(True),
     associateStrip = cms.bool(True),
+    usePhase2Tracker = cms.bool(False),
     pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
     stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+    phase2TrackerSimLinkSrc  = cms.InputTag("simSiPixelDigis","Tracker"),
     associateRecoTracks = cms.bool(True),
     #                                
     ROUList = cms.vstring('TrackerHitsTIBLowTof', 
@@ -142,6 +144,6 @@ muonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( muonAssociatorByHits, useGEMs = cms.bool(True) )
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( muonAssociatorByHits, usePhase2Tracker = cms.bool(True) )
 phase2_tracker.toModify( muonAssociatorByHits, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )
-phase2_tracker.toModify( muonAssociatorByHits, stripSimLinkSrc = "simSiPixelDigis:Tracker" )
-
+#phase2_tracker.toModify( muonAssociatorByHits, stripSimLinkSrc = "simSiPixelDigis:Tracker" )

--- a/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/MuonAssociatorByHits_cfi.py
@@ -146,4 +146,3 @@ run3_GEM.toModify( muonAssociatorByHits, useGEMs = cms.bool(True) )
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify( muonAssociatorByHits, usePhase2Tracker = cms.bool(True) )
 phase2_tracker.toModify( muonAssociatorByHits, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )
-#phase2_tracker.toModify( muonAssociatorByHits, stripSimLinkSrc = "simSiPixelDigis:Tracker" )

--- a/SimMuon/MCTruth/python/NewMuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/NewMuonAssociatorByHits_cfi.py
@@ -146,4 +146,3 @@ run3_GEM.toModify( NewMuonAssociatorByHits, useGEMs = cms.bool(True) )
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify( NewMuonAssociatorByHits, usePhase2Tracker = cms.bool(True) )
 phase2_tracker.toModify( NewMuonAssociatorByHits, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )
-#phase2_tracker.toModify( NewMuonAssociatorByHits, stripSimLinkSrc = "simSiPixelDigis:Tracker" )

--- a/SimMuon/MCTruth/python/NewMuonAssociatorByHits_cfi.py
+++ b/SimMuon/MCTruth/python/NewMuonAssociatorByHits_cfi.py
@@ -70,8 +70,10 @@ NewMuonAssociatorByHitsCommonParameters = cms.PSet(
     #
     associatePixel = cms.bool(True),
     associateStrip = cms.bool(True),
+    usePhase2Tracker = cms.bool(False),
     pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
     stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+    phase2TrackerSimLinkSrc  = cms.InputTag("simSiPixelDigis","Tracker"),
     associateRecoTracks = cms.bool(True),
     #                                
     ROUList = cms.vstring('TrackerHitsTIBLowTof', 
@@ -142,6 +144,6 @@ NewMuonAssociatorByHits = cms.EDProducer("MuonAssociatorEDProducer",
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( NewMuonAssociatorByHits, useGEMs = cms.bool(True) )
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( NewMuonAssociatorByHits, usePhase2Tracker = cms.bool(True) )
 phase2_tracker.toModify( NewMuonAssociatorByHits, pixelSimLinkSrc = "simSiPixelDigis:Pixel" )
-phase2_tracker.toModify( NewMuonAssociatorByHits, stripSimLinkSrc = "simSiPixelDigis:Tracker" )
-
+#phase2_tracker.toModify( NewMuonAssociatorByHits, stripSimLinkSrc = "simSiPixelDigis:Tracker" )

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -41,6 +41,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
@@ -57,9 +58,9 @@ class TrackerHitAssociator {
   struct Config {
     Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
     Config(edm::ConsumesCollector && iC);
-    bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
+    bool doPixel_, doStrip_, useOTph2_, doTrackAssoc_, assocHitbySimTrack_;
     edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripToken_;
-    edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_;
+    edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_, ph2OTrToken_;
     std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit> > > cfTokens_;
     std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simHitTokens_;
   };
@@ -92,7 +93,8 @@ class TrackerHitAssociator {
 
   std::vector<SimHitIdpr> associateMatchedRecHit(const SiStripMatchedRecHit2D * matchedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<SimHitIdpr> associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit, std::vector<simhitAddr>* simhitCFPos=0) const;
-  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simhitid, std::vector<simhitAddr>* simhitCFPos=0) const;
+  void associatePhase2TrackerRecHit(const Phase2TrackerRecHit1D* rechit, std::vector<SimHitIdpr> & simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
+  void associatePixelRecHit(const SiPixelRecHit * pixelrechit, std::vector<SimHitIdpr> & simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<SimHitIdpr> associateFastRecHit(const FastTrackerRecHit * rechit) const;
   std::vector<SimHitIdpr> associateMultiRecHitId(const SiTrackerMultiRecHit * multirechit, std::vector<simhitAddr>* simhitCFPos=0) const;
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
@@ -109,7 +111,8 @@ class TrackerHitAssociator {
   void makeMaps(const edm::Event& theEvent, const Config& config);
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
-  bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
+  edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  ph2trackerdigisimlink;
+  bool doPixel_, doStrip_, useOTph2_, doTrackAssoc_, assocHitbySimTrack_;
 };
 
 #endif

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -26,10 +26,14 @@ using namespace edm;
 TrackerHitAssociator::Config::Config(edm::ConsumesCollector && iC) :
   doPixel_(true),
   doStrip_(true),
+  useOTph2_(false),
   doTrackAssoc_(false),
   assocHitbySimTrack_(false) {
 
-  if(doStrip_) stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
+  if(doStrip_) {
+    if (useOTph2_) ph2OTrToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+    else           stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
+  }
   if(doPixel_) pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
   if(!doTrackAssoc_) {
     std::vector<std::string> trackerContainers;
@@ -61,10 +65,14 @@ TrackerHitAssociator::Config::Config(edm::ConsumesCollector && iC) :
 TrackerHitAssociator::Config::Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
+  useOTph2_( conf.getParameter<bool>("usePhase2Tracker") ),
   doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
   assocHitbySimTrack_(conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false) {
 
-  if(doStrip_) stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(conf.getParameter<edm::InputTag>("stripSimLinkSrc"));
+  if(doStrip_) {
+    if (useOTph2_) ph2OTrToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(conf.getParameter<edm::InputTag>("phase2TrackerSimLinkSrc"));
+    else           stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(conf.getParameter<edm::InputTag>("stripSimLinkSrc"));
+  }
   if(doPixel_) pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(conf.getParameter<edm::InputTag>("pixelSimLinkSrc"));
   if(!doTrackAssoc_) {
     std::vector<std::string> trackerContainers(conf.getParameter<std::vector<std::string> >("ROUList"));
@@ -83,6 +91,7 @@ TrackerHitAssociator::Config::Config(const edm::ParameterSet& conf, edm::Consume
 TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const TrackerHitAssociator::Config& config) :
   doPixel_(config.doPixel_),
   doStrip_(config.doStrip_),
+  useOTph2_(config.useOTph2_),
   doTrackAssoc_(config.doTrackAssoc_),
   assocHitbySimTrack_(config.assocHitbySimTrack_) {
   //if track association there is no need to access the input collections
@@ -90,7 +99,10 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const TrackerHit
     makeMaps(e, config);
   }
 
-  if(doStrip_) e.getByToken(config.stripToken_, stripdigisimlink);
+  if(doStrip_) {
+    if (useOTph2_) e.getByToken(config.ph2OTrToken_, ph2trackerdigisimlink);
+    else e.getByToken(config.stripToken_, stripdigisimlink);
+  }
   if(doPixel_) e.getByToken(config.pixelToken_, pixeldigisimlink);
 }
 
@@ -325,65 +337,38 @@ std::vector< SimHitIdpr > TrackerHitAssociator::associateHitId(const TrackingRec
 void TrackerHitAssociator::associateHitId(const TrackingRecHit & thit, std::vector< SimHitIdpr > & simtkid,
                                           std::vector<simhitAddr>* simhitCFPos) const
 {
+  simtkid.clear();
+    
+  if (const SiTrackerMultiRecHit * rechit = dynamic_cast<const SiTrackerMultiRecHit *>(&thit))
+    simtkid = associateMultiRecHitId(rechit, simhitCFPos);
+    
+  //check if it is a simple SiStripRecHit2D
+  if (const SiStripRecHit2D * rechit = dynamic_cast<const SiStripRecHit2D *>(&thit))
+    associateSiStripRecHit(rechit, simtkid, simhitCFPos);
 
-    simtkid.clear();
-    
-  //get the Detector type of the rechit
-    DetId detid=  thit.geographicalId();
-    if (const SiTrackerMultiRecHit * rechit = dynamic_cast<const SiTrackerMultiRecHit *>(&thit)){
-       simtkid=associateMultiRecHitId(rechit, simhitCFPos);
-    }
-    
-  // cout << "Associator ---> get Detid " << detID << endl;
-  //check we are in the strip tracker
-    if(detid.subdetId() == StripSubdetector::TIB ||
-       detid.subdetId() == StripSubdetector::TOB || 
-       detid.subdetId() == StripSubdetector::TID ||
-       detid.subdetId() == StripSubdetector::TEC) 
-      {
-	//check if it is a simple SiStripRecHit2D
-	if(const SiStripRecHit2D * rechit = 
-	   dynamic_cast<const SiStripRecHit2D *>(&thit))
-	  {	  
-	    associateSiStripRecHit(rechit, simtkid, simhitCFPos);
-	  }
-	//check if it is a SiStripRecHit1D
-	else  if(const SiStripRecHit1D * rechit = 
-		 dynamic_cast<const SiStripRecHit1D *>(&thit))
-	  {	  
-	    associateSiStripRecHit(rechit, simtkid, simhitCFPos);
-	  }
-	//check if it is a SiStripMatchedRecHit2D
-	else  if(const SiStripMatchedRecHit2D * rechit = 
-		 dynamic_cast<const SiStripMatchedRecHit2D *>(&thit))
-	  {	  
-	    simtkid = associateMatchedRecHit(rechit, simhitCFPos);
-	  }
-	//check if it is a  ProjectedSiStripRecHit2D
-	else if(const ProjectedSiStripRecHit2D * rechit = 
-		dynamic_cast<const ProjectedSiStripRecHit2D *>(&thit))
-	  {	  
-	    simtkid = associateProjectedRecHit(rechit, simhitCFPos);
-	  }
-	else{
-	  //std::cout << "associate to invalid" << std::endl;
-	  //throw cms::Exception("Unknown RecHit Type") << "TrackerHitAssociator failed second casting of " << typeid(thit).name() << " type ";
-	}
-      }
-    //check we are in the pixel tracker
-    else if( (unsigned int)(detid.subdetId()) == PixelSubdetector::PixelBarrel || 
-	     (unsigned int)(detid.subdetId()) == PixelSubdetector::PixelEndcap) 
-      {
-      if(const SiPixelRecHit * rechit = dynamic_cast<const SiPixelRecHit *>(&thit))
-	{	  
-	  associatePixelRecHit(rechit, simtkid, simhitCFPos);
-	}
-      }
-    //check if these are GSRecHits (from FastSim)
-    if(trackerHitRTTI::isFast(thit))
-      {
-	  simtkid = associateFastRecHit(static_cast<const FastTrackerRecHit *>(&thit));
-      }
+  //check if it is a SiStripRecHit1D
+  else  if(const SiStripRecHit1D * rechit = dynamic_cast<const SiStripRecHit1D *>(&thit))
+    associateSiStripRecHit(rechit, simtkid, simhitCFPos);
+
+  //check if it is a SiStripMatchedRecHit2D
+  else  if(const SiStripMatchedRecHit2D * rechit = dynamic_cast<const SiStripMatchedRecHit2D *>(&thit))
+    simtkid = associateMatchedRecHit(rechit, simhitCFPos);
+
+  //check if it is a  ProjectedSiStripRecHit2D
+  else if(const ProjectedSiStripRecHit2D * rechit = dynamic_cast<const ProjectedSiStripRecHit2D *>(&thit))
+    simtkid = associateProjectedRecHit(rechit, simhitCFPos);
+
+  //check if it is a Phase2TrackerRecHit1D
+  else if(const Phase2TrackerRecHit1D * rechit = dynamic_cast<const Phase2TrackerRecHit1D *>(&thit))
+    associatePhase2TrackerRecHit(rechit, simtkid, simhitCFPos);
+
+  //check if it is a SiPixelRecHit
+  else if(const SiPixelRecHit * rechit = dynamic_cast<const SiPixelRecHit *>(&thit))
+    associatePixelRecHit(rechit, simtkid, simhitCFPos);
+
+  //check if these are GSRecHits (from FastSim)
+  if(trackerHitRTTI::isFast(thit))
+    simtkid = associateFastRecHit(static_cast<const FastTrackerRecHit *>(&thit));
 }
 
 template<typename T>
@@ -533,7 +518,6 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateMatchedRecHit(const SiSt
   return simtrackid;
 }
 
-
 std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const ProjectedSiStripRecHit2D * projectedrechit,
 									std::vector<simhitAddr>* simhitCFPos) const
 {
@@ -544,6 +528,73 @@ std::vector<SimHitIdpr>  TrackerHitAssociator::associateProjectedRecHit(const Pr
   const SiStripRecHit2D mono = projectedrechit->originalHit();
   associateSiStripRecHit(&mono, matched_mono, simhitCFPos);
   return matched_mono;
+}
+
+void TrackerHitAssociator::associatePhase2TrackerRecHit(const Phase2TrackerRecHit1D* rechit,
+							std::vector<SimHitIdpr> & simtrackid,
+							std::vector<simhitAddr>* simhitCFPos) const
+{
+  //
+  // Phase 2 outer tracker associator
+  //
+  DetId detid=  rechit->geographicalId();
+  uint32_t detID = detid.rawId();
+
+  edm::DetSetVector<PixelDigiSimLink>::const_iterator isearch =  ph2trackerdigisimlink->find(detID); 
+  if(isearch !=  ph2trackerdigisimlink->end()) {  //if it is not empty
+    edm::DetSet<PixelDigiSimLink> link_detset = (*isearch);
+    Phase2TrackerRecHit1D::CluRef const& cluster = rechit->cluster();
+    
+    //check the reference is valid
+    
+    if(!(cluster.isNull())){//if the cluster is valid
+      int minRow = (*cluster).firstStrip();
+      int maxRow = (*cluster).firstStrip() + (*cluster).size();
+      int Col = (*cluster).column();
+      // std::cout << "    Cluster minRow " << minRow << " maxRow " << maxRow << " column " << Col << std::endl;
+      edm::DetSet<PixelDigiSimLink>::const_iterator linkiter = link_detset.data.begin(), linkEnd = link_detset.data.end();
+      int dsl = 0;
+      std::vector<SimHitIdpr> idcachev;
+      std::vector<simhitAddr> CFposcachev;
+      for( ; linkiter != linkEnd; ++linkiter) {
+	++dsl;
+	std::pair<int,int> coord = Phase2TrackerDigi::channelToPixel(linkiter->channel());
+	// std::cout << "    " << dsl << ") Digi link: row " << pixel_coord.first << " col " << pixel_coord.second << std::endl;      
+	if(  coord.first  <= maxRow && 
+	     coord.first  >= minRow &&
+	     coord.second == Col ) {
+	  // std::cout << "      !-> trackid   " << linkiter->SimTrackId() << endl;
+	  // std::cout << "          fraction  " << linkiter->fraction()   << endl;
+	  SimHitIdpr currentId(linkiter->SimTrackId(), linkiter->eventId());
+	  if(find(idcachev.begin(),idcachev.end(),currentId) == idcachev.end()){
+	    simtrackid.push_back(currentId);
+	    idcachev.push_back(currentId);
+	  }
+
+	  if (simhitCFPos != 0) {
+	  //create a vector that contains all the position (in the MixCollection) of the SimHits that contributed to the RecHit
+	  //write position only once
+	    unsigned int currentCFPos = linkiter->CFposition();
+	    unsigned int tofBin = linkiter->TofBin();
+	    subDetTofBin theSubDetTofBin = std::make_pair(detid.subdetId(), tofBin);
+	    simhit_collectionMap::const_iterator it = SimHitCollMap.find(theSubDetTofBin);
+	    if (it!= SimHitCollMap.end()) {
+	      simhitAddr currentAddr = std::make_pair(it->second, currentCFPos);
+	      if(find(CFposcachev.begin(), CFposcachev.end(), currentAddr) == CFposcachev.end()) {
+		CFposcachev.push_back(currentAddr);
+		simhitCFPos->push_back(currentAddr);
+	      }
+	    }
+	  }
+
+	} 
+      }  // end of simlink loop
+    }
+    else{      
+      edm::LogError("TrackerHitAssociator")<<"no Pixel cluster reference attached";
+      
+    }
+  }      
 }
 
 void  TrackerHitAssociator::associatePixelRecHit(const SiPixelRecHit * pixelrechit,

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -31,10 +31,13 @@ TrackerHitAssociator::Config::Config(edm::ConsumesCollector && iC) :
   assocHitbySimTrack_(false) {
 
   if(doStrip_) {
-    if (useOTph2_) ph2OTrToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+    if (useOTph2_) ph2OTrToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis","Tracker"));
     else           stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
   }
-  if(doPixel_) pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+  if(doPixel_) {
+    if (useOTph2_) pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis","Pixel"));
+    else           pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+  }
   if(!doTrackAssoc_) {
     std::vector<std::string> trackerContainers;
     trackerContainers.reserve(12);
@@ -65,7 +68,8 @@ TrackerHitAssociator::Config::Config(edm::ConsumesCollector && iC) :
 TrackerHitAssociator::Config::Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
-  useOTph2_( conf.getParameter<bool>("usePhase2Tracker") ),
+  useOTph2_( conf.existsAs<bool>("usePhase2Tracker") ? conf.getParameter<bool>("usePhase2Tracker") : false),
+  //
   doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
   assocHitbySimTrack_(conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false) {
 

--- a/Validation/RecoMuon/python/NewAssociators_cff.py
+++ b/Validation/RecoMuon/python/NewAssociators_cff.py
@@ -37,6 +37,7 @@ MABH.PurityCut_muon = 0.75
 MABH.includeZeroHitMuons = False
 #
 MABHhlt = MABH.clone()
+MABHhlt.EfficiencyCut_track = 0. # backup solution as UseGrouped/UseSplitting are always assumed to be true
 MABHhlt.DTrechitTag = 'hltDt1DRecHits'
 MABHhlt.ignoreMissingTrackCollection = True
 ################################################


### PR DESCRIPTION
This is a bugfix to the muon validation for Phase2 upgrade.

The standard muon validation was silently broken for Phase2 (since 81X, while it worked in 620_SLHCx), due to changes in the Tracker data formats. In particular the outer tracker hits were not associated at all in the TrackerHitAssociator, due to the missing format Phase2TrackerRecHit1D.
This bug was not spotted until now in the standard muon validation as no threshold was asked in the fraction of shared hits. By applying minimum thresholds as in the configuration of the New validation this became apparent. 
The TrackerHitAssociator has been kindly updated by Bill Ford (@wmtford). It is also meant to be used for tracker hit validation.

This PR has been tested on SingleMuonPt100 RelVal (with Phase2 conditions 2023 D4T) generated in CMSSW_9_1_0_pre5. 
The current validation (OldVal, soon to become obsolete) wrt to plain CMSSW_9_1_0_pre5 is at:
https://cmsdoc.cern.ch/cms/Physics/muon/CMSSW/Performance/RecoMuon/Validation/val/test_NewValidation_fix_Phase2TrackerAssociation/RelValSingleMuPt100Extended_UP2023D4T_noPU/OldVal-fix_Phase2TrackerAssociation_Vs_910pre5/

The comparison of the New validation with respect to the current one is obtained by applying this PR on top of the PR#18290, and is visible here:
https://cmsdoc.cern.ch/cms/Physics/muon/CMSSW/Performance/RecoMuon/Validation/val/test_NewValidation_fix_Phase2TrackerAssociation/RelValSingleMuPt100Extended_UP2023D4T_noPU/fix_Phase2TrackerAssociation-910pre5-NEWVal_Vs_OLDVal/

Comments:
- In the current validation (OldVal) there is almost no difference for base Tracker tracks or Global muons, due to the zero thresholds (that's why this bug did not break anything before), see:
https://cmsdoc.cern.ch/cms/Physics/muon/CMSSW/Performance/RecoMuon/Validation/val/test_NewValidation_fix_Phase2TrackerAssociation/RelValSingleMuPt100Extended_UP2023D4T_noPU/OldVal-fix_Phase2TrackerAssociation_Vs_910pre5/probeTrks.pdf

or: https://cmsdoc.cern.ch/cms/Physics/muon/CMSSW/Performance/RecoMuon/Validation/val/test_NewValidation_fix_Phase2TrackerAssociation/RelValSingleMuPt100Extended_UP2023D4T_noPU/OldVal-fix_Phase2TrackerAssociation_Vs_910pre5/extractedGlobalMuons.pdf

- however for Displaced tracks and displaced Global muons there are large effects, see:
https://cmsdoc.cern.ch/cms/Physics/muon/CMSSW/Performance/RecoMuon/Validation/val/test_NewValidation_fix_Phase2TrackerAssociation/RelValSingleMuPt100Extended_UP2023D4T_noPU/OldVal-fix_Phase2TrackerAssociation_Vs_910pre5/displacedTrks.pdf
and: https://cmsdoc.cern.ch/cms/Physics/muon/CMSSW/Performance/RecoMuon/Validation/val/test_NewValidation_fix_Phase2TrackerAssociation/RelValSingleMuPt100Extended_UP2023D4T_noPU/OldVal-fix_Phase2TrackerAssociation_Vs_910pre5/displacedGlobalMuons.pdf

- Comparing the NEW vs OLD validation the observed features are all expected for base muon collections

- For displaced tracks and global muons the comparison of NEW vs OLD validation demonstrates clearly the improvements of the NEW one, in terms of sharpness. In particular there is a reduced efficiency and increased fake rate in the New validation, as a consequence of the quality cuts. This shows that the recovery of efficiency obtained by this PR on the current (OLD) validation is just recovering low quality tracks. In other words there seems to be a real reconstruction problem with the reconstruction of displaced tracks and displaced global muons. (obviously this has to do with reconstruction, not with its validation)

This bugfix is needed (quite urgently) for muon performance studies for Phase2 TDRs.
@calabria  @HuguesBrun @calderona

