### PR TITLE
Removing kPoorCalib filter from energy plots

### DIFF
--- a/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
@@ -69,14 +69,14 @@ ecalClusterTask = cms.untracked.PSet(
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('ProjEta'),
-            description = cms.untracked.string('Projection of the mean size (number of crystals) of the basic clusters.')
+            description = cms.untracked.string('Eta-projection of the number of crystals in basic clusters.')
         ),
         BCSizeMapProjPhi = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC size projection phi%(suffix)s'),
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('ProjPhi'),
-            description = cms.untracked.string('Projection of the mean size (number of crystals) of the basic clusters.')
+            description = cms.untracked.string('Phi-projection of the number of crystals in basic clusters.')
         ),
         BCSize = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC size'),
@@ -88,7 +88,7 @@ ecalClusterTask = cms.untracked.PSet(
                 low = cms.untracked.double(0.0)
             ),
             btype = cms.untracked.string('User'),
-            description = cms.untracked.string('Distribution of the basic cluster size (number of crystals).')
+            description = cms.untracked.string('Distribution of the number of crystals in basic clusters.')
         ),
         BCE = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC energy'),
@@ -108,7 +108,7 @@ ecalClusterTask = cms.untracked.PSet(
             kind = cms.untracked.string('TProfile2D'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
-            description = cms.untracked.string('2D distribution of the mean size (number of crystals) of the basic clusters.')
+            description = cms.untracked.string('2D distribution of the mean number of crystals in basic clusters.')
         ),
         BCNum = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC number'),

--- a/DQM/EcalMonitorTasks/src/EnergyTask.cc
+++ b/DQM/EcalMonitorTasks/src/EnergyTask.cc
@@ -52,13 +52,14 @@ namespace ecaldqm
     MESet& meHit(MEs_.at("Hit"));
     MESet& meHitAll(MEs_.at("HitAll"));
 
-    uint32_t notGood(~(0x1 << EcalRecHit::kGood));
+    uint32_t neitherGoodNorPoorCalib(~(0x1 << EcalRecHit::kGood |
+                                       0x1 << EcalRecHit::kPoorCalib));
     uint32_t neitherGoodNorOOT(~(0x1 << EcalRecHit::kGood |
                                  0x1 << EcalRecHit::kOutOfTime));
 
     for(EcalRecHitCollection::const_iterator hitItr(_hits.begin()); hitItr != _hits.end(); ++hitItr){
 
-      if(isPhysicsRun_ && hitItr->checkFlagMask(notGood)) continue;
+      if(isPhysicsRun_ && hitItr->checkFlagMask(neitherGoodNorPoorCalib)) continue;
       if(!isPhysicsRun_ && hitItr->checkFlagMask(neitherGoodNorOOT)) continue;
 
       float energy(hitItr->energy());


### PR DESCRIPTION
Currently, hits with the kPoorCalib flag set are not included in the calculation of rechit energies shown in the 2D maps. However, hits with this flag set are included in offline reconstruction, so if something is wrong with the rechit energies, DQM should not artificially mask the problem. With this PR we modify the mask.

In addition, there are a few minor changes to plot descriptions to stay consistent with some minor changes to DQMGUI descriptions that will be included in the next PR.

Link to PR to master: https://github.com/cms-sw/cmssw/pull/18468