### PR TITLE
Use multiple tasks for end stream transitions

### DIFF
--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -87,12 +87,29 @@ namespace edm {
     void doBeginStream(unsigned int);
     void doEndStream(unsigned int);
     void doStreamBeginRun(unsigned int iID, RunPrincipal const& principal, IOVSyncValue const& ts);
+    void doStreamBeginRunAsync(WaitingTaskHolder iHolder,
+                               unsigned int iID,
+                               RunPrincipal const& principal,
+                               IOVSyncValue const& ts);
 
     void doStreamEndRun(unsigned int iID, RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
+    void doStreamEndRunAsync(WaitingTaskHolder iHolder,
+                             unsigned int iID, RunPrincipal const& principal,
+                             IOVSyncValue const& ts,
+                             bool cleaningUpAfterException);
 
     void doStreamBeginLuminosityBlock(unsigned int iID, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
+    void doStreamBeginLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                           unsigned int iID,
+                                           LuminosityBlockPrincipal const& principal,
+                                           IOVSyncValue const& ts);
 
     void doStreamEndLuminosityBlock(unsigned int iID, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
+    void doStreamEndLuminosityBlockAsync(WaitingTaskHolder iHolder,
+                                         unsigned int iID,
+                                         LuminosityBlockPrincipal const& principal,
+                                         IOVSyncValue const& ts,
+                                         bool cleaningUpAfterException);
 
 
     // Write the luminosity block

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -20,6 +20,7 @@
 
 // system include files
 #include <memory>
+#include <mutex>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -149,6 +150,7 @@ namespace edm {
         }
         void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) override final {
           //NOTE: in future this will need to be serialized
+          std::lock_guard<std::mutex> guard(mutex_);
           streamEndRunSummary(id,rp,c,cache_.get());
         }
         void doEndRunSummary_(Run const& rp, EventSetup const& c) override final {
@@ -162,6 +164,7 @@ namespace edm {
 
         //When threaded we will have a container for N items where N is # of simultaneous runs
         std::shared_ptr<C> cache_;
+        std::mutex mutex_;
       };
 
       template<typename T, typename C> class EndLuminosityBlockSummaryProducer;
@@ -183,6 +186,7 @@ namespace edm {
 
         virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lb, EventSetup const& c) override final
         {
+          std::lock_guard<std::mutex> guard(mutex_);
           streamEndLuminosityBlockSummary(id,lb,c,cache_.get());
         }
         void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) override final {
@@ -196,6 +200,7 @@ namespace edm {
         
         //When threaded we will have a container for N items where N is # of simultaneous Lumis
         std::shared_ptr<C> cache_;
+        std::mutex mutex_;
       };
 
       

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -95,6 +95,7 @@ namespace edm {
                                edm::Run const& iRun,
                                edm::EventSetup const& iES) override final {
         auto s = m_runSummaries[iRun.index()].get();
+        std::lock_guard<decltype(m_runSummaryLock)> guard(m_runSummaryLock);
         MyGlobalRunSummary::streamEndRunSummary(iProd,iRun,iES,s);
       }
  
@@ -106,6 +107,7 @@ namespace edm {
                                            edm::LuminosityBlock const& iLumi,
                                            edm::EventSetup const& iES) override final {
         auto s = m_lumiSummaries[iLumi.index()].get();
+        std::lock_guard<decltype(m_lumiSummaryLock)> guard(m_lumiSummaryLock);
         MyGlobalLuminosityBlockSummary::streamEndLuminosityBlockSummary(iProd,iLumi,iES,s);
       }
 
@@ -180,7 +182,9 @@ namespace edm {
       typename impl::choose_shared_vec<typename T::RunCache const>::type m_runs;
       typename impl::choose_shared_vec<typename T::LuminosityBlockCache const>::type m_lumis;
       typename impl::choose_shared_vec<typename T::RunSummaryCache>::type m_runSummaries;
+      typename impl::choose_mutex<typename T::RunSummaryCache>::type m_runSummaryLock;
       typename impl::choose_shared_vec<typename T::LuminosityBlockSummaryCache>::type m_lumiSummaries;
+      typename impl::choose_mutex<typename T::LuminosityBlockSummaryCache>::type m_lumiSummaryLock;
       ParameterSet const* m_pset;
     };
   }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -89,6 +89,7 @@ namespace edm {
                                edm::Run const& iRun,
                                edm::EventSetup const& iES) override final {
         auto s = m_runSummaries[iRun.index()].get();
+        std::lock_guard<decltype(m_runSummaryLock)> guard(m_runSummaryLock);
         MyGlobalRunSummary::streamEndRunSummary(iProd,iRun,iES,s);
       }
  
@@ -100,6 +101,7 @@ namespace edm {
                                            edm::LuminosityBlock const& iLumi,
                                            edm::EventSetup const& iES) override final {
         auto s = m_lumiSummaries[iLumi.index()].get();
+        std::lock_guard<decltype(m_lumiSummaryLock)> guard(m_lumiSummaryLock);
         MyGlobalLuminosityBlockSummary::streamEndLuminosityBlockSummary(iProd,iLumi,iES,s);
       }
 
@@ -189,7 +191,9 @@ namespace edm {
       typename impl::choose_shared_vec<typename T::RunCache const>::type m_runs;
       typename impl::choose_shared_vec<typename T::LuminosityBlockCache const>::type m_lumis;
       typename impl::choose_shared_vec<typename T::RunSummaryCache>::type m_runSummaries;
+      typename impl::choose_mutex<typename T::RunSummaryCache>::type m_runSummaryLock;
       typename impl::choose_shared_vec<typename T::LuminosityBlockSummaryCache>::type m_lumiSummaries;
+      typename impl::choose_mutex<typename T::LuminosityBlockSummaryCache>::type m_lumiSummaryLock;
       ParameterSet const* m_pset;
     };
   }

--- a/FWCore/Framework/interface/stream/dummy_helpers.h
+++ b/FWCore/Framework/interface/stream/dummy_helpers.h
@@ -19,7 +19,9 @@
 //
 
 // system include files
-
+#include <memory>
+#include <vector>
+#include <mutex>
 // user include files
 
 // forward declarations
@@ -37,6 +39,12 @@ namespace edm {
         void resize(size_t) {}
         dummy_ptr operator[](unsigned int) { return dummy_ptr();}
       };
+      
+      struct dummy_mutex {
+        void lock() {}
+        void unlock() {}
+      };
+      
       template<typename T>
       struct choose_unique_ptr {
         typedef std::unique_ptr<T> type;
@@ -62,6 +70,14 @@ namespace edm {
       template<>
       struct choose_shared_vec<void const> {
         typedef dummy_vec type;
+      };
+      template<typename T>
+      struct choose_mutex {
+        using type = std::mutex;
+      };
+      template<>
+      struct choose_mutex<void> {
+        using type = dummy_mutex;
       };
     }
   }

--- a/FWCore/Framework/src/streamTransitionAsync.h
+++ b/FWCore/Framework/src/streamTransitionAsync.h
@@ -1,0 +1,146 @@
+#ifndef FWCore_Framework_streamTransitionAsync_h
+#define FWCore_Framework_streamTransitionAsync_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Function:    streamTransitionAsync
+// 
+/**\function streamTransitionAsync streamTransitionAsync.h "streamTransitionAsync.h"
+
+ Description: Helper functions for handling asynchronous stream transitions
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Tue, 06 Sep 2016 16:04:26 GMT
+//
+
+// system include files
+#include "FWCore/Framework/interface/Schedule.h"
+#include "FWCore/Framework/interface/SubProcess.h"
+#include "FWCore/Concurrency/interface/WaitingTask.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  class IOVSyncValue;
+  class EventSetup;
+  class LuminosityBlockPrincipal;
+  class RunPrincipal;
+  
+  //This is code in common between beginStreamRun and beginStreamLuminosityBlock
+  inline void subProcessDoStreamBeginTransitionAsync(WaitingTaskHolder iHolder,SubProcess& iSubProcess, unsigned int i, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS) {
+    iSubProcess.doStreamBeginLuminosityBlockAsync(std::move(iHolder),i,iPrincipal, iTS);
+  }
+  
+  inline void subProcessDoStreamBeginTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, unsigned int i, RunPrincipal& iPrincipal, IOVSyncValue const& iTS) {
+    iSubProcess.doStreamBeginRunAsync(std::move(iHolder),i,iPrincipal, iTS);
+  }
+  
+  inline void subProcessDoStreamEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, unsigned int i, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
+    iSubProcess.doStreamEndLuminosityBlockAsync(std::move(iHolder),i,iPrincipal, iTS,cleaningUpAfterException);
+  }
+  
+  inline void subProcessDoStreamEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, unsigned int i, RunPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
+    iSubProcess.doStreamEndRunAsync(std::move(iHolder), i ,iPrincipal, iTS, cleaningUpAfterException);
+  }
+
+
+  template<typename Traits, typename P, typename SC >
+  void beginStreamTransitionAsync(WaitingTaskHolder iWait,
+                                  Schedule& iSchedule,
+                                  unsigned int iStreamIndex,
+                                  P& iPrincipal,
+                                  IOVSyncValue const & iTS,
+                                  EventSetup const& iES,
+                                  SC& iSubProcesses) {
+    ServiceToken token = ServiceRegistry::instance().presentToken();
+
+    //When we are done processing the stream for this process,
+    // we need to run the stream for all SubProcesses
+    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,iStreamIndex,&iPrincipal,iTS,token](std::exception_ptr const* iPtr) mutable {
+      if(iPtr) {
+        iWait.doneWaiting(*iPtr);
+        return;
+      }
+      ServiceRegistry::Operate op(token);
+      for_all(iSubProcesses, [&iWait,iStreamIndex, &iPrincipal, iTS](auto& subProcess){ subProcessDoStreamBeginTransitionAsync(iWait,subProcess,iStreamIndex,iPrincipal, iTS); });
+    });
+    
+    WaitingTaskHolder h(subs);
+    iSchedule.processOneStreamAsync<Traits>(std::move(h), iStreamIndex,iPrincipal, iES);
+  }
+
+  
+  template<typename Traits, typename P, typename SC >
+  void beginStreamsTransitionAsync(WaitingTask* iWait,
+                                  Schedule& iSchedule,
+                                  unsigned int iNStreams,
+                                  P& iPrincipal,
+                                  IOVSyncValue const & iTS,
+                                  EventSetup const& iES,
+                                  SC& iSubProcesses)
+  {
+    WaitingTaskHolder holdUntilAllStreamsCalled(iWait);
+    for(unsigned int i=0; i<iNStreams;++i) {
+      beginStreamTransitionAsync<Traits>(WaitingTaskHolder(iWait), iSchedule,i,iPrincipal,iTS,iES,iSubProcesses);
+    }
+  }
+  
+  template<typename Traits, typename P, typename SC >
+  void endStreamTransitionAsync(WaitingTaskHolder iWait,
+                                Schedule& iSchedule,
+                                unsigned int iStreamIndex,
+                                P& iPrincipal,
+                                IOVSyncValue const & iTS,
+                                EventSetup const& iES,
+                                SC& iSubProcesses,
+                                bool cleaningUpAfterException)
+  {
+    ServiceToken token = ServiceRegistry::instance().presentToken();
+    
+    //When we are done processing the stream for this process,
+    // we need to run the stream for all SubProcesses
+    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,iStreamIndex,&iPrincipal,iTS,token,cleaningUpAfterException](std::exception_ptr const* iPtr) mutable {
+      if(iPtr) {
+        iWait.doneWaiting(*iPtr);
+        return;
+      }
+      ServiceRegistry::Operate op(token);
+      for_all(iSubProcesses, [&iWait,iStreamIndex, &iPrincipal, iTS,cleaningUpAfterException](auto& subProcess){
+        subProcessDoStreamEndTransitionAsync(iWait,subProcess,iStreamIndex,iPrincipal, iTS,cleaningUpAfterException); });
+    });
+    
+    WaitingTaskHolder h(subs);
+    iSchedule.processOneStreamAsync<Traits>(std::move(h), iStreamIndex,iPrincipal, iES,cleaningUpAfterException);
+      
+    
+  }
+
+  template<typename Traits, typename P, typename SC >
+  void endStreamsTransitionAsync(WaitingTask* iWait,
+                                Schedule& iSchedule,
+                                unsigned int iNStreams,
+                                P& iPrincipal,
+                                IOVSyncValue const & iTS,
+                                EventSetup const& iES,
+                                SC& iSubProcesses,
+                                bool cleaningUpAfterException)
+  {
+    WaitingTaskHolder holdUntilAllStreamsCalled(iWait);
+    for(unsigned int i=0; i<iNStreams;++i) {
+      endStreamTransitionAsync<Traits>(WaitingTaskHolder(iWait),
+                                       iSchedule,i,
+                                       iPrincipal,iTS,iES,
+                                       iSubProcesses,cleaningUpAfterException);
+    }
+  }
+};
+
+#endif

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -552,6 +552,12 @@ ModuleCallingContext state = Running
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
+++++++ starting: end lumi for module: stream = 0 label = 'result4' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'result4' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'result2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'result2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'result1' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'result1' id = 4
 ++++++ starting: end lumi for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -576,12 +582,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end lumi for module: stream = 0 label = 'result1' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'result1' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'result2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'result2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'result4' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'result4' id = 6
 ++++++ starting: end lumi for module: stream = 0 label = 'get' id = 2
 ++++++ finished: end lumi for module: stream = 0 label = 'get' id = 2
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
@@ -622,6 +622,12 @@ ModuleCallingContext state = Running
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
+++++++ starting: end run for module: stream = 0 label = 'result4' id = 6
+++++++ finished: end run for module: stream = 0 label = 'result4' id = 6
+++++++ starting: end run for module: stream = 0 label = 'result2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'result2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'result1' id = 4
+++++++ finished: end run for module: stream = 0 label = 'result1' id = 4
 ++++++ starting: end run for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -646,12 +652,6 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end run for module: stream = 0 label = 'result1' id = 4
-++++++ finished: end run for module: stream = 0 label = 'result1' id = 4
-++++++ starting: end run for module: stream = 0 label = 'result2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'result2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'result4' id = 6
-++++++ finished: end run for module: stream = 0 label = 'result4' id = 6
 ++++++ starting: end run for module: stream = 0 label = 'get' id = 2
 ++++++ finished: end run for module: stream = 0 label = 'get' id = 2
 ++++ finished: end run: stream = 0 run = 1 time = 1000030

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -160,14 +160,14 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'one' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'one' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'getOne' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'getOne' id = 3
 ++++++ starting: end lumi for module: stream = 0 label = 'two' id = 4
 ++++++ finished: end lumi for module: stream = 0 label = 'two' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'getOne' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'getOne' id = 3
 ++++++ starting: end lumi for module: stream = 0 label = 'getTwo' id = 5
 ++++++ finished: end lumi for module: stream = 0 label = 'getTwo' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'one' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'one' id = 2
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++++ starting: global end lumi for module: label = 'one' id = 2
@@ -182,14 +182,14 @@
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'one' id = 2
-++++++ finished: end run for module: stream = 0 label = 'one' id = 2
-++++++ starting: end run for module: stream = 0 label = 'getOne' id = 3
-++++++ finished: end run for module: stream = 0 label = 'getOne' id = 3
 ++++++ starting: end run for module: stream = 0 label = 'two' id = 4
 ++++++ finished: end run for module: stream = 0 label = 'two' id = 4
+++++++ starting: end run for module: stream = 0 label = 'getOne' id = 3
+++++++ finished: end run for module: stream = 0 label = 'getOne' id = 3
 ++++++ starting: end run for module: stream = 0 label = 'getTwo' id = 5
 ++++++ finished: end run for module: stream = 0 label = 'getTwo' id = 5
+++++++ starting: end run for module: stream = 0 label = 'one' id = 2
+++++++ finished: end run for module: stream = 0 label = 'one' id = 2
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
 ++++++ starting: global end run for module: label = 'one' id = 2

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -860,6 +860,8 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -884,18 +886,16 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: end lumi for module: stream = 0 label = 'a1' id = 3
 ++++++ finished: end lumi for module: stream = 0 label = 'a1' id = 3
 ++++++ starting: end lumi for module: stream = 0 label = 'a2' id = 4
 ++++++ finished: end lumi for module: stream = 0 label = 'a2' id = 4
 ++++++ starting: end lumi for module: stream = 0 label = 'a3' id = 5
 ++++++ finished: end lumi for module: stream = 0 label = 'a3' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 6
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 6
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
@@ -990,6 +990,8 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 8
 ++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -1014,18 +1016,16 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: end run for module: stream = 0 label = 'a1' id = 3
 ++++++ finished: end run for module: stream = 0 label = 'a1' id = 3
 ++++++ starting: end run for module: stream = 0 label = 'a2' id = 4
 ++++++ finished: end run for module: stream = 0 label = 'a2' id = 4
 ++++++ starting: end run for module: stream = 0 label = 'a3' id = 5
 ++++++ finished: end run for module: stream = 0 label = 'a3' id = 5
+++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 2
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 6
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 6
 ++++ finished: end run: stream = 0 run = 1 time = 15000001

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -677,10 +677,10 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 5
 ++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -763,10 +763,10 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 5
 ++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 4
 ++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -219,54 +219,54 @@
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
-++++ finished: begin run: stream = 0 run = 1 time = 1
-++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -335,54 +335,54 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: source event
 ++++ finished: source event
@@ -933,54 +933,54 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
@@ -1109,54 +1109,54 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: source event
 ++++ finished: source event
@@ -1707,54 +1707,54 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
@@ -1883,54 +1883,54 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: source event
 ++++ finished: source event
@@ -2209,54 +2209,54 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
@@ -2323,54 +2323,54 @@
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end run for module: stream = 0 label = 'get' id = 3
-++++++ finished: end run for module: stream = 0 label = 'get' id = 3
-++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end run for module: stream = 0 label = 'get' id = 3
+++++++ finished: end run for module: stream = 0 label = 'get' id = 3
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end run for module: stream = 0 label = 'test' id = 11
-++++++ finished: end run for module: stream = 0 label = 'test' id = 11
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end run for module: stream = 0 label = 'get' id = 13
-++++++ finished: end run for module: stream = 0 label = 'get' id = 13
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end run for module: stream = 0 label = 'out' id = 16
-++++++ finished: end run for module: stream = 0 label = 'out' id = 16
-++++ finished: end run: stream = 0 run = 1 time = 0
-++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'get' id = 21
+++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end run for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end run for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end run for module: stream = 0 label = 'get' id = 21
-++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 24
+++++ finished: end run: stream = 0 run = 1 time = 0
+++++ starting: end run: stream = 0 run = 1 time = 0
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end run for module: stream = 0 label = 'get' id = 13
+++++++ finished: end run for module: stream = 0 label = 'get' id = 13
+++++++ starting: end run for module: stream = 0 label = 'test' id = 11
+++++++ finished: end run for module: stream = 0 label = 'test' id = 11
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end run for module: stream = 0 label = 'out' id = 16
+++++++ finished: end run for module: stream = 0 label = 'out' id = 16
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: global end run 1 : time = 50000001
 ++++ finished: global end run 1 : time = 50000001
@@ -2499,54 +2499,54 @@
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
-++++ finished: begin run: stream = 0 run = 2 time = 55000001
-++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2615,54 +2615,54 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: source event
 ++++ finished: source event
@@ -3213,54 +3213,54 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
@@ -3389,54 +3389,54 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: source event
 ++++ finished: source event
@@ -3987,54 +3987,54 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
@@ -4163,54 +4163,54 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: source event
 ++++ finished: source event
@@ -4489,54 +4489,54 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
@@ -4603,54 +4603,54 @@
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end run for module: stream = 0 label = 'get' id = 3
-++++++ finished: end run for module: stream = 0 label = 'get' id = 3
-++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end run for module: stream = 0 label = 'get' id = 3
+++++++ finished: end run for module: stream = 0 label = 'get' id = 3
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end run for module: stream = 0 label = 'test' id = 11
-++++++ finished: end run for module: stream = 0 label = 'test' id = 11
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end run for module: stream = 0 label = 'get' id = 13
-++++++ finished: end run for module: stream = 0 label = 'get' id = 13
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end run for module: stream = 0 label = 'out' id = 16
-++++++ finished: end run for module: stream = 0 label = 'out' id = 16
-++++ finished: end run: stream = 0 run = 2 time = 0
-++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'get' id = 21
+++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end run for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end run for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end run for module: stream = 0 label = 'get' id = 21
-++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 24
+++++ finished: end run: stream = 0 run = 2 time = 0
+++++ starting: end run: stream = 0 run = 2 time = 0
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end run for module: stream = 0 label = 'get' id = 13
+++++++ finished: end run for module: stream = 0 label = 'get' id = 13
+++++++ starting: end run for module: stream = 0 label = 'test' id = 11
+++++++ finished: end run for module: stream = 0 label = 'test' id = 11
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end run for module: stream = 0 label = 'out' id = 16
+++++++ finished: end run for module: stream = 0 label = 'out' id = 16
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: global end run 2 : time = 100000001
 ++++ finished: global end run 2 : time = 100000001
@@ -4779,54 +4779,54 @@
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
-++++ finished: begin run: stream = 0 run = 3 time = 105000001
-++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin run for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin run for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4895,54 +4895,54 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: source event
 ++++ finished: source event
@@ -5493,54 +5493,54 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
@@ -5669,54 +5669,54 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: source event
 ++++ finished: source event
@@ -6267,54 +6267,54 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
@@ -6443,54 +6443,54 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: source event
 ++++ finished: source event
@@ -6769,54 +6769,54 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end lumi for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
@@ -6883,54 +6883,54 @@
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ starting: end run for module: stream = 0 label = 'get' id = 3
-++++++ finished: end run for module: stream = 0 label = 'get' id = 3
-++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
 ++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end run for module: stream = 0 label = 'get' id = 3
+++++++ finished: end run for module: stream = 0 label = 'get' id = 3
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end run for module: stream = 0 label = 'test' id = 11
-++++++ finished: end run for module: stream = 0 label = 'test' id = 11
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end run for module: stream = 0 label = 'get' id = 13
-++++++ finished: end run for module: stream = 0 label = 'get' id = 13
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end run for module: stream = 0 label = 'out' id = 16
-++++++ finished: end run for module: stream = 0 label = 'out' id = 16
-++++ finished: end run: stream = 0 run = 3 time = 0
-++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'get' id = 21
+++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end run for module: stream = 0 label = 'test' id = 19
 ++++++ finished: end run for module: stream = 0 label = 'test' id = 19
 ++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 20
 ++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 20
-++++++ starting: end run for module: stream = 0 label = 'get' id = 21
-++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++++ starting: end run for module: stream = 0 label = 'getInt' id = 22
 ++++++ finished: end run for module: stream = 0 label = 'getInt' id = 22
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 24
+++++ finished: end run: stream = 0 run = 3 time = 0
+++++ starting: end run: stream = 0 run = 3 time = 0
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end run for module: stream = 0 label = 'get' id = 13
+++++++ finished: end run for module: stream = 0 label = 'get' id = 13
+++++++ starting: end run for module: stream = 0 label = 'test' id = 11
+++++++ finished: end run for module: stream = 0 label = 'test' id = 11
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end run for module: stream = 0 label = 'out' id = 16
+++++++ finished: end run for module: stream = 0 label = 'out' id = 16
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: global end run 3 : time = 150000001
 ++++ finished: global end run 3 : time = 150000001


### PR DESCRIPTION
During end of Run and end of LuminosityBlock stream transitions, each module is now assign its own TBB tasks and all the tasks are run concurrently.
SubProcess running during those transitions are also broken into multiple tasks to run concurrently. In addition, if a process has multiple SubProcesses, all the SubProcesses are run concurrently during those transitions.