### PR TITLE
Changed logic of dZVertex assignement 

### DIFF
--- a/CommonTools/RecoAlgos/interface/PrimaryVertexAssignment.h
+++ b/CommonTools/RecoAlgos/interface/PrimaryVertexAssignment.h
@@ -22,6 +22,7 @@ class PrimaryVertexAssignment {
   PrimaryVertexAssignment(const edm::ParameterSet& iConfig):
    maxDzSigForPrimaryAssignment_(iConfig.getParameter<double>("maxDzSigForPrimaryAssignment")),
    maxDzForPrimaryAssignment_(iConfig.getParameter<double>("maxDzForPrimaryAssignment")),
+   maxDzErrorForPrimaryAssignment_(iConfig.getParameter<double>("maxDzErrorForPrimaryAssignment")),
    maxJetDeltaR_(iConfig.getParameter<double>("maxJetDeltaR")),
    minJetPt_(iConfig.getParameter<double>("minJetPt")),
    maxDistanceToJetAxis_(iConfig.getParameter<double>("maxDistanceToJetAxis")),
@@ -73,6 +74,7 @@ class PrimaryVertexAssignment {
  private  :
     double    maxDzSigForPrimaryAssignment_;
     double    maxDzForPrimaryAssignment_;
+    double    maxDzErrorForPrimaryAssignment_;
     double    maxJetDeltaR_;
     double    minJetPt_;
     double    maxDistanceToJetAxis_;

--- a/CommonTools/RecoAlgos/python/sortedPFPrimaryVertices_cfi.py
+++ b/CommonTools/RecoAlgos/python/sortedPFPrimaryVertices_cfi.py
@@ -4,7 +4,8 @@ sortedPFPrimaryVertices = cms.EDProducer("PFCandidatePrimaryVertexSorter",
     assignment = cms.PSet(
     #cuts to assign primary tracks not used in PV fit based on dZ compatibility
     maxDzSigForPrimaryAssignment = cms.double(5.0), # in AND with next
-    maxDzForPrimaryAssignment = cms.double(0.03), # in AND with prev
+    maxDzForPrimaryAssignment = cms.double(0.1), # in AND with prev
+    maxDzErrorForPrimaryAssignment = cms.double(0.05), # in AND with prev, tracks with uncertainty above 500um cannot tell us which pv they come from
 
     # cuts used to recover b-tracks if they are closed to jet axis
     maxJetDeltaR = cms.double(0.5),

--- a/CommonTools/RecoAlgos/python/sortedPFPrimaryVertices_cfi.py
+++ b/CommonTools/RecoAlgos/python/sortedPFPrimaryVertices_cfi.py
@@ -3,8 +3,8 @@ sortedPFPrimaryVertices = cms.EDProducer("PFCandidatePrimaryVertexSorter",
     sorting = cms.PSet(),
     assignment = cms.PSet(
     #cuts to assign primary tracks not used in PV fit based on dZ compatibility
-    maxDzSigForPrimaryAssignment = cms.double(5.0), # in OR with next
-    maxDzForPrimaryAssignment = cms.double(0.03), # in OR with prev
+    maxDzSigForPrimaryAssignment = cms.double(5.0), # in AND with next
+    maxDzForPrimaryAssignment = cms.double(0.03), # in AND with prev
 
     # cuts used to recover b-tracks if they are closed to jet axis
     maxJetDeltaR = cms.double(0.5),

--- a/CommonTools/RecoAlgos/python/sortedPrimaryVertices_cfi.py
+++ b/CommonTools/RecoAlgos/python/sortedPrimaryVertices_cfi.py
@@ -3,8 +3,8 @@ sortedPrimaryVertices = cms.EDProducer("RecoChargedRefCandidatePrimaryVertexSort
     sorting = cms.PSet(),
     assignment = cms.PSet(
     #cuts to assign primary tracks not used in PV fit based on dZ compatibility
-    maxDzSigForPrimaryAssignment = cms.double(5.0), # in OR with next
-    maxDzForPrimaryAssignment = cms.double(0.03), # in OR with prev
+    maxDzSigForPrimaryAssignment = cms.double(5.0), # in AND with next
+    maxDzForPrimaryAssignment = cms.double(0.1), # in AND with prev
 
     # cuts used to recover b-tracks if they are closed to jet axis
     maxJetDeltaR = cms.double(0.5),

--- a/CommonTools/RecoAlgos/python/sortedPrimaryVertices_cfi.py
+++ b/CommonTools/RecoAlgos/python/sortedPrimaryVertices_cfi.py
@@ -5,6 +5,7 @@ sortedPrimaryVertices = cms.EDProducer("RecoChargedRefCandidatePrimaryVertexSort
     #cuts to assign primary tracks not used in PV fit based on dZ compatibility
     maxDzSigForPrimaryAssignment = cms.double(5.0), # in AND with next
     maxDzForPrimaryAssignment = cms.double(0.1), # in AND with prev
+    maxDzErrorForPrimaryAssignment = cms.double(0.05), # in AND with prev, tracks with uncertainty above 500um cannot tell us which pv they come from
 
     # cuts used to recover b-tracks if they are closed to jet axis
     maxJetDeltaR = cms.double(0.5),

--- a/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
@@ -41,7 +41,7 @@ PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vert
       }
    }
   // first use "closest in Z" with tight cuts (targetting primary particles)
-    if(vtxIdMinDz>=0 and (dzmin < maxDzForPrimaryAssignment_ and dzmin/track->dzError() < maxDzSigForPrimaryAssignment_ ))
+    if(vtxIdMinDz>=0 and (dzmin < maxDzForPrimaryAssignment_ and dzmin/track->dzError() < maxDzSigForPrimaryAssignment_  and track->dzError()<maxDzErrorForPrimaryAssignment_))
     {
         iVertex=vtxIdMinDz;
     }
@@ -56,7 +56,7 @@ PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vert
       if( ij->pt() < minJetPt_ ) continue; // skip jets below the jet Pt threshold
 
       double deltaR = reco::deltaR( *ij, *track );
-      if( deltaR < minDeltaR )
+      if( deltaR < minDeltaR and track->dzError()<maxDzErrorForPrimaryAssignment_ )
       {
         minDeltaR = deltaR;
         jetIdx = std::distance(jets.begin(), ij);

--- a/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
@@ -41,7 +41,7 @@ PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vert
       }
    }
   // first use "closest in Z" with tight cuts (targetting primary particles)
-    if(vtxIdMinDz>=0 and (dzmin < maxDzForPrimaryAssignment_ or dzmin/track->dzError() < maxDzSigForPrimaryAssignment_ ))
+    if(vtxIdMinDz>=0 and (dzmin < maxDzForPrimaryAssignment_ and dzmin/track->dzError() < maxDzSigForPrimaryAssignment_ ))
     {
         iVertex=vtxIdMinDz;
     }

--- a/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
@@ -41,7 +41,8 @@ PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vert
       }
    }
   // first use "closest in Z" with tight cuts (targetting primary particles)
-    if(vtxIdMinDz>=0 and (dzmin < maxDzForPrimaryAssignment_ and dzmin/track->dzError() < maxDzSigForPrimaryAssignment_  and track->dzError()<maxDzErrorForPrimaryAssignment_))
+    float dzE=sqrt(track->dzError()*track->dzError()+vertices[vtxIdMinDz].covariance(2,2));
+    if(vtxIdMinDz>=0 and (dzmin < maxDzForPrimaryAssignment_ and dzmin/dzE < maxDzSigForPrimaryAssignment_  and track->dzError()<maxDzErrorForPrimaryAssignment_))
     {
         iVertex=vtxIdMinDz;
     }

--- a/CommonTools/RecoAlgos/test/pvSorting.py
+++ b/CommonTools/RecoAlgos/test/pvSorting.py
@@ -12,14 +12,14 @@ process.source = cms.Source("PoolSource",
 #   skipEvents=cms.untracked.uint32(0),
     fileNames = cms.untracked.vstring(
 #'root://xrootd.ba.infn.it//store/mc/RunIISpring15DR74/WprimeToWZToLLQQ_M-4000_TuneCUETP8M1_13TeV-pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/10000/126A3AFB-9607-E511-A527-90B11C12EA74.root'
-    'root://xrootd.ba.infn.it//store/mc/RunIISpring15DR74/WprimeToMuNu_M-5800_TuneCUETP8M1_13TeV-pythia8/AODSIM/Asympt50ns_MCRUN2_74_V9A-v2/10000/580F0D5E-760C-E511-A9D6-047D7B881D62.root'
+    'file:///afs/cern.ch/user/a/arizzi/workspace/444C11E2-EAB2-E611-B3D4-B083FED14CE0.root'
 #     'file:../../../00387B2C-4A1C-E511-A4E0-0026189438B3.root'
     )
 )
 
 
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True))
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(500) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.load("Configuration.EventContent.EventContent_cff")
 process.out = cms.OutputModule(
     "PoolOutputModule",

--- a/PhysicsTools/PatAlgos/python/slimming/primaryVertexAssociation_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/primaryVertexAssociation_cfi.py
@@ -1,31 +1,10 @@
 import FWCore.ParameterSet.Config as cms
-primaryVertexAssociation = cms.EDProducer("PFCandidatePrimaryVertexSorter",
-    sorting = cms.PSet(),
-    assignment = cms.PSet(
-    #cuts to assign primary tracks not used in PV fit based on dZ compatibility
-    maxDzSigForPrimaryAssignment = cms.double(5.0), # in OR with next
-    maxDzForPrimaryAssignment = cms.double(0.03), # in OR with prev
+from CommonTools.RecoAlgos.sortedPFPrimaryVertices_cfi import sortedPFPrimaryVertices
 
-    # cuts used to recover b-tracks if they are closed to jet axis
-    maxJetDeltaR = cms.double(0.5),
-    minJetPt = cms.double(25),
-    maxDistanceToJetAxis = cms.double(0.07), # std cut in b-tag is 700um
-    maxDzForJetAxisAssigment = cms.double(0.1), # 1mm, because b-track IP is boost invariant
-    maxDxyForJetAxisAssigment = cms.double(0.1), # 1mm, because b-track IP is boost invariant
-
-    #cuts used to identify primary tracks compatible with beamspot
-    maxDxySigForNotReconstructedPrimary = cms.double(2), #in AND with next
-    maxDxyForNotReconstructedPrimary = cms.double(0.01), #in AND with prev
-    ),
-  particles = cms.InputTag("particleFlow"),
-  vertices= cms.InputTag("offlinePrimaryVertices"),
-  jets= cms.InputTag("ak4PFJets"),
-  qualityForPrimary = cms.int32(2),
-  usePVMET = cms.bool(True),
-  produceAssociationToOriginalVertices = cms.bool(True),
+primaryVertexAssociation = sortedPFPrimaryVertices.clone(
+  qualityForPrimary = cms.int32(2),  
   produceSortedVertices = cms.bool(False),
-  producePileUpCollection  = cms.bool(False),
-  produceNoPileUpCollection = cms.bool(False),
-
+  producePileUpCollection  = cms.bool(False),  
+  produceNoPileUpCollection = cms.bool(False)
 )
 


### PR DESCRIPTION
The category PrimaryDz (CompatibilityDz in MiniAOD) is using the OR between compatibility in value and significance. 
This PR changes the OR to an AND in order to avoid outliers.
Because now it is an "AND" the absolute value cut is also increased from 300um to 1mm

This is a request received long ago from VBF community and recently reported to create troubles on searches on gamma+jets samples.

@azzurrip @gpetruc @rovere @VinInn 

PS: basic tests  are done but we should check on larger samples before merging