### PR TITLE
pr91x Turn on L1T Calo Calibration 2017.

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/hackConditions_cff.py
@@ -43,7 +43,7 @@ if stage2L1Trigger.isChosen():
         from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_1_HI_cfi import *    
     else:
         sys.stderr.write("L1TCalorimeter Conditions configured for Stage-2 (2016) trigger. \n")
-        from L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_1_cfi import *    
+        from L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_4_cfi import *
     
     # What about CaloConfig?  Related:  How will we switch PP/HH?
     #


### PR DESCRIPTION
Turn on 2017 Calo Layer1 and Layer2 calibration 2017_1_4 (i.e. set as default)
as they are blessed by L1T.

This will have to go into 92X.
