### PR TITLE
produces call can record which transition to use

### DIFF
--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -48,6 +48,7 @@ namespace edm {
                       ParameterSetID const& parameterSetID,
                       TypeWithDict const& theTypeWithDict,
                       bool produced = true,
+                      bool availableOnlyAtEndTransition = false,
                       std::set<std::string> const& aliases = std::set<std::string>());
 
     BranchDescription(BranchDescription const& aliasForBranch,
@@ -86,6 +87,7 @@ namespace edm {
     void setDropped(bool isDropped) {transient_.dropped_ = isDropped;}
     bool onDemand() const {return transient_.onDemand_;}
     void setOnDemand(bool isOnDemand) {transient_.onDemand_ = isOnDemand;}
+    bool availableOnlyAtEndTransition() const {return transient_.availableOnlyAtEndTransition_; }
     bool transient() const {return transient_.transient_;}
     void setTransient(bool isTransient) {transient_.transient_ = isTransient;}
     TypeWithDict const& wrappedType() const {return transient_.wrappedType_;}
@@ -135,6 +137,20 @@ namespace edm {
       // The wrapped class name, which is currently derivable fron the other attributes.
       std::string wrappedName_;
 
+      // A TypeWithDict object for the wrapped object
+      TypeWithDict wrappedType_;
+
+      // A TypeWithDict object for the unwrapped object
+      TypeWithDict unwrappedType_;
+
+      // The split level of the branch, as marked
+      // in the data dictionary.
+      int splitLevel_;
+
+      // The basket size of the branch, as marked
+      // in the data dictionary.
+      int basketSize_;
+      
       // Was this branch produced in this process rather than in a previous process
       bool produced_;
 
@@ -151,19 +167,8 @@ namespace edm {
       // in the data dictionary
       bool transient_;
 
-      // A TypeWithDict object for the wrapped object
-      TypeWithDict wrappedType_;
-
-      // A TypeWithDict object for the unwrapped object
-      TypeWithDict unwrappedType_;
-
-      // The split level of the branch, as marked
-      // in the data dictionary.
-      int splitLevel_;
-
-      // The basket size of the branch, as marked
-      // in the data dictionary.
-      int basketSize_;
+      // if Run or Lumi based, can only get at end transition
+      bool availableOnlyAtEndTransition_;
     };
 
   private:

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -21,14 +21,15 @@ namespace edm {
     moduleName_(),
     branchName_(),
     wrappedName_(),
+    wrappedType_(),
+    unwrappedType_(),
+    splitLevel_(),
+    basketSize_(),
     produced_(false),
     onDemand_(false),
     dropped_(false),
     transient_(false),
-    wrappedType_(),
-    unwrappedType_(),
-    splitLevel_(),
-    basketSize_() {
+    availableOnlyAtEndTransition_(false){
    }
 
   void
@@ -46,7 +47,7 @@ namespace edm {
     productInstanceName_(),
     branchAliases_(),
     aliasForBranchID_(),
-    transient_() {
+    transient_(){
     // do not call init here! It will result in an exception throw.
   }
 
@@ -61,6 +62,7 @@ namespace edm {
                         ParameterSetID const& parameterSetID,
                         TypeWithDict const& theTypeWithDict,
                         bool produced,
+                        bool availableOnlyAtEndTransition,
                         std::set<std::string> const& aliases) :
       branchType_(branchType),
       moduleLabel_(moduleLabel),
@@ -76,6 +78,7 @@ namespace edm {
     setOnDemand(false);
     transient_.moduleName_ = moduleName;
     transient_.parameterSetID_ = parameterSetID;
+    transient_.availableOnlyAtEndTransition_=availableOnlyAtEndTransition;
     setUnwrappedType(theTypeWithDict);
     init();
   }
@@ -97,6 +100,7 @@ namespace edm {
     setDropped(false);
     setProduced(aliasForBranch.produced());
     setOnDemand(aliasForBranch.onDemand());
+    transient_.availableOnlyAtEndTransition_=aliasForBranch.availableOnlyAtEndTransition();
     transient_.moduleName_ = aliasForBranch.moduleName();
     transient_.parameterSetID_ = aliasForBranch.parameterSetID();
     setUnwrappedType(aliasForBranch.unwrappedType());

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -8,6 +8,7 @@ ProductRegistryHelper:
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Utilities/interface/TypeID.h"
+#include "FWCore/Utilities/interface/Transition.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include <string>
 #include <list>
@@ -22,12 +23,12 @@ namespace edm {
     ~ProductRegistryHelper();
  
     struct TypeLabelItem {
-      TypeLabelItem (BranchType const& branchType, TypeID const& tid, std::string const& pin) :
-	branchType_(branchType),
+      TypeLabelItem (Transition const& transition, TypeID const& tid, std::string const& pin) :
+	      transition_(transition),
         typeID_(tid),
         productInstanceName_(pin),
         branchAlias_() {}
-      BranchType branchType_;
+      Transition transition_;
       TypeID typeID_;
       std::string productInstanceName_;
       mutable std::string branchAlias_;
@@ -75,16 +76,33 @@ namespace edm {
       return produces<B>(tid,instanceName);
     }
 
+    template <typename ProductType, Transition B>
+    TypeLabelItem const& produces() {
+      return produces<ProductType, B>(std::string());
+    }
+    
+    template <typename ProductType, Transition B>
+    TypeLabelItem const& produces(std::string const& instanceName) {
+      TypeID tid(typeid(ProductType));
+      return produces<B>(tid,instanceName);
+    }
+
    
     TypeLabelItem const& produces(const TypeID& id, std::string const& instanceName=std::string()) {
-       return produces<InEvent>(id,instanceName);
+      return produces<Transition::Event>(id,instanceName);
     }
 
     template <BranchType B>
     TypeLabelItem const& produces(const TypeID& id, std::string const& instanceName=std::string()) {
-       typeLabelList_.emplace_back(B, id, instanceName);
+       typeLabelList_.emplace_back(convertToTransition(B), id, instanceName);
        return *typeLabelList_.rbegin();
     }
+    template <Transition B>
+    TypeLabelItem const& produces(const TypeID& id, std::string const& instanceName=std::string()) {
+      typeLabelList_.emplace_back(B, id, instanceName);
+      return *typeLabelList_.rbegin();
+    }
+
   private:
     TypeLabelList typeLabelList_;
   };

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -37,7 +37,7 @@ namespace edm {
       }
 
       TypeWithDict type(p->typeID_.typeInfo());
-      BranchDescription pdesc(p->branchType_,
+      BranchDescription pdesc(convertToBranchType(p->transition_),
                               iDesc.moduleLabel(),
                               iDesc.processName(),
                               p->typeID_.userClassName(),
@@ -45,7 +45,9 @@ namespace edm {
                               p->productInstanceName_,
                               iDesc.moduleName(),
                               iDesc.parameterSetID(),
-                              type);
+                              type,
+                              true,
+                              isEndTransition(p->transition_));
 
       if (pdesc.transient()) {
         if (!checkDictionary(missingDictionaries, pdesc.wrappedName(), pdesc.wrappedType())) {

--- a/FWCore/Integration/test/ThingExtSource.cc
+++ b/FWCore/Integration/test/ThingExtSource.cc
@@ -9,10 +9,10 @@ namespace edmtest {
   ThingExtSource::ThingExtSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc) :
     ProducerSourceFromFiles(pset, desc, true), alg_() {
     produces<ThingCollection>();
-    produces<ThingCollection, edm::InLumi>("beginLumi");
-    produces<ThingCollection, edm::InLumi>("endLumi");
-    produces<ThingCollection, edm::InRun>("beginRun");
-    produces<ThingCollection, edm::InRun>("endRun");
+    produces<ThingCollection, edm::Transition::BeginLuminosityBlock>("beginLumi");
+    produces<ThingCollection, edm::Transition::EndLuminosityBlock>("endLumi");
+    produces<ThingCollection, edm::Transition::BeginRun>("beginRun");
+    produces<ThingCollection, edm::Transition::EndRun>("endRun");
   }
 
   // Virtual destructor needed.

--- a/FWCore/Integration/test/ThingProducer.cc
+++ b/FWCore/Integration/test/ThingProducer.cc
@@ -12,10 +12,10 @@ namespace edmtest {
   noPut_(iConfig.getUntrackedParameter<bool>("noPut")) // used for testing with missing products
   {
     produces<ThingCollection>();
-    produces<ThingCollection, edm::InLumi>("beginLumi");
-    produces<ThingCollection, edm::InLumi>("endLumi");
-    produces<ThingCollection, edm::InRun>("beginRun");
-    produces<ThingCollection, edm::InRun>("endRun");
+    produces<ThingCollection, edm::Transition::BeginLuminosityBlock>("beginLumi");
+    produces<ThingCollection, edm::Transition::EndLuminosityBlock>("endLumi");
+    produces<ThingCollection, edm::Transition::BeginRun>("beginRun");
+    produces<ThingCollection, edm::Transition::EndRun>("endRun");
   }
 
   // Virtual destructor needed.

--- a/FWCore/Integration/test/ThingSource.cc
+++ b/FWCore/Integration/test/ThingSource.cc
@@ -9,10 +9,10 @@ namespace edmtest {
   ThingSource::ThingSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc) :
     ProducerSourceBase(pset, desc, false), alg_() {
     produces<ThingCollection>();
-    produces<ThingCollection, edm::InLumi>("beginLumi");
-    produces<ThingCollection, edm::InLumi>("endLumi");
-    produces<ThingCollection, edm::InRun>("beginRun");
-    produces<ThingCollection, edm::InRun>("endRun");
+    produces<ThingCollection, edm::Transition::BeginLuminosityBlock>("beginLumi");
+    produces<ThingCollection, edm::Transition::EndLuminosityBlock>("endLumi");
+    produces<ThingCollection, edm::Transition::BeginRun>("beginRun");
+    produces<ThingCollection, edm::Transition::EndRun>("endRun");
   }
 
   // Virtual destructor needed.

--- a/FWCore/Integration/test/ThingWithMergeProducer.cc
+++ b/FWCore/Integration/test/ThingWithMergeProducer.cc
@@ -27,21 +27,21 @@ namespace edmtest {
 {
     produces<Thing>("event");
     produces<Thing, edm::InLumi>("beginLumi");
-    produces<Thing, edm::InLumi>("endLumi");
+    produces<Thing, edm::Transition::EndLuminosityBlock>("endLumi");
     produces<Thing, edm::InRun>("beginRun");
-    produces<Thing, edm::InRun>("endRun");
+    produces<Thing, edm::Transition::EndRun>("endRun");
 
     produces<ThingWithMerge>("event");
-    produces<ThingWithMerge, edm::InLumi>("beginLumi");
-    produces<ThingWithMerge, edm::InLumi>("endLumi");
-    produces<ThingWithMerge, edm::InRun>("beginRun");
-    produces<ThingWithMerge, edm::InRun>("endRun");
+    produces<ThingWithMerge, edm::Transition::BeginLuminosityBlock>("beginLumi");
+    produces<ThingWithMerge, edm::Transition::EndLuminosityBlock>("endLumi");
+    produces<ThingWithMerge, edm::Transition::BeginRun>("beginRun");
+    produces<ThingWithMerge, edm::Transition::EndRun>("endRun");
 
     produces<ThingWithIsEqual>("event");
-    produces<ThingWithIsEqual, edm::InLumi>("beginLumi");
-    produces<ThingWithIsEqual, edm::InLumi>("endLumi");
-    produces<ThingWithIsEqual, edm::InRun>("beginRun");
-    produces<ThingWithIsEqual, edm::InRun>("endRun");
+    produces<ThingWithIsEqual, edm::Transition::BeginLuminosityBlock>("beginLumi");
+    produces<ThingWithIsEqual, edm::Transition::EndLuminosityBlock>("endLumi");
+    produces<ThingWithIsEqual, edm::Transition::BeginRun>("beginRun");
+    produces<ThingWithIsEqual, edm::Transition::EndRun>("endRun");
 
     const std::string s_prod("PROD");
     for(auto const& label: labelsToGet_) {

--- a/FWCore/Utilities/interface/Transition.h
+++ b/FWCore/Utilities/interface/Transition.h
@@ -1,0 +1,36 @@
+#ifndef FWCore_Utilities_Transition_h
+#define FWCore_Utilities_Transition_h
+/*----------------------------------------------------------------------
+  
+Transition: The allowed framework transitions
+
+----------------------------------------------------------------------*/
+#include "FWCore/Utilities/interface/BranchType.h"
+#include <type_traits>
+
+namespace edm {
+  enum class Transition {
+    Event,
+    BeginLuminosityBlock,
+    EndLuminosityBlock,
+    BeginRun,
+    EndRun
+  };
+  
+  //Useful for converting EndBranchType to BranchType
+  constexpr BranchType convertToBranchType(Transition iValue) {
+    constexpr BranchType branches[]={InEvent,InLumi,InLumi,InRun,InRun};
+    return branches[static_cast<std::underlying_type<Transition>::type>(iValue)];
+  }
+
+  constexpr Transition convertToTransition(BranchType iValue) {
+    constexpr Transition trans[]={Transition::Event,Transition::BeginLuminosityBlock,Transition::BeginRun};
+    return trans[iValue];
+  }
+
+  constexpr bool isEndTransition(Transition iValue) {
+    return iValue==Transition::EndLuminosityBlock or iValue==Transition::EndRun;
+  }
+  
+}
+#endif


### PR DESCRIPTION
The call to produces can now record if the data product will be produced at begin or end transitions.
This is the first step towards enforcing that the information is given.