### PR TITLE
(Do not merge) Special timing window configuration for splash events

### DIFF
--- a/DQM/EcalMonitorClient/python/TimingClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TimingClient_cfi.py
@@ -12,7 +12,7 @@ minTowerEntriesFwd = 160
 toleranceMeanFwd = 6.
 toleranceRMSFwd = 12.
 tailPopulThreshold = 0.4
-timeWindow = 25. 
+timeWindow = 30.
 
 ecalTimingClient = cms.untracked.PSet(
     params = cms.untracked.PSet(

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -78,7 +78,8 @@ namespace ecaldqm
 
       DetId id(qItr->getId());
 
-      int minChannelEntries(minChannelEntries_);
+      // int minChannelEntries(minChannelEntries_);
+      int minChannelEntries(0);
       float meanThresh(toleranceMean_);
       float rmsThresh(toleranceRMS_);
 

--- a/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
@@ -69,14 +69,14 @@ ecalClusterTask = cms.untracked.PSet(
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('ProjEta'),
-            description = cms.untracked.string('Projection of the mean size (number of crystals) of the basic clusters.')
+            description = cms.untracked.string('Eta-projection of the number of crystals in basic clusters.')
         ),
         BCSizeMapProjPhi = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC size projection phi%(suffix)s'),
             kind = cms.untracked.string('TProfile'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('ProjPhi'),
-            description = cms.untracked.string('Projection of the mean size (number of crystals) of the basic clusters.')
+            description = cms.untracked.string('Phi-projection of the number of crystals in basic clusters.')
         ),
         BCSize = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC size'),
@@ -88,7 +88,7 @@ ecalClusterTask = cms.untracked.PSet(
                 low = cms.untracked.double(0.0)
             ),
             btype = cms.untracked.string('User'),
-            description = cms.untracked.string('Distribution of the basic cluster size (number of crystals).')
+            description = cms.untracked.string('Distribution of the number of crystals in basic clusters.')
         ),
         BCE = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC energy'),
@@ -108,7 +108,7 @@ ecalClusterTask = cms.untracked.PSet(
             kind = cms.untracked.string('TProfile2D'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
-            description = cms.untracked.string('2D distribution of the mean size (number of crystals) of the basic clusters.')
+            description = cms.untracked.string('2D distribution of the mean number of crystals in basic clusters.')
         ),
         BCNum = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT BC number'),

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -8,8 +8,8 @@ chi2ThresholdEE = 50.
 chi2ThresholdEB = 16.
 energyThresholdEE = 3.
 energyThresholdEB = 1.
-timeWindow = 12.5
-summaryTimeWindow = 7.
+timeWindow = 30.
+summaryTimeWindow = 25.
 
 ecalTimingTask = cms.untracked.PSet(
     params = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/src/EnergyTask.cc
+++ b/DQM/EcalMonitorTasks/src/EnergyTask.cc
@@ -52,13 +52,14 @@ namespace ecaldqm
     MESet& meHit(MEs_.at("Hit"));
     MESet& meHitAll(MEs_.at("HitAll"));
 
-    uint32_t notGood(~(0x1 << EcalRecHit::kGood));
+    uint32_t neitherGoodNorPoorCalib(~(0x1 << EcalRecHit::kGood |
+                                       0x1 << EcalRecHit::kPoorCalib));
     uint32_t neitherGoodNorOOT(~(0x1 << EcalRecHit::kGood |
                                  0x1 << EcalRecHit::kOutOfTime));
 
     for(EcalRecHitCollection::const_iterator hitItr(_hits.begin()); hitItr != _hits.end(); ++hitItr){
 
-      if(isPhysicsRun_ && hitItr->checkFlagMask(notGood)) continue;
+      if(isPhysicsRun_ && hitItr->checkFlagMask(neitherGoodNorPoorCalib)) continue;
       if(!isPhysicsRun_ && hitItr->checkFlagMask(neitherGoodNorOOT)) continue;
 
       float energy(hitItr->energy());

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -77,7 +77,7 @@ namespace ecaldqm
                     float energy(hit.energy());
 
                     // Apply cut on chi2 of pulse shape fit
-                    float chi2Threshold = ( id.subdetId() == EcalBarrel ) ? chi2ThresholdEB_ : chi2ThresholdEE_;
+                    // float chi2Threshold = ( id.subdetId() == EcalBarrel ) ? chi2ThresholdEB_ : chi2ThresholdEE_;
                     if ( id.subdetId() == EcalBarrel )
                       signedSubdet = EcalBarrel;
                     else {
@@ -89,7 +89,7 @@ namespace ecaldqm
                     }
                     if ( energy > threshold )
                       meChi2.fill(signedSubdet, hit.chi2());
-                    if ( hit.chi2() > chi2Threshold ) return;
+                    // if ( hit.chi2() > chi2Threshold ) return;
 
                     meTimeAmp.fill(id, energy, time);
                     meTimeAmpAll.fill(id, energy, time);


### PR DESCRIPTION
During splash events, we often have very poor signal shapes. In addition, it is useful to view these events in a wider time window than the default configuration. This PR changes the timing windows and removes a chi-square constraint to make DQM more useful during splash events. This is not meant to be merged into CMSSW.

This PR is based on top of the recent PR#18467 ( https://github.com/cms-sw/cmssw/pull/18467 ) to ensure no issues while merging in production.

Link to Deployment PR: https://github.com/dmwm/deployment/pull/471