### PR TITLE
Fix forward declaration of RefHolderBase in wrong namespace.

### DIFF
--- a/DataFormats/Common/interface/BaseHolder.h
+++ b/DataFormats/Common/interface/BaseHolder.h
@@ -9,9 +9,9 @@
 
 namespace edm {
   class ProductID;
-  class RefHolderBase;
 
   namespace reftobase {
+    class RefHolderBase;
     template<typename T> class BaseVectorHolder;
     class RefVectorHolderBase;
 


### PR DESCRIPTION
RefHolderBase is in the namespace edm::reftobase, but it was
forward declared in namespace edm. This could cause a compilation
error when instantiating this template under some circumstances (such
as when we compile the header into a module).

This patch moves the forward declaration to the correct namespace.