### PR TITLE
L1TObjectTypeInCond typedef instead of an overriding ObjectTypeInCond

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalObjectMap.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMap.h
@@ -31,7 +31,6 @@
 // class declaration
 class GlobalObjectMap
 {
-  using ObjectTypeInCond=L1TObjectTypeInCond;
 public:
 
     /// constructor(s)
@@ -103,13 +102,13 @@ public:
 
     /// get / set the vector of object types
     /// return a constant reference to the vector of operand tokens
-    inline const std::vector<ObjectTypeInCond>& objectTypeVector() const {
+    inline const std::vector<L1TObjectTypeInCond>& objectTypeVector() const {
         return m_objectTypeVector;
     }
-    void setObjectTypeVector(const std::vector<ObjectTypeInCond>& objectTypeVectorValue) {
+    void setObjectTypeVector(const std::vector<L1TObjectTypeInCond>& objectTypeVectorValue) {
         m_objectTypeVector = objectTypeVectorValue;
     }
-    void swapObjectTypeVector(std::vector<ObjectTypeInCond>& objectTypeVectorValue) {
+    void swapObjectTypeVector(std::vector<L1TObjectTypeInCond>& objectTypeVectorValue) {
       m_objectTypeVector.swap(objectTypeVectorValue);
     }
     
@@ -151,7 +150,7 @@ private:
     std::vector<CombinationsInCond> m_combinationVector;
 
     // vector of object type vectors for all conditions in an algorithm
-    std::vector<ObjectTypeInCond> m_objectTypeVector;
+    std::vector<L1TObjectTypeInCond> m_objectTypeVector;
 
 };
 

--- a/DataFormats/L1TGlobal/interface/GlobalObjectMap.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMap.h
@@ -31,7 +31,7 @@
 // class declaration
 class GlobalObjectMap
 {
-
+  using ObjectTypeInCond=L1TObjectTypeInCond;
 public:
 
     /// constructor(s)

--- a/DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h
@@ -31,7 +31,7 @@ typedef std::vector<int> SingleCombInCond;
 /// all the object combinations evaluated to true in the condition
 typedef std::vector<SingleCombInCond> CombinationsInCond;
 
-typedef std::vector<l1t::GlobalObject> ObjectTypeInCond;
+typedef std::vector<l1t::GlobalObject> L1TObjectTypeInCond;
 //typedef std::vector<int> ObjectTypeInCond;
 
 #endif /* L1GlobalTrigger_L1TGtObjectMapFwd_h */

--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -28,7 +28,7 @@
 #include "HLTrigger/HLTfilters/interface/HLTL1TSeed.h"
 
 using namespace std;
-
+using ObjectTypeInCond=L1TObjectTypeInCond;
 
 // constructors
 HLTL1TSeed::HLTL1TSeed(const edm::ParameterSet& parSet) : 

--- a/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTL1TSeed.cc
@@ -28,7 +28,6 @@
 #include "HLTrigger/HLTfilters/interface/HLTL1TSeed.h"
 
 using namespace std;
-using ObjectTypeInCond=L1TObjectTypeInCond;
 
 // constructors
 HLTL1TSeed::HLTL1TSeed(const edm::ParameterSet& parSet) : 
@@ -519,7 +518,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent,
       if(!algoSeedResult) continue; 
 
       const std::vector<GlobalLogicParser::OperandToken>& opTokenVecObjMap = objMap->operandTokenVector();
-      const std::vector<ObjectTypeInCond>&  condObjTypeVec = objMap->objectTypeVector();
+      const std::vector<L1TObjectTypeInCond>&  condObjTypeVec = objMap->objectTypeVector();
       const std::vector<CombinationsInCond>& condCombinations = objMap->combinationVector();
 
       LogTrace("HLTL1TSeed")

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -60,7 +60,6 @@
 
 using namespace edm;
 using namespace std;
-using ObjectTypeInCond=L1TObjectTypeInCond;
 
 namespace l1t {
 
@@ -278,7 +277,7 @@ namespace l1t {
 
                    // Combination
 		   const std::vector<GlobalLogicParser::OperandToken>& opTokenVecObjMap = oMap.operandTokenVector();
-		   const std::vector<ObjectTypeInCond>&  condObjTypeVec = oMap.objectTypeVector();
+		   const std::vector<L1TObjectTypeInCond>&  condObjTypeVec = oMap.objectTypeVector();
 //		   const std::vector<CombinationsInCond>& condCombinations = oMapcombinationVector();
 		   
 		   for(size_t iCond=0; iCond<opTokenVecObjMap.size(); iCond++) {

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -60,6 +60,7 @@
 
 using namespace edm;
 using namespace std;
+using ObjectTypeInCond=L1TObjectTypeInCond;
 
 namespace l1t {
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -53,6 +53,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 // forward declarations
+using ObjectTypeInCond=L1TObjectTypeInCond;
 
 // constructor
 l1t::GlobalBoard::GlobalBoard() :

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -53,7 +53,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 // forward declarations
-using ObjectTypeInCond=L1TObjectTypeInCond;
 
 // constructor
 l1t::GlobalBoard::GlobalBoard() :
@@ -750,12 +749,12 @@ void l1t::GlobalBoard::runGTL(
         // object maps only for BxInEvent = 0
         if (produceL1GtObjectMapRecord && (iBxInEvent == 0)) {
 
-	  std::vector<ObjectTypeInCond> otypes;	  
+	  std::vector<L1TObjectTypeInCond> otypes;	  
 	  for (auto iop = gtAlg.operandTokenVector().begin(); iop != gtAlg.operandTokenVector().end(); ++iop){
 	    //cout << "INFO:  operand name:  " << iop->tokenName << "\n";
 	    int myChip = -1;
 	    int found =0;
-	    ObjectTypeInCond otype;	      
+	    L1TObjectTypeInCond otype;	      
 	    for (auto imap = conditionMap.begin(); imap != conditionMap.end(); imap++) {
 	      myChip++;
 	      auto match = imap->find(iop->tokenName);


### PR DESCRIPTION
Globally-defined typedefs better be unique in DataFormats as they are globally known to ROOT (same typedef name should correspond to the same type; multiple definitions of the same typedef are apparently OK).
ObjectTypeInCond is defined in the legacy L1 already.

This should clear rather verbose errors in Tree::Draw with selections made from FWLite similar to 
```
In file included from DataFormatsL1GlobalTrigger_xr dictionary payload:48:
In file included from L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h:23:
DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapFwd.h:34:33: error: typedef redefinition with different types ('vector<L1GtObject>' vs 'vector<l1t::GlobalObject>')
typedef std::vector<L1GtObject> ObjectTypeInCond;
                                ^
DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h:34:40: note: previous definition is here
typedef std::vector<l1t::GlobalObject> ObjectTypeInCond;
```

