### PR TITLE
Clean up aging.py and set up HB TDR aging

### DIFF
--- a/CalibCalorimetry/HcalPlugins/python/HBHEDarkening_cff.py
+++ b/CalibCalorimetry/HcalPlugins/python/HBHEDarkening_cff.py
@@ -5,28 +5,41 @@ import FWCore.ParameterSet.Config as cms
 # [lumirate] = fb-1/hr
 # dose maps only produced for 8 and 14 TeV - used also for 7 and 13 TeV, respectively
 
+# total for phase0/1 ~ 300 fb-1
+_years_LHC = cms.VPSet(
+    cms.PSet(year = cms.string("2011"), intlumi = cms.double(5.6), lumirate = cms.double(0.005), energy = cms.int32(8)),
+    cms.PSet(year = cms.string("2012"), intlumi = cms.double(23.3), lumirate = cms.double(0.013), energy = cms.int32(8)),
+    cms.PSet(year = cms.string("2015"), intlumi = cms.double(4.1), lumirate = cms.double(0.009), energy = cms.int32(14)),
+    cms.PSet(year = cms.string("2016"), intlumi = cms.double(41.0), lumirate = cms.double(0.026), energy = cms.int32(14)),
+    cms.PSet(year = cms.string("2017"), intlumi = cms.double(45.0), lumirate = cms.double(0.043), energy = cms.int32(14)),
+    cms.PSet(year = cms.string("2018"), intlumi = cms.double(45.0), lumirate = cms.double(0.043), energy = cms.int32(14)),
+    cms.PSet(year = cms.string("2021"), intlumi = cms.double(45.0), lumirate = cms.double(0.05), energy = cms.int32(14)),
+    cms.PSet(year = cms.string("2022"), intlumi = cms.double(45.0), lumirate = cms.double(0.05), energy = cms.int32(14)),
+    cms.PSet(year = cms.string("2023"), intlumi = cms.double(50.0), lumirate = cms.double(0.05), energy = cms.int32(14)),
+)
+
+# total for phase2 nominal = 3000 fb-1 (including phase0/1) @ 5.0E34/cm^2/s
+_years_HLLHC_nominal = cms.VPSet(
+    cms.PSet(year = cms.string("2038"), intlumi = cms.double(2700), lumirate = cms.double(0.15), energy = cms.int32(14)),
+)
+
+# total for phase2 ultimate = 4500 fb-1 (including phase0/1) @ 7.5E34/cm^2/s
+_years_HLLHC_ultimate = cms.VPSet(
+    cms.PSet(year = cms.string("2029"), intlumi = cms.double(700), lumirate = cms.double(0.15), energy = cms.int32(14)),
+    cms.PSet(year = cms.string("2039"), intlumi = cms.double(3500), lumirate = cms.double(0.225), energy = cms.int32(14)),
+)
+
 HEDarkeningEP = cms.ESSource("HBHEDarkeningEP",
     appendToDataLabel = cms.string("HE"),
     ieta_shift = cms.int32(16),
+    # parameters taken from https://indico.cern.ch/event/624984/contributions/2528379/attachments/1438631/2216142/2017.04.04_HCAL_CMS_week_v7.pdf, slide 12
     drdA = cms.double(4.0),
     drdB = cms.double(0.575),
     dosemaps = cms.VPSet(
         cms.PSet(energy = cms.int32(8), file = cms.FileInPath("CalibCalorimetry/HcalPlugins/data/dosemapHE_4TeV.txt")),
         cms.PSet(energy = cms.int32(14), file = cms.FileInPath("CalibCalorimetry/HcalPlugins/data/dosemapHE_7TeV.txt")),
     ),
-    years = cms.VPSet(
-        cms.PSet(year = cms.string("2011"), intlumi = cms.double(5.6), lumirate = cms.double(0.005), energy = cms.int32(8)),
-        cms.PSet(year = cms.string("2012"), intlumi = cms.double(23.3), lumirate = cms.double(0.013), energy = cms.int32(8)),
-        cms.PSet(year = cms.string("2015"), intlumi = cms.double(4.1), lumirate = cms.double(0.009), energy = cms.int32(14)),
-        cms.PSet(year = cms.string("2016"), intlumi = cms.double(41.0), lumirate = cms.double(0.026), energy = cms.int32(14)),
-        cms.PSet(year = cms.string("2017"), intlumi = cms.double(45.0), lumirate = cms.double(0.043), energy = cms.int32(14)),
-        cms.PSet(year = cms.string("2018"), intlumi = cms.double(45.0), lumirate = cms.double(0.043), energy = cms.int32(14)),
-        cms.PSet(year = cms.string("2021"), intlumi = cms.double(45.0), lumirate = cms.double(0.05), energy = cms.int32(14)),
-        cms.PSet(year = cms.string("2022"), intlumi = cms.double(45.0), lumirate = cms.double(0.05), energy = cms.int32(14)),
-        cms.PSet(year = cms.string("2023"), intlumi = cms.double(50.0), lumirate = cms.double(0.05), energy = cms.int32(14)),
-        # assume 3000 fb-1 for Phase2
-        cms.PSet(year = cms.string("2033"), intlumi = cms.double(3000), lumirate = cms.double(0.15), energy = cms.int32(14)),
-    ),
+    years = _years_LHC + _years_HLLHC_nominal,
 )
 
 HBDarkeningEP = HEDarkeningEP.clone(

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -1,20 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-def agePixel(process,lumi):
-    prd=1.0
-    if lumi>299:
-        prd=1.0
-    if lumi>499:
-        prd=1.5
-    if lumi>999:
-        prd=0.
-        
-    # danger - watch for someone turning off pixel aging - if off - leave off
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'pixel') and not hasattr(process.mix.digitizers.pixel,'NoAging'):
-        process.mix.digitizers.pixel.PseudoRadDamage =  cms.double(float(prd*7.65))
-        process.mix.digitizers.pixel.PseudoRadDamageRadius =  cms.double(16.5)
-    return process    
-
 # handle normal mixing or premixing
 def getHcalDigitizer(process):
     if hasattr(process,'mixData'):
@@ -133,97 +118,23 @@ def ageEcal(process,lumi):
         process.g4SimHits.ECalSD.DelivLuminosity = cms.double(float(lumi))
     return process
 
-def customise_aging_100(process):
-
-    process=ageHcal(process,100)
-    process=ageEcal(process,100)
-    process=agePixel(process,100)
-    return process
-
-def customise_aging_200(process):
-
-    process=ageHcal(process,200)
-    process=ageEcal(process,200)
-    process=agePixel(process,200)
-    return process
-
 def customise_aging_300(process):
 
     process=ageHcal(process,300)
     process=ageEcal(process,300)
-    process=agePixel(process,300)
-    return process
-
-def customise_aging_400(process):
-
-    process=ageHcal(process,400)
-    process=ageEcal(process,400)
-    process=agePixel(process,400)
-    return process
-
-def customise_aging_500(process):
-
-    process=ageHcal(process,500)
-    process=ageEcal(process,500)
-    process=agePixel(process,500)
-    return process
-
-def customise_aging_600(process):
-
-    process=ageHcal(process,600)
-    process=ageEcal(process,600)
-    process=agePixel(process,600)
-    return process
-
-def customise_aging_700(process):
-
-    process=ageHcal(process,700)
-    process=ageEcal(process,700)
-    process=agePixel(process,700)
     return process
 
 def customise_aging_1000(process):
 
     process=ageHcal(process,1000)
     process=ageEcal(process,1000)
-    process=agePixel(process,1000)
     return process
 
 def customise_aging_3000(process):
 
     process=ageHcal(process,3000)
     process=ageEcal(process,3000)
-    process=agePixel(process,3000)
     return process
-
-def customise_aging_ecalonly_300(process):
-
-    process=ageEcal(process,300)
-    return process
-
-def customise_aging_ecalonly_1000(process):
-
-    process=ageEcal(process,1000)
-    return process
-
-def customise_aging_ecalonly_3000(process):
-
-    process=ageEcal(process,3000)
-    return process
-
-def customise_aging_newpixel_1000(process):
-
-    process=ageEcal(process,1000)
-    process=ageHcal(process,1000)
-    return process
-
-def customise_aging_newpixel_3000(process):
-
-    process=ageEcal(process,3000)
-    process=ageHcal(process,3000)
-    return process
-
-#no hcal 3000
 
 def ecal_complete_aging(process):
     if hasattr(process,'g4SimHits'):
@@ -231,121 +142,3 @@ def ecal_complete_aging(process):
     if hasattr(process,'ecal_digi_parameters'):    
         process.ecal_digi_parameters.UseLCcorrection = cms.untracked.bool(False)
     return process
-
-def turn_off_Pixel_aging(process):
-
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):    
-        setattr(process.mix.digitizers.pixel,'NoAging',cms.double(1.))
-        process.mix.digitizers.pixel.PseudoRadDamage =  cms.double(0.)
-    return process
-
-def turn_on_Pixel_aging_1000(process):
-    # just incase we want aging afterall
-    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'hcal'):    
-        process.mix.digitizers.pixel.PseudoRadDamage =  cms.double(1.5)
-        process.mix.digitizers.pixel.PseudoRadDamageRadius =  cms.double(4.0)
-
-    return process
-
-def ecal_complete_aging_300(process):
-    process=ecal_complete_aging(process)
-
-    if not hasattr(process.GlobalTag,'toGet'):
-        process.GlobalTag.toGet=cms.VPSet()
-    process.GlobalTag.toGet.extend( cms.VPSet(
-        cms.PSet(record = cms.string("EcalPedestalsRcd"),
-                 tag = cms.string("EcalPedestals_TL300_IL1E34_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        ## laser D
-        cms.PSet(record = cms.string("EcalLaserAPDPNRatiosRcd"),
-                 tag = cms.string("EcalLaserAPDPNRatios_TL300_IL1E34_v2_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        ## L1 trigger
-        cms.PSet(record = cms.string("EcalTPGLinearizationConstRcd"),
-                 tag = cms.string("EcalTPGLinearizationConst_TL300_IL1E34_v2_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        cms.PSet(record = cms.string('EcalLaserAlphasRcd'),
-                 tag = cms.string('EcalLaserAlphas_EB_sic1_btcp1_EE_sic1_btcp1'),
-                 connect = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS')
-                 ),
-        #VPT aging
-        cms.PSet(record = cms.string('EcalLinearCorrectionsRcd'),
-                 tag = cms.string('EcalLinearCorrections_mc'),
-                 connect = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS')
-                 )
-        )
-                                    )
-    return process
-
-    
-def ecal_complete_aging_1000(process):
-    process=ecal_complete_aging(process)
-
-    if not hasattr(process.GlobalTag,'toGet'):
-        process.GlobalTag.toGet=cms.VPSet()
-    process.GlobalTag.toGet.extend( cms.VPSet(
-        cms.PSet(record = cms.string("EcalPedestalsRcd"),
-                 tag = cms.string("EcalPedestals_TL1000_IL5E34_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        ## laser D
-        cms.PSet(record = cms.string("EcalLaserAPDPNRatiosRcd"),
-                 tag = cms.string("EcalLaserAPDPNRatios_TL1000_IL5E34_v2_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        ## L1 trigger
-        cms.PSet(record = cms.string("EcalTPGLinearizationConstRcd"),
-                 tag = cms.string("EcalTPGLinearizationConst_TL1000_IL5E34_v2_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        cms.PSet(record = cms.string('EcalLaserAlphasRcd'),
-                 tag = cms.string('EcalLaserAlphas_EB_sic1_btcp1_EE_sic1_btcp1'),
-                 connect = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS')
-                 ),
-        #VPT aging
-        cms.PSet(record = cms.string('EcalLinearCorrectionsRcd'),
-                 tag = cms.string('EcalLinearCorrections_mc'),
-                 connect = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS')
-                 )
-        )
-                                    )
-    return process
-
-
-def ecal_complete_aging_3000(process):
-    process=ecal_complete_aging(process)
-
-    if not hasattr(process.GlobalTag,'toGet'):
-        process.GlobalTag.toGet=cms.VPSet()
-    process.GlobalTag.toGet.extend( cms.VPSet(
-        cms.PSet(record = cms.string("EcalPedestalsRcd"),
-                 tag = cms.string("EcalPedestals_TL3000_IL5E34_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        ## laser D
-        cms.PSet(record = cms.string("EcalLaserAPDPNRatiosRcd"),
-                 tag = cms.string("EcalLaserAPDPNRatios_TL3000_IL5E34_v2_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        ## L1 trigger
-        cms.PSet(record = cms.string("EcalTPGLinearizationConstRcd"),
-                 tag = cms.string("EcalTPGLinearizationConst_TL3000_IL5E34_v2_mc"),
-                 connect = cms.untracked.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 ),
-        cms.PSet(record = cms.string('EcalLaserAlphasRcd'),
-                 tag = cms.string('EcalLaserAlphas_EB_sic1_btcp1_EE_sic1_btcp1'),
-                 connect = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS')
-                 ),
-        #VPT aging
-        cms.PSet(record = cms.string('EcalLinearCorrectionsRcd'),
-                 tag = cms.string('EcalLinearCorrections_mc'),
-                 connect = cms.untracked.string('frontier://FrontierProd/CMS_CONDITIONS')
-                 )
-        )
-                                    )
-
-    return process
-


### PR DESCRIPTION
Followup to #18118 to set up the aging customise functions for the barrel TDR. I removed a bunch of very old stuff from aging.py, and added a set of functions and corresponding HCAL conditions for the agreed-upon aging scenarios:
>i) 300 fb-1, 1000fb-1 and 3000fb-1 with an instantaneous luminosity of 5E34, the nominal scenario
>ii) 3000fb-1 and 4500fb-1 with an instantaneous luminosity of 7.5E34, the ultimate scenario

Currently the HCAL conditions ignore the lumi ramp-up period after LS3/4 and just use the final instantaneous lumi (for simplicity).

For future reference, here are the two HL-LHC schedules:
![HL-LHC schedules](http://kjplanet.com/pr/HL-LHC-lumi-profile-ultimate.png)