### PR TITLE
Use native:: only on x86_64/i386

### DIFF
--- a/HLTrigger/Timer/test/chrono/test/benchmark.h
+++ b/HLTrigger/Timer/test/chrono/test/benchmark.h
@@ -40,6 +40,8 @@ double to_nanoseconds(boost::chrono::duration<Rep, Period> duration) {
 #endif // HAVE_BOOST_CHRONO
 
 
+#if defined(__x86_64__) || defined(__i386__)
+
 // native chrono types
 template <class Rep, class Period>
 double to_seconds(native::native_duration<Rep, Period> duration) {
@@ -51,6 +53,7 @@ double to_nanoseconds(native::native_duration<Rep, Period> duration) {
     return std::chrono::duration_cast<std::chrono::duration<double, std::nano>>(duration).count();
 }
 
+#endif
 
 static constexpr unsigned int SIZE = 1000000;
 


### PR DESCRIPTION
This is part is failing on aarch64 and ppc64le architectures. Looking
at other files seems that `native::` should only be used on x86_64/i386.

Build tested with CMSSW_9_1_X on slc7_aarch64_gcc700.

Signed-off-by: David Abdurachmanov <davidlt@cern.ch>