### PR TITLE
Moving from DA to DA_vect clusterizer in PrimaryVertexValidation

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -52,6 +52,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "MagneticField/Engine/interface/MagneticField.h" 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
@@ -106,6 +107,9 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
     theTrackClusterizer_ = new GapClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkGapClusParameters"));
   }else if(clusteringAlgorithm=="DA"){
     theTrackClusterizer_ = new DAClusterizerInZ(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters"));
+    // provide the vectorized version of the clusterizer, if supported by the build
+  } else if(clusteringAlgorithm=="DA_vect") {
+    theTrackClusterizer_ = new DAClusterizerInZ_vect(iConfig.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters"));
   }else{
     throw VertexException("PrimaryVertexProducerAlgorithm: unknown clustering algorithm: " + clusteringAlgorithm);  
   }

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -154,7 +154,7 @@ if isDA:
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
-                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA'),
+                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA_vect'),
                                                                      TkDAClusParameters = cms.PSet(coolingFactor = cms.double(0.8),  # moderate annealing speed
                                                                                                    Tmin = cms.double(4.),            # end of annealing
                                                                                                    vertexSize = cms.double(0.05),    # ~ resolution / sqrt(Tmin)

--- a/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
@@ -226,7 +226,7 @@ if isDA:
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
-                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA'),
+                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA_vect'),
                                                                      TkDAClusParameters = cms.PSet(coolingFactor = cms.double(0.8),  # moderate annealing speed
                                                                                                    Tmin = cms.double(4.),            # end of annealing
                                                                                                    vertexSize = cms.double(0.05),    # ~ resolution / sqrt(Tmin)

--- a/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
@@ -232,7 +232,7 @@ if isDA:
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
-                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA'),
+                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA_vect'),
                                                                      TkDAClusParameters = cms.PSet(coolingFactor = cms.double(0.8),  # moderate annealing speed
                                                                                                    Tmin = cms.double(4.),            # end of annealing
                                                                                                    vertexSize = cms.double(0.05),    # ~ resolution / sqrt(Tmin)

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -219,7 +219,7 @@ if isDA:
                                                                          trackQuality = cms.string("any")
                                                                          ),
                                            
-                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA'),
+                                           TkClusParameters=cms.PSet(algorithm=cms.string('DA_vect'),
                                                                      TkDAClusParameters = cms.PSet(coolingFactor = cms.double(0.8),  # moderate annealing speed
                                                                                                    Tmin = cms.double(4.),            # end of annealing
                                                                                                    vertexSize = cms.double(0.05),    # ~ resolution / sqrt(Tmin)


### PR DESCRIPTION
 Greetings, 
base on the discussion in #18330, looks like `DAClusterizerInZ` is legacy code, and in the process of being de-commissioned.  `PrimaryVertexValidation` and its configuration files are being updated accordingly.
Negligible regressions are observed when testing with 2016C `HLTPhysics` data.
   * Biases:

![biasescanvas_run 275657da_vect_vs_da](https://cloud.githubusercontent.com/assets/5082376/25332259/0eded086-28e6-11e7-874b-da88fedc4ac5.png)

   * Resolutions: 

![resolutionscanvas_run 275657da_vect_vs_da](https://cloud.githubusercontent.com/assets/5082376/25332263/10d2d112-28e6-11e7-9e24-f7738b0093e1.png)


