### PR TITLE
Add cmsRunJE and make jemalloc only default on x86_64

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -40,7 +40,10 @@
   <use   name="boost"/>
   <use   name="boost_program_options"/>
   <use   name="boost_python"/>
-  <use   name="jemalloc"/>
+  <!-- jemalloc is mostly tested on x86_64 in upstream -->
+  <architecture name=".*_amd64_.*">
+    <use   name="jemalloc"/>
+  </architecture>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/MessageLogger"/>
   <use   name="FWCore/PluginManager"/>
@@ -51,6 +54,20 @@
 </bin>
 <bin   name="cmsRunVDT" file="cmsRun.cpp">
   <use   name="vdt"/>
+  <use   name="tbb"/>
+  <use   name="boost"/>
+  <use   name="boost_program_options"/>
+  <use   name="boost_python"/>
+  <use   name="jemalloc"/>
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/MessageLogger"/>
+  <use   name="FWCore/PluginManager"/>
+  <use   name="FWCore/ServiceRegistry"/>
+  <use   name="FWCore/Utilities"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="FWCore/PythonParameterSet"/>
+</bin>
+<bin   name="cmsRunJE" file="cmsRun.cpp">
   <use   name="tbb"/>
   <use   name="boost"/>
   <use   name="boost_program_options"/>


### PR DESCRIPTION
Until we can fully figure out issues on AArch64 let's switch to glibc
allocator which is more battle tested on different architectures.

cmsRun continues to use jemalloc on x86_64. It only affects other
architectures.

Signed-off-by: David Abdurachmanov <davidlt@cern.ch>