### PR TITLE
update "chrono" tests

### DIFF
--- a/HLTrigger/Timer/test/BuildFile.xml
+++ b/HLTrigger/Timer/test/BuildFile.xml
@@ -9,7 +9,6 @@
 <bin name="testChrono" file="chrono/test/chrono.cc chrono/src/*.cc chrono/src/native/*.cc">
   <use   name="boost"/>
   <use   name="tbb"/>
-  <use   name="sockets"/>       <!-- imply -lrt on Linux -->
   <flags CXXFLAGS="-I${CMSSW_BASE}/src/HLTrigger/Timer/test/chrono -I${CMSSW_RELEASE_BASE}/src/HLTrigger/Timer/test/chrono -fopenmp -DHAVE_TBB"/>
   <flags NO_TESTRUN="1"/>
 </bin>

--- a/HLTrigger/Timer/test/BuildFile.xml
+++ b/HLTrigger/Timer/test/BuildFile.xml
@@ -9,6 +9,6 @@
 <bin name="testChrono" file="chrono/test/chrono.cc chrono/src/*.cc chrono/src/native/*.cc">
   <use   name="boost"/>
   <use   name="tbb"/>
-  <flags CXXFLAGS="-I${CMSSW_BASE}/src/HLTrigger/Timer/test/chrono -I${CMSSW_RELEASE_BASE}/src/HLTrigger/Timer/test/chrono -fopenmp -DHAVE_TBB"/>
+  <flags CXXFLAGS="-I${CMSSW_BASE}/src/HLTrigger/Timer/test/chrono -I${CMSSW_RELEASE_BASE}/src/HLTrigger/Timer/test/chrono -fopenmp -DHAVE_TBB -DHAVE_BOOST_CHRONO -lboost_chrono"/>
   <flags NO_TESTRUN="1"/>
 </bin>

--- a/HLTrigger/Timer/test/chrono/doc/Ubuntu Linux 16.04.02 LTS - Intel Core i7-6700HQ 2.60GHz
+++ b/HLTrigger/Timer/test/chrono/doc/Ubuntu Linux 16.04.02 LTS - Intel Core i7-6700HQ 2.60GHz
@@ -1,0 +1,257 @@
+Linux 4.10.9-041009-lowlatency x86_64
+glibc version: 2.23
+clock source:  tsc
+boost version: 1.58.0
+tbb version:   9.2 (interface) 9.2 (runtime)
+For each timer the resolution reported is the MINIMUM (MEDIAN) (MEAN +/- its STDDEV) of the increments measured during the test.
+
+Performance of std::chrono::steady_clock
+	Average time per call:       20.4 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         19.0 ns (median: 20.0 ns) (sigma: 60.1 ns) (average: 20.4 +/- 0.1 ns)
+
+Performance of std::chrono::system_clock
+	Average time per call:       22.4 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         18.0 ns (median: 21.0 ns) (sigma: 123.6 ns) (average: 22.4 +/- 0.1 ns)
+
+Performance of std::chrono::high_resolution_clock
+	Average time per call:       20.7 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         19.0 ns (median: 21.0 ns) (sigma: 38.5 ns) (average: 20.7 +/- 0.1 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_REALTIME)
+	Average time per call:       88.0 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         84.0 ns (median: 87.0 ns) (sigma: 141.7 ns) (average: 88.0 +/- 0.1 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_REALTIME_COARSE)
+	Average time per call:       72.8 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:    1000007.0 ns (median: 1000007.0 ns) (sigma: 0.5 ns) (average: 1000007.3 +/- 0.1 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_MONOTONIC)
+	Average time per call:       87.2 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         84.0 ns (median: 86.0 ns) (sigma: 115.3 ns) (average: 87.2 +/- 0.1 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_MONOTONIC_COARSE)
+	Average time per call:       75.3 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:    1000007.0 ns (median: 1000007.0 ns) (sigma: 0.5 ns) (average: 1000007.3 +/- 0.1 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_MONOTONIC_RAW)
+	Average time per call:       88.3 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         84.0 ns (median: 86.0 ns) (sigma: 182.3 ns) (average: 88.3 +/- 0.2 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_BOOTTIME)
+	Average time per call:       90.3 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         87.0 ns (median: 89.0 ns) (sigma: 131.5 ns) (average: 90.3 +/- 0.1 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_PROCESS_CPUTIME_ID)
+	Average time per call:      148.0 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:        141.0 ns (median: 145.0 ns) (sigma: 201.6 ns) (average: 148.0 +/- 0.2 ns)
+
+Performance of syscall(SYS_clock_gettime, CLOCK_THREAD_CPUTIME_ID)
+	Average time per call:      141.0 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:        134.0 ns (median: 138.0 ns) (sigma: 207.1 ns) (average: 141.0 +/- 0.2 ns)
+
+Performance of clock_gettime(CLOCK_REALTIME)
+	Average time per call:       19.5 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         17.0 ns (median: 19.0 ns) (sigma: 56.5 ns) (average: 19.5 +/- 0.1 ns)
+
+Performance of clock_gettime(CLOCK_REALTIME_COARSE)
+	Average time per call:        5.1 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:    1000007.0 ns (median: 1000007.0 ns) (sigma: 0.5 ns) (average: 1000007.4 +/- 0.2 ns)
+
+Performance of clock_gettime(CLOCK_MONOTONIC)
+	Average time per call:       19.1 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         17.0 ns (median: 19.0 ns) (sigma: 48.8 ns) (average: 19.1 +/- 0.1 ns)
+
+Performance of clock_gettime(CLOCK_MONOTONIC_COARSE)
+	Average time per call:        4.6 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:    1000007.0 ns (median: 1000007.0 ns) (sigma: 0.5 ns) (average: 1000007.4 +/- 0.2 ns)
+
+Performance of clock_gettime(CLOCK_MONOTONIC_RAW)
+	Average time per call:       89.0 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         85.0 ns (median: 88.0 ns) (sigma: 135.9 ns) (average: 89.0 +/- 0.1 ns)
+
+Performance of clock_gettime(CLOCK_BOOTTIME)
+	Average time per call:       94.0 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         90.0 ns (median: 93.0 ns) (sigma: 131.5 ns) (average: 94.0 +/- 0.1 ns)
+
+Performance of clock_gettime(CLOCK_PROCESS_CPUTIME_ID)
+	Average time per call:      148.7 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:        142.0 ns (median: 147.0 ns) (sigma: 140.5 ns) (average: 148.7 +/- 0.1 ns)
+
+Performance of clock_gettime(CLOCK_THREAD_CPUTIME_ID)
+	Average time per call:      142.5 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:        135.0 ns (median: 140.0 ns) (sigma: 193.3 ns) (average: 142.5 +/- 0.2 ns)
+
+Performance of gettimeofday()
+	Average time per call:       20.4 ns
+	Clock tick period:         1000.0 ns
+	Measured resolution:       1000.0 ns (median: 1000.0 ns) (sigma: 322.3 ns) (average: 1007.7 +/- 2.3 ns)
+
+Performance of times() (wall-clock time)
+	Average time per call:       42.5 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of times() (cpu time)
+	Average time per call:      180.8 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of times() (wall-clock time) (using double)
+	Average time per call:       40.0 ns
+	Clock tick period:            n/a
+	Measured resolution:    9999999.8 ns (median: 9999999.8 ns) (sigma: 0.5 ns) (average: 10000000.0 +/- 0.2 ns)
+
+Performance of times() (cpu time) (using double)
+	Average time per call:      174.3 ns
+	Clock tick period:            n/a
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of times() (wall-clock time) (using fixed math)
+	Average time per call:       40.3 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of times() (cpu time) (using fixed math)
+	Average time per call:      175.9 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of clock()
+	Average time per call:      150.3 ns
+	Clock tick period:         1000.0 ns
+	Measured resolution:       1000.0 ns (median: 1000.0 ns) (sigma: 391.9 ns) (average: 1010.5 +/- 1.0 ns)
+
+Performance of getrusage(RUSAGE_SELF)
+	Average time per call:      231.9 ns
+	Clock tick period:         1000.0 ns
+	Measured resolution:    1000000.0 ns (median: 1000000.0 ns) (sigma: 0.1 ns) (average: 1000000.0 +/- 0.1 ns)
+
+Performance of getrusage(RUSAGE_THREAD)
+	Average time per call:      143.6 ns
+	Clock tick period:         1000.0 ns
+	Measured resolution:    1000000.0 ns (median: 1000000.0 ns) (sigma: 0.1 ns) (average: 1000000.0 +/- 0.1 ns)
+
+Performance of RDTSC (2591.979 MHz) (using nanoseconds)
+	Average time per call:        7.3 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:          6.0 ns (median: 7.0 ns) (sigma: 42.4 ns) (average: 7.3 +/- 0.1 ns)
+
+Performance of LFENCE; RDTSC (2591.979 MHz) (using nanoseconds)
+	Average time per call:       13.8 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         11.0 ns (median: 13.0 ns) (sigma: 88.0 ns) (average: 13.8 +/- 0.1 ns)
+
+Performance of MFENCE; RDTSC (2591.979 MHz) (using nanoseconds)
+	Average time per call:       21.6 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         19.0 ns (median: 21.0 ns) (sigma: 73.8 ns) (average: 21.6 +/- 0.1 ns)
+
+Performance of RDTSCP (2591.979 MHz) (using nanoseconds)
+	Average time per call:       12.9 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         11.0 ns (median: 13.0 ns) (sigma: 34.9 ns) (average: 12.9 +/- 0.1 ns)
+
+Performance of run-time selected serialising RDTSC (2591.979 MHz) (using nanoseconds)
+	Average time per call:       14.2 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         11.0 ns (median: 13.0 ns) (sigma: 103.2 ns) (average: 14.2 +/- 0.1 ns)
+
+Performance of RDTSC (2591.979 MHz) (native)
+	Average time per call:        7.2 ns
+	Clock tick period:            0.4 ns
+	Measured resolution:          6.2 ns (median: 6.9 ns) (sigma: 4.0 ns) (average: 7.2 +/- 0.1 ns)
+
+Performance of LFENCE; RDTSC (2591.979 MHz) (native)
+	Average time per call:       11.0 ns
+	Clock tick period:            0.4 ns
+	Measured resolution:          9.3 ns (median: 10.8 ns) (sigma: 24.4 ns) (average: 11.0 +/- 0.1 ns)
+
+Performance of MFENCE; RDTSC (2591.979 MHz) (native)
+	Average time per call:       19.2 ns
+	Clock tick period:            0.4 ns
+	Measured resolution:         17.0 ns (median: 18.5 ns) (sigma: 52.6 ns) (average: 19.2 +/- 0.1 ns)
+
+Performance of RDTSCP (2591.979 MHz) (native)
+	Average time per call:       10.7 ns
+	Clock tick period:            0.4 ns
+	Measured resolution:          9.3 ns (median: 10.8 ns) (sigma: 34.1 ns) (average: 10.7 +/- 0.1 ns)
+
+Performance of run-time selected serialising RDTSC (2591.979 MHz) (native)
+	Average time per call:       11.2 ns
+	Clock tick period:            0.4 ns
+	Measured resolution:          9.3 ns (median: 10.8 ns) (sigma: 47.5 ns) (average: 11.2 +/- 0.1 ns)
+
+Performance of boost::timer (wall-clock time)
+	Average time per call:      196.7 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:        189.0 ns (median: 195.0 ns) (sigma: 171.4 ns) (average: 196.7 +/- 0.2 ns)
+
+Performance of boost::timer (cpu time)
+	Average time per call:      199.1 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of boost::chrono::steady_clock
+	Average time per call:       20.4 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         19.0 ns (median: 20.0 ns) (sigma: 70.3 ns) (average: 20.4 +/- 0.1 ns)
+
+Performance of boost::chrono::system_clock
+	Average time per call:       20.2 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         18.0 ns (median: 20.0 ns) (sigma: 34.6 ns) (average: 20.2 +/- 0.1 ns)
+
+Performance of boost::chrono::high_resolution_clock
+	Average time per call:       20.3 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:         18.0 ns (median: 20.0 ns) (sigma: 50.7 ns) (average: 20.3 +/- 0.1 ns)
+
+Performance of boost::chrono::process_real_cpu_clock
+	Average time per call:      176.8 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of boost::chrono::process_user_cpu_clock
+	Average time per call:      172.9 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of boost::chrono::process_system_cpu_clock
+	Average time per call:      172.3 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:   10000000.0 ns (median: 10000000.0 ns) (sigma: 0.1 ns) (average: 10000000.0 +/- 0.1 ns)
+
+Performance of boost::chrono::thread_clock
+	Average time per call:      144.5 ns
+	Clock tick period:            1.0 ns
+	Measured resolution:        137.0 ns (median: 142.0 ns) (sigma: 196.0 ns) (average: 144.5 +/- 0.2 ns)
+
+Performance of tbb::tick_count
+	Average time per call:       21.5 ns
+	Clock tick period:            n/a
+	Measured resolution:         19.0 ns (median: 21.0 ns) (sigma: 58.8 ns) (average: 21.5 +/- 0.1 ns)
+
+Performance of omp_get_wtime
+	Average time per call:       25.9 ns
+	Clock tick period:            n/a
+	Measured resolution:         24.0 ns (median: 26.0 ns) (sigma: 64.1 ns) (average: 25.9 +/- 0.1 ns)
+

--- a/HLTrigger/Timer/test/chrono/interface/syscall_clock_gettime.h
+++ b/HLTrigger/Timer/test/chrono/interface/syscall_clock_gettime.h
@@ -1,5 +1,5 @@
-#ifndef posix_clock_gettime_h
-#define posix_clock_gettime_h
+#ifndef syscall_clock_gettime_h
+#define syscall_clock_gettime_h
 
 // C++ standard headers
 #include <chrono>
@@ -9,227 +9,217 @@
 #include <time.h>
 
 // check available capabilities
-#if (defined(_POSIX_TIMERS) && (_POSIX_TIMERS >= 0))
-
-#define HAVE_POSIX_CLOCK_REALTIME
-
-#if (defined(_POSIX_MONOTONIC_CLOCK) && (_POSIX_MONOTONIC_CLOCK >= 0))
-#define HAVE_POSIX_CLOCK_MONOTONIC           
-#endif // _POSIX_MONOTONIC_CLOCK
-
-#if (defined(_POSIX_CPUTIME) && (_POSIX_CPUTIME >= 0))
-#define HAVE_POSIX_CLOCK_PROCESS_CPUTIME_ID
-#endif // _POSIX_CPUTIME
-
-#if (defined(_POSIX_THREAD_CPUTIME) && (_POSIX_THREAD_CPUTIME >= 0))
-#define HAVE_POSIX_CLOCK_THREAD_CPUTIME_ID
-#endif // _POSIX_THREAD_CPUTIME
-
 #ifdef __linux__
 #include <linux/version.h>
+#include <sys/syscall.h>
+
+#define HAVE_SYSCALL_CLOCK_REALTIME
+#define HAVE_SYSCALL_CLOCK_MONOTONIC           
+#define HAVE_SYSCALL_CLOCK_PROCESS_CPUTIME_ID
+#define HAVE_SYSCALL_CLOCK_THREAD_CPUTIME_ID
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 28)
-#define HAVE_POSIX_CLOCK_MONOTONIC_RAW
+#define HAVE_SYSCALL_CLOCK_MONOTONIC_RAW
 #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 28)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32)
-#define HAVE_POSIX_CLOCK_REALTIME_COARSE
-#define HAVE_POSIX_CLOCK_MONOTONIC_COARSE
+#define HAVE_SYSCALL_CLOCK_REALTIME_COARSE
+#define HAVE_SYSCALL_CLOCK_MONOTONIC_COARSE
 #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 32)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)
-#define HAVE_POSIX_CLOCK_BOOTTIME
+#define HAVE_SYSCALL_CLOCK_BOOTTIME
 #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)
+
+#ifdef HAVE_SYSCALL_CLOCK_REALTIME
+// based on syscall(SYS_clock_gettime, CLOCK_REALTIME, ...)
+struct clock_syscall_realtime
+{
+  typedef std::chrono::nanoseconds                                      duration;
+  typedef duration::rep                                                 rep;
+  typedef duration::period                                              period;
+  typedef std::chrono::time_point<clock_syscall_realtime, duration>     time_point;
+
+  static constexpr bool is_steady = false;
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_REALTIME, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_REALTIME
+
+
+#ifdef HAVE_SYSCALL_CLOCK_REALTIME_COARSE
+// based on syscall(SYS_clock_gettime, CLOCK_REALTIME_COARSE, ...)
+struct clock_syscall_realtime_coarse
+{
+  typedef std::chrono::nanoseconds                                          duration;
+  typedef duration::rep                                                     rep;
+  typedef duration::period                                                  period;
+  typedef std::chrono::time_point<clock_syscall_realtime_coarse, duration>  time_point;
+
+  static constexpr bool is_steady = false;
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_REALTIME_COARSE, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_REALTIME_COARSE
+
+
+#ifdef HAVE_SYSCALL_CLOCK_MONOTONIC
+// based on syscall(SYS_clock_gettime, CLOCK_MONOTONIC, ...)
+struct clock_syscall_monotonic
+{
+  typedef std::chrono::nanoseconds                                      duration;
+  typedef duration::rep                                                 rep;
+  typedef duration::period                                              period;
+  typedef std::chrono::time_point<clock_syscall_monotonic, duration>    time_point;
+
+  static constexpr bool is_steady = true;
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_MONOTONIC
+
+
+#ifdef HAVE_SYSCALL_CLOCK_MONOTONIC_COARSE
+// based on syscall(SYS_clock_gettime, CLOCK_MONOTONIC_COARSE, ...)
+struct clock_syscall_monotonic_coarse
+{
+  typedef std::chrono::nanoseconds                                          duration;
+  typedef duration::rep                                                     rep;
+  typedef duration::period                                                  period;
+  typedef std::chrono::time_point<clock_syscall_monotonic_coarse, duration> time_point;
+
+  static constexpr bool is_steady = true;
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_MONOTONIC_COARSE, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_MONOTONIC_COARSE
+
+
+#ifdef HAVE_SYSCALL_CLOCK_MONOTONIC_RAW
+// based on syscall(SYS_clock_gettime, CLOCK_MONOTONIC_RAW, ...)
+struct clock_syscall_monotonic_raw
+{
+  typedef std::chrono::nanoseconds                                          duration;
+  typedef duration::rep                                                     rep;
+  typedef duration::period                                                  period;
+  typedef std::chrono::time_point<clock_syscall_monotonic_raw, duration>    time_point;
+
+  static constexpr bool is_steady = true;
+  static const     bool is_available;
+
+  static inline time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_MONOTONIC_RAW, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_MONOTONIC_RAW
+
+
+#ifdef HAVE_SYSCALL_CLOCK_BOOTTIME
+// based on syscall(SYS_clock_gettime, CLOCK_BOOTTIME, ...)
+struct clock_syscall_boottime
+{
+  typedef std::chrono::nanoseconds                                          duration;
+  typedef duration::rep                                                     rep;
+  typedef duration::period                                                  period;
+  typedef std::chrono::time_point<clock_syscall_boottime, duration>         time_point;
+
+  static constexpr bool is_steady = true;
+  static const     bool is_available;
+
+  static inline time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_BOOTTIME, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_BOOTTIME
+
+
+#ifdef HAVE_SYSCALL_CLOCK_PROCESS_CPUTIME_ID
+// based on syscall(SYS_clock_gettime, CLOCK_PROCESS_CPUTIME_ID, ...)
+struct clock_syscall_process_cputime
+{
+  typedef std::chrono::nanoseconds                                              duration;
+  typedef duration::rep                                                         rep;
+  typedef duration::period                                                      period;
+  typedef std::chrono::time_point<clock_syscall_process_cputime, duration>      time_point;
+
+  static constexpr bool is_steady = false;  // FIXME can this be considered "steady" ?
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_PROCESS_CPUTIME_ID, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_PROCESS_CPUTIME_ID
+
+
+#ifdef HAVE_SYSCALL_CLOCK_THREAD_CPUTIME_ID
+// based on syscall(SYS_clock_gettime, CLOCK_THREAD_CPUTIME_ID, ...)
+struct clock_syscall_thread_cputime
+{
+  typedef std::chrono::nanoseconds                                              duration;
+  typedef duration::rep                                                         rep;
+  typedef duration::period                                                      period;
+  typedef std::chrono::time_point<clock_syscall_thread_cputime, duration>       time_point;
+
+  static constexpr bool is_steady = false;  // FIXME can this be considered "steady" ?
+  static const     bool is_available;
+
+  static time_point now() noexcept
+  {
+    timespec t;
+    syscall(SYS_clock_gettime, CLOCK_THREAD_CPUTIME_ID, &t);
+
+    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
+  }
+
+};
+#endif // HAVE_SYSCALL_CLOCK_THREAD_CPUTIME_ID
+
 #endif // __linux__
 
-#endif // _POSIX_TIMERS
-
-#ifdef HAVE_POSIX_CLOCK_REALTIME
-// based on clock_gettime(CLOCK_REALTIME, ...)
-struct clock_gettime_realtime
-{
-  typedef std::chrono::nanoseconds                                      duration;
-  typedef duration::rep                                                 rep;
-  typedef duration::period                                              period;
-  typedef std::chrono::time_point<clock_gettime_realtime, duration>     time_point;
-
-  static constexpr bool is_steady = false;
-  static const     bool is_available;
-
-  static time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_REALTIME, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_REALTIME
-
-
-#ifdef HAVE_POSIX_CLOCK_REALTIME_COARSE
-// based on clock_gettime(CLOCK_REALTIME_COARSE, ...)
-struct clock_gettime_realtime_coarse
-{
-  typedef std::chrono::nanoseconds                                          duration;
-  typedef duration::rep                                                     rep;
-  typedef duration::period                                                  period;
-  typedef std::chrono::time_point<clock_gettime_realtime_coarse, duration>  time_point;
-
-  static constexpr bool is_steady = false;
-  static const     bool is_available;
-
-  static time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_REALTIME_COARSE, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_REALTIME_COARSE
-
-
-#ifdef HAVE_POSIX_CLOCK_MONOTONIC
-// based on clock_gettime(CLOCK_MONOTONIC, ...)
-struct clock_gettime_monotonic
-{
-  typedef std::chrono::nanoseconds                                      duration;
-  typedef duration::rep                                                 rep;
-  typedef duration::period                                              period;
-  typedef std::chrono::time_point<clock_gettime_monotonic, duration>    time_point;
-
-  static constexpr bool is_steady = true;
-  static const     bool is_available;
-
-  static time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_MONOTONIC, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_MONOTONIC
-
-
-#ifdef HAVE_POSIX_CLOCK_MONOTONIC_COARSE
-// based on clock_gettime(CLOCK_MONOTONIC_COARSE, ...)
-struct clock_gettime_monotonic_coarse
-{
-  typedef std::chrono::nanoseconds                                          duration;
-  typedef duration::rep                                                     rep;
-  typedef duration::period                                                  period;
-  typedef std::chrono::time_point<clock_gettime_monotonic_coarse, duration> time_point;
-
-  static constexpr bool is_steady = true;
-  static const     bool is_available;
-
-  static time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_MONOTONIC_COARSE, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_MONOTONIC_COARSE
-
-
-#ifdef HAVE_POSIX_CLOCK_MONOTONIC_RAW
-// based on clock_gettime(CLOCK_MONOTONIC_RAW, ...)
-struct clock_gettime_monotonic_raw
-{
-  typedef std::chrono::nanoseconds                                          duration;
-  typedef duration::rep                                                     rep;
-  typedef duration::period                                                  period;
-  typedef std::chrono::time_point<clock_gettime_monotonic_raw, duration>    time_point;
-
-  static constexpr bool is_steady = true;
-  static const     bool is_available;
-
-  static inline time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_MONOTONIC_RAW
-
-
-#ifdef HAVE_POSIX_CLOCK_BOOTTIME
-// based on clock_gettime(CLOCK_BOOTTIME, ...)
-struct clock_gettime_boottime
-{
-  typedef std::chrono::nanoseconds                                          duration;
-  typedef duration::rep                                                     rep;
-  typedef duration::period                                                  period;
-  typedef std::chrono::time_point<clock_gettime_boottime, duration>         time_point;
-
-  static constexpr bool is_steady = true;
-  static const     bool is_available;
-
-  static inline time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_BOOTTIME, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_BOOTTIME
-
-
-#ifdef HAVE_POSIX_CLOCK_PROCESS_CPUTIME_ID
-// based on clock_gettime(CLOCK_PROCESS_CPUTIME_ID, ...)
-struct clock_gettime_process_cputime
-{
-  typedef std::chrono::nanoseconds                                              duration;
-  typedef duration::rep                                                         rep;
-  typedef duration::period                                                      period;
-  typedef std::chrono::time_point<clock_gettime_process_cputime, duration>      time_point;
-
-  static constexpr bool is_steady = false;  // FIXME can this be considered "steady" ?
-  static const     bool is_available;
-
-  static time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_PROCESS_CPUTIME_ID
-
-
-#ifdef HAVE_POSIX_CLOCK_THREAD_CPUTIME_ID
-// based on clock_gettime(CLOCK_THREAD_CPUTIME_ID, ...)
-struct clock_gettime_thread_cputime
-{
-  typedef std::chrono::nanoseconds                                              duration;
-  typedef duration::rep                                                         rep;
-  typedef duration::period                                                      period;
-  typedef std::chrono::time_point<clock_gettime_thread_cputime, duration>       time_point;
-
-  static constexpr bool is_steady = false;  // FIXME can this be considered "steady" ?
-  static const     bool is_available;
-
-  static time_point now() noexcept
-  {
-    timespec t;
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t);
-
-    return time_point( std::chrono::seconds(t.tv_sec) + std::chrono::nanoseconds(t.tv_nsec) );
-  }
-
-};
-#endif // HAVE_POSIX_CLOCK_THREAD_CPUTIME_ID
-
-#endif // posix_clock_gettime_h
+#endif // syscall_clock_gettime_h

--- a/HLTrigger/Timer/test/chrono/src/posix_clock_gettime.cc
+++ b/HLTrigger/Timer/test/chrono/src/posix_clock_gettime.cc
@@ -27,6 +27,11 @@ const bool clock_gettime_monotonic_raw::is_available = true;
 #endif // HAVE_POSIX_CLOCK_MONOTONIC_RAW
 
 
+#ifdef HAVE_POSIX_CLOCK_BOOTTIME
+const bool clock_gettime_boottime::is_available = true;
+#endif // HAVE_POSIX_CLOCK_BOOTTIME
+
+
 #ifdef HAVE_POSIX_CLOCK_PROCESS_CPUTIME_ID
 const bool clock_gettime_process_cputime::is_available = (sysconf(_SC_CPUTIME) > 0);
 #endif // HAVE_POSIX_CLOCK_PROCESS_CPUTIME_ID

--- a/HLTrigger/Timer/test/chrono/src/syscall_clock_gettime.cc
+++ b/HLTrigger/Timer/test/chrono/src/syscall_clock_gettime.cc
@@ -1,0 +1,40 @@
+#include "interface/syscall_clock_gettime.h"
+
+#ifdef HAVE_SYSCALL_CLOCK_REALTIME
+const bool clock_syscall_realtime::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_REALTIME
+
+
+#ifdef HAVE_SYSCALL_CLOCK_REALTIME_COARSE
+const bool clock_syscall_realtime_coarse::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_REALTIME_COARSE
+
+
+#ifdef HAVE_SYSCALL_CLOCK_MONOTONIC
+const bool clock_syscall_monotonic::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_MONOTONIC
+
+
+#ifdef HAVE_SYSCALL_CLOCK_MONOTONIC_COARSE
+const bool clock_syscall_monotonic_coarse::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_MONOTONIC_COARSE
+
+
+#ifdef HAVE_SYSCALL_CLOCK_MONOTONIC_RAW
+const bool clock_syscall_monotonic_raw::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_MONOTONIC_RAW
+
+
+#ifdef HAVE_SYSCALL_CLOCK_BOOTTIME
+const bool clock_syscall_boottime::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_BOOTTIME
+
+
+#ifdef HAVE_SYSCALL_CLOCK_PROCESS_CPUTIME_ID
+const bool clock_syscall_process_cputime::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_PROCESS_CPUTIME_ID
+
+
+#ifdef HAVE_SYSCALL_CLOCK_THREAD_CPUTIME_ID
+const bool clock_syscall_thread_cputime::is_available = true;
+#endif // HAVE_SYSCALL_CLOCK_THREAD_CPUTIME_ID

--- a/HLTrigger/Timer/test/chrono/test/benchmark.h
+++ b/HLTrigger/Timer/test/chrono/test/benchmark.h
@@ -12,6 +12,45 @@
 #include <stdexcept>
 #include <chrono>
 
+// std chrono types
+template <class Rep, class Period>
+double to_seconds(std::chrono::duration<Rep, Period> duration) {
+    return std::chrono::duration_cast<std::chrono::duration<double>>(duration).count();
+}
+
+template <class Rep, class Period>
+double to_nanoseconds(std::chrono::duration<Rep, Period> duration) {
+    return std::chrono::duration_cast<std::chrono::duration<double, std::nano>>(duration).count();
+}
+
+#ifdef HAVE_BOOST_CHRONO
+// boost headers
+#include <boost/chrono/chrono.hpp>
+
+// boost chrono types
+template <class Rep, class Period>
+double to_seconds(boost::chrono::duration<Rep, Period> duration) {
+    return boost::chrono::duration_cast<boost::chrono::duration<double>>(duration).count();
+}
+
+template <class Rep, class Period>
+double to_nanoseconds(boost::chrono::duration<Rep, Period> duration) {
+    return boost::chrono::duration_cast<boost::chrono::duration<double, boost::nano>>(duration).count();
+}
+#endif // HAVE_BOOST_CHRONO
+
+
+// native chrono types
+template <class Rep, class Period>
+double to_seconds(native::native_duration<Rep, Period> duration) {
+    return std::chrono::duration_cast<std::chrono::duration<double>>(duration).count();
+}
+
+template <class Rep, class Period>
+double to_nanoseconds(native::native_duration<Rep, Period> duration) {
+    return std::chrono::duration_cast<std::chrono::duration<double, std::nano>>(duration).count();
+}
+
 
 static constexpr unsigned int SIZE = 1000000;
 
@@ -111,13 +150,13 @@ public:
 
   // return the delta between two time_points, expressed in seconds
   double delta(const time_point & start, const time_point & stop) const {
-    return std::chrono::duration_cast<std::chrono::duration<double>>(stop - start).count();
+    return to_seconds(stop - start);
   }
 
   // extract the characteristics of the timer from the measurements
   void compute() {
     // per-call overhead
-    overhead = std::chrono::duration_cast<std::chrono::duration<double>>(stop - start).count() / SIZE;
+    overhead = to_seconds(stop - start) / SIZE;
 
     // resolution (min, median and average of the increments)
     std::vector<double> steps;
@@ -156,9 +195,9 @@ public:
     std::cout << "Performance of " << description << std::endl;
     std::cout << "\tAverage time per call: " << std::right << std::setw(10) << overhead    * 1e9 << " ns" << std::endl;
     if (not std::chrono::treat_as_floating_point<typename clock_type::rep>::value) {
-      typename clock_type::duration             tick(1);
-      std::chrono::duration<double, std::nano>  ns = std::chrono::duration_cast<std::chrono::duration<double, std::nano>>(tick);
-      std::cout << "\tClock tick period:     " << std::right << std::setw(10) << ns.count() << " ns" << std::endl;
+      typename clock_type::duration tick(1);
+      double                        ns = to_nanoseconds(tick);
+      std::cout << "\tClock tick period:     " << std::right << std::setw(10) << ns << " ns" << std::endl;
     } else {
       std::cout << "\tClock tick period:     " << std::right << std::setw(10) << "n/a" << std::endl;
     }


### PR DESCRIPTION
  - print boost and tbb versions
  - add suport for boost::chrono clocks
  - add support for clock_gettime(CLOCK_BOOTTIME, ...) (Linux >= 2.6.39)
  - add support for syscall interface for clock_gettime
  - add results from Ubuntu Linux 16.04.02