### PR TITLE
Does not use PF cluster cleaning in ECAL clusters.

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -117,7 +117,7 @@ _pfClusterizer_ECAL = cms.PSet(
 particleFlowClusterECALUncorrected = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitECAL"),
-    recHitCleaners = cms.VPSet(_spikeAndDoubleSpikeCleaner_ECAL),
+    recHitCleaners = cms.VPSet(),
     seedFinder = _localMaxSeeds_ECAL,
     initialClusteringStep = _topoClusterizer_ECAL,
     pfClusterBuilder = _pfClusterizer_ECAL,


### PR DESCRIPTION
Does not apply PF Cluster cleaning while making ECAL PF Clusters.

Please, refer to discussion in #17859 

ECAL already provides cleaned rechits (by flagging them kOutOfTime, kWeird, kDiWeird).  No additional cleaning is needed.

Attention: @emanueledimarco @Sam-Harper @knash @jainshilpi