### PR TITLE
Remove hard-coded RPC conditions

### DIFF
--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -23,23 +23,7 @@ _run3_muonDigi += muonGEMDigi
 _phase2_muonDigi = _run3_muonDigi.copy()
 _phase2_muonDigi += muonME0Digi
 
-def _modifySimMuonForPhase2( theProcess ):
-    theProcess.rpcphase2recovery_essource = cms.ESSource("PoolDBESSource",
-         toGet = cms.VPSet(cms.PSet(
-             record = cms.string("RPCStripNoisesRcd"),             
-             tag = cms.string("RPC_testCondition_192Strips_mc"),
-             connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-            ),
-         cms.PSet(record = cms.string("RPCClusterSizeRcd"),
-                 tag = cms.string("RPCClusterSize_PhaseII_mc"),
-                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-                 )
-         )
-    )
-    theProcess.rpcphase2recovery_esprefer = cms.ESPrefer("PoolDBESSource","rpcphase2recovery_essource")
-
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonDigi, _run3_muonDigi )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( muonDigi, _phase2_muonDigi )
-modifyConfigurationStandardSequencesSimMuonPhase2_ = phase2_muon.makeProcessModifier( _modifySimMuonForPhase2 )

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -14,8 +14,6 @@ from SimMuon.DTDigitizer.muondtdigi_cfi import *
 from SimMuon.RPCDigitizer.muonrpcdigi_cfi import *
 muonDigi = cms.Sequence(simMuonCSCDigis+simMuonDTDigis+simMuonRPCDigis)
 
-from CondCore.DBCommon.CondDBCommon_cfi import *
-
 from SimMuon.GEMDigitizer.muonGEMDigi_cff import *
 from SimMuon.GEMDigitizer.muonME0Digi_cff import *
 

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -14,6 +14,8 @@ from SimMuon.DTDigitizer.muondtdigi_cfi import *
 from SimMuon.RPCDigitizer.muonrpcdigi_cfi import *
 muonDigi = cms.Sequence(simMuonCSCDigis+simMuonDTDigis+simMuonRPCDigis)
 
+#from CondCore.CondDB.CondDB_cfi import *
+
 from SimMuon.GEMDigitizer.muonGEMDigi_cff import *
 from SimMuon.GEMDigitizer.muonME0Digi_cff import *
 
@@ -25,7 +27,7 @@ _phase2_muonDigi += muonME0Digi
 
 def _modifySimMuonForPhase2( theProcess ):
     theProcess.rpcphase2recovery_essource = cms.ESSource("PoolDBESSource",
-         CondDBCommon,
+ #        CondDBCommon,
          #    using CondDBSetup
          toGet = cms.VPSet(cms.PSet(
              record = cms.string("RPCStripNoisesRcd"),             

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -14,8 +14,6 @@ from SimMuon.DTDigitizer.muondtdigi_cfi import *
 from SimMuon.RPCDigitizer.muonrpcdigi_cfi import *
 muonDigi = cms.Sequence(simMuonCSCDigis+simMuonDTDigis+simMuonRPCDigis)
 
-#from CondCore.CondDB.CondDB_cfi import *
-
 from SimMuon.GEMDigitizer.muonGEMDigi_cff import *
 from SimMuon.GEMDigitizer.muonME0Digi_cff import *
 
@@ -27,8 +25,6 @@ _phase2_muonDigi += muonME0Digi
 
 def _modifySimMuonForPhase2( theProcess ):
     theProcess.rpcphase2recovery_essource = cms.ESSource("PoolDBESSource",
- #        CondDBCommon,
-         #    using CondDBSetup
          toGet = cms.VPSet(cms.PSet(
              record = cms.string("RPCStripNoisesRcd"),             
              tag = cms.string("RPC_testCondition_192Strips_mc"),


### PR DESCRIPTION
The conditions are now managed in the Global Tag, so we could remove the hard-coded conditions.