### PR TITLE
avoiding Pixel templates usage in trackingRecoMaterialAnalyzer [91x] 

### DIFF
--- a/DQM/TrackingMonitor/python/trackingRecoMaterialAnalyzer_cfi.py
+++ b/DQM/TrackingMonitor/python/trackingRecoMaterialAnalyzer_cfi.py
@@ -21,6 +21,9 @@ materialDumperAnalyzer = cms.EDAnalyzer("TrackingRecoMaterialAnalyser",
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(materialDumperAnalyzer, TrackerRecHitBuilder='WithTrackAngle')
 
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(materialDumperAnalyzer, TrackerRecHitBuilder='WithTrackAngle')
+
 materialDumper = cms.Sequence(materialDumperAnalyzer)
 materialDumper_step = cms.Path(materialDumper)
 


### PR DESCRIPTION
This PR intends to fix the crash oberved at Tier0 described in : 
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1577.html
90X PR is here : #18417 
