### PR TITLE
Digi occupancy plot rotated + FED range adjusted (91X)

### DIFF
--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -120,7 +120,7 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
   dimensions = 0,
   specs = VPSet(
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row/col")
-                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_Y")
+                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_X")
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
                    .save(),
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/col")
@@ -130,7 +130,7 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row/col")
-                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_Y")
+                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_X")
                    .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_X")
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/col")

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -121,7 +121,7 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
   specs = VPSet(
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row/col")
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_X")
-                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
+                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_Y")
                    .save(),
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/col")
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
@@ -131,7 +131,7 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row/col")
                    .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_X")
-                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_X")
+                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_Y")
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/col")
                    .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_X")

--- a/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
+++ b/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
@@ -57,7 +57,7 @@ SiPixelPhase1RawDataTBMType = DefaultHisto.clone(
   name = "tbmtype",
   title = "Type of TBM trailer",
   xlabel = "TBM type",
-  range_min = -0.5, range_max = 4.5, range_nbins = 4,
+  range_min = -0.5, range_max = 4.5, range_nbins = 5,
   dimensions = 1,
   specs = VPSet(
     Specification().groupBy("FED/FED").save(),
@@ -69,7 +69,7 @@ SiPixelPhase1RawDataTypeNErrors = DefaultHisto.clone(
   name = "nerrors_per_type",
   title = "Number of Errors per Type",
   xlabel = "Error Type",
-  range_min = -0.5, range_max = 50.5, range_nbins = 51,#TODO: proper range here
+  range_min = 24.5, range_max = 40.5, range_nbins = 16,#TODO: proper range here
   dimensions = 1,
   specs = VPSet(
     Specification().groupBy("FED/FED").save(),

--- a/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
+++ b/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
@@ -69,7 +69,7 @@ SiPixelPhase1RawDataTypeNErrors = DefaultHisto.clone(
   name = "nerrors_per_type",
   title = "Number of Errors per Type",
   xlabel = "Error Type",
-  range_min = 24.5, range_max = 40.5, range_nbins = 16,#TODO: proper range here
+  range_min = 24.5, range_max = 40.5, range_nbins = 16,
   dimensions = 1,
   specs = VPSet(
     Specification().groupBy("FED/FED").save(),


### PR DESCRIPTION
1. Rotated per-module digi-occupancy plot so that col is on x-axis and row is on y-axis (91X fix)
2. Adjusted range for FED info plots