### PR TITLE
Reactivation of fat event filter for uGMT ZS online DQM

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -40,10 +40,10 @@ process.rawToDigiPath = cms.Path(process.RawToDigi)
 # Stage2 Unpacker and DQM Path
 
 # Filter fat events
-#from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
-#process.hltFatEventFilter = hltHighLevel.clone()
-#process.hltFatEventFilter.throw = cms.bool(False)
-#process.hltFatEventFilter.HLTPaths = cms.vstring('HLT_L1FatEvents_v*')
+from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+process.hltFatEventFilter = hltHighLevel.clone()
+process.hltFatEventFilter.throw = cms.bool(False)
+process.hltFatEventFilter.HLTPaths = cms.vstring('HLT_L1FatEvents_v*')
 
 # This can be used if HLT filter not available in a run
 process.selfFatEventFilter = cms.EDFilter("HLTL1NumberFilter",
@@ -57,17 +57,17 @@ process.load("DQM.L1TMonitor.L1TStage2_cff")
 
 # zero suppression DQM module running before the fat event filter
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import l1tStage2uGMTZeroSupp
-process.l1tStage2uGMTZeroSuppAllEvts = l1tStage2uGMTZeroSupp.clone()
-process.l1tStage2uGMTZeroSuppAllEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts")
+process.l1tStage2uGMTZeroSupp.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts")
 # customise path for zero suppression module analysing only fat events
-process.l1tStage2uGMTZeroSupp.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
+process.l1tStage2uGMTZeroSuppFatEvts = l1tStage2uGMTZeroSupp.clone()
+process.l1tStage2uGMTZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
 
 process.l1tMonitorPath = cms.Path(
-    process.l1tStage2uGMTZeroSuppAllEvts +
-#    process.hltFatEventFilter +
-#    process.selfFatEventFilter +
     process.l1tStage2Unpack +
-    process.l1tStage2OnlineDQM
+    process.l1tStage2OnlineDQM +
+    process.hltFatEventFilter +
+#    process.selfFatEventFilter +
+    process.l1tStage2uGMTZeroSuppFatEvts
 )
 
 # Remove DQM Modules

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -16,7 +16,7 @@ l1tStage2uGMT = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateBMTF = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsBMTF"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/BMTF"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/BMTF"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
     verbose = cms.untracked.bool(False),
 )
@@ -24,7 +24,7 @@ l1tStage2uGMTIntermediateBMTF = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFNeg = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/OMTF_neg"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -32,7 +32,7 @@ l1tStage2uGMTIntermediateOMTFNeg = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFPos = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/OMTF_pos"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -40,7 +40,7 @@ l1tStage2uGMTIntermediateOMTFPos = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFNeg = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/EMTF_neg"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -48,7 +48,7 @@ l1tStage2uGMTIntermediateEMTFNeg = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFPos = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/EMTF_pos"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -73,7 +73,7 @@ l1tStage2uGMTZeroSupp = cms.EDAnalyzer(
                                       0x0003FC00,
                                       0x00000000),
     # no masks defined for caption IDs 0 and 3-11
-    maxFEDReadoutSize = cms.untracked.int32(6000),
+    maxFEDReadoutSize = cms.untracked.int32(9000),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression"),
     verbose = cms.untracked.bool(False),
 )

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cfi.py
@@ -8,7 +8,7 @@ l1tStage2uGMTEmul = cms.EDAnalyzer(
     omtfProducer = cms.InputTag("gmtStage2Digis", "OMTF"), # not used for emulator DQM
     emtfProducer = cms.InputTag("gmtStage2Digis", "EMTF"), # not used for emulator DQM
     muonProducer = cms.InputTag("valGmtStage2Digis"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT"),
     emulator = cms.untracked.bool(True),
     verbose = cms.untracked.bool(False),
 )
@@ -17,7 +17,7 @@ l1tStage2uGMTEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsBMTF"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/BMTF"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/BMTF"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
     verbose = cms.untracked.bool(False),
 )
@@ -25,7 +25,7 @@ l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -33,7 +33,7 @@ l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -41,7 +41,7 @@ l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -49,7 +49,7 @@ l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFPosEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -60,7 +60,7 @@ l1tdeStage2uGMT = cms.EDAnalyzer(
     "L1TStage2MuonComp",
     muonCollection1 = cms.InputTag("gmtStage2Digis", "Muon"),
     muonCollection2 = cms.InputTag("valGmtStage2Digis"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/data_vs_emulator_comparison"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison"),
     muonCollection1Title = cms.untracked.string("uGMT data"),
     muonCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT emulator muons"),


### PR DESCRIPTION
Add the fat event filter (keeps every 107th event) again to the L1 trigger online DQM configuration.
This is needed for the uGMT zero suppression DQM module because for those events the ZS is in validation mode and does only flag and not suppress the data blocks.

In addition the "2016" string was removed from the DQM directory names and the maximum FED readout size was increased.