### PR TITLE
Fix overflow filling in MultiTrackValidator and PackedCandidateTrackValidator

### DIFF
--- a/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
+++ b/DQM/TrackingMonitor/src/PackedCandidateTrackValidator.cc
@@ -27,8 +27,15 @@
 #include <iomanip>
 
 namespace {
-  template<typename T> void fillNoFlow(MonitorElement* h, T val){
-    h->Fill(std::min(std::max(val,((T) h->getTH1()->GetXaxis()->GetXmin())),((T) h->getTH1()->GetXaxis()->GetXmax())));
+  template<typename T> void fillNoFlow(MonitorElement* me, T val){
+    auto h = me->getTH1();
+    const auto xaxis = h->GetXaxis();
+    if(val <= xaxis->GetXmin())
+      h->AddBinContent(xaxis->GetFirst());
+    else if(val >= xaxis->GetXmax())
+      h->AddBinContent(xaxis->GetLast());
+    else
+      h->Fill(val);
   }
 
   class HitPatternPrinter {

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -31,8 +31,15 @@ namespace {
     axis->Set(bins, new_bins.data());
   }
 
-  template<typename T> void fillPlotNoFlow(MonitorElement *h, T val) {
-    h->Fill(std::min(std::max(val,((T) h->getTH1()->GetXaxis()->GetXmin())),((T) h->getTH1()->GetXaxis()->GetXmax())));
+  template<typename T> void fillPlotNoFlow(MonitorElement *me, T val) {
+    auto h = me->getTH1();
+    const auto xaxis = h->GetXaxis();
+    if(val <= xaxis->GetXmin())
+      h->AddBinContent(xaxis->GetFirst());
+    else if(val >= xaxis->GetXmax())
+      h->AddBinContent(xaxis->GetLast());
+    else
+      h->Fill(val);
   }
 
   void setBinLabels(MonitorElement *h, const std::vector<std::string>& labels) {


### PR DESCRIPTION
This PR fixes `fill(Plot)NoFlow` functions in MultiTrackValidator and PackedCandidateTrackValidator to fill the last bin instead of overflow bin in case of overflow. This is the intention, and is already correctly done for underflows.

Thanks to @arizzi for noticing the bug (https://github.com/cms-sw/cmssw/pull/18092#issuecomment-292480134).

Tested in 9_1_0_pre2, expecting changes in MultiTrackValidator and PackedCandidateTrackValidator histograms that are filled with "no under/overflow" (=nearly all) in the last bin.

@rovere @VinInn 