### PR TITLE
Initial commit for 91X for pixel phase 1 validation code for master branch

### DIFF
--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -37,6 +37,7 @@ from Validation.RPCRecHits.rpcRecHitValidation_cfi import *
 from Validation.DTRecHits.DTRecHitQuality_cfi import *
 from Validation.RecoTau.DQMMCValidation_cfi import *
 from Validation.L1T.L1Validator_cfi import *
+from Validation.SiPixelPhase1ConfigV.SiPixelPhase1OfflineDQM_sourceV_cff import *
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 from Validation.RecoB.BDHadronTrackValidation_cff import *
 
@@ -173,7 +174,12 @@ _run3_globalValidation += gemSimValid
 _phase2_globalValidation = _run3_globalValidation.copy()
 _phase2_globalValidation += me0SimValid
 
+_phase_1_globalValidation = globalValidation.copy()
+_phase_1_globalValidation += siPixelPhase1OfflineDQM_sourceV
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( globalValidation, _run3_globalValidation )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( globalValidation, _phase2_globalValidation )
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toReplaceWith( globalValidation, _phase_1_globalValidation )

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -63,6 +63,7 @@ from Validation.MuonGEMDigis.PostProcessor_cff import *
 from Validation.MuonGEMRecHits.PostProcessor_cff import *
 from Validation.MuonME0Validation.PostProcessor_cff import *
 from Validation.HGCalValidation.HGCalPostProcessor_cff import *
+from Validation.SiPixelPhase1ConfigV.SiPixelPhase1OfflineDQM_harvestingV_cff import *
 
 postValidation_common = cms.Sequence()
 
@@ -114,7 +115,12 @@ _phase2_postValidation += hgcalPostProcessor
 _phase2_postValidation += MuonME0DigisPostProcessors
 _phase2_postValidation += MuonME0SegPostProcessors
 
+_phase1_postValidation = postValidation.copy()
+_phase1_postValidation += siPixelPhase1OfflineDQM_harvestingV
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( postValidation, _run3_postValidation )
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith( postValidation, _phase2_postValidation )
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toReplaceWith( postValidation, _phase1_postValidation )

--- a/Validation/Configuration/python/trackerSimValid_cff.py
+++ b/Validation/Configuration/python/trackerSimValid_cff.py
@@ -7,4 +7,11 @@ from Validation.TrackerDigis.trackerDigisValidation_cff import *
 from Validation.TrackerRecHits.trackerRecHitsValidation_cff import *
 from Validation.TrackingMCTruth.trackingTruthValidation_cfi import *
 from Validation.RecoTrack.SiTrackingRecHitsValid_cff import *
+from Validation.SiPixelPhase1ConfigV.SiPixelPhase1OfflineDQM_sourceV_cff import *
+
 trackerSimValid = cms.Sequence(trackerHitsValidation+trackerDigisValidation+trackerRecHitsValidation+trackingTruthValid+trackingRecHitsValid)
+trackPhase1SimValid = cms.Sequence(siPixelPhase1OfflineDQM_sourceV)
+
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toReplaceWith( trackerSimValid, trackPhase1SimValid )
+

--- a/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_harvestingV_cff.py
+++ b/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_harvestingV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+from  Validation.SiPixelPhase1ConfigV.SiPixelPhase1OfflineDQM_sourceV_cff import *
+
+siPixelPhase1OfflineDQM_harvestingV = cms.Sequence(SiPixelPhase1DigisHarvesterV
+                                                + SiPixelPhase1RecHitsHarvesterV
+                                                + SiPixelPhase1HitsHarvesterV
+                                                + SiPixelPhase1RecHitsHarvesterV
+                                                + SiPixelPhase1TrackClustersHarvesterV
+					        + SiPixelPhase1TrackingParticleHarvesterV
+                                                )
+

--- a/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
+++ b/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+# Pixel Digi Monitoring
+from Validation.SiPixelPhase1DigisV.SiPixelPhase1DigisV_cfi import *
+# Hits
+from Validation.SiPixelPhase1HitsV.SiPixelPhase1HitsV_cfi import *
+# RecHit (clusters)
+from Validation.SiPixelPhase1RecHitsV.SiPixelPhase1RecHitsV_cfi import *
+# Clusters ontrack/offtrack (also general tracks)
+from Validation.SiPixelPhase1TrackClustersV.SiPixelPhase1TrackClustersV_cfi import *
+# Tracking Truth MC
+from Validation.SiPixelPhase1TrackingParticleV.SiPixelPhase1TrackingParticleV_cfi import *
+
+PerModule.enabled = False
+
+siPixelPhase1OfflineDQM_sourceV = cms.Sequence(SiPixelPhase1DigisAnalyzerV
+                                            + SiPixelPhase1HitsAnalyzerV
+                                            + SiPixelPhase1RecHitsAnalyzerV
+                                            + SiPixelPhase1TrackClustersAnalyzerV
+					    + SiPixelPhase1TrackingParticleAnalyzerV
+                                            )
+

--- a/Validation/SiPixelPhase1DigisV/BuildFile.xml
+++ b/Validation/SiPixelPhase1DigisV/BuildFile.xml
@@ -1,0 +1,3 @@
+<use   name="DQMServices/Core"/>
+<use   name="DQM/SiPixelPhase1Common"/>
+<flags   EDM_PLUGIN="1"/>

--- a/Validation/SiPixelPhase1DigisV/interface/SiPixelPhase1DigisV.h
+++ b/Validation/SiPixelPhase1DigisV/interface/SiPixelPhase1DigisV.h
@@ -1,0 +1,54 @@
+#ifndef SiPixelPhase1DigisV_h // Can we use #pragma once?
+#define SiPixelPhase1DigisV_h
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1DigisV
+// Class  :     SiPixelPhase1DigisV
+// 
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+// Input data stuff
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+
+// PixelDQM Framework
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+
+class SiPixelPhase1DigisV : public SiPixelPhase1Base {
+  // List of quantities to be plotted. 
+  enum {
+    ADC, // digi ADC readouts
+    NDIGIS, // number of digis per event and module
+    ROW, // number of digis per row
+    COLUMN, // number of digis per column
+
+    MAX_HIST // a sentinel that gives the number of quantities (not a plot).
+  };
+  public:
+  explicit SiPixelPhase1DigisV(const edm::ParameterSet& conf);
+
+  void analyze(const edm::Event&, const edm::EventSetup&) ;
+
+  private:
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> srcToken_;
+
+};
+
+class SiPixelPhase1DigisHarvesterV : public SiPixelPhase1Harvester {
+  enum {
+    ADC, // digi ADC readouts
+    NDIGIS, // number of digis per event and module
+    ROW, // number of digis per row
+    COLUMN, // number of digis per column
+
+    MAX_HIST
+  };
+  public:
+  explicit SiPixelPhase1DigisHarvesterV(const edm::ParameterSet& conf);
+
+};
+
+#endif
+

--- a/Validation/SiPixelPhase1DigisV/python/SiPixelPhase1DigisV_cfi.py
+++ b/Validation/SiPixelPhase1DigisV/python/SiPixelPhase1DigisV_cfi.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+# this might also go into te Common config,as we do not reference it
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+SiPixelPhase1DigisADC = DefaultHisto.clone(
+  name = "adc",
+  title = "Digi ADC values",
+  xlabel = "ADC counts",
+  range_min = 0,
+  range_max = 300,
+  range_nbins = 300,
+  topFolderName = "PixelPhase1V/Digis",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save()
+  )
+)
+
+SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
+  name = "digis", # 'Count of' added automatically
+  title = "Digis",
+  xlabel = "Number of Digis",
+  range_min = 0,
+  range_max = 30,
+  range_nbins = 30,
+  dimensions = 0, # this is a count
+  topFolderName = "PixelPhase1V/Digis",
+  specs = VPSet(
+    Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/PXLadder/PXModuleName/Event")
+                            .reduce("COUNT")
+                            .groupBy("PXBarrel/Shell/PXLayer/PXLadder/PXModuleName")
+                            .save(),
+    Specification(PerModule).groupBy("PXForward/HalfCylinder/PXDisk/PXRing/PXBlade/PXModuleName/Event")
+                            .reduce("COUNT")
+                            .groupBy("PXForward/HalfCylinder/PXDisk/PXRing/PXBlade/PXModuleName")
+                            .save(),
+  )
+)
+
+SiPixelPhase1DigisRows = DefaultHisto.clone(
+  name = "row",
+  title = "Digi Rows",
+  xlabel = "Row",
+  range_min = 0,
+  range_max = 200,
+  range_nbins = 200,
+  topFolderName = "PixelPhase1V/Digis",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save()
+  )
+)
+
+SiPixelPhase1DigisColumns = DefaultHisto.clone(
+  name = "column",
+  title = "Digi Columns",
+  xlabel = "Column",
+  range_min = 0,
+  range_max = 300,
+  range_nbins = 300,
+  topFolderName = "PixelPhase1V/Digis",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save()
+ )
+)
+
+# This has to match the order of the names in the C++ enum.
+SiPixelPhase1DigisConf = cms.VPSet(
+  SiPixelPhase1DigisADC,
+  SiPixelPhase1DigisNdigis,
+  SiPixelPhase1DigisRows,
+  SiPixelPhase1DigisColumns,
+)
+
+SiPixelPhase1DigisAnalyzerV = cms.EDAnalyzer("SiPixelPhase1DigisV",
+        src = cms.InputTag("simSiPixelDigis"), 
+        histograms = SiPixelPhase1DigisConf,
+        geometry = SiPixelPhase1Geometry
+)
+
+SiPixelPhase1DigisHarvesterV = cms.EDAnalyzer("SiPixelPhase1DigisHarvesterV",
+        histograms = SiPixelPhase1DigisConf,
+        geometry = SiPixelPhase1Geometry
+)
+

--- a/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisHarvesterV.cc
+++ b/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisHarvesterV.cc
@@ -1,0 +1,18 @@
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1DigisHarvesterV
+// Class:       SiPixelPhase1DigisHarvesterV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "Validation/SiPixelPhase1DigisV/interface/SiPixelPhase1DigisV.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+SiPixelPhase1DigisHarvesterV::SiPixelPhase1DigisHarvesterV(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Harvester(iConfig) 
+{}
+
+DEFINE_FWK_MODULE(SiPixelPhase1DigisHarvesterV);
+

--- a/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisV.cc
+++ b/Validation/SiPixelPhase1DigisV/src/SiPixelPhase1DigisV.cc
@@ -1,0 +1,48 @@
+// -*- C++ -*-
+//
+// Package:    SiPixelPhase1DigisV
+// Class:      SiPixelPhase1DigisV
+//
+
+// Original Author: Marcel Schneider
+
+#include "Validation/SiPixelPhase1DigisV/interface/SiPixelPhase1DigisV.h"
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+// C++ stuff
+#include <iostream>
+
+// CMSSW stuff
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+// DQM Stuff
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+SiPixelPhase1DigisV::SiPixelPhase1DigisV(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Base(iConfig)
+{
+  srcToken_ = consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("src"));
+} 
+
+void SiPixelPhase1DigisV::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  edm::Handle<edm::DetSetVector<PixelDigi>> input;
+  iEvent.getByToken(srcToken_, input);
+  if (!input.isValid()) return; 
+
+  edm::DetSetVector<PixelDigi>::const_iterator it;
+  for (it = input->begin(); it != input->end(); ++it) {
+    for(PixelDigi const& digi : *it) {
+      histo[ADC].fill((double) digi.adc(), DetId(it->detId()), &iEvent);
+      histo[NDIGIS    ].fill(DetId(it->detId()), &iEvent); // count
+      histo[ROW].fill((double) digi.row(), DetId(it->detId()), &iEvent);
+      histo[COLUMN].fill((double) digi.column(), DetId(it->detId()), &iEvent);
+    }
+  }
+  histo[NDIGIS    ].executePerEventHarvesting(&iEvent);
+}
+
+DEFINE_FWK_MODULE(SiPixelPhase1DigisV);
+

--- a/Validation/SiPixelPhase1HitsV/BuildFile.xml
+++ b/Validation/SiPixelPhase1HitsV/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="DQM/SiPixelPhase1Common"/>
+<use   name="DataFormats/TrackerRecHit2D"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
+<use   name="DataFormats/TrackReco"/>
+<flags   EDM_PLUGIN="1"/>
+

--- a/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
+++ b/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
@@ -1,0 +1,58 @@
+#ifndef SiPixelPhase1HitsV_h 
+#define SiPixelPhase1HitsV_h 
+// -*- C++ -*-
+// 
+// Package:     SiPixelPhase1HitsV
+// Class  :     SiPixelPhase1HitsV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+
+namespace reco {
+  class TrackToTrackingParticleAssociator;
+}
+
+class SiPixelPhase1HitsV : public SiPixelPhase1Base {
+  enum {
+    ELOSS,
+    ENTRY_EXIT_X,
+    ENTRY_EXIT_Y,
+    ENTRY_EXIT_Z,
+    LOCAL_X,
+    LOCAL_Y,
+    LOCAL_Z,
+    LOCAL_PHI,
+    LOCAL_ETA,
+//    EFFICIENCY_HIT
+    EFFICIENCY_TRACK,
+    EFFICIENCY_TRACK_PT,
+    EFFICIENCY_TRACK_ETA
+  };
+
+  public:
+  explicit SiPixelPhase1HitsV(const edm::ParameterSet& conf);
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+  private:
+  edm::EDGetTokenT<edm::PSimHitContainer> pixelBarrelLowToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> pixelBarrelHighToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> pixelForwardLowToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> pixelForwardHighToken_;
+
+  edm::EDGetTokenT< edm::View<reco::Track> > tracksToken_;
+  edm::EDGetTokenT< TrackingParticleCollection > tpToken_;
+  edm::EDGetTokenT< edm::SimTrackContainer > simTracksToken_;
+  edm::EDGetTokenT< reco::TrackToTrackingParticleAssociator > trackAssociatorByHitsToken_;
+  reco::TrackToTrackingParticleAssociator const * associatorByHits;
+  edm::SimTrackContainer const * simTC;
+
+};
+
+#endif
+

--- a/Validation/SiPixelPhase1HitsV/python/SiPixelPhase1HitsV_cfi.py
+++ b/Validation/SiPixelPhase1HitsV/python/SiPixelPhase1HitsV_cfi.py
@@ -1,0 +1,163 @@
+import FWCore.ParameterSet.Config as cms
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+SiPixelPhase1HitsEnergyLoss = DefaultHisto.clone(
+  name = "eloss",
+  title = "Energy loss",
+  range_min = 0, range_max = 0.001, range_nbins = 10000,
+  xlabel = "Energy Loss",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/Hits",
+  specs = VPSet(
+   Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+   Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1HitsEntryExitX = DefaultHisto.clone(
+  name = "entry_exit_x",
+  title = "Entryx-Exitx",
+  range_min = -0.03, range_max = 0.03, range_nbins = 10000,
+  xlabel = "",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/Hits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1HitsEntryExitY = SiPixelPhase1HitsEntryExitX.clone(
+  name = "entry_exit_y",
+  title = "Entryy-Exity",
+  xlabel = "",
+  range_min = -0.03, range_max = 0.03, range_nbins = 10000,
+)
+
+SiPixelPhase1HitsEntryExitZ = SiPixelPhase1HitsEntryExitX.clone(
+  name = "entry_exit_z",
+  title = "Entryz-Exitz",
+  xlabel = "",
+  range_min = 0.0, range_max = 0.05, range_nbins = 10000,
+)
+
+SiPixelPhase1HitsPosX = DefaultHisto.clone(
+  name = "local_x",
+  title = "X position of Hits",
+  range_min = -3.5, range_max = 3.5, range_nbins = 10000,
+  xlabel = "Hit position X dimension",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/Hits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1HitsPosY = SiPixelPhase1HitsPosX.clone(
+  name = "local_y",
+  title = "Y position of Hits",
+  xlabel = "Hit position Y dimension",
+  range_min = -3.5, range_max = 3.5, range_nbins = 10000,
+)
+
+SiPixelPhase1HitsPosZ = SiPixelPhase1HitsPosX.clone(
+  name = "local_z",
+  title = "Z position of Hits",
+  xlabel = "Hit position Z dimension",
+  range_min = -0.05, range_max = 0.05, range_nbins = 500,
+)
+
+SiPixelPhase1HitsPosPhi = SiPixelPhase1HitsPosX.clone(
+  name = "local_phi",
+  title = "Phi position of Hits",
+  xlabel = "Hit position phi dimension",
+  range_min = -3.5, range_max = 3.5, range_nbins = 10000,
+)
+
+SiPixelPhase1HitsPosEta = SiPixelPhase1HitsPosX.clone(
+  name = "local_eta",
+  title = "Eta position of Hits",
+  xlabel = "Hit position Eta dimension",
+  range_min = -0.1, range_max = 0.1, range_nbins = 1000,
+)
+
+SiPixelPhase1HitsEfficiencyTrack = DefaultHistoTrack.clone(
+  name = "trackefficiency",
+  title = "Track Efficiency (by hits)",
+  xlabel = "#valid/(#valid+#missing)",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/Hits",
+  specs = VPSet(
+    StandardSpecification2DProfile,
+  )
+)
+
+SiPixelPhase1HitsEfficiencyTrackPt = DefaultHistoTrack.clone(
+  name = "trackefficiencypt",
+  title = "Track Efficiency (by hits) vs Pt",
+  xlabel = "pT",
+  dimensions = 1,
+#  range_min = -0.1, range_max = 100.0, range_nbins = 100,
+  topFolderName = "PixelPhase1V/Hits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel")
+                   .reduce("Mean")
+                   .save(),
+    Specification().groupBy("PXForward")
+                   .reduce("Mean")
+                   .save(),
+  )
+)
+
+SiPixelPhase1HitsEfficiencyTrackEta = SiPixelPhase1HitsEfficiencyTrackPt.clone(
+  name = "trackefficiencyeta",
+  title = "Track Efficiency (by hits) vs eta",
+  xlabel = "eta",
+  range_min = -7.1, range_max = 7.1, range_nbins = 100,
+)
+
+SiPixelPhase1HitsConf = cms.VPSet(
+  SiPixelPhase1HitsEnergyLoss,
+  SiPixelPhase1HitsEntryExitX,
+  SiPixelPhase1HitsEntryExitY,
+  SiPixelPhase1HitsEntryExitZ,
+  SiPixelPhase1HitsPosX,
+  SiPixelPhase1HitsPosY,
+  SiPixelPhase1HitsPosZ,
+  SiPixelPhase1HitsPosPhi,
+  SiPixelPhase1HitsPosEta,
+#  SiPixelPhase1HitsEfficiencyHit,
+  SiPixelPhase1HitsEfficiencyTrack,
+  SiPixelPhase1HitsEfficiencyTrackPt,
+  SiPixelPhase1HitsEfficiencyTrackEta,
+)
+
+SiPixelPhase1HitsAnalyzerV = cms.EDAnalyzer("SiPixelPhase1HitsV",
+        pixBarrelLowSrc = cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+        pixBarrelHighSrc = cms.InputTag("g4SimHits","TrackerHitsPixelBarrelHighTof"),
+        pixForwardLowSrc = cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"),
+        pixForwardHighSrc = cms.InputTag("g4SimHits","TrackerHitsPixelEndcapHighTof"),
+
+	# Hit Efficiency stuff
+        associateRecoTracks = cms.bool(True),
+        tracksTag = cms.InputTag("generalTracks"),
+	tpTag = cms.InputTag("mix","MergedTrackTruth"),
+        simTracksTag = cms.InputTag("g4SimHits",""),
+        trackAssociatorByHitsTag = cms.InputTag("trackAssociatorByHits"),
+        associateStrip = cms.bool(True),
+        associatePixel = cms.bool(True),
+        ROUList = cms.vstring('g4SimHitsTrackerHitsPixelBarrelLowTof', 
+          'g4SimHitsTrackerHitsPixelBarrelHighTof', 
+          'g4SimHitsTrackerHitsPixelEndcapLowTof', 
+          'g4SimHitsTrackerHitsPixelEndcapHighTof'),
+
+        # Track assoc. parameters
+        histograms = SiPixelPhase1HitsConf,
+        geometry = SiPixelPhase1Geometry
+)
+
+SiPixelPhase1HitsHarvesterV = cms.EDAnalyzer("SiPixelPhase1Harvester",
+        histograms = SiPixelPhase1HitsConf,
+        geometry = SiPixelPhase1Geometry
+)

--- a/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
+++ b/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
@@ -1,0 +1,216 @@
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1HitsV
+// Class:       SiPixelPhase1HitsV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+class TrackAssociatorByHits; 
+
+SiPixelPhase1HitsV::SiPixelPhase1HitsV(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Base(iConfig),
+  pixelBarrelLowToken_ ( consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixBarrelLowSrc")) ),
+  pixelBarrelHighToken_ ( consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixBarrelHighSrc")) ),
+  pixelForwardLowToken_ ( consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixForwardLowSrc")) ),
+  pixelForwardHighToken_ ( consumes<edm::PSimHitContainer>(iConfig.getParameter<edm::InputTag>("pixForwardHighSrc")) ),
+
+  tracksToken_ ( consumes< edm::View<reco::Track> >(iConfig.getParameter<edm::InputTag>("tracksTag")) ),
+  tpToken_ ( consumes< TrackingParticleCollection >(iConfig.getParameter<edm::InputTag>("tpTag")) ),
+  simTracksToken_ ( consumes< edm::SimTrackContainer >(iConfig.getParameter<edm::InputTag>("simTracksTag")) ),
+  trackAssociatorByHitsToken_ ( consumes< reco::TrackToTrackingParticleAssociator >(iConfig.getParameter<edm::InputTag>("trackAssociatorByHitsTag")) )
+{}
+
+void SiPixelPhase1HitsV::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  edm::Handle<edm::PSimHitContainer> barrelLowInput;
+  iEvent.getByToken(pixelBarrelLowToken_, barrelLowInput);
+  if (!barrelLowInput.isValid()) return;
+
+  edm::Handle<edm::PSimHitContainer> barrelHighInput;
+  iEvent.getByToken(pixelBarrelHighToken_, barrelHighInput);
+  if (!barrelHighInput.isValid()) return;
+
+  edm::Handle<edm::PSimHitContainer> forwardLowInput;
+  iEvent.getByToken(pixelForwardLowToken_, forwardLowInput);
+  if (!forwardLowInput.isValid()) return;
+
+  edm::Handle<edm::PSimHitContainer> forwardHighInput;
+  iEvent.getByToken(pixelForwardHighToken_, forwardHighInput);
+  if (!forwardHighInput.isValid()) return;
+
+  edm::PSimHitContainer::const_iterator it;
+
+  // get low barrel info
+  for (it = barrelLowInput->begin(); it != barrelLowInput->end(); ++it) {
+    auto id = DetId(it->detUnitId());
+
+    float energyLoss = it->energyLoss();
+
+    float entryExitX = ( it->entryPoint().x() - it->exitPoint().x() );
+    float entryExitY = ( it->entryPoint().y() - it->exitPoint().y() );
+    float entryExitZ = std::abs( it->entryPoint().z() - it->exitPoint().z() );
+
+    float localX = it->localPosition().x();
+    float localY = it->localPosition().y();
+    float localZ = it->localPosition().z();
+    float localPhi = it->localPosition().phi();
+    float localEta = it->localPosition().eta();
+
+    histo[ELOSS].fill(energyLoss, id, &iEvent);
+    histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
+    histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
+    histo[ENTRY_EXIT_Z].fill(entryExitZ, id, &iEvent);
+    histo[LOCAL_X].fill(localX, id, &iEvent);
+    histo[LOCAL_Y].fill(localY,  id, &iEvent);
+    histo[LOCAL_Z].fill(localZ,  id, &iEvent);
+    histo[LOCAL_PHI].fill(localPhi,  id, &iEvent);
+    histo[LOCAL_ETA].fill(localEta,  id, &iEvent);
+  } 
+  // get high barrel info
+  for (it = barrelHighInput->begin(); it != barrelHighInput->end(); ++it) {
+    auto id = DetId(it->detUnitId());
+
+    float energyLoss = it->energyLoss();
+
+    float entryExitX = ( it->entryPoint().x() - it->exitPoint().x() );
+    float entryExitY = ( it->entryPoint().y() - it->exitPoint().y() );
+    float entryExitZ = std::abs( it->entryPoint().z() - it->exitPoint().z() );
+
+    float localX = it->localPosition().x();
+    float localY = it->localPosition().y();
+    float localZ = it->localPosition().z();
+    float localPhi = it->localPosition().phi();
+    float localEta = it->localPosition().eta();
+
+    histo[ELOSS].fill(energyLoss, id, &iEvent);
+    histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
+    histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
+    histo[ENTRY_EXIT_Z].fill(entryExitZ, id, &iEvent);
+    histo[LOCAL_X].fill(localX, id, &iEvent);
+    histo[LOCAL_Y].fill(localY, id, &iEvent);
+    histo[LOCAL_Z].fill(localZ,  id, &iEvent);
+    histo[LOCAL_PHI].fill(localPhi,  id, &iEvent);
+    histo[LOCAL_ETA].fill(localEta,  id, &iEvent);
+  }
+
+  // get low forward info
+  for (it = forwardLowInput->begin(); it != forwardLowInput->end(); ++it) {
+    auto id = DetId(it->detUnitId());
+
+    float energyLoss = it->energyLoss();
+
+    float entryExitX = ( it->entryPoint().x() - it->exitPoint().x() );
+    float entryExitY = ( it->entryPoint().y() - it->exitPoint().y() );
+    float entryExitZ = std::abs( it->entryPoint().z() - it->exitPoint().z() );
+
+    float localX = it->localPosition().x();
+    float localY = it->localPosition().y();
+    float localZ = it->localPosition().z();
+    float localPhi = it->localPosition().phi();
+    float localEta = it->localPosition().eta();
+
+    histo[ELOSS].fill(energyLoss, id, &iEvent);
+    histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
+    histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
+    histo[ENTRY_EXIT_Z].fill(entryExitZ, id, &iEvent);
+    histo[LOCAL_X].fill(localX, id, &iEvent);
+    histo[LOCAL_Y].fill(localY, id, &iEvent);
+    histo[LOCAL_Z].fill(localZ,  id, &iEvent);
+    histo[LOCAL_PHI].fill(localPhi,  id, &iEvent);
+    histo[LOCAL_ETA].fill(localEta,  id, &iEvent);
+  }
+
+  // get high forward info
+  for (it = forwardHighInput->begin(); it != forwardHighInput->end(); ++it) {
+    auto id = DetId(it->detUnitId());
+
+    float energyLoss = it->energyLoss();
+
+    float entryExitX = ( it->entryPoint().x() - it->exitPoint().x() );
+    float entryExitY = ( it->entryPoint().y() - it->exitPoint().y() );
+    float entryExitZ = std::abs( it->entryPoint().z() - it->exitPoint().z() );
+
+    float localX = it->localPosition().x();
+    float localY = it->localPosition().y();
+    float localZ = it->localPosition().z();
+    float localPhi = it->localPosition().phi();
+    float localEta = it->localPosition().eta();
+
+    histo[ELOSS].fill(energyLoss, id, &iEvent);
+    histo[ENTRY_EXIT_X].fill(entryExitX, id, &iEvent);
+    histo[ENTRY_EXIT_Y].fill(entryExitY, id, &iEvent);
+    histo[ENTRY_EXIT_Z].fill(entryExitZ, id, &iEvent);
+    histo[LOCAL_X].fill(localX, id, &iEvent);
+    histo[LOCAL_Y].fill(localY, id, &iEvent);
+    histo[LOCAL_Z].fill(localZ,  id, &iEvent);
+    histo[LOCAL_PHI].fill(localPhi,  id, &iEvent);
+    histo[LOCAL_ETA].fill(localEta,  id, &iEvent);
+  }
+
+
+  // Sim Hit efficiency info
+  edm::Handle< edm::View<reco::Track> > trackCollectionH;
+  iEvent.getByToken(tracksToken_, trackCollectionH);
+  const edm::View<reco::Track>&  tC = *(trackCollectionH.product()); 
+
+  edm::Handle<TrackingParticleCollection> TPCollectionH;
+  iEvent.getByToken(tpToken_,TPCollectionH);
+
+  edm::Handle<reco::TrackToTrackingParticleAssociator> theHitsAssociator;
+  iEvent.getByToken(trackAssociatorByHitsToken_,theHitsAssociator);
+  if ( theHitsAssociator.isValid() ) {
+    associatorByHits = theHitsAssociator.product();
+  }
+
+  edm::Handle<edm::SimTrackContainer> simTrackCollection;
+  iEvent.getByToken(simTracksToken_, simTrackCollection);
+  if ( simTrackCollection.isValid() ) {
+    simTC = simTrackCollection.product();
+  }  
+
+
+
+  if ( TPCollectionH.isValid() && trackCollectionH.isValid() ) {
+    reco::RecoToSimCollection p = associatorByHits->associateRecoToSim(trackCollectionH,TPCollectionH);
+
+    for(edm::View<reco::Track>::size_type i=0; i<tC.size(); ++i) {
+      edm::RefToBase<reco::Track> track(trackCollectionH, i);
+      const reco::Track& t = *track;
+      auto id = DetId(track->innerDetId()); // histo manager requires a det ID, use innermost ID for ease
+
+      try { 
+        std::vector<std::pair<TrackingParticleRef, double> > tp = p[track];
+//        std::cout << "Reco track matched to " << tp.size() << " MC tracks." << std::endl;
+        histo[EFFICIENCY_TRACK].fill(1, id, &iEvent);
+        histo[EFFICIENCY_TRACK_PT].fill(1, t.pt(), id, &iEvent);
+        histo[EFFICIENCY_TRACK_ETA].fill(1, t.eta(), id, &iEvent);
+//        histo[EFFICIENCY_TRACK_PT].fill(t.pt(), 1, id, &iEvent);
+//        histo[EFFICIENCY_TRACK_ETA].fill(t.eta(), 1, id, &iEvent);
+      } 
+      catch (edm::Exception event) {
+        histo[EFFICIENCY_TRACK].fill(0, id, &iEvent);
+        histo[EFFICIENCY_TRACK_PT].fill(0, t.pt(), id, &iEvent);
+        histo[EFFICIENCY_TRACK_ETA].fill(0, t.eta(), id, &iEvent);
+//        histo[EFFICIENCY_TRACK_PT].fill(t.pt(), 0, id, &iEvent);
+//        histo[EFFICIENCY_TRACK_ETA].fill(t.eta(), 0, id, &iEvent);
+//        std::cout << "Reco track has not matched to at least one sim hit" << std::endl;
+      }
+    }
+
+  }
+
+}
+
+DEFINE_FWK_MODULE(SiPixelPhase1HitsV);
+

--- a/Validation/SiPixelPhase1RecHitsV/BuildFile.xml
+++ b/Validation/SiPixelPhase1RecHitsV/BuildFile.xml
@@ -1,0 +1,5 @@
+<use   name="DQM/SiPixelPhase1Common"/>
+<use   name="DataFormats/TrackerRecHit2D"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
+<flags   EDM_PLUGIN="1"/>
+

--- a/Validation/SiPixelPhase1RecHitsV/interface/SiPixelPhase1RecHitsV.h
+++ b/Validation/SiPixelPhase1RecHitsV/interface/SiPixelPhase1RecHitsV.h
@@ -1,0 +1,40 @@
+#ifndef SiPixelPhase1RecHitsV_h 
+#define SiPixelPhase1RecHitsV_h 
+// -*- C++ -*-
+// 
+// Package:     SiPixelPhase1RecHitsV
+// Class  :     SiPixelPhase1RecHitsV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+
+class SiPixelPhase1RecHitsV : public SiPixelPhase1Base {
+  enum {
+    IN_TIME_BUNCH,
+    OUT_TIME_BUNCH,
+    NSIMHITS,
+    RECHIT_X,
+    RECHIT_Y,
+    RES_X,
+    RES_Y,
+    ERROR_X,
+    ERROR_Y,
+    PULL_X,
+    PULL_Y,
+  };
+
+  public:
+  explicit SiPixelPhase1RecHitsV(const edm::ParameterSet& conf);
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+  private:
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+  edm::EDGetTokenT<SiPixelRecHitCollection> srcToken_;
+};
+
+#endif

--- a/Validation/SiPixelPhase1RecHitsV/python/SiPixelPhase1RecHitsV_cfi.py
+++ b/Validation/SiPixelPhase1RecHitsV/python/SiPixelPhase1RecHitsV_cfi.py
@@ -1,0 +1,168 @@
+import FWCore.ParameterSet.Config as cms
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+SiPixelPhase1RecHitsInTimeEvents = DefaultHisto.clone(
+  name = "in_time_bunch",
+  title = "Events (in-time bunch)",
+  range_min = 0, range_max = 10, range_nbins = 10,
+  xlabel = "number of in-time rechits events",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/RecHits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+  )
+)
+
+SiPixelPhase1RecHitsOutTimeEvents = DefaultHisto.clone(
+  name = "out_time_bunch",
+  title = "Events (out-time bunch)",
+  range_min = 0, range_max = 10, range_nbins = 10,
+  xlabel = "number of out-time rechit events",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/RecHits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+  )
+)
+
+
+SiPixelPhase1RecHitsNSimHits = DefaultHisto.clone(
+  name = "nsimhits",
+  title = "SimHits",
+  range_min = 0, range_max = 100, range_nbins = 100,
+  xlabel = "sim hit event number in event",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/RecHits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+  )
+)
+
+SiPixelPhase1RecHitsPosX = DefaultHisto.clone(
+  name = "rechit_x",
+  title = "X position of RecHits",
+  range_min = -2., range_max = 2., range_nbins = 80,
+  xlabel = "RecHit position X dimension",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/RecHits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1RecHitsPosY = SiPixelPhase1RecHitsPosX.clone(
+  name = "rechit_y",
+  title = "Y position of RecHits",
+  xlabel = "RecHit position Y dimension",
+  range_min = -4., range_max = 4., range_nbins = 80,
+)
+
+SiPixelPhase1RecHitsResX = DefaultHisto.clone(
+  name = "res_x",
+  title = "X resolution of RecHits",
+  range_min = -200., range_max = 200., range_nbins = 200,
+  xlabel = "RecHit resolution X dimension",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/RecHits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel").save(),
+    Specification().groupBy("PXForward").save(),
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1RecHitsResY = SiPixelPhase1RecHitsResX.clone(
+  name = "res_y",
+  title = "Y resolution of RecHits",
+  xlabel = "RecHit resolution Y dimension"
+)
+
+SiPixelPhase1RecHitsErrorX = DefaultHisto.clone(
+  name = "rechiterror_x",
+  title = "RecHit Error in X-direction",
+  range_min = 0, range_max = 0.02, range_nbins = 100,
+  xlabel = "X error",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/RecHits",
+  specs = VPSet(
+    Specification().groupBy("").save(),
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+  )
+)
+
+SiPixelPhase1RecHitsErrorY = SiPixelPhase1RecHitsErrorX.clone(
+  name = "rechiterror_y",
+  title = "RecHit Error in Y-direction",
+  xlabel = "Y error"
+)
+
+SiPixelPhase1RecHitsPullX = DefaultHisto.clone(
+  name = "pull_x",
+  title = "RecHit Pull in X-direction",
+  range_min = -10., range_max = 10., range_nbins = 100,
+  xlabel = "X Pull",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/RecHits",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer").save(),
+    Specification().groupBy("PXForward/PXDisk").save(),
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1RecHitsPullY = SiPixelPhase1RecHitsPullX.clone(
+  name = "pull_y",
+  title = "RecHit Pull in Y-direction",
+  xlabel = "Y Pull"
+)
+
+SiPixelPhase1RecHitsConf = cms.VPSet(
+  SiPixelPhase1RecHitsInTimeEvents,
+  SiPixelPhase1RecHitsOutTimeEvents,
+  SiPixelPhase1RecHitsNSimHits,
+  SiPixelPhase1RecHitsPosX,
+  SiPixelPhase1RecHitsPosY,
+  SiPixelPhase1RecHitsResX,
+  SiPixelPhase1RecHitsResY,
+  SiPixelPhase1RecHitsErrorX,
+  SiPixelPhase1RecHitsErrorY,
+  SiPixelPhase1RecHitsPullX,
+  SiPixelPhase1RecHitsPullY,
+)
+
+SiPixelPhase1RecHitsAnalyzerV = cms.EDAnalyzer("SiPixelPhase1RecHitsV",
+        src = cms.InputTag("siPixelRecHits"),
+        # Track assoc. parameters
+        associatePixel = cms.bool(True),
+        ROUList = cms.vstring('g4SimHitsTrackerHitsPixelBarrelLowTof', 
+            'g4SimHitsTrackerHitsPixelBarrelHighTof', 
+            'g4SimHitsTrackerHitsPixelEndcapLowTof', 
+            'g4SimHitsTrackerHitsPixelEndcapHighTof'),
+        associateStrip = cms.bool(False),
+        associateRecoTracks = cms.bool(False),
+        pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+        stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+        histograms = SiPixelPhase1RecHitsConf,
+        geometry = SiPixelPhase1Geometry
+)
+
+SiPixelPhase1RecHitsHarvesterV = cms.EDAnalyzer("SiPixelPhase1Harvester",
+        histograms = SiPixelPhase1RecHitsConf,
+        geometry = SiPixelPhase1Geometry
+)
+

--- a/Validation/SiPixelPhase1RecHitsV/src/SiPixelPhase1RecHitsV.cc
+++ b/Validation/SiPixelPhase1RecHitsV/src/SiPixelPhase1RecHitsV.cc
@@ -1,0 +1,106 @@
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1RecHitsV
+// Class:       SiPixelPhase1RecHitsV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "Validation/SiPixelPhase1RecHitsV/interface/SiPixelPhase1RecHitsV.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+SiPixelPhase1RecHitsV::SiPixelPhase1RecHitsV(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Base(iConfig),
+  trackerHitAssociatorConfig_( iConfig, consumesCollector() ),
+  srcToken_ ( consumes<SiPixelRecHitCollection>(iConfig.getParameter<edm::InputTag>("src")) )
+{}
+
+void SiPixelPhase1RecHitsV::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<SiPixelRecHitCollection> input;
+  iEvent.getByToken(srcToken_, input);
+  if (!input.isValid()) return;
+
+  TrackerHitAssociator associate(iEvent, trackerHitAssociatorConfig_);
+
+  SiPixelRecHitCollection::const_iterator it;
+  for (it = input->begin(); it != input->end(); ++it) {
+    auto id = DetId(it->detId());
+
+    for(SiPixelRecHit const& rechit : *it) {
+      SiPixelRecHit::ClusterRef const& clust = rechit.cluster();
+
+      std::vector<PSimHit> associateSimHit;
+      associateSimHit = associate.associateHit(rechit);
+      std::vector<PSimHit>::const_iterator closestIt = associateSimHit.begin();
+
+      LocalPoint lp = rechit.localPosition();
+      float rechit_x = lp.x();
+      float rechit_y = lp.y();
+      
+      LocalError lerr = rechit.localPositionError();
+      float lerr_x = sqrt(lerr.xx());
+      float lerr_y = sqrt(lerr.yy());
+
+      // loop over associated sim hits and find the closest
+      if ( !associateSimHit.empty() ) {
+      float closestSimHit = 9999.9;
+
+       for (std::vector<PSimHit>::const_iterator m = associateSimHit.begin(); m < associateSimHit.end(); m++) {
+	  float sim_x1 ( (*m).entryPoint().x() ), sim_x2 ( (*m).exitPoint().x() ), sim_xpos ( 0.5*(sim_x1+sim_x2) );
+	  float sim_y1 ( (*m).entryPoint().y() ), sim_y2 ( (*m).exitPoint().y() ), sim_ypos ( 0.5*(sim_y1+sim_y2) );
+
+          float xres ( std::abs(sim_xpos - rechit_x) ), yres ( std::abs(sim_ypos - rechit_y) );
+          float dist = std::sqrt( xres*xres + yres*yres );
+
+          if ( dist < closestSimHit ) {
+            closestSimHit = dist;
+            closestIt = m;
+          }
+        }
+      }
+
+      // Sim Hit stuff
+      const PSimHit& simHit = *closestIt;
+      int bunch = simHit.eventId().bunchCrossing();
+      int event = simHit.eventId().event();
+
+      float sim_x1 ( simHit.entryPoint().x() ), sim_x2 ( simHit.exitPoint().x() ), sim_xpos ( 0.5*(sim_x1 + sim_x2) );
+      float sim_y1 ( simHit.entryPoint().y() ), sim_y2 ( simHit.exitPoint().y() ), sim_ypos ( 0.5*(sim_y1 + sim_y2) );
+
+      float res_x = (rechit_x - sim_xpos) * 10000.0;
+      float res_y = (rechit_y - sim_ypos) * 10000.0;
+
+      float pull_x = ( rechit_x - sim_xpos ) / lerr_x;
+      float pull_y = ( rechit_y - sim_ypos ) / lerr_y;
+
+      // Now Plotting stuff
+      if ( bunch == 0 ) histo[IN_TIME_BUNCH].fill(bunch, id, &iEvent);
+      if ( bunch != 0 ) histo[OUT_TIME_BUNCH].fill(bunch, id, &iEvent);
+ 
+      histo[NSIMHITS].fill(event, id, &iEvent);
+
+      histo[RECHIT_X].fill(rechit_x, id, &iEvent);
+      histo[RECHIT_Y].fill(rechit_y, id, &iEvent);
+
+      histo[RES_X].fill(res_x, id, &iEvent);
+      histo[RES_Y].fill(res_y, id, &iEvent);
+
+      histo[ERROR_X].fill(lerr_x, id, &iEvent);
+      histo[ERROR_Y].fill(lerr_y, id, &iEvent);
+
+      histo[PULL_X].fill(pull_x, id, &iEvent);
+      histo[PULL_Y].fill(pull_y, id, &iEvent); 
+    }
+  }
+
+}
+
+DEFINE_FWK_MODULE(SiPixelPhase1RecHitsV);
+

--- a/Validation/SiPixelPhase1TrackClustersV/BuildFile.xml
+++ b/Validation/SiPixelPhase1TrackClustersV/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="DQM/SiPixelPhase1Common"/>
+<use   name="DataFormats/TrackerRecHit2D"/>
+<use   name="TrackingTools/TrackFitters"/>
+
+<flags   EDM_PLUGIN="1"/>
+

--- a/Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h
+++ b/Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h
@@ -1,0 +1,33 @@
+#ifndef SiPixelPhase1TrackClustersV_h 
+#define SiPixelPhase1TrackClustersV_h 
+// -*- C++ -*-
+// 
+// Package:     SiPixelPhase1TrackClustersV
+// Class  :     SiPixelPhase1TrackClustersV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+
+class SiPixelPhase1TrackClustersV : public SiPixelPhase1Base {
+  enum {
+    CHARGE,
+    SIZE_X,
+    SIZE_Y,
+  };
+
+  public:
+  explicit SiPixelPhase1TrackClustersV(const edm::ParameterSet& conf);
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+  private:
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > clustersToken_;
+  edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+};
+
+#endif
+

--- a/Validation/SiPixelPhase1TrackClustersV/python/SiPixelPhase1TrackClustersV_cfi.py
+++ b/Validation/SiPixelPhase1TrackClustersV/python/SiPixelPhase1TrackClustersV_cfi.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+SiPixelPhase1TrackClustersCharge = DefaultHisto.clone(
+  name = "charge",
+  title = "Corrected Cluster Charge",
+  range_min = 0, range_max = 100, range_nbins = 200,
+  xlabel = "Charge size (in ke)",
+  topFolderName = "PixelPhase1V/Clusters",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1TrackClustersSizeX = DefaultHisto.clone(
+  name = "size_x",
+  title = "Cluster Size X",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "Cluster size (in pixels)",
+  topFolderName = "PixelPhase1V/Clusters",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1TrackClustersSizeY = DefaultHisto.clone(
+  name = "size_y",
+  title = "Cluster Size Y",
+  range_min = 0, range_max = 30, range_nbins = 30,
+  xlabel = "Cluster size (in pixels)",
+  topFolderName = "PixelPhase1V/Clusters",
+  specs = VPSet(
+    Specification().groupBy("PXBarrel/PXLayer/PXModuleName").save(),
+    Specification().groupBy("PXForward/PXDisk/PXModuleName").save(),
+  )
+)
+
+SiPixelPhase1TrackClustersConf = cms.VPSet(
+  SiPixelPhase1TrackClustersCharge,
+  SiPixelPhase1TrackClustersSizeX,
+  SiPixelPhase1TrackClustersSizeY
+)
+
+
+SiPixelPhase1TrackClustersAnalyzerV = cms.EDAnalyzer("SiPixelPhase1TrackClustersV",
+        clusters = cms.InputTag("siPixelClusters"),
+        tracks = cms.InputTag("generalTracks"),
+        histograms = SiPixelPhase1TrackClustersConf,
+        geometry = SiPixelPhase1Geometry
+)
+
+SiPixelPhase1TrackClustersHarvesterV = cms.EDAnalyzer("SiPixelPhase1Harvester",
+        histograms = SiPixelPhase1TrackClustersConf,
+        geometry = SiPixelPhase1Geometry
+)

--- a/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
+++ b/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
@@ -1,0 +1,109 @@
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1TrackClustersV
+// Class:       SiPixelPhase1TrackClustersV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
+
+
+SiPixelPhase1TrackClustersV::SiPixelPhase1TrackClustersV(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Base(iConfig) 
+{
+  clustersToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("clusters"));
+  tracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+}
+
+void SiPixelPhase1TrackClustersV::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  // get geometry
+  edm::ESHandle<TrackerGeometry> tracker;
+  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+  assert(tracker.isValid());
+  
+  //get the map
+  edm::Handle<reco::TrackCollection> tracks;
+  iEvent.getByToken( tracksToken_, tracks);
+  
+  // get clusters
+  edm::Handle< edmNew::DetSetVector<SiPixelCluster> >  clusterColl;
+  iEvent.getByToken( clustersToken_, clusterColl );
+  
+  // we need to store some per-cluster data. Instead of a map, we use a vector,
+  // exploiting the fact that all custers live in the DetSetVector and we can 
+  // use the same indices to refer to them.
+  // corr_charge is not strictly needed but cleaner to have it.
+  std::vector<bool>  ontrack    (clusterColl->data().size(), false);
+  std::vector<float> corr_charge(clusterColl->data().size(), -1.0f);
+
+  for (auto const & track : *tracks) {
+
+    auto const & trajParams = track.extra()->trajParams();
+    assert(trajParams.size()==track.recHitsSize());
+    auto hb = track.recHitsBegin();
+    for(unsigned int h=0;h<track.recHitsSize();h++){
+      auto hit = *(hb+h);
+      if (!hit->isValid()) continue;
+      DetId id = hit->geographicalId();
+
+      // check that we are in the pixel
+      uint32_t subdetid = (id.subdetId());
+      if (subdetid != PixelSubdetector::PixelBarrel && subdetid != PixelSubdetector::PixelEndcap) continue;
+      auto pixhit = dynamic_cast<const SiPixelRecHit*>(hit->hit());
+      if (!pixhit) continue;
+
+      // get the cluster
+      auto clust = pixhit->cluster();
+      if (clust.isNull()) continue;
+      ontrack[clust.key()] = true; // mark cluster as ontrack
+
+
+      // correct charge for track impact angle
+      auto const & ltp = trajParams[h];
+      LocalVector localDir = ltp.momentum()/ltp.momentum().mag();
+
+      float clust_alpha = atan2(localDir.z(), localDir.x());
+      float clust_beta  = atan2(localDir.z(), localDir.y());
+      double corrCharge = clust->charge()/1000. * sqrt( 1.0 / ( 1.0/pow( tan(clust_alpha), 2 ) + 
+                                                          1.0/pow( tan(clust_beta ), 2 ) + 
+                                                          1.0 ));
+      corr_charge[clust.key()] = (float) corrCharge;
+    }
+
+  edmNew::DetSetVector<SiPixelCluster>::const_iterator it;
+  for (it = clusterColl->begin(); it != clusterColl->end(); ++it) {
+    auto id = DetId(it->detId());
+
+    for(auto subit = it->begin(); subit != it->end(); ++subit) {
+      // we could do subit-...->data().front() as well, but this seems cleaner.
+      auto key = edmNew::makeRefTo(clusterColl, subit).key(); 
+      float corrected_charge = corr_charge[key];
+      SiPixelCluster const& cluster = *subit;
+
+      histo[CHARGE].fill(double(corrected_charge), id, &iEvent);
+      histo[SIZE_X].fill(double(cluster.sizeX() ), id, &iEvent);
+      histo[SIZE_Y].fill(double(cluster.sizeY() ), id, &iEvent);
+      }
+    }
+  }
+
+}
+
+DEFINE_FWK_MODULE(SiPixelPhase1TrackClustersV);
+

--- a/Validation/SiPixelPhase1TrackingParticleV/BuildFile.xml
+++ b/Validation/SiPixelPhase1TrackingParticleV/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="DQM/SiPixelPhase1Common"/>
+<use   name="DataFormats/TrackerRecHit2D"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
+<use   name="DataFormats/TrackReco"/>
+<flags   EDM_PLUGIN="1"/>
+

--- a/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
+++ b/Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h
@@ -1,0 +1,49 @@
+#ifndef SiPixelPhase1TrackingParticleV_h 
+#define SiPixelPhase1TrackingParticleV_h 
+// -*- C++ -*-
+// 
+// Package:     SiPixelPhase1TrackingParticleV
+// Class  :     SiPixelPhase1TrackingParticleV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+
+namespace reco {
+  class TrackToTrackingParticleAssociator;
+}
+
+class SiPixelPhase1TrackingParticleV : public SiPixelPhase1Base {
+  enum {
+    MASS,
+    CHARGE,
+    ID,
+    NHITS,
+    MATCHED,
+    PT,
+    PHI,
+    ETA,
+    VTX,
+    VTY,
+    VYZ,
+    TIP,
+    LIP,
+  };
+
+  public:
+  explicit SiPixelPhase1TrackingParticleV(const edm::ParameterSet& conf);
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+  private:
+  edm::EDGetTokenT<TrackingParticleCollection> vec_TrackingParticle_Token_;
+  std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simHitTokens_;
+  std::vector<std::pair<unsigned int, const PSimHit *>> trackIdToHitPtr_;
+};
+
+#endif
+

--- a/Validation/SiPixelPhase1TrackingParticleV/python/SiPixelPhase1TrackingParticleV_cfi.py
+++ b/Validation/SiPixelPhase1TrackingParticleV/python/SiPixelPhase1TrackingParticleV_cfi.py
@@ -1,0 +1,132 @@
+import FWCore.ParameterSet.Config as cms
+from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
+
+SiPixelPhase1TrackingParticleMass = DefaultHisto.clone(
+  name = "mass",
+  title = "Tracking Particle Mass",
+  range_min = -1.0, range_max = 5.0, range_nbins = 100,
+  xlabel = "Mass",
+  dimensions = 1,
+  topFolderName = "PixelPhase1V/TrackingParticle",
+  specs = VPSet(
+   Specification().groupBy("").save(),
+   Specification().groupBy("PXBarrel").save(),
+   Specification().groupBy("PXForward").save(),
+  )
+)
+
+SiPixelPhase1TrackingParticleCharge = SiPixelPhase1TrackingParticleMass.clone(
+  name = "charge",
+  title = "Tracking Particle Charge",
+  range_min = -5, range_max = 5.0, range_nbins = 10,
+  xlabel = "Charge",
+)
+
+SiPixelPhase1TrackingParticleId = SiPixelPhase1TrackingParticleMass.clone(
+  name = "id",
+  title = "Tracking Particle Id",
+  range_min = -5000, range_max = 5000, range_nbins = 500,
+  xlabel = "PID",
+)
+
+SiPixelPhase1TrackingParticleNhits = SiPixelPhase1TrackingParticleMass.clone(
+  name = "charge",
+  title = "Tracking Particle All Hits",
+  range_min = -0.5, range_max = 199.5, range_nbins = 200,
+  xlabel = "Total # Hits",
+)
+
+SiPixelPhase1TrackingParticleMatched = SiPixelPhase1TrackingParticleMass.clone(
+  name = "matched",
+  title = "Tracking Particle Matched Hits",
+  range_min = -0.5, range_max = 99.5, range_nbins = 100,
+  xlabel = "Matched Hits",
+)
+
+SiPixelPhase1TrackingParticlePt = SiPixelPhase1TrackingParticleMass.clone(
+  name = "charge",
+  title = "Tracking Particle Pt",
+  range_min = 0, range_max = 100, range_nbins = 100,
+  xlabel = "Pt",
+)
+
+SiPixelPhase1TrackingParticlePhi = SiPixelPhase1TrackingParticleMass.clone(
+  name = "phi",
+  title = "Tracking Particle Phi",
+  range_min = -4, range_max = 4, range_nbins = 100,
+  xlabel = "Phi",
+)
+
+SiPixelPhase1TrackingParticleEta = SiPixelPhase1TrackingParticleMass.clone(
+  name = "eta",
+  title = "Tracking Particle Eta",
+  range_min = -7, range_max = 7, range_nbins = 100,
+  xlabel = "Eta",
+)
+
+SiPixelPhase1TrackingParticleVtx = SiPixelPhase1TrackingParticleMass.clone(
+  name = "Vtx",
+  title = "Tracking Particle VtxX",
+  range_min = -100, range_max = 100, range_nbins = 100,
+  xlabel = "VtxX",
+)
+
+SiPixelPhase1TrackingParticleVty = SiPixelPhase1TrackingParticleMass.clone(
+  name = "Vty",
+  title = "Tracking Particle VtxY",
+  range_min = -100, range_max = 100, range_nbins = 100,
+  xlabel = "VtxY",
+)
+
+SiPixelPhase1TrackingParticleVtz = SiPixelPhase1TrackingParticleMass.clone(
+  name = "Vtz",
+  title = "Tracking Particle VtxZ",
+  range_min = -100, range_max = 100, range_nbins = 100,
+  xlabel = "VtxZ",
+)
+
+SiPixelPhase1TrackingParticleTip = SiPixelPhase1TrackingParticleMass.clone(
+  name = "tip",
+  title = "Tracking Particle tip",
+  range_min = 0, range_max = 1000, range_nbins = 100,
+  xlabel = "tip",
+)
+
+SiPixelPhase1TrackingParticleLip = SiPixelPhase1TrackingParticleMass.clone(
+  name = "lip",
+  title = "Tracking Particle lip",
+  range_min = 0, range_max = 1000, range_nbins = 100,
+  xlabel = "lip",
+)
+
+SiPixelPhase1TrackingParticleConf = cms.VPSet(
+    SiPixelPhase1TrackingParticleMass,
+    SiPixelPhase1TrackingParticleCharge,
+    SiPixelPhase1TrackingParticleId,
+    SiPixelPhase1TrackingParticleNhits,
+    SiPixelPhase1TrackingParticleMatched,
+    SiPixelPhase1TrackingParticlePt,
+    SiPixelPhase1TrackingParticlePhi,
+    SiPixelPhase1TrackingParticleEta,
+    SiPixelPhase1TrackingParticleVtx,
+    SiPixelPhase1TrackingParticleVty,
+    SiPixelPhase1TrackingParticleVtz,
+    SiPixelPhase1TrackingParticleTip,
+    SiPixelPhase1TrackingParticleLip,
+)
+
+SiPixelPhase1TrackingParticleAnalyzerV = cms.EDAnalyzer("SiPixelPhase1TrackingParticleV",
+    src = cms.InputTag("mix","MergedTrackTruth"),
+    simHitToken = cms.VInputTag(
+                            cms.InputTag( 'g4SimHits','TrackerHitsPixelBarrelLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsPixelBarrelHighTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsPixelEndcapLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsPixelEndcapHighTof') ),
+    histograms = SiPixelPhase1TrackingParticleConf,
+    geometry = SiPixelPhase1Geometry
+)
+
+SiPixelPhase1TrackingParticleHarvesterV = cms.EDAnalyzer("SiPixelPhase1Harvester",
+        histograms = SiPixelPhase1TrackingParticleConf,
+        geometry = SiPixelPhase1Geometry
+)

--- a/Validation/SiPixelPhase1TrackingParticleV/src/SiPixelPhase1TrackingParticleV.cc
+++ b/Validation/SiPixelPhase1TrackingParticleV/src/SiPixelPhase1TrackingParticleV.cc
@@ -1,0 +1,115 @@
+// -*- C++ -*-
+//
+// Package:     SiPixelPhase1TrackingParticleV
+// Class:       SiPixelPhase1TrackingParticleV
+//
+
+// Original Author: Marcel Schneider
+// Additional Authors: Alexander Morton - modifying code for validation use
+
+#include "Validation/SiPixelPhase1TrackingParticleV/interface/SiPixelPhase1TrackingParticleV.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+
+#include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+class TrackAssociatorByHits; 
+
+namespace {
+  bool trackIdHitPairLess(const std::pair<unsigned int, const PSimHit*>& a, const std::pair<unsigned int, const PSimHit*>& b) {
+    return a.first < b.first;
+  }
+
+  bool trackIdHitPairLessSort(const std::pair<unsigned int, const PSimHit*>& a, const std::pair<unsigned int, const PSimHit*>& b) {
+    if(a.first == b.first) {
+      const auto atof = edm::isFinite(a.second->timeOfFlight()) ? a.second->timeOfFlight() : std::numeric_limits<decltype(a.second->timeOfFlight())>::max();
+      const auto btof = edm::isFinite(b.second->timeOfFlight()) ? b.second->timeOfFlight() : std::numeric_limits<decltype(b.second->timeOfFlight())>::max();
+      return atof < btof;
+    }
+    return a.first < b.first;
+  }
+}
+
+
+SiPixelPhase1TrackingParticleV::SiPixelPhase1TrackingParticleV(const edm::ParameterSet& iConfig) :
+  SiPixelPhase1Base(iConfig),
+  vec_TrackingParticle_Token_( consumes<TrackingParticleCollection>( iConfig.getParameter<edm::InputTag>( "src" ) ) )
+{
+  for(const auto& tag: iConfig.getParameter<std::vector<edm::InputTag>>("simHitToken")) {
+    simHitTokens_.push_back(consumes<std::vector<PSimHit>>(tag));
+  }
+}
+
+void SiPixelPhase1TrackingParticleV::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  edm::Handle<TrackingParticleCollection>  TruthTrackContainer;
+  iEvent.getByToken( vec_TrackingParticle_Token_, TruthTrackContainer );
+  const TrackingParticleCollection *tPC   = TruthTrackContainer.product();
+
+  // A multimap linking SimTrack::trackId() to a pointer to PSimHit
+  // Similar to TrackingTruthAccumulator
+  for(const auto& simHitToken: simHitTokens_) {
+    edm::Handle<std::vector<PSimHit> > hsimhits;
+    iEvent.getByToken(simHitToken, hsimhits);
+    trackIdToHitPtr_.reserve(trackIdToHitPtr_.size()+hsimhits->size());
+    for(const auto& simHit: *hsimhits) {
+      trackIdToHitPtr_.emplace_back(simHit.trackId(), &simHit);
+    }
+  }
+  std::stable_sort(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), trackIdHitPairLessSort);
+
+
+  // Loop over TrackingParticle's
+  for (TrackingParticleCollection::const_iterator t = tPC -> begin(); t != tPC -> end(); ++t) {
+
+    // histo manager requires a det ID, use first tracker hit
+
+    bool isBpixtrack = false, isFpixtrack = false;
+    DetId id;
+
+    for(const SimTrack& simTrack: t->g4Tracks()) {
+      // Logic is from TrackingTruthAccumulator
+      auto range = std::equal_range(trackIdToHitPtr_.begin(), trackIdToHitPtr_.end(), std::pair<unsigned int, const PSimHit *>(simTrack.trackId(), nullptr), trackIdHitPairLess);
+      if(range.first == range.second) continue;
+
+      auto iHitPtr = range.first;
+      for(; iHitPtr != range.second; ++iHitPtr) {
+        const PSimHit& simHit = *(iHitPtr->second);
+        if(simHit.eventId() != t->eventId())
+          continue;
+        id = DetId( simHit.detUnitId() );
+
+        // check we are in pixel
+        uint32_t subdetid = (id.subdetId());
+	if (subdetid == PixelSubdetector::PixelBarrel) isBpixtrack = true;
+	if (subdetid == PixelSubdetector::PixelEndcap) isFpixtrack = true;
+	if (subdetid != PixelSubdetector::PixelBarrel && subdetid != PixelSubdetector::PixelEndcap) continue;
+      }
+    }
+
+    if ( isBpixtrack || isFpixtrack ) {
+      histo[MASS].fill(t->mass(), id, &iEvent);
+      histo[CHARGE].fill(t->charge(), id, &iEvent);
+      histo[ID].fill(t->pdgId(), id, &iEvent);
+      histo[NHITS].fill(t->numberOfTrackerHits(), id, &iEvent);
+      histo[MATCHED].fill(t->numberOfTrackerLayers(), id, &iEvent);
+      histo[PT].fill(sqrt(t->momentum().perp2()), id, &iEvent);
+      histo[PHI].fill(t->momentum().Phi(), id, &iEvent);
+      histo[ETA].fill(t->momentum().eta(), id, &iEvent);
+      histo[VTX].fill(t->vx(), id, &iEvent);
+      histo[VTY].fill(t->vy(), id, &iEvent);
+      histo[VYZ].fill(t->vz(), id, &iEvent);
+      histo[TIP].fill(sqrt(t->vertex().perp2()), id, &iEvent);
+      histo[LIP].fill(t->vz(), id, &iEvent);
+    }
+  }
+}
+
+DEFINE_FWK_MODULE(SiPixelPhase1TrackingParticleV);
+


### PR DESCRIPTION
Added validation modules for the phase 1 pixel code based off the phase 1 dqm framework. Replicates the functionality of the phase 0 code, namely:

Digis
Hits
RecHits
Track Clusters
Tracking MC Truth (referred to as TrackingParticle in the phase 1 validation directory structure)
Validation/Configuration/python/globalValidation_cff.py; Validation/Configuration/python/postValidation_cff.py;
and Validation/Configuration/python/trackerSimValid_cff.py; have been modified so that if the era is phase1Pixel, the new validation code is used.

@fioriNTU @lunik1 @leggat might be interested in this.
