### PR TITLE
Speed up MultiTrackValidator

### DIFF
--- a/CommonTools/Utils/interface/associationMapFilterValues.h
+++ b/CommonTools/Utils/interface/associationMapFilterValues.h
@@ -6,7 +6,7 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/AssociationMapHelpers.h"
 
-#include <unordered_set>
+#include "FWCore/Utilities/interface/IndexSet.h"
 
 namespace associationMapFilterValuesHelpers {
   // Common implementation
@@ -16,7 +16,7 @@ namespace associationMapFilterValuesHelpers {
   void findInsert(T_AssociationMap& ret, const T_Key& key,
                   const T_ValueIndex& valueIndex, const T_Value& value,
                   const T_ValueIndices& value_indices) {
-    if(value_indices.find(valueIndex) != value_indices.end()) {
+    if(value_indices.has(valueIndex)) {
       ret.insert(key, value);
     }
   }
@@ -134,7 +134,8 @@ T_AssociationMap associationMapFilterValues(const T_AssociationMap& map, const T
   T_AssociationMap ret(map.refProd());
 
   // First copy the keys of values to a set for faster lookup of their existence in the map
-  std::unordered_set<typename T_AssociationMap::index_type> value_indices;
+  edm::IndexSet value_indices;
+  value_indices.reserve(valueRefs.size()); // hopefully a good guess of the last ref index without having to do the gymnastics for genericity
   associationMapFilterValuesHelpers::FillIndices<T_RefVector>::fill(value_indices, valueRefs, map.refProd());
 
   for(const auto& keyValue: map) {

--- a/FWCore/Utilities/interface/IndexSet.h
+++ b/FWCore/Utilities/interface/IndexSet.h
@@ -1,0 +1,42 @@
+#ifndef FWCore_Utilities_IndexSet_h
+#define FWCore_Utilities_IndexSet_h
+
+#include <vector>
+
+
+namespace edm {
+  class IndexSet {
+  public:
+    IndexSet(): numTrueElements_(0) {}
+
+    bool empty() const { return numTrueElements_ == 0; }
+    unsigned int size() const { return numTrueElements_; }
+
+    void reserve(unsigned int size) {
+      if(size >= content_.size()) {
+        content_.resize(size, false);
+      }
+    }
+
+    void clear() {
+      std::fill(begin(content_), end(content_), false);
+      numTrueElements_ = 0;
+    }
+
+    void insert(unsigned int index) {
+      reserve(index+1);
+      numTrueElements_ += !content_[index]; // count increases if value was false
+      content_[index] = true;
+    }
+
+    bool has(unsigned int index) const {
+      return index < content_.size() && content_[index];
+    }
+
+  private:
+    std::vector<bool> content_;
+    unsigned int numTrueElements_; /// Count of true elements is equivalent of "size()" of std::set
+  };
+}
+
+#endif

--- a/FWCore/Utilities/interface/IndexSet.h
+++ b/FWCore/Utilities/interface/IndexSet.h
@@ -5,36 +5,59 @@
 
 
 namespace edm {
+  /**
+   * A simple class representing a set of indices to another container
+   * for fast insert and search.
+   *
+   * This class can be useful if one needs to record the indices of
+   * objects that form a subset of a container (e.g. passing some
+   * selection), and then repeatedly check if an object of a given
+   * index belongs to that subset. As the elements are assumed to be
+   * indices, the set can be implemented as a vector<bool> such that
+   * each possible element corresponds an index in the vector. Then
+   * the insert and search are (almost) array access operations.
+   *
+   * From the set opreations, only insertion, search, and clear are
+   * supported for now. More can be added if needed.
+   */
   class IndexSet {
   public:
+    /// Construct empty set
     IndexSet(): numTrueElements_(0) {}
 
+    /// Check if the set is empty
     bool empty() const { return numTrueElements_ == 0; }
+
+    /// Number of elements in the set
     unsigned int size() const { return numTrueElements_; }
 
+    /// Reserve memory for the set
     void reserve(unsigned int size) {
       if(size >= content_.size()) {
         content_.resize(size, false);
       }
     }
 
+    /// Clear the set
     void clear() {
       std::fill(begin(content_), end(content_), false);
       numTrueElements_ = 0;
     }
 
+    /// Insert an element (=index) to the set
     void insert(unsigned int index) {
       reserve(index+1);
       numTrueElements_ += !content_[index]; // count increases if value was false
       content_[index] = true;
     }
 
+    /// Check if an element (=index) is in the set
     bool has(unsigned int index) const {
       return index < content_.size() && content_[index];
     }
 
   private:
-    std::vector<bool> content_;
+    std::vector<bool> content_;    /// Each possible element of the set corresponds an index in this vector. The value of an element tells if that index exists in the set (true) or not (false).
     unsigned int numTrueElements_; /// Count of true elements is equivalent of "size()" of std::set
   };
 }

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -31,7 +31,7 @@
 <bin   file="MallocOpts_t.cpp">
   <use   name="cppunit"/>
 </bin>
-<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp">
+<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp,indexset.cppunit.cpp">
   <use   name="cppunit"/>
 </bin>
 

--- a/FWCore/Utilities/test/indexset.cppunit.cpp
+++ b/FWCore/Utilities/test/indexset.cppunit.cpp
@@ -1,0 +1,70 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "FWCore/Utilities/interface/IndexSet.h"
+
+class testIndexSet: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testIndexSet);
+  CPPUNIT_TEST(test);
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void test();
+  template <typename T>
+  void testIterators(T& array);
+  template <typename T>
+  void testIterator(T iter, T end);
+
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testIndexSet);
+
+void testIndexSet::test() {
+  edm::IndexSet set;
+  CPPUNIT_ASSERT(set.empty());
+  CPPUNIT_ASSERT(set.size() == 0);
+  CPPUNIT_ASSERT(!set.has(0));
+
+  set.reserve(10);
+
+  CPPUNIT_ASSERT(set.empty());
+  CPPUNIT_ASSERT(set.size() == 0);
+  CPPUNIT_ASSERT(!set.has(0));
+
+  set.insert(0);
+  CPPUNIT_ASSERT(!set.empty());
+  CPPUNIT_ASSERT(set.size() == 1);
+  CPPUNIT_ASSERT(set.has(0));
+  CPPUNIT_ASSERT(!set.has(1));
+
+  set.insert(2);
+  CPPUNIT_ASSERT(set.size() == 2);
+  CPPUNIT_ASSERT(set.has(0));
+  CPPUNIT_ASSERT(!set.has(1));
+  CPPUNIT_ASSERT(set.has(2));
+  CPPUNIT_ASSERT(!set.has(3));
+
+  set.insert(20);
+  CPPUNIT_ASSERT(set.size() == 3);
+  CPPUNIT_ASSERT(set.has(0));
+  CPPUNIT_ASSERT(!set.has(1));
+  CPPUNIT_ASSERT(set.has(2));
+  CPPUNIT_ASSERT(!set.has(3));
+  CPPUNIT_ASSERT(!set.has(19));
+  CPPUNIT_ASSERT(set.has(20));
+  CPPUNIT_ASSERT(!set.has(21));
+
+  set.insert(2);
+  CPPUNIT_ASSERT(set.size() == 3);
+  CPPUNIT_ASSERT(set.has(2));
+
+  set.clear();
+  CPPUNIT_ASSERT(set.empty());
+  CPPUNIT_ASSERT(set.size() == 0);
+  CPPUNIT_ASSERT(!set.has(0));
+  CPPUNIT_ASSERT(!set.has(1));
+  CPPUNIT_ASSERT(!set.has(2));
+  CPPUNIT_ASSERT(!set.has(3));
+}

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -84,8 +84,8 @@ namespace
 		return collection[index];
 	}
 
-  template <typename T>
-  void fillKeys(std::unordered_set<T>& keys, const edm::RefVector<TrackingParticleCollection>& collection) {
+  void fillKeys(edm::IndexSet& keys, const edm::RefVector<TrackingParticleCollection>& collection) {
+    keys.reserve(collection.size());
     for(const auto& ref: collection) {
       keys.insert(ref.key());
     }
@@ -331,7 +331,7 @@ template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<
 	// TrackingParticleRefVector overloads). The trackingParticles
 	// parameter is still ignored since looping over it on every call
 	// would be expensive, but the keys of the TrackingParticleRefs are
-	// cached to an unordered_set (trackingParticleKeys) which is used
+	// cached to an IndexSet (trackingParticleKeys) which is used
 	// as a fast search structure.
 
 	// The pairs in this vector have a Ref to the associated TrackingParticle as "first" and the weighted number of associated clusters as "second"
@@ -357,7 +357,7 @@ template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<
 
 				const TrackingParticleRef trackingParticle=(ip->second);
 
-                                if(trackingParticleKeys && trackingParticleKeys->find(trackingParticle.key()) == trackingParticleKeys->end())
+                                if(trackingParticleKeys && !trackingParticleKeys->has(trackingParticle.key()))
                                   continue;
 
 				// Historically there was a requirement that pTrackingParticle->numberOfHits() > 0

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -7,7 +7,7 @@
 
 #include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
 
-#include <unordered_set>
+#include "FWCore/Utilities/interface/IndexSet.h"
 
 // Forward declarations
 class TrackerHitAssociator;
@@ -106,7 +106,7 @@ public:
  private:
   typedef std::pair<uint32_t,EncodedEventId> SimTrackIdentifiers; ///< @brief This is enough information to uniquely identify a sim track
   
-  typedef std::unordered_set<reco::RecoToSimCollection::index_type> TrackingParticleRefKeySet; ///< @brief Set for TrackingParticleRef keys
+  typedef edm::IndexSet TrackingParticleRefKeySet; ///< @brief Set for TrackingParticleRef keys
 
   // - added by S. Sarkar
   static bool tpIntPairGreater(std::pair<edm::Ref<TrackingParticleCollection>,size_t> i, std::pair<edm::Ref<TrackingParticleCollection>,size_t> j) { return (i.first.key()>j.first.key()); }

--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -12,6 +12,8 @@
 #include "Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h"
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 #include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
+#include "SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h"
+#include "CommonTools/Utils/interface/DynArray.h"
 
 class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorBase {
  public:
@@ -45,6 +47,21 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
   std::unique_ptr<MTVHistoProducerAlgoForTracker> histoProducerAlgo_;
 
  private:
+  const TrackingVertex::LorentzVector *getSimPVPosition(const edm::Handle<TrackingVertexCollection>& htv) const;
+  const reco::Vertex::Point *getRecoPVPosition(const edm::Event& event, const edm::Handle<TrackingVertexCollection>& htv) const;
+  void tpParametersAndSelection(const TrackingParticleRefVector& tPCeff,
+                                const ParametersDefinerForTP& parametersDefinerTP,
+                                const edm::Event& event, const edm::EventSetup& setup,
+                                const reco::BeamSpot& bs,
+                                std::vector<std::tuple<TrackingParticle::Vector, TrackingParticle::Point> >& momVert_tPCeff,
+                                std::vector<size_t>& selected_tPCeff) const;
+  size_t tpDR(const TrackingParticleRefVector& tPCeff,
+              const std::vector<size_t>& selected_tPCeff,
+              DynArray<float>& dR_tPCeff) const;
+  void trackDR(const edm::View<reco::Track>& trackCollection,
+               const edm::View<reco::Track>& trackCollectionDr,
+               DynArray<float>& dR_trk) const;
+
   std::vector<edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator>> associatorTokens;
   std::vector<edm::EDGetTokenT<reco::SimToRecoCollection>> associatormapStRs;
   std::vector<edm::EDGetTokenT<reco::RecoToSimCollection>> associatormapRtSs;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -28,8 +28,8 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "CommonTools/Utils/interface/associationMapFilterValues.h"
+#include "FWCore/Utilities/interface/IndexSet.h"
 #include<type_traits>
-#include <unordered_set>
 
 
 #include "TMath.h"
@@ -279,13 +279,14 @@ namespace {
     }
 
     // Same technique as in associationMapFilterValues
-    std::unordered_set<reco::RecoToSimCollection::index_type> fakeKeys;
+    edm::IndexSet fakeKeys;
+    fakeKeys.reserve(fake.size());
     for(const auto& ref: fake) {
       fakeKeys.insert(ref.key());
     }
 
     for(const auto& ref: eff) {
-      if(fakeKeys.find(ref.key()) == fakeKeys.end()) {
+      if(!fakeKeys.has(ref.key())) {
         throw cms::Exception("Configuration") << "Efficiency TrackingParticle " << ref.key() << " is not found from the set of fake TPs. This is not supported. The efficiency TP set must be the same or a subset of the fake TP set.";
       }
     }

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -402,9 +402,8 @@ size_t MultiTrackValidator::tpDR(const TrackingParticleRefVector& tPCeff,
     double dR = std::numeric_limits<double>::max();
     if(dRtpSelector(tp)) {//only for those needed for efficiency!
       ++n_selTP_dr;
-      auto  && p = tp.momentum();
-      float eta = etaFromXYZ(p.x(),p.y(),p.z());
-      float phi = atan2f(p.y(),p.x());
+      float eta = etaL[iTP1];
+      float phi = phiL[iTP1];
       for(size_t iTP2: selected_tPCeff) {
         //calculare dR wrt inclusive collection (also with PU, low pT, displaced)
         if (iTP1==iTP2) {continue;}

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -293,6 +293,160 @@ namespace {
   }
 }
 
+const TrackingVertex::LorentzVector *MultiTrackValidator::getSimPVPosition(const edm::Handle<TrackingVertexCollection>& htv) const {
+  for(const auto& simV: *htv) {
+    if(simV.eventId().bunchCrossing() != 0) continue; // remove OOTPU
+    if(simV.eventId().event() != 0) continue; // pick the PV of hard scatter
+    return &(simV.position());
+  }
+  return nullptr;
+}
+
+const reco::Vertex::Point *MultiTrackValidator::getRecoPVPosition(const edm::Event& event, const edm::Handle<TrackingVertexCollection>& htv) const {
+  edm::Handle<edm::View<reco::Vertex> > hvertex;
+  event.getByToken(recoVertexToken_, hvertex);
+
+  edm::Handle<reco::VertexToTrackingVertexAssociator> hvassociator;
+  event.getByToken(vertexAssociatorToken_, hvassociator);
+
+  auto v_r2s = hvassociator->associateRecoToSim(hvertex, htv);
+  auto pvPtr = hvertex->refAt(0);
+  if(pvPtr->isFake() || pvPtr->ndof() < 0) // skip junk vertices
+    return nullptr;
+
+  auto pvFound = v_r2s.find(pvPtr);
+  if(pvFound == v_r2s.end())
+    return nullptr;
+
+  for(const auto& vertexRefQuality: pvFound->val) {
+    const TrackingVertex& tv = *(vertexRefQuality.first);
+    if(tv.eventId().event() == 0 && tv.eventId().bunchCrossing() == 0) {
+      return &(pvPtr->position());
+    }
+  }
+
+  return nullptr;
+}
+
+void MultiTrackValidator::tpParametersAndSelection(const TrackingParticleRefVector& tPCeff,
+                                                   const ParametersDefinerForTP& parametersDefinerTP,
+                                                   const edm::Event& event, const edm::EventSetup& setup,
+                                                   const reco::BeamSpot& bs,
+                                                   std::vector<std::tuple<TrackingParticle::Vector, TrackingParticle::Point> >& momVert_tPCeff,
+                                                   std::vector<size_t>& selected_tPCeff) const {
+  selected_tPCeff.reserve(tPCeff.size());
+  momVert_tPCeff.reserve(tPCeff.size());
+  int nIntimeTPs = 0;
+  if(parametersDefinerIsCosmic_) {
+    for(size_t j=0; j<tPCeff.size(); ++j) {
+      const TrackingParticleRef& tpr = tPCeff[j];
+
+      TrackingParticle::Vector momentum = parametersDefinerTP.momentum(event,setup,tpr);
+      TrackingParticle::Point vertex = parametersDefinerTP.vertex(event,setup,tpr);
+      if(doSimPlots_) {
+        histoProducerAlgo_->fill_generic_simTrack_histos(momentum, vertex, tpr->eventId().bunchCrossing());
+      }
+      if(tpr->eventId().bunchCrossing() == 0)
+        ++nIntimeTPs;
+
+      if(cosmictpSelector(tpr,&bs,event,setup)) {
+        selected_tPCeff.push_back(j);
+        momVert_tPCeff.emplace_back(momentum, vertex);
+      }
+    }
+  }
+  else {
+    size_t j=0;
+    for(auto const& tpr: tPCeff) {
+      const TrackingParticle& tp = *tpr;
+
+      // TODO: do we want to fill these from all TPs that include IT
+      // and OOT (as below), or limit to IT+OOT TPs passing tpSelector
+      // (as it was before)? The latter would require another instance
+      // of tpSelector with intimeOnly=False.
+      if(doSimPlots_) {
+        histoProducerAlgo_->fill_generic_simTrack_histos(tp.momentum(), tp.vertex(), tp.eventId().bunchCrossing());
+      }
+      if(tp.eventId().bunchCrossing() == 0)
+        ++nIntimeTPs;
+
+      if(tpSelector(tp)) {
+        selected_tPCeff.push_back(j);
+        TrackingParticle::Vector momentum = parametersDefinerTP.momentum(event,setup,tpr);
+        TrackingParticle::Point vertex = parametersDefinerTP.vertex(event,setup,tpr);
+        momVert_tPCeff.emplace_back(momentum, vertex);
+      }
+      ++j;
+    }
+  }
+  if(doSimPlots_) {
+    histoProducerAlgo_->fill_simTrackBased_histos(nIntimeTPs);
+  }
+}
+
+
+size_t MultiTrackValidator::tpDR(const TrackingParticleRefVector& tPCeff,
+                                 const std::vector<size_t>& selected_tPCeff,
+                                 DynArray<float>& dR_tPCeff) const {
+  float etaL[tPCeff.size()], phiL[tPCeff.size()];
+  size_t n_selTP_dr = 0;
+  for(size_t iTP: selected_tPCeff) {
+    //calculare dR wrt inclusive collection (also with PU, low pT, displaced)
+    auto const& tp2 = *(tPCeff[iTP]);
+    auto  && p = tp2.momentum();
+    etaL[iTP] = etaFromXYZ(p.x(),p.y(),p.z());
+    phiL[iTP] = atan2f(p.y(),p.x());
+  }
+  for(size_t iTP1: selected_tPCeff) {
+    auto const& tp = *(tPCeff[iTP1]);
+    double dR = std::numeric_limits<double>::max();
+    if(dRtpSelector(tp)) {//only for those needed for efficiency!
+      ++n_selTP_dr;
+      auto  && p = tp.momentum();
+      float eta = etaFromXYZ(p.x(),p.y(),p.z());
+      float phi = atan2f(p.y(),p.x());
+      for(size_t iTP2: selected_tPCeff) {
+        //calculare dR wrt inclusive collection (also with PU, low pT, displaced)
+        if (iTP1==iTP2) {continue;}
+        auto dR_tmp = reco::deltaR2(eta, phi, etaL[iTP2], phiL[iTP2]);
+        if (dR_tmp<dR) dR=dR_tmp;
+      }  // ttp2 (iTP)
+    }
+    dR_tPCeff[iTP1] = std::sqrt(dR);
+  }  // tp
+  return n_selTP_dr;
+}
+
+void MultiTrackValidator::trackDR(const edm::View<reco::Track>& trackCollection, const edm::View<reco::Track>& trackCollectionDr, DynArray<float>& dR_trk) const {
+  int i=0;
+  float etaL[trackCollectionDr.size()];
+  float phiL[trackCollectionDr.size()];
+  bool validL[trackCollectionDr.size()];
+  for (auto const & track2 : trackCollectionDr) {
+    auto  && p = track2.momentum();
+    etaL[i] = etaFromXYZ(p.x(),p.y(),p.z());
+    phiL[i] = atan2f(p.y(),p.x());
+    validL[i] = !trackFromSeedFitFailed(track2);
+    ++i;
+  }
+  for(View<reco::Track>::size_type i=0; i<trackCollection.size(); ++i){
+    auto const &  track = trackCollection[i];
+    auto dR = std::numeric_limits<float>::max();
+    if(!trackFromSeedFitFailed(track)) {
+      auto  && p = track.momentum();
+      float eta = etaFromXYZ(p.x(),p.y(),p.z());
+      float phi = atan2f(p.y(),p.x());
+      for(View<reco::Track>::size_type j=0; j<trackCollectionDr.size(); ++j){
+        if(!validL[j]) continue;
+        auto dR_tmp = reco::deltaR2(eta, phi, etaL[j], phiL[j]);
+        if ( (dR_tmp<dR) & (dR_tmp>std::numeric_limits<float>::min())) dR=dR_tmp;
+      }
+    }
+    dR_trk[i] = std::sqrt(dR);
+  }
+}
+
+
 void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup& setup){
   using namespace reco;
 
@@ -362,60 +516,28 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
   dRTrackSelector->init(event, setup);
   histoProducerAlgo_->init(event, setup);
 
-  const reco::Vertex::Point *thePVposition = nullptr;
-  const TrackingVertex::LorentzVector *theSimPVPosition = nullptr;
   // Find the sim PV and tak its position
   edm::Handle<TrackingVertexCollection> htv;
   event.getByToken(label_tv, htv);
-  {
-    const TrackingVertexCollection& tv = *htv;
-    for(size_t i=0; i<tv.size(); ++i) {
-      const TrackingVertex& simV = tv[i];
-      if(simV.eventId().bunchCrossing() != 0) continue; // remove OOTPU
-      if(simV.eventId().event() != 0) continue; // pick the PV of hard scatter
-      theSimPVPosition = &(simV.position());
-      break;
-    }
-  }
+  const TrackingVertex::LorentzVector *theSimPVPosition = getSimPVPosition(htv);
   if(simPVMaxZ_ >= 0) {
     if(!theSimPVPosition) return;
     if(std::abs(theSimPVPosition->z()) > simPVMaxZ_) return;
   }
 
   // Check, when necessary, if reco PV matches to sim PV
+  const reco::Vertex::Point *thePVposition = nullptr;
   if(doPlotsOnlyForTruePV_ || doPVAssociationPlots_) {
-    edm::Handle<edm::View<reco::Vertex> > hvertex;
-    event.getByToken(recoVertexToken_, hvertex);
-
-    edm::Handle<reco::VertexToTrackingVertexAssociator> hvassociator;
-    event.getByToken(vertexAssociatorToken_, hvassociator);
-
-    auto v_r2s = hvassociator->associateRecoToSim(hvertex, htv);
-    auto pvPtr = hvertex->refAt(0);
-    if(!(pvPtr->isFake() || pvPtr->ndof() < 0)) { // skip junk vertices
-      auto pvFound = v_r2s.find(pvPtr);
-      if(pvFound != v_r2s.end()) {
-        bool matchedToSimPV = false;
-        for(const auto& vertexRefQuality: pvFound->val) {
-          const TrackingVertex& tv = *(vertexRefQuality.first);
-          if(tv.eventId().event() == 0 && tv.eventId().bunchCrossing() == 0) {
-            matchedToSimPV = true;
-            break;
-          }
-        }
-        if(matchedToSimPV) {
-          if(doPVAssociationPlots_) {
-            thePVposition = &(pvPtr->position());
-          }
-        }
-        else if(doPlotsOnlyForTruePV_)
-          return;
-      }
-      else if(doPlotsOnlyForTruePV_)
-        return;
-    }
-    else if(doPlotsOnlyForTruePV_)
+    thePVposition = getRecoPVPosition(event, htv);
+    if(doPlotsOnlyForTruePV_ && !thePVposition)
       return;
+
+    // Rest of the code assumes that if thePVposition is non-null, the
+    // PV-association histograms get filled. In above, the "nullness"
+    // is used to deliver the information if the reco PV is matched to
+    // the sim PV.
+    if(!doPVAssociationPlots_)
+      thePVposition = nullptr;
   }
 
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
@@ -432,12 +554,6 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
       break;
     }
   }
-
-  /*
-  edm::Handle<TrackingVertexCollection> tvH;
-  event.getByToken(label_tv,tvH);
-  TrackingVertexCollection const & tv = *tvH;
-  */
 
   // Number of 3D layers for TPs
   edm::Handle<edm::ValueMap<unsigned int>> tpNLayersH;
@@ -470,85 +586,11 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
   // for "efficiency" TPs.
   std::vector<size_t> selected_tPCeff;
   std::vector<std::tuple<TrackingParticle::Vector, TrackingParticle::Point>> momVert_tPCeff;
-  selected_tPCeff.reserve(tPCeff.size());
-  momVert_tPCeff.reserve(tPCeff.size());
-  int nIntimeTPs = 0;
-  if(parametersDefinerIsCosmic_) {
-    for(size_t j=0; j<tPCeff.size(); ++j) {
-      const TrackingParticleRef& tpr = tPCeff[j];
-
-      TrackingParticle::Vector momentum = parametersDefinerTP->momentum(event,setup,tpr);
-      TrackingParticle::Point vertex = parametersDefinerTP->vertex(event,setup,tpr);
-      if(doSimPlots_) {
-        histoProducerAlgo_->fill_generic_simTrack_histos(momentum, vertex, tpr->eventId().bunchCrossing());
-      }
-      if(tpr->eventId().bunchCrossing() == 0)
-        ++nIntimeTPs;
-
-      if(cosmictpSelector(tpr,&bs,event,setup)) {
-        selected_tPCeff.push_back(j);
-        momVert_tPCeff.emplace_back(momentum, vertex);
-      }
-    }
-  }
-  else {
-    size_t j=0;
-    for(auto const& tpr: tPCeff) {
-      const TrackingParticle& tp = *tpr;
-
-      // TODO: do we want to fill these from all TPs that include IT
-      // and OOT (as below), or limit to IT+OOT TPs passing tpSelector
-      // (as it was before)? The latter would require another instance
-      // of tpSelector with intimeOnly=False.
-      if(doSimPlots_) {
-        histoProducerAlgo_->fill_generic_simTrack_histos(tp.momentum(), tp.vertex(), tp.eventId().bunchCrossing());
-      }
-      if(tp.eventId().bunchCrossing() == 0)
-        ++nIntimeTPs;
-
-      if(tpSelector(tp)) {
-        selected_tPCeff.push_back(j);
-        TrackingParticle::Vector momentum = parametersDefinerTP->momentum(event,setup,tpr);
-        TrackingParticle::Point vertex = parametersDefinerTP->vertex(event,setup,tpr);
-        momVert_tPCeff.emplace_back(momentum, vertex);
-      }
-      ++j;
-    }
-  }
-  if(doSimPlots_) {
-    histoProducerAlgo_->fill_simTrackBased_histos(nIntimeTPs);
-  }
+  tpParametersAndSelection(tPCeff, *parametersDefinerTP, event, setup, bs, momVert_tPCeff, selected_tPCeff);
 
   //calculate dR for TPs
-  float dR_tPCeff[tPCeff.size()];
-  size_t n_selTP_dr = 0;
-  {
-    float etaL[tPCeff.size()], phiL[tPCeff.size()];
-    for(size_t iTP: selected_tPCeff) {
-      //calculare dR wrt inclusive collection (also with PU, low pT, displaced)
-      auto const& tp2 = *(tPCeff[iTP]);
-      auto  && p = tp2.momentum();
-      etaL[iTP] = etaFromXYZ(p.x(),p.y(),p.z());
-      phiL[iTP] = atan2f(p.y(),p.x());
-    }
-    for(size_t iTP1: selected_tPCeff) {
-      auto const& tp = *(tPCeff[iTP1]);
-      double dR = std::numeric_limits<double>::max();
-      if(dRtpSelector(tp)) {//only for those needed for efficiency!
-        ++n_selTP_dr;
-        auto  && p = tp.momentum();
-        float eta = etaFromXYZ(p.x(),p.y(),p.z());
-        float phi = atan2f(p.y(),p.x());
-        for(size_t iTP2: selected_tPCeff) {
-          //calculare dR wrt inclusive collection (also with PU, low pT, displaced)
-	  if (iTP1==iTP2) {continue;}
-          auto dR_tmp = reco::deltaR2(eta, phi, etaL[iTP2], phiL[iTP2]);
-          if (dR_tmp<dR) dR=dR_tmp;
-        }  // ttp2 (iTP)
-      }
-      dR_tPCeff[iTP1] = std::sqrt(dR);
-    }  // tp
-  }
+  declareDynArray(float, tPCeff.size(), dR_tPCeff);
+  size_t n_selTP_dr = tpDR(tPCeff, selected_tPCeff, dR_tPCeff);
 
   edm::Handle<View<Track> >  trackCollectionForDrCalculation;
   if(calculateDrSingleCollection_) {
@@ -826,33 +868,8 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
       if(calculateDrSingleCollection_) {
         trackCollectionDr = trackCollectionForDrCalculation.product();
       }
-      float dR_trk[trackCollection.size()];
-      int i=0;
-      float etaL[trackCollectionDr->size()];
-      float phiL[trackCollectionDr->size()];
-      bool validL[trackCollectionDr->size()];
-      for (auto const & track2 : *trackCollectionDr) {
-         auto  && p = track2.momentum();
-         etaL[i] = etaFromXYZ(p.x(),p.y(),p.z());
-         phiL[i] = atan2f(p.y(),p.x());
-         validL[i] = !trackFromSeedFitFailed(track2);
-         ++i;
-      }
-      for(View<Track>::size_type i=0; i<trackCollection.size(); ++i){
-	auto const &  track = trackCollection[i];
-	auto dR = std::numeric_limits<float>::max();
-        if(!trackFromSeedFitFailed(track)) {
-          auto  && p = track.momentum();
-          float eta = etaFromXYZ(p.x(),p.y(),p.z());
-          float phi = atan2f(p.y(),p.x());
-          for(View<Track>::size_type j=0; j<trackCollectionDr->size(); ++j){
-            if(!validL[j]) continue;
-            auto dR_tmp = reco::deltaR2(eta, phi, etaL[j], phiL[j]);
-            if ( (dR_tmp<dR) & (dR_tmp>std::numeric_limits<float>::min())) dR=dR_tmp;
-          }
-        }
-	dR_trk[i] = std::sqrt(dR);
-      }
+      declareDynArray(float, trackCollection.size(), dR_trk);
+      trackDR(trackCollection, *trackCollectionDr, dR_trk);
 
       for(View<Track>::size_type i=0; i<trackCollection.size(); ++i){
         auto track = trackCollection.refAt(i);

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -382,7 +382,6 @@ trackValidatorFromPVAllTP = trackValidatorFromPV.clone(
     label_tp_fake = trackValidator.label_tp_fake.value(),
     label_tp_effic_refvector = False,
     label_tp_fake_refvector = False,
-    associators = trackValidator.associators.value(),
     doSimPlots = False,
     doSimTrackPlots = False,
 )
@@ -440,8 +439,6 @@ trackValidatorBHadron = trackValidator.clone(
     dirName = "Tracking/TrackBHadron/",
     label_tp_effic = "trackingParticlesBHadron",
     label_tp_effic_refvector = True,
-    associators = ["quickTrackAssociatorByHits"],
-    UseAssociators = True,
     doSimPlots = True,
     doRecoTrackPlots = False, # Fake rate is defined wrt. all TPs, and that is already included in trackValidator
     dodEdxPlots = False,


### PR DESCRIPTION
This PR speeds up trackingOnly validation by ~2x at PU200 (most speedup is in seed validation, so since that is not part of the standard validation sequence, the effect on standard workflows is smaller). The main optimizations are
- replace `std::unordered_set<unsigned>` that are sets of indices with a newly added `edm::IndexSet`
  * `edm::IndexSet` is just a `std::vector<bool>` with set-style interface
- use the already-made track<->TrackingParticle association (`trackingParticleRecoTrackAsssociation`) also for B-hadron MTV instance
- in `VertexAssociatorByPositionAndTracks::associateRecoToSim()`, select sim PVs only once from all `TrackingVertices`
- call `associationMapFilterValues()` to recoToSim association only once as there is no need to repeat it for each track collection (that is used as the key for searches on the association)
- (last commit 7c30497 was originally a shortening of a loop over TrackingParticles, but that went already in with #18073, so it got left as removing repeated calculation of eta and phi)

In addition certain parts of the `analyze()` body were moved to separate functions so that they become visible in profiler.

There is potential for further improvements, but those need more thought and work (now the hottest spot is calculation of DeltaR between seeds).

Tested in 9_1_0_pre2, no changes expected.

@rovere @VinInn @ebrondol 