### PR TITLE
L1T2016 is completely tranported to L1T - 90x missing commit

### DIFF
--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -12,7 +12,7 @@
 import FWCore.ParameterSet.Config as cms
 
 l1tStage2EventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
-    monitorDir = cms.untracked.string("L1T2016"),
+    monitorDir = cms.untracked.string("L1T"),
 
     # decide when to run and update the results of the quality tests
     # retrieval of quality test results must be consistent with the event / LS / Run execution
@@ -44,12 +44,12 @@ l1tStage2EventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
                         QualityTests = cms.VPSet(
                             cms.PSet(
                                 QualityTestName = cms.string("Layer1LinkErrorThreshold"),
-                                QualityTestHist = cms.string("L1T2016/L1TStage2CaloLayer1/MismatchDetail/maxEvtLinkErrorsByLumiECAL"),
+                                QualityTestHist = cms.string("L1T/L1TStage2CaloLayer1/MismatchDetail/maxEvtLinkErrorsByLumiECAL"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("Layer1MismatchThreshold"),
-                                QualityTestHist = cms.string("L1T2016/L1TStage2CaloLayer1/MismatchDetail/maxEvtMismatchByLumiECAL"),
+                                QualityTestHist = cms.string("L1T/L1TStage2CaloLayer1/MismatchDetail/maxEvtMismatchByLumiECAL"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )
@@ -61,12 +61,12 @@ l1tStage2EventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
                         QualityTests = cms.VPSet(
                             cms.PSet(
                                 QualityTestName = cms.string("Layer1LinkErrorThreshold"),
-                                QualityTestHist = cms.string("L1T2016/L1TStage2CaloLayer1/MismatchDetail/maxEvtLinkErrorsByLumiHCAL"),
+                                QualityTestHist = cms.string("L1T/L1TStage2CaloLayer1/MismatchDetail/maxEvtLinkErrorsByLumiHCAL"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("Layer1MismatchThreshold"),
-                                QualityTestHist = cms.string("L1T2016/L1TStage2CaloLayer1/MismatchDetail/maxEvtMismatchByLumiHCAL"),
+                                QualityTestHist = cms.string("L1T/L1TStage2CaloLayer1/MismatchDetail/maxEvtMismatchByLumiHCAL"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )
@@ -78,12 +78,12 @@ l1tStage2EventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
                         QualityTests = cms.VPSet(
                             cms.PSet(
                                 QualityTestName = cms.string("Layer1LinkErrorThreshold"),
-                                QualityTestHist = cms.string("L1T2016/L1TStage2CaloLayer1/maxEvtLinkErrorsByLumi"),
+                                QualityTestHist = cms.string("L1T/L1TStage2CaloLayer1/maxEvtLinkErrorsByLumi"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("Layer1MismatchThreshold"),
-                                QualityTestHist = cms.string("L1T2016/L1TStage2CaloLayer1/maxEvtMismatchByLumi"),
+                                QualityTestHist = cms.string("L1T/L1TStage2CaloLayer1/maxEvtMismatchByLumi"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )


### PR DESCRIPTION
This PR adds a missing commit that was left out of the backport in #18043 
The 91x version is already merged with #18352 and the first commit of the PR is contained already in #18043

The commit is needed to remove the L1T2016 directory from the online DQM.