### PR TITLE
fix HGC recHit energy scale for FTFP_BERT_EMM

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -79,8 +79,8 @@ HGCalRecHit = cms.EDProducer(
 
     # EM Scale calibrations
     layerWeights = dEdX_weights,
-    thicknessCorrection = cms.vdouble(0.964,0.920,0.909), # 100, 200, 300 um
-    
+    thicknessCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um 
+
     # algo
     algo = cms.string("HGCalRecHitWorkerSimple")
     


### PR DESCRIPTION
This is a fix to the energy scale for HGC rechits after the change in the G4 physics list. Documentation of the study was presented in https://indico.cern.ch/event/607331/contributions/2453642/attachments/1401757/2139714/SimAndPerf_25Jan17.pdf

To be noted that the values fixing the scale (1.174, 1.187, 1.192) were measured on top of what was previously in release (https://github.com/cms-sw/cmssw/blob/CMSSW_8_1_X/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py#L82), so the product of the two provides the fix.

A validation with the code from the PR was shown in slide 4 of https://indico.cern.ch/event/619113/contributions/2509419/attachments/1424487/2184573/ClusteringUpdate08March17.pdf