### PR TITLE
Generalize DetId parsing in TrackingNtuple

### DIFF
--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -600,6 +600,13 @@ class TrackerTopology {
   bool hasField(const DetId &id, DetIdFields idx) const {
     return id.subdetId() == bits_per_field[idx].subdet;
   }
+
+  const PixelBarrelValues& pbVals() const { return pbVals_; }
+  const PixelEndcapValues& pfVals() const { return pfVals_; }
+  const TOBValues& tobVals() const { return tobVals_; }
+  const TIBValues& tibVals() const { return tibVals_; }
+  const TIDValues& tidVals() const { return tidVals_; }
+  const TECValues& tecVals() const { return tecVals_; }
  
  private:
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -470,6 +470,13 @@ private:
 
   HistoryBase tracer_;
 
+  TH1 *pbVals = nullptr;
+  TH1 *pfVals = nullptr;
+  TH1 *tobVals = nullptr;
+  TH1 *tibVals = nullptr;
+  TH1 *tidVals = nullptr;
+  TH1 *tecVals = nullptr;
+
   TTree* t;
   // event
   edm::RunNumber_t ev_run;
@@ -811,6 +818,14 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
 
   usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
+
+  pbVals = fs->make<TH1I>("pbVals", "pbVals", 6,0,6);
+  pfVals = fs->make<TH1I>("pfVals", "pfVals", 10,0,10);
+  tobVals = fs->make<TH1I>("tobVals", "tobVals", 10,0,10);
+  tibVals = fs->make<TH1I>("tibVals", "tibVals", 12,0,12);
+  tidVals = fs->make<TH1I>("tidVals", "tidVals", 12,0,12);
+  tecVals = fs->make<TH1I>("tecVals", "tecVals", 14,0,14);
+
   t = fs->make<TTree>("tree","tree");
 
   t->Branch("event"        , &ev_event);
@@ -1400,6 +1415,98 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   const reco::TrackToTrackingParticleAssociator& associatorByHits = *theAssociator;
 
   LogDebug("TrackingNtuple") << "Analyzing new event";
+
+  // In first event, dump the TrackerTopology numbers
+  if(pbVals) {
+    auto set = [&](TH1 *h, int bin, const char *name, unsigned int value) {
+      h->GetXaxis()->SetBinLabel(bin, name);
+      h->SetBinContent(bin, value);
+    };
+
+    // a bit ugly but reduces a lot of error-prone copy-paste
+#define SET(hist, bin, name) set(hist, bin, #name, tTopo.hist().name##_)
+
+    SET(pbVals, 1, layerStartBit);
+    SET(pbVals, 2, ladderStartBit);
+    SET(pbVals, 3, moduleStartBit);
+    SET(pbVals, 4, layerMask);
+    SET(pbVals, 5, ladderMask);
+    SET(pbVals, 6, moduleMask);
+
+    SET(pfVals, 1, sideStartBit);
+    SET(pfVals, 2, diskStartBit);
+    SET(pfVals, 3, bladeStartBit);
+    SET(pfVals, 4, panelStartBit);
+    SET(pfVals, 5, moduleStartBit);
+    SET(pfVals, 6, sideMask);
+    SET(pfVals, 7, diskMask);
+    SET(pfVals, 8, bladeMask);
+    SET(pfVals, 9, panelMask);
+    SET(pfVals, 10, moduleMask);
+
+    SET(tobVals, 1, layerStartBit);
+    SET(tobVals, 2, rod_fw_bwStartBit);
+    SET(tobVals, 3, rodStartBit);
+    SET(tobVals, 4, moduleStartBit);
+    SET(tobVals, 5, sterStartBit);
+    SET(tobVals, 6, layerMask);
+    SET(tobVals, 7, rod_fw_bwMask);
+    SET(tobVals, 8, rodMask);
+    SET(tobVals, 9, moduleMask);
+    SET(tobVals, 10, sterMask);
+
+    SET(tibVals, 1, layerStartBit);
+    SET(tibVals, 2, str_fw_bwStartBit);
+    SET(tibVals, 3, str_int_extStartBit);
+    SET(tibVals, 4, strStartBit);
+    SET(tibVals, 5, moduleStartBit);
+    SET(tibVals, 6, sterStartBit);
+    SET(tibVals, 7, layerMask);
+    SET(tibVals, 8, str_fw_bwMask);
+    SET(tibVals, 9, str_int_extMask);
+    SET(tibVals, 10, strMask);
+    SET(tibVals, 11, moduleMask);
+    SET(tibVals, 12, sterMask);
+
+    SET(tidVals, 1, sideStartBit);
+    SET(tidVals, 2, wheelStartBit);
+    SET(tidVals, 3, ringStartBit);
+    SET(tidVals, 4, module_fw_bwStartBit);
+    SET(tidVals, 5, moduleStartBit);
+    SET(tidVals, 6, sterStartBit);
+    SET(tidVals, 7, sideMask);
+    SET(tidVals, 8, wheelMask);
+    SET(tidVals, 9, ringMask);
+    SET(tidVals, 10, module_fw_bwMask);
+    SET(tidVals, 11, moduleMask);
+    SET(tidVals, 12, sterMask);
+
+    SET(tecVals, 1, sideStartBit);
+    SET(tecVals, 2, wheelStartBit);
+    SET(tecVals, 3, petal_fw_bwStartBit);
+    SET(tecVals, 4, petalStartBit);
+    SET(tecVals, 5, ringStartBit);
+    SET(tecVals, 6, moduleStartBit);
+    SET(tecVals, 7, sterStartBit);
+    SET(tecVals, 8, sideMask);
+    SET(tecVals, 9, wheelMask);
+    SET(tecVals, 10, petal_fw_bwMask);
+    SET(tecVals, 11, petalMask);
+    SET(tecVals, 12, ringMask);
+    SET(tecVals, 13, moduleMask);
+    SET(tecVals, 14, sterMask);
+
+#undef SET
+
+    // use null value to denote that the TrackerTopology values have been dumped
+    pbVals = nullptr;
+    pfVals = nullptr;
+    tobVals = nullptr;
+    tibVals = nullptr;
+    tidVals = nullptr;
+    tecVals = nullptr;
+
+  }
 
   //initialize tree variables
   clearVariables();

--- a/Validation/RecoTrack/python/plotting/ntupleDataFormat.py
+++ b/Validation/RecoTrack/python/plotting/ntupleDataFormat.py
@@ -710,7 +710,7 @@ class StripHits(_Collection):
         super(StripHits, self).__init__(ntuple, "str_isBarrel", StripHit)
 
 ##########
-class GluedHit(_Object, _LayerStrAdaptor):
+class GluedHit(_Object, _DetIdAdaptor, _LayerStrAdaptor):
     """Class representing a matched strip hit."""
     def __init__(self, ntuple, index):
         """Constructor.

--- a/Validation/RecoTrack/python/plotting/ntuplePrintersDiff.py
+++ b/Validation/RecoTrack/python/plotting/ntuplePrintersDiff.py
@@ -7,7 +7,6 @@ import collections
 
 from operator import itemgetter, methodcaller
 
-from Validation.RecoTrack.plotting.ntupleDetId import *
 from Validation.RecoTrack.plotting.ntupleDataFormat import *
 
 # Common track-track matching by hits (=clusters)
@@ -769,7 +768,7 @@ class _RecHitPrinter(_IndentPrinter):
                         matched += " "+",".join(matches)
 
                 coord = "x,y,z %f,%f,%f" % (hit.x(), hit.y(), hit.z())
-            detId = parseDetId(hit.detId())
+            detId = hit.detIdParsed()
             lst.append(self._prefix+"%s %d detid %d %s %s %s" % (hit.layerStr(), hit.index(), detId.detid, str(detId), coord, matched))
         return lst
 
@@ -1098,7 +1097,7 @@ class TrackingParticlePrinter(_IndentPrinter):
         if self._hits:
             lst.append(self._prefix+" sim hits"+_hitPatternSummary(tp.simHits()))
             for simhit in tp.simHits():
-                detId = parseDetId(simhit.detId())
+                detId = simhit.detIdParsed()
                 tmp = []
                 for h in simhit.hits():
                     tmp.append(",".join([str(trk.index()) for trk in h.tracks()]) + ":%d"%h.index())


### PR DESCRIPTION
This PR generalizes the (tracker) DetId parsing in the TrackingNtuple python library to be agnostic on the detector geometry. The chosen approach is to dump the TrackerTopology constants to the output root file, and use them in the python library. While it leads to some code duplication, it allows flexible debugging (including the TrackerTopology constants) without increasing the ntuple size (and if all the pieces of DetIds were stored on separate branches, one would have to deal with the fact that BPix/FPix and TIB/TID/TOB/TEC DetIds have different structure).

Tested in 9_1_0_pre2, no changes expected.

@rovere @VinInn @ebrondol 