### PR TITLE
Add -fno-aggressive-loop-optimizations to flags black list

### DIFF
--- a/CondFormats/Serialization/python/condformats_serialization_generate.py
+++ b/CondFormats/Serialization/python/condformats_serialization_generate.py
@@ -511,7 +511,7 @@ class SerializationCodeGenerator(object):
 
     def cleanFlags(self, flagsIn):
         flags = [ flag for flag in flagsIn if not flag.startswith(('-march', '-mtune', '-fdebug-prefix-map', '-ax', '-wd')) ]
-        blackList = ['--', '-fipa-pta', '-xSSE3', '-fno-crossjumping']
+        blackList = ['--', '-fipa-pta', '-xSSE3', '-fno-crossjumping', '-fno-aggressive-loop-optimizations']
         return [x for x in flags if x not in blackList]
 
     def generate(self, outFileName):


### PR DESCRIPTION
Clang does not support such flag thus add it to the black list.

    [2017-04-18 03:43:08,913] ERROR: Diagnostic: [Error] unknown argument:
    '-fno-aggressive-loop-optimizations'

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>