### PR TITLE
HLTrigger/ cleaned up by clang-tidy modernize checks

### DIFF
--- a/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
@@ -48,7 +48,7 @@ HLTDisplacedEgammaFilter::HLTDisplacedEgammaFilter(const edm::ParameterSet& iCon
 
 }
 
-HLTDisplacedEgammaFilter::~HLTDisplacedEgammaFilter(){}
+HLTDisplacedEgammaFilter::~HLTDisplacedEgammaFilter()= default;
 
 void
 HLTDisplacedEgammaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -85,9 +85,6 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
     filterproduct.addCollectionTag(l1EGTag_);
   }
 
-  // Ref to Candidate object to be recorded in filter object
-   edm::Ref<reco::RecoEcalCandidateCollection> ref;
-
   // get hold of filtered candidates
   //edm::Handle<reco::HLTFilterObjectWithRefs> recoecalcands;
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
@@ -110,9 +107,8 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   // look at all candidates,  check cuts and add to filter object
   int n(0);
 
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
+  for (auto const & ref : recoecalcands) {
 
-    ref = recoecalcands[i] ;
     if ( EBOnly &&  std::abs( ref->eta() ) >= 1.479  ) continue ;
 
 
@@ -129,16 +125,16 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
     // seed Time
     std::pair<DetId, float> maxRH = EcalClusterTools::getMaximum( *SCseed, rechits );
     DetId seedCrystalId = maxRH.first;
-    EcalRecHitCollection::const_iterator seedRH = rechits->find(seedCrystalId);
+    auto seedRH = rechits->find(seedCrystalId);
     float seedTime = (float)seedRH->time();
     if ( seedTime < seedTimeMin || seedTime > seedTimeMax ) continue ;
 
     //Track Veto
 
     int nTrk = 0 ;
-    for (reco::TrackCollection::const_iterator it = tracks->begin(); it != tracks->end(); it++ )  {
-        if ( it->pt() < trkPtCut ) continue ;
-        LorentzVector trkP4( it->px(), it->py(), it->pz(), it->p() ) ;
+    for (auto const & it : *tracks)  {
+        if ( it.pt() < trkPtCut ) continue ;
+        LorentzVector trkP4( it.px(), it.py(), it.pz(), it.p() ) ;
         double dR =  ROOT::Math::VectorUtil::DeltaR( trkP4 , ref->p4()  ) ;
         if ( dR < trkdRCut )  nTrk++ ;
         if ( nTrk > maxTrkCut ) break ;

--- a/HLTrigger/Egamma/src/HLTEgammaAllCombMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaAllCombMassFilter.cc
@@ -29,7 +29,7 @@ HLTEgammaAllCombMassFilter::HLTEgammaAllCombMassFilter(const edm::ParameterSet& 
   secondLegLastFilterToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(secondLegLastFilterTag_);
 }
 
-HLTEgammaAllCombMassFilter::~HLTEgammaAllCombMassFilter(){}
+HLTEgammaAllCombMassFilter::~HLTEgammaAllCombMassFilter()= default;
 
 void
 HLTEgammaAllCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -60,9 +60,9 @@ bool HLTEgammaAllCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventS
   getP4OfLegCands(iEvent,secondLegLastFilterToken_,secondLegP4s);
 
   bool accept=false;
-  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){
-    for(size_t secondLegNr=0;secondLegNr<secondLegP4s.size();secondLegNr++){
-      math::XYZTLorentzVector pairP4 = firstLegP4s[firstLegNr] + secondLegP4s[secondLegNr];
+  for(auto & firstLegP4 : firstLegP4s){
+    for(auto & secondLegP4 : secondLegP4s){
+      math::XYZTLorentzVector pairP4 = firstLegP4 + secondLegP4;
       double mass = pairP4.M();
       if(mass>=minMass_) accept=true;
     }
@@ -99,16 +99,16 @@ void  HLTEgammaAllCombMassFilter::getP4OfLegCands(const edm::Event& iEvent, cons
   filterOutput->getObjects(trigger::TriggerElectron,eleCands);
 
   if(!phoCands.empty()){ //its photons
-    for(size_t candNr=0;candNr<phoCands.size();candNr++){
-      p4s.push_back(phoCands[candNr]->p4());
+    for(auto & phoCand : phoCands){
+      p4s.push_back(phoCand->p4());
     }
   }else if(!clusCands.empty()){ //try trigger cluster (should never be this, at the time of writing (17/1/11) this would indicate an error)
-    for(size_t candNr=0;candNr<clusCands.size();candNr++){
-      p4s.push_back(clusCands[candNr]->p4());
+    for(auto & clusCand : clusCands){
+      p4s.push_back(clusCand->p4());
     }
   }else if(!eleCands.empty()){
-    for(size_t candNr=0;candNr<eleCands.size();candNr++){
-      p4s.push_back(eleCands[candNr]->p4());
+    for(auto & eleCand : eleCands){
+      p4s.push_back(eleCand->p4());
     }
   }
 }

--- a/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
@@ -44,7 +44,7 @@ HLTEgammaCaloIsolFilterPairs::HLTEgammaCaloIsolFilterPairs(const edm::ParameterS
   if(AlsoNonIso_1 || AlsoNonIso_2) nonIsoToken_ = consumes<reco::RecoEcalCandidateIsolationMap>(nonIsoTag_);
 }
 
-HLTEgammaCaloIsolFilterPairs::~HLTEgammaCaloIsolFilterPairs(){}
+HLTEgammaCaloIsolFilterPairs::~HLTEgammaCaloIsolFilterPairs()= default;
 
 void
 HLTEgammaCaloIsolFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Egamma/src/HLTEgammaCombMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCombMassFilter.cc
@@ -29,7 +29,7 @@ HLTEgammaCombMassFilter::HLTEgammaCombMassFilter(const edm::ParameterSet& iConfi
   secondLegLastFilterToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(secondLegLastFilterTag_);
 }
 
-HLTEgammaCombMassFilter::~HLTEgammaCombMassFilter(){}
+HLTEgammaCombMassFilter::~HLTEgammaCombMassFilter()= default;
 
 void
 HLTEgammaCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -58,9 +58,9 @@ bool HLTEgammaCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   getP4OfLegCands(iEvent,secondLegLastFilterToken_,secondLegP4s);
 
   bool accept=false;
-  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){
-    for(size_t secondLegNr=0;secondLegNr<secondLegP4s.size();secondLegNr++){
-      math::XYZTLorentzVector pairP4 = firstLegP4s[firstLegNr] + secondLegP4s[secondLegNr];
+  for(auto & firstLegP4 : firstLegP4s){
+    for(auto & secondLegP4 : secondLegP4s){
+      math::XYZTLorentzVector pairP4 = firstLegP4 + secondLegP4;
       double mass = pairP4.M();
       if(mass>=minMass_) accept=true;
     }
@@ -83,16 +83,16 @@ void  HLTEgammaCombMassFilter::getP4OfLegCands(const edm::Event& iEvent, const e
   filterOutput->getObjects(trigger::TriggerElectron,eleCands);
 
   if(!phoCands.empty()){ //its photons
-    for(size_t candNr=0;candNr<phoCands.size();candNr++){
-      p4s.push_back(phoCands[candNr]->p4());
+    for(auto & phoCand : phoCands){
+      p4s.push_back(phoCand->p4());
     }
   }else if(!clusCands.empty()){ //try trigger cluster (should never be this, at the time of writing (17/1/11) this would indicate an error)
-    for(size_t candNr=0;candNr<clusCands.size();candNr++){
-      p4s.push_back(clusCands[candNr]->p4());
+    for(auto & clusCand : clusCands){
+      p4s.push_back(clusCand->p4());
     }
   }else if(!eleCands.empty()){
-    for(size_t candNr=0;candNr<eleCands.size();candNr++){
-      p4s.push_back(eleCands[candNr]->p4());
+    for(auto & eleCand : eleCands){
+      p4s.push_back(eleCand->p4());
     }
   }
 }

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
@@ -28,7 +28,7 @@ HLTEgammaDoubleEtDeltaPhiFilter::HLTEgammaDoubleEtDeltaPhiFilter(const edm::Para
    inputToken_  = consumes<trigger::TriggerFilterObjectWithRefs> (inputTag_);
 }
 
-HLTEgammaDoubleEtDeltaPhiFilter::~HLTEgammaDoubleEtDeltaPhiFilter(){}
+HLTEgammaDoubleEtDeltaPhiFilter::~HLTEgammaDoubleEtDeltaPhiFilter()= default;
 
 void
 HLTEgammaDoubleEtDeltaPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -64,8 +64,7 @@ HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventS
 
    // look at all candidates,  check cuts
    int n(0);
-   for(unsigned int i=0; i<recoecalcands.size(); i++) {
-      const edm::Ref<reco::RecoEcalCandidateCollection> & ref = recoecalcands[i];
+   for(auto & ref : recoecalcands) {
       if( ref->et() >= etcut_) {
 	++n;
 	if(n==1)  ref1 = ref;

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
@@ -37,7 +37,7 @@ HLTEgammaDoubleEtFilter::HLTEgammaDoubleEtFilter(const edm::ParameterSet& iConfi
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
 }
 
-HLTEgammaDoubleEtFilter::~HLTEgammaDoubleEtFilter(){}
+HLTEgammaDoubleEtFilter::~HLTEgammaDoubleEtFilter()= default;
 
 void
 HLTEgammaDoubleEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
@@ -38,7 +38,7 @@ HLTEgammaDoubleEtPhiFilter::HLTEgammaDoubleEtPhiFilter(const edm::ParameterSet& 
    candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
 }
 
-HLTEgammaDoubleEtPhiFilter::~HLTEgammaDoubleEtPhiFilter(){}
+HLTEgammaDoubleEtPhiFilter::~HLTEgammaDoubleEtPhiFilter()= default;
 
 void
 HLTEgammaDoubleEtPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
@@ -48,7 +48,7 @@ HLTEgammaDoubleLegCombFilter::fillDescriptions(edm::ConfigurationDescriptions& d
   descriptions.add("hltEgammaDoubleLegCombFilter",desc);
 }
 
-HLTEgammaDoubleLegCombFilter::~HLTEgammaDoubleLegCombFilter(){}
+HLTEgammaDoubleLegCombFilter::~HLTEgammaDoubleLegCombFilter()= default;
 
 
 // ------------ method called to produce the data  ------------
@@ -73,11 +73,11 @@ bool HLTEgammaDoubleLegCombFilter::hltFilter(edm::Event& iEvent, const edm::Even
   int nr2ndLegOnly=0;
   int nrBoth=0;;
 
-  for(size_t candNr=0;candNr<matchedCands.size();candNr++){
-    if(matchedCands[candNr].first>=0){ //we found a first leg cand
-      if(matchedCands[candNr].second>=0) nrBoth++;//we also found a second leg cand
+  for(auto & matchedCand : matchedCands){
+    if(matchedCand.first>=0){ //we found a first leg cand
+      if(matchedCand.second>=0) nrBoth++;//we also found a second leg cand
       else nr1stLegOnly++; //we didnt find a second leg cand
-    }else if(matchedCands[candNr].second>=0) nr2ndLegOnly++; //we found a second leg cand but we didnt find a first leg
+    }else if(matchedCand.second>=0) nr2ndLegOnly++; //we found a second leg cand but we didnt find a first leg
 
   }
 
@@ -133,23 +133,23 @@ void  HLTEgammaDoubleLegCombFilter::getP3OfLegCands(const edm::Event& iEvent,con
   filterOutput->getObjects(trigger::TriggerJet,jetCands);
 
   if(!phoCands.empty()){ //its photons
-    for(size_t candNr=0;candNr<phoCands.size();candNr++){
-      p3s.push_back(phoCands[candNr]->superCluster()->position());
+    for(auto & phoCand : phoCands){
+      p3s.push_back(phoCand->superCluster()->position());
     }
   }else if(!clusCands.empty()){ //try trigger cluster (should never be this, at the time of writing (17/1/11) this would indicate an error)
-    for(size_t candNr=0;candNr<clusCands.size();candNr++){
-      p3s.push_back(clusCands[candNr]->superCluster()->position());
+    for(auto & clusCand : clusCands){
+      p3s.push_back(clusCand->superCluster()->position());
     }
   }else if(!eleCands.empty()){
-    for(size_t candNr=0;candNr<eleCands.size();candNr++){
-      p3s.push_back(eleCands[candNr]->superCluster()->position());
+    for(auto & eleCand : eleCands){
+      p3s.push_back(eleCand->superCluster()->position());
     }
   }else if(!jetCands.empty()){
-    for(size_t candNr=0;candNr<jetCands.size();candNr++){
+    for(auto & jetCand : jetCands){
       math::XYZPoint p3;
-      p3.SetX(jetCands[candNr]->p4().x());
-      p3.SetY(jetCands[candNr]->p4().y());
-      p3.SetZ(jetCands[candNr]->p4().z());
+      p3.SetX(jetCand->p4().x());
+      p3.SetY(jetCand->p4().y());
+      p3.SetZ(jetCand->p4().z());
       p3s.push_back(p3);
     }
   }

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
@@ -40,7 +40,7 @@ HLTEgammaEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
    descriptions.add("hltEgammaEtFilter", desc);
 }
 
-HLTEgammaEtFilter::~HLTEgammaEtFilter(){}
+HLTEgammaEtFilter::~HLTEgammaEtFilter()= default;
 
 
 // ------------ method called to produce the data  ------------
@@ -69,9 +69,9 @@ HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
   // look at all candidates,  check cuts and add to filter object
   int n(0);
 
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
+  for (auto & recoecalcand : recoecalcands) {
 
-    ref = recoecalcands[i] ;
+    ref = recoecalcand ;
 
     if( ( fabs(ref->eta()) < 1.479 &&  ref->et()  >= etcutEB_ ) || ( fabs(ref->eta()) >= 1.479 &&  ref->et()  >= etcutEE_ ) ){
       n++;

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
@@ -42,7 +42,7 @@ HLTEgammaEtFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& descrip
    descriptions.add("hltEgammaEtFilterPairs", desc);
 }
 
-HLTEgammaEtFilterPairs::~HLTEgammaEtFilterPairs(){}
+HLTEgammaEtFilterPairs::~HLTEgammaEtFilterPairs()= default;
 
 
 // ------------ method called to produce the data  ------------

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -83,7 +83,7 @@ HLTEgammaGenericQuadraticEtaFilter::fillDescriptions(edm::ConfigurationDescripti
   descriptions.add("hltEgammaGenericQuadraticEtaFilter", desc);
 }
 
-HLTEgammaGenericQuadraticEtaFilter::~HLTEgammaGenericQuadraticEtaFilter(){}
+HLTEgammaGenericQuadraticEtaFilter::~HLTEgammaGenericQuadraticEtaFilter()= default;
 
 
 // ------------ method called to produce the data  ------------
@@ -116,9 +116,9 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
   // look at all photons, check cuts and add to filter object
   int n = 0;
 
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
+  for (auto & recoecalcand : recoecalcands) {
 
-    ref = recoecalcands[i];
+    ref = recoecalcand;
     reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
 
     float vali = mapi->val;

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
@@ -63,7 +63,7 @@ HLTEgammaGenericQuadraticFilter::fillDescriptions(edm::ConfigurationDescriptions
   descriptions.add("hltEgammaGenericQuadraticFilter", desc);
 }
 
-HLTEgammaGenericQuadraticFilter::~HLTEgammaGenericQuadraticFilter(){}
+HLTEgammaGenericQuadraticFilter::~HLTEgammaGenericQuadraticFilter()= default;
 
 
 // ------------ method called to produce the data  ------------
@@ -96,9 +96,9 @@ HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventS
   // look at all photons, check cuts and add to filter object
   int n = 0;
 
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
+  for (auto & recoecalcand : recoecalcands) {
 
-    ref = recoecalcands[i];
+    ref = recoecalcand;
     reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
 
     float vali = mapi->val;

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
@@ -52,7 +52,7 @@ HLTEgammaL1MatchFilterPairs::HLTEgammaL1MatchFilterPairs(const edm::ParameterSet
    L1SeedFilterToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(L1SeedFilterTag_);
 }
 
-HLTEgammaL1MatchFilterPairs::~HLTEgammaL1MatchFilterPairs(){}
+HLTEgammaL1MatchFilterPairs::~HLTEgammaL1MatchFilterPairs()= default;
 
 void
 HLTEgammaL1MatchFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -90,14 +90,14 @@ HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup
   iEvent.getByToken(candNonIsolatedToken_,recoNonIsolecalcands);
 
   // create pairs <L1Iso,L1Iso> and optionally <L1Iso, L1NonIso>
-   for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand1= recoIsolecalcands->begin(); recoecalcand1!=recoIsolecalcands->end(); recoecalcand1++) {
+   for (auto recoecalcand1= recoIsolecalcands->begin(); recoecalcand1!=recoIsolecalcands->end(); recoecalcand1++) {
      edm::Ref<reco::RecoEcalCandidateCollection> ref1 =  edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand1) );
-       for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand2= recoIsolecalcands->begin(); recoecalcand2!=recoIsolecalcands->end(); recoecalcand2++) {
+       for (auto recoecalcand2= recoIsolecalcands->begin(); recoecalcand2!=recoIsolecalcands->end(); recoecalcand2++) {
 	 edm::Ref<reco::RecoEcalCandidateCollection> ref2 =  edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand2) );
 	 if( &(*ref1) != &(*ref2) ) {thePairs.push_back(std::pair< edm::Ref<reco::RecoEcalCandidateCollection>, edm::Ref<reco::RecoEcalCandidateCollection> > (ref1,ref2) );}
        }
        if (AlsoNonIsolatedSecond_){
-	 for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand2= recoNonIsolecalcands->begin(); recoecalcand2!=recoNonIsolecalcands->end(); recoecalcand2++) {
+	 for (auto recoecalcand2= recoNonIsolecalcands->begin(); recoecalcand2!=recoNonIsolecalcands->end(); recoecalcand2++) {
 	   edm::Ref<reco::RecoEcalCandidateCollection> ref2 =  edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand2) );
 	   if( &(*ref1) != &(*ref2) ) {thePairs.push_back(std::pair< edm::Ref<reco::RecoEcalCandidateCollection>, edm::Ref<reco::RecoEcalCandidateCollection> > (ref1,ref2) );}
 	 }
@@ -107,14 +107,14 @@ HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup
 
   // create pairs <L1NonIso,L1Iso> and optionally <L1NonIso, L1NonIso>
    if (AlsoNonIsolatedFirst_){
-     for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand1= recoNonIsolecalcands->begin(); recoecalcand1!=recoNonIsolecalcands->end(); recoecalcand1++) {
+     for (auto recoecalcand1= recoNonIsolecalcands->begin(); recoecalcand1!=recoNonIsolecalcands->end(); recoecalcand1++) {
        edm::Ref<reco::RecoEcalCandidateCollection> ref1 =  edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand1) );
-       for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand2= recoIsolecalcands->begin(); recoecalcand2!=recoIsolecalcands->end(); recoecalcand2++) {
+       for (auto recoecalcand2= recoIsolecalcands->begin(); recoecalcand2!=recoIsolecalcands->end(); recoecalcand2++) {
 	 edm::Ref<reco::RecoEcalCandidateCollection> ref2 =  edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand2) );
 	 if( &(*ref1) != &(*ref2) ) {thePairs.push_back(std::pair< edm::Ref<reco::RecoEcalCandidateCollection>, edm::Ref<reco::RecoEcalCandidateCollection> > (ref1,ref2) );}
        }
        if (AlsoNonIsolatedSecond_){
-	 for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand2= recoNonIsolecalcands->begin(); recoecalcand2!=recoNonIsolecalcands->end(); recoecalcand2++) {
+	 for (auto recoecalcand2= recoNonIsolecalcands->begin(); recoecalcand2!=recoNonIsolecalcands->end(); recoecalcand2++) {
 	   edm::Ref<reco::RecoEcalCandidateCollection> ref2 =  edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand2) );
 	   if( &(*ref1) != &(*ref2) ) {thePairs.push_back(std::pair< edm::Ref<reco::RecoEcalCandidateCollection>, edm::Ref<reco::RecoEcalCandidateCollection> > (ref1,ref2) );}
 	 }
@@ -168,20 +168,20 @@ HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup
 
 bool HLTEgammaL1MatchFilterPairs::CheckL1Matching(edm::Ref<reco::RecoEcalCandidateCollection> ref, std::vector<l1extra::L1EmParticleRef >& l1EGIso, std::vector<l1extra::L1EmParticleRef >& l1EGNonIso) const {
 
-  for (unsigned int i=0; i<l1EGIso.size(); i++) {
+  for (auto & i : l1EGIso) {
     //ORCA matching method
     double etaBinLow  = 0.;
     double etaBinHigh = 0.;	
     if(fabs(ref->eta()) < barrel_end_){
-      etaBinLow = l1EGIso[i]->eta() - region_eta_size_/2.;
+      etaBinLow = i->eta() - region_eta_size_/2.;
       etaBinHigh = etaBinLow + region_eta_size_;
     }
     else{
-      etaBinLow = l1EGIso[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinLow = i->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
 
-    float deltaphi=fabs(ref->phi() -l1EGIso[i]->phi());
+    float deltaphi=fabs(ref->phi() -i->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>M_PI) deltaphi=TWOPI-deltaphi;
 
@@ -189,20 +189,20 @@ bool HLTEgammaL1MatchFilterPairs::CheckL1Matching(edm::Ref<reco::RecoEcalCandida
 
   }
 
-  for (unsigned int i=0; i<l1EGNonIso.size(); i++) {
+  for (auto & i : l1EGNonIso) {
     //ORCA matching method
     double etaBinLow  = 0.;
     double etaBinHigh = 0.;	
     if(fabs(ref->eta()) < barrel_end_){
-      etaBinLow = l1EGNonIso[i]->eta() - region_eta_size_/2.;
+      etaBinLow = i->eta() - region_eta_size_/2.;
       etaBinHigh = etaBinLow + region_eta_size_;
     }
     else{
-      etaBinLow = l1EGNonIso[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinLow = i->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
 
-    float deltaphi=fabs(ref->phi() - l1EGNonIso[i]->phi());
+    float deltaphi=fabs(ref->phi() - i->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>M_PI) deltaphi=TWOPI-deltaphi;
 

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
@@ -52,7 +52,7 @@ HLTEgammaL1MatchFilterRegional::HLTEgammaL1MatchFilterRegional(const edm::Parame
    L1SeedFilterToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(L1SeedFilterTag_);
 }
 
-HLTEgammaL1MatchFilterRegional::~HLTEgammaL1MatchFilterRegional(){}
+HLTEgammaL1MatchFilterRegional::~HLTEgammaL1MatchFilterRegional()= default;
 
 void
 HLTEgammaL1MatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -119,7 +119,7 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
   std::vector<l1extra::L1JetParticleRef> l1Jets;
   L1SeedOutput->getObjects(TriggerL1CenJet, l1Jets);
 
-  for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
+  for (auto recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
 
 
     if(fabs(recoecalcand->eta()) < endcap_end_){
@@ -159,7 +159,7 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
     edm::Handle<reco::RecoEcalCandidateCollection> recoNonIsolecalcands;
     iEvent.getByToken(candNonIsolatedToken_,recoNonIsolecalcands);
 
-    for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
+    for (auto recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
       if(fabs(recoecalcand->eta()) < endcap_end_){
 	bool matchedSCNonIso =  matchedToL1Cand(l1EGNonIso,recoecalcand->eta(),recoecalcand->phi());
 	
@@ -188,20 +188,20 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
 bool
 HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1EmParticleRef >& l1Cands,const float scEta,const float scPhi) const
 {
-  for (unsigned int i=0; i<l1Cands.size(); i++) {
+  for (auto const & l1Cand : l1Cands) {
     //ORCA matching method
     double etaBinLow  = 0.;
     double etaBinHigh = 0.;	
     if(fabs(scEta) < barrel_end_){
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_/2.;
       etaBinHigh = etaBinLow + region_eta_size_;
     }
     else{
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
 
-    float deltaphi=fabs(scPhi -l1Cands[i]->phi());
+    float deltaphi=fabs(scPhi -l1Cand->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
 
@@ -215,20 +215,20 @@ HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1EmP
 bool
 HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1JetParticleRef >& l1Cands,const float scEta,const float scPhi) const
 {
-  for (unsigned int i=0; i<l1Cands.size(); i++) {
+  for (auto const & l1Cand : l1Cands) {
     //ORCA matching method
     double etaBinLow  = 0.;
     double etaBinHigh = 0.;	
     if(fabs(scEta) < barrel_end_){
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_/2.;
       etaBinHigh = etaBinLow + region_eta_size_;
     }
     else{
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
 
-    float deltaphi=fabs(scPhi -l1Cands[i]->phi());
+    float deltaphi=fabs(scPhi -l1Cand->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
 

--- a/HLTrigger/Egamma/src/HLTEgammaL1TMatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1TMatchFilterRegional.cc
@@ -53,7 +53,7 @@ HLTEgammaL1TMatchFilterRegional::HLTEgammaL1TMatchFilterRegional(const edm::Para
    L1SeedFilterToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(L1SeedFilterTag_);
 }
 
-HLTEgammaL1TMatchFilterRegional::~HLTEgammaL1TMatchFilterRegional(){}
+HLTEgammaL1TMatchFilterRegional::~HLTEgammaL1TMatchFilterRegional()= default;
 
 void
 HLTEgammaL1TMatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -121,7 +121,7 @@ HLTEgammaL1TMatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
   L1SeedOutput->getObjects(TriggerL1Tau, l1Taus);
 
   int countCand=0;
-  for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
+  for (auto recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
     countCand++;
     if(fabs(recoecalcand->eta()) < endcap_end_){
       //SC should be inside the ECAL fiducial volume
@@ -149,7 +149,7 @@ HLTEgammaL1TMatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
     edm::Handle<reco::RecoEcalCandidateCollection> recoNonIsolecalcands;
     iEvent.getByToken(candNonIsolatedToken_,recoNonIsolecalcands);
 
-    for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
+    for (auto recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
       countCand++;
  
       if(fabs(recoecalcand->eta()) < endcap_end_){
@@ -179,20 +179,20 @@ HLTEgammaL1TMatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
 bool
 HLTEgammaL1TMatchFilterRegional::matchedToL1Cand(const std::vector<l1t::EGammaRef>& l1Cands,const float scEta,const float scPhi) const
 {
-  for (unsigned int i=0; i<l1Cands.size(); i++) {
+  for (auto const & l1Cand : l1Cands) {
     //ORCA matching method
     double etaBinLow  = 0.;
     double etaBinHigh = 0.;	
     if(fabs(scEta) < barrel_end_){
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_/2.;
       etaBinHigh = etaBinLow + region_eta_size_;
     }
     else{
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
 
-    float deltaphi=fabs(scPhi -l1Cands[i]->phi());
+    float deltaphi=fabs(scPhi -l1Cand->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
 
@@ -207,20 +207,20 @@ bool
 //HLTEgammaL1TMatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1JetParticleRef >& l1Cands,const float scEta,const float scPhi) const
 HLTEgammaL1TMatchFilterRegional::matchedToL1Cand(const std::vector<l1t::JetRef>& l1Cands,const float scEta,const float scPhi) const
 {
-  for (unsigned int i=0; i<l1Cands.size(); i++) {
+  for (auto const & l1Cand : l1Cands) {
     //ORCA matching method
     double etaBinLow  = 0.;
     double etaBinHigh = 0.;	
     if(fabs(scEta) < barrel_end_){
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_/2.;
       etaBinHigh = etaBinLow + region_eta_size_;
     }
     else{
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
 
-    float deltaphi=fabs(scPhi -l1Cands[i]->phi());
+    float deltaphi=fabs(scPhi -l1Cand->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
 
@@ -234,20 +234,20 @@ bool
 //HLTEgammaL1TMatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1JetParticleRef >& l1Cands,const float scEta,const float scPhi) const
 HLTEgammaL1TMatchFilterRegional::matchedToL1Cand(const std::vector<l1t::TauRef>& l1Cands,const float scEta,const float scPhi) const
 {
-  for (unsigned int i=0; i<l1Cands.size(); i++) {
+  for (auto const & l1Cand : l1Cands) {
     //ORCA matching method
     double etaBinLow  = 0.;
     double etaBinHigh = 0.;	
     if(fabs(scEta) < barrel_end_){
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_/2.;
       etaBinHigh = etaBinLow + region_eta_size_;
     }
     else{
-      etaBinLow = l1Cands[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinLow = l1Cand->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
 
-    float deltaphi=fabs(scPhi -l1Cands[i]->phi());
+    float deltaphi=fabs(scPhi -l1Cand->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
 

--- a/HLTrigger/Egamma/src/HLTEgammaTriggerFilterObjectWrapper.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaTriggerFilterObjectWrapper.cc
@@ -41,7 +41,7 @@ HLTEgammaTriggerFilterObjectWrapper::fillDescriptions(edm::ConfigurationDescript
   descriptions.add("hltEgammaTriggerFilterObjectWrapper",desc);
 }
 
-HLTEgammaTriggerFilterObjectWrapper::~HLTEgammaTriggerFilterObjectWrapper(){}
+HLTEgammaTriggerFilterObjectWrapper::~HLTEgammaTriggerFilterObjectWrapper()= default;
 
 
 // ------------ method called to produce the data  ------------
@@ -56,7 +56,7 @@ bool HLTEgammaTriggerFilterObjectWrapper::hltFilter(edm::Event& iEvent, const ed
 
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
   // transform the L1Iso_RecoEcalCandidate into the TriggerFilterObjectWithRefs
-  for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
+  for (auto recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
     ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand) );
     filterproduct.addObject(TriggerCluster, ref);
   }
@@ -65,7 +65,7 @@ bool HLTEgammaTriggerFilterObjectWrapper::hltFilter(edm::Event& iEvent, const ed
     // transform the L1NonIso_RecoEcalCandidate into the TriggerFilterObjectWithRefs and add them to the L1Iso ones.
     edm::Handle<reco::RecoEcalCandidateCollection> recoNonIsolecalcands;
     iEvent.getByToken(candNonIsolatedToken_,recoNonIsolecalcands);
-    for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
+    for (auto recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
       ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand) );
       filterproduct.addObject(TriggerCluster, ref);
     }

--- a/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
@@ -35,7 +35,7 @@ HLTElectronEoverpFilterRegional::HLTElectronEoverpFilterRegional(const edm::Para
    if(!doIsolated_) electronNonIsolatedToken_ = consumes<reco::ElectronCollection>(electronNonIsolatedProducer_);
 }
 
-HLTElectronEoverpFilterRegional::~HLTElectronEoverpFilterRegional(){}
+HLTElectronEoverpFilterRegional::~HLTElectronEoverpFilterRegional()= default;
 
 void
 HLTElectronEoverpFilterRegional::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -86,11 +86,11 @@ HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
     //(the matching is done checking the super clusters)
     // and put into the event a Ref to the Electron objects that passes the
     // selections
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    reco::SuperClusterRef recr2 = recoecalcands[i]->superCluster();
+  for (auto & recoecalcand : recoecalcands) {
+    reco::SuperClusterRef recr2 = recoecalcand->superCluster();
 
     //loop over the electrons to find the matching one
-    for(reco::ElectronCollection::const_iterator iElectron = electronIsolatedHandle->begin(); iElectron != electronIsolatedHandle->end(); iElectron++){
+    for(auto iElectron = electronIsolatedHandle->begin(); iElectron != electronIsolatedHandle->end(); iElectron++){
 
       reco::ElectronRef electronref(reco::ElectronRef(electronIsolatedHandle,iElectron - electronIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();
@@ -119,7 +119,7 @@ HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
 
     if(!doIsolated_) {
     //loop over the electrons to find the matching one
-    for(reco::ElectronCollection::const_iterator iElectron = electronNonIsolatedHandle->begin(); iElectron != electronNonIsolatedHandle->end(); iElectron++){
+    for(auto iElectron = electronNonIsolatedHandle->begin(); iElectron != electronNonIsolatedHandle->end(); iElectron++){
 
       reco::ElectronRef electronref(reco::ElectronRef(electronNonIsolatedHandle,iElectron - electronNonIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();

--- a/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
@@ -37,7 +37,7 @@ HLTElectronEtFilter::HLTElectronEtFilter(const edm::ParameterSet& iConfig) : HLT
   candToken_ =  consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
 }
 
-HLTElectronEtFilter::~HLTElectronEtFilter(){}
+HLTElectronEtFilter::~HLTElectronEtFilter()= default;
 
 void
 HLTElectronEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -73,9 +73,9 @@ bool HLTElectronEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   // look at all photons, check cuts and add to filter object
   int n = 0;
 
-  for (unsigned int i=0; i<elecands.size(); i++) {
+  for (auto & elecand : elecands) {
 
-    ref = elecands[i];
+    ref = elecand;
     float Pt = ref->pt();
     float Eta = fabs(ref->eta());
 

--- a/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
@@ -41,7 +41,7 @@ HLTElectronGenericFilter::HLTElectronGenericFilter(const edm::ParameterSet& iCon
   varToken_     = consumes<reco::ElectronIsolationMap>(varTag_);
 }
 
-HLTElectronGenericFilter::~HLTElectronGenericFilter(){}
+HLTElectronGenericFilter::~HLTElectronGenericFilter()= default;
 
 void
 HLTElectronGenericFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -88,9 +88,9 @@ HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   // look at all photons, check cuts and add to filter object
   int n = 0;
 
-  for (unsigned int i=0; i<elecands.size(); i++) {
+  for (auto & elecand : elecands) {
 
-    ref = elecands[i];
+    ref = elecand;
     reco::ElectronIsolationMap::const_iterator mapi = (*depMap).find( ref );
 
     float vali = mapi->val;

--- a/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
@@ -27,8 +27,7 @@ HLTElectronMissingHitsFilter::HLTElectronMissingHitsFilter(const edm::ParameterS
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
 }
 
-HLTElectronMissingHitsFilter::~HLTElectronMissingHitsFilter()
-{}
+HLTElectronMissingHitsFilter::~HLTElectronMissingHitsFilter() = default;
 
 void HLTElectronMissingHitsFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -62,10 +61,10 @@ bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::Even
   int n(0);
 
   edm::RefToBase<reco::Candidate> candref;
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
+  for (auto & recoecalcand : recoecalcands) {
 
-    reco::SuperClusterRef scCand = recoecalcands[i]->superCluster();
-    for(reco::ElectronCollection::const_iterator iElectron = electronHandle->begin(); iElectron != electronHandle->end(); iElectron++) {
+    reco::SuperClusterRef scCand = recoecalcand->superCluster();
+    for(auto iElectron = electronHandle->begin(); iElectron != electronHandle->end(); iElectron++) {
       reco::ElectronRef electronref(reco::ElectronRef(electronHandle, iElectron - electronHandle->begin()));
       const reco::SuperClusterRef scEle = electronref->superCluster();
       if(scCand == scEle) {

--- a/HLTrigger/Egamma/src/HLTElectronMuonInvMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMuonInvMassFilter.cc
@@ -32,7 +32,7 @@ HLTElectronMuonInvMassFilter::HLTElectronMuonInvMassFilter(const edm::ParameterS
 }
 
 
-HLTElectronMuonInvMassFilter::~HLTElectronMuonInvMassFilter(){}
+HLTElectronMuonInvMassFilter::~HLTElectronMuonInvMassFilter()= default;
 
 void
 HLTElectronMuonInvMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -90,24 +90,24 @@ HLTElectronMuonInvMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   
   int nEleMuPairs = 0;
   
-  for(unsigned int i=0; i<electrons.size(); i++) {
-    for(unsigned int j=0; j<l3muons.size(); j++) {
-      double mass = (electrons[i]->p4()+l3muons[j]->p4()).mass();
+  for(auto & electron : electrons) {
+    for(auto & l3muon : l3muons) {
+      double mass = (electron->p4()+l3muon->p4()).mass();
       if(mass>=lowerMassCut_ && mass<=upperMassCut_){
 	nEleMuPairs++;
-	filterproduct.addObject(TriggerElectron, electrons[i]);
-	filterproduct.addObject(TriggerMuon, l3muons[j]);
+	filterproduct.addObject(TriggerElectron, electron);
+	filterproduct.addObject(TriggerMuon, l3muon);
       }
     }
   }
   
-  for(unsigned int i=0; i<clusCands.size(); i++) {
-    for(unsigned int j=0; j<l3muons.size(); j++) {
-      double mass = (clusCands[i]->p4()+l3muons[j]->p4()).mass();
+  for(auto & clusCand : clusCands) {
+    for(auto & l3muon : l3muons) {
+      double mass = (clusCand->p4()+l3muon->p4()).mass();
       if(mass>=lowerMassCut_ && mass<=upperMassCut_){
 	nEleMuPairs++;
-	filterproduct.addObject(TriggerElectron, clusCands[i]);
-	filterproduct.addObject(TriggerMuon, l3muons[j]);
+	filterproduct.addObject(TriggerElectron, clusCand);
+	filterproduct.addObject(TriggerMuon, l3muon);
       }
     }
   }

--- a/HLTrigger/Egamma/src/HLTElectronOneOEMinusOneOPFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTElectronOneOEMinusOneOPFilterRegional.cc
@@ -50,7 +50,7 @@ HLTElectronOneOEMinusOneOPFilterRegional::fillDescriptions(edm::ConfigurationDes
   descriptions.add("hltElectronOneOEMinusOneOPFilterRegional",desc);
 }
 
-HLTElectronOneOEMinusOneOPFilterRegional::~HLTElectronOneOEMinusOneOPFilterRegional(){}
+HLTElectronOneOEMinusOneOPFilterRegional::~HLTElectronOneOEMinusOneOPFilterRegional()= default;
 
 
 // ------------ method called to produce the data  ------------
@@ -91,11 +91,11 @@ HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const ed
     // selections
 
   edm::RefToBase<reco::Candidate> candref;
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
+  for (auto & recoecalcand : recoecalcands) {
 
-    reco::SuperClusterRef recr2 = recoecalcands[i]->superCluster();
+    reco::SuperClusterRef recr2 = recoecalcand->superCluster();
     //loop over the electrons to find the matching one
-    for(reco::ElectronCollection::const_iterator iElectron = electronIsolatedHandle->begin(); iElectron != electronIsolatedHandle->end(); iElectron++){
+    for(auto iElectron = electronIsolatedHandle->begin(); iElectron != electronIsolatedHandle->end(); iElectron++){
       // ElectronRef is a Ref<reco::RecoEcalCandidateCollection>
       reco::ElectronRef electronref(reco::ElectronRef(electronIsolatedHandle,iElectron - electronIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();
@@ -123,7 +123,7 @@ HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const ed
 
     if(!doIsolated_) {
     //loop over the electrons to find the matching one
-    for(reco::ElectronCollection::const_iterator iElectron = electronNonIsolatedHandle->begin(); iElectron != electronNonIsolatedHandle->end(); iElectron++){
+    for(auto iElectron = electronNonIsolatedHandle->begin(); iElectron != electronNonIsolatedHandle->end(); iElectron++){
 
       reco::ElectronRef electronref(reco::ElectronRef(electronNonIsolatedHandle,iElectron - electronNonIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();

--- a/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
@@ -20,7 +20,7 @@ HLTElectronPFMTFilter<T>::HLTElectronPFMTFilter(const edm::ParameterSet& iConfig
 }
 
 template <typename T> 
-HLTElectronPFMTFilter<T>::~HLTElectronPFMTFilter(){}
+HLTElectronPFMTFilter<T>::~HLTElectronPFMTFilter()= default;
 
 template <typename T> 
 void HLTElectronPFMTFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
@@ -60,8 +60,7 @@ HLTElectronPixelMatchFilter::HLTElectronPixelMatchFilter(const edm::ParameterSet
 
 }
 
-HLTElectronPixelMatchFilter::~HLTElectronPixelMatchFilter()
-{}
+HLTElectronPixelMatchFilter::~HLTElectronPixelMatchFilter() = default;
 
 float HLTElectronPixelMatchFilter::calDPhi1Sq(reco::ElectronSeedCollection::const_iterator seed, int charge)const
 {
@@ -135,9 +134,9 @@ bool HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::Event
   
   // look at all egammas,  check cuts and add to filter object
   int n = 0;
-  for (unsigned int i=0; i<recoecalcands.size(); i++) {
+  for (auto & recoecalcand : recoecalcands) {
 
-    ref = recoecalcands[i];
+    ref = recoecalcand;
     reco::SuperClusterRef recr2 = ref->superCluster();
     
     int nmatch = getNrOfMatches(l1PixelSeeds, recr2);
@@ -165,7 +164,7 @@ int HLTElectronPixelMatchFilter::getNrOfMatches(edm::Handle<reco::ElectronSeedCo
 						reco::SuperClusterRef& candSCRef)const
 {
   int nrMatch=0;
-  for(reco::ElectronSeedCollection::const_iterator seedIt = eleSeeds->begin(); seedIt != eleSeeds->end(); seedIt++){
+  for(auto seedIt = eleSeeds->begin(); seedIt != eleSeeds->end(); seedIt++){
     edm::RefToBase<reco::CaloCluster> caloCluster = seedIt->caloCluster() ;
     reco::SuperClusterRef scRef = caloCluster.castTo<reco::SuperClusterRef>() ;
     if(&(*candSCRef) ==  &(*scRef)){

--- a/HLTrigger/Egamma/src/HLTPMDocaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMDocaFilter.cc
@@ -29,7 +29,7 @@ HLTPMDocaFilter::HLTPMDocaFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
 }
 
-HLTPMDocaFilter::~HLTPMDocaFilter(){}
+HLTPMDocaFilter::~HLTPMDocaFilter()= default;
 
 void
 HLTPMDocaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Egamma/src/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMMassFilter.cc
@@ -30,7 +30,7 @@ HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
   beamSpotToken_ = consumes<reco::BeamSpot> (beamSpot_);
 }
 
-HLTPMMassFilter::~HLTPMMassFilter(){}
+HLTPMMassFilter::~HLTPMMassFilter()= default;
 
 void
 HLTPMMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -95,9 +95,9 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     vector< Ref< ElectronCollection > > electrons;
     PrevFilterOutput->getObjects(TriggerElectron, electrons);
 
-    for (unsigned int i=0; i<electrons.size(); i++) {
+    for (auto & electron : electrons) {
 
-      refele = electrons[i];
+      refele = electron;
 
       TLorentzVector pThisEle(refele->px(), refele->py(),
 			      refele->pz(), refele->energy() );
@@ -136,9 +136,9 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     PrevFilterOutput->getObjects(TriggerCluster, scs);
     if(scs.empty()) PrevFilterOutput->getObjects(TriggerPhoton, scs);  //we dont know if its type trigger cluster or trigger photon
 
-    for (unsigned int i=0; i<scs.size(); i++) {
+    for (auto & i : scs) {
 
-      refsc = scs[i];
+      refsc = i;
       const reco::SuperClusterRef sc = refsc->superCluster();
       TLorentzVector pscPos = approxMomAtVtx(theMagField.product(), vertexPos, sc, 1);
       pEleCh1.push_back( pscPos );

--- a/HLTrigger/Egamma/src/HLTScoutingEgammaProducer.cc
+++ b/HLTrigger/Egamma/src/HLTScoutingEgammaProducer.cc
@@ -48,8 +48,7 @@ HLTScoutingEgammaProducer::HLTScoutingEgammaProducer(const edm::ParameterSet& iC
     produces<ScoutingPhotonCollection>();
 }
 
-HLTScoutingEgammaProducer::~HLTScoutingEgammaProducer()
-{ }
+HLTScoutingEgammaProducer::~HLTScoutingEgammaProducer() = default;
 
 // ------------ method called to produce the data  ------------
 void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const

--- a/HLTrigger/HLTanalyzers/plugins/RemovePileUpDominatedEventsGen.cc
+++ b/HLTrigger/HLTanalyzers/plugins/RemovePileUpDominatedEventsGen.cc
@@ -34,11 +34,11 @@ For more information on the theory of this method see Appendix B of https://www.
 class RemovePileUpDominatedEventsGen : public edm::stream::EDFilter <>{
    public:
       explicit RemovePileUpDominatedEventsGen(const edm::ParameterSet&);
-      ~RemovePileUpDominatedEventsGen();
+      ~RemovePileUpDominatedEventsGen() override;
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      bool filter(edm::Event&, const edm::EventSetup&) override;
 
       const edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupSummaryInfos_;
       const edm::EDGetTokenT<GenEventInfoProduct > generatorInfo_;
@@ -53,7 +53,7 @@ bunchCrossing=0;
 produces<float>();
 }
 
-RemovePileUpDominatedEventsGen::~RemovePileUpDominatedEventsGen() {}
+RemovePileUpDominatedEventsGen::~RemovePileUpDominatedEventsGen() = default;
 
 bool RemovePileUpDominatedEventsGen::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
    using namespace edm;

--- a/HLTrigger/HLTanalyzers/src/EventHeader.cc
+++ b/HLTrigger/HLTanalyzers/src/EventHeader.cc
@@ -18,9 +18,7 @@ EventHeader::EventHeader() :
   _Debug( false )
 { }
 
-EventHeader::~EventHeader() {
-
-}
+EventHeader::~EventHeader() = default;
 
 /*  Setup the analysis to put the branch-variables into the tree. */
 void EventHeader::setup(edm::ConsumesCollector && iC, TTree* HltTree) {

--- a/HLTrigger/HLTanalyzers/src/HLTBitAnalyzer.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTBitAnalyzer.cc
@@ -98,7 +98,7 @@ HLTBitAnalyzer::HLTBitAnalyzer(edm::ParameterSet const& conf)  :
   
   _UseTFileService = conf.getUntrackedParameter<bool>("UseTFileService",false);
 	
-  m_file = 0;   // set to null
+  m_file = nullptr;   // set to null
   errCnt = 0;
 
   // read run parameters with a default value
@@ -258,12 +258,12 @@ void HLTBitAnalyzer::endJob() {
 		
 		HltTree->Write();
 		delete HltTree;
-		HltTree = 0;
+		HltTree = nullptr;
 		
 		if (m_file) {         // if there was a tree file...
 			m_file->Write();    // write out the branches
 			delete m_file;      // close and delete the file
-			m_file = 0;         // set to zero to clean up
+			m_file = nullptr;         // set to zero to clean up
 		}
 	}
 }

--- a/HLTrigger/HLTanalyzers/src/HLTGetDigi.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTGetDigi.cc
@@ -152,8 +152,7 @@ HLTGetDigi::HLTGetDigi(const edm::ParameterSet& ps)
 
 }
 
-HLTGetDigi::~HLTGetDigi()
-{ }
+HLTGetDigi::~HLTGetDigi() = default;
 
 void
 HLTGetDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -222,9 +221,9 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     edm::Handle<L1GctEtMiss> GctEtMiss ; 
     edm::Handle<L1GctEtTotal> GctEtTotal ; 
 
-    const L1GctEtHad*   etHad   = 0 ; 
-    const L1GctEtMiss*  etMiss  = 0 ; 
-    const L1GctEtTotal* etTotal = 0 ;
+    const L1GctEtHad*   etHad   = nullptr ; 
+    const L1GctEtMiss*  etMiss  = nullptr ; 
+    const L1GctEtTotal* etTotal = nullptr ;
 
     if (getGctEtDigis_) {
         iEvent.getByToken(GctEtHadToken_,GctEtHad) ; 
@@ -242,8 +241,8 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     edm::Handle<L1GctEmCandCollection> GctIsoEM ; 
     edm::Handle<L1GctEmCandCollection> GctNonIsoEM ; 
 
-    const L1GctEmCandCollection* isoEMdigis = 0 ; 
-    const L1GctEmCandCollection* nonIsoEMdigis = 0 ; 
+    const L1GctEmCandCollection* isoEMdigis = nullptr ; 
+    const L1GctEmCandCollection* nonIsoEMdigis = nullptr ; 
     if (getGctEmDigis_) {
         iEvent.getByToken(GctIsoEmToken_,GctIsoEM) ;
         isoEMdigis = GctIsoEM.product() ; 
@@ -258,10 +257,10 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     edm::Handle<L1GctJetCandCollection> GctTauJets ; 
     edm::Handle<L1GctJetCounts> GctJetCounts ; 
 
-    const L1GctJetCandCollection* cenJetDigis = 0 ; 
-    const L1GctJetCandCollection* forJetDigis = 0 ; 
-    const L1GctJetCandCollection* tauJetDigis = 0 ;
-    std::auto_ptr<L1GctJetCounts> newCounts( new L1GctJetCounts() ) ;
+    const L1GctJetCandCollection* cenJetDigis = nullptr ; 
+    const L1GctJetCandCollection* forJetDigis = nullptr ; 
+    const L1GctJetCandCollection* tauJetDigis = nullptr ;
+    std::unique_ptr<L1GctJetCounts> newCounts( new L1GctJetCounts() ) ;
     L1GctJetCounts* counts = newCounts.get() ; 
         
     if (getGctJetDigis_) {
@@ -284,8 +283,8 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     edm::Handle<L1CaloEmCollection> GctCaloEm ; 
     edm::Handle<L1CaloRegionCollection> GctCaloRegion ; 
     
-    const L1CaloEmCollection* caloEm = 0 ; 
-    const L1CaloRegionCollection* caloRegion = 0 ; 
+    const L1CaloEmCollection* caloEm = nullptr ; 
+    const L1CaloRegionCollection* caloRegion = nullptr ; 
 
     if (getL1Calo_) {
         iEvent.getByToken(GctCaloEmToken_,GctCaloEm) ; 
@@ -306,9 +305,9 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     iSetup.get< L1GtParametersRcd >().get( l1GtPar ) ;
     int nBx = l1GtPar->gtTotalBxInEvent() ; 
     
-    std::auto_ptr<L1GlobalTriggerEvmReadoutRecord> newGtEvm( new L1GlobalTriggerEvmReadoutRecord(nBx) ) ; 
-    std::auto_ptr<L1GlobalTriggerObjectMapRecord> newGtMap( new L1GlobalTriggerObjectMapRecord() ) ; 
-    std::auto_ptr<L1GlobalTriggerReadoutRecord> newGtRR( new L1GlobalTriggerReadoutRecord(nBx) ) ; 
+    std::unique_ptr<L1GlobalTriggerEvmReadoutRecord> newGtEvm( new L1GlobalTriggerEvmReadoutRecord(nBx) ) ; 
+    std::unique_ptr<L1GlobalTriggerObjectMapRecord> newGtMap( new L1GlobalTriggerObjectMapRecord() ) ; 
+    std::unique_ptr<L1GlobalTriggerReadoutRecord> newGtRR( new L1GlobalTriggerReadoutRecord(nBx) ) ; 
     L1GlobalTriggerEvmReadoutRecord* evm = newGtEvm.get() ; 
     L1GlobalTriggerObjectMapRecord* map = newGtMap.get() ; 
     L1GlobalTriggerReadoutRecord* rr = newGtRR.get() ; 
@@ -328,8 +327,8 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     
     edm::Handle< std::vector<L1MuGMTCand> > GmtCands ;
     edm::Handle<L1MuGMTReadoutCollection> GmtMuCollection ; 
-    std::auto_ptr<std::vector<L1MuGMTCand> > cands( new std::vector<L1MuGMTCand> ) ;
-    std::auto_ptr<L1MuGMTReadoutCollection> muCollection(new L1MuGMTReadoutCollection(nBx)) ;
+    std::unique_ptr<std::vector<L1MuGMTCand> > cands( new std::vector<L1MuGMTCand> ) ;
+    std::unique_ptr<L1MuGMTReadoutCollection> muCollection(new L1MuGMTReadoutCollection(nBx)) ;
  
     if (getGmtCands_) {
         iEvent.getByToken(GmtCandsToken_,GmtCands) ; 
@@ -343,7 +342,7 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
     
     edm::Handle< DetSetVector<PixelDigi> >  input;
-    auto_ptr<DetSetVector<PixelDigi> > NewPixelDigi(new DetSetVector<PixelDigi> );
+    unique_ptr<DetSetVector<PixelDigi> > NewPixelDigi(new DetSetVector<PixelDigi> );
     DetSetVector<PixelDigi>* tt = NewPixelDigi.get();
     if (getPixelDigis_) {
         iEvent.getByToken(PXLdigiToken_, input);
@@ -351,7 +350,7 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
 
     edm::Handle< edm::DetSetVector<SiStripDigi> >  input2;
-    auto_ptr<DetSetVector<SiStripDigi> > NewSiDigi(new DetSetVector<SiStripDigi> );
+    unique_ptr<DetSetVector<SiStripDigi> > NewSiDigi(new DetSetVector<SiStripDigi> );
     DetSetVector<SiStripDigi>* uu = NewSiDigi.get();
     if (getStripDigis_) {
         iEvent.getByToken(SSTdigiToken_, input2);
@@ -361,9 +360,9 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     Handle<EBDigiCollection> EcalDigiEB;
     Handle<EEDigiCollection> EcalDigiEE;
     Handle<ESDigiCollection> EcalDigiES;
-    const EBDigiCollection* EBdigis = 0;
-    const EEDigiCollection* EEdigis = 0;
-    const ESDigiCollection* ESdigis = 0; 
+    const EBDigiCollection* EBdigis = nullptr;
+    const EEDigiCollection* EEdigis = nullptr;
+    const ESDigiCollection* ESdigis = nullptr; 
 
     if (getEcalDigis_) {
         iEvent.getByToken( EBdigiToken_, EcalDigiEB );
@@ -384,9 +383,9 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     Handle<HBHEDigiCollection> HcalDigiHBHE ; 
     Handle<HODigiCollection> HcalDigiHO ; 
     Handle<HFDigiCollection> HcalDigiHF ; 
-    const HBHEDigiCollection* HBHEdigis = 0 ;
-    const HODigiCollection* HOdigis = 0 ;
-    const HFDigiCollection* HFdigis = 0 ; 
+    const HBHEDigiCollection* HBHEdigis = nullptr ;
+    const HODigiCollection* HOdigis = nullptr ;
+    const HFDigiCollection* HFdigis = nullptr ; 
 
     if (getHcalDigis_) {
         iEvent.getByToken( HBHEdigiToken_, HcalDigiHBHE );
@@ -410,17 +409,15 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
         iEvent.getByToken( CSCWiredigiToken_,  CSCDigiWire );
 
         int numDigis = 0 ; 
-        for (CSCStripDigiCollection::DigiRangeIterator iter=CSCDigiStrip->begin();
-             iter!=CSCDigiStrip->end(); iter++) {
-            for ( vector<CSCStripDigi>::const_iterator digiIter = (*iter).second.first;
-                  digiIter != (*iter).second.second; digiIter++) numDigis++ ;
+        for (auto && iter : *CSCDigiStrip) {
+            for ( auto digiIter = iter.second.first;
+                  digiIter != iter.second.second; digiIter++) numDigis++ ;
         }
         LogDebug("DigiInfo") << "total # CSCstripdigis: " << numDigis ;
         numDigis = 0 ; 
-        for (CSCWireDigiCollection::DigiRangeIterator iter=CSCDigiWire->begin();
-             iter!=CSCDigiWire->end(); iter++) {
-            for ( vector<CSCWireDigi>::const_iterator digiIter = (*iter).second.first;
-                  digiIter != (*iter).second.second; digiIter++) numDigis++ ;
+        for (auto && iter : *CSCDigiWire) {
+            for ( auto digiIter = iter.second.first;
+                  digiIter != iter.second.second; digiIter++) numDigis++ ;
         }
         LogDebug("DigiInfo") << "total # CSCwiredigis: " << numDigis ;
     }
@@ -431,10 +428,9 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
         iEvent.getByToken( DTdigiToken_, DTDigiHandle );
     
         int numDigis = 0 ; 
-        for (DTDigiCollection::DigiRangeIterator iter=DTDigiHandle->begin();
-             iter!=DTDigiHandle->end(); iter++) {
-            for ( vector<DTDigi>::const_iterator digiIter = (*iter).second.first;
-                  digiIter != (*iter).second.second; digiIter++) numDigis++ ;
+        for (auto && iter : *DTDigiHandle) {
+            for ( auto digiIter = iter.second.first;
+                  digiIter != iter.second.second; digiIter++) numDigis++ ;
         }
         LogDebug("DigiInfo") << "total # DTdigis: " << numDigis ;
     }
@@ -445,10 +441,9 @@ HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
         iEvent.getByToken( RPCdigiToken_, RPCDigiHandle );
 
         int numDigis = 0 ; 
-        for (RPCDigiCollection::DigiRangeIterator iter=RPCDigiHandle->begin();
-             iter!=RPCDigiHandle->end(); iter++) {
-            for ( vector<RPCDigi>::const_iterator digiIter = (*iter).second.first;
-                  digiIter != (*iter).second.second; digiIter++) numDigis++ ;
+        for (auto && iter : *RPCDigiHandle) {
+            for ( auto digiIter = iter.second.first;
+                  digiIter != iter.second.second; digiIter++) numDigis++ ;
         }
         LogDebug("DigiInfo") << "total # RPCdigis: " << numDigis ;
     }

--- a/HLTrigger/HLTanalyzers/src/HLTGetRaw.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTGetRaw.cc
@@ -21,9 +21,7 @@ HLTGetRaw::HLTGetRaw(const edm::ParameterSet& ps) :
 {
 }
 
-HLTGetRaw::~HLTGetRaw()
-{
-}
+HLTGetRaw::~HLTGetRaw() = default;
 
 void
 HLTGetRaw::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/HLTanalyzers/src/HLTInfo.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTInfo.cc
@@ -57,9 +57,8 @@ void HLTInfo::setup(const edm::ParameterSet& pSet, TTree* HltTree) {
   edm::ParameterSet myHltParams = pSet.getParameter<edm::ParameterSet>("RunParameters") ;
   std::vector<std::string> parameterNames = myHltParams.getParameterNames() ;
   
-  for ( std::vector<std::string>::iterator iParam = parameterNames.begin();
-        iParam != parameterNames.end(); iParam++ ){
-    if ( (*iParam) == "Debug" ) _Debug =  myHltParams.getParameter<bool>( *iParam );
+  for (auto & parameterName : parameterNames){
+    if ( parameterName == "Debug" ) _Debug =  myHltParams.getParameter<bool>( parameterName );
   }
 
   dummyBranches_ = pSet.getUntrackedParameter<std::vector<std::string> >("dummyBranches",std::vector<std::string>(0));
@@ -114,8 +113,8 @@ void HLTInfo::analyze(const edm::Handle<edm::TriggerResults>                 & h
       }
 
       int itdum = ntrigs;
-      for (unsigned int idum = 0; idum < dummyBranches_.size(); ++idum) {
-	TString trigName(dummyBranches_[idum].data());
+      for (auto & dummyBranche : dummyBranches_) {
+	TString trigName(dummyBranche.data());
 	bool addThisBranch = 1;
 	for (int itrig = 0; itrig != ntrigs; ++itrig) {
 	  TString realTrigName = triggerNames.triggerName(itrig);

--- a/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
@@ -26,11 +26,10 @@ void HLTMCtruth::setup(const edm::ParameterSet& pSet, TTree* HltTree) {
   edm::ParameterSet myMCParams = pSet.getParameter<edm::ParameterSet>("RunParameters") ;
   std::vector<std::string> parameterNames = myMCParams.getParameterNames() ;
   
-  for ( std::vector<std::string>::iterator iParam = parameterNames.begin();
-	iParam != parameterNames.end(); iParam++ ){
-    if  ( (*iParam) == "Monte" ) _Monte =  myMCParams.getParameter<bool>( *iParam );
-    else if ( (*iParam) == "GenTracks" ) _Gen =  myMCParams.getParameter<bool>( *iParam );
-    else if ( (*iParam) == "Debug" ) _Debug =  myMCParams.getParameter<bool>( *iParam );
+  for (auto & parameterName : parameterNames){
+    if  ( parameterName == "Monte" ) _Monte =  myMCParams.getParameter<bool>( parameterName );
+    else if ( parameterName == "GenTracks" ) _Gen =  myMCParams.getParameter<bool>( parameterName );
+    else if ( parameterName == "Debug" ) _Debug =  myMCParams.getParameter<bool>( parameterName );
   }
 
   const int kMaxMcTruth = 10000;
@@ -121,15 +120,15 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView> & mctruth,
     }
 
     if((simTracks.isValid())&&(simVertices.isValid())){
-      for (unsigned int j=0; j<simTracks->size(); j++) {
-	int pdgid = simTracks->at(j).type();
+      for (auto const & j : *simTracks) {
+	int pdgid = j.type();
 	if (abs(pdgid)!=13) continue;
-	double pt = simTracks->at(j).momentum().pt();
+	double pt = j.momentum().pt();
 	if (pt<5.0) continue;
-	double eta = simTracks->at(j).momentum().eta();
+	double eta = j.momentum().eta();
 	if (abs(eta)>2.5) continue;
-	if (simTracks->at(j).noVertex()) continue;
-	int vertIndex = simTracks->at(j).vertIndex();
+	if (j.noVertex()) continue;
+	int vertIndex = j.vertIndex();
 	double x = simVertices->at(vertIndex).position().x();
 	double y = simVertices->at(vertIndex).position().y();
 	double r = sqrt(x*x+y*y);

--- a/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
@@ -114,7 +114,7 @@ HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig) :
 
 }
 
-HLTrigReport::~HLTrigReport() { }
+HLTrigReport::~HLTrigReport() = default;
 
 void
 HLTrigReport::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -235,8 +235,8 @@ void HLTrigReport::reset(bool changed /* = false */) {
     // reset the matrix of hlAccTotDS_
     for (unsigned int ds = 0; ds < datasetNames_.size(); ds++) {
       hlAllTotDS_[ds]=0;
-      for (unsigned int i = 0; i < hlAccTotDS_[ds].size(); ++i)
-          hlAccTotDS_[ds][i] = 0;
+      for (unsigned int & i : hlAccTotDS_[ds])
+          i = 0;
     }
   }
 
@@ -268,8 +268,8 @@ void HLTrigReport::reset(bool changed /* = false */) {
     // reset the matrix of dsAccTotS_
     for (unsigned int s = 0; s < streamNames_.size(); ++s) {
       dsAllTotS_[s]=0;
-      for (unsigned int i = 0; i < dsAccTotS_[s].size(); ++i)
-        dsAccTotS_[s][i] = 0;
+      for (unsigned int & i : dsAccTotS_[s])
+        i = 0;
     }
   }
 

--- a/HLTrigger/HLTanalyzers/src/RECOVertex.cc
+++ b/HLTrigger/HLTanalyzers/src/RECOVertex.cc
@@ -51,9 +51,8 @@ void RECOVertex::setup(const edm::ParameterSet& pSet, TTree* HltTree, std::strin
   edm::ParameterSet myHltParams = pSet.getParameter<edm::ParameterSet>("RunParameters") ;
   std::vector<std::string> parameterNames = myHltParams.getParameterNames() ;
   
-  for ( std::vector<std::string>::iterator iParam = parameterNames.begin();
-        iParam != parameterNames.end(); iParam++ ){
-    if ( (*iParam) == "Debug" ) _Debug =  myHltParams.getParameter<bool>( *iParam );
+  for (auto & parameterName : parameterNames){
+    if ( parameterName == "Debug" ) _Debug =  myHltParams.getParameter<bool>( parameterName );
   }
 
   TString br_recoNVrt = "recoNVrt";

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
@@ -39,9 +39,7 @@ HLTEventAnalyzerAOD::HLTEventAnalyzerAOD(const edm::ParameterSet& ps) :
 
 }
 
-HLTEventAnalyzerAOD::~HLTEventAnalyzerAOD()
-{
-}
+HLTEventAnalyzerAOD::~HLTEventAnalyzerAOD() = default;
 
 //
 // member functions

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -55,9 +55,7 @@ HLTEventAnalyzerRAW::HLTEventAnalyzerRAW(const edm::ParameterSet& ps) :
 
 }
 
-HLTEventAnalyzerRAW::~HLTEventAnalyzerRAW()
-{
-}
+HLTEventAnalyzerRAW::~HLTEventAnalyzerRAW() = default;
 
 //
 // member functions

--- a/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
@@ -42,8 +42,8 @@ HLTPrescaleRecorder::HLTPrescaleRecorder(const edm::ParameterSet& ps) :
   hltInputTag_(ps.getParameter<InputTag>("hltInputTag")),
   hltInputToken_(),
   hltDBTag_(ps.getParameter<string>("hltDBTag")),
-  ps_(0),
-  db_(0),
+  ps_(nullptr),
+  db_(nullptr),
   hltHandle_(),
   hltESHandle_(),
   hlt_()
@@ -83,9 +83,7 @@ HLTPrescaleRecorder::HLTPrescaleRecorder(const edm::ParameterSet& ps) :
 
 }
 
-HLTPrescaleRecorder::~HLTPrescaleRecorder()
-{
-}
+HLTPrescaleRecorder::~HLTPrescaleRecorder() = default;
 
 //
 // member functions
@@ -142,7 +140,7 @@ void HLTPrescaleRecorder::beginRun(edm::Run const& iRun, const edm::EventSetup& 
   } else  if (src_==0) {
     /// From PrescaleService
     /// default index updated at lumi block boundaries
-    if (ps_!=0) {
+    if (ps_!=nullptr) {
       hlt_=HLTPrescaleTable(ps_->getLvl1IndexDefault(), ps_->getLvl1Labels(), ps_->getPrescaleTable());
     } else {
       hlt_=HLTPrescaleTable();
@@ -170,7 +168,7 @@ void HLTPrescaleRecorder::beginLuminosityBlock(edm::LuminosityBlock const& iLumi
   if (src_==0) {
     /// From PrescaleService
     /// default index updated at lumi block boundaries
-    if (ps_!=0) {
+    if (ps_!=nullptr) {
       hlt_=HLTPrescaleTable(ps_->getLvl1IndexDefault(), ps_->getLvl1Labels(), ps_->getPrescaleTable());
     } else {
       hlt_=HLTPrescaleTable();
@@ -247,15 +245,15 @@ void HLTPrescaleRecorder::endRun(edm::Run const& iRun, const edm::EventSetup& iS
 
   if (condDB_) {
     /// Writing to CondDB (needs PoolDBOutputService)
-    if (db_!=0) {
-      HLTPrescaleTableCond* product (new HLTPrescaleTableCond(hlt_));
+    if (db_!=nullptr) {
+      auto  product (new HLTPrescaleTableCond(hlt_));
       const string rcdName("HLTPrescaleTableRcd");
       if ( db_->isNewTagRequest(rcdName) ) {
 	db_->createNewIOV<HLTPrescaleTableCond>(product,
 	      db_->beginOfTime(),db_->endOfTime(),rcdName);
       } else {
 	::timeval tv;
-	gettimeofday(&tv,0);
+	gettimeofday(&tv,nullptr);
 	edm::Timestamp tstamp((unsigned long long)tv.tv_sec);
 	db_->appendSinceTime<HLTPrescaleTableCond>(product,
 //            db_->currentTime()

--- a/HLTrigger/HLTcore/plugins/HLTPrescaler.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaler.cc
@@ -35,7 +35,7 @@ HLTPrescaler::HLTPrescaler(edm::ParameterSet const& iConfig, const trigger::Effi
   , acceptCount_(0)
   , offsetCount_(0)
   , offsetPhase_(iConfig.getParameter<unsigned int>("offset"))
-  , prescaleService_(0)
+  , prescaleService_(nullptr)
   , newLumi_(true)
   , gtDigiTag_ (iConfig.getParameter<edm::InputTag>("L1GtReadoutRecordTag"))
   , gtDigi1Token_ (consumes<L1GlobalTriggerReadoutRecord>(gtDigiTag_))
@@ -48,10 +48,7 @@ HLTPrescaler::HLTPrescaler(edm::ParameterSet const& iConfig, const trigger::Effi
 }
 
 //_____________________________________________________________________________    
-HLTPrescaler::~HLTPrescaler()
-{
-  
-}
+HLTPrescaler::~HLTPrescaler() = default;
 
 ////////////////////////////////////////////////////////////////////////////////
 // implementation of member functions

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerAOD.cc
@@ -19,9 +19,7 @@ TriggerSummaryAnalyzerAOD::TriggerSummaryAnalyzerAOD(const edm::ParameterSet& ps
   inputToken_(consumes<trigger::TriggerEvent>(inputTag_))
 { }
 
-TriggerSummaryAnalyzerAOD::~TriggerSummaryAnalyzerAOD()
-{
-}
+TriggerSummaryAnalyzerAOD::~TriggerSummaryAnalyzerAOD() = default;
 
 //
 // member functions

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
@@ -19,9 +19,7 @@ TriggerSummaryAnalyzerRAW::TriggerSummaryAnalyzerRAW(const edm::ParameterSet& ps
   inputToken_(consumes<trigger::TriggerEventWithRefs>(inputTag_))
 { }
 
-TriggerSummaryAnalyzerRAW::~TriggerSummaryAnalyzerRAW()
-{
-}
+TriggerSummaryAnalyzerRAW::~TriggerSummaryAnalyzerRAW() = default;
 
 //
 // member functions

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -178,9 +178,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   });
 }
 
-TriggerSummaryProducerAOD::~TriggerSummaryProducerAOD()
-{
-}
+TriggerSummaryProducerAOD::~TriggerSummaryProducerAOD() = default;
 
 //
 // member functions

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
@@ -49,9 +49,7 @@ TriggerSummaryProducerRAW::TriggerSummaryProducerRAW(const edm::ParameterSet& ps
   callWhenNewProductsRegistered(getterOfProducts_);
 }
 
-TriggerSummaryProducerRAW::~TriggerSummaryProducerRAW()
-{
-}
+TriggerSummaryProducerRAW::~TriggerSummaryProducerRAW() = default;
 
 //
 // member functions

--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -70,7 +70,7 @@ void HLTConfigData::extract()
 
    // Extract globaltag
    globalTag_="";
-   const ParameterSet* GlobalTagPSet(0);
+   const ParameterSet* GlobalTagPSet(nullptr);
    if (processPSet_->exists("GlobalTag")) {
      GlobalTagPSet = &(processPSet_->getParameterSet("GlobalTag"));
    } else if (processPSet_->exists("PoolDBESSource@GlobalTag")) {
@@ -255,10 +255,10 @@ void HLTConfigData::extract()
    unsigned int stage1(0),stage2(0);
    if (processPSet_->existsAs<std::vector<std::string>>("@all_modules")) {
      const std::vector<std::string>& allModules(processPSet_->getParameter<std::vector<std::string>>("@all_modules"));
-     for (unsigned int i=0; i<allModules.size(); i++) {
-       if ((moduleType(allModules[i]) == "HLTLevel1GTSeed") or (moduleType(allModules[i]) == "L1GlobalTrigger")){
+     for (auto const & allModule : allModules) {
+       if ((moduleType(allModule) == "HLTLevel1GTSeed") or (moduleType(allModule) == "L1GlobalTrigger")){
 	 stage1 += 1;
-       } else if ((moduleType(allModules[i]) == "HLTL1TSeed") or (moduleType(allModules[i]) == "L1TGlobalProducer")){
+       } else if ((moduleType(allModule) == "HLTL1TSeed") or (moduleType(allModule) == "L1TGlobalProducer")){
 	 stage2 += 1;
        }
      }

--- a/HLTrigger/HLTcore/src/HLTConfigProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigProvider.cc
@@ -63,7 +63,7 @@ void HLTConfigProvider::init(const edm::ProcessHistory& iHistory, const std::str
    const ProcessHistory::const_iterator he(iHistory.end());
 
    ProcessConfiguration processConfiguration;
-   const edm::ParameterSet* processPSet(0);
+   const edm::ParameterSet* processPSet(nullptr);
 
    processName_=processName;
    if (processName_=="*") {
@@ -71,7 +71,7 @@ void HLTConfigProvider::init(const edm::ProcessHistory& iHistory, const std::str
      for (ProcessHistory::const_iterator hi=hb; hi!=he; ++hi) {
        if (iHistory.getConfigurationForProcess(hi->processName(),processConfiguration)) {
 	 processPSet = edm::pset::Registry::instance()->getMapped(processConfiguration.parameterSetID());
-	 if ((processPSet!=0) && (processPSet->exists("hltTriggerSummaryAOD"))) {
+	 if ((processPSet!=nullptr) && (processPSet->exists("hltTriggerSummaryAOD"))) {
 	   processName_=hi->processName();
 	 }	 
        }
@@ -120,13 +120,13 @@ void HLTConfigProvider::getDataFrom(const edm::ParameterSetID& iID)
   //is it in our registry?
   HLTConfigDataRegistry* reg = HLTConfigDataRegistry::instance();
   const HLTConfigData* d = reg->getMapped(iID);
-  if(0 != d) {
+  if(nullptr != d) {
     changed_ = true;
     inited_  = true;
     hltConfigData_ = d;
   } else {
-    const edm::ParameterSet* processPSet = 0;
-    if ( 0 != (processPSet = edm::pset::Registry::instance()->getMapped(iID))) {
+    const edm::ParameterSet* processPSet = nullptr;
+    if ( nullptr != (processPSet = edm::pset::Registry::instance()->getMapped(iID))) {
        if (not processPSet->id().isValid()) {
          clear();
          edm::LogError("HLTConfigProvider") << "ProcessPSet found is empty!";
@@ -163,7 +163,7 @@ void HLTConfigProvider::init(const std::string& processName)
    // processName) from pset registry
    string pNames("");
    string hNames("");
-   const ParameterSet*   pset = 0;
+   const ParameterSet*   pset = nullptr;
    ParameterSetID psetID;
    unsigned int   nPSets(0);
    const edm::pset::Registry * registry_(pset::Registry::instance());
@@ -178,7 +178,7 @@ void HLTConfigProvider::init(const std::string& processName)
          nPSets++;
          if ((hltConfigData_ != s_dummyHLTConfigData()) && (hltConfigData_->id()==psetID)) {
            hNames += tableName();
-         } else if ( 0 != (pset = registry_->getMapped(psetID))) {
+         } else if ( nullptr != (pset = registry_->getMapped(psetID))) {
            if (pset->exists("HLTConfigVersion")) {
              const ParameterSet& HLTPSet(pset->getParameterSet("HLTConfigVersion"));
              if (HLTPSet.exists("tableName")) {

--- a/HLTrigger/HLTcore/src/HLTFilter.cc
+++ b/HLTrigger/HLTcore/src/HLTFilter.cc
@@ -30,8 +30,7 @@ HLTFilter::makeHLTFilterDescription(edm::ParameterSetDescription& desc) {
   desc.add<bool>("saveTags",true);
 }
 
-HLTFilter::~HLTFilter()
-{ }
+HLTFilter::~HLTFilter() = default;
 
 bool HLTFilter::filter(edm::StreamID, edm::Event & event, const edm::EventSetup & setup) const {
   std::unique_ptr<trigger::TriggerFilterObjectWithRefs> filterproduct( new trigger::TriggerFilterObjectWithRefs(path(event), module(event)) );

--- a/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
@@ -237,8 +237,8 @@ HLTPrescaleProvider::prescaleValuesInDetail(const edm::Event& iEvent,
     const std::vector<std::pair<std::string, int> >& errorCodes(l1Logical.errorCodes(iEvent));
     result.first = l1Logical.prescaleFactors();
     int               l1error(l1Logical.isValid() ? 0 : 1);
-    for (unsigned int i=0; i<errorCodes.size(); ++i) {
-      l1error += std::abs(errorCodes[i].second);
+    for (auto const & errorCode : errorCodes) {
+      l1error += std::abs(errorCode.second);
     }
     if (l1error!=0) {
       if (count_[3]<countMax) {
@@ -288,8 +288,8 @@ HLTPrescaleProvider::prescaleValuesInDetail(const edm::Event& iEvent,
     const std::vector<GlobalLogicParser::OperandToken> l1tSeeds = l1tGlobalLogicParser.expressionSeedsOperandList();
     int l1error(0);
     int l1tPrescale(-1);
-    for (unsigned int i=0; i<l1tSeeds.size(); ++i) {
-      const string& l1tSeed = l1tSeeds[i].tokenName;
+    for (auto const & i : l1tSeeds) {
+      const string& l1tSeed = i.tokenName;
       if (!l1tGlobalUtil_.getPrescaleByName(l1tSeed,l1tPrescale)) {
 	l1error += 1;
       }

--- a/HLTrigger/HLTcore/src/HLTStreamFilter.cc
+++ b/HLTrigger/HLTcore/src/HLTStreamFilter.cc
@@ -30,8 +30,7 @@ HLTStreamFilter::makeHLTFilterDescription(edm::ParameterSetDescription& desc) {
   desc.add<bool>("saveTags",true);
 }
 
-HLTStreamFilter::~HLTStreamFilter()
-{ }
+HLTStreamFilter::~HLTStreamFilter() = default;
 
 bool HLTStreamFilter::filter(edm::Event & event, const edm::EventSetup & setup) {
   std::unique_ptr<trigger::TriggerFilterObjectWithRefs> filterproduct( new trigger::TriggerFilterObjectWithRefs(path(event), module(event)) );

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -23,7 +23,7 @@ const T * get(const edm::Event & event, const edm::EDGetTokenT<T> & token) {
   if (not handle.isValid()) {
     auto const & error = handle.whyFailed();
     edm::LogWarning(error->category()) << error->what();
-    return 0;
+    return nullptr;
   } else {
     return handle.product();
   }

--- a/HLTrigger/HLTfilters/src/HLTBeamModeFilter.cc
+++ b/HLTrigger/HLTfilters/src/HLTBeamModeFilter.cc
@@ -127,10 +127,9 @@ bool HLTBeamModeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& evS
 
     edm::LogInfo("HLTBeamModeFilter") << "Beam mode: " << beamModeValue;
 
-    for (std::vector<unsigned int>::const_iterator itMode =
-            m_allowedBeamMode.begin(); itMode != m_allowedBeamMode.end(); ++itMode) {
+    for (unsigned int itMode : m_allowedBeamMode) {
 
-        if (beamModeValue == (*itMode)) {
+        if (beamModeValue == itMode) {
             filterResult = true;
 
             //LogTrace("HLTBeamModeFilter") << "Event selected - beam mode: "

--- a/HLTrigger/HLTfilters/src/HLTBool.cc
+++ b/HLTrigger/HLTfilters/src/HLTBool.cc
@@ -22,9 +22,7 @@ HLTBool::HLTBool(const edm::ParameterSet& iConfig) :
   LogDebug("HLTBool") << " configured result is: " << result_;
 }
 
-HLTBool::~HLTBool()
-{
-}
+HLTBool::~HLTBool() = default;
 
 void
 HLTBool::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/HLTfilters/src/HLTDoublet.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoublet.cc
@@ -68,9 +68,7 @@ HLTDoublet<T1,T2>::HLTDoublet(const edm::ParameterSet& iConfig) : HLTFilter(iCon
 }
 
 template<typename T1, typename T2>
-HLTDoublet<T1,T2>::~HLTDoublet()
-{
-}
+HLTDoublet<T1,T2>::~HLTDoublet() = default;
 template<typename T1, typename T2>
 void
 HLTDoublet<T1,T2>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
@@ -317,9 +317,9 @@ HLTDoubletDZ<reco::RecoEcalCandidate, reco::RecoChargedCandidate>::computeDZ(edm
   if ( reco::deltaR(*r1, *r2) < minDR_ ) 
     return false;
   reco::Electron e1;
-  for(reco::ElectronCollection::const_iterator eleIt = electronHandle_->begin(); eleIt != electronHandle_->end(); eleIt++) {
-    if (eleIt->superCluster() == r1->superCluster())
-      e1 = *(eleIt);
+  for(auto const & eleIt : *electronHandle_) {
+    if (eleIt.superCluster() == r1->superCluster())
+      e1 = eleIt;
   }
   
   const reco::RecoChargedCandidate& candidate2(*r2);
@@ -346,9 +346,9 @@ HLTDoubletDZ<reco::RecoChargedCandidate, reco::RecoEcalCandidate>::computeDZ(edm
   if ( reco::deltaR(*r1, *r2) < minDR_ ) 
     return false;
   reco::Electron e2;
-  for(reco::ElectronCollection::const_iterator eleIt = electronHandle_->begin(); eleIt != electronHandle_->end(); eleIt++) {
-    if (eleIt->superCluster() == r2->superCluster())
-      e2 = *(eleIt);
+  for(auto const & eleIt : *electronHandle_) {
+    if (eleIt.superCluster() == r2->superCluster())
+      e2 = eleIt;
   }
   
   const reco::RecoChargedCandidate& candidate1(*r1);	
@@ -375,11 +375,11 @@ HLTDoubletDZ<reco::RecoEcalCandidate, reco::RecoEcalCandidate>::computeDZ(edm::E
   if ( reco::deltaR(*r1, *r2) < minDR_ ) 
     return false;
   reco::Electron e1, e2;
-  for(reco::ElectronCollection::const_iterator eleIt = electronHandle_->begin(); eleIt != electronHandle_->end(); eleIt++) {
-    if (eleIt->superCluster() == r2->superCluster())
-      e2 = *(eleIt);
-    if (eleIt->superCluster() == r1->superCluster())
-      e1 = *(eleIt);
+  for(auto const & eleIt : *electronHandle_) {
+    if (eleIt.superCluster() == r2->superCluster())
+      e2 = eleIt;
+    if (eleIt.superCluster() == r1->superCluster())
+      e1 = eleIt;
   }
   
   bool skipDZ = false;

--- a/HLTrigger/HLTfilters/src/HLTFiltCand.cc
+++ b/HLTrigger/HLTfilters/src/HLTFiltCand.cc
@@ -75,9 +75,7 @@ HLTFiltCand::HLTFiltCand(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
    ;
 }
 
-HLTFiltCand::~HLTFiltCand()
-{
-}
+HLTFiltCand::~HLTFiltCand() = default;
 
 //
 // member functions
@@ -155,8 +153,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // photons
    int nphot(0);
-   RecoEcalCandidateCollection::const_iterator aphot(photons->begin());
-   RecoEcalCandidateCollection::const_iterator ophot(photons->end());
+   auto aphot(photons->begin());
+   auto ophot(photons->end());
    RecoEcalCandidateCollection::const_iterator iphot;
    for (iphot=aphot; iphot!=ophot; iphot++) {
      if (iphot->pt() >= min_Pt_) {
@@ -168,8 +166,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // electrons
    int nelec(0);
-   ElectronCollection::const_iterator aelec(electrons->begin());
-   ElectronCollection::const_iterator oelec(electrons->end());
+   auto aelec(electrons->begin());
+   auto oelec(electrons->end());
    ElectronCollection::const_iterator ielec;
    for (ielec=aelec; ielec!=oelec; ielec++) {
      if (ielec->pt() >= min_Pt_) {
@@ -181,8 +179,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // muon
    int nmuon(0);
-   RecoChargedCandidateCollection::const_iterator amuon(muons->begin());
-   RecoChargedCandidateCollection::const_iterator omuon(muons->end());
+   auto amuon(muons->begin());
+   auto omuon(muons->end());
    RecoChargedCandidateCollection::const_iterator imuon;
    for (imuon=amuon; imuon!=omuon; imuon++) {
      if (imuon->pt() >= min_Pt_) {
@@ -194,8 +192,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // taus (are stored as jets)
    int ntaus(0);
-   CaloJetCollection::const_iterator ataus(taus->begin());
-   CaloJetCollection::const_iterator otaus(taus->end());
+   auto ataus(taus->begin());
+   auto otaus(taus->end());
    CaloJetCollection::const_iterator itaus;
    for (itaus=ataus; itaus!=otaus; itaus++) {
      if (itaus->pt() >= min_Pt_) {
@@ -207,8 +205,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // jets
    int njets(0);
-   CaloJetCollection::const_iterator ajets(jets->begin());
-   CaloJetCollection::const_iterator ojets(jets->end());
+   auto ajets(jets->begin());
+   auto ojets(jets->end());
    CaloJetCollection::const_iterator ijets;
    for (ijets=ajets; ijets!=ojets; ijets++) {
      if (ijets->pt() >= min_Pt_) {
@@ -220,8 +218,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // mets
    int nmets(0);
-   CaloMETCollection::const_iterator amets(mets->begin());
-   CaloMETCollection::const_iterator omets(mets->end());
+   auto amets(mets->begin());
+   auto omets(mets->end());
    CaloMETCollection::const_iterator imets;
    for (imets=amets; imets!=omets; imets++) {
      if (imets->pt() >= min_Pt_) {
@@ -233,8 +231,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // mhts
    int nmhts(0);
-   METCollection::const_iterator amhts(mhts->begin());
-   METCollection::const_iterator omhts(mhts->end());
+   auto amhts(mhts->begin());
+   auto omhts(mhts->end());
    METCollection::const_iterator imhts;
    for (imhts=amhts; imhts!=omhts; imhts++) {
      if (imhts->pt() >= min_Pt_) {
@@ -246,8 +244,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // trcks
    int ntrck(0);
-   RecoChargedCandidateCollection::const_iterator atrcks(trcks->begin());
-   RecoChargedCandidateCollection::const_iterator otrcks(trcks->end());
+   auto atrcks(trcks->begin());
+   auto otrcks(trcks->end());
    RecoChargedCandidateCollection::const_iterator itrcks;
    for (itrcks=atrcks; itrcks!=otrcks; itrcks++) {
      if (itrcks->pt() >= min_Pt_) {
@@ -259,8 +257,8 @@ HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
 
    // ecals
    int necal(0);
-   RecoEcalCandidateCollection::const_iterator aecals(ecals->begin());
-   RecoEcalCandidateCollection::const_iterator oecals(ecals->end());
+   auto aecals(ecals->begin());
+   auto oecals(ecals->end());
    RecoEcalCandidateCollection::const_iterator iecals;
    for (iecals=aecals; iecals!=oecals; iecals++) {
      if (iecals->pt() >= min_Pt_) {

--- a/HLTrigger/HLTfilters/src/HLTGlobalSums.cc
+++ b/HLTrigger/HLTfilters/src/HLTGlobalSums.cc
@@ -66,9 +66,7 @@ HLTGlobalSums<T>::HLTGlobalSums(const edm::ParameterSet& iConfig) : HLTFilter(iC
 }
 
 template<typename T>
-HLTGlobalSums<T>::~HLTGlobalSums()
-{
-}
+HLTGlobalSums<T>::~HLTGlobalSums() = default;
 
 template<typename T>
 void

--- a/HLTrigger/HLTfilters/src/HLTHighLevel.cc
+++ b/HLTrigger/HLTfilters/src/HLTHighLevel.cc
@@ -43,7 +43,7 @@ HLTHighLevel::HLTHighLevel(const edm::ParameterSet& iConfig) :
   andOr_        (iConfig.getParameter<bool> ("andOr")),
   throw_        (iConfig.getParameter<bool> ("throw")),
   eventSetupPathsKey_(iConfig.getParameter<std::string>("eventSetupPathsKey")),
-  watchAlCaRecoTriggerBitsRcd_(0),
+  watchAlCaRecoTriggerBitsRcd_(nullptr),
   HLTPatterns_  (iConfig.getParameter<std::vector<std::string> >("HLTPaths")),
   HLTPathsByName_(),
   HLTPathsByIndex_()
@@ -132,7 +132,7 @@ void HLTHighLevel::init(const edm::TriggerResults & result,
             edm::LogInfo("Configuration") << "requested pattern \"" << pattern <<  "\" does not match any HLT paths";
         } else {
           // store the matching patterns
-          BOOST_FOREACH(std::vector<std::string>::const_iterator match, matches)
+          BOOST_FOREACH(auto match, matches)
             HLTPathsByName_.push_back(*match);
         }
       } else {
@@ -191,7 +191,7 @@ HLTHighLevel::pathsFromSetup(const std::string &key, const edm::Event &event, co
   typedef std::map<std::string, std::string> TriggerMap;
   const TriggerMap &triggerMap = triggerBits->m_alcarecoToTrig;
 
-  TriggerMap::const_iterator listIter = triggerMap.find(key);
+  auto listIter = triggerMap.find(key);
   if (listIter == triggerMap.end()) {
     throw cms::Exception("Configuration")
       << " HLTHighLevel [instance: " << moduleLabel() << " - path: " << pathName(event)

--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -430,23 +430,23 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
     std::vector<GlobalLogicParser::OperandToken>& algOpTokenVector =
             m_l1AlgoLogicParser.operandTokenVector();
 
-    for (size_t i = 0; i < algOpTokenVector.size(); ++i) {
+    for (auto & i : algOpTokenVector) {
 
         // rest token result 
         //
-        (algOpTokenVector[i]).tokenResult = false;
+        i.tokenResult = false;
 
     }
 
     // Update m_l1AlgoLogicParser and store emulator results for algOpTokens 
     // /////////////////////////////////////////////////////////////////////
-    for (size_t i = 0; i < algOpTokenVector.size(); ++i) {
+    for (auto & i : algOpTokenVector) {
 
-        std::string algoName = (algOpTokenVector[i]).tokenName;
+        std::string algoName = i.tokenName;
 
         const GlobalObjectMap* objMap = gtObjectMapRecord->getObjectMap(algoName);
 
-        if(objMap == 0) {
+        if(objMap == nullptr) {
 
           throw cms::Exception("FailModule") << "\nAlgorithm " << algoName 
             << ", requested as seed by a HLT path, cannot be matched to a L1 algo name in any GlobalObjectMap\n" 
@@ -459,7 +459,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
           int bit = objMap->algoBitNumber();
           bool finalAlgoDecision = (uGtAlgoBlocks->at(0,0)).getAlgoDecisionFinal(bit);
-          (algOpTokenVector[i]).tokenResult = finalAlgoDecision;
+          i.tokenResult = finalAlgoDecision;
 
         }
 
@@ -490,7 +490,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
       const GlobalObjectMap* objMap = gtObjectMapRecord->getObjectMap(algoSeedName);
 
-      if(objMap == 0) {
+      if(objMap == nullptr) {
 
           // Should not get here
           //
@@ -552,10 +552,10 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
         std::vector<l1t::GlobalObject> condObjType = condObjTypeVec[condNumber];
 
-        for (size_t jOb =0; jOb < condObjType.size(); jOb++) {
+        for (auto & jOb : condObjType) {
 
           LogTrace("HLTL1TSeed")
-          << setw(15) << "\tcondObjType = " << condObjType[jOb] << endl;
+          << setw(15) << "\tcondObjType = " << jOb << endl;
 
         }
 
@@ -575,14 +575,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
         LogTrace("HLTL1TSeed")
         << setw(15) << "\tcondCombinations = " << condComb->size() << endl;
 
-        for (std::vector<SingleCombInCond>::const_iterator itComb = (*condComb).begin(); itComb != (*condComb).end(); itComb++) {
+        for (auto const & itComb : (*condComb)) {
 
             LogTrace("HLTL1TSeed")
             << setw(15) << "\tnew combination" << endl;
 
             // loop over objects in a combination for a given condition
             //
-            for (SingleCombInCond::const_iterator itObject = (*itComb).begin(); itObject != (*itComb).end(); itObject++) {
+            for (auto itObject = itComb.begin(); itObject != itComb.end(); itObject++) {
 
                 // in case of object-less triggers (e.g. L1_ZeroBias) condObjType vector is empty, so don't seed!
                 //
@@ -596,7 +596,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
                 }
 
                 // the index of the object type is the same as the index of the object
-                size_t iType = std::distance((*itComb).begin(), itObject);
+                size_t iType = std::distance(itComb.begin(), itObject);
 
                 // get object type and push indices on the list
                 //

--- a/HLTrigger/HLTfilters/src/HLTLevel1Activity.cc
+++ b/HLTrigger/HLTfilters/src/HLTLevel1Activity.cc
@@ -39,9 +39,9 @@
 class HLTLevel1Activity : public edm::stream::EDFilter<> {
 public:
   explicit HLTLevel1Activity(const edm::ParameterSet&);
-  ~HLTLevel1Activity();
+  ~HLTLevel1Activity() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool filter(edm::Event &, edm::EventSetup const &) override final;
+  bool filter(edm::Event &, edm::EventSetup const &) final;
 
 private:
   edm::InputTag                                  m_gtReadoutRecordTag;
@@ -96,9 +96,7 @@ HLTLevel1Activity::HLTLevel1Activity(const edm::ParameterSet & config) :
   }
 }
 
-HLTLevel1Activity::~HLTLevel1Activity()
-{
-}
+HLTLevel1Activity::~HLTLevel1Activity() = default;
 
 void
 HLTLevel1Activity::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
@@ -392,7 +392,7 @@ const std::vector<L1GtObject>* HLTLevel1GTSeed::objectTypeVec(const int chipNr,
     const ConditionMap& conditionMap =
             (m_l1GtMenu->gtConditionMap()).at(chipNr);
 
-    CItCond itCond = conditionMap.find(cndName);
+    auto itCond = conditionMap.find(cndName);
     if (itCond != conditionMap.end())
         return (&((itCond->second)->objectType()));
 
@@ -416,15 +416,15 @@ void HLTLevel1GTSeed::updateAlgoLogicParser(const L1GtTriggerMenu* l1GtMenu, con
 
     //
 
-    for (size_t i = 0; i < algOpTokenVector.size(); ++i) {
+    for (auto & i : algOpTokenVector) {
 
-        CItAlgo itAlgo = algorithmMap.find((algOpTokenVector[i]).tokenName);
+        auto itAlgo = algorithmMap.find(i.tokenName);
         if (itAlgo != algorithmMap.end()) {
 
             int bitNr = (itAlgo->second).algoBitNumber();
             int chipNr = (itAlgo->second).algoChipNumber();
 
-            (algOpTokenVector[i]).tokenNumber = bitNr;
+            i.tokenNumber = bitNr;
 
             // algOpTokenVector and m_l1AlgoSeeds must have the same ordering
             // of the algorithms
@@ -435,7 +435,7 @@ void HLTLevel1GTSeed::updateAlgoLogicParser(const L1GtTriggerMenu* l1GtMenu, con
                 //    << std::endl;
 
                 if ((m_l1AlgoSeeds[jSeed]).tokenName
-                        == (algOpTokenVector[i]).tokenName) {
+                        == i.tokenName) {
 
                     (m_l1AlgoSeeds[jSeed]).tokenNumber = bitNr;
 
@@ -472,7 +472,7 @@ void HLTLevel1GTSeed::updateAlgoLogicParser(const L1GtTriggerMenu* l1GtMenu, con
         } else {
 
             throw cms::Exception("FailModule") << "\nAlgorithm  "
-                    << (algOpTokenVector[i]).tokenName
+                    << i.tokenName
                     << ", requested as seed by a HLT path, not found in the L1 trigger menu\n   "
                     << l1GtMenu->gtTriggerMenuName()
                     << "\nIncompatible L1 and HLT menus.\n" << std::endl;
@@ -498,8 +498,8 @@ void HLTLevel1GTSeed::updateAlgoLogicParser(const std::vector<bool>& gtWord,
     std::vector<L1GtLogicParser::OperandToken>& algOpTokenVector =
             m_l1AlgoLogicParser.operandTokenVector();
 
-    for (size_t i = 0; i < algOpTokenVector.size(); ++i) {
-        int iBit = (algOpTokenVector[i]).tokenNumber;
+    for (auto & i : algOpTokenVector) {
+        int iBit = i.tokenNumber;
         bool iResult = gtWord.at(iBit);
 
         int triggerMaskBit = triggerMask[iBit] & (1 << physicsDaqPartition);
@@ -517,12 +517,12 @@ void HLTLevel1GTSeed::updateAlgoLogicParser(const std::vector<bool>& gtWord,
             //<< std::endl;
         }
 
-        (algOpTokenVector[i]).tokenResult = iResult;
+        i.tokenResult = iResult;
 
     }
 
-    for (size_t i = 0; i < m_l1AlgoSeeds.size(); ++i) {
-        int iBit = (m_l1AlgoSeeds[i]).tokenNumber;
+    for (auto & m_l1AlgoSeed : m_l1AlgoSeeds) {
+        int iBit = m_l1AlgoSeed.tokenNumber;
         bool iResult = gtWord.at(iBit);
 
         int triggerMaskBit = triggerMask[iBit] & (1 << physicsDaqPartition);
@@ -540,7 +540,7 @@ void HLTLevel1GTSeed::updateAlgoLogicParser(const std::vector<bool>& gtWord,
             //<< std::endl;
         }
 
-        (m_l1AlgoSeeds[i]).tokenResult = iResult;
+        m_l1AlgoSeed.tokenResult = iResult;
 
     }
 
@@ -558,9 +558,9 @@ void HLTLevel1GTSeed::convertStringToBitNumber() {
     std::vector<L1GtLogicParser::OperandToken> & algOpTokenVector =
             m_l1AlgoLogicParser.operandTokenVector();
 
-    for (size_t i = 0; i < algOpTokenVector.size(); ++i) {
+    for (auto & i : algOpTokenVector) {
 
-        std::string bitString = (algOpTokenVector[i]).tokenName;
+        std::string bitString = i.tokenName;
         std::istringstream bitStream(bitString);
         int bitInt;
 
@@ -573,13 +573,13 @@ void HLTLevel1GTSeed::convertStringToBitNumber() {
                     << std::endl;
         }
 
-        (algOpTokenVector[i]).tokenNumber = bitInt;
+        i.tokenNumber = bitInt;
 
     }
 
-    for (size_t i = 0; i < m_l1AlgoSeeds.size(); ++i) {
+    for (auto & m_l1AlgoSeed : m_l1AlgoSeeds) {
 
-        std::string bitString = (m_l1AlgoSeeds[i]).tokenName;
+        std::string bitString = m_l1AlgoSeed.tokenName;
         std::istringstream bitStream(bitString);
         int bitInt;
 
@@ -592,7 +592,7 @@ void HLTLevel1GTSeed::convertStringToBitNumber() {
                     << std::endl;
         }
 
-        (m_l1AlgoSeeds[i]).tokenNumber = bitInt;
+        m_l1AlgoSeed.tokenNumber = bitInt;
     }
 
 }
@@ -628,12 +628,12 @@ void HLTLevel1GTSeed::debugPrint(bool newMenu) const
             << "\n\nupdateAlgoLogicParser: algOpTokenVector.size() = "
             << algOpTokenVector.size() << std::endl;
 
-    for (size_t i = 0; i < algOpTokenVector.size(); ++i) {
+    for (auto const & i : algOpTokenVector) {
 
         LogTrace("HLTLevel1GTSeed") << "      " << std::setw(5)
-                << (algOpTokenVector[i]).tokenNumber << "\t" << std::setw(25)
-                << (algOpTokenVector[i]).tokenName << "\t"
-                << (algOpTokenVector[i]).tokenResult << std::endl;
+                << i.tokenNumber << "\t" << std::setw(25)
+                << i.tokenName << "\t"
+                << i.tokenResult << std::endl;
     }
 
     LogTrace("HLTLevel1GTSeed") << std::endl;
@@ -642,12 +642,12 @@ void HLTLevel1GTSeed::debugPrint(bool newMenu) const
             << "\nupdateAlgoLogicParser: m_l1AlgoSeeds.size() = "
             << m_l1AlgoSeeds.size() << std::endl;
 
-    for (size_t i = 0; i < m_l1AlgoSeeds.size(); ++i) {
+    for (auto const & m_l1AlgoSeed : m_l1AlgoSeeds) {
 
         LogTrace("HLTLevel1GTSeed") << "      " << std::setw(5)
-                << (m_l1AlgoSeeds[i]).tokenNumber << "\t" << std::setw(25)
-                << (m_l1AlgoSeeds[i]).tokenName << "\t"
-                << (m_l1AlgoSeeds[i]).tokenResult << std::endl;
+                << m_l1AlgoSeed.tokenNumber << "\t" << std::setw(25)
+                << m_l1AlgoSeed.tokenName << "\t"
+                << m_l1AlgoSeed.tokenResult << std::endl;
     }
 
     LogTrace("HLTLevel1GTSeed") << std::endl;
@@ -660,16 +660,16 @@ void HLTLevel1GTSeed::debugPrint(bool newMenu) const
             << "\nupdateAlgoLogicParser: m_l1AlgoSeedsRpn.size() = "
             << m_l1AlgoSeedsRpn.size() << std::endl;
 
-    for (size_t i = 0; i < m_l1AlgoSeedsRpn.size(); ++i) {
+    for (auto i : m_l1AlgoSeedsRpn) {
 
         LogTrace("HLTLevel1GTSeed") << "  Rpn vector size: "
-                << (m_l1AlgoSeedsRpn[i])->size() << std::endl;
+                << i->size() << std::endl;
 
-        for (size_t j = 0; j < (m_l1AlgoSeedsRpn[i])->size(); ++j) {
+        for (size_t j = 0; j < i->size(); ++j) {
 
             LogTrace("HLTLevel1GTSeed") << "      ( "
-                    << (*(m_l1AlgoSeedsRpn[i]))[j].operation << ", "
-                    << (*(m_l1AlgoSeedsRpn[i]))[j].operand << " )" << std::endl;
+                    << (*i)[j].operation << ", "
+                    << (*i)[j].operand << " )" << std::endl;
 
         }
     }
@@ -680,21 +680,21 @@ void HLTLevel1GTSeed::debugPrint(bool newMenu) const
             << "algorithms in seed expression: m_l1AlgoSeedsObjType.size() = "
             << m_l1AlgoSeedsObjType.size() << std::endl;
 
-    for (size_t i = 0; i < m_l1AlgoSeedsObjType.size(); ++i) {
+    for (auto const & i : m_l1AlgoSeedsObjType) {
 
         LogTrace("HLTLevel1GTSeed")
                 << "  Conditions for an algorithm: vector size: "
-                << (m_l1AlgoSeedsObjType[i]).size() << std::endl;
+                << i.size() << std::endl;
 
-        for (size_t j = 0; j < (m_l1AlgoSeedsObjType[i]).size(); ++j) {
+        for (size_t j = 0; j < i.size(); ++j) {
 
             LogTrace("HLTLevel1GTSeed")
                     << "    Condition object type vector: size: "
-                    << ((m_l1AlgoSeedsObjType[i])[j])->size() << std::endl;
+                    << (i[j])->size() << std::endl;
 
-            for (size_t k = 0; k < ((m_l1AlgoSeedsObjType[i])[j])->size(); ++k) {
+            for (size_t k = 0; k < (i[j])->size(); ++k) {
 
-                L1GtObject obj = (*((m_l1AlgoSeedsObjType[i])[j]))[k];
+                L1GtObject obj = (*(i[j]))[k];
                 LogTrace("HLTLevel1GTSeed") << "      " << obj << " ";
 
             }
@@ -809,7 +809,7 @@ bool HLTLevel1GTSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
         // algorithm result is true - get object map, loop over conditions in the algorithm
         const L1GlobalTriggerObjectMap* objMap = gtObjectMapRecord->getObjectMap(algBit);
 
-        if (objMap == 0) {
+        if (objMap == nullptr) {
             edm::LogWarning("HLTLevel1GTSeed")
             << "\nWarning: L1GlobalTriggerObjectMap for algorithm  " << algName
             << " (bit number " << algBit << ") does not exist.\nReturn false.\n"
@@ -841,12 +841,12 @@ bool HLTLevel1GTSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
             << condSeeds.size()
             << std::endl;
 
-            for (size_t i = 0; i < condSeeds.size(); ++i) {
+            for (auto & condSeed : condSeeds) {
 
                 LogTrace("HLTLevel1GTSeed")
-                << "      " << std::setw(5) << (condSeeds[i]).tokenNumber << "\t"
-                << std::setw(25) << (condSeeds[i]).tokenName << "\t"
-                << (condSeeds[i]).tokenResult
+                << "      " << std::setw(5) << condSeed.tokenNumber << "\t"
+                << std::setw(25) << condSeed.tokenName << "\t"
+                << condSeed.tokenResult
                 << std::endl;
             }
 
@@ -878,13 +878,12 @@ bool HLTLevel1GTSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
 
             const CombinationsInCond* cndComb = objMap->getCombinationsInCond(cndNumber);
 
-            for (std::vector<SingleCombInCond>::const_iterator
-                    itComb = (*cndComb).begin(); itComb != (*cndComb).end(); itComb++) {
+            for (auto const & itComb : (*cndComb)) {
 
                 // loop over objects in a combination for a given condition
                 int iObj = 0;
-                for (SingleCombInCond::const_iterator
-                        itObject = (*itComb).begin(); itObject != (*itComb).end(); itObject++) {
+                for (auto
+                        itObject = itComb.begin(); itObject != itComb.end(); itObject++) {
 
                     // get object type and push indices on the list
                     const L1GtObject objTypeVal = (*cndObjTypeVec).at(iObj);
@@ -1383,15 +1382,14 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
     // loop over the list of required algorithms for seeding
     int iAlgo = -1;
 
-    for (std::vector<L1GtLogicParser::OperandToken>::const_iterator itSeed =
-            m_l1AlgoSeeds.begin(); itSeed != m_l1AlgoSeeds.end(); ++itSeed) {
+    for (auto const & m_l1AlgoSeed : m_l1AlgoSeeds) {
 
         //
         iAlgo++;
         //
-        int algBit = (*itSeed).tokenNumber;
-        std::string algName = (*itSeed).tokenName;
-        bool algResult = (*itSeed).tokenResult;
+        int algBit = m_l1AlgoSeed.tokenNumber;
+        std::string algName = m_l1AlgoSeed.tokenName;
+        bool algResult = m_l1AlgoSeed.tokenResult;
 
         LogTrace("HLTLevel1GTSeed") << "\nHLTLevel1GTSeed::hltFilter "
                 << "\n  Algorithm " << algName << " with bit number " << algBit
@@ -1406,18 +1404,15 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
         // loop over all object types found for an algorithm and fill the lists
         //
-        for (std::vector<const std::vector<L1GtObject>*>::const_iterator itVec =
-                algoSeedsObjTypeVec.begin(); itVec != algoSeedsObjTypeVec.end(); ++itVec) {
+        for (auto condObj : algoSeedsObjTypeVec) {
 
-            const std::vector<L1GtObject>* condObj = *itVec;
-            for (std::vector<L1GtObject>::const_iterator itObj =
-                    (*condObj).begin(); itObj != (*condObj).end(); ++itObj) {
+            for (auto itObj : (*condObj)) {
 
                 LogTrace("HLTLevel1GTSeed")
                         << "  Object type in conditions from this algorithm = "
-                        << (*itObj) << std::endl;
+                        << itObj << std::endl;
 
-                switch (*itObj) {
+                switch (itObj) {
                     case Mu: {
                         if (includeMuon) {
 
@@ -1434,7 +1429,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1MuonParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1Muon->begin(); objIter
                                         != l1Muon->end(); ++objIter) {
 
@@ -1472,7 +1467,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1EmParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1IsoEG->begin(); objIter
                                         != l1IsoEG->end(); ++objIter) {
 
@@ -1510,7 +1505,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1EmParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1NoIsoEG->begin(); objIter
                                         != l1NoIsoEG->end(); ++objIter) {
 
@@ -1548,7 +1543,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1JetParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1CenJet->begin(); objIter
                                         != l1CenJet->end(); ++objIter) {
 
@@ -1587,7 +1582,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1JetParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1ForJet->begin(); objIter
                                         != l1ForJet->end(); ++objIter) {
 
@@ -1626,7 +1621,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1JetParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1TauJet->begin(); objIter
                                         != l1TauJet->end(); ++objIter) {
 
@@ -1664,7 +1659,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1JetParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1IsoTauJet->begin(); objIter
                                         != l1IsoTauJet->end(); ++objIter) {
 
@@ -1711,7 +1706,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1EtMissParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1EnergySums->begin(); objIter
                                         != l1EnergySums->end(); ++objIter) {
 
@@ -1758,7 +1753,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1EtMissParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1EnergySums->begin(); objIter
                                         != l1EnergySums->end(); ++objIter) {
 
@@ -1805,7 +1800,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1EtMissParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1EnergySums->begin(); objIter
                                         != l1EnergySums->end(); ++objIter) {
 
@@ -1851,7 +1846,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                             } else {
                                 int iObj = -1;
-                                for (l1extra::L1EtMissParticleCollection::const_iterator
+                                for (auto
                                         objIter = l1EnergySums->begin(); objIter
                                         != l1EnergySums->end(); ++objIter) {
 
@@ -1886,7 +1881,7 @@ bool HLTLevel1GTSeed::seedsL1Extra(edm::Event & iEvent, trigger::TriggerFilterOb
 
                         LogDebug("HLTLevel1GTSeed")
                                 << "\n    HLTLevel1GTSeed::hltFilter "
-                                << "\n      Unknown object of type " << *itObj
+                                << "\n      Unknown object of type " << itObj
                                 << " in the seed list." << std::endl;
                     }
                         break;

--- a/HLTrigger/HLTfilters/src/HLTLevel1Pattern.cc
+++ b/HLTrigger/HLTfilters/src/HLTLevel1Pattern.cc
@@ -33,9 +33,9 @@
 class HLTLevel1Pattern : public edm::EDFilter {
 public:
   explicit HLTLevel1Pattern(const edm::ParameterSet&);
-  ~HLTLevel1Pattern();
+  ~HLTLevel1Pattern() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::InputTag     m_gtReadoutRecord;
@@ -89,9 +89,7 @@ HLTLevel1Pattern::HLTLevel1Pattern(const edm::ParameterSet & config) :
     m_triggerPattern[i] = (bool) pattern[i];
 }
 
-HLTLevel1Pattern::~HLTLevel1Pattern()
-{
-}
+HLTLevel1Pattern::~HLTLevel1Pattern() = default;
 
 void
 HLTLevel1Pattern::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/HLTfilters/src/HLTSinglet.cc
+++ b/HLTrigger/HLTfilters/src/HLTSinglet.cc
@@ -91,9 +91,7 @@ HLTSinglet<T>::HLTSinglet(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 }
 
 template<typename T>
-HLTSinglet<T>::~HLTSinglet()
-{
-}
+HLTSinglet<T>::~HLTSinglet() = default;
 
 template<typename T>
 void

--- a/HLTrigger/HLTfilters/src/HLTSmartSinglet.cc
+++ b/HLTrigger/HLTfilters/src/HLTSmartSinglet.cc
@@ -39,9 +39,7 @@ HLTSmartSinglet<T>::HLTSmartSinglet(const edm::ParameterSet& iConfig) : HLTFilte
 }
 
 template<typename T>
-HLTSmartSinglet<T>::~HLTSmartSinglet()
-{
-}
+HLTSmartSinglet<T>::~HLTSmartSinglet() = default;
 
 template<typename T>
 void

--- a/HLTrigger/HLTfilters/src/HLTSummaryFilter.cc
+++ b/HLTrigger/HLTfilters/src/HLTSummaryFilter.cc
@@ -33,9 +33,7 @@ HLTSummaryFilter::HLTSummaryFilter(const edm::ParameterSet& iConfig) : HLTFilter
      << cut_<< " " << min_N_ ;
 }
 
-HLTSummaryFilter::~HLTSummaryFilter()
-{
-}
+HLTSummaryFilter::~HLTSummaryFilter() = default;
 
 //
 // member functions

--- a/HLTrigger/HLTfilters/src/TestBXVectorRefProducer.cc
+++ b/HLTrigger/HLTfilters/src/TestBXVectorRefProducer.cc
@@ -40,14 +40,14 @@
 class TestBXVectorRefProducer : public edm::stream::EDProducer<> {
    public:
       explicit TestBXVectorRefProducer(const edm::ParameterSet&);
-      ~TestBXVectorRefProducer();
+      ~TestBXVectorRefProducer() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginStream(edm::StreamID) override;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endStream() override;
+      void beginStream(edm::StreamID) override;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      void endStream() override;
 
       //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;

--- a/HLTrigger/HLTfilters/src/TriggerResultsFilter.cc
+++ b/HLTrigger/HLTfilters/src/TriggerResultsFilter.cc
@@ -29,7 +29,7 @@
 // constructors and destructor
 //
 TriggerResultsFilter::TriggerResultsFilter(const edm::ParameterSet & config) :
-  m_expression(0),
+  m_expression(nullptr),
   m_eventCache(config, consumesCollector())
 {
   const std::vector<std::string> & expressions = config.getParameter<std::vector<std::string>>("triggerConditions");

--- a/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
+++ b/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
@@ -33,7 +33,7 @@
 TriggerResultsFilterFromDB::TriggerResultsFilterFromDB(const edm::ParameterSet & config) :
   m_eventSetupPathsKey(config.getParameter<std::string>("eventSetupPathsKey")),
   m_eventSetupWatcher(),
-  m_expression(0),
+  m_expression(nullptr),
   m_eventCache(config, consumesCollector())
 {
 }
@@ -97,7 +97,7 @@ void TriggerResultsFilterFromDB::pathsFromSetup(const edm::Event & event, const 
   typedef std::map<std::string, std::string> TriggerMap;
   const TriggerMap & triggerMap = triggerBits->m_alcarecoToTrig;
 
-  TriggerMap::const_iterator listIter = triggerMap.find(m_eventSetupPathsKey);
+  auto listIter = triggerMap.find(m_eventSetupPathsKey);
   if (listIter == triggerMap.end()) {
     throw cms::Exception("Configuration") << "TriggerResultsFilterFromDB [instance: " << moduleDescription().moduleLabel()
                                           << "]: No triggerList with key " << m_eventSetupPathsKey << " in AlCaRecoTriggerBitsRcd";

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -29,9 +29,7 @@ HLTriggerJSONMonitoring::HLTriggerJSONMonitoring(const edm::ParameterSet& ps) :
                                                      
 }
 
-HLTriggerJSONMonitoring::~HLTriggerJSONMonitoring()
-{
-}
+HLTriggerJSONMonitoring::~HLTriggerJSONMonitoring() = default;
 
 void
 HLTriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -158,8 +156,8 @@ HLTriggerJSONMonitoring::resetLumi(){
     hltErrors_[i] = 0;
   }
   //Reset per-dataset counter         
-  for (unsigned int i = 0; i < hltDatasets_.size(); i++) {
-    hltDatasets_[i] = 0;
+  for (unsigned int & hltDataset : hltDatasets_) {
+    hltDataset = 0;
   }
 
 }//End resetLumi function  
@@ -203,13 +201,13 @@ HLTriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& i
     Json::StyledWriter writer;
 
     Json::Value hltNamesVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < hltNames_.size(); ui++){
-      hltNamesVal.append(hltNames_.at(ui));
+    for (auto & hltName : hltNames_){
+      hltNamesVal.append(hltName);
     }
 
     Json::Value datasetNamesVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < datasetNames_.size(); ui++){
-      datasetNamesVal.append(datasetNames_.at(ui));
+    for (auto & datasetName : datasetNames_){
+      datasetNamesVal.append(datasetName);
     }
 
     hltIni["Path-Names"]    = hltNamesVal;
@@ -270,8 +268,8 @@ HLTriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& i
       iSummary->hltReject->update(hltReject_.at(ui));
       iSummary->hltErrors->update(hltErrors_.at(ui));
     }
-    for (unsigned int ui = 0; ui < hltDatasets_.size(); ui++){
-      iSummary->hltDatasets->update(hltDatasets_.at(ui));
+    for (unsigned int hltDataset : hltDatasets_){
+      iSummary->hltDatasets->update(hltDataset);
     }
 
     iSummary->stHltJsd   = stHltJsd_;

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -28,9 +28,7 @@ L1TriggerJSONMonitoring::L1TriggerJSONMonitoring(const edm::ParameterSet& ps) :
                                                      
 }
 
-L1TriggerJSONMonitoring::~L1TriggerJSONMonitoring()
-{
-}
+L1TriggerJSONMonitoring::~L1TriggerJSONMonitoring() = default;
 
 void
 L1TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -66,7 +64,7 @@ L1TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup
   //The GlobalAlgBlkBxCollection is a vector of vectors, but the second layer can only ever
   //have one entry since there can't be more than one collection per bunch crossing. The "0"
   //here means BX = 0, the "begin" is used to access the first and only element
-  std::vector<GlobalAlgBlk>::const_iterator algBlk = l1tResults->begin(0);
+  auto algBlk = l1tResults->begin(0);
   
   for (unsigned int i = 0; i < algBlk->maxPhysicsTriggers; i++){
     if (algBlk->getAlgoDecisionFinal(i)){
@@ -130,8 +128,8 @@ L1TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& i
 
   //Update trigger and dataset names, clear L1 names and counters   
   L1AlgoNames_.resize(alg.maxPhysicsTriggers);         
-  for (unsigned int i = 0; i < L1AlgoNames_.size(); i++) {
-    L1AlgoNames_.at(i) = "";
+  for (auto & L1AlgoName : L1AlgoNames_) {
+    L1AlgoName = "";
   }
   
   //Get L1 algorithm trigger names -      
@@ -141,9 +139,9 @@ L1TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& i
   m_l1GtMenu = l1GtMenu.product();
   m_algorithmMap = &(m_l1GtMenu->getAlgorithmMap());
 
-  for (std::map<std::string, L1TUtmAlgorithm>::const_iterator itAlgo = m_algorithmMap->begin(); itAlgo != m_algorithmMap->end(); itAlgo++) {
-    int bitNumber = (itAlgo->second).getIndex();
-    L1AlgoNames_.at(bitNumber) = itAlgo->first;
+  for (auto const & itAlgo : *m_algorithmMap) {
+    int bitNumber = (itAlgo.second).getIndex();
+    L1AlgoNames_.at(bitNumber) = itAlgo.first;
   }
   
   L1GlobalType_.clear();   
@@ -189,13 +187,13 @@ L1TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& i
     Json::StyledWriter writer;
 
     Json::Value l1AlgoNamesVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < L1AlgoNames_.size(); ui++){
-      l1AlgoNamesVal.append(L1AlgoNames_.at(ui));
+    for (auto & L1AlgoName : L1AlgoNames_){
+      l1AlgoNamesVal.append(L1AlgoName);
     }
 
     Json::Value eventTypeVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < L1GlobalType_.size(); ui++){
-      eventTypeVal.append(L1GlobalType_.at(ui));
+    for (auto & ui : L1GlobalType_){
+      eventTypeVal.append(ui);
     }
 
     l1Ini["L1-Algo-Names"] = l1AlgoNamesVal;

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -32,9 +32,7 @@ TriggerJSONMonitoring::TriggerJSONMonitoring(const edm::ParameterSet& ps) :
                                                      
 }
 
-TriggerJSONMonitoring::~TriggerJSONMonitoring()
-{
-}
+TriggerJSONMonitoring::~TriggerJSONMonitoring() = default;
 
 void
 TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -160,8 +158,8 @@ TriggerJSONMonitoring::resetRun(bool changed){
     datasetContents_ = hltConfig_.datasetContents();
 
     L1AlgoNames_.resize(m_l1tAlgoMask->gtTriggerMask().size());         
-    for (unsigned int i = 0; i < L1AlgoNames_.size(); i++) {
-      L1AlgoNames_.at(i) = "";
+    for (auto & L1AlgoName : L1AlgoNames_) {
+      L1AlgoName = "";
     }
     //Get L1 algorithm trigger names -      
     for (CItAlgo itAlgo = algorithmMap.begin(); itAlgo != algorithmMap.end(); itAlgo++) {
@@ -170,8 +168,8 @@ TriggerJSONMonitoring::resetRun(bool changed){
     }
 
     L1TechNames_.resize(m_l1tTechMask->gtTriggerMask().size());    
-    for (unsigned int i = 0; i < L1TechNames_.size(); i++) {
-      L1TechNames_.at(i) = "";
+    for (auto & L1TechName : L1TechNames_) {
+      L1TechName = "";
     }
     //Get L1 technical trigger names -           
     for (CItAlgo itAlgo = technicalMap.begin(); itAlgo != technicalMap.end(); itAlgo++) {
@@ -263,8 +261,8 @@ TriggerJSONMonitoring::resetLumi(){
     hltErrors_[i] = 0;
   }
   //Reset per-dataset counter         
-  for (unsigned int i = 0; i < hltDatasets_.size(); i++) {
-    hltDatasets_[i] = 0;
+  for (unsigned int & hltDataset : hltDatasets_) {
+    hltDataset = 0;
   }
   //Reset L1 per-algo counters -     
   for (unsigned int i = 0; i < L1AlgoAccept_.size(); i++) {
@@ -353,13 +351,13 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
     Json::StyledWriter writer;
 
     Json::Value hltNamesVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < hltNames_.size(); ui++){
-      hltNamesVal.append(hltNames_.at(ui));
+    for (auto & hltName : hltNames_){
+      hltNamesVal.append(hltName);
     }
 
     Json::Value datasetNamesVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < datasetNames_.size(); ui++){
-      datasetNamesVal.append(datasetNames_.at(ui));
+    for (auto & datasetName : datasetNames_){
+      datasetNamesVal.append(datasetName);
     }
 
     hltIni["Path-Names"]    = hltNamesVal;
@@ -378,18 +376,18 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
     Json::Value l1Ini;
 
     Json::Value l1AlgoNamesVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < L1AlgoNames_.size(); ui++){
-      l1AlgoNamesVal.append(L1AlgoNames_.at(ui));
+    for (auto & L1AlgoName : L1AlgoNames_){
+      l1AlgoNamesVal.append(L1AlgoName);
     }
 
     Json::Value l1TechNamesVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < L1TechNames_.size(); ui++){
-      l1TechNamesVal.append(L1TechNames_.at(ui));
+    for (auto & L1TechName : L1TechNames_){
+      l1TechNamesVal.append(L1TechName);
     }
 
     Json::Value eventTypeVal(Json::arrayValue);
-    for (unsigned int ui = 0; ui < L1GlobalType_.size(); ui++){
-      eventTypeVal.append(L1GlobalType_.at(ui));
+    for (auto & ui : L1GlobalType_){
+      eventTypeVal.append(ui);
     }
 
     l1Ini["L1-Algo-Names"] = l1AlgoNamesVal;
@@ -470,8 +468,8 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
       iSummary->hltReject->update(hltReject_.at(ui));
       iSummary->hltErrors->update(hltErrors_.at(ui));
     }
-    for (unsigned int ui = 0; ui < hltDatasets_.size(); ui++){
-      iSummary->hltDatasets->update(hltDatasets_.at(ui));
+    for (unsigned int hltDataset : hltDatasets_){
+      iSummary->hltDatasets->update(hltDataset);
     }
     iSummary->prescaleIndex = prescaleIndex_;
 

--- a/HLTrigger/JetMET/plugins/HLTCATopTagFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTCATopTagFilter.cc
@@ -40,7 +40,7 @@ HLTCATopTagFilter::HLTCATopTagFilter(const edm::ParameterSet& iConfig) : HLTFilt
 }
 
 
-HLTCATopTagFilter::~HLTCATopTagFilter(){}
+HLTCATopTagFilter::~HLTCATopTagFilter()= default;
 
 
 void HLTCATopTagFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
@@ -79,9 +79,9 @@ bool HLTCATopTagFilter::hltFilter( edm::Event& iEvent, const edm::EventSetup& iS
   CATopJetProperties properties;
 
   // Now loop over the hard jets and do kinematic cuts
-  reco::BasicJetCollection::const_iterator ihardJet = pBasicJets->begin(),
+  auto ihardJet = pBasicJets->begin(),
     ihardJetEnd = pBasicJets->end();
-  reco::PFJetCollection::const_iterator ipfJet = pfJets->begin();
+  auto ipfJet = pfJets->begin();
   bool pass = false;
   
   for ( ; ihardJet != ihardJetEnd; ++ihardJet, ++ipfJet ) {

--- a/HLTrigger/JetMET/plugins/HLTCAWZTagFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTCAWZTagFilter.cc
@@ -41,9 +41,7 @@ HLTCAWZTagFilter::HLTCAWZTagFilter(const edm::ParameterSet& iConfig): HLTFilter(
 }
 
 
-HLTCAWZTagFilter::~HLTCAWZTagFilter()
-{
-}
+HLTCAWZTagFilter::~HLTCAWZTagFilter() = default;
 
 
 void HLTCAWZTagFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
@@ -82,9 +80,9 @@ bool HLTCAWZTagFilter::hltFilter( edm::Event& iEvent, const edm::EventSetup& iSe
   CATopJetProperties properties;
 
   // Now loop over the hard jets and do kinematic cuts
-  reco::BasicJetCollection::const_iterator ihardJet = pBasicJets->begin(),
+  auto ihardJet = pBasicJets->begin(),
     ihardJetEnd = pBasicJets->end();
-  reco::PFJetCollection::const_iterator ipfJet = pfJets->begin();
+  auto ipfJet = pfJets->begin();
   bool pass = false;
 
   for ( ; ihardJet != ihardJetEnd; ++ihardJet, ++ipfJet ) {

--- a/HLTrigger/JetMET/plugins/HLTJetHbbFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTJetHbbFilter.cc
@@ -81,7 +81,7 @@ HLTJetHbbFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& description
 template<typename T> float HLTJetHbbFilter<T>::findCSV(const typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection  & jetTags){
   float minDr = 0.1; //matching jet tag with jet
   float tmpCSV = -20 ;
-  for (reco::JetTagCollection::const_iterator jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
+  for (auto jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
     float tmpDr = reco::deltaR(*jet,*(jetb->first));
     if (tmpDr < minDr) {
       minDr = tmpDr ;
@@ -139,10 +139,10 @@ HLTJetHbbFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup,tr
   double etajet2 = -99.;
 
   //looping through sets of jets
-  for (typename TCollection::const_iterator jet1=jets->begin(); (jet1!=jets->end()); ++jet1) {
+  for (auto jet1=jets->begin(); (jet1!=jets->end()); ++jet1) {
     tag1 = findCSV(jet1, *jetTags);
     ++nJet;
-    for (typename TCollection::const_iterator jet2=(jet1+1); (jet2!=jets->end()); ++jet2) {
+    for (auto jet2=(jet1+1); (jet2!=jets->end()); ++jet2) {
       tag2 = findCSV(jet2, *jetTags);
 
       ejet1   = jet1->energy();

--- a/HLTrigger/JetMET/plugins/HLTRFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTRFilter.cc
@@ -55,9 +55,7 @@ HLTRFilter::HLTRFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
 
 }
 
-HLTRFilter::~HLTRFilter()
-{
-}
+HLTRFilter::~HLTRFilter() = default;
 
 void
 HLTRFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JetMET/plugins/HLTRHemisphere.cc
+++ b/HLTrigger/JetMET/plugins/HLTRHemisphere.cc
@@ -49,9 +49,7 @@ HLTRHemisphere::HLTRHemisphere(const edm::ParameterSet& iConfig) :
    produces<std::vector<math::XYZTLorentzVector> >();
 }
 
-HLTRHemisphere::~HLTRHemisphere()
-{
-}
+HLTRHemisphere::~HLTRHemisphere() = default;
 
 void
 HLTRHemisphere::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -98,9 +96,9 @@ HLTRHemisphere::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    // look at all objects, check cuts and add to filter object
    int n(0);
    vector<math::XYZTLorentzVector> JETS;
-   for (unsigned int i=0; i<jets->size(); i++) {
-     if(std::abs(jets->at(i).eta()) < max_Eta_ && jets->at(i).pt() >= min_Jet_Pt_){
-       JETS.push_back(jets->at(i).p4());
+   for (auto const & i : *jets) {
+     if(std::abs(i.eta()) < max_Eta_ && i.pt() >= min_Jet_Pt_){
+       JETS.push_back(i.p4());
        n++;
      }
    }

--- a/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
@@ -39,12 +39,12 @@ Description: Producer for ScoutingCaloJets from reco::CaloJet objects
 class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
     public:
         explicit HLTScoutingCaloProducer(const edm::ParameterSet&);
-        ~HLTScoutingCaloProducer();
+        ~HLTScoutingCaloProducer() override;
 
         static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     private:
-        virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const override final;
+        void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const final;
 
         const edm::EDGetTokenT<reco::CaloJetCollection> caloJetCollection_;
         const edm::EDGetTokenT<reco::JetTagCollection> caloJetBTagCollection_;
@@ -84,8 +84,7 @@ HLTScoutingCaloProducer::HLTScoutingCaloProducer(const edm::ParameterSet& iConfi
     produces<double>("caloMetPhi");
 }
 
-HLTScoutingCaloProducer::~HLTScoutingCaloProducer()
-{ }
+HLTScoutingCaloProducer::~HLTScoutingCaloProducer() = default;
 
 // ------------ method called to produce the data  ------------
     void

--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -42,12 +42,12 @@ Description: Producer for ScoutingPFJets from reco::PFJet objects, ScoutingVerte
 class HLTScoutingPFProducer : public edm::global::EDProducer<> {
     public:
         explicit HLTScoutingPFProducer(const edm::ParameterSet&);
-        ~HLTScoutingPFProducer();
+        ~HLTScoutingPFProducer() override;
 
         static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     private:
-        virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const override final;
+        void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const final;
 
         const edm::EDGetTokenT<reco::PFJetCollection> pfJetCollection_;
         const edm::EDGetTokenT<reco::JetTagCollection> pfJetTagCollection_;
@@ -90,8 +90,7 @@ HLTScoutingPFProducer::HLTScoutingPFProducer(const edm::ParameterSet& iConfig):
     produces<double>("pfMetPhi");
 }
 
-HLTScoutingPFProducer::~HLTScoutingPFProducer()
-{ }
+HLTScoutingPFProducer::~HLTScoutingPFProducer() = default;
 
 // ------------ method called to produce the data  ------------
 void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const

--- a/HLTrigger/JetMET/plugins/HLTScoutingPrimaryVertexProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPrimaryVertexProducer.cc
@@ -20,12 +20,12 @@
 class HLTScoutingPrimaryVertexProducer : public edm::global::EDProducer<> {
 public:
   explicit HLTScoutingPrimaryVertexProducer(const edm::ParameterSet&);
-  ~HLTScoutingPrimaryVertexProducer();
+  ~HLTScoutingPrimaryVertexProducer() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const override final;
+  void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const final;
   const edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
 };
 
@@ -40,8 +40,7 @@ HLTScoutingPrimaryVertexProducer::HLTScoutingPrimaryVertexProducer(const edm::Pa
   
 }
 
-HLTScoutingPrimaryVertexProducer::~HLTScoutingPrimaryVertexProducer()
-{ }
+HLTScoutingPrimaryVertexProducer::~HLTScoutingPrimaryVertexProducer() = default;
 
 // ------------ method called to produce the data  ------------
 void

--- a/HLTrigger/JetMET/plugins/PixelJetPuId.cc
+++ b/HLTrigger/JetMET/plugins/PixelJetPuId.cc
@@ -56,12 +56,12 @@ Implementation:
 class PixelJetPuId : public edm::global::EDProducer <>{
     public:
         PixelJetPuId(const edm::ParameterSet&);
-        virtual ~PixelJetPuId();
+        ~PixelJetPuId() override;
         
         static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
         
     private:
-        virtual void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
+        void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
         
         // ----------member data ---------------------------
         edm::InputTag m_primaryVertex;
@@ -118,7 +118,7 @@ PixelJetPuId::PixelJetPuId(const edm::ParameterSet& iConfig)
 }
 
 
-PixelJetPuId::~PixelJetPuId() {}
+PixelJetPuId::~PixelJetPuId() = default;
 
 
 void
@@ -200,7 +200,7 @@ void PixelJetPuId::produce(edm::StreamID sid, edm::Event& iEvent, const edm::Eve
                 else 
                 {
                     //loop on tracks
-                    std::vector<reco::Track>::const_iterator itTrack = tracks->begin();
+                    auto itTrack = tracks->begin();
                     for (unsigned int i=0; i<tsize; ++i) {
                         float deltaR2=reco::deltaR2(itJet->eta(),itJet->phi(), teta[i],tphi[i]);
                         if(deltaR2<0.25) {

--- a/HLTrigger/JetMET/src/AnyJetToCaloJetProducer.cc
+++ b/HLTrigger/JetMET/src/AnyJetToCaloJetProducer.cc
@@ -12,7 +12,7 @@ AnyJetToCaloJetProducer::AnyJetToCaloJetProducer(const edm::ParameterSet& iConfi
   produces<reco::CaloJetCollection>();
 }
 
-AnyJetToCaloJetProducer::~AnyJetToCaloJetProducer(){ }
+AnyJetToCaloJetProducer::~AnyJetToCaloJetProducer()= default;
 
 void
 AnyJetToCaloJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JetMET/src/HLT2jetGapFilter.cc
+++ b/HLTrigger/JetMET/src/HLT2jetGapFilter.cc
@@ -33,7 +33,7 @@ HLT2jetGapFilter::HLT2jetGapFilter(const edm::ParameterSet& iConfig) : HLTFilter
 
 }
 
-HLT2jetGapFilter::~HLT2jetGapFilter(){}
+HLT2jetGapFilter::~HLT2jetGapFilter()= default;
 
 void
 HLT2jetGapFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -69,7 +69,7 @@ HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     double etajet2=0.;
     int countjets =0;
 
-    for (reco::CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
+    for (auto recocalojet = recocalojets->begin();
 	 recocalojet<=(recocalojets->begin()+1); recocalojet++) {
 
       if(countjets==0) {
@@ -84,7 +84,7 @@ HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     }
 
   if(etjet1>minEt_ && etjet2>minEt_ && (etajet1*etajet2)<0 && std::abs(etajet1)>minEta_ && std::abs(etajet2)>minEta_){
-      for (reco::CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
+      for (auto recocalojet = recocalojets->begin();
 	   recocalojet<=(recocalojets->begin()+1); recocalojet++) {
 	reco::CaloJetRef ref(reco::CaloJetRef(recocalojets,distance(recocalojets->begin(),recocalojet)));
 	filterproduct.addObject(TriggerJet,ref);

--- a/HLTrigger/JetMET/src/HLTAcoFilter.cc
+++ b/HLTrigger/JetMET/src/HLTAcoFilter.cc
@@ -41,7 +41,7 @@ HLTAcoFilter::HLTAcoFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig
    m_theMETToken = consumes<trigger::TriggerFilterObjectWithRefs>(inputMETTag_);
 }
 
-HLTAcoFilter::~HLTAcoFilter(){}
+HLTAcoFilter::~HLTAcoFilter()= default;
 
 void
 HLTAcoFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -99,7 +99,7 @@ HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigg
   CaloJetRef ref1,ref2;
 
   if (JetNum>0) {
-    CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
+    auto recocalojet = recocalojets->begin();
 	
     etjet1 = recocalojet->et();
     phijet1 = recocalojet->phi();

--- a/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
+++ b/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
@@ -58,7 +58,7 @@ HLTAlphaTFilter<T>::HLTAlphaTFilter(const edm::ParameterSet& iConfig) : HLTFilte
 }
 
 template<typename T>
-HLTAlphaTFilter<T>::~HLTAlphaTFilter(){}
+HLTAlphaTFilter<T>::~HLTAlphaTFilter()= default;
 
 template<typename T>
 void HLTAlphaTFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JetMET/src/HLTCaloJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTCaloJetIDProducer.cc
@@ -30,7 +30,7 @@ HLTCaloJetIDProducer::HLTCaloJetIDProducer(const edm::ParameterSet& iConfig) :
 }
 
 // Destructor
-HLTCaloJetIDProducer::~HLTCaloJetIDProducer() {}
+HLTCaloJetIDProducer::~HLTCaloJetIDProducer() = default;
 
 // Fill descriptions
 void HLTCaloJetIDProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
@@ -62,26 +62,26 @@ void HLTCaloJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
     edm::Handle<reco::CaloJetCollection> calojets;
     iEvent.getByToken(m_theCaloJetToken, calojets);
 
-    for (reco::CaloJetCollection::const_iterator j = calojets->begin(); j != calojets->end(); ++j) {
+    for (auto const & j : *calojets) {
         bool pass = false;
 
-        if (!(j->energy() > 0.))  continue;  // skip jets with zero or negative energy
+        if (!(j.energy() > 0.))  continue;  // skip jets with zero or negative energy
 
-        if (std::abs(j->eta()) >= 2.6) {
+        if (std::abs(j.eta()) >= 2.6) {
             pass = true;
 
         } else {
-            if (min_N90hits_ > 0)  jetIDHelper_.calculate(iEvent, *j);
-            if ((j->emEnergyFraction() >= min_EMF_) &&
-                (j->emEnergyFraction() <= max_EMF_) &&
-                (j->n90() >= min_N90_) &&
+            if (min_N90hits_ > 0)  jetIDHelper_.calculate(iEvent, j);
+            if ((j.emEnergyFraction() >= min_EMF_) &&
+                (j.emEnergyFraction() <= max_EMF_) &&
+                (j.n90() >= min_N90_) &&
                 ((min_N90hits_ <= 0) || (jetIDHelper_.n90Hits() >= min_N90hits_)) ) {
 
                 pass = true;
             }
         }
 
-        if (pass)  result->push_back(*j);
+        if (pass)  result->push_back(j);
     }
 
     // Put the products into the Event

--- a/HLTrigger/JetMET/src/HLTCaloTowerHtMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTCaloTowerHtMhtProducer.cc
@@ -30,7 +30,7 @@ HLTCaloTowerHtMhtProducer::HLTCaloTowerHtMhtProducer(const edm::ParameterSet & i
 }
 
 // Destructor
-HLTCaloTowerHtMhtProducer::~HLTCaloTowerHtMhtProducer() {}
+HLTCaloTowerHtMhtProducer::~HLTCaloTowerHtMhtProducer() = default;
 
 // Fill descriptions
 void HLTCaloTowerHtMhtProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
@@ -57,12 +57,12 @@ void HLTCaloTowerHtMhtProducer::produce(edm::Event& iEvent, const edm::EventSetu
     double ht = 0., mhx = 0., mhy = 0.;
 
     if (towers->size() > 0) {
-        for(CaloTowerCollection::const_iterator j = towers->begin(); j != towers->end(); ++j) {
-            double pt = usePt_ ? j->pt() : j->et();
-            double eta = j->eta();
-            double phi = j->phi();
-            double px = usePt_ ? j->px() : j->et() * cos(phi);
-            double py = usePt_ ? j->py() : j->et() * sin(phi);
+        for(auto const & j : *towers) {
+            double pt = usePt_ ? j.pt() : j.et();
+            double eta = j.eta();
+            double phi = j.phi();
+            double px = usePt_ ? j.px() : j.et() * cos(phi);
+            double py = usePt_ ? j.py() : j.et() * sin(phi);
 
             if (pt > minPtTowerHt_ && std::abs(eta) < maxEtaTowerHt_) {
                 ht += pt;

--- a/HLTrigger/JetMET/src/HLTDiJetAveEtaFilter.cc
+++ b/HLTrigger/JetMET/src/HLTDiJetAveEtaFilter.cc
@@ -45,7 +45,7 @@ HLTDiJetAveEtaFilter<T>::HLTDiJetAveEtaFilter(const edm::ParameterSet& iConfig) 
 }
 
 template<typename T>
-HLTDiJetAveEtaFilter<T>::~HLTDiJetAveEtaFilter(){}
+HLTDiJetAveEtaFilter<T>::~HLTDiJetAveEtaFilter()= default;
 
 template<typename T>
 void

--- a/HLTrigger/JetMET/src/HLTDiJetAveFilter.cc
+++ b/HLTrigger/JetMET/src/HLTDiJetAveFilter.cc
@@ -39,7 +39,7 @@ HLTDiJetAveFilter<T>::HLTDiJetAveFilter(const edm::ParameterSet& iConfig) : HLTF
 }
 
 template<typename T>
-HLTDiJetAveFilter<T>::~HLTDiJetAveFilter(){}
+HLTDiJetAveFilter<T>::~HLTDiJetAveFilter()= default;
 
 template<typename T>
 void

--- a/HLTrigger/JetMET/src/HLTDiJetEtaTopologyFilter.cc
+++ b/HLTrigger/JetMET/src/HLTDiJetEtaTopologyFilter.cc
@@ -52,7 +52,7 @@ HLTDiJetEtaTopologyFilter<T>::HLTDiJetEtaTopologyFilter(const edm::ParameterSet&
 }
 
 template<typename T>
-HLTDiJetEtaTopologyFilter<T>::~HLTDiJetEtaTopologyFilter(){}
+HLTDiJetEtaTopologyFilter<T>::~HLTDiJetEtaTopologyFilter()= default;
 
 template<typename T>
 void

--- a/HLTrigger/JetMET/src/HLTExclDiJetFilter.cc
+++ b/HLTrigger/JetMET/src/HLTExclDiJetFilter.cc
@@ -45,7 +45,7 @@ HLTExclDiJetFilter<T>::HLTExclDiJetFilter(const edm::ParameterSet& iConfig) :
 }
 
 template<typename T>
-HLTExclDiJetFilter<T>::~HLTExclDiJetFilter(){}
+HLTExclDiJetFilter<T>::~HLTExclDiJetFilter()= default;
 
 template<typename T>
 void
@@ -135,10 +135,10 @@ HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
      Handle<CaloTowerCollection> o;
      iEvent.getByToken(m_theCaloTowerCollectionToken,o);
 //     if( o.isValid()) {
-      for( CaloTowerCollection::const_iterator cc = o->begin(); cc != o->end(); ++cc ) {
-       if(std::abs(cc->ieta())>28 && cc->energy()<4.0) continue;
-        if(cc->ieta()>28)  ehfp+=cc->energy();  // HF+ energy
-        if(cc->ieta()<-28) ehfm+=cc->energy();  // HF- energy
+      for(auto const & cc : *o) {
+       if(std::abs(cc.ieta())>28 && cc.energy()<4.0) continue;
+        if(cc.ieta()>28)  ehfp+=cc.energy();  // HF+ energy
+        if(cc.ieta()<-28) ehfm+=cc.energy();  // HF- energy
       }
  //    }
 

--- a/HLTrigger/JetMET/src/HLTFatJetMassFilter.cc
+++ b/HLTrigger/JetMET/src/HLTFatJetMassFilter.cc
@@ -49,7 +49,7 @@ HLTFatJetMassFilter<jetType>::HLTFatJetMassFilter(const edm::ParameterSet& iConf
 }
 
 template<typename jetType>
-HLTFatJetMassFilter<jetType>::~HLTFatJetMassFilter(){}
+HLTFatJetMassFilter<jetType>::~HLTFatJetMassFilter()= default;
 
 template<typename jetType>
 void 

--- a/HLTrigger/JetMET/src/HLTForwardBackwardJetsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTForwardBackwardJetsFilter.cc
@@ -47,7 +47,7 @@ HLTForwardBackwardJetsFilter<T>::HLTForwardBackwardJetsFilter(const edm::Paramet
 }
 
 template<typename T>
-HLTForwardBackwardJetsFilter<T>::~HLTForwardBackwardJetsFilter(){}
+HLTForwardBackwardJetsFilter<T>::~HLTForwardBackwardJetsFilter()= default;
 
 template<typename T>
 void

--- a/HLTrigger/JetMET/src/HLTHPDFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHPDFilter.cc
@@ -84,7 +84,7 @@ HLTHPDFilter::HLTHPDFilter(const edm::ParameterSet& iConfig) :
   m_theRecHitCollectionToken = consumes<HBHERecHitCollection>(mInputTag);
 }
 
-HLTHPDFilter::~HLTHPDFilter(){}
+HLTHPDFilter::~HLTHPDFilter()= default;
 
 void
 HLTHPDFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -107,7 +107,7 @@ bool HLTHPDFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   
   // collect energies
   float hpdEnergy[4][73];
-  for (size_t i = 0; i < 4; ++i) for (size_t j = 0; j < 73; ++j) hpdEnergy[i][j] = 0;
+  for (auto & i : hpdEnergy) for (size_t j = 0; j < 73; ++j) i[j] = 0;
   
   // select hist above threshold
   for (unsigned i = 0; i < hbhe->size(); ++i) {
@@ -119,14 +119,14 @@ bool HLTHPDFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   
   // not single HPD spike
   if (mHPDSpikeEnergyThreshold > 0) {
-    for (size_t partition = 0; partition < 4; ++partition) {
+    for (auto & partition : hpdEnergy) {
       for (size_t i = 1; i < 73; ++i) {
-	if (hpdEnergy [partition][i] > mHPDSpikeEnergyThreshold) {
+	if (partition[i] > mHPDSpikeEnergyThreshold) {
 	  int hpdPlus = i + 1;
 	  if (hpdPlus == 73) hpdPlus = 1;
 	  int hpdMinus = i - 1;
 	  if (hpdMinus == 0) hpdMinus = 72;
-	  double maxNeighborEnergy = fmax (hpdEnergy[partition][hpdPlus], hpdEnergy[partition][hpdMinus]);
+	  double maxNeighborEnergy = fmax (partition[hpdPlus], partition[hpdMinus]);
 	  if (maxNeighborEnergy < mHPDSpikeIsolationEnergyThreshold)  return false; // HPD spike found
 	}
       }
@@ -135,7 +135,7 @@ bool HLTHPDFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   // not RBX flash
   if (mRBXSpikeEnergyThreshold > 0) {
-    for (size_t partition = 0; partition < 4; ++partition) {
+    for (auto & partition : hpdEnergy) {
       for (size_t rbx = 1; rbx < 19; ++rbx) {
 	int ifirst = (rbx-1)*4-1;
 	int iend = (rbx-1)*4+3;
@@ -145,13 +145,13 @@ bool HLTHPDFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	for (int irm = ifirst; irm < iend; ++irm) {
 	  int hpd = irm;
 	  if (hpd <= 0) hpd = 72 + hpd;
-	  totalEnergy += hpdEnergy[partition][hpd];
+	  totalEnergy += partition[hpd];
 	  if (minEnergy > maxEnergy) {
-	    minEnergy = maxEnergy = hpdEnergy[partition][hpd];
+	    minEnergy = maxEnergy = partition[hpd];
 	  }
 	  else {
-	    if (hpdEnergy[partition][hpd] < minEnergy) minEnergy = hpdEnergy[partition][hpd];
-	    if (hpdEnergy[partition][hpd] > maxEnergy) maxEnergy = hpdEnergy[partition][hpd];
+	    if (partition[hpd] < minEnergy) minEnergy = partition[hpd];
+	    if (partition[hpd] > maxEnergy) maxEnergy = partition[hpd];
 	  }
 	}
 	if (totalEnergy > mRBXSpikeEnergyThreshold) {

--- a/HLTrigger/JetMET/src/HLTHcalLaserFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHcalLaserFilter.cc
@@ -47,7 +47,7 @@ HLTHcalLaserFilter::HLTHcalLaserFilter(const edm::ParameterSet& iConfig) :
 }
 
 
-HLTHcalLaserFilter::~HLTHcalLaserFilter(){}
+HLTHcalLaserFilter::~HLTHcalLaserFilter()= default;
 
 void
 HLTHcalLaserFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -105,33 +105,33 @@ bool HLTHcalLaserFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
       // loop over calibration channels
       
       //for timing reasons, we abort within the loop if a field ever goes out of bounds
-      for(HcalCalibDigiCollection::const_iterator digi = hCalib->begin(); digi != hCalib->end(); digi++)
+      for(auto const & digi : *hCalib)
 	{
-	  if(digi->id().hcalSubdet() == 0)
+	  if(digi.id().hcalSubdet() == 0)
 	    continue;
 	  
 
-	  HcalCalibDetId myid=(HcalCalibDetId)digi->id();
+	  HcalCalibDetId myid=(HcalCalibDetId)digi.id();
 	  if (myid.hcalSubdet()==HcalBarrel || myid.hcalSubdet()==HcalEndcap)
 	    {
 	      if ( myid.calibFlavor()==HcalCalibDetId::HOCrosstalk)
 		continue; // ignore HOCrosstalk channels
 	  
 	      // Add this digi to total calibration charge
-	      for(int i = 0; i < (int)digi->size(); i++)
-		totalCalibCharge = totalCalibCharge + adc2fC[digi->sample(i).adc()&0xff];
+	      for(int i = 0; i < (int)digi.size(); i++)
+		totalCalibCharge = totalCalibCharge + adc2fC[digi.sample(i).adc()&0xff];
 	      
 	      if(maxTotalCalibCharge_ >= 0 && totalCalibCharge > maxTotalCalibCharge_) return false;
 	      
 	      // Compute total charge found in the provided subset of timeslices
 	      double sumCharge=0;
 	      unsigned int NTS=timeSlices_.size();
-	      int digisize=(int)digi->size(); // gives value of largest time slice
+	      int digisize=(int)digi.size(); // gives value of largest time slice
 	      
 	      for (unsigned int ts=0;ts<NTS;++ts) // loop over provided timeslices
 		{
 		  if (timeSlices_[ts]<0 || timeSlices_[ts]>digisize) continue;
-		  sumCharge+=adc2fC[digi->sample(timeSlices_[ts]).adc()&0xff];
+		  sumCharge+=adc2fC[digi.sample(timeSlices_[ts]).adc()&0xff];
 		}
 	      
 	      // Check multiplicity and charge against filter settings for each charge threshold

--- a/HLTrigger/JetMET/src/HLTHcalMETNoiseCleaner.cc
+++ b/HLTrigger/JetMET/src/HLTHcalMETNoiseCleaner.cc
@@ -93,7 +93,7 @@ HLTHcalMETNoiseCleaner::HLTHcalMETNoiseCleaner(const edm::ParameterSet& iConfig)
 }
 
 
-HLTHcalMETNoiseCleaner::~HLTHcalMETNoiseCleaner(){}
+HLTHcalMETNoiseCleaner::~HLTHcalMETNoiseCleaner()= default;
 
 void
 HLTHcalMETNoiseCleaner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -180,8 +180,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
 
   // create a sorted set of the RBXs, ordered by energy
   noisedataset_t data;
-  for(HcalNoiseRBXCollection::const_iterator it=rbxs_h->begin(); it!=rbxs_h->end(); ++it) {
-    const HcalNoiseRBX &rbx=(*it);
+  for(auto const & rbx : *rbxs_h) {
     CommonHcalNoiseRBXData d(rbx, minRecHitE_, minLowHitE_, minHighHitE_, TS4TS5EnergyThreshold_,
 			     TS4TS5UpperCut_, TS4TS5LowerCut_, minR45HitE_);
     data.insert(d);
@@ -202,7 +201,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
 
   TVector3 noiseHPDVector(0,0,0);
   TVector3 secondHPDVector(0,0,0);
-  for(noisedataset_t::const_iterator it=data.begin();
+  for(auto it=data.begin();
       it!=data.end() && cntr<numRBXsToConsider_;
       it++, cntr++) {
     bool isNoise=false;

--- a/HLTrigger/JetMET/src/HLTHcalMETNoiseFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHcalMETNoiseFilter.cc
@@ -74,7 +74,7 @@ HLTHcalMETNoiseFilter::HLTHcalMETNoiseFilter(const edm::ParameterSet& iConfig) :
 }
 
 
-HLTHcalMETNoiseFilter::~HLTHcalMETNoiseFilter(){}
+HLTHcalMETNoiseFilter::~HLTHcalMETNoiseFilter()= default;
 
 void
 HLTHcalMETNoiseFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -141,8 +141,7 @@ bool HLTHcalMETNoiseFilter::filter(edm::Event& iEvent, const edm::EventSetup& iS
 
   // create a sorted set of the RBXs, ordered by energy
   noisedataset_t data;
-  for(HcalNoiseRBXCollection::const_iterator it=rbxs_h->begin(); it!=rbxs_h->end(); ++it) {
-    const HcalNoiseRBX &rbx=(*it);
+  for(auto const & rbx : *rbxs_h) {
     CommonHcalNoiseRBXData d(rbx, minRecHitE_, minLowHitE_, minHighHitE_, TS4TS5EnergyThreshold_,
 			     TS4TS5UpperCut_, TS4TS5LowerCut_, minR45HitE_);
     data.insert(d);
@@ -151,7 +150,7 @@ bool HLTHcalMETNoiseFilter::filter(edm::Event& iEvent, const edm::EventSetup& iS
   // data is now sorted by RBX energy
   // only consider top N=numRBXsToConsider_ energy RBXs
   int cntr=0;
-  for(noisedataset_t::const_iterator it=data.begin();
+  for(auto it=data.begin();
       it!=data.end() && cntr<numRBXsToConsider_;
       ++it, ++cntr) {
 

--- a/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleaner.cc
+++ b/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleaner.cc
@@ -97,7 +97,7 @@ HLTHcalTowerNoiseCleaner::HLTHcalTowerNoiseCleaner(const edm::ParameterSet& iCon
 }
 
 
-HLTHcalTowerNoiseCleaner::~HLTHcalTowerNoiseCleaner(){}
+HLTHcalTowerNoiseCleaner::~HLTHcalTowerNoiseCleaner()= default;
 
 void
 HLTHcalTowerNoiseCleaner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -175,8 +175,7 @@ void HLTHcalTowerNoiseCleaner::produce(edm::Event& iEvent, const edm::EventSetup
 		
   // create a sorted set of the RBXs, ordered by energy
   noisedataset_t data;
-  for(HcalNoiseRBXCollection::const_iterator it=rbxs_h->begin(); it!=rbxs_h->end(); ++it) {
-    const HcalNoiseRBX &rbx=(*it);
+  for(auto const & rbx : *rbxs_h) {
     CommonHcalNoiseRBXData d(rbx, minRecHitE_, minLowHitE_, minHighHitE_, TS4TS5EnergyThreshold_,
 			     TS4TS5UpperCut_, TS4TS5LowerCut_, minR45HitE_);
     data.insert(d);
@@ -185,25 +184,23 @@ void HLTHcalTowerNoiseCleaner::produce(edm::Event& iEvent, const edm::EventSetup
   // data is now sorted by RBX energy
   // only consider top N=numRBXsToConsider_ energy RBXs
   if(severity_>0){
-    for(noisedataset_t::const_iterator it=data.begin();
-	it!=data.end();
-	it++) {
+    for(auto const & it : data) {
       
       
       bool passFilter=true;
       bool passEMF=true;
-      if(it->energy()>minRBXEnergy_) {
-	if(it->validRatio() && it->ratio()<minRatio_)        passFilter=false;
-	else if(it->validRatio() && it->ratio()>maxRatio_)   passFilter=false;
-	else if(it->numHPDHits()>=minHPDHits_)               passFilter=false;
-	else if(it->numRBXHits()>=minRBXHits_)               passFilter=false;
-	else if(it->numHPDNoOtherHits()>=minHPDNoOtherHits_) passFilter=false;
-	else if(it->numZeros()>=minZeros_)                   passFilter=false;
-	else if(it->minHighEHitTime()<minHighEHitTime_)      passFilter=false;
-	else if(it->maxHighEHitTime()>maxHighEHitTime_)      passFilter=false;
-	else if(!it->PassTS4TS5())                           passFilter=false;
+      if(it.energy()>minRBXEnergy_) {
+	if(it.validRatio() && it.ratio()<minRatio_)        passFilter=false;
+	else if(it.validRatio() && it.ratio()>maxRatio_)   passFilter=false;
+	else if(it.numHPDHits()>=minHPDHits_)               passFilter=false;
+	else if(it.numRBXHits()>=minRBXHits_)               passFilter=false;
+	else if(it.numHPDNoOtherHits()>=minHPDNoOtherHits_) passFilter=false;
+	else if(it.numZeros()>=minZeros_)                   passFilter=false;
+	else if(it.minHighEHitTime()<minHighEHitTime_)      passFilter=false;
+	else if(it.maxHighEHitTime()>maxHighEHitTime_)      passFilter=false;
+	else if(!it.PassTS4TS5())                           passFilter=false;
 	
-	if(it->RBXEMF()<maxRBXEMF_){
+	if(it.RBXEMF()<maxRBXEMF_){
 	  passEMF=false;
 	}
       }
@@ -211,18 +208,18 @@ void HLTHcalTowerNoiseCleaner::produce(edm::Event& iEvent, const edm::EventSetup
       if((needEMFCoincidence_ && !passEMF && !passFilter) ||
 	 (!needEMFCoincidence_ && !passFilter)) { // check for noise
 	LogDebug("") << "HLTHcalTowerNoiseCleaner debug: Found a noisy RBX: "
-		     << "energy=" << it->energy() << "; "
-		     << "ratio=" << it->ratio() << "; "
-		     << "# RBX hits=" << it->numRBXHits() << "; "
-		     << "# HPD hits=" << it->numHPDHits() << "; "
-		     << "# Zeros=" << it->numZeros() << "; "
-		     << "min time=" << it->minHighEHitTime() << "; "
-		     << "max time=" << it->maxHighEHitTime() << "; "
-		     << "passTS4TS5=" << it->PassTS4TS5() << "; "
-		     << "RBX EMF=" << it->RBXEMF()
+		     << "energy=" << it.energy() << "; "
+		     << "ratio=" << it.ratio() << "; "
+		     << "# RBX hits=" << it.numRBXHits() << "; "
+		     << "# HPD hits=" << it.numHPDHits() << "; "
+		     << "# Zeros=" << it.numZeros() << "; "
+		     << "min time=" << it.minHighEHitTime() << "; "
+		     << "max time=" << it.maxHighEHitTime() << "; "
+		     << "passTS4TS5=" << it.PassTS4TS5() << "; "
+		     << "RBX EMF=" << it.RBXEMF()
 		     << std::endl;
 	// add calotowers associated with this RBX to the noise list
-	edm::RefVector<CaloTowerCollection> noiseTowers = it->rbxTowers();
+	edm::RefVector<CaloTowerCollection> noiseTowers = it.rbxTowers();
 	edm::RefVector<CaloTowerCollection>::const_iterator noiseTowersIt;
 	//add these calotowers to the noisy list
 	for( noiseTowersIt = noiseTowers.begin(); noiseTowersIt != noiseTowers.end(); noiseTowersIt++){

--- a/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
+++ b/HLTrigger/JetMET/src/HLTHcalTowerNoiseCleanerWithrechit.cc
@@ -98,7 +98,7 @@ HLTHcalTowerNoiseCleanerWithrechit::HLTHcalTowerNoiseCleanerWithrechit(const edm
 }
 
 
-HLTHcalTowerNoiseCleanerWithrechit::~HLTHcalTowerNoiseCleanerWithrechit(){}
+HLTHcalTowerNoiseCleanerWithrechit::~HLTHcalTowerNoiseCleanerWithrechit()= default;
 
 void
 HLTHcalTowerNoiseCleanerWithrechit::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -181,8 +181,7 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
 		
   // create a sorted set of the RBXs, ordered by energy
   noisedataset_t data;
-  for(HcalNoiseRBXCollection::const_iterator it=rbxs_h->begin(); it!=rbxs_h->end(); ++it) {
-    const HcalNoiseRBX &rbx=(*it);
+  for(auto const & rbx : *rbxs_h) {
     CommonHcalNoiseRBXData d(rbx, minRecHitE_, minLowHitE_, minHighHitE_, TS4TS5EnergyThreshold_,
 			     TS4TS5UpperCut_, TS4TS5LowerCut_, minR45HitE_);
     data.insert(d);
@@ -191,15 +190,13 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
   // data is now sorted by RBX energy
   // only consider top N=numRBXsToConsider_ energy RBXs
   if(severity_>0){
-    for(noisedataset_t::const_iterator it=data.begin();
-	it!=data.end();
-	it++) {
+    for(auto const & it : data) {
       // Check the Rechit-R45 filter
       // Taken from http://cmslxr.fnal.gov/lxr/source/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc?v=CMSSW_7_4_6#0256
      bool passRechitr45 = true;
-      int r45Count = it->r45Count();
-      double r45Fraction = it->r45Fraction();
-      double r45EnergyFraction = it->r45EnergyFraction();
+      int r45Count = it.r45Count();
+      double r45Fraction = it.r45Fraction();
+      double r45EnergyFraction = it.r45EnergyFraction();
       for(int i = 0; i + 3 < (int)hltMinRBXRechitR45Cuts_.size(); i = i + 4) {
 	double Value = r45Count * hltMinRBXRechitR45Cuts_[i] + r45Fraction * hltMinRBXRechitR45Cuts_[i+1] + r45EnergyFraction * hltMinRBXRechitR45Cuts_[i+2] + hltMinRBXRechitR45Cuts_[i+3];
 	if (Value > 0) passRechitr45=false;
@@ -207,17 +204,17 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
 
       bool passFilter=true;
       bool passEMF=true;
-      if(it->energy()>minRBXEnergy_) {
-	if(it->validRatio() && it->ratio()<minRatio_)        passFilter=false;
-	else if(it->validRatio() && it->ratio()>maxRatio_)   passFilter=false;
-	else if(it->numHPDHits()>=minHPDHits_)               passFilter=false;
-	else if(it->numRBXHits()>=minRBXHits_)               passFilter=false;
-	else if(it->numHPDNoOtherHits()>=minHPDNoOtherHits_) passFilter=false;
-	else if(it->numZeros()>=minZeros_)                   passFilter=false;
-	else if(it->minHighEHitTime()<minHighEHitTime_)      passFilter=false;
-	else if(it->maxHighEHitTime()>maxHighEHitTime_)      passFilter=false;
+      if(it.energy()>minRBXEnergy_) {
+	if(it.validRatio() && it.ratio()<minRatio_)        passFilter=false;
+	else if(it.validRatio() && it.ratio()>maxRatio_)   passFilter=false;
+	else if(it.numHPDHits()>=minHPDHits_)               passFilter=false;
+	else if(it.numRBXHits()>=minRBXHits_)               passFilter=false;
+	else if(it.numHPDNoOtherHits()>=minHPDNoOtherHits_) passFilter=false;
+	else if(it.numZeros()>=minZeros_)                   passFilter=false;
+	else if(it.minHighEHitTime()<minHighEHitTime_)      passFilter=false;
+	else if(it.maxHighEHitTime()>maxHighEHitTime_)      passFilter=false;
 	else if (passRechitr45==false)                       passFilter=false;
-	if(it->RBXEMF()<maxRBXEMF_){
+	if(it.RBXEMF()<maxRBXEMF_){
 	  passEMF=false;
 	}
       }
@@ -225,17 +222,17 @@ void HLTHcalTowerNoiseCleanerWithrechit::produce(edm::Event& iEvent, const edm::
       if((needEMFCoincidence_ && !passEMF && !passFilter) ||
 	 (!needEMFCoincidence_ && !passFilter)) { // check for noise
 	LogDebug("") << "HLTHcalTowerNoiseCleanerWithrechit debug: Found a noisy RBX: "
-		     << "energy=" << it->energy() << "; "
-		     << "ratio=" << it->ratio() << "; "
-		     << "# RBX hits=" << it->numRBXHits() << "; "
-		     << "# HPD hits=" << it->numHPDHits() << "; "
-		     << "# Zeros=" << it->numZeros() << "; "
-		     << "min time=" << it->minHighEHitTime() << "; "
-		     << "max time=" << it->maxHighEHitTime() << "; "
-		     << "RBX EMF=" << it->RBXEMF()
+		     << "energy=" << it.energy() << "; "
+		     << "ratio=" << it.ratio() << "; "
+		     << "# RBX hits=" << it.numRBXHits() << "; "
+		     << "# HPD hits=" << it.numHPDHits() << "; "
+		     << "# Zeros=" << it.numZeros() << "; "
+		     << "min time=" << it.minHighEHitTime() << "; "
+		     << "max time=" << it.maxHighEHitTime() << "; "
+		     << "RBX EMF=" << it.RBXEMF()
 		     << std::endl;
 	// add calotowers associated with this RBX to the noise list
-	edm::RefVector<CaloTowerCollection> noiseTowers = it->rbxTowers();
+	edm::RefVector<CaloTowerCollection> noiseTowers = it.rbxTowers();
 	edm::RefVector<CaloTowerCollection>::const_iterator noiseTowersIt;
 	//add these calotowers to the noisy list
 	for( noiseTowersIt = noiseTowers.begin(); noiseTowersIt != noiseTowers.end(); noiseTowersIt++){

--- a/HLTrigger/JetMET/src/HLTHemiDPhiFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHemiDPhiFilter.cc
@@ -34,9 +34,7 @@ HLTHemiDPhiFilter::HLTHemiDPhiFilter(const edm::ParameterSet& iConfig) : HLTFilt
 		<< accept_NJ_ << ".";
 }
 
-HLTHemiDPhiFilter::~HLTHemiDPhiFilter()
-{
-}
+HLTHemiDPhiFilter::~HLTHemiDPhiFilter() = default;
 
 void
 HLTHemiDPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JetMET/src/HLTHtMhtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHtMhtFilter.cc
@@ -46,7 +46,7 @@ HLTHtMhtFilter::HLTHtMhtFilter(const edm::ParameterSet & iConfig) : HLTFilter(iC
 }
 
 // Destructor
-HLTHtMhtFilter::~HLTHtMhtFilter() {}
+HLTHtMhtFilter::~HLTHtMhtFilter() = default;
 
 // Fill descriptions
 void HLTHtMhtFilter::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {

--- a/HLTrigger/JetMET/src/HLTHtMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTHtMhtProducer.cc
@@ -34,7 +34,7 @@ HLTHtMhtProducer::HLTHtMhtProducer(const edm::ParameterSet & iConfig) :
 }
 
 // Destructor
-HLTHtMhtProducer::~HLTHtMhtProducer() {}
+HLTHtMhtProducer::~HLTHtMhtProducer() = default;
 
 // Fill descriptions
 void HLTHtMhtProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
@@ -94,10 +94,10 @@ void HLTHtMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     }
 
     if (excludePFMuons_) {
-        for (reco::PFCandidateCollection::const_iterator j = pfCandidates->begin(); j != pfCandidates->end(); ++j) {
-            if (std::abs(j->pdgId()) == 13) {
-                mhx += j->px();
-                mhy += j->py();
+        for (auto const & j : *pfCandidates) {
+            if (std::abs(j.pdgId()) == 13) {
+                mhx += j.px();
+                mhy += j.py();
             }
         }
     }

--- a/HLTrigger/JetMET/src/HLTJetCollForElePlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollForElePlusJets.cc
@@ -89,28 +89,28 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
   std::vector<TVector3> ElePs;
 
   if(!clusCands.empty()){ //try trigger cluster
-    for(size_t candNr=0;candNr<clusCands.size();candNr++){
+    for(auto & clusCand : clusCands){
       TVector3 positionVector(
-			      clusCands[candNr]->superCluster()->position().x(),
-			      clusCands[candNr]->superCluster()->position().y(),
-			      clusCands[candNr]->superCluster()->position().z());
+			      clusCand->superCluster()->position().x(),
+			      clusCand->superCluster()->position().y(),
+			      clusCand->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }else if(!eleCands.empty()){ // try trigger electrons
-    for(size_t candNr=0;candNr<eleCands.size();candNr++){
+    for(auto & eleCand : eleCands){
       TVector3 positionVector(
-			      eleCands[candNr]->superCluster()->position().x(),
-			      eleCands[candNr]->superCluster()->position().y(),
-			      eleCands[candNr]->superCluster()->position().z());
+			      eleCand->superCluster()->position().x(),
+			      eleCand->superCluster()->position().y(),
+			      eleCand->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }
   else if(!photonCands.empty()){ // try trigger photons
-    for(size_t candNr=0;candNr<photonCands.size();candNr++){
+    for(auto & photonCand : photonCands){
       TVector3 positionVector(
-                  photonCands[candNr]->superCluster()->position().x(),
-                  photonCands[candNr]->superCluster()->position().y(),
-                  photonCands[candNr]->superCluster()->position().z());
+                  photonCand->superCluster()->position().x(),
+                  photonCand->superCluster()->position().y(),
+                  photonCand->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }
@@ -126,7 +126,7 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
   
   bool foundSolution(false);
 
-  for (unsigned int i = 0; i < ElePs.size(); i++) {
+  for (auto & EleP : ElePs) {
     
     bool VBFJetPair = false;
     std::vector<int> store_jet;
@@ -135,7 +135,7 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
     for (unsigned int j = 0; j < theJetCollection.size(); j++) {
       TVector3 JetP(theJetCollection[j].px(), theJetCollection[j].py(),
                     theJetCollection[j].pz());
-      double DR = ElePs[i].DeltaR(JetP);
+      double DR = EleP.DeltaR(JetP);
       
       if (JetP.Pt() > minJetPt_ && std::abs(JetP.Eta()) < maxAbsJetEta_ && DR > minDeltaR_) {
 	store_jet.push_back(j);
@@ -144,7 +144,7 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
 	  for ( unsigned int k = j+1; k < theJetCollection.size(); k++ ) {
 	    TVector3 SoftJetP(theJetCollection[k].px(), theJetCollection[k].py(),
 			      theJetCollection[k].pz());
-	    double softDR = ElePs[i].DeltaR(SoftJetP);
+	    double softDR = EleP.DeltaR(SoftJetP);
 	    
 	    if (SoftJetP.Pt() > minSoftJetPt_ && std::abs(SoftJetP.Eta()) < maxAbsJetEta_ && softDR > minDeltaR_)
 	      if ( std::abs(SoftJetP.Eta() - JetP.Eta()) > minDeltaEta_ ) {
@@ -162,13 +162,13 @@ HLTJetCollForElePlusJets<T>::produce(edm::Event& iEvent, const edm::EventSetup& 
     store_jet.erase( unique( store_jet.begin(), store_jet.end() ), store_jet.end() );
     
     // Now save the cleaned jets
-    for ( unsigned int ijet = 0; ijet < store_jet.size(); ijet++ )
+    for (int & ijet : store_jet)
       {
 	//store all selections
-	refVector.push_back(TRef(theJetCollectionHandle, store_jet.at(ijet)));
+	refVector.push_back(TRef(theJetCollectionHandle, ijet));
 	//store first selection which matches the criteria
 	if(!foundSolution)
-	  theFilteredJetCollection->push_back(theJetCollection[store_jet.at(ijet)]);
+	  theFilteredJetCollection->push_back(theJetCollection[ijet]);
       }
     //store all selections
     allSelections->push_back(refVector);

--- a/HLTrigger/JetMET/src/HLTJetCollectionsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsFilter.cc
@@ -37,7 +37,7 @@ HLTJetCollectionsFilter<jetType>::HLTJetCollectionsFilter(const edm::ParameterSe
 }
 
 template <typename jetType>
-HLTJetCollectionsFilter<jetType>::~HLTJetCollectionsFilter(){}
+HLTJetCollectionsFilter<jetType>::~HLTJetCollectionsFilter()= default;
 
 template <typename jetType>
 void

--- a/HLTrigger/JetMET/src/HLTJetCollectionsForElePlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsForElePlusJets.cc
@@ -93,28 +93,28 @@ HLTJetCollectionsForElePlusJets<T>::produce(edm::Event& iEvent, const edm::Event
   std::vector<TVector3> ElePs;
 
   if(!clusCands.empty()){ //try trigger cluster
-    for(size_t candNr=0;candNr<clusCands.size();candNr++){
+    for(auto & clusCand : clusCands){
       TVector3 positionVector(
-                  clusCands[candNr]->superCluster()->position().x(),
-                  clusCands[candNr]->superCluster()->position().y(),
-                  clusCands[candNr]->superCluster()->position().z());
+                  clusCand->superCluster()->position().x(),
+                  clusCand->superCluster()->position().y(),
+                  clusCand->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }else if(!eleCands.empty()){ // try trigger electrons
-    for(size_t candNr=0;candNr<eleCands.size();candNr++){
+    for(auto & eleCand : eleCands){
       TVector3 positionVector(
-                  eleCands[candNr]->superCluster()->position().x(),
-                  eleCands[candNr]->superCluster()->position().y(),
-                  eleCands[candNr]->superCluster()->position().z());
+                  eleCand->superCluster()->position().x(),
+                  eleCand->superCluster()->position().y(),
+                  eleCand->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }
   else if(!photonCands.empty()){ // try trigger photons
-    for(size_t candNr=0;candNr<photonCands.size();candNr++){
+    for(auto & photonCand : photonCands){
       TVector3 positionVector(
-                  photonCands[candNr]->superCluster()->position().x(),
-                  photonCands[candNr]->superCluster()->position().y(),
-                  photonCands[candNr]->superCluster()->position().z());
+                  photonCand->superCluster()->position().x(),
+                  photonCand->superCluster()->position().y(),
+                  photonCand->superCluster()->position().z());
       ElePs.push_back(positionVector);
     }
   }
@@ -130,7 +130,7 @@ HLTJetCollectionsForElePlusJets<T>::produce(edm::Event& iEvent, const edm::Event
   
  //bool foundSolution(false);
 
-    for (unsigned int i = 0; i < ElePs.size(); i++) {
+    for (auto & EleP : ElePs) {
 
        // bool VBFJetPair = false;
         //std::vector<int> store_jet;
@@ -138,7 +138,7 @@ HLTJetCollectionsForElePlusJets<T>::produce(edm::Event& iEvent, const edm::Event
 
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {
             TVector3 JetP(theJetCollection[j].px(), theJetCollection[j].py(), theJetCollection[j].pz());
-            double DR = ElePs[i].DeltaR(JetP);
+            double DR = EleP.DeltaR(JetP);
 
             if (DR > minDeltaR_)
         refVector.push_back(TRef(theJetCollectionHandle, j));

--- a/HLTrigger/JetMET/src/HLTJetCollectionsForLeptonPlusJets.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsForLeptonPlusJets.cc
@@ -94,40 +94,40 @@ HLTJetCollectionsForLeptonPlusJets<jetType>::produce(edm::Event& iEvent, const e
   unique_ptr < JetCollectionVector > allSelections(new JetCollectionVector());
   
  if(!clusCands.empty()){ // try trigger clusters
-    for(size_t candNr=0;candNr<clusCands.size();candNr++){  
+    for(auto & clusCand : clusCands){  
         JetRefVector refVector;
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {
-          if (deltaR(clusCands[candNr]->superCluster()->position(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
+          if (deltaR(clusCand->superCluster()->position(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
         }
     allSelections->push_back(refVector);
     }
  }
 
  if(!eleCands.empty()){ // try electrons
-    for(size_t candNr=0;candNr<eleCands.size();candNr++){  
+    for(auto & eleCand : eleCands){  
         JetRefVector refVector;
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {
-          if (deltaR(eleCands[candNr]->superCluster()->position(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
+          if (deltaR(eleCand->superCluster()->position(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
         }
     allSelections->push_back(refVector);
     }
  }
  
  if(!photonCands.empty()){ // try photons
-    for(size_t candNr=0;candNr<photonCands.size();candNr++){  
+    for(auto & photonCand : photonCands){  
         JetRefVector refVector;
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {
-          if (deltaR(photonCands[candNr]->superCluster()->position(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
+          if (deltaR(photonCand->superCluster()->position(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
         }
     allSelections->push_back(refVector);
     }
  }
 
  if(!muonCands.empty()){ // muons
-    for(size_t candNr=0;candNr<muonCands.size();candNr++){  
+    for(auto & muonCand : muonCands){  
         JetRefVector refVector;
         for (unsigned int j = 0; j < theJetCollection.size(); j++) {
-	  if (deltaR(muonCands[candNr]->p4(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
+	  if (deltaR(muonCand->p4(),theJetCollection[j]) > minDeltaR_) refVector.push_back(JetRef(theJetCollectionHandle, j));
         }
     allSelections->push_back(refVector);
     }

--- a/HLTrigger/JetMET/src/HLTJetCollectionsVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsVBFFilter.cc
@@ -39,7 +39,7 @@ HLTJetCollectionsVBFFilter<T>::HLTJetCollectionsVBFFilter(const edm::ParameterSe
 }
 
 template <typename T>
-HLTJetCollectionsVBFFilter<T>::~HLTJetCollectionsVBFFilter(){}
+HLTJetCollectionsVBFFilter<T>::~HLTJetCollectionsVBFFilter()= default;
 
 template <typename T>
 void

--- a/HLTrigger/JetMET/src/HLTJetEtaTopologyFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetEtaTopologyFilter.cc
@@ -43,7 +43,7 @@ HLTJetEtaTopologyFilter<T>::HLTJetEtaTopologyFilter(const edm::ParameterSet& iCo
 }
 
 template<typename T>
-HLTJetEtaTopologyFilter<T>::~HLTJetEtaTopologyFilter(){}
+HLTJetEtaTopologyFilter<T>::~HLTJetEtaTopologyFilter()= default;
 
 template<typename T>
 void

--- a/HLTrigger/JetMET/src/HLTJetL1MatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1MatchProducer.cc
@@ -34,10 +34,7 @@ void HLTJetL1MatchProducer<T>::beginJob()
 }
 
 template<typename T>
-HLTJetL1MatchProducer<T>::~HLTJetL1MatchProducer()
-{
-
-}
+HLTJetL1MatchProducer<T>::~HLTJetL1MatchProducer() = default;
 
 template<typename T>
 void HLTJetL1MatchProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
@@ -31,10 +31,7 @@ void HLTJetL1TMatchProducer<T>::beginJob()
 }
 
 template<typename T>
-HLTJetL1TMatchProducer<T>::~HLTJetL1TMatchProducer()
-{
-
-}
+HLTJetL1TMatchProducer<T>::~HLTJetL1TMatchProducer() = default;
 
 template<typename T>
 void HLTJetL1TMatchProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -51,8 +51,7 @@ HLTJetSortedVBFFilter<T>::HLTJetSortedVBFFilter(const edm::ParameterSet& iConfig
 
 
 	template<typename T>
-HLTJetSortedVBFFilter<T>::~HLTJetSortedVBFFilter()
-{ }
+HLTJetSortedVBFFilter<T>::~HLTJetSortedVBFFilter() = default;
 
 template<typename T>
 void
@@ -77,7 +76,7 @@ HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descr
 template<typename T> float HLTJetSortedVBFFilter<T>::findCSV(const typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection  & jetTags){
 	float minDr = 0.1;
 	float tmpCSV = -20 ;
-	for (reco::JetTagCollection::const_iterator jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
+	for (auto jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
 		float tmpDr = reco::deltaR(*jet,*(jetb->first));
 
 		if (tmpDr < minDr) {

--- a/HLTrigger/JetMET/src/HLTJetVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetVBFFilter.cc
@@ -42,7 +42,7 @@ HLTJetVBFFilter<T>::HLTJetVBFFilter(const edm::ParameterSet& iConfig) : HLTFilte
 }
 
 template<typename T>
-HLTJetVBFFilter<T>::~HLTJetVBFFilter(){}
+HLTJetVBFFilter<T>::~HLTJetVBFFilter()= default;
 
 template<typename T>
 void

--- a/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
+++ b/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
@@ -26,7 +26,7 @@ HLTMETCleanerUsingJetID::HLTMETCleanerUsingJetID(const edm::ParameterSet& iConfi
 }
 
 // Destructor
-HLTMETCleanerUsingJetID::~HLTMETCleanerUsingJetID() {}
+HLTMETCleanerUsingJetID::~HLTMETCleanerUsingJetID() = default;
 
 // Fill descriptions
 void HLTMETCleanerUsingJetID::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -57,11 +57,11 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
     double mey_jets = 0.;
     double sumet_jets = 0.;
     if (jets->size() > 0 ) {
-        for(reco::CaloJetCollection::const_iterator j = jets->begin(); j != jets->end(); ++j) {
-            double pt =  j->pt() ;
-            double eta = j->eta();
-            double px =  j->px() ;
-            double py =  j->py() ;
+        for(auto const & j : *jets) {
+            double pt =  j.pt() ;
+            double eta = j.eta();
+            double px =  j.px() ;
+            double py =  j.py() ;
 
             if (pt > minPt_ && std::abs(eta) < maxEta_) {
                 mex_jets -= px;
@@ -75,11 +75,11 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
     double mey_goodJets = 0.;
     double sumet_goodJets = 0.;
     if (goodJets->size() > 0) {
-        for(reco::CaloJetCollection::const_iterator j = goodJets->begin(); j != goodJets->end(); ++j) {
-            double pt =  j->pt() ;
-            double eta = j->eta();
-            double px =  j->px() ;
-            double py =  j->py() ;
+        for(auto const & j : *goodJets) {
+            double pt =  j.pt() ;
+            double eta = j.eta();
+            double px =  j.px() ;
+            double py =  j.py() ;
 
             if (pt > minPt_ && std::abs(eta) < maxEta_) {
                 mex_goodJets -= px;

--- a/HLTrigger/JetMET/src/HLTMhtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMhtFilter.cc
@@ -33,7 +33,7 @@ HLTMhtFilter::HLTMhtFilter(const edm::ParameterSet & iConfig) : HLTFilter(iConfi
 }
 
 // Destructor
-HLTMhtFilter::~HLTMhtFilter() {}
+HLTMhtFilter::~HLTMhtFilter() = default;
 
 // Fill descriptions
 void HLTMhtFilter::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {

--- a/HLTrigger/JetMET/src/HLTMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTMhtProducer.cc
@@ -32,7 +32,7 @@ HLTMhtProducer::HLTMhtProducer(const edm::ParameterSet & iConfig) :
 }
 
 // Destructor
-HLTMhtProducer::~HLTMhtProducer() {}
+HLTMhtProducer::~HLTMhtProducer() = default;
 
 // Fill descriptions
 void HLTMhtProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
@@ -82,10 +82,10 @@ void HLTMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
     }
 
     if (excludePFMuons_) {
-        for (reco::PFCandidateCollection::const_iterator j = pfCandidates->begin(); j != pfCandidates->end(); ++j) {
-            if (std::abs(j->pdgId()) == 13) {
-                mhx += j->px();
-                mhy += j->py();
+        for (auto const & j : *pfCandidates) {
+            if (std::abs(j.pdgId()) == 13) {
+                mhx += j.px();
+                mhy += j.py();
             }
         }
     }

--- a/HLTrigger/JetMET/src/HLTMinDPhiMETFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMinDPhiMETFilter.cc
@@ -34,7 +34,7 @@ HLTMinDPhiMETFilter::HLTMinDPhiMETFilter(const edm::ParameterSet& iConfig) : HLT
 }
 
 // Destructor
-HLTMinDPhiMETFilter::~HLTMinDPhiMETFilter() {}
+HLTMinDPhiMETFilter::~HLTMinDPhiMETFilter() = default;
 
 // Fill descriptions
 void HLTMinDPhiMETFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JetMET/src/HLTMonoJetFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMonoJetFilter.cc
@@ -39,7 +39,7 @@ HLTMonoJetFilter<T>::HLTMonoJetFilter(const edm::ParameterSet& iConfig) : HLTFil
 }
 
 template<typename T>
-HLTMonoJetFilter<T>::~HLTMonoJetFilter(){}
+HLTMonoJetFilter<T>::~HLTMonoJetFilter()= default;
 
 template<typename T>
 void 

--- a/HLTrigger/JetMET/src/HLTNVFilter.cc
+++ b/HLTrigger/JetMET/src/HLTNVFilter.cc
@@ -34,7 +34,7 @@ HLTNVFilter::HLTNVFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
    m_theMETToken = consumes<trigger::TriggerFilterObjectWithRefs>(inputMETTag_);
 }
 
-HLTNVFilter::~HLTNVFilter(){}
+HLTNVFilter::~HLTNVFilter()= default;
 
 
 void HLTNVFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -86,7 +86,7 @@ HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
     etmiss=vrefMET.at(0)->et();
 
     CaloJetRef ref1,ref2;
-    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
+    for (auto recocalojet = recocalojets->begin();
 	 recocalojet<=(recocalojets->begin()+1); recocalojet++) {
 
       if(countjets==0) {

--- a/HLTrigger/JetMET/src/HLTPFEnergyFractionsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTPFEnergyFractionsFilter.cc
@@ -42,7 +42,7 @@ HLTPFEnergyFractionsFilter::HLTPFEnergyFractionsFilter(const edm::ParameterSet& 
   m_thePFJetToken = consumes<reco::PFJetCollection>(inputPFJetTag_);
 }
 
-HLTPFEnergyFractionsFilter::~HLTPFEnergyFractionsFilter(){}
+HLTPFEnergyFractionsFilter::~HLTPFEnergyFractionsFilter()= default;
 
 void 
 HLTPFEnergyFractionsFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -85,7 +85,7 @@ HLTPFEnergyFractionsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup&
     accept = true;
     unsigned int countJet(0);
     //PF information
-    PFJetCollection::const_iterator i (recopfjets->begin());
+    auto i (recopfjets->begin());
     for(; i != recopfjets->end(); ++i ){
       if(countJet>=nJet_) break;
       //
@@ -108,7 +108,7 @@ HLTPFEnergyFractionsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup&
     //Store NJet_ jets
     if(accept==true){ 
       countJet = 0; 
-      PFJetCollection::const_iterator i (recopfjets->begin());
+      auto i (recopfjets->begin());
       for(; i != recopfjets->end(); ++i ){
 	if(countJet>=nJet_) break;
 	filterproduct.addObject(triggerType_,PFJetRef(recopfjets,distance(recopfjets->begin(),i)));

--- a/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
@@ -33,7 +33,7 @@ HLTPFJetIDProducer::HLTPFJetIDProducer(const edm::ParameterSet& iConfig) :
 }
 
 // Destructor
-HLTPFJetIDProducer::~HLTPFJetIDProducer() {}
+HLTPFJetIDProducer::~HLTPFJetIDProducer() = default;
 
 // Fill descriptions
 void HLTPFJetIDProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
@@ -60,10 +60,10 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
     edm::Handle<reco::PFJetCollection> pfjets;
     iEvent.getByToken(m_thePFJetToken, pfjets);
 
-    for (reco::PFJetCollection::const_iterator j = pfjets->begin(); j != pfjets->end(); ++j) {
+    for (auto const & j : *pfjets) {
         bool pass = false;
-        double pt = j->pt();
-        double eta = j->eta();
+        double pt = j.pt();
+        double eta = j.eta();
 	double abseta = std::abs(eta);
 
         if (!(pt > 0.))  continue;  // skip jets with zero or negative pt
@@ -75,14 +75,14 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
             pass = true;
 
         } else {
-            double chf  = j->chargedHadronEnergyFraction();
+            double chf  = j.chargedHadronEnergyFraction();
             //double nhf  = j->neutralHadronEnergyFraction() + j->HFHadronEnergyFraction();
-            double nhf  = j->neutralHadronEnergyFraction();
-            double cef  = j->chargedEmEnergyFraction();
-            double nef  = j->neutralEmEnergyFraction();
-	    double cftot= chf + cef + j->chargedMuEnergyFraction();
-            int    nch  = j->chargedMultiplicity();
-            int    ntot = j->numberOfDaughters();
+            double nhf  = j.neutralHadronEnergyFraction();
+            double cef  = j.chargedEmEnergyFraction();
+            double nef  = j.neutralEmEnergyFraction();
+	    double cftot= chf + cef + j.chargedMuEnergyFraction();
+            int    nch  = j.chargedMultiplicity();
+            int    ntot = j.numberOfDaughters();
 
             pass = true;
             pass = pass && (ntot > NTOT_);
@@ -94,7 +94,7 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	    pass = pass && (cftot < maxCF_ || abseta >= 2.4);
         }
 
-        if (pass)  result->push_back(*j);
+        if (pass)  result->push_back(j);
     }
 
     // Put the products into the Event

--- a/HLTrigger/JetMET/src/HLTPhi2METFilter.cc
+++ b/HLTrigger/JetMET/src/HLTPhi2METFilter.cc
@@ -34,7 +34,7 @@ HLTPhi2METFilter::HLTPhi2METFilter(const edm::ParameterSet& iConfig) : HLTFilter
    m_theMETToken = consumes<trigger::TriggerFilterObjectWithRefs>(inputMETTag_);
 }
 
-HLTPhi2METFilter::~HLTPhi2METFilter(){}
+HLTPhi2METFilter::~HLTPhi2METFilter()= default;
 
 void HLTPhi2METFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -84,7 +84,7 @@ HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     double phimiss = vrefMET.at(0)->phi();
     int countjets =0;
 
-    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
+    for (auto recocalojet = recocalojets->begin();
 	 recocalojet<=(recocalojets->begin()+1); recocalojet++) {
 
       if(countjets==0) {

--- a/HLTrigger/JetMET/src/HLTRapGapFilter.cc
+++ b/HLTrigger/JetMET/src/HLTRapGapFilter.cc
@@ -31,7 +31,7 @@ HLTRapGapFilter::HLTRapGapFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
    m_theJetToken = consumes<reco::CaloJetCollection>(inputTag_);
 }
 
-HLTRapGapFilter::~HLTRapGapFilter(){}
+HLTRapGapFilter::~HLTRapGapFilter()= default;
 
 void HLTRapGapFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -69,11 +69,10 @@ HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     double sumets=0.;
     int countjets =0;
 
-    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
-	 recocalojet!=(recocalojets->end()); recocalojet++) {
+    for (auto const & recocalojet : *recocalojets) {
 
-      etjet = recocalojet->energy();
-      etajet = recocalojet->eta();
+      etjet = recocalojet.energy();
+      etajet = recocalojet.eta();
 
       if(std::abs(etajet) > absEtaMin_ && std::abs(etajet) < absEtaMax_)
 	{
@@ -87,7 +86,7 @@ HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     //std::cout << "Sum jet energy = " << sumets << std::endl;
     if(sumets<=caloThresh_){
       //std::cout << "Passed filter!" << std::endl;
-      for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
+      for (auto recocalojet = recocalojets->begin();
 	   recocalojet!=(recocalojets->end()); recocalojet++) {
 	CaloJetRef ref(CaloJetRef(recocalojets,distance(recocalojets->begin(),recocalojet)));
 	filterproduct.addObject(TriggerJet,ref);

--- a/HLTrigger/JetMET/src/HLTTrackMETProducer.cc
+++ b/HLTrigger/JetMET/src/HLTTrackMETProducer.cc
@@ -39,7 +39,7 @@ HLTTrackMETProducer::HLTTrackMETProducer(const edm::ParameterSet & iConfig) :
 }
 
 // Destructor
-HLTTrackMETProducer::~HLTTrackMETProducer() {}
+HLTTrackMETProducer::~HLTTrackMETProducer() = default;
 
 // Fill descriptions
 void HLTTrackMETProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
@@ -108,11 +108,11 @@ void HLTTrackMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         }
 
     } else if (useTracks_ && tracks->size() > 0) {
-        for (reco::TrackCollection::const_iterator j = tracks->begin(); j != tracks->end(); ++j) {
-            double pt = j->pt();
-            double px = j->px();
-            double py = j->py();
-            double eta = j->eta();
+        for (auto const & j : *tracks) {
+            double pt = j.pt();
+            double px = j.px();
+            double py = j.py();
+            double eta = j.eta();
 
             if (pt > minPtJet_ && std::abs(eta) < maxEtaJet_) {
                 mhx -= px;
@@ -123,11 +123,11 @@ void HLTTrackMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         }
 
     } else if (usePFRecTracks_ && pfRecTracks->size() > 0) {
-        for (reco::PFRecTrackCollection::const_iterator j = pfRecTracks->begin(); j != pfRecTracks->end(); ++j) {
-            double pt = j->trackRef()->pt();
-            double px = j->trackRef()->px();
-            double py = j->trackRef()->py();
-            double eta = j->trackRef()->eta();
+        for (auto const & j : *pfRecTracks) {
+            double pt = j.trackRef()->pt();
+            double px = j.trackRef()->px();
+            double py = j.trackRef()->py();
+            double eta = j.trackRef()->eta();
 
             if (pt > minPtJet_ && std::abs(eta) < maxEtaJet_) {
                 mhx -= px;
@@ -138,12 +138,12 @@ void HLTTrackMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         }
 
     } else if ((usePFCandidatesCharged_ || usePFCandidates_) && pfCandidates->size() > 0) {
-        for (reco::PFCandidateCollection::const_iterator j = pfCandidates->begin(); j != pfCandidates->end(); ++j) {
-            if (usePFCandidatesCharged_ && j->charge() == 0)  continue;
-            double pt = j->pt();
-            double px = j->px();
-            double py = j->py();
-            double eta = j->eta();
+        for (auto const & j : *pfCandidates) {
+            if (usePFCandidatesCharged_ && j.charge() == 0)  continue;
+            double pt = j.pt();
+            double px = j.px();
+            double py = j.py();
+            double eta = j.eta();
 
             if (pt > minPtJet_ && std::abs(eta) < maxEtaJet_) {
                 mhx -= px;
@@ -155,10 +155,10 @@ void HLTTrackMETProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     }
 
     if (excludePFMuons_) {
-        for (reco::PFCandidateCollection::const_iterator j = pfCandidates->begin(); j != pfCandidates->end(); ++j) {
-            if (std::abs(j->pdgId()) == 13) {
-                mhx += j->px();
-                mhy += j->py();
+        for (auto const & j : *pfCandidates) {
+            if (std::abs(j.pdgId()) == 13) {
+                mhx += j.px();
+                mhy += j.py();
             }
         }
     }

--- a/HLTrigger/JetMET/src/PFJetsMatchedToFilteredCaloJetsProducer.cc
+++ b/HLTrigger/JetMET/src/PFJetsMatchedToFilteredCaloJetsProducer.cc
@@ -26,7 +26,7 @@ PFJetsMatchedToFilteredCaloJetsProducer::PFJetsMatchedToFilteredCaloJetsProducer
   produces<PFJetCollection>();
 }
 
-PFJetsMatchedToFilteredCaloJetsProducer::~PFJetsMatchedToFilteredCaloJetsProducer(){ }
+PFJetsMatchedToFilteredCaloJetsProducer::~PFJetsMatchedToFilteredCaloJetsProducer()= default;
 
 void PFJetsMatchedToFilteredCaloJetsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -64,13 +64,13 @@ void PFJetsMatchedToFilteredCaloJetsProducer::produce(edm::Event& iEvent, const 
 	math::XYZPoint a(0.,0.,0.);
 	PFJet::Specific f;
 		
-	for( unsigned int iCalo=0; iCalo <jetRefVec.size();iCalo++)
+	for(auto & iCalo : jetRefVec)
 	  {  
 	    // std::cout << "\tiTriggerJet: " << iCalo << " pT= " << jetRefVec[iCalo]->pt() << std::endl;
 	    for(unsigned int iPF=0;iPF<PFJets->size();iPF++)
 	      {
 		const Candidate &  myJet = (*PFJets)[iPF];
-		double deltaR = ROOT::Math::VectorUtil::DeltaR(myJet.p4().Vect(), (jetRefVec[iCalo]->p4()).Vect());
+		double deltaR = ROOT::Math::VectorUtil::DeltaR(myJet.p4().Vect(), (iCalo->p4()).Vect());
 		if(deltaR < DeltaR_ ) {
 		  PFJet myPFJet(myJet.p4(),a,f);
 		  pfjets->push_back(myPFJet);

--- a/HLTrigger/Muon/src/HLTDiMuonGlbTrkFilter.cc
+++ b/HLTrigger/Muon/src/HLTDiMuonGlbTrkFilter.cc
@@ -141,8 +141,8 @@ HLTDiMuonGlbTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
       }
   }
 
-  for ( std::set<unsigned int>::const_iterator itr = mus.begin(); itr != mus.end(); ++itr )
-    filterproduct.addObject(trigger::TriggerMuon, reco::RecoChargedCandidateRef(cands,*itr));
+  for (unsigned int mu : mus)
+    filterproduct.addObject(trigger::TriggerMuon, reco::RecoChargedCandidateRef(cands,mu));
 
   return npassed>0;
 }

--- a/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
+++ b/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
@@ -47,8 +47,7 @@ HLTL1MuonNoL2Selector::HLTL1MuonNoL2Selector(const edm::ParameterSet& iConfig) :
 }
 
 // destructor
-HLTL1MuonNoL2Selector::~HLTL1MuonNoL2Selector(){
-}
+HLTL1MuonNoL2Selector::~HLTL1MuonNoL2Selector()= default;
 
 void
 HLTL1MuonNoL2Selector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -103,12 +102,12 @@ void HLTL1MuonNoL2Selector::produce(edm::StreamID, edm::Event& iEvent, const edm
       
       // Loop over L2's to find whether the L1 fired this L2. 
       bool isTriggeredByL1=false;
-      for (RecoChargedCandidateCollection::const_iterator cand = L2cands->begin(); cand != L2cands->end(); cand++) {
-	TrackRef l2muon = cand->get<TrackRef>();    
+      for (auto const & cand : *L2cands) {
+	TrackRef l2muon = cand.get<TrackRef>();    
 	const edm::RefVector<L2MuonTrajectorySeedCollection>& seeds = (*seedMapHandle)[l2muon->seedRef().castTo<edm::Ref<L2MuonTrajectorySeedCollection> >()];
-	for(size_t i=0; i<seeds.size(); i++){
+	for(auto const & seed : seeds){
 	  // Check if the L2 was seeded by a triggered L1, in such case skip the loop. 
-	  if(find(firedL1Muons_.begin(), firedL1Muons_.end(), seeds[i]->l1tParticle()) != firedL1Muons_.end()){
+	  if(find(firedL1Muons_.begin(), firedL1Muons_.end(), seed->l1tParticle()) != firedL1Muons_.end()){
 	    isTriggeredByL1 = true;
 	    break;
 	  }

--- a/HLTrigger/Muon/src/HLTL1MuonSelector.cc
+++ b/HLTrigger/Muon/src/HLTL1MuonSelector.cc
@@ -41,8 +41,7 @@ HLTL1MuonSelector::HLTL1MuonSelector(const edm::ParameterSet& iConfig) :
 }
 
 // destructor
-HLTL1MuonSelector::~HLTL1MuonSelector(){
-}
+HLTL1MuonSelector::~HLTL1MuonSelector()= default;
 
 void
 HLTL1MuonSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Muon/src/HLTL1TMuonSelector.cc
+++ b/HLTrigger/Muon/src/HLTL1TMuonSelector.cc
@@ -42,8 +42,7 @@ HLTL1TMuonSelector::HLTL1TMuonSelector(const edm::ParameterSet& iConfig) :
 }
 
 // destructor
-HLTL1TMuonSelector::~HLTL1TMuonSelector(){
-}
+HLTL1TMuonSelector::~HLTL1TMuonSelector()= default;
 
 void
 HLTL1TMuonSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Muon/src/HLTMuonDimuonL2Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL2Filter.cc
@@ -87,9 +87,7 @@ HLTMuonDimuonL2Filter::HLTMuonDimuonL2Filter(const edm::ParameterSet& iConfig): 
       << " " << nsigma_Pt_;
 }
 
-HLTMuonDimuonL2Filter::~HLTMuonDimuonL2Filter()
-{
-}
+HLTMuonDimuonL2Filter::~HLTMuonDimuonL2Filter() = default;
 
 
 //
@@ -296,8 +294,8 @@ HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
             bool i2done = false;
             vector<RecoChargedCandidateRef> vref;
 	    filterproduct.getObjects(TriggerMuon,vref);
-            for (unsigned int i=0; i<vref.size(); i++) {
-	      RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+            for (auto & i : vref) {
+	      RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
 	      TrackRef tktmp = candref->get<TrackRef>();
 	      if (tktmp==tk1) {
                         i1done = true;

--- a/HLTrigger/Muon/src/HLTMuonDimuonL2FromL1TFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL2FromL1TFilter.cc
@@ -86,9 +86,7 @@ HLTMuonDimuonL2FromL1TFilter::HLTMuonDimuonL2FromL1TFilter(const edm::ParameterS
       << " " << nsigma_Pt_;
 }
 
-HLTMuonDimuonL2FromL1TFilter::~HLTMuonDimuonL2FromL1TFilter()
-{
-}
+HLTMuonDimuonL2FromL1TFilter::~HLTMuonDimuonL2FromL1TFilter() = default;
 
 
 //
@@ -295,8 +293,8 @@ HLTMuonDimuonL2FromL1TFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
             bool i2done = false;
             vector<RecoChargedCandidateRef> vref;
 	    filterproduct.getObjects(TriggerMuon,vref);
-            for (unsigned int i=0; i<vref.size(); i++) {
-	      RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+            for (auto & i : vref) {
+	      RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
 	      TrackRef tktmp = candref->get<TrackRef>();
 	      if (tktmp==tk1) {
                         i1done = true;

--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -92,9 +92,7 @@ HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig) :
       << " " << max_YPair_;
 }
 
-HLTMuonDimuonL3Filter::~HLTMuonDimuonL3Filter()
-{
-}
+HLTMuonDimuonL3Filter::~HLTMuonDimuonL3Filter() = default;
 
 void
 HLTMuonDimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -197,8 +195,8 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
    double e1,e2;
    Particle::LorentzVector p,p1,p2;
 
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it1 = L2toL3s.begin();
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_end = L2toL3s.end();
+   auto L2toL3s_it1 = L2toL3s.begin();
+   auto L2toL3s_end = L2toL3s.end();
    bool atLeastOnePair=false;
    for (; L2toL3s_it1!=L2toL3s_end; ++L2toL3s_it1){
 
@@ -235,7 +233,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
        // Don't convert to 90% efficiency threshold
        LogDebug("HLTMuonDimuonL3Filter") << " ... 1st muon in loop, pt1= "
 					 << pt1 << ", ptLx1= " << ptLx1;
-       std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it2 = L2toL3s_it1;
+       auto L2toL3s_it2 = L2toL3s_it1;
        L2toL3s_it2++;
        for (; L2toL3s_it2!=L2toL3s_end; ++L2toL3s_it2){
 	 if (!triggeredByLevel2(L2toL3s_it2->first,vl2cands)) continue;
@@ -355,8 +353,8 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	      bool i2done = false;
 	      vector<RecoChargedCandidateRef> vref;
 	      filterproduct.getObjects(TriggerMuon,vref);
-	      for (unsigned int i=0; i<vref.size(); i++) {
-		RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+	      for (auto & i : vref) {
+		RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
 		TrackRef tktmp = candref->get<TrackRef>();
 		if (tktmp==tk1) {
 		  i1done = true;
@@ -404,8 +402,8 @@ bool
 HLTMuonDimuonL3Filter::triggeredByLevel2(TrackRef const & staTrack,vector<RecoChargedCandidateRef> const & vcands)
 {
   bool ok=false;
-  for (unsigned int i=0; i<vcands.size(); i++) {
-    if ( vcands[i]->get<TrackRef>() == staTrack ) {
+  for (auto const & vcand : vcands) {
+    if ( vcand->get<TrackRef>() == staTrack ) {
       ok=true;
       LogDebug("HLTMuonL3PreFilter") << "The L2 track triggered";
       break;

--- a/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
@@ -37,7 +37,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
    previousCandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
    depTag_  (iConfig.getParameter< std::vector< edm::InputTag > >("DepTag" ) ),
    depToken_(0),
-   theDepositIsolator(0),
+   theDepositIsolator(nullptr),
    min_N_   (iConfig.getParameter<int> ("MinN"))
 {
   std::stringstream tags;
@@ -53,7 +53,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
 
    edm::ParameterSet isolatorPSet = iConfig.getParameter<edm::ParameterSet>("IsolatorPSet");
    if (isolatorPSet.empty()) {
-     theDepositIsolator=0;
+     theDepositIsolator=nullptr;
        }else{
      std::string type = isolatorPSet.getParameter<std::string>("ComponentName");
      theDepositIsolator = MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector());
@@ -62,9 +62,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
    if (theDepositIsolator) produces<edm::ValueMap<bool> >();
 }
 
-HLTMuonIsoFilter::~HLTMuonIsoFilter()
-{
-}
+HLTMuonIsoFilter::~HLTMuonIsoFilter() = default;
 
 //
 // member functions

--- a/HLTrigger/Muon/src/HLTMuonL1Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1Filter.cc
@@ -46,11 +46,11 @@ HLTMuonL1Filter::HLTMuonL1Filter(const edm::ParameterSet& iConfig) : HLTFilter(i
   //set the quality bit mask
   qualityBitMask_ = 0;
   vector<int> selectQualities = iConfig.getParameter<vector<int> >("SelectQualities");
-  for(size_t i=0; i<selectQualities.size(); i++){
-    if(selectQualities[i] > 7){
+  for(int selectQualitie : selectQualities){
+    if(selectQualitie > 7){
       throw edm::Exception(edm::errors::Configuration) << "QualityBits must be smaller than 8!";
     }
-    qualityBitMask_ |= 1<<selectQualities[i];
+    qualityBitMask_ |= 1<<selectQualitie;
   }
 
   // dump parameters for debugging
@@ -74,9 +74,7 @@ HLTMuonL1Filter::HLTMuonL1Filter(const edm::ParameterSet& iConfig) : HLTFilter(i
   }
 }
 
-HLTMuonL1Filter::~HLTMuonL1Filter()
-{
-}
+HLTMuonL1Filter::~HLTMuonL1Filter() = default;
 
 void
 HLTMuonL1Filter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -209,7 +207,7 @@ bool HLTMuonL1Filter::isSingleSegmentCSC(l1extra::L1MuonParticleRef const & muon
   int csctfMode = -999;
 
   // loop over the CSCTF tracks
-  for(L1CSCTrackCollection::const_iterator trk = csctfTracks.begin(); trk < csctfTracks.end(); trk++){
+  for(auto trk = csctfTracks.begin(); trk < csctfTracks.end(); trk++){
 
     int trEndcap = (trk->first.endcap()==2 ? trk->first.endcap()-3 : trk->first.endcap());
     int trSector = 6*(trk->first.endcap()-1)+trk->first.sector();

--- a/HLTrigger/Muon/src/HLTMuonL1RegionalFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1RegionalFilter.cc
@@ -48,11 +48,11 @@ HLTMuonL1RegionalFilter::HLTMuonL1RegionalFilter(const edm::ParameterSet& iConfi
     //set the quality bit masks
     qualityBitMasks_.push_back( 0 );
     vector<unsigned int> qualities = cuts[i].getParameter<vector<unsigned int> >("QualityBits");
-    for(size_t j=0; j<qualities.size(); j++){
-      if(7U < qualities[j]){ // qualities[j] >= 0, since qualities[j] is unsigned
+    for(unsigned int qualitie : qualities){
+      if(7U < qualitie){ // qualities[j] >= 0, since qualities[j] is unsigned
         throw edm::Exception(errors::Configuration) << "QualityBits must be between 0 and 7 !";
       }
-      qualityBitMasks_[i] |= 1 << qualities[j];
+      qualityBitMasks_[i] |= 1 << qualitie;
     }
   }
 
@@ -83,8 +83,7 @@ HLTMuonL1RegionalFilter::HLTMuonL1RegionalFilter(const edm::ParameterSet& iConfi
   }
 }
 
-HLTMuonL1RegionalFilter::~HLTMuonL1RegionalFilter(){
-}
+HLTMuonL1RegionalFilter::~HLTMuonL1RegionalFilter()= default;
 
 void
 HLTMuonL1RegionalFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Muon/src/HLTMuonL1TFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1TFilter.cc
@@ -39,11 +39,11 @@ HLTMuonL1TFilter::HLTMuonL1TFilter(const edm::ParameterSet& iConfig) : HLTFilter
   //set the quality bit mask
   qualityBitMask_ = 0;
   vector<int> selectQualities = iConfig.getParameter<vector<int> >("SelectQualities");
-  for(size_t i=0; i<selectQualities.size(); i++){
+  for(int selectQualitie : selectQualities){
 //     if(selectQualities[i] > 7){  // FIXME: this will be updated once we have info from L1
 //       throw edm::Exception(edm::errors::Configuration) << "QualityBits must be smaller than 8!";
 //     }
-    qualityBitMask_ |= 1<<selectQualities[i];
+    qualityBitMask_ |= 1<<selectQualitie;
   }
 
   // dump parameters for debugging
@@ -68,9 +68,7 @@ HLTMuonL1TFilter::HLTMuonL1TFilter(const edm::ParameterSet& iConfig) : HLTFilter
 }
 
 
-HLTMuonL1TFilter::~HLTMuonL1TFilter()
-{
-}
+HLTMuonL1TFilter::~HLTMuonL1TFilter() = default;
 
 
  

--- a/HLTrigger/Muon/src/HLTMuonL1TRegionalFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1TRegionalFilter.cc
@@ -46,11 +46,11 @@ HLTMuonL1TRegionalFilter::HLTMuonL1TRegionalFilter(const edm::ParameterSet& iCon
     //set the quality bit masks
     qualityBitMasks_.push_back( 0 );
     vector<unsigned int> qualities = cuts[i].getParameter<vector<unsigned int> >("QualityBits");
-    for(size_t j=0; j<qualities.size(); j++){
+    for(unsigned int qualitie : qualities){
 //       if(7U < qualities[j]){ // qualities[j] >= 0, since qualities[j] is unsigned   //FIXME: this will be updated once we have info from L1
 //         throw edm::Exception(errors::Configuration) << "QualityBits must be between 0 and 7 !";
 //       }
-      qualityBitMasks_[i] |= 1 << qualities[j];
+      qualityBitMasks_[i] |= 1 << qualitie;
     }
   }
 
@@ -81,8 +81,7 @@ HLTMuonL1TRegionalFilter::HLTMuonL1TRegionalFilter(const edm::ParameterSet& iCon
   }
 }
 
-HLTMuonL1TRegionalFilter::~HLTMuonL1TRegionalFilter(){
-}
+HLTMuonL1TRegionalFilter::~HLTMuonL1TRegionalFilter()= default;
 
 void
 HLTMuonL1TRegionalFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/Muon/src/HLTMuonL1TtoL3TkPreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1TtoL3TkPreFilter.cc
@@ -64,9 +64,7 @@ HLTMuonL1TtoL3TkPreFilter::HLTMuonL1TtoL3TkPreFilter(const ParameterSet& iConfig
    produces<TriggerFilterObjectWithRefs>();
 }
 
-HLTMuonL1TtoL3TkPreFilter::~HLTMuonL1TtoL3TkPreFilter()
-{
-}
+HLTMuonL1TtoL3TkPreFilter::~HLTMuonL1TtoL3TkPreFilter() = default;
 
 //
 // member functions
@@ -125,8 +123,8 @@ HLTMuonL1TtoL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tr
    vector<l1t::MuonRef> vl1cands;
    previousLevelCands->getObjects(TriggerL1Mu,vl1cands);
 
-   std::map<l1t::MuonRef, std::vector<RecoChargedCandidateRef> > ::iterator L1toL3s_it = L1toL3s.begin();
-   std::map<l1t::MuonRef, std::vector<RecoChargedCandidateRef> > ::iterator L1toL3s_end = L1toL3s.end();
+   auto L1toL3s_it = L1toL3s.begin();
+   auto L1toL3s_end = L1toL3s.end();
    for (; L1toL3s_it!=L1toL3s_end; ++L1toL3s_it){
 
      if (!triggeredAtL1(L1toL3s_it->first,vl1cands)) continue;
@@ -172,8 +170,8 @@ HLTMuonL1TtoL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tr
 
    vector<RecoChargedCandidateRef> vref;
    filterproduct.getObjects(TriggerMuon,vref);
-   for (unsigned int i=0; i<vref.size(); i++ ) {
-     TrackRef tk = vref[i]->track();
+   for (auto & i : vref) {
+     TrackRef tk = i->track();
      LogDebug("HLTMuonL1TtoL3TkPreFilter")
        << " Track passing filter: pt= " << tk->pt() << ", eta: "
        << tk->eta();
@@ -193,9 +191,9 @@ HLTMuonL1TtoL3TkPreFilter::triggeredAtL1(const l1t::MuonRef & l1mu,std::vector<l
   bool ok=false;
 
   // compare to previously triggered L1
-  for (unsigned int i=0; i<vcands.size(); i++) {
+  for (auto & vcand : vcands) {
     //    l1extra::L1MuonParticleRef candref =  L1MuonParticleRef(vcands[i]);
-    if (vcands[i] == l1mu){
+    if (vcand == l1mu){
       ok=true;
       LogDebug("HLTMuonL1TtoL3TkPreFilter") << "The L1 mu triggered";
       break;}

--- a/HLTrigger/Muon/src/HLTMuonL1toL3TkPreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1toL3TkPreFilter.cc
@@ -64,9 +64,7 @@ HLTMuonL1toL3TkPreFilter::HLTMuonL1toL3TkPreFilter(const ParameterSet& iConfig) 
    produces<TriggerFilterObjectWithRefs>();
 }
 
-HLTMuonL1toL3TkPreFilter::~HLTMuonL1toL3TkPreFilter()
-{
-}
+HLTMuonL1toL3TkPreFilter::~HLTMuonL1toL3TkPreFilter() = default;
 
 //
 // member functions
@@ -125,8 +123,8 @@ HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tri
    vector<l1extra::L1MuonParticleRef> vl1cands;
    previousLevelCands->getObjects(TriggerL1Mu,vl1cands);
 
-   std::map<l1extra::L1MuonParticleRef, std::vector<RecoChargedCandidateRef> > ::iterator L1toL3s_it = L1toL3s.begin();
-   std::map<l1extra::L1MuonParticleRef, std::vector<RecoChargedCandidateRef> > ::iterator L1toL3s_end = L1toL3s.end();
+   auto L1toL3s_it = L1toL3s.begin();
+   auto L1toL3s_end = L1toL3s.end();
    for (; L1toL3s_it!=L1toL3s_end; ++L1toL3s_it){
 
      if (!triggeredAtL1(L1toL3s_it->first,vl1cands)) continue;
@@ -172,8 +170,8 @@ HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tri
 
    vector<RecoChargedCandidateRef> vref;
    filterproduct.getObjects(TriggerMuon,vref);
-   for (unsigned int i=0; i<vref.size(); i++ ) {
-     TrackRef tk = vref[i]->track();
+   for (auto & i : vref) {
+     TrackRef tk = i->track();
      LogDebug("HLTMuonL1toL3TkPreFilter")
        << " Track passing filter: pt= " << tk->pt() << ", eta: "
        << tk->eta();
@@ -193,9 +191,9 @@ HLTMuonL1toL3TkPreFilter::triggeredAtL1(const l1extra::L1MuonParticleRef & l1mu,
   bool ok=false;
 
   // compare to previously triggered L1
-  for (unsigned int i=0; i<vcands.size(); i++) {
+  for (auto & vcand : vcands) {
     //    l1extra::L1MuonParticleRef candref =  L1MuonParticleRef(vcands[i]);
-    if (vcands[i] == l1mu){
+    if (vcand == l1mu){
       ok=true;
       LogDebug("HLTMuonL1toL3TkPreFilter") << "The L1 mu triggered";
       break;}

--- a/HLTrigger/Muon/src/HLTMuonL2FromL1TPreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL2FromL1TPreFilter.cc
@@ -102,9 +102,7 @@ HLTMuonL2FromL1TPreFilter::HLTMuonL2FromL1TPreFilter(const edm::ParameterSet& iC
   }
 }
 
-HLTMuonL2FromL1TPreFilter::~HLTMuonL2FromL1TPreFilter()
-{
-}
+HLTMuonL2FromL1TPreFilter::~HLTMuonL2FromL1TPreFilter() = default;
 
 void
 HLTMuonL2FromL1TPreFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -167,7 +165,7 @@ bool HLTMuonL2FromL1TPreFilter::hltFilter(edm::Event& iEvent, const edm::EventSe
 
   // look at all allMuons,  check cuts and add to filter object
   int n = 0;
-  for(RecoChargedCandidateCollection::const_iterator cand=allMuons->begin(); cand!=allMuons->end(); cand++){
+  for(auto cand=allMuons->begin(); cand!=allMuons->end(); cand++){
     TrackRef mu = cand->get<TrackRef>();
 
     // check if this muon passed previous level
@@ -242,7 +240,7 @@ bool HLTMuonL2FromL1TPreFilter::hltFilter(edm::Event& iEvent, const edm::EventSe
       <<'\t'<<"isFired"
       <<endl;
     ss<<"-----------------------------------------------------------------------------------------------------------------------"<<endl;
-    for (RecoChargedCandidateCollection::const_iterator cand = allMuons->begin(); cand != allMuons->end(); cand++) {
+    for (auto cand = allMuons->begin(); cand != allMuons->end(); cand++) {
       TrackRef mu = cand->get<TrackRef>();
       ss<<setprecision(2)
         <<cand-allMuons->begin()

--- a/HLTrigger/Muon/src/HLTMuonL2PreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL2PreFilter.cc
@@ -103,9 +103,7 @@ HLTMuonL2PreFilter::HLTMuonL2PreFilter(const edm::ParameterSet& iConfig): HLTFil
   }
 }
 
-HLTMuonL2PreFilter::~HLTMuonL2PreFilter()
-{
-}
+HLTMuonL2PreFilter::~HLTMuonL2PreFilter() = default;
 
 void
 HLTMuonL2PreFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -168,7 +166,7 @@ bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 
   // look at all allMuons,  check cuts and add to filter object
   int n = 0;
-  for(RecoChargedCandidateCollection::const_iterator cand=allMuons->begin(); cand!=allMuons->end(); cand++){
+  for(auto cand=allMuons->begin(); cand!=allMuons->end(); cand++){
     TrackRef mu = cand->get<TrackRef>();
 
     // check if this muon passed previous level
@@ -243,7 +241,7 @@ bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
       <<'\t'<<"isFired"
       <<endl;
     ss<<"-----------------------------------------------------------------------------------------------------------------------"<<endl;
-    for (RecoChargedCandidateCollection::const_iterator cand = allMuons->begin(); cand != allMuons->end(); cand++) {
+    for (auto cand = allMuons->begin(); cand != allMuons->end(); cand++) {
       TrackRef mu = cand->get<TrackRef>();
       ss<<setprecision(2)
         <<cand-allMuons->begin()

--- a/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
@@ -74,9 +74,7 @@ HLTMuonL3PreFilter::HLTMuonL3PreFilter(const ParameterSet& iConfig) : HLTFilter(
       << " " << nsigma_Pt_;
 }
 
-HLTMuonL3PreFilter::~HLTMuonL3PreFilter()
-{
-}
+HLTMuonL3PreFilter::~HLTMuonL3PreFilter() = default;
 
 void
 HLTMuonL3PreFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -164,8 +162,8 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trig
 
      // look at all mucands,  check cuts and add to filter object
      int n = 0;
-     std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it = L2toL3s.begin();
-     std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_end = L2toL3s.end();
+     auto L2toL3s_it = L2toL3s.begin();
+     auto L2toL3s_end = L2toL3s.end();
      LogDebug("HLTMuonL3PreFilter")<<"looking at: "<<L2toL3s.size()<<" L2->L3s from: "<<mucands->size();
      for (; L2toL3s_it!=L2toL3s_end; ++L2toL3s_it){
   
@@ -240,8 +238,8 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trig
   
      vector<RecoChargedCandidateRef> vref;
      filterproduct.getObjects(TriggerMuon,vref);
-     for (unsigned int i=0; i<vref.size(); i++ ) {
-       RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+     for (auto & i : vref) {
+       RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
        TrackRef tk = candref->get<TrackRef>();
        LogDebug("HLTMuonL3PreFilter")
          << " Track passing filter: trackRef pt= " << tk->pt() << " (" << candref->pt() << ") " << ", eta: " << tk->eta() << " (" << candref->eta() << ") ";
@@ -266,8 +264,8 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trig
     // Loop over RecoChargedCandidates:
     for(unsigned int i(0); i < mucands->size(); ++i){
       RecoChargedCandidateRef cand(mucands,i);
-      for(unsigned int l(0); l <links->size(); ++l){
-        const reco::MuonTrackLinks* link = &links->at(l);
+      for(auto const & l : *links){
+        const reco::MuonTrackLinks* link = &l;
 	bool useThisLink=false;
 	TrackRef tk = cand->track();
 	reco::TrackRef trkTrack = link->trackerTrack();
@@ -354,8 +352,8 @@ bool
 HLTMuonL3PreFilter::triggeredByLevel2(const TrackRef& staTrack,vector<RecoChargedCandidateRef>& vcands) const
 {
   bool ok=false;
-  for (unsigned int i=0; i<vcands.size(); i++) {
-    if ( vcands[i]->get<TrackRef>() == staTrack ) {
+  for (auto & vcand : vcands) {
+    if ( vcand->get<TrackRef>() == staTrack ) {
       ok=true;
       LogDebug("HLTMuonL3PreFilter") << "The L2 track triggered";
       break;

--- a/HLTrigger/Muon/src/HLTMuonPFIsoFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonPFIsoFilter.cc
@@ -53,9 +53,7 @@ HLTMuonPFIsoFilter::HLTMuonPFIsoFilter(const edm::ParameterSet& iConfig) : HLTFi
 }
 
  
-HLTMuonPFIsoFilter::~HLTMuonPFIsoFilter()
-{
-}
+HLTMuonPFIsoFilter::~HLTMuonPFIsoFilter() = default;
 
 //
 // member functions

--- a/HLTrigger/Muon/src/HLTMuonTrackMassFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrackMassFilter.cc
@@ -242,12 +242,12 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
   reco::Particle::LorentzVector p4Muon;
   reco::Particle::LorentzVector p4JPsi;
 //   std::ostringstream stream3;
-  for ( unsigned int im=0; im<selectedMuonRefs.size(); ++im ) {
-    const reco::RecoChargedCandidate& muon = *selectedMuonRefs[im];
+  for (auto & selectedMuonRef : selectedMuonRefs) {
+    const reco::RecoChargedCandidate& muon = *selectedMuonRef;
     int qMuon = muon.charge();
     p4Muon = muon.p4();
-    for ( unsigned int it=0; it<selectedTrackRefs.size(); ++it ) {
-      const reco::RecoChargedCandidate& track = *selectedTrackRefs[it];
+    for (auto & selectedTrackRef : selectedTrackRefs) {
+      const reco::RecoChargedCandidate& track = *selectedTrackRef;
 //       stream3 << "Combination " << im << " / " << it << " with dz / q / mass = "
 // 	      << muon.track()->dz(beamspot)-track.track()->dz(beamspot) << " "
 // 	      << track.charge()+qMuon << " "
@@ -283,15 +283,15 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 
       if ( checkPrevTracks ) {
 	if ( !pairMatched(prevMuonRefs,prevTrackRefs,
-			  selectedMuonRefs[im],
-			  selectedTrackRefs[it]) ) continue;
+			  selectedMuonRef,
+			  selectedTrackRef) ) continue;
       }
       double mass = (p4Muon+track.p4()).mass();
       for ( unsigned int j=0; j<minMasses_.size(); ++j ) {
 	if ( mass>minMasses_[j] && mass<maxMasses_[j] ) {
 	  ++nComb;
-	  filterproduct.addObject(trigger::TriggerMuon,selectedMuonRefs[im]);
-	  filterproduct.addObject(trigger::TriggerTrack,selectedTrackRefs[it]);
+	  filterproduct.addObject(trigger::TriggerMuon,selectedMuonRef);
+	  filterproduct.addObject(trigger::TriggerTrack,selectedTrackRef);
 // 	  stream3 << "... accepted\n";
 	  break;
 	}

--- a/HLTrigger/Muon/src/HLTMuonTrimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrimuonL3Filter.cc
@@ -86,9 +86,7 @@ HLTMuonTrimuonL3Filter::HLTMuonTrimuonL3Filter(const edm::ParameterSet& iConfig)
       << " " << max_YTriplet_;
 }
 
-HLTMuonTrimuonL3Filter::~HLTMuonTrimuonL3Filter()
-{
-}
+HLTMuonTrimuonL3Filter::~HLTMuonTrimuonL3Filter() = default;
 
 void
 HLTMuonTrimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -167,8 +165,8 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
    double e1,e2,e3;
    Particle::LorentzVector p,p1,p2,p3;
 
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it1 = L2toL3s.begin();
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_end = L2toL3s.end();
+   auto L2toL3s_it1 = L2toL3s.begin();
+   auto L2toL3s_end = L2toL3s.end();
    bool atLeastOneTriplet=false;
    for (; L2toL3s_it1!=L2toL3s_end; ++L2toL3s_it1){
 
@@ -205,7 +203,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
        // Don't convert to 90% efficiency threshold
        LogDebug("HLTMuonTrimuonL3Filter") << " ... 1st muon in loop, pt1= "
 					 << pt1 << ", ptLx1= " << ptLx1;
-       std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it2 = L2toL3s_it1;
+       auto L2toL3s_it2 = L2toL3s_it1;
        L2toL3s_it2++;
        for (; L2toL3s_it2!=L2toL3s_end; ++L2toL3s_it2){
 	 if (!triggeredByLevel2(L2toL3s_it2->first,vl2cands)) continue;
@@ -240,7 +238,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 	      LogDebug("HLTMuonTrimuonL3Filter") << " ... 2nd muon in loop, pt2= "
 						 << pt2 << ", ptLx2= " << ptLx2;
 	
-	      std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it3 = L2toL3s_it2;
+	      auto L2toL3s_it3 = L2toL3s_it2;
 	      L2toL3s_it3++;
 	      for (; L2toL3s_it3!=L2toL3s_end; ++L2toL3s_it3){
 		
@@ -381,8 +379,8 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		  bool i3done = false;
 		  vector<RecoChargedCandidateRef> vref;
 		  filterproduct.getObjects(TriggerMuon,vref);
-		  for (unsigned int i=0; i<vref.size(); i++) {
-		    RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+		  for (auto & i : vref) {
+		    RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
 		    TrackRef tktmp = candref->get<TrackRef>();
 		    if (tktmp==tk1) {
 		      i1done = true;
@@ -439,8 +437,8 @@ bool
 HLTMuonTrimuonL3Filter::triggeredByLevel2(const TrackRef& staTrack,vector<RecoChargedCandidateRef>& vcands)
 {
   bool ok=false;
-  for (unsigned int i=0; i<vcands.size(); i++) {
-    if ( vcands[i]->get<TrackRef>() == staTrack ) {
+  for (auto & vcand : vcands) {
+    if ( vcand->get<TrackRef>() == staTrack ) {
       ok=true;
       LogDebug("HLTMuonL3PreFilter") << "The L2 track triggered";
       break;

--- a/HLTrigger/Muon/src/HLTMuonTrkFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrkFilter.cc
@@ -97,7 +97,7 @@ HLTMuonTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     // check for dR match to L1 muons
     if (check_l1match) {
       bool matchl1 = false;
-      for (std::vector<l1extra::L1MuonParticleRef>::iterator l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
+      for (auto l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
         if (deltaR(muon,**l1cand) < 0.3) {
           matchl1 = true;
           break;

--- a/HLTrigger/Muon/src/HLTMuonTrkL1TFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrkL1TFilter.cc
@@ -95,7 +95,7 @@ HLTMuonTrkL1TFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
     // check for dR match to L1 muons
     if (check_l1match) {
       bool matchl1 = false;
-      for (std::vector<l1t::MuonRef>::iterator l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
+      for (auto l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
         if (deltaR(muon,**l1cand) < 0.3) {
           matchl1 = true;
           break;

--- a/HLTrigger/Muon/src/HLTScoutingMuonProducer.cc
+++ b/HLTrigger/Muon/src/HLTScoutingMuonProducer.cc
@@ -42,8 +42,7 @@ HLTScoutingMuonProducer::HLTScoutingMuonProducer(const edm::ParameterSet& iConfi
     produces<ScoutingVertexCollection>("displacedVtx");
 }
 
-HLTScoutingMuonProducer::~HLTScoutingMuonProducer()
-{ }
+HLTScoutingMuonProducer::~HLTScoutingMuonProducer() = default;
 
 // ------------ method called to produce the data  ------------
 void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event & iEvent,
@@ -97,17 +96,17 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event & iEvent,
 	if (vtxProb < minVtxProbCut) continue;
 	
 	// Get the 2 tracks associated to displaced vertex
-	reco::Vertex::trackRef_iterator trackIt =  dispvtx.tracks_begin();
+	auto trackIt =  dispvtx.tracks_begin();
 	reco::TrackRef vertextkRef1 =  (*trackIt).castTo<reco::TrackRef>() ;
 	trackIt++;
 	reco::TrackRef vertextkRef2 =  (*trackIt).castTo<reco::TrackRef>();
 	
 	// Get the muons associated with the tracks
 	int iFoundRefs = 0;
-	for (reco::RecoChargedCandidateCollection::const_iterator cand=ChargedCandidateCollection->begin(); cand!=ChargedCandidateCollection->end(); cand++) {
-	  reco::TrackRef tkRef = cand->get<reco::TrackRef>();
-	  if(tkRef == vertextkRef1) {ivtxMuPair.first= (*cand); iFoundRefs++ ;}
-	  if(tkRef == vertextkRef2) {ivtxMuPair.second= (*cand); iFoundRefs++ ;}
+	for (auto const & cand : *ChargedCandidateCollection) {
+	  reco::TrackRef tkRef = cand.get<reco::TrackRef>();
+	  if(tkRef == vertextkRef1) {ivtxMuPair.first= cand; iFoundRefs++ ;}
+	  if(tkRef == vertextkRef2) {ivtxMuPair.second= cand; iFoundRefs++ ;}
 	}
 	if (iFoundRefs<2) continue;
 	vtxMuPair.push_back(ivtxMuPair);

--- a/HLTrigger/Muon/test/HLTMuonRateAnalyzer.cc
+++ b/HLTrigger/Muon/test/HLTMuonRateAnalyzer.cc
@@ -39,8 +39,8 @@ HLTMuonRateAnalyzer::HLTMuonRateAnalyzer(const ParameterSet& pset)
   theHLTCollectionLabels = pset.getUntrackedParameter<std::vector<InputTag> >("HLTCollectionLabels");
   theGenToken = consumes<edm::HepMCProduct>(theGenLabel);
   theL1CollectionToken = consumes<trigger::TriggerFilterObjectWithRefs>(theL1CollectionLabel);
-  for (unsigned int i=0; i<theHLTCollectionLabels.size(); ++i) {
-    theHLTCollectionTokens.push_back(consumes<trigger::TriggerFilterObjectWithRefs>(theHLTCollectionLabels[i]));
+  for (auto & theHLTCollectionLabel : theHLTCollectionLabels) {
+    theHLTCollectionTokens.push_back(consumes<trigger::TriggerFilterObjectWithRefs>(theHLTCollectionLabel));
   }
   theL1ReferenceThreshold = pset.getUntrackedParameter<double>("L1ReferenceThreshold");
   theNSigmas = pset.getUntrackedParameter<std::vector<double> >("NSigmas90");
@@ -60,8 +60,7 @@ HLTMuonRateAnalyzer::HLTMuonRateAnalyzer(const ParameterSet& pset)
 }
 
 /// Destructor
-HLTMuonRateAnalyzer::~HLTMuonRateAnalyzer(){
-}
+HLTMuonRateAnalyzer::~HLTMuonRateAnalyzer()= default;
 
 void HLTMuonRateAnalyzer::beginJob(){
   // Create the root file
@@ -77,12 +76,12 @@ void HLTMuonRateAnalyzer::beginJob(){
   snprintf(chtitle, 255, "Rate (Hz) vs L1 Pt threshold (GeV), label=%s, L=%.2E (cm^{-2} s^{-1})", theL1CollectionLabel.encode().c_str(), theLuminosity*1.e33);
   hL1rate = new TH1F(chname, chtitle, theNbins, thePtMin, thePtMax);
 
-  for (unsigned int i=0; i<theHLTCollectionLabels.size(); i++) {
-      snprintf(chname, 255, "eff_%s", theHLTCollectionLabels[i].encode().c_str());
-      snprintf(chtitle, 255, "Efficiency (%%) vs HLT Pt threshold (GeV), label=%s", theHLTCollectionLabels[i].encode().c_str());
+  for (auto & theHLTCollectionLabel : theHLTCollectionLabels) {
+      snprintf(chname, 255, "eff_%s", theHLTCollectionLabel.encode().c_str());
+      snprintf(chtitle, 255, "Efficiency (%%) vs HLT Pt threshold (GeV), label=%s", theHLTCollectionLabel.encode().c_str());
       hHLTeff.push_back(new TH1F(chname, chtitle, theNbins, thePtMin, thePtMax));
-      snprintf(chname, 255, "rate_%s", theHLTCollectionLabels[i].encode().c_str());
-      snprintf(chtitle, 255, "Rate (Hz) vs HLT Pt threshold (GeV), label=%s, L=%.2E (cm^{-2} s^{-1})", theHLTCollectionLabels[i].encode().c_str(), theLuminosity*1.e33);
+      snprintf(chname, 255, "rate_%s", theHLTCollectionLabel.encode().c_str());
+      snprintf(chtitle, 255, "Rate (Hz) vs HLT Pt threshold (GeV), label=%s, L=%.2E (cm^{-2} s^{-1})", theHLTCollectionLabel.encode().c_str(), theLuminosity*1.e33);
       hHLTrate.push_back(new TH1F(chname, chtitle, theNbins, thePtMin, thePtMax));
   }
 
@@ -176,8 +175,8 @@ void HLTMuonRateAnalyzer::analyze(const Event & event, const EventSetup& eventSe
   double epsilon = 0.001;
   vector<L1MuonParticleRef> l1mu;
   l1cands->getObjects(TriggerL1Mu,l1mu);
-  for (unsigned int k=0; k<l1mu.size(); k++) {
-      L1MuonParticleRef candref = L1MuonParticleRef(l1mu[k]);
+  for (auto & k : l1mu) {
+      L1MuonParticleRef candref = L1MuonParticleRef(k);
       // L1 PTs are "quantized" due to LUTs. 
       // Their meaning: true_pt > ptLUT more than 90% pof the times
       double ptLUT = candref->pt();
@@ -190,8 +189,8 @@ void HLTMuonRateAnalyzer::analyze(const Event & event, const EventSetup& eventSe
 
       // L1 filling
       unsigned int nFound = 0;
-      for (unsigned int k=0; k<l1mu.size(); k++) {
-            L1MuonParticleRef candref = L1MuonParticleRef(l1mu[k]);
+      for (auto & k : l1mu) {
+            L1MuonParticleRef candref = L1MuonParticleRef(k);
             double pt = candref->pt();
             if (pt>ptcut) nFound++;
       }
@@ -205,8 +204,8 @@ void HLTMuonRateAnalyzer::analyze(const Event & event, const EventSetup& eventSe
             unsigned nFound = 0;
 	    vector<RecoChargedCandidateRef> vref;
 	    hltcands[i]->getObjects(TriggerMuon,vref);
-            for (unsigned int k=0; k<vref.size(); k++) {
-                  RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[k]);
+            for (auto & k : vref) {
+                  RecoChargedCandidateRef candref =  RecoChargedCandidateRef(k);
                   TrackRef tk = candref->get<TrackRef>();
                   double pt = tk->pt();
                   double err0 = tk->error(0);

--- a/HLTrigger/Muon/test/HLTMuonRateAnalyzerWithWeight.cc
+++ b/HLTrigger/Muon/test/HLTMuonRateAnalyzerWithWeight.cc
@@ -39,8 +39,8 @@ HLTMuonRateAnalyzerWithWeight::HLTMuonRateAnalyzerWithWeight(const ParameterSet&
   theHLTCollectionLabels = pset.getUntrackedParameter<std::vector<InputTag> >("HLTCollectionLabels");
   theGenToken = consumes<edm::HepMCProduct>(theGenLabel);
   theL1CollectionToken = consumes<trigger::TriggerFilterObjectWithRefs>(theL1CollectionLabel);
-  for (unsigned int i=0; i<theHLTCollectionLabels.size(); ++i) {
-    theHLTCollectionTokens.push_back(consumes<trigger::TriggerFilterObjectWithRefs>(theHLTCollectionLabels[i]));
+  for (auto & theHLTCollectionLabel : theHLTCollectionLabels) {
+    theHLTCollectionTokens.push_back(consumes<trigger::TriggerFilterObjectWithRefs>(theHLTCollectionLabel));
   }
   theL1ReferenceThreshold = pset.getUntrackedParameter<double>("L1ReferenceThreshold");
   theNSigmas = pset.getUntrackedParameter<std::vector<double> >("NSigmas90");
@@ -62,8 +62,7 @@ HLTMuonRateAnalyzerWithWeight::HLTMuonRateAnalyzerWithWeight(const ParameterSet&
 }
 
 /// Destructor
-HLTMuonRateAnalyzerWithWeight::~HLTMuonRateAnalyzerWithWeight(){
-}
+HLTMuonRateAnalyzerWithWeight::~HLTMuonRateAnalyzerWithWeight()= default;
 
 void HLTMuonRateAnalyzerWithWeight::beginJob(){
   // Create the root file
@@ -239,8 +238,8 @@ void HLTMuonRateAnalyzerWithWeight::analyze(const Event & event, const EventSetu
   double epsilon = 0.001;
   vector<L1MuonParticleRef> l1mu;
   l1cands->getObjects(TriggerL1Mu,l1mu);
-  for (unsigned int k=0; k<l1mu.size(); k++) {
-      L1MuonParticleRef candref = L1MuonParticleRef(l1mu[k]);
+  for (auto & k : l1mu) {
+      L1MuonParticleRef candref = L1MuonParticleRef(k);
       // L1 PTs are "quantized" due to LUTs. 
       // Their meaning: true_pt > ptLUT more than 90% pof the times
       double ptLUT = candref->pt();
@@ -253,8 +252,8 @@ void HLTMuonRateAnalyzerWithWeight::analyze(const Event & event, const EventSetu
 
       // L1 filling
       unsigned int nFound = 0;
-      for (unsigned int k=0; k<l1mu.size(); k++) {
-	L1MuonParticleRef candref = L1MuonParticleRef(l1mu[k]);
+      for (auto & k : l1mu) {
+	L1MuonParticleRef candref = L1MuonParticleRef(k);
 	double pt = candref->pt();
 	if (pt>ptcut) nFound++;
       }
@@ -270,8 +269,8 @@ void HLTMuonRateAnalyzerWithWeight::analyze(const Event & event, const EventSetu
             unsigned nFound = 0;
 	    vector<RecoChargedCandidateRef> vref;
 	    hltcands[i]->getObjects(TriggerMuon,vref);
-            for (unsigned int k=0; k<vref.size(); k++) {
-                  RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[k]);
+            for (auto & k : vref) {
+                  RecoChargedCandidateRef candref =  RecoChargedCandidateRef(k);
                   TrackRef tk = candref->get<TrackRef>();
                   double pt = tk->pt();
                   double err0 = tk->error(0);
@@ -308,7 +307,7 @@ bool HLTMuonRateAnalyzerWithWeight::isbc(HepMC::GenEvent const & Gevt){
 	    break;
 	  } else {
 	    HepMC::GenVertex* parent=(*particle)->production_vertex();
-	    for (HepMC::GenVertex::particles_in_const_iterator ic=parent->particles_in_const_begin() ; ic!=parent->particles_in_const_end() ; ic++ )
+	    for (auto ic=parent->particles_in_const_begin() ; ic!=parent->particles_in_const_end() ; ic++ )
 	      {
 		int pid=(*ic)->pdg_id(); 
 		if (pid == 21 && id==5 ) nb++;
@@ -331,7 +330,7 @@ double HLTMuonRateAnalyzerWithWeight::parentWeight(HepMC::GenEvent const & Gevt)
 	double pt=(*particle)->momentum().perp();
 	if (id==13 && pt>10 ){
 	  HepMC::GenVertex* parent=(*particle)->production_vertex();
-	  for (HepMC::GenVertex::particles_in_const_iterator ic=parent->particles_in_const_begin() ; ic!=parent->particles_in_const_end() ; ic++ )
+	  for (auto ic=parent->particles_in_const_begin() ; ic!=parent->particles_in_const_end() ; ic++ )
 	    {
 	      int apid=abs((*ic)->pdg_id());
 	      LogInfo("HLTMuonRateAnalyzerWithWeight") << " Absolute parent id is "<<apid;

--- a/HLTrigger/Muon/test/HLTMuonTurnOnAnalyzer.cc
+++ b/HLTrigger/Muon/test/HLTMuonTurnOnAnalyzer.cc
@@ -41,8 +41,8 @@ HLTMuonTurnOnAnalyzer::HLTMuonTurnOnAnalyzer(const ParameterSet& pset)
   theHLTCollectionLabels = pset.getUntrackedParameter<std::vector<InputTag> >("HLTCollectionLabels");
   theGenToken = consumes<edm::HepMCProduct>(theGenLabel);
   theL1CollectionToken = consumes<trigger::TriggerFilterObjectWithRefs>(theL1CollectionLabel);
-  for (unsigned int i=0; i<theHLTCollectionLabels.size(); ++i) {
-    theHLTCollectionTokens.push_back(consumes<trigger::TriggerFilterObjectWithRefs>(theHLTCollectionLabels[i]));
+  for (auto & theHLTCollectionLabel : theHLTCollectionLabels) {
+    theHLTCollectionTokens.push_back(consumes<trigger::TriggerFilterObjectWithRefs>(theHLTCollectionLabel));
   }
   theReferenceThreshold = pset.getUntrackedParameter<double>("ReferenceThreshold");
 
@@ -56,8 +56,7 @@ HLTMuonTurnOnAnalyzer::HLTMuonTurnOnAnalyzer(const ParameterSet& pset)
 }
 
 /// Destructor
-HLTMuonTurnOnAnalyzer::~HLTMuonTurnOnAnalyzer(){
-}
+HLTMuonTurnOnAnalyzer::~HLTMuonTurnOnAnalyzer()= default;
 
 void HLTMuonTurnOnAnalyzer::beginJob(){
   // Create the root file
@@ -71,9 +70,9 @@ void HLTMuonTurnOnAnalyzer::beginJob(){
   hL1eff = new TH1F(chname, chtitle, theNbins, thePtMin, thePtMax);
   hL1nor = new TH1F(chname, chtitle, theNbins, thePtMin, thePtMax);
 
-  for (unsigned int i=0; i<theHLTCollectionLabels.size(); i++) {
-      snprintf(chname, 255, "eff_%s", theHLTCollectionLabels[i].encode().c_str());
-      snprintf(chtitle, 255, "Efficiency (%%) vs Generated Pt (GeV), label=%s", theHLTCollectionLabels[i].encode().c_str());
+  for (auto & theHLTCollectionLabel : theHLTCollectionLabels) {
+      snprintf(chname, 255, "eff_%s", theHLTCollectionLabel.encode().c_str());
+      snprintf(chtitle, 255, "Efficiency (%%) vs Generated Pt (GeV), label=%s", theHLTCollectionLabel.encode().c_str());
       hHLTeff.push_back(new TH1F(chname, chtitle, theNbins, thePtMin, thePtMax));
       hHLTnor.push_back(new TH1F(chname, chtitle, theNbins, thePtMin, thePtMax));
   }
@@ -156,8 +155,8 @@ void HLTMuonTurnOnAnalyzer::analyze(const Event & event, const EventSetup& event
       unsigned int i=modules_in_this_event-1;
       vector<RecoChargedCandidateRef> vref;
       hltcands[i]->getObjects(TriggerMuon,vref);
-      for (unsigned int k=0; k<vref.size(); k++) {
-	RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[k]);
+      for (auto & k : vref) {
+	RecoChargedCandidateRef candref =  RecoChargedCandidateRef(k);
             TrackRef tk = candref->get<TrackRef>();
             double pt = tk->pt();
             if (pt>ptuse) {
@@ -179,8 +178,8 @@ void HLTMuonTurnOnAnalyzer::analyze(const Event & event, const EventSetup& event
   double epsilon = 0.001;
   vector<L1MuonParticleRef> l1mu;
   l1cands->getObjects(TriggerL1Mu,l1mu);
-  for (unsigned int k=0; k<l1mu.size(); k++) {
-      L1MuonParticleRef candref = L1MuonParticleRef(l1mu[k]);
+  for (auto & k : l1mu) {
+      L1MuonParticleRef candref = L1MuonParticleRef(k);
       // L1 PTs are "quantized" due to LUTs. 
       // Their meaning: true_pt > ptLUT more than 90% pof the times
       double ptLUT = candref->pt();
@@ -198,8 +197,8 @@ void HLTMuonTurnOnAnalyzer::analyze(const Event & event, const EventSetup& event
       unsigned nFound = 0;
       vector<RecoChargedCandidateRef> vref;
       hltcands[i]->getObjects(TriggerMuon,vref);
-      for (unsigned int k=0; k<vref.size(); k++) {
-            RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[k]);
+      for (auto & k : vref) {
+            RecoChargedCandidateRef candref =  RecoChargedCandidateRef(k);
             TrackRef tk = candref->get<TrackRef>();
             double pt = tk->pt();
             if (pt>ptcut) nFound++;

--- a/HLTrigger/Muon/test/MuEnrichRenormalizer.cc
+++ b/HLTrigger/Muon/test/MuEnrichRenormalizer.cc
@@ -48,7 +48,7 @@ void MuEnrichRenormalizer::analyze( const Event& e, const EventSetup& )
   int npart=0;
   int nb=0;
   int nc=0;
-  if (Gevt != 0 ) {   
+  if (Gevt != nullptr ) {   
     for ( HepMC::GenEvent::particle_const_iterator
 	    particle=Gevt->particles_begin(); particle!=Gevt->particles_end(); ++particle )
       {
@@ -61,7 +61,7 @@ void MuEnrichRenormalizer::analyze( const Event& e, const EventSetup& )
 	    break;
 	  } else {
 	    HepMC::GenVertex* parent=(*particle)->production_vertex();
-	    for (HepMC::GenVertex::particles_in_const_iterator ic=parent->particles_in_const_begin() ; ic!=parent->particles_in_const_end() ; ic++ )
+	    for (auto ic=parent->particles_in_const_begin() ; ic!=parent->particles_in_const_end() ; ic++ )
 	      {
 		int pid=(*ic)->pdg_id(); 
 		if (pid == 21 && id==5 ) nb++;

--- a/HLTrigger/Muon/test/MuEnrichType1Filter.cc
+++ b/HLTrigger/Muon/test/MuEnrichType1Filter.cc
@@ -76,7 +76,7 @@ MuEnrichType1Filter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    Handle< HepMCProduct > EvtHandle ;
    iEvent.getByToken(theGenToken, EvtHandle) ;
    const GenEvent* Evt = EvtHandle->GetEvent() ;
-   if (Evt != 0 ) {   
+   if (Evt != nullptr ) {   
      edm::LogVerbatim ("MuEnrichFltr")  << "------------------------------";
      for ( HepMC::GenEvent::particle_const_iterator
 	     part=Evt->particles_begin(); part!=Evt->particles_end(); ++part )

--- a/HLTrigger/Timer/plugins/ThroughputService.cc
+++ b/HLTrigger/Timer/plugins/ThroughputService.cc
@@ -34,9 +34,7 @@ ThroughputService::ThroughputService(const edm::ParameterSet & config, edm::Acti
   registry.watchPostEvent(          this, & ThroughputService::postEvent );
 }
 
-ThroughputService::~ThroughputService()
-{
-}
+ThroughputService::~ThroughputService() = default;
 
 void
 ThroughputService::preallocate(edm::service::SystemBounds const & bounds)

--- a/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
+++ b/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
@@ -26,7 +26,7 @@
 class ThroughputServiceClient : public DQMEDHarvester {
 public:
   explicit ThroughputServiceClient(edm::ParameterSet const &);
-  ~ThroughputServiceClient();
+  ~ThroughputServiceClient() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
@@ -43,10 +43,6 @@ private:
 
 ThroughputServiceClient::ThroughputServiceClient(edm::ParameterSet const & config) :
   m_dqm_path( config.getUntrackedParameter<std::string>( "dqmPath" ) )
-{
-}
-
-ThroughputServiceClient::~ThroughputServiceClient()
 {
 }
 

--- a/HLTrigger/btau/src/ConeIsolationAlgorithm.cc
+++ b/HLTrigger/btau/src/ConeIsolationAlgorithm.cc
@@ -3,8 +3,7 @@ using namespace std;
 using namespace reco;
 using namespace edm;
 
-ConeIsolationAlgorithm::ConeIsolationAlgorithm(void)
-{ }
+ConeIsolationAlgorithm::ConeIsolationAlgorithm() = default;
 
 ConeIsolationAlgorithm::ConeIsolationAlgorithm(const ParameterSet & parameters)
 {
@@ -57,19 +56,19 @@ pair<float,IsolatedTauTagInfo> ConeIsolationAlgorithm::tag(const JetTracksAssoci
 
   // Selection of the Tracks
   float z_pv = pv.z();
-  for(edm::RefVector<reco::TrackCollection>::const_iterator it = tracks.begin(); it!= tracks.end(); ++it)
+  for(auto && track : tracks)
   {
-    if ( (*it)->pt()                                  >  m_cutMinPt                     &&
-         (*it)->normalizedChi2()                      <  m_cutMaxChiSquared             &&
-         fabs((*it)->dxy(pv.position()))                            <  m_cutMaxTIP                    &&
-         (*it)->recHitsSize()                         >= (unsigned int) m_cutTotalHits  &&
-         (*it)->hitPattern().numberOfValidPixelHits() >= m_cutPixelHits ) 
+    if ( (track)->pt()                                  >  m_cutMinPt                     &&
+         (track)->normalizedChi2()                      <  m_cutMaxChiSquared             &&
+         fabs((track)->dxy(pv.position()))                            <  m_cutMaxTIP                    &&
+         (track)->recHitsSize()                         >= (unsigned int) m_cutTotalHits  &&
+         (track)->hitPattern().numberOfValidPixelHits() >= m_cutPixelHits ) 
     {
       if (useVertexConstrain_ && z_pv > -500.) {
-        if (fabs((*it)->dz(pv.position())) < dZ_vertex)
-          myTracks.push_back(*it);
+        if (fabs((track)->dz(pv.position())) < dZ_vertex)
+          myTracks.push_back(track);
       } else
-        myTracks.push_back(*it);
+        myTracks.push_back(track);
     }
   }
   IsolatedTauTagInfo resultExtended(myTracks,jetTracks);

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
@@ -51,10 +51,7 @@ HLTDisplacedmumuFilter::HLTDisplacedmumuFilter(const edm::ParameterSet& iConfig)
 }
 
 
-HLTDisplacedmumuFilter::~HLTDisplacedmumuFilter()
-{
-
-}
+HLTDisplacedmumuFilter::~HLTDisplacedmumuFilter() = default;
 
 void HLTDisplacedmumuFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -120,9 +117,7 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
   bool triggered = false;
 
   // loop over vertex collection
-  for(reco::VertexCollection::iterator it = displacedVertexColl.begin(); it!= displacedVertexColl.end(); it++){
-          reco::Vertex displacedVertex = *it;
-
+  for(auto displacedVertex : displacedVertexColl){
           // check if the vertex actually consists of exactly two muon tracks, throw exception if not
           if(displacedVertex.tracksSize() != 2)  throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition. It now has n muons = "
         									    << displacedVertex.tracksSize() << std::endl;
@@ -135,7 +130,7 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	  if (vtxProb < minVtxProbability_) continue;
 
           // get the two muons from the vertex
-          reco::Vertex::trackRef_iterator trackIt =  displacedVertex.tracks_begin();
+          auto trackIt =  displacedVertex.tracks_begin();
           reco::TrackRef vertextkRef1 =  (*trackIt).castTo<reco::TrackRef>() ;
           // the second one
           trackIt++;
@@ -146,7 +141,7 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	  reco::RecoChargedCandidateCollection::const_iterator cand2;	
 
 	  int iFoundRefs = 0;
-	  for (reco::RecoChargedCandidateCollection::const_iterator cand=mucands->begin(); cand!=mucands->end(); cand++) {
+	  for (auto cand=mucands->begin(); cand!=mucands->end(); cand++) {
 	    reco::TrackRef tkRef = cand->get<reco::TrackRef>();
 	    if(tkRef == vertextkRef1) {cand1 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}

--- a/HLTrigger/btau/src/HLTDisplacedmumuVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuVtxProducer.cc
@@ -49,10 +49,7 @@ HLTDisplacedmumuVtxProducer::HLTDisplacedmumuVtxProducer(const edm::ParameterSet
 }
 
 
-HLTDisplacedmumuVtxProducer::~HLTDisplacedmumuVtxProducer()
-{
-
-}
+HLTDisplacedmumuVtxProducer::~HLTDisplacedmumuVtxProducer() = default;
 
 void
 HLTDisplacedmumuVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -186,8 +183,8 @@ void HLTDisplacedmumuVtxProducer::produce(edm::Event& iEvent, const edm::EventSe
 
 bool HLTDisplacedmumuVtxProducer::checkPreviousCand(const TrackRef& trackref, vector<RecoChargedCandidateRef> & refVect){
   bool ok=false;
-  for (unsigned int i=0; i<refVect.size(); i++) {
-    if ( refVect[i]->get<TrackRef>() == trackref ) {
+  for (auto & i : refVect) {
+    if ( i->get<TrackRef>() == trackref ) {
       ok=true;
       break;
     }

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
@@ -51,10 +51,7 @@ HLTDisplacedmumumuFilter::HLTDisplacedmumumuFilter(const edm::ParameterSet& iCon
 }
 
 
-HLTDisplacedmumumuFilter::~HLTDisplacedmumumuFilter()
-{
-
-}
+HLTDisplacedmumumuFilter::~HLTDisplacedmumumuFilter() = default;
 
 void HLTDisplacedmumumuFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -122,9 +119,7 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
   bool triggered = false;
 
   // loop over vertex collection
-  for(reco::VertexCollection::iterator it = displacedVertexColl.begin(); it!= displacedVertexColl.end(); it++){
-          reco::Vertex displacedVertex = *it;
-
+  for(auto displacedVertex : displacedVertexColl){
           // check if the vertex actually consists of exactly two muon tracks, throw exception if not
           if(displacedVertex.tracksSize() != 3)  throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the Jpsi vertex must have exactly three muons by definition. It now has n muons = "
         									    << displacedVertex.tracksSize() << std::endl;
@@ -137,7 +132,7 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 	  if (vtxProb < minVtxProbability_) continue;
 
           // get the two muons from the vertex
-          reco::Vertex::trackRef_iterator trackIt =  displacedVertex.tracks_begin();
+          auto trackIt =  displacedVertex.tracks_begin();
           reco::TrackRef vertextkRef1 =  (*trackIt).castTo<reco::TrackRef>() ;
           // the second one
           trackIt++;
@@ -152,7 +147,7 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 
 	  // first find these two tracks in the muon collection
 	  int iFoundRefs = 0;
-	  for (reco::RecoChargedCandidateCollection::const_iterator cand=mucands->begin(); cand!=mucands->end(); cand++) {
+	  for (auto cand=mucands->begin(); cand!=mucands->end(); cand++) {
 	    reco::TrackRef tkRef = cand->get<reco::TrackRef>();
 	    if(tkRef == vertextkRef1) {cand1 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}

--- a/HLTrigger/btau/src/HLTDisplacedmumumuVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuVtxProducer.cc
@@ -49,10 +49,7 @@ HLTDisplacedmumumuVtxProducer::HLTDisplacedmumumuVtxProducer(const edm::Paramete
 }
 
 
-HLTDisplacedmumumuVtxProducer::~HLTDisplacedmumumuVtxProducer()
-{
-  
-}
+HLTDisplacedmumumuVtxProducer::~HLTDisplacedmumumuVtxProducer() = default;
 
 void
 HLTDisplacedmumumuVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -204,8 +201,8 @@ void HLTDisplacedmumumuVtxProducer::produce(edm::Event& iEvent, const edm::Event
 
 bool HLTDisplacedmumumuVtxProducer::checkPreviousCand(const TrackRef& trackref, vector<RecoChargedCandidateRef> & refVect){
   bool ok=false;
-  for (unsigned int i=0; i<refVect.size(); i++) {
-    if ( refVect[i]->get<TrackRef>() == trackref ) {
+  for (auto & i : refVect) {
+    if ( i->get<TrackRef>() == trackref ) {
       ok=true;
       break;
     }

--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
@@ -52,10 +52,7 @@ HLTDisplacedtktkFilter::HLTDisplacedtktkFilter(const edm::ParameterSet& iConfig)
 }
 
 
-HLTDisplacedtktkFilter::~HLTDisplacedtktkFilter()
-{
-
-}
+HLTDisplacedtktkFilter::~HLTDisplacedtktkFilter() = default;
 
 void HLTDisplacedtktkFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -122,9 +119,7 @@ bool HLTDisplacedtktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
   bool triggered = false;
 
   // loop over vertex collection
-  for(reco::VertexCollection::iterator it = displacedVertexColl.begin(); it!= displacedVertexColl.end(); it++){
-          reco::Vertex displacedVertex = *it;
-
+  for(auto displacedVertex : displacedVertexColl){
           // check if the vertex actually consists of exactly two track tracks, reject the event if not
           if(displacedVertex.tracksSize() != 2){
             edm::LogError("HLTDisplacedtktkFilter") << "HLTDisplacedtktkFilter: ERROR: the Jpsi vertex must have exactly two tracks by definition. It now has n tracks = "<< displacedVertex.tracksSize() << std::endl;
@@ -139,7 +134,7 @@ bool HLTDisplacedtktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	  if (vtxProb < minVtxProbability_) continue;
 
           // get the two tracks from the vertex
-          reco::Vertex::trackRef_iterator trackIt =  displacedVertex.tracks_begin();
+          auto trackIt =  displacedVertex.tracks_begin();
           reco::TrackRef vertextkRef1 =  (*trackIt).castTo<reco::TrackRef>() ;
           // the second one
           trackIt++;
@@ -150,7 +145,7 @@ bool HLTDisplacedtktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	  reco::RecoChargedCandidateCollection::const_iterator cand2;	
 
 	  int iFoundRefs = 0;
-	  for (reco::RecoChargedCandidateCollection::const_iterator cand=trackcands->begin(); cand!=trackcands->end(); cand++) {
+	  for (auto cand=trackcands->begin(); cand!=trackcands->end(); cand++) {
 	    reco::TrackRef tkRef = cand->get<reco::TrackRef>();
 	    if(tkRef == vertextkRef1) {cand1 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}

--- a/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.cc
@@ -52,10 +52,7 @@ HLTDisplacedtktkVtxProducer::HLTDisplacedtktkVtxProducer(const edm::ParameterSet
 }
 
 
-HLTDisplacedtktkVtxProducer::~HLTDisplacedtktkVtxProducer()
-{
-
-}
+HLTDisplacedtktkVtxProducer::~HLTDisplacedtktkVtxProducer() = default;
 
 void
 HLTDisplacedtktkVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -199,8 +196,8 @@ void HLTDisplacedtktkVtxProducer::produce(edm::Event& iEvent, const edm::EventSe
 
 bool HLTDisplacedtktkVtxProducer::checkPreviousCand(const TrackRef& trackref, vector<RecoChargedCandidateRef> & refVect){
   bool ok=false;
-  for (unsigned int i=0; i<refVect.size(); i++) {
-    if ( refVect[i]->get<TrackRef>() == trackref ) {
+  for (auto & i : refVect) {
+    if ( i->get<TrackRef>() == trackref ) {
       ok=true;
       break;
     }

--- a/HLTrigger/btau/src/HLTJetPairDzMatchFilter.cc
+++ b/HLTrigger/btau/src/HLTJetPairDzMatchFilter.cc
@@ -46,7 +46,7 @@ HLTJetPairDzMatchFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& des
 }
 
 template<typename T>
-HLTJetPairDzMatchFilter<T>::~HLTJetPairDzMatchFilter(){}
+HLTJetPairDzMatchFilter<T>::~HLTJetPairDzMatchFilter()= default;
 
 template<typename T>
 bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs & filterproduct) const

--- a/HLTrigger/btau/src/HLTJetTag.cc
+++ b/HLTrigger/btau/src/HLTJetTag.cc
@@ -52,9 +52,7 @@ HLTJetTag<T>::HLTJetTag(const edm::ParameterSet & config) : HLTFilter(config),
 }
 
 template<typename T>
-HLTJetTag<T>::~HLTJetTag()
-{
-}
+HLTJetTag<T>::~HLTJetTag() = default;
 
 template<typename T>
 void
@@ -110,14 +108,14 @@ HLTJetTag<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger
   // Look at all jets in decreasing order of Et.
   int nJet = 0;
   int nTag = 0;
-  for (JetTagCollection::const_iterator jet = h_JetTags->begin(); jet != h_JetTags->end(); ++jet) {
-    jetRef = TRef(h_Jets,jet->first.key());
+  for (auto const & jet : *h_JetTags) {
+    jetRef = TRef(h_Jets,jet.first.key());
     LogTrace("") << "Jet " << nJet
-                 << " : Et = " << jet->first->et()
-                 << " , tag value = " << jet->second;
+                 << " : Et = " << jet.first->et()
+                 << " , tag value = " << jet.second;
     ++nJet;
     // Check if jet is tagged.
-    if ( (m_MinTag <= jet->second) and (jet->second <= m_MaxTag) ) {
+    if ( (m_MinTag <= jet.second) and (jet.second <= m_MaxTag) ) {
       ++nTag;
 
       // Store a reference to the jets which passed tagging cuts

--- a/HLTrigger/btau/src/HLTJetTagWithMatching.cc
+++ b/HLTrigger/btau/src/HLTJetTagWithMatching.cc
@@ -51,13 +51,11 @@ HLTJetTagWithMatching<T>::HLTJetTagWithMatching(const edm::ParameterSet & config
 }
 
 template<typename T>
-HLTJetTagWithMatching<T>::~HLTJetTagWithMatching()
-{
-}
+HLTJetTagWithMatching<T>::~HLTJetTagWithMatching() = default;
 
 template<typename T> float HLTJetTagWithMatching<T>::findCSV(const typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection  & jetTags, float minDr){
          float tmpCSV = -20 ;
-         for (reco::JetTagCollection::const_iterator jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
+         for (auto jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
          float tmpDr = reco::deltaR(*jet,*(jetb->first));
  
          if (tmpDr < minDr) {

--- a/HLTrigger/btau/src/HLTmmkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkFilter.cc
@@ -58,9 +58,7 @@ HLTmmkFilter::HLTmmkFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig
 
 
 // ----------------------------------------------------------------------
-HLTmmkFilter::~HLTmmkFilter() {
-
-}
+HLTmmkFilter::~HLTmmkFilter() = default;
 
 void
 HLTmmkFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -151,7 +149,7 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
   int counter = 0;
 
   //run algorithm
-  for (RecoChargedCandidateCollection::const_iterator mucand1=mucands->begin(), endCand1=mucands->end(); mucand1!=endCand1; ++mucand1) {
+  for (auto mucand1=mucands->begin(), endCand1=mucands->end(); mucand1!=endCand1; ++mucand1) {
 
   	if ( mucands->size()<2) break;
   	if ( trkcands->size()<1) break;
@@ -165,9 +163,9 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	// Pt threshold cut
 	if (trk1->pt() < minPt_) continue;
 
-  	RecoChargedCandidateCollection::const_iterator mucand2 = mucand1; ++mucand2;
+  	auto mucand2 = mucand1; ++mucand2;
   	
-  	for (RecoChargedCandidateCollection::const_iterator endCand2=mucands->end(); mucand2!=endCand2; ++mucand2) {
+  	for (auto endCand2=mucands->end(); mucand2!=endCand2; ++mucand2) {
 
   		TrackRef trk2 = mucand2->get<TrackRef>();
 
@@ -214,7 +212,7 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
  			//skip overlapping muon candidates
 			bool skip=false;
- 			for (unsigned int itmc=0;itmc<trkMuCands.size();itmc++) if(trk3==trkMuCands.at(itmc)) skip=true;
+ 			for (auto & trkMuCand : trkMuCands) if(trk3==trkMuCand) skip=true;
 			if(skip) continue;
 
 			//skip already used tracks
@@ -304,8 +302,8 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 			bool i3done = false;
 			vector<RecoChargedCandidateRef> vref;
 			filterproduct.getObjects(TriggerMuon,vref);
-			for (unsigned int i=0; i<vref.size(); i++) {
-				RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+			for (auto & i : vref) {
+				RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
 				TrackRef trktmp = candref->get<TrackRef>();
 				if (trktmp==trk1) {
 					i1done = true;

--- a/HLTrigger/btau/src/HLTmmkkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkkFilter.cc
@@ -59,9 +59,7 @@ HLTmmkkFilter::HLTmmkkFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConf
 
 
 // ----------------------------------------------------------------------
-HLTmmkkFilter::~HLTmmkkFilter() {
-
-}
+HLTmmkkFilter::~HLTmmkkFilter() = default;
 
 void
 HLTmmkkFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -155,7 +153,7 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
   int counter = 0;
 
   //run algorithm
-  for (RecoChargedCandidateCollection::const_iterator mucand1=mucands->begin(), endCand1=mucands->end(); mucand1!=endCand1; ++mucand1) {
+  for (auto mucand1=mucands->begin(), endCand1=mucands->end(); mucand1!=endCand1; ++mucand1) {
 
   	if ( mucands->size()<2) break;
   	if ( trkcands->size()<2) break;
@@ -169,9 +167,9 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 	// Pt threshold cut
 	if (trk1->pt() < minPt_) continue;
 
-  	RecoChargedCandidateCollection::const_iterator mucand2 = mucand1; ++mucand2;
+  	auto mucand2 = mucand1; ++mucand2;
   	
-  	for (RecoChargedCandidateCollection::const_iterator endCand2=mucands->end(); mucand2!=endCand2; ++mucand2) {
+  	for (auto endCand2=mucands->end(); mucand2!=endCand2; ++mucand2) {
 
   		TrackRef trk2 = mucand2->get<TrackRef>();
 
@@ -218,7 +216,7 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 
  			//skip overlapping muon candidates
 			bool skip=false;
- 			for (unsigned int itmc=0;itmc<trkMuCands.size();itmc++) if(trk3==trkMuCands.at(itmc)) skip=true;
+ 			for (auto & trkMuCand : trkMuCands) if(trk3==trkMuCand) skip=true;
 			if(skip) continue;
 
 			//skip already used tracks
@@ -244,7 +242,7 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 
                           //skip overlapping muon candidates
 			  bool skip2=false;
-			  for (unsigned int itmc=0;itmc<trkMuCands.size();itmc++) if(trk4==trkMuCands.at(itmc)) skip2=true;
+			  for (auto & trkMuCand : trkMuCands) if(trk4==trkMuCand) skip2=true;
 			  if(skip2) continue;
 
                           //skip already used tracks
@@ -344,8 +342,8 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 			  bool i4done = false;
 			  vector<RecoChargedCandidateRef> vref;
 			  filterproduct.getObjects(TriggerMuon,vref);
-			  for (unsigned int i=0; i<vref.size(); i++) {
-			    RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+			  for (auto & i : vref) {
+			    RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
 			    TrackRef trktmp = candref->get<TrackRef>();
 			    if (trktmp==trk1) {
 			      i1done = true;

--- a/HLTrigger/btau/src/HLTmumutkFilter.cc
+++ b/HLTrigger/btau/src/HLTmumutkFilter.cc
@@ -46,7 +46,7 @@ HLTmumutkFilter::HLTmumutkFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
 }
 
 // ----------------------------------------------------------------------
-HLTmumutkFilter::~HLTmumutkFilter() {}
+HLTmumutkFilter::~HLTmumutkFilter() = default;
 
 void
 HLTmumutkFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -118,7 +118,7 @@ bool HLTmumutkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
     if (vtxProb < minVtxProbability_) continue;
 
     // get the three tracks from the vertex
-    reco::Vertex::trackRef_iterator trackIt =  displacedVertex.tracks_begin();
+    auto trackIt =  displacedVertex.tracks_begin();
     reco::TrackRef vertextkRef1 =  (*trackIt).castTo<reco::TrackRef>() ;
     trackIt++;
     reco::TrackRef vertextkRef2 =  (*trackIt).castTo<reco::TrackRef>();
@@ -132,7 +132,7 @@ bool HLTmumutkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
 
     int iFoundRefs = 0;
     bool threeMuons = false;
-    for (reco::RecoChargedCandidateCollection::const_iterator cand=mucands->begin(); cand!=mucands->end(); cand++) {
+    for (auto cand=mucands->begin(); cand!=mucands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
       if     (tkRef == vertextkRef1 && iFoundRefs==0) {mucand1 = cand; iFoundRefs++;}
       else if(tkRef == vertextkRef1 && iFoundRefs==1) {mucand2 = cand; iFoundRefs++;}
@@ -149,7 +149,7 @@ bool HLTmumutkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
 
     bool twoTrks = false;
     int iTrkFoundRefs = 0;
-    for (reco::RecoChargedCandidateCollection::const_iterator cand=trkcands->begin(); cand!=trkcands->end(); cand++) {
+    for (auto cand=trkcands->begin(); cand!=trkcands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
       if     (tkRef == vertextkRef1 && iTrkFoundRefs==0) {tkcand = cand; iTrkFoundRefs++;}
       else if(tkRef == vertextkRef1 && iTrkFoundRefs==1) {twoTrks = true;}

--- a/HLTrigger/btau/src/HLTmumutkVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTmumutkVtxProducer.cc
@@ -50,7 +50,7 @@ HLTmumutkVtxProducer::HLTmumutkVtxProducer(const edm::ParameterSet& iConfig):
 }
 
 // ----------------------------------------------------------------------
-HLTmumutkVtxProducer::~HLTmumutkVtxProducer() {}
+HLTmumutkVtxProducer::~HLTmumutkVtxProducer() = default;
 
 void
 HLTmumutkVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -224,8 +224,8 @@ bool HLTmumutkVtxProducer::overlap(const TrackRef& trackref1, const TrackRef& tr
 
 bool HLTmumutkVtxProducer::checkPreviousCand(const TrackRef& trackref, vector<RecoChargedCandidateRef> & refVect){
   bool ok=false;
-  for (unsigned int i=0; i<refVect.size(); i++) {
-    if ( refVect[i]->get<TrackRef>() == trackref ) {
+  for (auto & i : refVect) {
+    if ( i->get<TrackRef>() == trackref ) {
       ok=true;
       break;
     }

--- a/HLTrigger/btau/src/HLTmumutktkFilter.cc
+++ b/HLTrigger/btau/src/HLTmumutktkFilter.cc
@@ -46,7 +46,7 @@ HLTmumutktkFilter::HLTmumutktkFilter(const edm::ParameterSet& iConfig) : HLTFilt
 }
 
 // ----------------------------------------------------------------------
-HLTmumutktkFilter::~HLTmumutktkFilter() {}
+HLTmumutktkFilter::~HLTmumutktkFilter() = default;
 
 void
 HLTmumutktkFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -120,7 +120,7 @@ bool HLTmumutktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 
     // get the four tracks from the vertex
     std::vector <reco::TrackRef> vertexTrksRefVec;
-    reco::Vertex::trackRef_iterator trackIt =  displacedVertex.tracks_begin();
+    auto trackIt =  displacedVertex.tracks_begin();
     for (trackIt = displacedVertex.tracks_begin(); trackIt != displacedVertex.tracks_end(); trackIt++){
         vertexTrksRefVec.push_back((*trackIt).castTo<reco::TrackRef>());
     }
@@ -128,19 +128,19 @@ bool HLTmumutktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
     // first find the tracks in the input muon/track collection
     std::vector<reco::RecoChargedCandidateCollection::const_iterator> mucandVec;
     std::vector<reco::RecoChargedCandidateCollection::const_iterator> trkcandVec;
-    for (reco::RecoChargedCandidateCollection::const_iterator cand=mucands->begin(); cand!=mucands->end(); cand++) {
+    for (auto cand=mucands->begin(); cand!=mucands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
-      for (unsigned int iVec=0; iVec < vertexTrksRefVec.size();iVec++){
-        if (tkRef == vertexTrksRefVec.at(iVec)) {mucandVec.push_back(cand); break;}
+      for (auto & iVec : vertexTrksRefVec){
+        if (tkRef == iVec) {mucandVec.push_back(cand); break;}
       }
     }
     if(mucandVec.size()!= 2) throw cms::Exception("BadLogic") << "HLTmumutktkFilterr: ERROR: the vertex must have "
                                                               << " exactly two muons by definition."  << std::endl;
 
-    for (reco::RecoChargedCandidateCollection::const_iterator cand=trkcands->begin(); cand!=trkcands->end(); cand++) {
+    for (auto cand=trkcands->begin(); cand!=trkcands->end(); cand++) {
       reco::TrackRef tkRef = cand->get<reco::TrackRef>();
-      for (unsigned int iVec = 0; iVec < vertexTrksRefVec.size();iVec++){
-        if (tkRef == vertexTrksRefVec.at(iVec)) {trkcandVec.push_back(cand); break;}
+      for (auto & iVec : vertexTrksRefVec){
+        if (tkRef == iVec) {trkcandVec.push_back(cand); break;}
       }
     }
     if(trkcandVec.size()!= 2 ) throw cms::Exception("BadLogic") << "HLTmumutktkFilterr: ERROR: the vertex must have "

--- a/HLTrigger/btau/src/HLTmumutktkVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTmumutktkVtxProducer.cc
@@ -55,7 +55,7 @@ HLTmumutktkVtxProducer::HLTmumutktkVtxProducer(const edm::ParameterSet& iConfig)
 }
 
 // ----------------------------------------------------------------------
-HLTmumutktkVtxProducer::~HLTmumutktkVtxProducer() {}
+HLTmumutktkVtxProducer::~HLTmumutktkVtxProducer() = default;
 
 void
 HLTmumutktkVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -270,8 +270,8 @@ bool HLTmumutktkVtxProducer::overlap(const TrackRef& trackref1, const TrackRef& 
 
 bool HLTmumutktkVtxProducer::checkPreviousCand(const TrackRef& trackref, vector<RecoChargedCandidateRef> & refVect){
   bool ok=false;
-  for (unsigned int i=0; i<refVect.size(); i++) {
-    if ( refVect[i]->get<TrackRef>() == trackref ) {
+  for (auto & i : refVect) {
+    if ( i->get<TrackRef>() == trackref ) {
       ok=true;
       break;
     }

--- a/HLTrigger/special/src/EcalMIPRecHitFilter.cc
+++ b/HLTrigger/special/src/EcalMIPRecHitFilter.cc
@@ -55,12 +55,12 @@
 class EcalMIPRecHitFilter : public edm::EDFilter {
 public:
   explicit EcalMIPRecHitFilter(const edm::ParameterSet&);
-  ~EcalMIPRecHitFilter();
+  ~EcalMIPRecHitFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool filter(edm::Event &, edm::EventSetup const &) override;
+  bool filter(edm::Event &, edm::EventSetup const &) override;
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<EcalRecHitCollection> EcalRecHitToken_;
@@ -134,12 +134,12 @@ EcalMIPRecHitFilter::filter(edm::Event & iEvent, edm::EventSetup const & iSetup)
 
   bool thereIsSignal = false;
   // loop on  rechits
-  for ( EcalRecHitCollection::const_iterator hitItr = recHits->begin(); hitItr != recHits->end(); ++hitItr ) {
+  for ( auto hitItr = recHits->begin(); hitItr != recHits->end(); ++hitItr ) {
 
     EcalRecHit const & hit = *hitItr;
 
     // masking noisy channels //KEEP this for now, just in case a few show up
-    std::vector<int>::const_iterator result = std::find( maskedList_.begin(), maskedList_.end(), EBDetId(hit.id()).hashedIndex() );
+    auto result = std::find( maskedList_.begin(), maskedList_.end(), EBDetId(hit.id()).hashedIndex() );
     if  (result != maskedList_.end())
       // LogWarning("EcalFilter") << "skipping uncalRecHit for channel: " << ic << " with amplitude " << ampli_ ;
       continue;
@@ -148,7 +148,7 @@ EcalMIPRecHitFilter::filter(edm::Event & iEvent, edm::EventSetup const & iSetup)
     EBDetId ebDet = hit.id();
 
     // find intercalib constant for this xtal
-    EcalIntercalibConstantMap::const_iterator icalit=icalMap.find(ebDet);
+    auto icalit=icalMap.find(ebDet);
     EcalIntercalibConstant icalconst = 1.;
     if( icalit!=icalMap.end() ){
       icalconst = (*icalit);
@@ -179,7 +179,7 @@ EcalMIPRecHitFilter::filter(edm::Event & iEvent, edm::EventSetup const & iSetup)
       float secondMin = 0.;
       for(std::vector<DetId>::const_iterator detitr = neighbors.begin(); detitr != neighbors.end(); ++detitr)
       {
-        EcalRecHitCollection::const_iterator thishit = recHits->find((*detitr));
+        auto thishit = recHits->find((*detitr));
         if (thishit == recHits->end())
         {
           //LogWarning("EcalMIPRecHitFilter") << "No RecHit available, for "<< EBDetId(*detitr);
@@ -189,7 +189,7 @@ EcalMIPRecHitFilter::filter(edm::Event & iEvent, edm::EventSetup const & iSetup)
         {
           float thisamp = (*thishit).energy();
           // find intercalib constant for this xtal
-          EcalIntercalibConstantMap::const_iterator icalit2=icalMap.find((*thishit).id());
+          auto icalit2=icalMap.find((*thishit).id());
           EcalIntercalibConstant icalconst2 = 1.;
           if( icalit2!=icalMap.end() ){
             icalconst2 = (*icalit2);

--- a/HLTrigger/special/src/EcalSimpleUncalibRecHitFilter.cc
+++ b/HLTrigger/special/src/EcalSimpleUncalibRecHitFilter.cc
@@ -42,12 +42,12 @@
 class EcalSimpleUncalibRecHitFilter : public edm::EDFilter {
 public:
   explicit EcalSimpleUncalibRecHitFilter(const edm::ParameterSet&);
-  ~EcalSimpleUncalibRecHitFilter();
+  ~EcalSimpleUncalibRecHitFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool filter(edm::Event &, edm::EventSetup const &) override;
+  bool filter(edm::Event &, edm::EventSetup const &) override;
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<EcalUncalibratedRecHitCollection> EcalUncalibRecHitToken_;
@@ -98,12 +98,10 @@ EcalSimpleUncalibRecHitFilter::filter(edm::Event & iEvent, edm::EventSetup const
 
   bool thereIsSignal = false;
   // loop on crude rechits
-  for ( EcalUncalibratedRecHitCollection::const_iterator hitItr = crudeHits->begin(); hitItr != crudeHits->end(); ++hitItr ) {
-
-    EcalUncalibratedRecHit hit = (*hitItr);
+  for (auto hit : *crudeHits) {
 
     // masking noisy channels
-    std::vector<int>::const_iterator result = std::find( maskedList_.begin(), maskedList_.end(), EBDetId(hit.id()).hashedIndex() );
+    auto result = std::find( maskedList_.begin(), maskedList_.end(), EBDetId(hit.id()).hashedIndex() );
     if  (result != maskedList_.end())
       // LogWarning("EcalFilter") << "skipping uncalRecHit for channel: " << ic << " with amplitude " << ampli_ ;
       continue;

--- a/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
+++ b/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
@@ -48,8 +48,8 @@ class HLTCSCAcceptBusyFilter : public HLTFilter {
 
 public:
   explicit HLTCSCAcceptBusyFilter(const edm::ParameterSet&);
-  virtual ~HLTCSCAcceptBusyFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  ~HLTCSCAcceptBusyFilter() override;
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
@@ -135,30 +135,30 @@ bool HLTCSCAcceptBusyFilter::AcceptManyHitsInChamber(unsigned int maxRecHitsPerC
   const unsigned int nRings(4);
   const unsigned int nChambers(36);
   unsigned int allRechits[nEndcaps][nStations][nRings][nChambers];
-  for(unsigned int iE = 0;iE<nEndcaps;++iE){
+  for(auto & allRechit : allRechits){
     for(unsigned int iS = 0;iS<nStations;++iS){
       for(unsigned int iR = 0;iR<nRings;++iR){
 	for(unsigned int iC = 0;iC<nChambers;++iC){
-	  allRechits[iE][iS][iR][iC] = 0;
+	  allRechit[iS][iR][iC] = 0;
 	}
       }
     }
   }
 
-  for(CSCRecHit2DCollection::const_iterator it = recHits->begin(); it != recHits->end(); it++) {
+  for(auto const & it : *recHits) {
     ++allRechits
-      [(*it).cscDetId().endcap()-1]
-      [(*it).cscDetId().station()-1]
-      [(*it).cscDetId().ring()-1]
-      [(*it).cscDetId().chamber()-1];
+      [it.cscDetId().endcap()-1]
+      [it.cscDetId().station()-1]
+      [it.cscDetId().ring()-1]
+      [it.cscDetId().chamber()-1];
   }
 
-  for(unsigned int iE = 0;iE<nEndcaps;++iE){
+  for(auto & allRechit : allRechits){
     for(unsigned int iS = 0;iS<nStations;++iS){
       for(unsigned int iR = 0;iR<nRings;++iR){
 	for(unsigned int iC = 0;iC<nChambers;++iC){
-	  if(allRechits[iE][iS][iR][iC] > maxNRecHitsPerChamber) {
-	    maxNRecHitsPerChamber = allRechits[iE][iS][iR][iC];
+	  if(allRechit[iS][iR][iC] > maxNRecHitsPerChamber) {
+	    maxNRecHitsPerChamber = allRechit[iS][iR][iC];
 	  }
 	  if(maxNRecHitsPerChamber > maxRecHitsPerChamber) {
 	    return true;

--- a/HLTrigger/special/src/HLTCSCActivityFilter.cc
+++ b/HLTrigger/special/src/HLTCSCActivityFilter.cc
@@ -37,8 +37,7 @@ HLTCSCActivityFilter::HLTCSCActivityFilter(const edm::ParameterSet& iConfig) : H
   m_cscStripDigiToken = consumes<CSCStripDigiCollection>(m_cscStripDigiTag);
 }
 
-HLTCSCActivityFilter::~HLTCSCActivityFilter() {
-}
+HLTCSCActivityFilter::~HLTCSCActivityFilter() = default;
 
 void
 HLTCSCActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -66,14 +65,14 @@ bool HLTCSCActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& 
   edm::Handle<CSCStripDigiCollection> cscStrips;
   iEvent.getByToken(m_cscStripDigiToken, cscStrips);
 
-  for (CSCStripDigiCollection::DigiRangeIterator dSDiter=cscStrips->begin(); dSDiter!=cscStrips->end(); ++dSDiter) {
-    CSCDetId id = (CSCDetId)(*dSDiter).first;
+  for (auto && dSDiter : *cscStrips) {
+    CSCDetId id = (CSCDetId)dSDiter.first;
     bool thisME = ((id.station()== m_StationNumb) && (id.ring()== m_RingNumb));
     if (m_MESR && thisME)
       continue;
 
-    std::vector<CSCStripDigi>::const_iterator stripIter = (*dSDiter).second.first;
-    std::vector<CSCStripDigi>::const_iterator lStrip    = (*dSDiter).second.second;
+    auto stripIter = dSDiter.second.first;
+    auto lStrip    = dSDiter.second.second;
     for( ; stripIter != lStrip; ++stripIter) {
       const std::vector<int> & myADCVals = stripIter->getADCCounts();
       const float pedestal  = 0.5 * (float) (myADCVals[0] + myADCVals[1]);

--- a/HLTrigger/special/src/HLTCSCOverlapFilter.cc
+++ b/HLTrigger/special/src/HLTCSCOverlapFilter.cc
@@ -21,10 +21,10 @@ HLTCSCOverlapFilter::HLTCSCOverlapFilter(const edm::ParameterSet& iConfig) : HLT
      , m_ring1(iConfig.getParameter<bool>("ring1"))
      , m_ring2(iConfig.getParameter<bool>("ring2"))
      , m_fillHists(iConfig.getParameter<bool>("fillHists"))
-     , m_nhitsNoWindowCut(0)
-     , m_xdiff(0)
-     , m_ydiff(0)
-     , m_pairsWithWindowCut(0)
+     , m_nhitsNoWindowCut(nullptr)
+     , m_xdiff(nullptr)
+     , m_ydiff(nullptr)
+     , m_pairsWithWindowCut(nullptr)
 {
    cscrechitsToken = consumes<CSCRecHit2DCollection>(m_input);
    if (m_fillHists) {
@@ -36,7 +36,7 @@ HLTCSCOverlapFilter::HLTCSCOverlapFilter(const edm::ParameterSet& iConfig) : HLT
    }
 }
 
-HLTCSCOverlapFilter::~HLTCSCOverlapFilter() { }
+HLTCSCOverlapFilter::~HLTCSCOverlapFilter() = default;
 
 void
 HLTCSCOverlapFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -61,8 +61,8 @@ bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 
    std::map<int, std::vector<const CSCRecHit2D*> > chamber_tohit;
 
-   for (CSCRecHit2DCollection::const_iterator hit = hits->begin();  hit != hits->end();  ++hit) {
-      CSCDetId id(hit->geographicalId());
+   for (auto const & hit : *hits) {
+      CSCDetId id(hit.geographicalId());
       int chamber_id = CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), 0).rawId();
 
       if ((m_ring1  &&  (id.ring() == 1  ||  id.ring() == 4))  ||
@@ -70,9 +70,9 @@ bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 	 std::map<int, std::vector<const CSCRecHit2D*> >::const_iterator chamber_iter = chamber_tohit.find(chamber_id);
 	 if (chamber_iter == chamber_tohit.end()) {
 	    std::vector<const CSCRecHit2D*> newlist;
-	    newlist.push_back(&(*hit));
+	    newlist.push_back(&hit);
 	 }
-	 chamber_tohit[chamber_id].push_back(&(*hit));
+	 chamber_tohit[chamber_id].push_back(&hit);
       } // end if this ring is selected
    } // end loop over hits
 
@@ -105,10 +105,10 @@ bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 	    }
 
 	    unsigned int pairs_in_window = 0;
-	    for (std::vector<const CSCRecHit2D*>::const_iterator hit1 = chamber_iter->second.begin();  hit1 != chamber_iter->second.end();  ++hit1) {
-	       for (std::vector<const CSCRecHit2D*>::const_iterator hit2 = chamber_next->second.begin();  hit2 != chamber_next->second.end();  ++hit2) {
+	    for (auto hit1 = chamber_iter->second.begin();  hit1 != chamber_iter->second.end();  ++hit1) {
+	       for (auto hit2 : chamber_next->second) {
 		  GlobalPoint pos1 = cscGeometry->idToDet((*hit1)->geographicalId())->surface().toGlobal((*hit1)->localPosition());
-		  GlobalPoint pos2 = cscGeometry->idToDet((*hit2)->geographicalId())->surface().toGlobal((*hit2)->localPosition());
+		  GlobalPoint pos2 = cscGeometry->idToDet(hit2->geographicalId())->surface().toGlobal(hit2->localPosition());
 
 		  if (m_fillHists) {
 		     m_xdiff->Fill(pos1.x() - pos2.x());

--- a/HLTrigger/special/src/HLTCSCRing2or3Filter.cc
+++ b/HLTrigger/special/src/HLTCSCRing2or3Filter.cc
@@ -22,7 +22,7 @@ HLTCSCRing2or3Filter::HLTCSCRing2or3Filter(const edm::ParameterSet& iConfig) : H
   cscrechitsToken = consumes<CSCRecHit2DCollection>(m_input);
 }
 
-HLTCSCRing2or3Filter::~HLTCSCRing2or3Filter() { }
+HLTCSCRing2or3Filter::~HLTCSCRing2or3Filter() = default;
 
 void
 HLTCSCRing2or3Filter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -44,17 +44,17 @@ bool HLTCSCRing2or3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& 
 
    std::map<int, std::vector<const CSCRecHit2D*> > chamber_tohit;
 
-   for (CSCRecHit2DCollection::const_iterator hit = hits->begin();  hit != hits->end();  ++hit) {
-      CSCDetId id(hit->geographicalId());
+   for (auto const & hit : *hits) {
+      CSCDetId id(hit.geographicalId());
       int chamber_id = CSCDetId(id.endcap(), id.station(), id.ring(), id.chamber(), 0).rawId();
 
       if (id.ring() == 2  ||  id.ring() == 3) {
 	 std::map<int, std::vector<const CSCRecHit2D*> >::const_iterator chamber_iter = chamber_tohit.find(chamber_id);
 	 if (chamber_iter == chamber_tohit.end()) {
 	    std::vector<const CSCRecHit2D*> newlist;
-	    newlist.push_back(&(*hit));
+	    newlist.push_back(&hit);
 	 }
-	 chamber_tohit[chamber_id].push_back(&(*hit));
+	 chamber_tohit[chamber_id].push_back(&hit);
       } // end if this ring is selected
    } // end loop over hits
 
@@ -70,8 +70,8 @@ bool HLTCSCRing2or3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& 
 	 }
 
 	 unsigned int pairs_in_window = 0;
-	 for (std::vector<const CSCRecHit2D*>::const_iterator hit1 = chamber_iter->second.begin();  hit1 != chamber_iter->second.end();  ++hit1) {
-	    for (std::vector<const CSCRecHit2D*>::const_iterator hit2 = chamber_iter->second.begin();  hit2 != hit1;  ++hit2) {
+	 for (auto hit1 = chamber_iter->second.begin();  hit1 != chamber_iter->second.end();  ++hit1) {
+	    for (auto hit2 = chamber_iter->second.begin();  hit2 != hit1;  ++hit2) {
 	       GlobalPoint pos1 = cscGeometry->idToDet((*hit1)->geographicalId())->surface().toGlobal((*hit1)->localPosition());
 	       GlobalPoint pos2 = cscGeometry->idToDet((*hit2)->geographicalId())->surface().toGlobal((*hit2)->localPosition());
 

--- a/HLTrigger/special/src/HLTCaloTowerFilter.cc
+++ b/HLTrigger/special/src/HLTCaloTowerFilter.cc
@@ -33,11 +33,11 @@
 class HLTCaloTowerFilter : public HLTFilter {
 public:
   explicit HLTCaloTowerFilter(const edm::ParameterSet&);
-  ~HLTCaloTowerFilter();
+  ~HLTCaloTowerFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
@@ -102,8 +102,8 @@ HLTCaloTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, t
 
   // look at all objects, check cuts and add to filter object
   unsigned int n = 0;
-  for (CaloTowerCollection::const_iterator i = caloTowers->begin(); i != caloTowers->end(); ++i) {
-    if ( (i->pt() >= min_Pt_) and ( (max_Eta_ < 0.0) or (std::abs(i->eta()) <= max_Eta_) ) )
+  for (auto const & i : *caloTowers) {
+    if ( (i.pt() >= min_Pt_) and ( (max_Eta_ < 0.0) or (std::abs(i.eta()) <= max_Eta_) ) )
       ++n;
       //edm::Ref<CaloTowerCollection> ref(towers, std::distance(caloTowers->begin(), i));
       //filterproduct.addObject(TriggerJet, ref);

--- a/HLTrigger/special/src/HLTDTActivityFilter.cc
+++ b/HLTrigger/special/src/HLTDTActivityFilter.cc
@@ -93,9 +93,7 @@ HLTDTActivityFilter::HLTDTActivityFilter(const edm::ParameterSet& iConfig) : HLT
 }
 
 
-HLTDTActivityFilter::~HLTDTActivityFilter() {
-
-}
+HLTDTActivityFilter::~HLTDTActivityFilter() = default;
 
 void
 HLTDTActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -148,8 +146,8 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
     edm::Handle<L1MuDTChambPhContainer> l1DTTPGPh;
     iEvent.getByToken(inputDCCToken_,l1DTTPGPh);
     vector<L1MuDTChambPhDigi> const*  phTrigs = l1DTTPGPh->getContainer();
-    vector<L1MuDTChambPhDigi>::const_iterator iph  = phTrigs->begin();
-    vector<L1MuDTChambPhDigi>::const_iterator iphe = phTrigs->end();
+    auto iph  = phTrigs->begin();
+    auto iphe = phTrigs->end();
 
     for(; iph !=iphe ; ++iph) {
 
@@ -249,8 +247,8 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 	int bx = (*candIt).bx();
 
 	if (bx>=minBX_[RPC] && bx<=maxBX_[RPC]) {
-	  activityMap::iterator actMapIt  = actMap.begin();
-	  activityMap::iterator actMapEnd = actMap.end();
+	  auto actMapIt  = actMap.begin();
+	  auto actMapEnd = actMap.end();
 	  for (; actMapIt!= actMapEnd; ++ actMapIt)
 	    if (matchChamber(actMapIt->first, *candIt, dtGeom.product()))
 	      actMapIt->second.set(RPC);

--- a/HLTrigger/special/src/HLTDTROMonitorFilter.cc
+++ b/HLTrigger/special/src/HLTDTROMonitorFilter.cc
@@ -24,7 +24,7 @@ HLTDTROMonitorFilter::HLTDTROMonitorFilter(const edm::ParameterSet& pset)
   inputToken = consumes<FEDRawDataCollection>(inputLabel);
 }
 
-HLTDTROMonitorFilter::~HLTDTROMonitorFilter(){}
+HLTDTROMonitorFilter::~HLTDTROMonitorFilter()= default;
 
 void
 HLTDTROMonitorFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTDummyCollections.cc
+++ b/HLTrigger/special/src/HLTDummyCollections.cc
@@ -70,11 +70,11 @@ Implementation:
 class HLTDummyCollections : public edm::EDProducer {
   public:
     explicit HLTDummyCollections(const edm::ParameterSet&);
-    ~HLTDummyCollections();
+    ~HLTDummyCollections() override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
 
   private:
-    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
     // ----------member data ---------------------------
 

--- a/HLTrigger/special/src/HLTDynamicPrescaler.cc
+++ b/HLTrigger/special/src/HLTDynamicPrescaler.cc
@@ -8,7 +8,7 @@
 class HLTDynamicPrescaler : public edm::EDFilter {
 public:
   explicit HLTDynamicPrescaler(edm::ParameterSet const & configuration);
-  ~HLTDynamicPrescaler();
+  ~HLTDynamicPrescaler() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   bool filter(edm::Event & event, edm::EventSetup const & setup) override;
 
@@ -22,8 +22,7 @@ HLTDynamicPrescaler::HLTDynamicPrescaler(edm::ParameterSet const & configuration
   m_scale(1) { 
 }
 
-HLTDynamicPrescaler::~HLTDynamicPrescaler() {
-}
+HLTDynamicPrescaler::~HLTDynamicPrescaler() = default;
 
 void
 HLTDynamicPrescaler::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTEcalIsolationFilter.cc
+++ b/HLTrigger/special/src/HLTEcalIsolationFilter.cc
@@ -21,7 +21,7 @@ HLTEcalIsolationFilter::HLTEcalIsolationFilter(const edm::ParameterSet& iConfig)
   candToken_ = consumes<reco::IsolatedPixelTrackCandidateCollection>(candTag_);
 }
 
-HLTEcalIsolationFilter::~HLTEcalIsolationFilter(){}
+HLTEcalIsolationFilter::~HLTEcalIsolationFilter()= default;
 
 void
 HLTEcalIsolationFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTEcalPhiSymFilter.cc
+++ b/HLTrigger/special/src/HLTEcalPhiSymFilter.cc
@@ -35,8 +35,7 @@ HLTEcalPhiSymFilter::HLTEcalPhiSymFilter(const edm::ParameterSet& config) :
 }
 
 
-HLTEcalPhiSymFilter::~HLTEcalPhiSymFilter()
-{}
+HLTEcalPhiSymFilter::~HLTEcalPhiSymFilter() = default;
 
 void
 HLTEcalPhiSymFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTEcalPixelIsolTrackFilter.cc
+++ b/HLTrigger/special/src/HLTEcalPixelIsolTrackFilter.cc
@@ -16,7 +16,7 @@ HLTEcalPixelIsolTrackFilter::HLTEcalPixelIsolTrackFilter(const edm::ParameterSet
   candTok = consumes<reco::IsolatedPixelTrackCandidateCollection>(candTag_);
 }
 
-HLTEcalPixelIsolTrackFilter::~HLTEcalPixelIsolTrackFilter(){}
+HLTEcalPixelIsolTrackFilter::~HLTEcalPixelIsolTrackFilter()= default;
 
 void HLTEcalPixelIsolTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/HLTrigger/special/src/HLTEcalResonanceFilter.cc
+++ b/HLTrigger/special/src/HLTEcalResonanceFilter.cc
@@ -231,7 +231,7 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   edm::ESHandle<CaloGeometry> geoHandle;
   iSetup.get<CaloGeometryRecord>().get(geoHandle); 
   const CaloSubdetectorGeometry *geometry_es = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  CaloSubdetectorTopology *topology_es=0;
+  CaloSubdetectorTopology *topology_es=nullptr;
   if (geometry_es) {
     topology_es  = new EcalPreshowerTopology(geoHandle);
   }else{
@@ -278,51 +278,47 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
     
     
     ///Now save all rechits in the selected clusters
-    for(int i = 0; i < int(indClusSelected.size()); i++){
-      int ind = indClusSelected[i];
-      reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection_eb->begin() + ind; 
+    for(int ind : indClusSelected){
+      auto it_bc3 = clusterCollection_eb->begin() + ind; 
       const std::vector< std::pair<DetId, float> > &vid =  it_bc3->hitsAndFractions(); 
-      for (std::vector<std::pair<DetId,float> >::const_iterator idItr = vid.begin();idItr != vid.end ();++idItr){
-	EcalRecHitCollection::const_iterator hit  = hitCollection_eb->find(idItr->first);
+      for (auto const & idItr : vid){
+	auto hit  = hitCollection_eb->find(idItr.first);
 	if( hit == hitCollection_eb->end()) continue;  //this should not happen.
 	selEBRecHitCollection->push_back(*hit); 
-	selectedEBDetIds.push_back(idItr->first);
+	selectedEBDetIds.push_back(idItr.first);
       }
     }
     
     
     if( store5x5RecHitEB_ ){
       ///stroe 5x5 of good clusters, 5x5 arleady got 
-      for(int i = 0; i < int( indCandClus.size()); i++){
-	int ind = indCandClus[i];
-	vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
-	for(int n=0; n< int(v5x5.size()); n++){
-	  DetId ed = v5x5[n].id(); 
-	  std::vector<DetId>::iterator itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed); 
+      for(int ind : indCandClus){
+		vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
+	for(auto & n : v5x5){
+	  DetId ed = n.id(); 
+	  auto itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed); 
 	  if( itdet == selectedEBDetIds.end()){
 	    selectedEBDetIds.push_back(ed); 
-	    selEBRecHitCollection->push_back(v5x5[n]);
+	    selEBRecHitCollection->push_back(n);
 	  }
 	}
       }
       
       
       ///store 5x5 of Iso clusters, need to getWindow of 5x5 
-      for(int i = 0; i < int( indIsoClus.size()); i++){
-	int ind = indIsoClus[i];
-	
-	std::vector<int>::iterator  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
+      for(int ind : indIsoClus){
+		auto  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
 	if( it != indCandClus.end()) continue; 
 	
-	reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection_eb->begin() + ind;
+	auto it_bc3 = clusterCollection_eb->begin() + ind;
 	DetId seedId = it_bc3->seed();
 	std::vector<DetId> clus_v5x5 = topology_eb->getWindow(seedId,5,5);
 	for( std::vector<DetId>::const_iterator idItr = clus_v5x5.begin(); idItr != clus_v5x5.end(); idItr++){
 	  DetId ed = *idItr;
-	  EcalRecHitCollection::const_iterator rit = hitCollection_eb->find( ed );
+	  auto rit = hitCollection_eb->find( ed );
 	  if ( rit == hitCollection_eb->end() ) continue;
 	  if( ! checkStatusOfEcalRecHit(channelStatus, *rit) ) continue; 
-	  std::vector<DetId>::iterator itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed);
+	  auto itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed);
 	  if( itdet == selectedEBDetIds.end()){
 	    selectedEBDetIds.push_back(ed);
 	    selEBRecHitCollection->push_back(*rit);
@@ -387,26 +383,25 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
 		 indCandClus,indIsoClus, indClusSelected);
     
     ///Now save all rechits in the selected clusters
-    for(int i = 0; i < int(indClusSelected.size()); i++){
-      int ind = indClusSelected[i];
-      reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection_ee->begin() + ind; 
+    for(int ind : indClusSelected){
+      auto it_bc3 = clusterCollection_ee->begin() + ind; 
       const std::vector< std::pair<DetId, float> > &vid =  it_bc3->hitsAndFractions(); 
-      for (std::vector<std::pair<DetId,float> >::const_iterator idItr = vid.begin();idItr != vid.end ();++idItr){
-	EcalRecHitCollection::const_iterator hit  = hitCollection_ee->find(idItr->first);
+      for (auto const & idItr : vid){
+	auto hit  = hitCollection_ee->find(idItr.first);
 	if( hit == hitCollection_ee->end()) continue;  //this should not happen.
 	selEERecHitCollection->push_back(*hit); 
-	selectedEEDetIds.push_back(idItr->first);
+	selectedEEDetIds.push_back(idItr.first);
       }
       ///save preshower rechits 
       if(storeRecHitES_){
 	std::set<DetId> used_strips_before = m_used_strips;  
 	makeClusterES(it_bc3->x(),it_bc3->y(),it_bc3->z(),geometry_es,topology_es);
-	std::set<DetId>::const_iterator ites = m_used_strips.begin();
+	auto ites = m_used_strips.begin();
 	for(; ites != m_used_strips.end(); ++ ites ){
 	  ESDetId d1 = ESDetId(*ites);
-	  std::set<DetId>::const_iterator ites2 = find(used_strips_before.begin(),used_strips_before.end(),d1);
+	  auto ites2 = find(used_strips_before.begin(),used_strips_before.end(),d1);
 	  if( (ites2 == used_strips_before.end())){
-	    std::map<DetId, EcalRecHit>::iterator itmap = m_esrechit_map.find(d1);
+	    auto itmap = m_esrechit_map.find(d1);
 	    selESRecHitCollection->push_back(itmap->second);
 	  }
 	}
@@ -416,36 +411,33 @@ HLTEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
 
     if( store5x5RecHitEE_ ){
       ///store 5x5 of good clusters, 5x5 arleady got 
-      for(int i = 0; i < int( indCandClus.size()); i++){
-	int ind = indCandClus[i];
-	vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
-	for(int n=0; n< int(v5x5.size()); n++){
-	  DetId ed = v5x5[n].id(); 
-	  std::vector<DetId>::iterator itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed); 
+      for(int ind : indCandClus){
+		vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
+	for(auto & n : v5x5){
+	  DetId ed = n.id(); 
+	  auto itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed); 
 	  if( itdet == selectedEEDetIds.end()){
 	    selectedEEDetIds.push_back(ed); 
-	    selEERecHitCollection->push_back(v5x5[n]);
+	    selEERecHitCollection->push_back(n);
 	  }
 	}
       }
       
       
       ///store 5x5 of Iso clusters, need to getWindow of 5x5 
-      for(int i = 0; i < int( indIsoClus.size()); i++){
-	int ind = indIsoClus[i];
-	
-	std::vector<int>::iterator  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
+      for(int ind : indIsoClus){
+		auto  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
 	if( it != indCandClus.end()) continue; 
 	
-	reco::BasicClusterCollection::const_iterator	it_bc3 = clusterCollection_ee->begin() + ind;
+	auto	it_bc3 = clusterCollection_ee->begin() + ind;
 	DetId seedId = it_bc3->seed();
 	std::vector<DetId> clus_v5x5 = topology_ee->getWindow(seedId,5,5);
 	for( std::vector<DetId>::const_iterator idItr = clus_v5x5.begin(); idItr != clus_v5x5.end(); idItr++){
 	  DetId ed = *idItr;
-	  EcalRecHitCollection::const_iterator rit = hitCollection_ee->find( ed );
+	  auto rit = hitCollection_ee->find( ed );
 	  if ( rit == hitCollection_ee->end() ) continue;
 	  if( ! checkStatusOfEcalRecHit(channelStatus, *rit) ) continue; 
-	  std::vector<DetId>::iterator itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed);
+	  auto itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed);
 	  if( itdet == selectedEEDetIds.end()){
 	    selectedEEDetIds.push_back(ed);
 	    selEERecHitCollection->push_back(*rit);
@@ -501,15 +493,15 @@ void HLTEcalResonanceFilter::doSelection(int detector, const reco::BasicClusterC
   
   vector<int> indClusPi0Candidates;  ///those clusters identified as pi0s
   if( detector ==EcalBarrel && removePi0CandidatesForEta_){
-    for( reco::BasicClusterCollection::const_iterator it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
-      for( reco::BasicClusterCollection::const_iterator it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
+    for( auto it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
+      for( auto it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
 	float m_pair,pt_pair,eta_pair, phi_pair; 
 	calcPaircluster(*it_bc,*it_bc2, m_pair, pt_pair,eta_pair,phi_pair); 
 	if(m_pair > massLowPi0Cand_ && m_pair < massHighPi0Cand_){
 	  int indtmp[2]={ int( it_bc - clusterCollection->begin()), int( it_bc2 - clusterCollection->begin())};
-	  for( int k=0;k<2; k++){
-	    std::vector<int>::iterator it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),indtmp[k]);
-	    if( it == indClusPi0Candidates.end()) indClusPi0Candidates.push_back(indtmp[k]);
+	  for(int & k : indtmp){
+	    auto it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),k);
+	    if( it == indClusPi0Candidates.end()) indClusPi0Candidates.push_back(k);
 	  }
 	}
       }
@@ -548,10 +540,10 @@ void HLTEcalResonanceFilter::doSelection(int detector, const reco::BasicClusterC
 
   map<int,bool> passShowerShape_clus;  //if this cluster passed showershape cut, so no need to compute the quantity again for each loop
   
-  for( reco::BasicClusterCollection::const_iterator it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
+  for( auto it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
     
     if( detector ==EcalBarrel && removePi0CandidatesForEta_){
-      std::vector<int>::iterator it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc - clusterCollection->begin()) );
+      auto it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc - clusterCollection->begin()) );
       if( it != indClusPi0Candidates.end()) continue; 
     }
     
@@ -560,16 +552,16 @@ void HLTEcalResonanceFilter::doSelection(int detector, const reco::BasicClusterC
     float pt1 = en1*sin(theta1);
  
     int ind1 = int( it_bc - clusterCollection->begin() );
-    std::map<int,bool>::iterator  itmap = passShowerShape_clus.find(ind1);
+    auto  itmap = passShowerShape_clus.find(ind1);
     if( itmap != passShowerShape_clus.end()){
       if( itmap->second == false){
 	continue; 
       }
     }
     
-    for( reco::BasicClusterCollection::const_iterator it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
+    for( auto it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
       if( detector ==EcalBarrel && removePi0CandidatesForEta_){
-	std::vector<int>::iterator it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc2 - clusterCollection->begin()) );
+	auto it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc2 - clusterCollection->begin()) );
 	if( it != indClusPi0Candidates.end()) continue; 
       }
       float en2 = it_bc2 ->energy();
@@ -577,7 +569,7 @@ void HLTEcalResonanceFilter::doSelection(int detector, const reco::BasicClusterC
       float pt2 = en2*sin(theta2);
       
       int ind2 = int( it_bc2 - clusterCollection->begin() );
-      std::map<int,bool>::iterator  itmap = passShowerShape_clus.find(ind2);
+      auto  itmap = passShowerShape_clus.find(ind2);
       if( itmap != passShowerShape_clus.end()){
 	if( itmap->second == false){
 	  continue; 
@@ -617,7 +609,7 @@ void HLTEcalResonanceFilter::doSelection(int detector, const reco::BasicClusterC
       IsoClus.push_back(ind2); 
       
       float Iso = 0;
-      for( reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection->begin(); it_bc3 != clusterCollection->end();it_bc3++){
+      for( auto it_bc3 = clusterCollection->begin(); it_bc3 != clusterCollection->end();it_bc3++){
 	if( it_bc3->seed() == it_bc->seed() || it_bc3->seed() == it_bc2->seed()) continue; 
 	float drcl = GetDeltaR(eta_pair,it_bc3->eta(),phi_pair,it_bc3->phi()); 
 	float dretacl = fabs( eta_pair - it_bc3->eta()); 
@@ -635,8 +627,8 @@ void HLTEcalResonanceFilter::doSelection(int detector, const reco::BasicClusterC
       bool failShowerShape = false;
       for(int n=0; n<2; n++){
 	int ind = IsoClus[n];
-	reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection->begin() + ind; 
-	std::map<int,bool>::iterator  itmap = passShowerShape_clus.find(ind);
+	auto it_bc3 = clusterCollection->begin() + ind; 
+	auto  itmap = passShowerShape_clus.find(ind);
 	if( itmap != passShowerShape_clus.end()){
 	  if( itmap->second == false){
 	    failShowerShape = true; 
@@ -667,16 +659,16 @@ void HLTEcalResonanceFilter::doSelection(int detector, const reco::BasicClusterC
 	int ind = IsoClus[iii];
 	
 	if( iii < 2){
-	  std::vector<int>::iterator it = find(indCandClus.begin(),indCandClus.end(), ind);  ///good cluster 
+	  auto it = find(indCandClus.begin(),indCandClus.end(), ind);  ///good cluster 
 	  if( it == indCandClus.end()) indCandClus.push_back(ind);
 	  else continue; 
 	}else{
-	  std::vector<int>::iterator it = find(indIsoClus.begin(),indIsoClus.end(), ind);  //iso cluster 
+	  auto it = find(indIsoClus.begin(),indIsoClus.end(), ind);  //iso cluster 
 	  if( it == indIsoClus.end()) indIsoClus.push_back(ind);
 	  else continue; 
 	}
 	
-	std::vector<int>::iterator it = find(indClusSelected.begin(),indClusSelected.end(),ind); 
+	auto it = find(indClusSelected.begin(),indClusSelected.end(),ind); 
 	if( it != indClusSelected.end()) continue; 
 	indClusSelected.push_back(ind);
       }
@@ -784,14 +776,14 @@ void HLTEcalResonanceFilter::calcShowerShape(const reco::BasicCluster &bc,   con
 	dx = x-seedx;
 	dy = y-seedy; 
       }
-      EcalRecHitCollection::const_iterator rit = recHits->find( ed );
+      auto rit = recHits->find( ed );
       if ( rit == recHits->end() ) continue; 
       if( ! checkStatusOfEcalRecHit(channelStatus, *rit) ) continue; 
       
       float energy = (*rit).energy();
       e5x5 += energy; 
       
-      std::vector<std::pair<DetId,float> >::const_iterator idItrF = std::find( vid.begin(),vid.end(), std::make_pair(ed,1.0f));  ///has to add "f", make it float 
+      auto idItrF = std::find( vid.begin(),vid.end(), std::make_pair(ed,1.0f));  ///has to add "f", make it float 
       if( idItrF == vid.end()){ ///only store those not belonging to this cluster
 	rechit5x5.push_back(*rit);
       }else{ /// S4, S9 are defined inside the cluster, the same as below. 
@@ -808,8 +800,8 @@ void HLTEcalResonanceFilter::calcShowerShape(const reco::BasicCluster &bc,   con
     
   }else{
     
-    for (std::vector<std::pair<DetId,float> >::const_iterator idItr = vid.begin();idItr != vid.end ();++idItr){
-      DetId ed = idItr->first; 
+    for (auto const & idItr : vid){
+      DetId ed = idItr.first; 
       if( InBarrel == true){
 	EBDetId ebd = EBDetId(ed); 
 	x = ebd.ieta();
@@ -824,7 +816,7 @@ void HLTEcalResonanceFilter::calcShowerShape(const reco::BasicCluster &bc,   con
 	dx = x-seedx;
 	dy = y-seedy; 
       }
-      EcalRecHitCollection::const_iterator rit = recHits->find( ed );
+      auto rit = recHits->find( ed );
       if ( rit == recHits->end() ) {
 	continue; 
       }

--- a/HLTrigger/special/src/HLTEcalTowerFilter.cc
+++ b/HLTrigger/special/src/HLTEcalTowerFilter.cc
@@ -30,11 +30,11 @@
 class HLTEcalTowerFilter : public HLTFilter {
 public:
   explicit HLTEcalTowerFilter(const edm::ParameterSet &);
-  ~HLTEcalTowerFilter();
+  ~HLTEcalTowerFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
   edm::InputTag inputTag_; // input tag identifying product
@@ -61,9 +61,7 @@ HLTEcalTowerFilter::HLTEcalTowerFilter(const edm::ParameterSet& config) : HLTFil
                << min_N_ ;
 }
 
-HLTEcalTowerFilter::~HLTEcalTowerFilter()
-{
-}
+HLTEcalTowerFilter::~HLTEcalTowerFilter() = default;
 
 void
 HLTEcalTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -104,8 +102,8 @@ HLTEcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, t
 
   // look at all objects, check cuts and add to filter object
   int n = 0;
-  for (CaloTowerCollection::const_iterator i = towers->begin(); i != towers->end(); ++i) {
-    if (i->emEnergy() >= min_E_ and fabs(i->eta()) <= max_Eta_) {
+  for (auto const & i : *towers) {
+    if (i.emEnergy() >= min_E_ and fabs(i.eta()) <= max_Eta_) {
       ++n;
       //edm::Ref<CaloTowerCollection> ref(towers, std::distance(towers->begin(), i));
       //filterproduct.addObject(TriggerJet, ref);

--- a/HLTrigger/special/src/HLTFEDSizeFilter.cc
+++ b/HLTrigger/special/src/HLTFEDSizeFilter.cc
@@ -40,11 +40,11 @@
 class HLTFEDSizeFilter : public HLTFilter {
 public:
     explicit HLTFEDSizeFilter(const edm::ParameterSet&);
-    ~HLTFEDSizeFilter();
+    ~HLTFEDSizeFilter() override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+    bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
     // ----------member data ---------------------------
     edm::EDGetTokenT<FEDRawDataCollection> RawCollectionToken_;

--- a/HLTrigger/special/src/HLTHFAsymmetryFilter.cc
+++ b/HLTrigger/special/src/HLTHFAsymmetryFilter.cc
@@ -12,9 +12,7 @@ HLTHFAsymmetryFilter::HLTHFAsymmetryFilter(const edm::ParameterSet& iConfig)
 }
 
 
-HLTHFAsymmetryFilter::~HLTHFAsymmetryFilter()
-{
-}
+HLTHFAsymmetryFilter::~HLTHFAsymmetryFilter() = default;
 
 void
 HLTHFAsymmetryFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -43,18 +41,18 @@ HLTHFAsymmetryFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   double e_hf[2] = {0.,0.};
 
   //Select interesting HFRecHits
-  for (HFRecHitCollection::const_iterator it=HFRecHitsH->begin(); it!=HFRecHitsH->end(); it++) {
-    if (it->energy()>eCut_HF_) 
+  for (auto const & it : *HFRecHitsH) {
+    if (it.energy()>eCut_HF_) 
     {
-      if (it->id().zside() == -1)
+      if (it.id().zside() == -1)
       {
 	++n_hf[0];
-	e_hf[0] += it->energy();
+	e_hf[0] += it.energy();
       }
       else
       {
 	++n_hf[1];
-	e_hf[1] += it->energy();
+	e_hf[1] += it.energy();
       }
     }
   }

--- a/HLTrigger/special/src/HLTHcalNoiseFilter.cc
+++ b/HLTrigger/special/src/HLTHcalNoiseFilter.cc
@@ -29,7 +29,7 @@ HLTHcalNoiseFilter::HLTHcalNoiseFilter(const edm::ParameterSet& iConfig) : HLTFi
   }
 }
 
-HLTHcalNoiseFilter::~HLTHcalNoiseFilter() { }
+HLTHcalNoiseFilter::~HLTHcalNoiseFilter() = default;
 
 void
 HLTHcalNoiseFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -81,15 +81,15 @@ bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
        TowerContainer.clear();
        JetContainer.clear();
        CaloTower seedTower;
-       for(CaloJetCollection::const_iterator calojetIter = calojetHandle->begin();calojetIter != calojetHandle->end();++calojetIter) {
-	 if( ((calojetIter->et())*cosh(calojetIter->eta()) > JetMinE_) and (calojetIter->energyFractionHadronic() > JetHCALminEnergyFraction_) ) {
-	   JetContainer.push_back(*calojetIter);
+       for(auto const & calojetIter : *calojetHandle) {
+	 if( ((calojetIter.et())*cosh(calojetIter.eta()) > JetMinE_) and (calojetIter.energyFractionHadronic() > JetHCALminEnergyFraction_) ) {
+	   JetContainer.push_back(calojetIter);
 	   double maxTowerE = 0.0;
-	   for(CaloTowerCollection::const_iterator kal = towerHandle->begin(); kal != towerHandle->end(); kal++) {
-	     double dR = deltaR((*calojetIter).eta(),(*calojetIter).phi(),(*kal).eta(),(*kal).phi());
-	     if( (dR < 0.50) and (kal->p() > maxTowerE) ) {
-	       maxTowerE = kal->p();
-	       seedTower = *kal;
+	   for(auto const & kal : *towerHandle) {
+	     double dR = deltaR(calojetIter.eta(),calojetIter.phi(),kal.eta(),kal.phi());
+	     if( (dR < 0.50) and (kal.p() > maxTowerE) ) {
+	       maxTowerE = kal.p();
+	       seedTower = kal;
 	     }
 	   }
 	   TowerContainer.push_back(seedTower);

--- a/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
+++ b/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
@@ -27,8 +27,7 @@ HLTHcalPhiSymFilter::HLTHcalPhiSymFilter(const edm::ParameterSet& iConfig) : HLT
 }
 
 
-HLTHcalPhiSymFilter::~HLTHcalPhiSymFilter()
-{}
+HLTHcalPhiSymFilter::~HLTHcalPhiSymFilter() = default;
 
 void
 HLTHcalPhiSymFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -65,27 +64,27 @@ HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
   std::unique_ptr< HFRecHitCollection > phiSymHFRecHitCollection( new HFRecHitCollection );
 
   //Select interesting HBHERecHits
-  for (HBHERecHitCollection::const_iterator it=HBHERecHitsH->begin(); it!=HBHERecHitsH->end(); it++) {
-    if (it->energy()>eCut_HB_&&it->id().subdet()==1) {
-        phiSymHBHERecHitCollection->push_back(*it);
+  for (auto const & it : *HBHERecHitsH) {
+    if (it.energy()>eCut_HB_&&it.id().subdet()==1) {
+        phiSymHBHERecHitCollection->push_back(it);
     }
-    if (it->energy()>eCut_HE_&&it->id().subdet()==2) {
-        phiSymHBHERecHitCollection->push_back(*it);
+    if (it.energy()>eCut_HE_&&it.id().subdet()==2) {
+        phiSymHBHERecHitCollection->push_back(it);
     }
 
   }
 
   //Select interesting HORecHits
-  for (HORecHitCollection::const_iterator it=HORecHitsH->begin(); it!=HORecHitsH->end(); it++) {
-    if (it->energy()>eCut_HO_&&it->id().subdet()==3) {
-      phiSymHORecHitCollection->push_back(*it);
+  for (auto const & it : *HORecHitsH) {
+    if (it.energy()>eCut_HO_&&it.id().subdet()==3) {
+      phiSymHORecHitCollection->push_back(it);
     }
   }
 
   //Select interesting HFRecHits
-  for (HFRecHitCollection::const_iterator it=HFRecHitsH->begin(); it!=HFRecHitsH->end(); it++) {
-    if (it->energy()>eCut_HF_&&it->id().subdet()==4) {
-      phiSymHFRecHitCollection->push_back(*it);
+  for (auto const & it : *HFRecHitsH) {
+    if (it.energy()>eCut_HF_&&it.id().subdet()==4) {
+      phiSymHFRecHitCollection->push_back(it);
     }
   }
 

--- a/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
+++ b/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
@@ -41,11 +41,11 @@
 class HLTHcalSimpleRecHitFilter : public HLTFilter {
 public:
     explicit HLTHcalSimpleRecHitFilter(const edm::ParameterSet&);
-    ~HLTHcalSimpleRecHitFilter();
+    ~HLTHcalSimpleRecHitFilter() override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+    bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
     // ----------member data ---------------------------
     edm::EDGetTokenT<HFRecHitCollection> HcalRecHitsToken_;
@@ -128,9 +128,7 @@ HLTHcalSimpleRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& 
     bool accept = false ;
 
     int nHitsNeg=0, nHitsPos=0;
-    for ( HFRecHitCollection::const_iterator hitItr = crudeHits->begin(); hitItr != crudeHits->end(); ++hitItr ) {
-       HFRecHit hit = (*hitItr);
-
+    for (auto hit : *crudeHits) {
        // masking noisy channels
        if (std::find( maskedList_.begin(), maskedList_.end(), hit.id().rawId() ) != maskedList_.end())
            continue;

--- a/HLTrigger/special/src/HLTHcalTowerFilter.cc
+++ b/HLTrigger/special/src/HLTHcalTowerFilter.cc
@@ -21,11 +21,11 @@ class HLTHcalTowerFilter : public HLTFilter
 {
 public:
   explicit HLTHcalTowerFilter(const edm::ParameterSet &);
-  ~HLTHcalTowerFilter();
+  ~HLTHcalTowerFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
   edm::InputTag inputTag_;    // input tag identifying product
@@ -77,9 +77,7 @@ HLTHcalTowerFilter::HLTHcalTowerFilter(const edm::ParameterSet& config) : HLTFil
   inputToken_ = consumes<CaloTowerCollection>(inputTag_);
 }
 
-HLTHcalTowerFilter::~HLTHcalTowerFilter()
-{
-}
+HLTHcalTowerFilter::~HLTHcalTowerFilter() = default;
 
 void
 HLTHcalTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -126,13 +124,13 @@ HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, t
   int n_HFP = 0;
   double abseta = 0.0;
   double eta = 0.0;
-  for(CaloTowerCollection::const_iterator i = towers->begin(); i != towers->end(); ++i)
+  for(auto const & i : *towers)
     {
-      eta    = i->eta();
+      eta    = i.eta();
       abseta = std::abs(eta);
       if(abseta<1.305)
 	{
-	  if(i->hadEnergy() >= min_E_HB_)
+	  if(i.hadEnergy() >= min_E_HB_)
 	    {
 	      n_HB++;
 	      //edm::Ref<CaloTowerCollection> ref(towers, std::distance(towers->begin(), i));
@@ -141,7 +139,7 @@ HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, t
 	}
       else if(abseta>=1.305 && abseta<3)
 	{
-	  if(i->hadEnergy() >= min_E_HE_)
+	  if(i.hadEnergy() >= min_E_HE_)
 	    {
 	      n_HE++;
 	      //edm::Ref<CaloTowerCollection> ref(towers, std::distance(towers->begin(), i));
@@ -150,7 +148,7 @@ HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, t
 	}
       else
 	{
-	  if(i->hadEnergy() >= min_E_HF_)
+	  if(i.hadEnergy() >= min_E_HF_)
 	    {
 	      n_HF++;
 	      //edm::Ref<CaloTowerCollection> ref(towers, std::distance(towers->begin(), i));

--- a/HLTrigger/special/src/HLTLogMonitorFilter.cc
+++ b/HLTrigger/special/src/HLTLogMonitorFilter.cc
@@ -37,7 +37,7 @@
 class HLTLogMonitorFilter : public edm::EDFilter {
 public:
     explicit HLTLogMonitorFilter(const edm::ParameterSet &);
-    ~HLTLogMonitorFilter();
+    ~HLTLogMonitorFilter() override;
 
     struct CategoryEntry {
       uint32_t threshold;       // configurable threshold, after which messages in this Category start to be logarithmically prescaled
@@ -79,13 +79,13 @@ public:
     // ---------- private methods -----------------------
 
     /// EDFilter accept method
-    virtual bool filter(edm::Event&, const edm::EventSetup &) override;
+    bool filter(edm::Event&, const edm::EventSetup &) override;
 
     /// EDFilter beginJob method
-    virtual void beginJob(void) override;
+    void beginJob() override;
 
     /// EDFilter endJob method
-    virtual void endJob(void) override;
+    void endJob() override;
 
     /// check if the requested category has a valid entry
     bool knownCategory(const std::string & category);
@@ -97,7 +97,7 @@ public:
     CategoryEntry & getCategory(const std::string & category);
 
     /// summarize to LogInfo
-    void summary(void);
+    void summary();
 
 
     // ---------- member data ---------------------------
@@ -129,18 +129,16 @@ HLTLogMonitorFilter::HLTLogMonitorFilter(const edm::ParameterSet & config) :
 
   typedef std::vector<edm::ParameterSet> VPSet; 
   const VPSet & categories = config.getParameter<VPSet>("categories");
-  for (VPSet::const_iterator category = categories.begin(); category != categories.end(); ++category) {
-    const std::string & name = category->getParameter<std::string>("name");
-    uint32_t threshold       = category->getParameter<uint32_t>("threshold");
+  for (auto const & categorie : categories) {
+    const std::string & name = categorie.getParameter<std::string>("name");
+    uint32_t threshold       = categorie.getParameter<uint32_t>("threshold");
     addCategory(name, threshold);
   }
 
   produces<std::vector<edm::ErrorSummaryEntry> >();
 }
 
-HLTLogMonitorFilter::~HLTLogMonitorFilter()
-{
-}
+HLTLogMonitorFilter::~HLTLogMonitorFilter() = default;
 
 //
 // member functions
@@ -189,11 +187,11 @@ bool HLTLogMonitorFilter::filter(edm::Event & event, const edm::EventSetup & set
 }
 
 // ------------ method called at the end of the Job ---------
-void HLTLogMonitorFilter::beginJob(void) {
+void HLTLogMonitorFilter::beginJob() {
   edm::EnableLoggedErrorsSummary();
 }
 // ------------ method called at the end of the Job ---------
-void HLTLogMonitorFilter::endJob(void) {
+void HLTLogMonitorFilter::endJob() {
   edm::DisableLoggedErrorsSummary();
   summary();
 }
@@ -215,7 +213,7 @@ HLTLogMonitorFilter::CategoryEntry & HLTLogMonitorFilter::addCategory(const std:
 /// return the entry for requested category, if it exists, or create a new one with the default threshold value
 HLTLogMonitorFilter::CategoryEntry & HLTLogMonitorFilter::getCategory(const std::string & category) {
   // check before inserting, to avoid the construction of a CategoryEntry object
-  CategoryMap::iterator i = m_data.find(category);
+  auto i = m_data.find(category);
   if (i != m_data.end())
     return i->second;
   else
@@ -223,7 +221,7 @@ HLTLogMonitorFilter::CategoryEntry & HLTLogMonitorFilter::getCategory(const std:
 }
 
 /// summarize to LogInfo
-void HLTLogMonitorFilter::summary(void) {
+void HLTLogMonitorFilter::summary() {
   std::stringstream out;
   out << "Log-Report ---------- HLTLogMonitorFilter Summary ------------\n"
       << "Log-Report  Threshold   Prescale     Issued   Accepted   Rejected Category\n";

--- a/HLTrigger/special/src/HLTMuonPointingFilter.cc
+++ b/HLTrigger/special/src/HLTMuonPointingFilter.cc
@@ -59,8 +59,7 @@ HLTMuonPointingFilter::HLTMuonPointingFilter(const edm::ParameterSet& pset) :
 }
 
 /// Destructor
-HLTMuonPointingFilter::~HLTMuonPointingFilter() {
-}
+HLTMuonPointingFilter::~HLTMuonPointingFilter() = default;
 
 /* Operations */
 bool HLTMuonPointingFilter::filter(edm::Event& event, const edm::EventSetup& eventSetup) {

--- a/HLTrigger/special/src/HLTPhysicsDeclared.cc
+++ b/HLTrigger/special/src/HLTPhysicsDeclared.cc
@@ -24,11 +24,11 @@
 class HLTPhysicsDeclared : public edm::EDFilter {
 public:
   explicit HLTPhysicsDeclared( const edm::ParameterSet & );
-  ~HLTPhysicsDeclared();
+  ~HLTPhysicsDeclared() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
 private:
-  virtual bool filter( edm::Event &, const edm::EventSetup & ) override;
+  bool filter( edm::Event &, const edm::EventSetup & ) override;
 
   bool          m_invert;
   edm::InputTag m_gtDigis;
@@ -51,9 +51,7 @@ HLTPhysicsDeclared::HLTPhysicsDeclared(const edm::ParameterSet & config) :
   m_gtDigisToken = consumes<L1GlobalTriggerReadoutRecord>(m_gtDigis);
 }
 
-HLTPhysicsDeclared::~HLTPhysicsDeclared()
-{
-}
+HLTPhysicsDeclared::~HLTPhysicsDeclared() = default;
 
 void
 HLTPhysicsDeclared::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTPixelActivityFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityFilter.cc
@@ -13,11 +13,11 @@
 class HLTPixelActivityFilter : public HLTFilter {
 public:
   explicit HLTPixelActivityFilter(const edm::ParameterSet&);
-  ~HLTPixelActivityFilter();
+  ~HLTPixelActivityFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::InputTag inputTag_;          // input tag identifying product containing pixel clusters
   unsigned int  min_clusters_;      // minimum number of clusters
@@ -49,9 +49,7 @@ HLTPixelActivityFilter::HLTPixelActivityFilter(const edm::ParameterSet& config) 
     LogDebug("") << "...but no more than " << max_clusters_ << " clusters";
 }
 
-HLTPixelActivityFilter::~HLTPixelActivityFilter()
-{
-}
+HLTPixelActivityFilter::~HLTPixelActivityFilter() = default;
 
 void
 HLTPixelActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityHFSumEnergyFilter.cc
@@ -22,9 +22,7 @@ HLTPixelActivityHFSumEnergyFilter::HLTPixelActivityHFSumEnergyFilter(const edm::
   LogDebug("") << "Using the " << inputTag_ << " input collection";
 }
 
-HLTPixelActivityHFSumEnergyFilter::~HLTPixelActivityHFSumEnergyFilter()
-{
-}
+HLTPixelActivityHFSumEnergyFilter::~HLTPixelActivityHFSumEnergyFilter() = default;
 
 void
 HLTPixelActivityHFSumEnergyFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -58,9 +56,9 @@ bool HLTPixelActivityHFSumEnergyFilter::filter(edm::Event& iEvent, const edm::Ev
 
   double sumE = 0.;
 
-  for (HFRecHitCollection::const_iterator it=HFRecHitsH->begin(); it!=HFRecHitsH->end(); it++) {
-    if (it->energy()>eCut_HF_) {
-      sumE += it->energy();
+  for (auto const & it : *HFRecHitsH) {
+    if (it.energy()>eCut_HF_) {
+      sumE += it.energy();
     }
   }
 

--- a/HLTrigger/special/src/HLTPixelAsymmetryFilter.cc
+++ b/HLTrigger/special/src/HLTPixelAsymmetryFilter.cc
@@ -28,9 +28,7 @@ HLTPixelAsymmetryFilter::HLTPixelAsymmetryFilter(const edm::ParameterSet& config
   LogDebug("") << "Only clusters with a charge larger than " << clus_thresh_ << " electrons will be used ";
 }
 
-HLTPixelAsymmetryFilter::~HLTPixelAsymmetryFilter()
-{
-}
+HLTPixelAsymmetryFilter::~HLTPixelAsymmetryFilter() = default;
 
 void
 HLTPixelAsymmetryFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
+++ b/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
@@ -13,7 +13,7 @@
 class HLTPixelClusterShapeFilter : public HLTFilter {
 public:
   explicit HLTPixelClusterShapeFilter(const edm::ParameterSet&);
-  ~HLTPixelClusterShapeFilter();
+  ~HLTPixelClusterShapeFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
@@ -35,7 +35,7 @@ private:
     float w;
   };
 
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
   int getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi) const;
 
 };
@@ -74,9 +74,7 @@ HLTPixelClusterShapeFilter::HLTPixelClusterShapeFilter(const edm::ParameterSet& 
   LogDebug("") << "Using the " << inputTag_ << " input collection";
 }
 
-HLTPixelClusterShapeFilter::~HLTPixelClusterShapeFilter()
-{
-}
+HLTPixelClusterShapeFilter::~HLTPixelClusterShapeFilter() = default;
 
 void
 HLTPixelClusterShapeFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -122,18 +120,17 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
     // loop over pixel rechits
     int nPxlHits=0;
     std::vector<VertexHit> vhits;
-    for(SiPixelRecHitCollection::DataContainer::const_iterator hit = hits->data().begin(),
-          end = hits->data().end(); hit != end; ++hit) {
-      if (!hit->isValid())
+    for(auto const & hit : hits->data()) {
+      if (!hit.isValid())
         continue;
       ++nPxlHits;
-      DetId id(hit->geographicalId());
+      DetId id(hit.geographicalId());
       if(id.subdetId() != int(PixelSubdetector::PixelBarrel))
         continue;
       const PixelGeomDetUnit *pgdu = static_cast<const PixelGeomDetUnit*>(tgeo->idToDet(id));
       if (1) {
         const PixelTopology *pixTopo = &(pgdu->specificTopology());
-        std::vector<SiPixelCluster::Pixel> pixels(hit->cluster()->pixels());
+        std::vector<SiPixelCluster::Pixel> pixels(hit.cluster()->pixels());
         bool pixelOnEdge = false;
         for(std::vector<SiPixelCluster::Pixel>::const_iterator pixel = pixels.begin();
             pixel != pixels.end(); ++pixel) {
@@ -148,14 +145,14 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
           continue;
       }
 
-      LocalPoint lpos = LocalPoint(hit->localPosition().x(),
-				   hit->localPosition().y(),
-				   hit->localPosition().z());
+      LocalPoint lpos = LocalPoint(hit.localPosition().x(),
+				   hit.localPosition().y(),
+				   hit.localPosition().z());
       GlobalPoint gpos = pgdu->toGlobal(lpos);
       VertexHit vh;
       vh.z = gpos.z();
       vh.r = gpos.perp();
-      vh.w = hit->cluster()->sizeY();
+      vh.w = hit.cluster()->sizeY();
       vhits.push_back(vh);
     }
 
@@ -214,10 +211,10 @@ int HLTPixelClusterShapeFilter::getContainedHits(const std::vector<VertexHit> &h
   int n = 0;
   chi   = 0.;
 
-  for(std::vector<VertexHit>::const_iterator hit = hits.begin(); hit!= hits.end(); hit++) {
-    double p = 2 * fabs(hit->z - z0)/hit->r + 0.5; // FIXME
-    if(fabs(p - hit->w) <= 1.) {
-      chi += fabs(p - hit->w);
+  for(auto hit : hits) {
+    double p = 2 * fabs(hit.z - z0)/hit.r + 0.5; // FIXME
+    if(fabs(p - hit.w) <= 1.) {
+      chi += fabs(p - hit.w);
       n++;
     }
   }

--- a/HLTrigger/special/src/HLTPixelIsolTrackFilter.cc
+++ b/HLTrigger/special/src/HLTPixelIsolTrackFilter.cc
@@ -25,7 +25,7 @@ HLTPixelIsolTrackFilter::HLTPixelIsolTrackFilter(const edm::ParameterSet& iConfi
   hltGTseedToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(hltGTseedlabel_);
 }
 
-HLTPixelIsolTrackFilter::~HLTPixelIsolTrackFilter(){}
+HLTPixelIsolTrackFilter::~HLTPixelIsolTrackFilter()= default;
 
 
 void
@@ -74,15 +74,15 @@ bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   l1trigobj->getObjects(trigger::TriggerL1CenJet, l1jetobjref);
   l1trigobj->getObjects(trigger::TriggerL1ForJet, l1forjetobjref);
 
-  for (unsigned int p=0; p<l1tauobjref.size(); p++)
-    if (l1tauobjref[p]->pt() > ptTriggered)
-      ptTriggered = l1tauobjref[p]->pt();
-  for (unsigned int p=0; p<l1jetobjref.size(); p++)
-    if (l1jetobjref[p]->pt() > ptTriggered)
-      ptTriggered = l1jetobjref[p]->pt();
-  for (unsigned int p=0; p<l1forjetobjref.size(); p++)
-    if (l1forjetobjref[p]->pt() > ptTriggered)
-      ptTriggered = l1forjetobjref[p]->pt();
+  for (auto & p : l1tauobjref)
+    if (p->pt() > ptTriggered)
+      ptTriggered = p->pt();
+  for (auto & p : l1jetobjref)
+    if (p->pt() > ptTriggered)
+      ptTriggered = p->pt();
+  for (auto & p : l1forjetobjref)
+    if (p->pt() > ptTriggered)
+      ptTriggered = p->pt();
 
   int n=0;
   for (unsigned int i=0; i<recotrackcands->size(); i++) {

--- a/HLTrigger/special/src/HLTPixelIsolTrackL1TFilter.cc
+++ b/HLTrigger/special/src/HLTPixelIsolTrackL1TFilter.cc
@@ -27,7 +27,7 @@ HLTPixelIsolTrackL1TFilter::HLTPixelIsolTrackL1TFilter(const edm::ParameterSet& 
   hltGTseedToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(hltGTseedlabel_);
 }
 
-HLTPixelIsolTrackL1TFilter::~HLTPixelIsolTrackL1TFilter(){}
+HLTPixelIsolTrackL1TFilter::~HLTPixelIsolTrackL1TFilter()= default;
 
 
 void

--- a/HLTrigger/special/src/HLTPixlMBFilt.cc
+++ b/HLTrigger/special/src/HLTPixlMBFilt.cc
@@ -41,9 +41,7 @@ HLTPixlMBFilt::HLTPixlMBFilt(const edm::ParameterSet& iConfig) : HLTFilter(iConf
   LogDebug("") << "Requesting tracks from same vertex eta-phi separation by " << min_sep_;
 }
 
-HLTPixlMBFilt::~HLTPixlMBFilt()
-{
-}
+HLTPixlMBFilt::~HLTPixlMBFilt() = default;
 
 void
 HLTPixlMBFilt::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -88,8 +86,8 @@ bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
    vector<double> phistore;
    vector<int> itstore;
    bool accept;
-   RecoChargedCandidateCollection::const_iterator apixl(tracks->begin());
-   RecoChargedCandidateCollection::const_iterator epixl(tracks->end());
+   auto apixl(tracks->begin());
+   auto epixl(tracks->end());
    RecoChargedCandidateCollection::const_iterator ipixl, jpixl;
    unsigned int nsame_vtx=0;
    int itrk = -1;
@@ -167,8 +165,7 @@ bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
    // we now move them to the filterproduct
 
    if (accept) {
-     for (unsigned int ipos=0; ipos < itstore.size(); ipos++) {
-       int iaddr=itstore.at(ipos);
+     for (int iaddr : itstore) {
        filterproduct.addObject(TriggerTrack,RecoChargedCandidateRef(tracks,iaddr));
      }
    }

--- a/HLTrigger/special/src/HLTPixlMBForAlignmentFilter.cc
+++ b/HLTrigger/special/src/HLTPixlMBForAlignmentFilter.cc
@@ -43,9 +43,7 @@ HLTPixlMBForAlignmentFilter::HLTPixlMBForAlignmentFilter(const edm::ParameterSet
   LogDebug("") << "Requesting track to be isolated within cone of " << min_isol_;
 }
 
-HLTPixlMBForAlignmentFilter::~HLTPixlMBForAlignmentFilter()
-{
-}
+HLTPixlMBForAlignmentFilter::~HLTPixlMBForAlignmentFilter() = default;
 
 void
 HLTPixlMBForAlignmentFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -90,8 +88,8 @@ bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::Event
    vector<double> ptstore;
    vector<int> itstore;
    bool accept = false;
-   RecoChargedCandidateCollection::const_iterator apixl(tracks->begin());
-   RecoChargedCandidateCollection::const_iterator epixl(tracks->end());
+   auto apixl(tracks->begin());
+   auto epixl(tracks->end());
    RecoChargedCandidateCollection::const_iterator ipixl, jpixl;
    int itrk = 0;
    double zvtxfit = 0.0;
@@ -157,10 +155,10 @@ bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::Event
              itsep.push_back(locisol.at(j));
            } else {
              bool is_separated = true;
-             for (unsigned int k=0; k<itsep.size(); k++){
+             for (int k : itsep){
 //             ...and the other ones, that are on the 'final acceptance' list already, if min_trks_ > 2
-               double phisep = phistore.at(itsep.at(k))-phistore.at(locisol.at(j));
-               double etasep = etastore.at(itsep.at(k))-etastore.at(locisol.at(j));
+               double phisep = phistore.at(k)-phistore.at(locisol.at(j));
+               double etasep = etastore.at(k)-etastore.at(locisol.at(j));
                double sep = sqrt(phisep*phisep + etasep*etasep);
                if (sep < min_sep_) {
 //               this one was no good, too close to some other already accepted
@@ -184,8 +182,8 @@ bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::Event
      // we now move them to the filterproduct
 
      if (accept) {
-       for (unsigned int ipos=0; ipos < itsep.size(); ipos++) {
-         int iaddr=itstore.at(itsep.at(ipos));
+       for (int ipos : itsep) {
+         int iaddr=itstore.at(ipos);
          filterproduct.addObject(TriggerTrack,RecoChargedCandidateRef(tracks,iaddr));
        }
        // std::cout << "Accept this event " << std::endl;

--- a/HLTrigger/special/src/HLTRPCTrigNoSyncFilter.cc
+++ b/HLTrigger/special/src/HLTRPCTrigNoSyncFilter.cc
@@ -160,14 +160,14 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 
     std::vector<RPC4DHit> PointsForGMT;
 
-    for(std::vector<RPC4DHit>::iterator Point = GlobalRPC4DHitsNoBx0.begin(); Point!=GlobalRPC4DHitsNoBx0.end(); ++Point){
-      float phiP = Point->gp.phi();
-      float etaP = Point->gp.eta();
+    for(auto & Point : GlobalRPC4DHitsNoBx0){
+      float phiP = Point.gp.phi();
+      float etaP = Point.gp.eta();
       //std::cout<<"\t \t GMT   phi="<<phi<<" eta="<<eta<<std::endl;
       //std::cout<<"\t \t Point phi="<<phiP<<" eta="<< etaP<<std::endl;
       //std::cout<<"\t \t "<<fabs(phi-phiP)<<" < 0,1? "<<fabs(eta-etaP)<<" < 0.20 ?"<<std::endl;
       if(fabs(phi-phiP) <=0.1 && fabs(eta-etaP)<=0.20){
-	PointsForGMT.push_back(*Point);
+	PointsForGMT.push_back(Point);
 	//std::cout<<"\t \t match!"<<std::endl;
       }
     }
@@ -189,7 +189,7 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
     bool incr = true;
 
     //std::cout<<"\t \t loop on the RPCHit4D!!!"<<std::endl;
-    for(std::vector<RPC4DHit>::iterator point = PointsForGMT.begin(); point < PointsForGMT.end(); ++point) {
+    for(auto point = PointsForGMT.begin(); point < PointsForGMT.end(); ++point) {
       //float r=point->gp.mag();
       outOfTime |= (point->bx!=0); //condition 1: at least one measurement must have BX!=0
       incr &= (point->bx>=lastbx); //condition 2: BX must be increase when going inside-out.

--- a/HLTrigger/special/src/HLTRechitsToDigis.cc
+++ b/HLTrigger/special/src/HLTRechitsToDigis.cc
@@ -42,13 +42,13 @@
 class HLTRechitsToDigis : public edm::stream::EDProducer<> {
 public:
   explicit HLTRechitsToDigis(const edm::ParameterSet&);
-  ~HLTRechitsToDigis();
+  ~HLTRechitsToDigis() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   enum ecalRegion {invalidRegion=0, barrel, endcap };  
   static const HLTRechitsToDigis::ecalRegion stringToRegion(const std::string& region);
 
 private:
-  virtual void produce( edm::Event&, edm::EventSetup const&) override;
+  void produce( edm::Event&, edm::EventSetup const&) override;
       
   // ----------member data ---------------------------  
   // tokens for the digi and rechits for matching

--- a/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
+++ b/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
@@ -309,7 +309,7 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
   edm::ESHandle<CaloGeometry> geoHandle;
   iSetup.get<CaloGeometryRecord>().get(geoHandle); 
   const CaloSubdetectorGeometry *geometry_es = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  CaloSubdetectorTopology *topology_es=0;
+  CaloSubdetectorTopology *topology_es=nullptr;
   if (geometry_es) {
     topology_es  = new EcalPreshowerTopology(geoHandle);
   }else{
@@ -357,51 +357,47 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
     
     
     ///Now save all rechits in the selected clusters
-    for(int i = 0; i < int(indClusSelected.size()); i++){
-      int ind = indClusSelected[i];
-      reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection_eb->begin() + ind; 
+    for(int ind : indClusSelected){
+      auto it_bc3 = clusterCollection_eb->begin() + ind; 
       const std::vector< std::pair<DetId, float> > &vid =  it_bc3->hitsAndFractions(); 
-      for (std::vector<std::pair<DetId,float> >::const_iterator idItr = vid.begin();idItr != vid.end ();++idItr){
-	EcalRecHitCollection::const_iterator hit  = hitCollection_eb->find(idItr->first);
+      for (auto const & idItr : vid){
+	auto hit  = hitCollection_eb->find(idItr.first);
 	if( hit == hitCollection_eb->end()) continue;  //this should not happen.
 	selEBRecHitCollection->push_back(*hit); 
-	selectedEBDetIds.push_back(idItr->first);
+	selectedEBDetIds.push_back(idItr.first);
       }
     }
     
     
     if( store5x5RecHitEB_ ){
       ///stroe 5x5 of good clusters, 5x5 arleady got 
-      for(int i = 0; i < int( indCandClus.size()); i++){
-	int ind = indCandClus[i];
-	vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
-	for(int n=0; n< int(v5x5.size()); n++){
-	  DetId ed = v5x5[n].id(); 
-	  std::vector<DetId>::iterator itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed); 
+      for(int ind : indCandClus){
+		vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
+	for(auto & n : v5x5){
+	  DetId ed = n.id(); 
+	  auto itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed); 
 	  if( itdet == selectedEBDetIds.end()){
 	    selectedEBDetIds.push_back(ed); 
-	    selEBRecHitCollection->push_back(v5x5[n]);
+	    selEBRecHitCollection->push_back(n);
 	  }
 	}
       }
       
       
       ///store 5x5 of Iso clusters, need to getWindow of 5x5 
-      for(int i = 0; i < int( indIsoClus.size()); i++){
-	int ind = indIsoClus[i];
-	
-	std::vector<int>::iterator  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
+      for(int ind : indIsoClus){
+		auto  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
 	if( it != indCandClus.end()) continue; 
 	
-	reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection_eb->begin() + ind;
+	auto it_bc3 = clusterCollection_eb->begin() + ind;
 	DetId seedId = it_bc3->seed();
 	std::vector<DetId> clus_v5x5 = topology_eb->getWindow(seedId,5,5);
 	for( std::vector<DetId>::const_iterator idItr = clus_v5x5.begin(); idItr != clus_v5x5.end(); idItr++){
 	  DetId ed = *idItr;
-	  EcalRecHitCollection::const_iterator rit = hitCollection_eb->find( ed );
+	  auto rit = hitCollection_eb->find( ed );
 	  if ( rit == hitCollection_eb->end() ) continue;
 	  if( ! checkStatusOfEcalRecHit(channelStatus, *rit) ) continue; 
-	  std::vector<DetId>::iterator itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed);
+	  auto itdet = find(selectedEBDetIds.begin(),selectedEBDetIds.end(),ed);
 	  if( itdet == selectedEBDetIds.end()){
 	    selectedEBDetIds.push_back(ed);
 	    selEBRecHitCollection->push_back(*rit);
@@ -468,26 +464,25 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
 		 indCandClus,indIsoClus, indClusSelected);
     
     ///Now save all rechits in the selected clusters
-    for(int i = 0; i < int(indClusSelected.size()); i++){
-      int ind = indClusSelected[i];
-      reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection_ee->begin() + ind; 
+    for(int ind : indClusSelected){
+      auto it_bc3 = clusterCollection_ee->begin() + ind; 
       const std::vector< std::pair<DetId, float> > &vid =  it_bc3->hitsAndFractions(); 
-      for (std::vector<std::pair<DetId,float> >::const_iterator idItr = vid.begin();idItr != vid.end ();++idItr){
-	EcalRecHitCollection::const_iterator hit  = hitCollection_ee->find(idItr->first);
+      for (auto const & idItr : vid){
+	auto hit  = hitCollection_ee->find(idItr.first);
 	if( hit == hitCollection_ee->end()) continue;  //this should not happen.
 	selEERecHitCollection->push_back(*hit); 
-	selectedEEDetIds.push_back(idItr->first);
+	selectedEEDetIds.push_back(idItr.first);
       }
       ///save preshower rechits 
       if(storeRecHitES_){
 	std::set<DetId> used_strips_before = m_used_strips;  
 	makeClusterES(it_bc3->x(),it_bc3->y(),it_bc3->z(),geometry_es,topology_es);
-	std::set<DetId>::const_iterator ites = m_used_strips.begin();
+	auto ites = m_used_strips.begin();
 	for(; ites != m_used_strips.end(); ++ ites ){
 	  ESDetId d1 = ESDetId(*ites);
-	  std::set<DetId>::const_iterator ites2 = find(used_strips_before.begin(),used_strips_before.end(),d1);
+	  auto ites2 = find(used_strips_before.begin(),used_strips_before.end(),d1);
 	  if( (ites2 == used_strips_before.end())){
-	    std::map<DetId, EcalRecHit>::iterator itmap = m_esrechit_map.find(d1);
+	    auto itmap = m_esrechit_map.find(d1);
 	    selESRecHitCollection->push_back(itmap->second);
 	  }
 	}
@@ -497,36 +492,33 @@ bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::Event
 
     if( store5x5RecHitEE_ ){
       ///store 5x5 of good clusters, 5x5 arleady got 
-      for(int i = 0; i < int( indCandClus.size()); i++){
-	int ind = indCandClus[i];
-	vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
-	for(int n=0; n< int(v5x5.size()); n++){
-	  DetId ed = v5x5[n].id(); 
-	  std::vector<DetId>::iterator itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed); 
+      for(int ind : indCandClus){
+		vector<EcalRecHit> v5x5 =  RecHits5x5_clus[ind]; 
+	for(auto & n : v5x5){
+	  DetId ed = n.id(); 
+	  auto itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed); 
 	  if( itdet == selectedEEDetIds.end()){
 	    selectedEEDetIds.push_back(ed); 
-	    selEERecHitCollection->push_back(v5x5[n]);
+	    selEERecHitCollection->push_back(n);
 	  }
 	}
       }
       
       
       ///store 5x5 of Iso clusters, need to getWindow of 5x5 
-      for(int i = 0; i < int( indIsoClus.size()); i++){
-	int ind = indIsoClus[i];
-	
-	std::vector<int>::iterator  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
+      for(int ind : indIsoClus){
+		auto  it = find(indCandClus.begin(),indCandClus.end(), ind);  ///check if already saved in the good cluster vector
 	if( it != indCandClus.end()) continue; 
 	
-	reco::BasicClusterCollection::const_iterator	it_bc3 = clusterCollection_ee->begin() + ind;
+	auto	it_bc3 = clusterCollection_ee->begin() + ind;
 	DetId seedId = it_bc3->seed();
 	std::vector<DetId> clus_v5x5 = topology_ee->getWindow(seedId,5,5);
 	for( std::vector<DetId>::const_iterator idItr = clus_v5x5.begin(); idItr != clus_v5x5.end(); idItr++){
 	  DetId ed = *idItr;
-	  EcalRecHitCollection::const_iterator rit = hitCollection_ee->find( ed );
+	  auto rit = hitCollection_ee->find( ed );
 	  if ( rit == hitCollection_ee->end() ) continue;
 	  if( ! checkStatusOfEcalRecHit(channelStatus, *rit) ) continue; 
-	  std::vector<DetId>::iterator itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed);
+	  auto itdet = find(selectedEEDetIds.begin(),selectedEEDetIds.end(),ed);
 	  if( itdet == selectedEEDetIds.end()){
 	    selectedEEDetIds.push_back(ed);
 	    selEERecHitCollection->push_back(*rit);
@@ -584,15 +576,15 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
   
   vector<int> indClusPi0Candidates;  ///those clusters identified as pi0s
   if( detector ==EcalBarrel && removePi0CandidatesForEta_){
-    for( reco::BasicClusterCollection::const_iterator it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
-      for( reco::BasicClusterCollection::const_iterator it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
+    for( auto it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
+      for( auto it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
 	float m_pair,pt_pair,eta_pair, phi_pair; 
 	calcPaircluster(*it_bc,*it_bc2, m_pair, pt_pair,eta_pair,phi_pair); 
 	if(m_pair > massLowPi0Cand_ && m_pair < massHighPi0Cand_){
 	  int indtmp[2]={ int( it_bc - clusterCollection->begin()), int( it_bc2 - clusterCollection->begin())};
-	  for( int k=0;k<2; k++){
-	    std::vector<int>::iterator it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),indtmp[k]);
-	    if( it == indClusPi0Candidates.end()) indClusPi0Candidates.push_back(indtmp[k]);
+	  for(int & k : indtmp){
+	    auto it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),k);
+	    if( it == indClusPi0Candidates.end()) indClusPi0Candidates.push_back(k);
 	  }
 	}
       }
@@ -635,10 +627,10 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
 
   map<int,bool> passShowerShape_clus;  //if this cluster passed showershape cut, so no need to compute the quantity again for each loop
   
-  for( reco::BasicClusterCollection::const_iterator it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
+  for( auto it_bc = clusterCollection->begin(); it_bc != clusterCollection->end();it_bc++){
     
     if( detector == EcalBarrel && removePi0CandidatesForEta_){
-      std::vector<int>::iterator it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc - clusterCollection->begin()) );
+      auto it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc - clusterCollection->begin()) );
       if( it != indClusPi0Candidates.end()) continue; 
     }
     
@@ -648,16 +640,16 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
     float pt1 = v1.Rho();   // Rho is equivalent to Pt when using XYZVector  
  
     int ind1 = int( it_bc - clusterCollection->begin() );
-    std::map<int,bool>::iterator  itmap = passShowerShape_clus.find(ind1);
+    auto  itmap = passShowerShape_clus.find(ind1);
     if( itmap != passShowerShape_clus.end()){
       if( itmap->second == false){
 	continue; 
       }
     }
     
-    for( reco::BasicClusterCollection::const_iterator it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
+    for( auto it_bc2 = it_bc + 1 ; it_bc2 != clusterCollection->end();it_bc2++){
       if( detector ==EcalBarrel && removePi0CandidatesForEta_){
-	std::vector<int>::iterator it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc2 - clusterCollection->begin()) );
+	auto it = find(indClusPi0Candidates.begin(),indClusPi0Candidates.end(),int(it_bc2 - clusterCollection->begin()) );
 	if( it != indClusPi0Candidates.end()) continue; 
       }
 
@@ -667,7 +659,7 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
       float pt2 = v2.Rho();   // Rho is equivalent to Pt when using XYZVector         
       
       int ind2 = int( it_bc2 - clusterCollection->begin() );
-      std::map<int,bool>::iterator  itmap = passShowerShape_clus.find(ind2);
+      auto  itmap = passShowerShape_clus.find(ind2);
       if( itmap != passShowerShape_clus.end()){
 	if( itmap->second == false){
 	  continue; 
@@ -719,7 +711,7 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
       IsoClus.push_back(ind2); 
       
       float Iso = 0;
-      for( reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection->begin(); it_bc3 != clusterCollection->end();it_bc3++){
+      for( auto it_bc3 = clusterCollection->begin(); it_bc3 != clusterCollection->end();it_bc3++){
 	if( it_bc3->seed() == it_bc->seed() || it_bc3->seed() == it_bc2->seed()) continue; 
 	float drcl = GetDeltaR(eta_pair,it_bc3->eta(),phi_pair,it_bc3->phi()); 
 	float dretacl = fabs( eta_pair - it_bc3->eta()); 
@@ -772,8 +764,8 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
       bool failShowerShape = false;
       for(int n=0; n<2; n++){
 	int ind = IsoClus[n];
-	reco::BasicClusterCollection::const_iterator it_bc3 = clusterCollection->begin() + ind; 
-	std::map<int,bool>::iterator  itmap = passShowerShape_clus.find(ind);
+	auto it_bc3 = clusterCollection->begin() + ind; 
+	auto  itmap = passShowerShape_clus.find(ind);
 	
 	if( itmap != passShowerShape_clus.end()){ // if we havent reached the end
 	  if( itmap->second == false){
@@ -841,17 +833,17 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
 	int ind = IsoClus[iii];
 	
 	if( iii < 2){
-	  std::vector<int>::iterator it = find(indCandClus.begin(),indCandClus.end(), ind);  ///good cluster 
+	  auto it = find(indCandClus.begin(),indCandClus.end(), ind);  ///good cluster 
 	  if( it == indCandClus.end()) indCandClus.push_back(ind);
 	  else continue; 
 	}
 	else{
-	  std::vector<int>::iterator it = find(indIsoClus.begin(),indIsoClus.end(), ind);  //iso cluster 
+	  auto it = find(indIsoClus.begin(),indIsoClus.end(), ind);  //iso cluster 
 	  if( it == indIsoClus.end()) indIsoClus.push_back(ind);
 	  else continue; 
 	}
 	
-	std::vector<int>::iterator it = find(indClusSelected.begin(),indClusSelected.end(),ind); 
+	auto it = find(indClusSelected.begin(),indClusSelected.end(),ind); 
 	if( it != indClusSelected.end()) continue; 
 	indClusSelected.push_back(ind);
       }      
@@ -954,14 +946,14 @@ void HLTRegionalEcalResonanceFilter::calcShowerShape(const reco::BasicCluster &b
 	dx = x-seedx;
 	dy = y-seedy; 
       }
-      EcalRecHitCollection::const_iterator rit = recHits->find( ed );
+      auto rit = recHits->find( ed );
       if ( rit == recHits->end() ) continue; 
       if( ! checkStatusOfEcalRecHit(channelStatus, *rit) ) continue; 
       
       float energy = (*rit).energy();
       e5x5 += energy; 
       
-      std::vector<std::pair<DetId,float> >::const_iterator idItrF = std::find( vid.begin(),vid.end(), std::make_pair(ed,1.0f));  ///has to add "f", make it float 
+      auto idItrF = std::find( vid.begin(),vid.end(), std::make_pair(ed,1.0f));  ///has to add "f", make it float 
       if( idItrF == vid.end()){ ///only store those not belonging to this cluster
 	rechit5x5.push_back(*rit);
       }else{ /// S4, S9 are defined inside the cluster, the same as below. 
@@ -978,8 +970,8 @@ void HLTRegionalEcalResonanceFilter::calcShowerShape(const reco::BasicCluster &b
     
   }else{
     
-    for (std::vector<std::pair<DetId,float> >::const_iterator idItr = vid.begin();idItr != vid.end ();++idItr){
-      DetId ed = idItr->first; 
+    for (auto const & idItr : vid){
+      DetId ed = idItr.first; 
       if( InBarrel == true){
 	EBDetId ebd = EBDetId(ed); 
 	x = ebd.ieta();
@@ -994,7 +986,7 @@ void HLTRegionalEcalResonanceFilter::calcShowerShape(const reco::BasicCluster &b
 	dx = x-seedx;
 	dy = y-seedy; 
       }
-      EcalRecHitCollection::const_iterator rit = recHits->find( ed );
+      auto rit = recHits->find( ed );
       if ( rit == recHits->end() ) {
 	continue; 
       }

--- a/HLTrigger/special/src/HLTSingleVertexPixelTrackFilter.cc
+++ b/HLTrigger/special/src/HLTSingleVertexPixelTrackFilter.cc
@@ -34,9 +34,7 @@ HLTSingleVertexPixelTrackFilter::HLTSingleVertexPixelTrackFilter(const edm::Para
   pixelTracksToken_ = consumes<reco::RecoChargedCandidateCollection>(pixelTracksTag_);
 }
 
-HLTSingleVertexPixelTrackFilter::~HLTSingleVertexPixelTrackFilter()
-{
-}
+HLTSingleVertexPixelTrackFilter::~HLTSingleVertexPixelTrackFilter() = default;
 
 void
 HLTSingleVertexPixelTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTTrackSeedMultiplicityFilter.cc
+++ b/HLTrigger/special/src/HLTTrackSeedMultiplicityFilter.cc
@@ -13,11 +13,11 @@
 class HLTTrackSeedMultiplicityFilter : public HLTFilter {
 public:
   explicit HLTTrackSeedMultiplicityFilter(const edm::ParameterSet&);
-  ~HLTTrackSeedMultiplicityFilter();
+  ~HLTTrackSeedMultiplicityFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::InputTag inputTag_;       // input tag identifying product containing track seeds
   unsigned int  min_seeds_;      // minimum number of track seeds
@@ -48,9 +48,7 @@ HLTTrackSeedMultiplicityFilter::HLTTrackSeedMultiplicityFilter(const edm::Parame
     LogDebug("") << "...but no more than " << max_seeds_ << " seeds";
 }
 
-HLTTrackSeedMultiplicityFilter::~HLTTrackSeedMultiplicityFilter()
-{
-}
+HLTTrackSeedMultiplicityFilter::~HLTTrackSeedMultiplicityFilter() = default;
 
 void
 HLTTrackSeedMultiplicityFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -80,7 +78,7 @@ bool HLTTrackSeedMultiplicityFilter::hltFilter(edm::Event& event, const edm::Eve
   edm::Handle<TrajectorySeedCollection> seedColl;
   event.getByToken(inputToken_, seedColl);
 
-  const TrajectorySeedCollection *rsSeedCollection = 0;
+  const TrajectorySeedCollection *rsSeedCollection = nullptr;
 
 
   if( seedColl.isValid() )

--- a/HLTrigger/special/src/HLTTrackerHaloFilter.cc
+++ b/HLTrigger/special/src/HLTTrackerHaloFilter.cc
@@ -28,9 +28,7 @@ HLTTrackerHaloFilter::HLTTrackerHaloFilter(const edm::ParameterSet& config) : HL
   clusterInputToken_ = consumes<edmNew::DetSetVector<SiStripCluster> >(inputTag_);
 }
 
-HLTTrackerHaloFilter::~HLTTrackerHaloFilter()
-{
-}
+HLTTrackerHaloFilter::~HLTTrackerHaloFilter() = default;
 
 void
 HLTTrackerHaloFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTTriggerTypeFilter.cc
+++ b/HLTrigger/special/src/HLTTriggerTypeFilter.cc
@@ -18,9 +18,7 @@ HLTTriggerTypeFilter::HLTTriggerTypeFilter(const edm::ParameterSet& iConfig) :
 {
 }
 
-HLTTriggerTypeFilter::~HLTTriggerTypeFilter()
-{
-}
+HLTTriggerTypeFilter::~HLTTriggerTypeFilter() = default;
 
 void
 HLTTriggerTypeFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/src/HLTVertexFilter.cc
+++ b/HLTrigger/special/src/HLTVertexFilter.cc
@@ -38,11 +38,11 @@
 class HLTVertexFilter : public HLTFilter {
 public:
   explicit HLTVertexFilter(const edm::ParameterSet & config);
-  ~HLTVertexFilter();
+  ~HLTVertexFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual
+  
   bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::EDGetTokenT<reco::VertexCollection> m_inputToken;
@@ -70,9 +70,7 @@ HLTVertexFilter::HLTVertexFilter(const edm::ParameterSet& config) : HLTFilter(co
 }
 
 
-HLTVertexFilter::~HLTVertexFilter()
-{
-}
+HLTVertexFilter::~HLTVertexFilter() = default;
 
 void
 HLTVertexFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/test/ArbitraryLogError.cc
+++ b/HLTrigger/special/test/ArbitraryLogError.cc
@@ -34,12 +34,12 @@ Implementation:
 class ArbitraryLogError : public edm::EDAnalyzer {
 public:
   explicit ArbitraryLogError(const edm::ParameterSet&);
-  ~ArbitraryLogError();
+  ~ArbitraryLogError() override;
 
 private:
-  virtual void beginJob() ;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  void beginJob() override ;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
 
   const std::string m_category;
   const bool        m_severity;
@@ -57,9 +57,7 @@ ArbitraryLogError::ArbitraryLogError(const edm::ParameterSet& config) :
 }
 
 // DTOR
-ArbitraryLogError::~ArbitraryLogError()
-{
-}
+ArbitraryLogError::~ArbitraryLogError() = default;
 
 
 // ------------ method called to for each event  ------------


### PR DESCRIPTION
Enabled checks:
    modernize-loop-convert
    modernize-make-unique
    modernize-pass-by-value
    modernize-redundant-void-arg
    modernize-replace-auto-ptr
    modernize-shrink-to-fit
    modernize-use-auto
    modernize-use-default
    modernize-use-nullptr
    modernize-use-override