### PR TITLE
Remove the process name dependence for HCAL DPG skims

### DIFF
--- a/DPGAnalysis/Skims/python/JetHTJetPlusHOFilter_cff.py
+++ b/DPGAnalysis/Skims/python/JetHTJetPlusHOFilter_cff.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 JetHTJetPlusHOFilterSkim = cms.EDFilter("JetHTJetPlusHOFilter",
     Photons = cms.InputTag("photons"),
-    PFJets = cms.InputTag("ak4PFJets","","RECO"),
-    particleFlowClusterHO = cms.InputTag("particleFlowClusterHO","","RECO"),
+    PFJets = cms.InputTag("ak4PFJets"),
+    particleFlowClusterHO = cms.InputTag("particleFlowClusterHO"),
     Ptcut = cms.untracked.double(200.0), 
     Etacut = cms.untracked.double(1.5),
     HOcut = cms.untracked.double(8.0)

--- a/DPGAnalysis/Skims/python/SinglePhotonJetPlusHOFilter_cff.py
+++ b/DPGAnalysis/Skims/python/SinglePhotonJetPlusHOFilter_cff.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 SinglePhotonJetPlusHOFilterSkim = cms.EDFilter("SinglePhotonJetPlusHOFilter",
     Photons = cms.InputTag("photons"),
-    PFJets = cms.InputTag("ak4PFJets","","RECO"),
-    particleFlowClusterHO = cms.InputTag("particleFlowClusterHO","","RECO"),
+    PFJets = cms.InputTag("ak4PFJets"),
+    particleFlowClusterHO = cms.InputTag("particleFlowClusterHO"),
     Ptcut = cms.untracked.double(90.0), 
     Etacut = cms.untracked.double(1.5),
     HOcut = cms.untracked.double(5.0), 


### PR DESCRIPTION
The process name was hard coded in the HCAL DPG skims (JetHTJetPlusHOFilter / PhotonJetPlusHOFilter). Remove this dependence. 