### PR TITLE
Run modules concurrently during global begin transitions

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -67,7 +67,7 @@ namespace edm {
     void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
     void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
 
-    std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFromEvent() const { return itemsToGetFromEvent_; }
+    std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const { return itemsToGetFromBranch_[iType]; }
 
     ///\return true if the product corresponding to the index was registered via consumes or mayConsume call
     bool registeredToConsume(ProductResolverIndex, bool, BranchType) const;
@@ -184,7 +184,7 @@ namespace edm {
     // for each of the 3 labels needed to id the data
     std::vector<char> m_tokenLabels;
 
-    std::vector<ProductResolverIndexAndSkipBit> itemsToGetFromEvent_;
+    std::array<std::vector<ProductResolverIndexAndSkipBit>, edm::NumBranchTypes> itemsToGetFromBranch_;
 
     bool frozen_;
   };

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -83,6 +83,9 @@ namespace edm {
 
     void clearPrincipal();
 
+    void setAtEndTransition(bool iAtEnd);
+    bool atEndTransition() const {return atEndTransition_;}
+    
     void deleteProduct(BranchID const& id) const;
     
     EDProductGetter const* prodGetter() const {return this;}
@@ -286,6 +289,7 @@ namespace edm {
     
     CacheIdentifier_t cacheIdentifier_;
 
+    bool atEndTransition_;
   };
 
   template <typename PROD>

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -144,6 +144,12 @@ namespace edm {
                           bool cleaningUpAfterException = false);
 
     template <typename T>
+    void processOneGlobalAsync(WaitingTaskHolder iTask,
+                               typename T::MyPrincipal& principal,
+                               EventSetup const& eventSetup,
+                               bool cleaningUpAfterException = false);
+
+    template <typename T>
     void processOneStream(unsigned int iStreamID,
                           typename T::MyPrincipal& principal,
                           EventSetup const& eventSetup,
@@ -325,5 +331,15 @@ namespace edm {
                                  bool cleaningUpAfterException) {
     globalSchedule_->processOneGlobal<T>(ep,es,cleaningUpAfterException);
   }
+  
+  template <typename T>
+  void
+  Schedule::processOneGlobalAsync(WaitingTaskHolder iTaskHolder,
+                                  typename T::MyPrincipal& ep,
+                                  EventSetup const& es,
+                                  bool cleaningUpAfterException) {
+    globalSchedule_->processOneGlobalAsync<T>(iTaskHolder,ep,es,cleaningUpAfterException);
+  }
+
 }
 #endif

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -76,10 +76,12 @@ namespace edm {
                       EventPrincipal const& principal);
 
     void doBeginRun(RunPrincipal const& principal, IOVSyncValue const& ts);
+    void doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts);
 
     void doEndRun(RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
 
     void doBeginLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
+    void doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts);
 
     void doEndLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException);
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -86,7 +86,7 @@ namespace edm {
       //Same interface as EDConsumerBase
       void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
       void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
-      std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFromEvent() const;
+      std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType) const;
 
       void updateLookup(BranchType iBranchType,
                         ProductResolverIndexHelper const&,

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -78,7 +78,7 @@ namespace edm {
       
       void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
       void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const;
-      std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFromEvent() const;
+      std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType) const;
 
       void updateLookup(BranchType iBranchType,
                         ProductResolverIndexHelper const&,

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -187,11 +187,9 @@ EDConsumerBase::updateLookup(BranchType iBranchType,
   }
   m_tokenInfo.shrink_to_fit();
 
-  if(iBranchType == InEvent) {
-    itemsToGet(iBranchType, itemsToGetFromEvent_);
-    if(iPrefetchMayGet) {
-      itemsMayGet(iBranchType, itemsToGetFromEvent_);
-    }
+  itemsToGet(iBranchType, itemsToGetFromBranch_[iBranchType]);
+  if(iPrefetchMayGet) {
+    itemsMayGet(iBranchType, itemsToGetFromBranch_[iBranchType]);
   }
 }
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1713,6 +1713,7 @@ namespace edm {
       //looper_->doStreamEndRun(schedule_->streamID(),runPrincipal, es);
     }
     {
+      runPrincipal.setAtEndTransition(true);
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
       schedule_->processOneGlobal<Traits>(runPrincipal, es, cleaningUpAfterException);
       for_all(subProcesses_, [&runPrincipal, &ts, cleaningUpAfterException](auto& subProcess){subProcess.doEndRun(runPrincipal, ts, cleaningUpAfterException); });
@@ -1827,6 +1828,7 @@ namespace edm {
       //looper_->doStreamEndLuminosityBlock(schedule_->streamID(),lumiPrincipal, es);
     }
     {
+      lumiPrincipal.setAtEndTransition(true);
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
       schedule_->processOneGlobal<Traits>(lumiPrincipal, es, cleaningUpAfterException);
       for_all(subProcesses_, [&lumiPrincipal, &ts, cleaningUpAfterException](auto& subProcess){	subProcess.doEndLuminosityBlock(lumiPrincipal, ts, cleaningUpAfterException); });

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -20,6 +20,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include <map>
 #include <memory>
@@ -27,6 +28,8 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include "boost/range/adaptor/reversed.hpp"
+
 
 namespace edm {
 
@@ -90,6 +93,12 @@ namespace edm {
     void processOneGlobal(typename T::MyPrincipal& principal,
                           EventSetup const& eventSetup,
                           bool cleaningUpAfterException = false);
+
+    template <typename T>
+    void processOneGlobalAsync(WaitingTaskHolder holder,
+                               typename T::MyPrincipal& principal,
+                               EventSetup const& eventSetup,
+                               bool cleaningUpAfterException = false);
 
     void beginJob(ProductRegistry const&);
     void endJob(ExceptionCollector & collector);
@@ -198,6 +207,78 @@ namespace edm {
     //If we got here no other exception has happened so we can propogate any Service related exceptions
     sentry.allowThrow();
   }
+  
+  template <typename T>
+  void
+  GlobalSchedule::processOneGlobalAsync(WaitingTaskHolder iHolder,
+                                        typename T::MyPrincipal& ep,
+                                        EventSetup const& es,
+                                        bool cleaningUpAfterException) {
+    ServiceToken token = ServiceRegistry::instance().presentToken();
+    
+    //need the doneTask to own the memory
+    auto globalContext = std::make_shared<GlobalContext>(T::makeGlobalContext(ep, processContext_));
+    
+    if(actReg_) {
+      T::preScheduleSignal(actReg_.get(), globalContext.get());
+    }
+    
+    
+    //If we are in an end transition, we need to reset failed items since they might
+    // be set this time around
+    if( not T::begin_) {
+      ep.resetFailedFromThisProcess();
+    }
+    
+    auto doneTask = make_waiting_task(tbb::task::allocate_root(),
+                                      [this,iHolder, cleaningUpAfterException, globalContext, token](std::exception_ptr const* iPtr) mutable
+                                      {
+                                        ServiceRegistry::Operate op(token);
+                                        std::exception_ptr excpt;
+                                        if(iPtr) {
+                                          excpt = *iPtr;
+                                          //add context information to the exception and print message
+                                          try {
+                                            convertException::wrap([&]() {
+                                              std::rethrow_exception(excpt);
+                                            });
+                                          } catch(cms::Exception& ex) {
+                                            //TODO: should add the transition type info
+                                            std::ostringstream ost;
+                                            if(ex.context().empty()) {
+                                              ost<<"Processing "<<T::transitionName()<<" ";
+                                            }
+                                            addContextAndPrintException(ost.str().c_str(), ex, cleaningUpAfterException);
+                                            excpt = std::current_exception();
+                                          }
+                                          if(actReg_) {
+                                            actReg_->preGlobalEarlyTerminationSignal_(*globalContext,TerminationOrigin::ExceptionFromThisContext);
+                                          }
+                                        }
+                                        if(actReg_) {
+                                          try {
+                                            T::postScheduleSignal(actReg_.get(), globalContext.get());
+                                          } catch(...) {
+                                            if(not excpt) {
+                                              excpt = std::current_exception();
+                                            }
+                                          }
+                                        }
+                                        iHolder.doneWaiting(excpt);
+                                        
+                                      });
+    workerManager_.resetAll();
+    
+    ParentContext parentContext(globalContext.get());
+
+    //make sure the task doesn't get run until all workers have beens started
+    WaitingTaskHolder holdForLoop(doneTask);
+    for(auto& worker: boost::adaptors::reverse((allWorkers()))) {
+      worker->doWorkAsync<T>(doneTask,ep,es,StreamID::invalidStreamID(),parentContext,globalContext.get());
+    }
+
+  }
+
   template <typename T>
   void
   GlobalSchedule::runNow(typename T::MyPrincipal const& p, EventSetup const& es,

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -114,7 +114,8 @@ namespace edm {
     reader_(),
     branchType_(bt),
     historyAppender_(historyAppender),
-    cacheIdentifier_(nextIdentifier())
+    cacheIdentifier_(nextIdentifier()),
+    atEndTransition_(false)
   {
     productResolvers_.resize(reg->getNextIndexValue(bt));
     //Now that these have been set, we can create the list of Branches we need.
@@ -306,6 +307,11 @@ namespace edm {
   }
 
   void
+  Principal::setAtEndTransition(bool iAtEnd) {
+    atEndTransition_ = iAtEnd;
+  }
+  
+  void
   Principal::deleteProduct(BranchID const& id) const {
     auto phb = getExistingProduct(id);
     assert(nullptr != phb);
@@ -319,6 +325,7 @@ namespace edm {
                            DelayedReader* reader) {
     //increment identifier here since clearPrincipal isn't called for Run/Lumi
     cacheIdentifier_=nextIdentifier();
+    atEndTransition_=false;
     if(reader) {
       reader_ = reader;
     }

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -369,6 +369,7 @@ namespace edm {
       mutable std::atomic<unsigned int> lastSkipCurrentCheckIndex_;
       mutable std::atomic<bool> prefetchRequested_;
       mutable std::atomic<bool> skippingPrefetchRequested_;
+      mutable std::atomic<bool> recheckedAtEnd_;
   };
 
   class SingleChoiceNoProcessProductResolver : public ProductResolverBase {

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/streamTransitionAsync.h"
+#include "FWCore/Framework/src/globalTransitionAsync.h"
 #include "FWCore/ParameterSet/interface/IllegalParameters.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -434,6 +435,35 @@ namespace edm {
   }
 
   void
+  SubProcess::doBeginRunAsync(WaitingTaskHolder iHolder, RunPrincipal const& principal, IOVSyncValue const& ts) {
+    ServiceRegistry::Operate operate(serviceToken_);
+
+    auto aux = std::make_shared<RunAuxiliary>(principal.aux());
+    aux->setProcessHistoryID(principal.processHistoryID());
+    auto rpp = std::make_shared<RunPrincipal>(aux, preg_, *processConfiguration_, &(historyAppenders_[historyRunOffset_+principal.index()]),principal.index(),false);
+    auto & processHistoryRegistry = processHistoryRegistries_[historyRunOffset_+principal.index()];
+    processHistoryRegistry.registerProcessHistory(principal.processHistory());
+    rpp->fillRunPrincipal(processHistoryRegistry, principal.reader());
+    principalCache_.insert(rpp);
+    
+    ProcessHistoryID const& parentInputReducedPHID = principal.reducedProcessHistoryID();
+    ProcessHistoryID const& inputReducedPHID       = rpp->reducedProcessHistoryID();
+    
+    parentToChildPhID_.insert(std::make_pair(parentInputReducedPHID,inputReducedPHID));
+    
+    RunPrincipal& rp = *principalCache_.runPrincipalPtr();
+    propagateProducts(InRun, principal, rp);
+    typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
+    beginGlobalTransitionAsync<Traits>(std::move(iHolder),
+                                       *schedule_,
+                                       rp,
+                                       ts,
+                                       esp_->eventSetupForInstance(ts),
+                                       subProcesses_);
+  }
+
+  
+  void
   SubProcess::doEndRun(RunPrincipal const& principal, IOVSyncValue const& ts, bool cleaningUpAfterException) {
     ServiceRegistry::Operate operate(serviceToken_);
     endRun(principal,ts,cleaningUpAfterException);
@@ -490,6 +520,29 @@ namespace edm {
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
     schedule_->processOneGlobal<Traits>(lbp, esp_->eventSetupForInstance(ts));
     for_all(subProcesses_, [&lbp, &ts](auto& subProcess){ subProcess.doBeginLuminosityBlock(lbp, ts); });
+  }
+
+  void
+  SubProcess::doBeginLuminosityBlockAsync(WaitingTaskHolder iHolder, LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
+    ServiceRegistry::Operate operate(serviceToken_);
+
+    auto aux = std::make_shared<LuminosityBlockAuxiliary>(principal.aux());
+    aux->setProcessHistoryID(principal.processHistoryID());
+    auto lbpp = std::make_shared<LuminosityBlockPrincipal>(aux, preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_+principal.index()]),principal.index(),false);
+    auto & processHistoryRegistry = processHistoryRegistries_[historyLumiOffset_+principal.index()];
+    processHistoryRegistry.registerProcessHistory(principal.processHistory());
+    lbpp->fillLuminosityBlockPrincipal(processHistoryRegistry, principal.reader());
+    lbpp->setRunPrincipal(principalCache_.runPrincipalPtr());
+    principalCache_.insert(lbpp);
+    LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();
+    propagateProducts(InLumi, principal, lbp);
+    typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
+    beginGlobalTransitionAsync<Traits>(std::move(iHolder),
+                                       *schedule_,
+                                       lbp,
+                                       ts,
+                                       esp_->eventSetupForInstance(ts),
+                                       subProcesses_);
   }
 
   void

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -445,6 +445,7 @@ namespace edm {
     rp.setComplete();
     propagateProducts(InRun, principal, rp);
     typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
+    rp.setAtEndTransition(true);
     schedule_->processOneGlobal<Traits>(rp, esp_->eventSetupForInstance(ts), cleaningUpAfterException);
     for_all(subProcesses_, [&rp, &ts, cleaningUpAfterException](auto& subProcess){ subProcess.doEndRun(rp, ts, cleaningUpAfterException); });
   }
@@ -503,6 +504,7 @@ namespace edm {
     lbp.setComplete();
     propagateProducts(InLumi, principal, lbp);
     typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
+    lbp.setAtEndTransition(true);
     schedule_->processOneGlobal<Traits>(lbp, esp_->eventSetupForInstance(ts), cleaningUpAfterException);
     for_all(subProcesses_, [&lbp, &ts, cleaningUpAfterException](auto& subProcess){ subProcess.doEndLuminosityBlock(lbp, ts, cleaningUpAfterException); });
   }

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -208,7 +208,9 @@ private:
 
     moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching,parentContext,nullptr);
     
-    actReg_->preModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(),moduleCallingContext_);
+    if(iPrincipal.branchType()==InEvent) {
+      actReg_->preModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(),moduleCallingContext_);
+    }
 
     //Need to be sure the ref count isn't set to 0 immediately
     iTask->increment_ref_count();
@@ -220,7 +222,9 @@ private:
       }
     }
     
-    preActionBeforeRunEventAsync(iTask,moduleCallingContext_,iPrincipal);
+    if(iPrincipal.branchType()==InEvent) {
+      preActionBeforeRunEventAsync(iTask,moduleCallingContext_,iPrincipal);
+    }
     
     if(0 == iTask->decrement_ref_count()) {
       //if everything finishes before we leave this routine, we need to launch the task

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -204,7 +204,7 @@ private:
   
   void Worker::prefetchAsync(WaitingTask* iTask, ParentContext const& parentContext, Principal const& iPrincipal) {
     // Prefetch products the module declares it consumes (not including the products it maybe consumes)
-    std::vector<ProductResolverIndexAndSkipBit> const& items = itemsToGetFromEvent();
+    std::vector<ProductResolverIndexAndSkipBit> const& items = itemsToGetFrom(iPrincipal.branchType());
 
     moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching,parentContext,nullptr);
     

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -216,7 +216,8 @@ namespace edm {
     virtual void itemsToGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const = 0;
     virtual void itemsMayGet(BranchType, std::vector<ProductResolverIndexAndSkipBit>&) const = 0;
 
-    virtual std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFromEvent() const = 0;
+    virtual std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType) const = 0;
+
 
     virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const = 0;
 

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -335,13 +335,15 @@ namespace edm {
         // to hold the exception_ptr
         std::exception_ptr temp_excptr;
         auto excptr = exceptionPtr();
-        try {
-          //pre was called in prefetchAsync
-          m_worker->emitPostModuleEventPrefetchingSignal();
-        }catch(...) {
-          temp_excptr = std::current_exception();
-          if(not excptr) {
-            excptr = &temp_excptr;
+        if(T::isEvent_) {
+          try {
+            //pre was called in prefetchAsync
+            m_worker->emitPostModuleEventPrefetchingSignal();
+          }catch(...) {
+            temp_excptr = std::current_exception();
+            if(not excptr) {
+              excptr = &temp_excptr;
+            }
           }
         }
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -128,7 +128,7 @@ namespace edm {
       module_->itemsMayGet(branchType, indexes);
     }
 
-    virtual std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFromEvent() const override { return module_->itemsToGetFromEvent(); }
+    virtual std::vector<ProductResolverIndexAndSkipBit> const& itemsToGetFrom(BranchType iType) const override final { return module_->itemsToGetFrom(iType); }
     
     virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
 

--- a/FWCore/Framework/src/globalTransitionAsync.h
+++ b/FWCore/Framework/src/globalTransitionAsync.h
@@ -1,0 +1,112 @@
+#ifndef FWCore_Framework_globalTransitionAsync_h
+#define FWCore_Framework_globalTransitionAsync_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Function:    globalTransitionAsync
+// 
+/**\function globalTransitionAsync globalTransitionAsync.h "globalTransitionAsync.h"
+
+ Description: Helper functions for handling asynchronous global transitions
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Tue, 06 Sep 2016 16:04:26 GMT
+//
+
+// system include files
+#include "FWCore/Framework/interface/Schedule.h"
+#include "FWCore/Framework/interface/SubProcess.h"
+#include "FWCore/Concurrency/interface/WaitingTask.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  class IOVSyncValue;
+  class EventSetup;
+  class LuminosityBlockPrincipal;
+  class RunPrincipal;
+  
+  //This is code in common between beginStreamRun and beginGlobalLuminosityBlock
+  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder,SubProcess& iSubProcess, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS) {
+    iSubProcess.doBeginLuminosityBlockAsync(std::move(iHolder),iPrincipal, iTS);
+  }
+  
+  inline void subProcessDoGlobalBeginTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, RunPrincipal& iPrincipal, IOVSyncValue const& iTS) {
+    iSubProcess.doBeginRunAsync(std::move(iHolder),iPrincipal, iTS);
+  }
+  
+  /*Not implemented yet
+  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, LuminosityBlockPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
+    iSubProcess.doEndLuminosityBlockAsync(std::move(iHolder),iPrincipal, iTS,cleaningUpAfterException);
+  }
+  
+  inline void subProcessDoGlobalEndTransitionAsync(WaitingTaskHolder iHolder, SubProcess& iSubProcess, RunPrincipal& iPrincipal, IOVSyncValue const& iTS, bool cleaningUpAfterException) {
+    iSubProcess.doEndRunAsync(std::move(iHolder), iPrincipal, iTS, cleaningUpAfterException);
+  }
+   */
+
+  template<typename Traits, typename P, typename SC >
+  void beginGlobalTransitionAsync(WaitingTaskHolder iWait,
+                                  Schedule& iSchedule,
+                                  P& iPrincipal,
+                                  IOVSyncValue const & iTS,
+                                  EventSetup const& iES,
+                                  SC& iSubProcesses) {
+    ServiceToken token = ServiceRegistry::instance().presentToken();
+
+    //When we are done processing the global for this process,
+    // we need to run the global for all SubProcesses
+    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,&iPrincipal,iTS,token](std::exception_ptr const* iPtr) mutable {
+      if(iPtr) {
+        iWait.doneWaiting(*iPtr);
+        return;
+      }
+      ServiceRegistry::Operate op(token);
+      for_all(iSubProcesses, [&iWait, &iPrincipal, iTS](auto& subProcess){ subProcessDoGlobalBeginTransitionAsync(iWait,subProcess,iPrincipal, iTS); });
+    });
+    
+    WaitingTaskHolder h(subs);
+    iSchedule.processOneGlobalAsync<Traits>(std::move(h),iPrincipal, iES);
+  }
+
+  
+  template<typename Traits, typename P, typename SC >
+  void endGlobalTransitionAsync(WaitingTaskHolder iWait,
+                                Schedule& iSchedule,
+                                P& iPrincipal,
+                                IOVSyncValue const & iTS,
+                                EventSetup const& iES,
+                                SC& iSubProcesses,
+                                bool cleaningUpAfterException)
+  {
+    ServiceToken token = ServiceRegistry::instance().presentToken();
+    
+    //When we are done processing the global for this process,
+    // we need to run the global for all SubProcesses
+    auto subs = make_waiting_task(tbb::task::allocate_root(), [&iSubProcesses, iWait,&iPrincipal,iTS,token,cleaningUpAfterException](std::exception_ptr const* iPtr) mutable {
+      if(iPtr) {
+        iWait.doneWaiting(*iPtr);
+        return;
+      }
+      ServiceRegistry::Operate op(token);
+      for_all(iSubProcesses, [&iWait, &iPrincipal, iTS,cleaningUpAfterException](auto& subProcess){
+        subProcessDoGlobalEndTransitionAsync(iWait,subProcess,iPrincipal, iTS,cleaningUpAfterException); });
+    });
+    
+    WaitingTaskHolder h(subs);
+    iSchedule.processOneGlobalAsync<Traits>(std::move(h),iPrincipal, iES,cleaningUpAfterException);
+      
+    
+  }
+
+};
+
+#endif

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -95,9 +95,9 @@ EDAnalyzerAdaptorBase::itemsMayGet(BranchType iType, std::vector<ProductResolver
 }
 
 std::vector<edm::ProductResolverIndexAndSkipBit> const&
-EDAnalyzerAdaptorBase::itemsToGetFromEvent() const {
+EDAnalyzerAdaptorBase::itemsToGetFrom(BranchType iType) const {
   assert(not m_streamModules.empty());
-  return m_streamModules[0]->itemsToGetFromEvent();  
+  return m_streamModules[0]->itemsToGetFrom(iType);
 }
 
 void

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -99,9 +99,9 @@ namespace edm {
 
     template<typename T>
     std::vector<edm::ProductResolverIndexAndSkipBit> const&
-    ProducingModuleAdaptorBase<T>::itemsToGetFromEvent() const {
+    ProducingModuleAdaptorBase<T>::itemsToGetFrom(BranchType iType) const {
       assert(not m_streamModules.empty());
-      return m_streamModules[0]->itemsToGetFromEvent();
+      return m_streamModules[0]->itemsToGetFrom(iType);
     }
 
     template< typename T>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -69,6 +69,10 @@
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_unscheduledFailOnOutput.sh"/>
     <use   name="FWCore/Utilities"/>
   </bin>
+  <bin   file="TestIntegration.cpp" name="TestIntegrationGetProductAtEnd">
+    <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test run_getProductAtEnd.sh"/>
+    <use   name="FWCore/Utilities"/>
+  </bin>
   <bin   file="TestIntegration.cpp" name="TestIntegrationParentless">
     <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Integration/test parentlessTest.sh"/>
     <use   name="FWCore/Utilities"/>
@@ -117,7 +121,7 @@
     <use   name="FWCore/ParameterSet"/>
     <use   name="FWCore/Framework"/>
   </library>
-  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc" name="SomeTestModules">
+  <library   file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,ThinningTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc, WaitingThreadIntProducer.cc, ThingAnalyzer.cc" name="SomeTestModules">
     <flags   EDM_PLUGIN="1"/>
     <use   name="FWCore/Framework"/>
     <use   name="DataFormats/TestObjects"/>

--- a/FWCore/Integration/test/ThingAnalyzer.cc
+++ b/FWCore/Integration/test/ThingAnalyzer.cc
@@ -1,0 +1,172 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     ThingAnalyzer
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  root
+//         Created:  Fri, 21 Apr 2017 13:34:58 GMT
+//
+
+// system include files
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+// user include files
+
+
+namespace edmtest {
+  struct Empty {};
+  class ThingAnalyzer : public edm::global::EDAnalyzer<edm::RunCache<Empty>,edm::LuminosityBlockCache<Empty>> {
+  public:
+    ThingAnalyzer(edm::ParameterSet const&);
+    
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override final;
+    std::shared_ptr<Empty> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override final;
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override final;
+    std::shared_ptr<Empty> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override final;
+    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override final;
+    
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    void shouldBeInvalid(edm::Handle<ThingCollection> const&) const;
+    
+    edm::EDGetTokenT<ThingCollection> beginRun_;
+    edm::EDGetTokenT<ThingCollection> beginLumi_;
+    edm::EDGetTokenT<ThingCollection> event_;
+    edm::EDGetTokenT<ThingCollection> endLumi_;
+    edm::EDGetTokenT<ThingCollection> endRun_;
+  };
+  
+  ThingAnalyzer::ThingAnalyzer(edm::ParameterSet const& iPSet):
+  beginRun_(consumes<ThingCollection,edm::InRun>(iPSet.getUntrackedParameter<edm::InputTag>("beginRun"))),
+  beginLumi_(consumes<ThingCollection,edm::InLumi>(iPSet.getUntrackedParameter<edm::InputTag>("beginLumi"))),
+  event_(consumes<ThingCollection>(iPSet.getUntrackedParameter<edm::InputTag>("event"))),
+  endLumi_(consumes<ThingCollection,edm::InLumi>(iPSet.getUntrackedParameter<edm::InputTag>("endLumi"))),
+  endRun_(consumes<ThingCollection,edm::InRun>(iPSet.getUntrackedParameter<edm::InputTag>("endRun")))
+  {
+    
+  }
+  
+  void
+  ThingAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+  {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked("beginRun",edm::InputTag{"thing","beginRun"})->setComment("Collection to get from Run");
+    desc.addUntracked("beginLumi",edm::InputTag{"thing","beginLumi"})->setComment("Collection to get from Lumi");
+    desc.addUntracked("event",edm::InputTag{"thing",""})->setComment("Collection to get from event");
+    desc.addUntracked("endLumi",edm::InputTag{"thing","endLumi"})->setComment("Collection to get from Lumi but only available at end");
+    desc.addUntracked("endRun",edm::InputTag{"thing","endRun"})->setComment("Collection to get from Run but only available at end");
+    descriptions.add("thingAnalyzer", desc);
+
+  }
+
+  void
+  ThingAnalyzer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const
+  {
+    auto const& lumi = iEvent.getLuminosityBlock();
+    
+    auto const& run = lumi.getRun();
+    
+    edm::Handle<ThingCollection> h;
+    run.getByToken(beginRun_,h);
+    *h;
+    
+    run.getByToken(endRun_,h);
+    shouldBeInvalid(h);
+    
+    lumi.getByToken(beginLumi_,h);
+    *h;
+    
+    lumi.getByToken(endLumi_,h);
+    shouldBeInvalid(h);
+
+    iEvent.getByToken(event_,h);
+    *h;
+  }
+  
+  std::shared_ptr<Empty>
+  ThingAnalyzer::globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const
+  {
+    edm::Handle<ThingCollection> h;
+    iRun.getByToken(beginRun_,h);
+    *h;
+    
+    iRun.getByToken(endRun_,h);
+    shouldBeInvalid(h);
+    
+    return std::shared_ptr<Empty>();
+  }
+  
+  void
+  ThingAnalyzer::globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const
+  {
+    edm::Handle<ThingCollection> h;
+    iRun.getByToken(beginRun_,h);
+    *h;
+    
+    iRun.getByToken(endRun_,h);
+    *h;
+  }
+  
+  std::shared_ptr<Empty>
+  ThingAnalyzer::globalBeginLuminosityBlock(edm::LuminosityBlock const&iLumi, edm::EventSetup const&) const
+  {
+    auto const& run = iLumi.getRun();
+    
+    edm::Handle<ThingCollection> h;
+    run.getByToken(beginRun_,h);
+    *h;
+    
+    run.getByToken(endRun_,h);
+    shouldBeInvalid(h);
+
+    iLumi.getByToken(beginLumi_,h);
+    *h;
+    
+    iLumi.getByToken(endLumi_,h);
+    shouldBeInvalid(h);
+
+    
+    return std::shared_ptr<Empty>();
+  }
+  
+  void
+  ThingAnalyzer::globalEndLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) const
+  {
+    auto const& run = iLumi.getRun();
+    
+    edm::Handle<ThingCollection> h;
+    run.getByToken(beginRun_,h);
+    *h;
+    
+    run.getByToken(endRun_,h);
+    shouldBeInvalid(h);
+    
+    iLumi.getByToken(beginLumi_,h);
+    *h;
+    
+    iLumi.getByToken(endLumi_,h);
+    *h;
+    
+  }
+  
+  void
+  ThingAnalyzer::shouldBeInvalid(edm::Handle<ThingCollection> const& iHandle) const {
+    if(iHandle.isValid()) {
+      throw cms::Exception("ShouldNotBeValid") <<"handle was valid when it should not have been";
+    }
+  }
+
+}
+
+DEFINE_FWK_MODULE(edmtest::ThingAnalyzer);

--- a/FWCore/Integration/test/run_getProductAtEnd.sh
+++ b/FWCore/Integration/test/run_getProductAtEnd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+  cmsRun ${LOCAL_TEST_DIR}/testGetProductAtEnd_cfg.py || die "cmsRun testGetProductAtEnd_cfg.py" $?
+  cmsRun ${LOCAL_TEST_DIR}/testGetProductAtEndUnscheduled_cfg.py || die "cmsRun testGetProductAtEndUnscheduled_cfg.py" $?
+
+popd
+
+exit 0

--- a/FWCore/Integration/test/testGetProductAtEndUnscheduled_cfg.py
+++ b/FWCore/Integration/test/testGetProductAtEndUnscheduled_cfg.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(2))
+
+process.thing = cms.EDProducer("ThingProducer")
+
+process.getThing = cms.EDAnalyzer("edmtest::ThingAnalyzer")
+
+process.thingTask = cms.Task(process.thing)
+process.e = cms.EndPath(process.getThing,process.thingTask)

--- a/FWCore/Integration/test/testGetProductAtEnd_cfg.py
+++ b/FWCore/Integration/test/testGetProductAtEnd_cfg.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(2))
+
+process.thing = cms.EDProducer("ThingProducer")
+
+process.getThing = cms.EDAnalyzer("edmtest::ThingAnalyzer")
+
+process.e = cms.EndPath(process.thing+process.getThing)

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -179,23 +179,6 @@
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin run for module: label = 'test' id = 11
-++++++ finished: global begin run for module: label = 'test' id = 11
-++++++ starting: global begin run for module: label = 'testmerge' id = 12
-++++++ finished: global begin run for module: label = 'testmerge' id = 12
-++++++ starting: global begin run for module: label = 'get' id = 13
-++++++ finished: global begin run for module: label = 'get' id = 13
-++++++ starting: global begin run for module: label = 'getInt' id = 14
-++++++ finished: global begin run for module: label = 'getInt' id = 14
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin run for module: label = 'out' id = 16
-++++++ finished: global begin run for module: label = 'out' id = 16
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
-++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -213,6 +196,23 @@
 ++++++ finished: global begin run for module: label = 'out' id = 24
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
+++++ finished: global begin run 1 : time = 1
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin run for module: label = 'test' id = 11
+++++++ finished: global begin run for module: label = 'test' id = 11
+++++++ starting: global begin run for module: label = 'testmerge' id = 12
+++++++ finished: global begin run for module: label = 'testmerge' id = 12
+++++++ starting: global begin run for module: label = 'get' id = 13
+++++++ finished: global begin run for module: label = 'get' id = 13
+++++++ starting: global begin run for module: label = 'getInt' id = 14
+++++++ finished: global begin run for module: label = 'getInt' id = 14
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin run for module: label = 'out' id = 16
+++++++ finished: global begin run for module: label = 'out' id = 16
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
@@ -295,23 +295,6 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -329,6 +312,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
@@ -1069,23 +1069,6 @@
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1103,6 +1086,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
@@ -1843,23 +1843,6 @@
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1877,6 +1860,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
@@ -2459,23 +2459,6 @@
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin run for module: label = 'test' id = 11
-++++++ finished: global begin run for module: label = 'test' id = 11
-++++++ starting: global begin run for module: label = 'testmerge' id = 12
-++++++ finished: global begin run for module: label = 'testmerge' id = 12
-++++++ starting: global begin run for module: label = 'get' id = 13
-++++++ finished: global begin run for module: label = 'get' id = 13
-++++++ starting: global begin run for module: label = 'getInt' id = 14
-++++++ finished: global begin run for module: label = 'getInt' id = 14
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin run for module: label = 'out' id = 16
-++++++ finished: global begin run for module: label = 'out' id = 16
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
-++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -2493,6 +2476,23 @@
 ++++++ finished: global begin run for module: label = 'out' id = 24
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
+++++ finished: global begin run 2 : time = 55000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin run for module: label = 'test' id = 11
+++++++ finished: global begin run for module: label = 'test' id = 11
+++++++ starting: global begin run for module: label = 'testmerge' id = 12
+++++++ finished: global begin run for module: label = 'testmerge' id = 12
+++++++ starting: global begin run for module: label = 'get' id = 13
+++++++ finished: global begin run for module: label = 'get' id = 13
+++++++ starting: global begin run for module: label = 'getInt' id = 14
+++++++ finished: global begin run for module: label = 'getInt' id = 14
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin run for module: label = 'out' id = 16
+++++++ finished: global begin run for module: label = 'out' id = 16
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
@@ -2575,23 +2575,6 @@
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -2609,6 +2592,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
@@ -3349,23 +3349,6 @@
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -3383,6 +3366,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
@@ -4123,23 +4123,6 @@
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4157,6 +4140,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
@@ -4739,23 +4739,6 @@
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin run for module: label = 'test' id = 11
-++++++ finished: global begin run for module: label = 'test' id = 11
-++++++ starting: global begin run for module: label = 'testmerge' id = 12
-++++++ finished: global begin run for module: label = 'testmerge' id = 12
-++++++ starting: global begin run for module: label = 'get' id = 13
-++++++ finished: global begin run for module: label = 'get' id = 13
-++++++ starting: global begin run for module: label = 'getInt' id = 14
-++++++ finished: global begin run for module: label = 'getInt' id = 14
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin run for module: label = 'out' id = 16
-++++++ finished: global begin run for module: label = 'out' id = 16
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
-++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
@@ -4773,6 +4756,23 @@
 ++++++ finished: global begin run for module: label = 'out' id = 24
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
+++++ finished: global begin run 3 : time = 105000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin run for module: label = 'test' id = 11
+++++++ finished: global begin run for module: label = 'test' id = 11
+++++++ starting: global begin run for module: label = 'testmerge' id = 12
+++++++ finished: global begin run for module: label = 'testmerge' id = 12
+++++++ starting: global begin run for module: label = 'get' id = 13
+++++++ finished: global begin run for module: label = 'get' id = 13
+++++++ starting: global begin run for module: label = 'getInt' id = 14
+++++++ finished: global begin run for module: label = 'getInt' id = 14
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin run for module: label = 'out' id = 16
+++++++ finished: global begin run for module: label = 'out' id = 16
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
@@ -4855,23 +4855,6 @@
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4889,6 +4872,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
@@ -5629,23 +5629,6 @@
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -5663,6 +5646,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
@@ -6403,23 +6403,6 @@
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
-++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6437,6 +6420,23 @@
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001


### PR DESCRIPTION
Modules are run concurrently during global begin Run and LuminosityBlock transitions.

We do not yet run concurrently during global end transitions because that would break the use of the DQMStore.