### PR TITLE
Adding distributions over eta and phi

### DIFF
--- a/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
@@ -85,6 +85,8 @@ class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 		// Histogram handler
 		std::vector< std::map<std::string, MonitorElement *> > H1_;
 		std::vector< std::map<std::string, MonitorElement *> > H2_;
+		std::vector< std::map<std::string, MonitorElement *> > H2Eta_;
+		std::vector< std::map<std::string, MonitorElement *> > H2Phi_;
 
 		// Other variables
 		edm::EDConsumerBase::Labels label;

--- a/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
@@ -46,12 +46,28 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 				efficsOK[flavour]=isOK;
 			}
 			label= m_histoName.at(ind)+std::string("___");
+			TString labelEta = label;
+			TString labelPhi = label;
 			label+=flavour+TString("_disc_pT");
+			labelEta+=flavour+TString("_disc_eta");
+			labelPhi+=flavour+TString("_disc_phi");
 			isOK=GetNumDenumerators (ibooker,igetter,(TString(dqmFolder_hist)+"/"+label).Data(),(TString(dqmFolder_hist)+"/"+label).Data(),num,den,1);
 			if (isOK) {
 			
 				//do the 'b-tag efficiency vs pT' plot
 				TH1F eff=calculateEfficiency1D(ibooker,igetter,*num,*den,(label+"_efficiency_vs_pT").Data());
+			}
+			isOK=GetNumDenumerators (ibooker,igetter,(TString(dqmFolder_hist)+"/"+labelEta).Data(),(TString(dqmFolder_hist)+"/"+labelEta).Data(),num,den,2);
+			if (isOK) {
+			
+				//do the 'b-tag efficiency vs Eta' plot
+				TH1F eff=calculateEfficiency1D(ibooker,igetter,*num,*den,(labelEta+"_efficiency_vs_eta").Data());
+			}
+			isOK=GetNumDenumerators (ibooker,igetter,(TString(dqmFolder_hist)+"/"+labelPhi).Data(),(TString(dqmFolder_hist)+"/"+labelPhi).Data(),num,den,2);
+			if (isOK) {
+			
+				//do the 'b-tag efficiency vs Phi' plot
+				TH1F eff=calculateEfficiency1D(ibooker,igetter,*num,*den,(labelPhi+"_efficiency_vs_phi").Data());
 			}
 		} /// for mc labels
 		
@@ -68,7 +84,8 @@ bool HLTBTagHarvestingAnalyzer::GetNumDenumerators(DQMStore::IBooker& ibooker, D
 /*
    possible types: 
    type =0 for eff_vs_discriminator
-   type =1 for eff_vs_pT ot eff_vs_Eta
+   type =1 for eff_vs_pT
+   type =2 for eff_vs_eta or eff_vs_phi
  */
 	MonitorElement *denME = NULL;
 	MonitorElement *numME = NULL;
@@ -118,6 +135,30 @@ bool HLTBTagHarvestingAnalyzer::GetNumDenumerators(DQMStore::IBooker& ibooker, D
 		cutg_den->SetPoint(1,-10.1,9999);
 		cutg_den->SetPoint(2,1.1,9999);
 		cutg_den->SetPoint(3,1.1,0);
+		ptrden = denH2->ProjectionY("denumerator",0,-1,"[cutg_den]");
+		delete cutg_num;
+		delete cutg_den;
+	}
+
+	if (type==2) //efficiency_vs_eta: fill "ptrden" with projection of the plots contained in "den" and fill "ptrnum" with projection of the plots contained in "num", having btag>m_minTag
+	{
+		TH2F* numH2 = numME->getTH2F();
+		TH2F* denH2 = denME->getTH2F();
+
+		///numerator preparing
+		TCutG * cutg_num= new TCutG("cutg_num",4);
+		cutg_num->SetPoint(0,m_minTag,-10);
+		cutg_num->SetPoint(1,m_minTag,10);
+		cutg_num->SetPoint(2,1.1,10);
+		cutg_num->SetPoint(3,1.1,-10);
+		ptrnum = numH2->ProjectionY("numerator",0,-1,"[cutg_num]");
+
+		///denominator preparing
+		TCutG * cutg_den= new TCutG("cutg_den",4);
+		cutg_den->SetPoint(0,-10.1,-10);
+		cutg_den->SetPoint(1,-10.1,10);
+		cutg_den->SetPoint(2,1.1,10);
+		cutg_den->SetPoint(3,1.1,-10);
 		ptrden = denH2->ProjectionY("denumerator",0,-1,"[cutg_den]");
 		delete cutg_num;
 		delete cutg_den;

--- a/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
@@ -154,8 +154,14 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
 					H1_.at(ind)[label.Data()]->Fill(std::fmax(0.0,BtagJT.second));	//fill 1D btag plot for 'b,c,uds'
 					label=JetTagCollection_Label[ind] + "___";
 					label+=flavour_str;
+					TString labelEta = label;
+					TString labelPhi = label;
 					label+=TString("_disc_pT");
 					H2_.at(ind)[label.Data()]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->pt());	//fill 2D btag, jetPt plot for 'b,c,uds'
+					labelEta+=TString("_disc_eta");
+					H2Eta_.at(ind)[labelEta.Data()]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->eta());	//fill 2D btag, jetEta plot for 'b,c,uds'
+					labelPhi+=TString("_disc_phi");
+					H2Phi_.at(ind)[labelPhi.Data()]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->phi());	//fill 2D btag, jetPhi plot for 'b,c,uds'
 				} /// for flavour
 			} /// if MCOK
 		} /// for BtagJT
@@ -179,6 +185,8 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 		dqmFolder = Form("HLT/BTag/Discriminator/%s",hltPathNames_[ind].c_str());
 		H1_.push_back(std::map<std::string, MonitorElement *>());
 		H2_.push_back(std::map<std::string, MonitorElement *>());
+		H2Eta_.push_back(std::map<std::string, MonitorElement *>());
+		H2Phi_.push_back(std::map<std::string, MonitorElement *>());
 		ibooker.setCurrentFolder(dqmFolder);
 		
 		//book 1D btag plot for 'all'
@@ -189,11 +197,19 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 		int nBinsPt=60;
 		double pTmin=30;
 		double pTMax=330;
+		int nBinsPhi=54;
+		double phimin=-3.14;
+		double phiMax=3.14;
+		int nBinsEta=40;
+		double etamin=-2.4;
+		double etaMax=2.4;
 
 		for (unsigned int i = 0; i < m_mcLabels.size(); ++i)
 		{
 			TString flavour= m_mcLabels[i].c_str();
 			TString label;
+			TString labelEta;
+			TString labelPhi;
 			if ( JetTagCollection_Label[ind] != "" && JetTagCollection_Label[ind] != "NULL" ) {
 				label=JetTagCollection_Label[ind]+"__";
 				label+=flavour;
@@ -202,12 +218,22 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 				H1_.back()[label.Data()] = 		 ibooker.book1D(label.Data(),   Form("%s %s",JetTagCollection_Label[ind].c_str(),flavour.Data()), btagBins, btagL, btagU );
 				H1_.back()[label.Data()]->setAxisTitle("disc",1);
 				label=JetTagCollection_Label[ind]+"___";
+				labelEta=label;
+				labelPhi=label;
 				label+=flavour+TString("_disc_pT");
+				labelEta+=flavour+TString("_disc_eta");
+				labelPhi+=flavour+TString("_disc_phi");
 
 				//book 2D btag plot for 'b,c,light,g'
 				H2_.back()[label.Data()] =  ibooker.book2D( label.Data(), label.Data(), btagBins, btagL, btagU, nBinsPt, pTmin, pTMax );
 				H2_.back()[label.Data()]->setAxisTitle("pT",2);
 				H2_.back()[label.Data()]->setAxisTitle("disc",1);
+				H2Eta_.back()[labelEta.Data()] =  ibooker.book2D( labelEta.Data(), labelEta.Data(), btagBins, btagL, btagU, nBinsEta, etamin, etaMax );
+				H2Eta_.back()[labelEta.Data()]->setAxisTitle("eta",2);
+				H2Eta_.back()[labelEta.Data()]->setAxisTitle("disc",1);
+				H2Phi_.back()[labelPhi.Data()] =  ibooker.book2D( labelPhi.Data(), labelPhi.Data(), btagBins, btagL, btagU, nBinsPhi, phimin, phiMax );
+				H2Phi_.back()[labelPhi.Data()]->setAxisTitle("phi",2);
+				H2Phi_.back()[labelPhi.Data()]->setAxisTitle("disc",1);
 			}
 		} /// for mc.size()
 	} /// for hltPathNames_.size()


### PR DESCRIPTION
Following last discussions with btagging@HLT conveners the distributions over eta and phi are to be added to the DQM validation chain.