### PR TITLE
Hotfix to disable num_feddigistrend_per_Lumisection_per_FED plot (91X)

### DIFF
--- a/DQM/SiPixelPhase1Digis/interface/SiPixelPhase1Digis.h
+++ b/DQM/SiPixelPhase1Digis/interface/SiPixelPhase1Digis.h
@@ -22,7 +22,7 @@ class SiPixelPhase1Digis : public SiPixelPhase1Base {
     NDIGIS, // number of digis per event and module
     NDIGISINCLUSIVE, //Total number of digis in BPix and FPix
     NDIGIS_FED, // number of digis per event and FED
-    NDIGIS_FEDtrend, // number of digis per event and FED 
+//    NDIGIS_FEDtrend, // number of digis per event and FED 
     EVENT, // event frequency
     MAP, // digi hitmap per module
     OCCUPANCY, // like map but coarser

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -172,7 +172,7 @@ SiPixelPhase1DigisConf = cms.VPSet(
   SiPixelPhase1DigisNdigis,
   SiPixelPhase1ClustersNdigisInclusive,
   SiPixelPhase1DigisNdigisPerFED,
-  SiPixelPhase1DigisNdigisPerFEDtrend,
+#  SiPixelPhase1DigisNdigisPerFEDtrend,
   SiPixelPhase1DigisEvents,
   SiPixelPhase1DigisHitmap,
   SiPixelPhase1DigisOccupancy,

--- a/DQM/SiPixelPhase1Digis/src/SiPixelPhase1Digis.cc
+++ b/DQM/SiPixelPhase1Digis/src/SiPixelPhase1Digis.cc
@@ -42,14 +42,14 @@ void SiPixelPhase1Digis::analyze(const edm::Event& iEvent, const edm::EventSetup
       histo[NDIGIS    ].fill(DetId(it->detId()), &iEvent); // count
       histo[NDIGISINCLUSIVE].fill(DetId(it->detId()), &iEvent); // count
       histo[NDIGIS_FED].fill(DetId(it->detId()), &iEvent); 
-      histo[NDIGIS_FEDtrend].fill(DetId(it->detId()), &iEvent);  
+//      histo[NDIGIS_FEDtrend].fill(DetId(it->detId()), &iEvent);  
     }
   }
   if (hasDigis) histo[EVENT].fill(DetId(0), &iEvent);
   histo[NDIGIS    ].executePerEventHarvesting(&iEvent);
   histo[NDIGISINCLUSIVE].executePerEventHarvesting(&iEvent);
   histo[NDIGIS_FED].executePerEventHarvesting(&iEvent); 
-  histo[NDIGIS_FEDtrend].executePerEventHarvesting(&iEvent);
+//  histo[NDIGIS_FEDtrend].executePerEventHarvesting(&iEvent);
 }
 
 DEFINE_FWK_MODULE(SiPixelPhase1Digis);


### PR DESCRIPTION
The DQM plot "num_feddigistrend_per_Lumisection_per_FED" is found to be too large and causing issues for the DQM GUI server.
Minimum patch to disable this plots for the time being.
Patch for 91X