### PR TITLE
Add deepCSV to b-tag DQM

### DIFF
--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -97,6 +97,46 @@ bTagCommonBlock = cms.PSet(
             label = cms.InputTag("pfCombinedMVAV2BJetTags"),
             folder = cms.string("combMVAv2")
         ), 
+        cms.PSet(
+            bTagGenericAnalysisBlock,
+            label = cms.InputTag("pfDeepCSVJetTags:probb"),
+            folder = cms.string("deepCSV_probb")
+        ),
+        cms.PSet(
+            bTagGenericAnalysisBlock,
+            label = cms.InputTag("pfDeepCSVJetTags:probc"),
+            folder = cms.string("deepCSV_probc")
+        ),
+        cms.PSet(
+            bTagGenericAnalysisBlock,
+            label = cms.InputTag("pfDeepCSVJetTags:probudsg"),
+            folder = cms.string("deepCSV_probudsg")
+        ),
+        cms.PSet(
+            bTagGenericAnalysisBlock,
+            label = cms.InputTag("pfDeepCSVJetTags:probbb"),
+            folder = cms.string("deepCSV_probbb")
+        ),
+        #cms.PSet(
+        #    bTagGenericAnalysisBlock,
+        #    label = cms.InputTag("pfDeepCMVAJetTags:probb"),
+        #    folder = cms.string("deepCMVA_probb")
+        #),
+        #cms.PSet(
+        #    bTagGenericAnalysisBlock,
+        #    label = cms.InputTag("pfDeepCMVAJetTags:probc"),
+        #    folder = cms.string("deepCMVA_probc")
+        #),
+        #cms.PSet(
+        #    bTagGenericAnalysisBlock,
+        #    label = cms.InputTag("pfDeepCMVAJetTags:probudsg"),
+        #    folder = cms.string("deepCMVA_probudsg")
+        #),
+        #cms.PSet(
+        #    bTagGenericAnalysisBlock,
+        #    label = cms.InputTag("pfDeepCMVAJetTags:probbb"),
+        #    folder = cms.string("deepCMVA_probbb")
+        #),
        cms.PSet(
             bTagSoftLeptonAnalysisBlock,
             label = cms.InputTag("softPFMuonBJetTags"),


### PR DESCRIPTION
This PR adds the new deepCSV tagger (with the four DNN outputs: probb, probc, probusdg, probbb) to the b-tag DQM.

DeepCMVA is also included but left commented out, just as in https://github.com/cms-sw/cmssw/blob/CMSSW_9_1_X/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py#L57