### PR TITLE
fix getcwd() usage to avoid undefined behavior

### DIFF
--- a/CommonTools/UtilAlgos/src/TFileService.cc
+++ b/CommonTools/UtilAlgos/src/TFileService.cc
@@ -88,9 +88,18 @@ void TFileService::afterBeginJob() {
 
   if(!fileName_.empty())  {
     if(!fileNameRecorded_) {
-      std::string fullName;
-      fullName.reserve(1024);
-      fullName = getcwd(&fullName[0],1024);
+      std::string fullName(1024, '\0');
+
+      while (getcwd(&fullName[0], fullName.size()) == nullptr) {
+	 if (errno != ERANGE) {
+	    throw cms::Exception("TFileService")
+	       << "Failed to get current directory (errno=" << errno 
+	       << "): " << strerror(errno);
+	 }
+	 fullName.resize(fullName.size()*2, '\0');
+      }   
+      fullName.resize(fullName.find('\0'));
+
       fullName += "/" + fileName_;
 
       std::map<std::string, std::string> fileData;


### PR DESCRIPTION
TFileService::afterBeginJob() abuses getcwd() in a way that depends on undefined behavior, breaking with gcc 6.3.0.  This patch fixes the undefined behavior and makes it more robust handling long paths and other errors that never happen.