### PR TITLE
Adding me0/gemmuon ID to the muon selectors and for miniAOD

### DIFF
--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -46,7 +46,11 @@ namespace muon {
       // less confusing for future generations of CMS members, I hope...
       TMLastStationOptimizedBarrelLowPtLoose = 22, // combination of TMLastStation and TMOneStation but with low pT optimization in barrel only
       TMLastStationOptimizedBarrelLowPtTight = 23, // combination of TMLastStation and TMOneStation but with low pT optimization in barrel only
-      RPCMuLoose = 24                              // checks isRPCMuon flag (require two well matched hits in different RPC layers)
+      RPCMuLoose = 24,                             // checks isRPCMuon flag (require two well matched hits in different RPC layers)
+      AllME0Muons = 25,
+      ME0MuonArbitrated = 26,
+      AllGEMMuons = 27,
+      GEMMuonArbitrated = 28
    };
 
    /// a lightweight "map" for selection type string label and enum value
@@ -60,7 +64,7 @@ namespace muon {
    // ===========================================================================
    //                               Support functions
    // 
-   enum AlgorithmType { TMLastStation, TM2DCompatibility, TMOneStation, RPCMu };
+   enum AlgorithmType { TMLastStation, TM2DCompatibility, TMOneStation, RPCMu, ME0Mu, GEMMu };
    
    // specialized GoodMuon functions called from main wrapper
    bool isGoodMuon( const reco::Muon& muon, 

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -572,7 +572,7 @@ bool muon::isGoodMuon( const reco::Muon& muon,
     int nMatch = 0;
     for ( const auto& chamberMatch : muon.matches() )
     {
-      if ( chamberMatch.detector() != 5 ) continue;
+      if ( chamberMatch.detector() != MuonSubdetId::ME0 ) continue;
 
       const double trkX = chamberMatch.x;
       const double errX = chamberMatch.xErr;
@@ -600,9 +600,9 @@ bool muon::isGoodMuon( const reco::Muon& muon,
       }
     }
 
-    if ( nMatch >= minNumberOfMatches ) return true;
-    else return false;
+  return ( nMatch >= minNumberOfMatches );
   } // ME0Mu
+    
   if ( type == GEMMu )
   {
     if ( minNumberOfMatches == 0 ) return true;
@@ -610,7 +610,7 @@ bool muon::isGoodMuon( const reco::Muon& muon,
     int nMatch = 0;
     for ( const auto& chamberMatch : muon.matches() )
     {
-      if ( chamberMatch.detector() != 4 ) continue;
+      if ( chamberMatch.detector() != MuonSubdetId::GEM ) continue;
 
       const double trkX = chamberMatch.x;
       const double errX = chamberMatch.xErr;
@@ -638,8 +638,7 @@ bool muon::isGoodMuon( const reco::Muon& muon,
       }
     }
 
-    if ( nMatch >= minNumberOfMatches ) return true;
-    else return false;
+   return ( nMatch >= minNumberOfMatches );
    } // GEMMu
 
    return goodMuon;

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -34,6 +34,10 @@ SelectionType selectionTypeFromString( const std::string &label )
       { "TMLastStationOptimizedBarrelLowPtLoose", TMLastStationOptimizedBarrelLowPtLoose },
       { "TMLastStationOptimizedBarrelLowPtTight", TMLastStationOptimizedBarrelLowPtTight },
       { "RPCMuLoose", RPCMuLoose },
+      { "AllME0Muons", AllME0Muons },
+      { "ME0MuonArbitrated", ME0MuonArbitrated },
+      { "AllGEMMuons", AllGEMMuons },
+      { "GEMMuonArbitrated", GEMMuonArbitrated },
       { 0, (SelectionType)-1 }
    };
 
@@ -560,6 +564,83 @@ bool muon::isGoodMuon( const reco::Muon& muon,
     if ( nMatch >= minNumberOfMatches ) return true;
     else return false;
   } // RPCMu
+    
+  if ( type == ME0Mu )
+  {
+    if ( minNumberOfMatches == 0 ) return true;
+    
+    int nMatch = 0;
+    for ( const auto& chamberMatch : muon.matches() )
+    {
+      if ( chamberMatch.detector() != 5 ) continue;
+
+      const double trkX = chamberMatch.x;
+      const double errX = chamberMatch.xErr;
+      const double trkY = chamberMatch.y;
+      const double errY = chamberMatch.yErr;
+
+      for ( const auto& segment : chamberMatch.me0Matches )
+      {
+          
+        const double me0X = segment.x;
+        const double me0ErrX = segment.xErr;
+        const double me0Y = segment.y;
+        const double me0ErrY = segment.yErr;
+
+        const double dX   = fabs(me0X - trkX);
+        const double dY   = fabs(me0Y - trkY);
+        const double pullX   = dX/std::sqrt(errX + me0ErrX);
+        const double pullY   = dY/std::sqrt(errY + me0ErrY);
+          
+        if ( (dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY) )
+        {
+          ++nMatch;
+          break;
+        }
+      }
+    }
+
+    if ( nMatch >= minNumberOfMatches ) return true;
+    else return false;
+  } // ME0Mu
+  if ( type == GEMMu )
+  {
+    if ( minNumberOfMatches == 0 ) return true;
+    
+    int nMatch = 0;
+    for ( const auto& chamberMatch : muon.matches() )
+    {
+      if ( chamberMatch.detector() != 4 ) continue;
+
+      const double trkX = chamberMatch.x;
+      const double errX = chamberMatch.xErr;
+      const double trkY = chamberMatch.y;
+      const double errY = chamberMatch.yErr;
+
+      for ( const auto& segment : chamberMatch.gemMatches )
+      {
+          
+        const double gemX = segment.x;
+        const double gemErrX = segment.xErr;
+        const double gemY = segment.y;
+        const double gemErrY = segment.yErr;
+
+        const double dX   = fabs(gemX - trkX);
+        const double dY   = fabs(gemY - trkY);
+        const double pullX   = dX/std::sqrt(errX + gemErrX);
+        const double pullY   = dY/std::sqrt(errY + gemErrY);
+          
+        if ( (dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY) )
+        {
+          ++nMatch;
+          break;
+        }
+      }
+    }
+
+    if ( nMatch >= minNumberOfMatches ) return true;
+    else return false;
+   } // GEMMu
 
    return goodMuon;
 }
@@ -667,6 +748,18 @@ bool muon::isGoodMuon( const reco::Muon& muon, SelectionType type,
       break;
     case muon::RPCMuLoose:
 	return muon.isRPCMuon() && isGoodMuon(muon, RPCMu, 2, 20, 4, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
+      break;
+    case muon::AllME0Muons:
+	  return muon.isME0Muon();
+      break;
+    case muon::ME0MuonArbitrated:
+	  return muon.isME0Muon() && isGoodMuon(muon, ME0Mu, 1, 1e9, 1e9, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
+      break;
+    case muon::AllGEMMuons:
+	  return muon.isGEMMuon();
+      break;
+    case muon::GEMMuonArbitrated:
+	  return muon.isGEMMuon() && isGoodMuon(muon, GEMMu, 1, 1e9, 1e9, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
       break;
     default:
       return false;

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -91,7 +91,7 @@ def miniAOD_customizeCommon(process):
     process.selectedPatMuons.cut = cms.string("pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose')))")
     
     from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
-    phase2_muon.toModify(process.selectedPatMuons, cut = "pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose') || muonID('ME0MuonArbitrated')))")
+    phase2_muon.toModify(process.selectedPatMuons, cut = "pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose') || muonID('ME0MuonArbitrated') || muonID('GEMMuonArbitrated')) )")
     
     process.selectedPatElectrons.cut = cms.string("")
     process.selectedPatTaus.cut = cms.string("pt > 18. && tauID('decayModeFindingNewDMs')> 0.5")

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -89,6 +89,10 @@ def miniAOD_customizeCommon(process):
     #
     process.selectedPatJets.cut = cms.string("pt > 10")
     process.selectedPatMuons.cut = cms.string("pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose')))")
+    
+    from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+    phase2_muon.toModify(process.selectedPatMuons, cut = "pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose') || muonID('ME0MuonArbitrated')))")
+    
     process.selectedPatElectrons.cut = cms.string("")
     process.selectedPatTaus.cut = cms.string("pt > 18. && tauID('decayModeFindingNewDMs')> 0.5")
     process.selectedPatPhotons.cut = cms.string("")


### PR DESCRIPTION
Adding me0muon and gemmuon IDs to the muon selectors and saving me0muons with 3 < pt < 5 gev for the miniAOD. Once we have a stable selection, we will add it.

@kpedro88 @HuguesBrun @jshlee @drkovalskyi 