### PR TITLE
Reactivation of fat event filter for uGMT ZS online DQM - 90x v2

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -23,8 +23,8 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 
 process.load("DQM.Integration.config.environment_cfi")
 
-process.dqmEnv.subSystemFolder = "L1T2016"
-process.dqmSaver.tag = "L1T2016"
+process.dqmEnv.subSystemFolder = "L1T"
+process.dqmSaver.tag = "L1T"
 process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/l1t_reference.root"
 
 process.dqmEndPath = cms.EndPath(process.dqmEnv * process.dqmSaver)
@@ -58,9 +58,9 @@ process.load("DQM.L1TMonitor.L1TStage2_cff")
 # zero suppression DQM module running before the fat event filter
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import l1tStage2uGMTZeroSupp
 process.l1tStage2uGMTZeroSuppAllEvts = l1tStage2uGMTZeroSupp.clone()
-process.l1tStage2uGMTZeroSuppAllEvts.monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/zeroSuppression/AllEvts")
+process.l1tStage2uGMTZeroSuppAllEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts")
 # customise path for zero suppression module analysing only fat events
-process.l1tStage2uGMTZeroSupp.monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/zeroSuppression/FatEvts")
+process.l1tStage2uGMTZeroSupp.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
 
 process.l1tMonitorPath = cms.Path(
     process.l1tStage2uGMTZeroSuppAllEvts +
@@ -87,8 +87,8 @@ process.l1tStage2MonitorClientPath = cms.Path(process.l1tStage2MonitorClient)
 # Legacy DQM EndPath
 # TODO: Is lumi scalers still relevant?
 
-process.load("DQM.L1TMonitor.L1TMonitor_cff")
-process.l1tMonitorEndPath = cms.EndPath(process.l1tMonitorEndPathSeq)
+#process.load("DQM.L1TMonitor.L1TMonitor_cff")
+#process.l1tMonitorEndPath = cms.EndPath(process.l1tMonitorEndPathSeq)
 
 #--------------------------------------------------
 # L1T Online DQM Schedule
@@ -97,7 +97,7 @@ process.schedule = cms.Schedule(
     process.rawToDigiPath,
     process.l1tMonitorPath,
     process.l1tStage2MonitorClientPath,
-    process.l1tMonitorEndPath,
+#    process.l1tMonitorEndPath,
     process.dqmEndPath
 )
 

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -40,10 +40,10 @@ process.rawToDigiPath = cms.Path(process.RawToDigi)
 # Stage2 Unpacker and DQM Path
 
 # Filter fat events
-#from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
-#process.hltFatEventFilter = hltHighLevel.clone()
-#process.hltFatEventFilter.throw = cms.bool(False)
-#process.hltFatEventFilter.HLTPaths = cms.vstring('HLT_L1FatEvents_v*')
+from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+process.hltFatEventFilter = hltHighLevel.clone()
+process.hltFatEventFilter.throw = cms.bool(False)
+process.hltFatEventFilter.HLTPaths = cms.vstring('HLT_L1FatEvents_v*')
 
 # This can be used if HLT filter not available in a run
 process.selfFatEventFilter = cms.EDFilter("HLTL1NumberFilter",
@@ -57,17 +57,17 @@ process.load("DQM.L1TMonitor.L1TStage2_cff")
 
 # zero suppression DQM module running before the fat event filter
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import l1tStage2uGMTZeroSupp
-process.l1tStage2uGMTZeroSuppAllEvts = l1tStage2uGMTZeroSupp.clone()
-process.l1tStage2uGMTZeroSuppAllEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts")
+process.l1tStage2uGMTZeroSupp.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts")
 # customise path for zero suppression module analysing only fat events
-process.l1tStage2uGMTZeroSupp.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
+process.l1tStage2uGMTZeroSuppFatEvts = l1tStage2uGMTZeroSupp.clone()
+process.l1tStage2uGMTZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
 
 process.l1tMonitorPath = cms.Path(
-    process.l1tStage2uGMTZeroSuppAllEvts +
-#    process.hltFatEventFilter +
-#    process.selfFatEventFilter +
     process.l1tStage2Unpack +
-    process.l1tStage2OnlineDQM
+    process.l1tStage2OnlineDQM +
+    process.hltFatEventFilter +
+#    process.selfFatEventFilter +
+    process.l1tStage2uGMTZeroSuppFatEvts
 )
 
 # Remove DQM Modules

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -29,8 +29,8 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 
 process.load("DQM.Integration.config.environment_cfi")
 
-process.dqmEnv.subSystemFolder = "L1T2016EMU"
-process.dqmSaver.tag = "L1T2016EMU"
+process.dqmEnv.subSystemFolder = "L1TEMU"
+process.dqmSaver.tag = "L1TEMU"
 process.DQMStore.referenceFileName = "/dqmdata/dqm/reference/l1temu_reference.root"
 
 process.dqmEndPath = cms.EndPath(

--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cfi.py
@@ -5,7 +5,7 @@ l1tStage2Bmtf = cms.EDAnalyzer(
     bmtfSource = cms.InputTag("bmtfDigis", "BMTF"),
 #    bmtfSourceTwinMux1 = cms.InputTag("BMTFStage2Digis", "TheDigis"),
 #    bmtfSourceTwinMux2 = cms.InputTag("BMTFStage2Digis", "PhiDigis"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2BMTF"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2BMTF"),
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer1_cfi.py
@@ -6,5 +6,5 @@ l1tStage2CaloLayer1 = cms.EDAnalyzer("L1TStage2CaloLayer1",
     ecalTPSourceSent = cms.InputTag("ecalDigis","EcalTriggerPrimitives"),
     hcalTPSourceSent = cms.InputTag("hcalDigis"),
     fedRawDataLabel  = cms.InputTag("rawDataCollector"),
-    histFolder = cms.string('L1T2016/L1TStage2CaloLayer1'),
+    histFolder = cms.string('L1T/L1TStage2CaloLayer1'),
 )

--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer2Emul_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer2Emul_cfi.py
@@ -5,6 +5,6 @@ l1tStage2CaloLayer2Emul = cms.EDAnalyzer("L1TStage2CaloLayer2",
                 stage2CaloLayer2EGammaSource = cms.InputTag("valCaloStage2Layer2Digis"),
                 stage2CaloLayer2TauSource = cms.InputTag("valCaloStage2Layer2Digis"),
                 stage2CaloLayer2EtSumSource = cms.InputTag("valCaloStage2Layer2Digis"),
-                monitorDir = cms.untracked.string("L1T2016EMU/L1TStage2CaloLayer2EMU")
+                monitorDir = cms.untracked.string("L1TEMU/L1TStage2CaloLayer2EMU")
 )
                                      

--- a/DQM/L1TMonitor/python/L1TStage2CaloLayer2_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CaloLayer2_cfi.py
@@ -5,6 +5,6 @@ l1tStage2CaloLayer2 = cms.EDAnalyzer("L1TStage2CaloLayer2",
                 stage2CaloLayer2EGammaSource = cms.InputTag("caloStage2Digis","EGamma"),
                 stage2CaloLayer2TauSource = cms.InputTag("caloStage2Digis","Tau"),
                 stage2CaloLayer2EtSumSource = cms.InputTag("caloStage2Digis","EtSum"),
-                monitorDir = cms.untracked.string("L1T2016/L1TStage2CaloLayer2")
+                monitorDir = cms.untracked.string("L1T/L1TStage2CaloLayer2")
 )
                                      

--- a/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2EMTF_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 l1tStage2Emtf = cms.EDAnalyzer(
     "L1TStage2EMTF",
     emtfSource = cms.InputTag("emtfStage2Digis"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2EMTF"), 
+    monitorDir = cms.untracked.string("L1T/L1TStage2EMTF"), 
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2OMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2OMTF_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 l1tStage2Omtf = cms.EDAnalyzer(
     "L1TStage2OMTF",
     omtfSource = cms.InputTag("omtfStage2Digis", "OMTF"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2OMTF"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2OMTF"),
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -73,7 +73,7 @@ l1tStage2uGMTZeroSupp = cms.EDAnalyzer(
                                       0x0003FC00,
                                       0x00000000),
     # no masks defined for caption IDs 0 and 3-11
-    maxFEDReadoutSize = cms.untracked.int32(6000),
+    maxFEDReadoutSize = cms.untracked.int32(9000),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression"),
     verbose = cms.untracked.bool(False),
 )

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -16,7 +16,7 @@ l1tStage2uGMT = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateBMTF = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsBMTF"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/BMTF"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/BMTF"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
     verbose = cms.untracked.bool(False),
 )
@@ -24,7 +24,7 @@ l1tStage2uGMTIntermediateBMTF = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFNeg = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/OMTF_neg"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -32,7 +32,7 @@ l1tStage2uGMTIntermediateOMTFNeg = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFPos = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsOMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/OMTF_pos"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -40,7 +40,7 @@ l1tStage2uGMTIntermediateOMTFPos = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFNeg = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/EMTF_neg"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -48,7 +48,7 @@ l1tStage2uGMTIntermediateEMTFNeg = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFPos = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("gmtStage2Digis", "imdMuonsEMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/intermediate_muons/EMTF_pos"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
     verbose = cms.untracked.bool(False),
 )

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -7,7 +7,7 @@ l1tStage2uGMT = cms.EDAnalyzer(
     omtfProducer = cms.InputTag("gmtStage2Digis", "OMTF"),
     emtfProducer = cms.InputTag("gmtStage2Digis", "EMTF"),
     muonProducer = cms.InputTag("gmtStage2Digis", "Muon"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT"),
     emulator = cms.untracked.bool(False),
     verbose = cms.untracked.bool(False),
 )
@@ -32,7 +32,7 @@ l1tStage2uGMTZeroSupp = cms.EDAnalyzer(
                                       0x00000000),
     # no masks defined for caption IDs 0 and 3-11
     maxFEDReadoutSize = cms.untracked.int32(6000),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/zeroSuppression"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression"),
     verbose = cms.untracked.bool(False),
 )
 
@@ -42,7 +42,7 @@ l1tStage2BmtfOutVsuGMTIn = cms.EDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("bmtfDigis", "BMTF"),
     regionalMuonCollection2 = cms.InputTag("gmtStage2Digis", "BMTF"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/BMTFoutput_vs_uGMTinput"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput"),
     regionalMuonCollection1Title = cms.untracked.string("BMTF output data"),
     regionalMuonCollection2Title = cms.untracked.string("uGMT input data from BMTF"),
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF output muons and uGMT input muons from BMTF"),
@@ -55,7 +55,7 @@ l1tStage2EmtfOutVsuGMTIn = cms.EDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("emtfStage2Digis"),
     regionalMuonCollection2 = cms.InputTag("gmtStage2Digis", "EMTF"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/EMTFoutput_vs_uGMTinput"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput"),
     regionalMuonCollection1Title = cms.untracked.string("EMTF output data"),
     regionalMuonCollection2Title = cms.untracked.string("uGMT input data from EMTF"),
     summaryTitle = cms.untracked.string("Summary of comparison between EMTF output muons and uGMT input muons from EMTF"),
@@ -68,7 +68,7 @@ l1tStage2uGMTOutVsuGTIn = cms.EDAnalyzer(
     "L1TStage2MuonComp",
     muonCollection1 = cms.InputTag("gmtStage2Digis", "Muon"),
     muonCollection2 = cms.InputTag("gtStage2Digis", "Muon"),
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGMT/uGMToutput_vs_uGTinput"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput"),
     muonCollection1Title = cms.untracked.string("uGMT output muons"),
     muonCollection2Title = cms.untracked.string("uGT input muons"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT output muons and uGT input muons"),

--- a/DQM/L1TMonitor/python/L1TStage2uGTEmul_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTEmul_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 l1tStage2uGtEmul = cms.EDAnalyzer("L1TStage2uGT",
     l1tStage2uGtSource = cms.InputTag("valGtStage2Digis"),    
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TStage2uGTEmul"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TStage2uGTEmul"),
     verbose = cms.untracked.bool(False)
 )

--- a/DQM/L1TMonitor/python/L1TStage2uGT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGT_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 l1tStage2uGt = cms.EDAnalyzer("L1TStage2uGT",
     l1tStage2uGtSource = cms.InputTag("gtStage2Digis"),    
-    monitorDir = cms.untracked.string("L1T2016/L1TStage2uGT"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGT"),
     verbose = cms.untracked.bool(False)
 )

--- a/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2BMTF_cfi.py
@@ -6,7 +6,7 @@ l1tdeStage2Bmtf = cms.EDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("bmtfDigis", "BMTF"),
     regionalMuonCollection2 = cms.InputTag("valBmtfDigis", "BMTF"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2BMTF"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2BMTF"),
     regionalMuonCollection1Title = cms.untracked.string("BMTF data"),
     regionalMuonCollection2Title = cms.untracked.string("BMTF emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF muons and BMTF emulator muons"),

--- a/DQM/L1TMonitor/python/L1TdeStage2CaloLayer1_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2CaloLayer1_cfi.py
@@ -3,5 +3,5 @@ import FWCore.ParameterSet.Config as cms
 l1tdeStage2CaloLayer1 = cms.EDAnalyzer("L1TdeStage2CaloLayer1",
     dataSource = cms.InputTag("caloStage2Digis", "CaloTower"),
     emulSource = cms.InputTag("valCaloStage2Layer1Digis"),
-    histFolder = cms.string('L1T2016EMU/L1TdeStage2CaloLayer1'),
+    histFolder = cms.string('L1TEMU/L1TdeStage2CaloLayer1'),
 )

--- a/DQM/L1TMonitor/python/L1TdeStage2EMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2EMTF_cfi.py
@@ -4,7 +4,7 @@ l1tdeStage2Emtf = cms.EDAnalyzer(
     "L1TdeStage2EMTF",
     dataSource = cms.InputTag("emtfStage2Digis"),
     emulSource = cms.InputTag("valEmtfStage2Digis", "EMTF"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2EMTF"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2EMTF"),
     verbose = cms.untracked.bool(False),
 )
 
@@ -14,7 +14,7 @@ l1tdeStage2EmtfComp = cms.EDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("emtfStage2Digis"),
     regionalMuonCollection2 = cms.InputTag("valEmtfStage2Digis", "EMTF"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2EMTF"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2EMTF"),
     regionalMuonCollection1Title = cms.untracked.string("EMTF data"),
     regionalMuonCollection2Title = cms.untracked.string("EMTF emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between EMTF muons and EMTF emulator muons"),

--- a/DQM/L1TMonitor/python/L1TdeStage2OMTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2OMTF_cfi.py
@@ -6,7 +6,7 @@ l1tdeStage2Omtf = cms.EDAnalyzer(
     "L1TStage2RegionalMuonCandComp",
     regionalMuonCollection1 = cms.InputTag("gmtStage2Digis", "OMTF"),
     regionalMuonCollection2 = cms.InputTag("valOmtfDigis", "OMTF"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2OMTF"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2OMTF"),
     regionalMuonCollection1Title = cms.untracked.string("uGMT input data from OMTF"),
     regionalMuonCollection2Title = cms.untracked.string("OMTF emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT input muons from OMTF and OMTF emulator muons"),

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cfi.py
@@ -8,7 +8,7 @@ l1tStage2uGMTEmul = cms.EDAnalyzer(
     omtfProducer = cms.InputTag("gmtStage2Digis", "OMTF"), # not used for emulator DQM
     emtfProducer = cms.InputTag("gmtStage2Digis", "EMTF"), # not used for emulator DQM
     muonProducer = cms.InputTag("valGmtStage2Digis"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT"),
     emulator = cms.untracked.bool(True),
     verbose = cms.untracked.bool(False),
 )
@@ -17,7 +17,7 @@ l1tStage2uGMTEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsBMTF"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/BMTF"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/BMTF"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
     verbose = cms.untracked.bool(False),
 )
@@ -25,7 +25,7 @@ l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -33,7 +33,7 @@ l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -41,7 +41,7 @@ l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFNeg"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
@@ -49,7 +49,7 @@ l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
 l1tStage2uGMTIntermediateEMTFPosEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
     muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFPos"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -60,7 +60,7 @@ l1tdeStage2uGMT = cms.EDAnalyzer(
     "L1TStage2MuonComp",
     muonCollection1 = cms.InputTag("gmtStage2Digis", "Muon"),
     muonCollection2 = cms.InputTag("valGmtStage2Digis"),
-    monitorDir = cms.untracked.string("L1T2016EMU/L1TdeStage2uGMT/data_vs_emulator_comparison"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison"),
     muonCollection1Title = cms.untracked.string("uGMT data"),
     muonCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT emulator muons"),

--- a/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 l1tStage2CaloLayer2DEClient = cms.EDAnalyzer("L1TStage2CaloLayer2DEClient",
-                  monitorDir = cms.untracked.string('L1T2016EMU/L1TStage2CaloLayer2DERatio'),
-                  inputDataDir = cms.untracked.string('L1T2016/L1TStage2CaloLayer2'),
-                  inputEmulDir = cms.untracked.string('L1T2016EMU/L1TStage2CaloLayer2EMU')
+                  monitorDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2DERatio'),
+                  inputDataDir = cms.untracked.string('L1T/L1TStage2CaloLayer2'),
+                  inputEmulDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2EMU')
 )
 
 


### PR DESCRIPTION
Backport from PR #18395

Add the fat event filter (keeps every 107th event) again to the L1 trigger online DQM configuration.
This is needed for the uGMT zero suppression DQM module because for those events the ZS is in validation mode and does only flag and not suppress the data blocks.

In addition the "2016" string was removed from the DQM directory names and the maximum FED readout size was increased.

This PR has the same changes as #18396 and in addition also contains what is already in PR #18043 in order to resolve a conflict when merging for the deployment at P5. The 91x version of #18043 is already merged.