### PR TITLE
Explicitly register to produce on end transition

### DIFF
--- a/Alignment/LaserAlignment/plugins/LaserAlignment.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignment.cc
@@ -91,7 +91,7 @@ LaserAlignment::LaserAlignment( edm::ParameterSet const& theConf ) :
   std::string alias ( theConf.getParameter<std::string>("@module_label") );  
 
   // declare the product to produce
-  produces<TkLasBeamCollection, edm::InRun>( "tkLaserBeams" ).setBranchAlias( alias + "TkLasBeamCollection" );
+  produces<TkLasBeamCollection, edm::Transition::EndRun>( "tkLaserBeams" ).setBranchAlias( alias + "TkLasBeamCollection" );
 
   // switch judge's zero filter depending on cfg
   judge.EnableZeroFilter( enableJudgeZeroFilter );

--- a/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
+++ b/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
@@ -190,8 +190,8 @@ TkLasBeamFitter::TkLasBeamFitter(const edm::ParameterSet &iConfig) :
   h_resVsHitTecPlus(0), h_resVsHitTecMinus(0), h_resVsHitAt(0)
 {
   // declare the products to produce
-  this->produces<TkFittedLasBeamCollection, edm::InRun>();
-  this->produces<TsosVectorCollection, edm::InRun>();
+  this->produces<TkFittedLasBeamCollection, edm::Transition::EndRun>();
+  this->produces<TsosVectorCollection, edm::Transition::EndRun>();
   
   //now do what ever other initialization is needed
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeFileConverter.cc
@@ -15,7 +15,7 @@ MillePedeFileConverter::MillePedeFileConverter(const edm::ParameterSet& iConfig)
       inputFileName_(iConfig.getParameter<std::string>("inputBinaryFile")),
       fileBlobLabel_(iConfig.getParameter<std::string>("fileBlobLabel")) {
   // We define what this producer produces: A FileBlobCollection
-  produces<FileBlobCollection, edm::InLumi>(fileBlobLabel_);
+  produces<FileBlobCollection, edm::Transition::EndLuminosityBlock>(fileBlobLabel_);
 }
 
 MillePedeFileConverter::~MillePedeFileConverter() {}

--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotFromDB.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotFromDB.cc
@@ -32,7 +32,7 @@ ________________________________________________________________**/
 AlcaBeamSpotFromDB::AlcaBeamSpotFromDB(const edm::ParameterSet& iConfig)
 {
 
-  produces<reco::BeamSpot, edm::InLumi>("alcaBeamSpot");  
+  produces<reco::BeamSpot, edm::Transition::EndLuminosityBlock>("alcaBeamSpot");  
 }
 
 

--- a/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotProducer.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/AlcaBeamSpotProducer.cc
@@ -52,7 +52,7 @@ AlcaBeamSpotProducer::AlcaBeamSpotProducer(const edm::ParameterSet& iConfig){
   countLumi_ = 0;
   beginLumiOfBSFit_ = endLumiOfBSFit_ = -1;
   
-  produces<reco::BeamSpot, edm::InLumi>("alcaBeamSpot");
+  produces<reco::BeamSpot, edm::Transition::EndLuminosityBlock>("alcaBeamSpot");
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/CommonTools/UtilAlgos/plugins/EventCountProducer.cc
+++ b/CommonTools/UtilAlgos/plugins/EventCountProducer.cc
@@ -53,7 +53,7 @@ using namespace std;
 
 
 EventCountProducer::EventCountProducer(const edm::ParameterSet& iConfig){
-  produces<edm::MergeableCounter, edm::InLumi>();
+  produces<edm::MergeableCounter, edm::Transition::EndLuminosityBlock>();
 }
 
 

--- a/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
+++ b/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
@@ -96,9 +96,9 @@ LogErrorEventFilter::LogErrorEventFilter(const edm::ParameterSet & iConfig) :
     taggedMode_(iConfig.getUntrackedParameter<bool>("taggedMode", false)),
     forcedValue_(iConfig.getUntrackedParameter<bool>("forcedValue", true))
 {
-    produces<ErrorList, edm::InLumi>();
-    produces<int, edm::InLumi>("pass");
-    produces<int, edm::InLumi>("fail");
+    produces<ErrorList, edm::Transition::EndLuminosityBlock>();
+    produces<int, edm::Transition::EndLuminosityBlock>("pass");
+    produces<int, edm::Transition::EndLuminosityBlock>("fail");
     //produces<ErrorList, edm::InRun>();
     produces<bool>();
 

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -51,32 +51,32 @@ MEtoEDMConverter::MEtoEDMConverter(const edm::ParameterSet & iPSet) :
   // create persistent objects
 
   sName = fName + "Run";
-  produces<MEtoEDM<TH1F>, edm::InRun>(sName);
-  produces<MEtoEDM<TH1S>, edm::InRun>(sName);
-  produces<MEtoEDM<TH1D>, edm::InRun>(sName);
-  produces<MEtoEDM<TH2F>, edm::InRun>(sName);
-  produces<MEtoEDM<TH2S>, edm::InRun>(sName);
-  produces<MEtoEDM<TH2D>, edm::InRun>(sName);
-  produces<MEtoEDM<TH3F>, edm::InRun>(sName);
-  produces<MEtoEDM<TProfile>, edm::InRun>(sName);
-  produces<MEtoEDM<TProfile2D>, edm::InRun>(sName);
-  produces<MEtoEDM<double>, edm::InRun>(sName);
-  produces<MEtoEDM<long long>, edm::InRun>(sName);
-  produces<MEtoEDM<TString>, edm::InRun>(sName);
+  produces<MEtoEDM<TH1F>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TH1S>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TH1D>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TH2F>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TH2S>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TH2D>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TH3F>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TProfile>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TProfile2D>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<double>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<long long>, edm::Transition::EndRun>(sName);
+  produces<MEtoEDM<TString>, edm::Transition::EndRun>(sName);
 
   sName = fName + "Lumi";
-  produces<MEtoEDM<TH1F>, edm::InLumi>(sName);
-  produces<MEtoEDM<TH1S>, edm::InLumi>(sName);
-  produces<MEtoEDM<TH1D>, edm::InLumi>(sName);
-  produces<MEtoEDM<TH2F>, edm::InLumi>(sName);
-  produces<MEtoEDM<TH2S>, edm::InLumi>(sName);
-  produces<MEtoEDM<TH2D>, edm::InLumi>(sName);
-  produces<MEtoEDM<TH3F>, edm::InLumi>(sName);
-  produces<MEtoEDM<TProfile>, edm::InLumi>(sName);
-  produces<MEtoEDM<TProfile2D>, edm::InLumi>(sName);
-  produces<MEtoEDM<double>, edm::InLumi>(sName);
-  produces<MEtoEDM<long long>, edm::InLumi>(sName);
-  produces<MEtoEDM<TString>, edm::InLumi>(sName);
+  produces<MEtoEDM<TH1F>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TH1S>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TH1D>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TH2F>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TH2S>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TH2D>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TH3F>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TProfile>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TProfile2D>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<double>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<long long>, edm::Transition::EndLuminosityBlock>(sName);
+  produces<MEtoEDM<TString>, edm::Transition::EndLuminosityBlock>(sName);
 
   iCount.clear();
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/src/ConditionDumperInEdm.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/ConditionDumperInEdm.cc
@@ -20,9 +20,9 @@ ConditionDumperInEdm::ConditionDumperInEdm(const edm::ParameterSet& iConfig)
 
 
   //per LUMI products
-  produces<edm::ConditionsInLumiBlock,edm::InLumi>();
+  produces<edm::ConditionsInLumiBlock,edm::Transition::EndLuminosityBlock>();
   //per RUN products
-  produces<edm::ConditionsInRunBlock,edm::InRun>();
+  produces<edm::ConditionsInRunBlock,edm::Transition::EndRun>();
   //per EVENT products
   produces<edm::ConditionsInEventBlock>();
 

--- a/GeneratorInterface/BeamHaloGenerator/src/BeamHaloProducer.cc
+++ b/GeneratorInterface/BeamHaloGenerator/src/BeamHaloProducer.cc
@@ -85,7 +85,7 @@ BeamHaloProducer::BeamHaloProducer( const ParameterSet & pset) :
 
   produces<HepMCProduct>("unsmeared");
   produces<GenEventInfoProduct>();
-  produces<GenRunInfoProduct, InRun>();
+  produces<GenRunInfoProduct, Transition::EndRun>();
 
   usesResource("BeamHaloProducer");
 

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -114,9 +114,9 @@ namespace edm
 
     produces<edm::HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
-    produces<GenLumiInfoHeader, edm::InLumi>();
-    produces<GenLumiInfoProduct, edm::InLumi>();
-    produces<GenRunInfoProduct, edm::InRun>();
+    produces<GenLumiInfoHeader, edm::Transtion::BeginLuminosityBlock>();
+    produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>();
+    produces<GenRunInfoProduct, edm::Transition::EndRun>();
  
   }
 

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -114,7 +114,7 @@ namespace edm
 
     produces<edm::HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
-    produces<GenLumiInfoHeader, edm::Transtion::BeginLuminosityBlock>();
+    produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>();
     produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>();
     produces<GenRunInfoProduct, edm::Transition::EndRun>();
  

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -161,11 +161,11 @@ namespace edm
 
     produces<edm::HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
-    produces<GenLumiInfoHeader, edm::InLumi>();
-    produces<GenLumiInfoProduct, edm::InLumi>();
-    produces<GenRunInfoProduct, edm::InRun>();
+    produces<GenLumiInfoHeader, edm::Transtion::BeginLuminosityBlock>();
+    produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>();
+    produces<GenRunInfoProduct, edm::Transition::EndRun>();
     if(filter_)
-      produces<GenFilterInfo, edm::InLumi>(); 
+      produces<GenFilterInfo, edm::Transition::EndLuminosityBlock>(); 
   }
 
   template <class HAD, class DEC>

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -161,7 +161,7 @@ namespace edm
 
     produces<edm::HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
-    produces<GenLumiInfoHeader, edm::Transtion::BeginLuminosityBlock>();
+    produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>();
     produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>();
     produces<GenRunInfoProduct, edm::Transition::EndRun>();
     if(filter_)

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyProducer.cc
@@ -105,7 +105,7 @@ GenFilterEfficiencyProducer::GenFilterEfficiencyProducer(const edm::ParameterSet
 
   triggerResultsToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults","",thisProcess));
   genEventInfoToken_ = consumes<GenEventInfoProduct>(edm::InputTag("generator",""));
-  produces<GenFilterInfo, edm::InLumi>(); 
+  produces<GenFilterInfo, edm::Transition::EndLuminosityBlock>(); 
 
   
 }

--- a/GeneratorInterface/CosmicMuonGenerator/src/CosMuoGenProducer.cc
+++ b/GeneratorInterface/CosmicMuonGenerator/src/CosMuoGenProducer.cc
@@ -93,7 +93,7 @@ edm::CosMuoGenProducer::CosMuoGenProducer( const ParameterSet & pset ) :
     CosMuoGen->setAcptAllMu(AllMu);
     produces<HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
-    produces<GenRunInfoProduct, edm::InRun>();
+    produces<GenRunInfoProduct, edm::Transition::EndRun>();
   }
 
 edm::CosMuoGenProducer::~CosMuoGenProducer(){

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -133,10 +133,10 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
 {
   if (npars_ != args_.size())
     throw cms::Exception("ExternalLHEProducer") << "Problem with configuration: " << args_.size() << " script arguments given, expected " << npars_;
-  produces<LHEXMLStringProduct, edm::InRun>("LHEScriptOutput"); 
+  produces<LHEXMLStringProduct, edm::Transition::BeginRun>("LHEScriptOutput"); 
 
   produces<LHEEventProduct>();
-  produces<LHERunInfoProduct, edm::InRun>();
+  produces<LHERunInfoProduct, edm::Transition::EndRun>();
 }
 
 

--- a/GeneratorInterface/TauolaInterface/interface/TauSpinnerCMS.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauSpinnerCMS.h
@@ -46,20 +46,14 @@
 
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 
-class TauSpinnerCMS : public edm::one::EDProducer<edm::EndRunProducer,edm::one::SharedResources>{
+class TauSpinnerCMS : public edm::one::EDProducer<edm::one::SharedResources>{
 public:
   explicit TauSpinnerCMS( const edm::ParameterSet& ) ;
   virtual ~TauSpinnerCMS(){}; // no need to delete ROOT stuff
 
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&){}
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {};
-  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {};
-  virtual void endRunProduce(edm::Run&, edm::EventSetup const&) override{};
   virtual void produce( edm::Event&, const edm::EventSetup&) override final;
   virtual void beginJob() override final;
-  virtual void endRun( const edm::Run&, const edm::EventSetup& ){};
   virtual void endJob() override final;
-  virtual void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup){};
   static double flat();
   void setRandomEngine(CLHEP::HepRandomEngine* v) { fRandomEngine = v; }
   virtual void initialize();

--- a/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
@@ -77,9 +77,9 @@ HLTPrescaleRecorder::HLTPrescaleRecorder(const edm::ParameterSet& ps) :
     LogError("HLTPrescaleRecorder")<<"PoolDBOutputService requested as destination but unavailable!";
   }
 
-  if (run_)   produces<HLTPrescaleTable,edm::InRun>("Run");
-  if (lumi_)  produces<HLTPrescaleTable,edm::InLumi>("Lumi");
-  if (event_) produces<HLTPrescaleTable,edm::InEvent>("Event");
+  if (run_)   produces<HLTPrescaleTable,edm::Transition::EndRun>("Run");
+  if (lumi_)  produces<HLTPrescaleTable,edm::Transition::EndLuminosityBlock>("Lumi");
+  if (event_) produces<HLTPrescaleTable,edm::Transition::Event>("Event");
 
 }
 

--- a/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
@@ -75,7 +75,7 @@ BaseFlatGunProducer::BaseFlatGunProducer( const ParameterSet& pset ) :
 
    fAddAntiParticle = pset.getParameter<bool>("AddAntiParticle") ;
 
-   produces<GenRunInfoProduct, InRun>();
+   produces<GenRunInfoProduct, Transition::EndRun>();
 }
 
 BaseFlatGunProducer::~BaseFlatGunProducer()

--- a/IOMC/ParticleGuns/src/BaseRandomtXiGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseRandomtXiGunProducer.cc
@@ -60,7 +60,7 @@ BaseRandomtXiGunProducer::BaseRandomtXiGunProducer( const edm::ParameterSet& pse
    fFireBackward = pset.getParameter<bool>("FireBackward") ;
    fFireForward  = pset.getParameter<bool>("FireForward") ;
 
-   produces<GenRunInfoProduct, InRun>();
+   produces<GenRunInfoProduct, Transition::EndRun>();
 }
 
 BaseRandomtXiGunProducer::~BaseRandomtXiGunProducer()

--- a/IOMC/ParticleGuns/src/FlatBaseThetaGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatBaseThetaGunProducer.cc
@@ -40,7 +40,7 @@ FlatBaseThetaGunProducer::FlatBaseThetaGunProducer(const edm::ParameterSet& pset
          "require it.";
   }
 
-  produces<GenRunInfoProduct, InRun>();
+  produces<GenRunInfoProduct, Transition::EndRun>();
 }
 
 FlatBaseThetaGunProducer::~FlatBaseThetaGunProducer() {

--- a/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiProducer.cc
@@ -246,9 +246,9 @@ LumiProducer::
 LumiProducer::LumiProducer(const edm::ParameterSet& iConfig):m_cachedrun(0),m_isNullRun(false),m_cachesize(0)
 {
   // register your products
-  produces<LumiSummaryRunHeader, edm::InRun>();
-  produces<LumiSummary, edm::InLumi>();
-  produces<LumiDetails, edm::InLumi>();
+  produces<LumiSummaryRunHeader, edm::Transition::EndRun>();
+  produces<LumiSummary, edm::Transition::BeginLuminosityBlock>();
+  produces<LumiDetails, edm::Transition::BeginLuminosityBlock>();
   // set up cache
   std::string connectStr=iConfig.getParameter<std::string>("connect");
   m_cachesize=iConfig.getUntrackedParameter<unsigned int>("ncacheEntries",5);

--- a/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/EmbeddingLHEProducer.cc
@@ -119,7 +119,7 @@ EmbeddingLHEProducer::EmbeddingLHEProducer(const edm::ParameterSet& iConfig)
 {
    //register your products
    produces<LHEEventProduct>();
-   produces<LHERunInfoProduct, edm::InRun>();
+   produces<LHERunInfoProduct, edm::Transition::EndRun>();
    produces<math::XYZTLorentzVectorD>("vertexPosition");
 
    muonsCollection_ = consumes<edm::View<pat::Muon>>(iConfig.getParameter<edm::InputTag>("src"));

--- a/Validation/GlobalHits/src/GlobalHitsProdHist.cc
+++ b/Validation/GlobalHits/src/GlobalHitsProdHist.cc
@@ -606,7 +606,7 @@ GlobalHitsProdHist::GlobalHitsProdHist(const edm::ParameterSet& iPSet) :
 
   // create persistent objects
   for (std::size_t i = 0; i < histName_.size(); ++i) {
-    produces<TH1F, edm::InRun>(histName_[i]).setBranchAlias(histName_[i]);
+    produces<TH1F, edm::Transition::EndRun>(histName_[i]).setBranchAlias(histName_[i]);
   }
 }
 


### PR DESCRIPTION
All modules which produce on end Run or end LuminosityBlock now explicitly call produces with that information. This is needed to properly schedule modules in upcoming framework changes.
