### PR TITLE
CTPPS: bug fix in run ranges for FEDs channels mapping

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -235,8 +235,8 @@ void TotemDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetu
 
     // event id "1:min" has a special meaning and is translated to a truly minimal event id (1:0:0)
     EventID startEventID = bl.validityRange.startEventID();
-    if (startEventID == EventID(1, 0, 1))
-      startEventID = EventID(1, 0, 0);
+    if (startEventID.event() == 1)
+      startEventID = EventID(startEventID.run(), startEventID.luminosityBlock(), 0);
 
     if (startEventID <= iosv.eventID() && iosv.eventID() <= bl.validityRange.endEventID())
     {

--- a/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
-ctppsDiamondRawToDigi = totemVFATRawToDigi.copy()
-ctppsDiamondRawToDigi.subSystem = "TimingDiamond"
+ctppsDiamondRawToDigi = totemVFATRawToDigi.clone(
+    subSystem = cms.string('TimingDiamond')
+)

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -18,13 +18,13 @@ totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSource
     ),
     # during TS2 (2016)
     cms.PSet(
-      validityRange = cms.EventRange("280386:min - 281600:max"),
+      validityRange = cms.EventRange("280385:min - 281600:max"),
       mappingFileNames = cms.vstring(),
       maskFileNames = cms.vstring()
     ),
     # after TS2 (2016)
     cms.PSet(
-      validityRange = cms.EventRange("281601:min - 999999999:max"),
+      validityRange = cms.EventRange("281600:min - 999999999:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_tracking_strip_from_fill_5330.xml"),
       maskFileNames = cms.vstring()
     )
@@ -48,7 +48,7 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
     ),
     # after diamonds inserted in DAQ
     cms.PSet(
-      validityRange = cms.EventRange("283820:min - 999999999:max"),
+      validityRange = cms.EventRange("283819:min - 999999999:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond.xml"),
       maskFileNames = cms.vstring()
     )

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -18,13 +18,13 @@ totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSource
     ),
     # during TS2 (2016)
     cms.PSet(
-      validityRange = cms.EventRange("280385:min - 281600:max"),
+      validityRange = cms.EventRange("280386:min - 281600:max"),
       mappingFileNames = cms.vstring(),
       maskFileNames = cms.vstring()
     ),
     # after TS2 (2016)
     cms.PSet(
-      validityRange = cms.EventRange("281600:min - 999999999:max"),
+      validityRange = cms.EventRange("281601:min - 999999999:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_tracking_strip_from_fill_5330.xml"),
       maskFileNames = cms.vstring()
     )
@@ -48,7 +48,7 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
     ),
     # after diamonds inserted in DAQ
     cms.PSet(
-      validityRange = cms.EventRange("283819:min - 999999999:max"),
+      validityRange = cms.EventRange("283820:min - 999999999:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond.xml"),
       maskFileNames = cms.vstring()
     )

--- a/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
-totemRPRawToDigi = totemVFATRawToDigi.copy()
-totemRPRawToDigi.subSystem = "TrackingStrip"
+totemRPRawToDigi = totemVFATRawToDigi.clone(
+    subSystem = cms.string('TrackingStrip')
+)

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -109,6 +109,7 @@ void RawToDigiConverter::RunCommon(const VFATFrameCollection &input, const Totem
       problemsPresent = true;
 
       if (verbosity > 0)
+        fes << "    CRC failure\n";
 
       if (testCRC == tfErr)
       {

--- a/EventFilter/CTPPSRawToDigi/test/test_standard_sequence_cfg.py
+++ b/EventFilter/CTPPSRawToDigi/test/test_standard_sequence_cfg.py
@@ -14,7 +14,8 @@ process.MessageLogger = cms.Service("MessageLogger",
 # raw data source
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-    '/store/express/Run2016H/ExpressPhysics/FEVT/Express-v2/000/283/877/00000/4EE44B0E-2499-E611-A155-02163E011938.root'
+#    '/store/express/Run2016H/ExpressPhysics/FEVT/Express-v2/000/283/877/00000/4EE44B0E-2499-E611-A155-02163E011938.root'
+    '/store/data/Run2016H/ZeroBias/RAW/v1/000/283/820/00000/462D2A5B-B19A-E611-B100-02163E01382E.root'
   )
 )
 


### PR DESCRIPTION
This PR modifies the run ranges parser to account for scenarios where the first event number in a run is `0` instead of `1`, thus preventing any channels mapping to be defined for this event.
It hence allows runs at the edge of these ranges to properly retrieve a channels mapping for both the strips and diamond detectors.
It also backports a bug fix raised in https://github.com/cms-sw/cmssw/pull/18283#issuecomment-296129695 by @perrotta preventing the CRC check to be performed on the VFAT frame is the unpacker verbosity is set to `0`.

`runTheMatrix -l limited` on bbc0068152f5d589f0610fe78c07ea5983a0b742 yielded `9 9 8 6 4 1 1 1 tests passed, 1 0 0 0 0 0 0 0 failed` (again, `DAS_ERROR` on `4.22`)