### PR TITLE
Bringing 2017 HF simulation in sync with the data configuration

### DIFF
--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -120,6 +120,18 @@ run2_HE_2017.toModify( hcalSimParameters,
     )
 )
 
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+run2_HF_2017.toModify( hcalSimParameters,
+    hf1 = dict(
+               readoutFrameSize = cms.int32(3), 
+               binOfMaximum     = cms.int32(2)
+              ),
+    hf2 = dict(
+               readoutFrameSize = cms.int32(3), 
+               binOfMaximum     = cms.int32(2)
+              )
+)
+
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify( hcalSimParameters,
     hb = dict(

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -55,5 +55,9 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
 )
 
 run2_HE_2017.toModify(simHcalTriggerPrimitiveDigis, upgradeHE=cms.bool(True))
-run2_HF_2017.toModify(simHcalTriggerPrimitiveDigis, upgradeHF=cms.bool(True))
+run2_HF_2017.toModify(simHcalTriggerPrimitiveDigis, 
+                      upgradeHF=cms.bool(True),
+                      numberOfSamplesHF = cms.int32(2),
+                      numberOfPresamplesHF = cms.int32(1)
+)
 run3_HB.toModify(simHcalTriggerPrimitiveDigis, upgradeHB=cms.bool(True))

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -26,3 +26,8 @@ phase2_hcal.toModify( simHcalDigis,
                              useConfigZSvalues = cms.int32(1),
                              HElevel = cms.int32(3)
 )
+
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+run2_HF_2017.toModify( simHcalDigis,
+                             HFregion = cms.vint32(1,2)
+)


### PR DESCRIPTION
At P5 HCAL moved from 4TS to 3TS HF configuration and changed SOI ("sample of interest" = trigger one)  from 3d to 2d TS. 
This PR brings 2017 HF MC (DIGI and L1 emulation) in sync with the data.

NB: no changes expected for end-user, neither in HCAL Reco nor in L1 emulation,
while some code snippets in Validation/HcalDigis need to be modified to move from using ("absolute") hardcoded HF TS numbers to SOI-related  ("relative") ones. To be done later.   