### PR TITLE
CTPPS: diamond mapping for 2017 data taking

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
+++ b/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
@@ -32,38 +32,38 @@
           <diamond_channel id="30"        hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="1?"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x205"           FEDId="583"             GOHId="1?"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x204"           FEDId="583"             GOHId="1?"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x203"           FEDId="583"             GOHId="1?"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x202"           FEDId="583"             GOHId="1?"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x201"           FEDId="583"             GOHId="1?"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x200"           FEDId="583"             GOHId="1?"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x20F"           FEDId="583"             GOHId="1?"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x20E"           FEDId="583"             GOHId="1?"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x20D"           FEDId="583"             GOHId="1?"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x20C"           FEDId="583"             GOHId="1?"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x20B"           FEDId="583"             GOHId="1?"               IdxInFiber="10"/>
+          <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="7"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x205"           FEDId="583"             GOHId="7"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x204"           FEDId="583"             GOHId="7"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x203"           FEDId="583"             GOHId="7"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x202"           FEDId="583"             GOHId="7"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x201"           FEDId="583"             GOHId="7"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x200"           FEDId="583"             GOHId="7"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x20F"           FEDId="583"             GOHId="7"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x20E"           FEDId="583"             GOHId="7"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x20D"           FEDId="583"             GOHId="7"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x20C"           FEDId="583"             GOHId="7"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x20B"           FEDId="583"             GOHId="7"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">  <!-- UFSD -->
-          <diamond_channel id="0"         hw_id="0x216"           FEDId="583"             GOHId="2?"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x215"           FEDId="583"             GOHId="2?"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x214"           FEDId="583"             GOHId="2?"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x213"           FEDId="583"             GOHId="2?"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x212"           FEDId="583"             GOHId="2?"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x211"           FEDId="583"             GOHId="2?"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x210"           FEDId="583"             GOHId="2?"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x21F"           FEDId="583"             GOHId="2?"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x21E"           FEDId="583"             GOHId="2?"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x21D"           FEDId="583"             GOHId="2?"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x21C"           FEDId="583"             GOHId="2?"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x21B"           FEDId="583"             GOHId="2?"               IdxInFiber="10"/>
-          <diamond_channel id="30"        hw_id="0x21F"           FEDId="583"             GOHId="2?"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x216"           FEDId="583"             GOHId="8"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x215"           FEDId="583"             GOHId="8"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x214"           FEDId="583"             GOHId="8"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x213"           FEDId="583"             GOHId="8"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x212"           FEDId="583"             GOHId="8"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x211"           FEDId="583"             GOHId="8"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x210"           FEDId="583"             GOHId="8"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x21F"           FEDId="583"             GOHId="8"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x21E"           FEDId="583"             GOHId="8"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x21D"           FEDId="583"             GOHId="8"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x21C"           FEDId="583"             GOHId="8"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x21B"           FEDId="583"             GOHId="8"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x21F"           FEDId="583"             GOHId="8"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>
   </arm>
-    <arm id="1">  <!-- 56 -->
+  <arm id="1">  <!-- 56 -->
     <station id="1">        <!-- 215 m -->
       <rp_detector_set id="6">        <!-- Timing -->
         <rp_plane_diamond id="0"> 
@@ -96,33 +96,33 @@
           <diamond_channel id="30"        hw_id="0x31F"           FEDId="582"             GOHId="7"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x406"           FEDId="582"             GOHId="8?"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x405"           FEDId="582"             GOHId="8?"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x404"           FEDId="582"             GOHId="8?"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x403"           FEDId="582"             GOHId="8?"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x402"           FEDId="582"             GOHId="8?"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x401"           FEDId="582"             GOHId="8?"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x400"           FEDId="582"             GOHId="8?"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x40F"           FEDId="582"             GOHId="8?"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x40E"           FEDId="582"             GOHId="8?"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x40D"           FEDId="582"             GOHId="8?"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x40C"           FEDId="582"             GOHId="8?"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x40B"           FEDId="582"             GOHId="8?"               IdxInFiber="10"/>
+          <diamond_channel id="0"         hw_id="0x406"           FEDId="582"             GOHId="9"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x405"           FEDId="582"             GOHId="9"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x404"           FEDId="582"             GOHId="9"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x403"           FEDId="582"             GOHId="9"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x402"           FEDId="582"             GOHId="9"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x401"           FEDId="582"             GOHId="9"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x400"           FEDId="582"             GOHId="9"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x40F"           FEDId="582"             GOHId="9"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x40E"           FEDId="582"             GOHId="9"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x40D"           FEDId="582"             GOHId="9"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x40C"           FEDId="582"             GOHId="9"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x40B"           FEDId="582"             GOHId="9"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">  <!-- UFSD -->
-          <diamond_channel id="0"         hw_id="0x416"           FEDId="582"             GOHId="7?"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x415"           FEDId="582"             GOHId="7?"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x414"           FEDId="582"             GOHId="7?"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x413"           FEDId="582"             GOHId="7?"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x412"           FEDId="582"             GOHId="7?"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x411"           FEDId="582"             GOHId="7?"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x410"           FEDId="582"             GOHId="7?"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x41F"           FEDId="582"             GOHId="7?"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x41E"           FEDId="582"             GOHId="7?"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x41D"           FEDId="582"             GOHId="7?"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x41C"           FEDId="582"             GOHId="7?"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x41B"           FEDId="582"             GOHId="7?"               IdxInFiber="10"/>
-          <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="7?"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x416"           FEDId="582"             GOHId="10"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x415"           FEDId="582"             GOHId="10"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x414"           FEDId="582"             GOHId="10"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x413"           FEDId="582"             GOHId="10"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x412"           FEDId="582"             GOHId="10"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x411"           FEDId="582"             GOHId="10"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x410"           FEDId="582"             GOHId="10"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x41F"           FEDId="582"             GOHId="10"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x41E"           FEDId="582"             GOHId="10"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x41D"           FEDId="582"             GOHId="10"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x41C"           FEDId="582"             GOHId="10"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x41B"           FEDId="582"             GOHId="10"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="10"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>

--- a/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
+++ b/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
@@ -1,0 +1,126 @@
+<top>   
+  <arm id="0">  <!-- 45 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x106"           FEDId="583"             GOHId="1"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x105"           FEDId="583"             GOHId="1"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x104"           FEDId="583"             GOHId="1"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x103"           FEDId="583"             GOHId="1"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x102"           FEDId="583"             GOHId="1"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x101"           FEDId="582"             GOHId="1"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x100"           FEDId="582"             GOHId="1"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x10F"           FEDId="583"             GOHId="1"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x10E"           FEDId="583"             GOHId="1"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x10D"           FEDId="583"             GOHId="1"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x10C"           FEDId="583"             GOHId="1"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x10B"           FEDId="583"             GOHId="1"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x116"           FEDId="583"             GOHId="2"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x115"           FEDId="583"             GOHId="2"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x114"           FEDId="583"             GOHId="2"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x113"           FEDId="583"             GOHId="2"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x112"           FEDId="583"             GOHId="2"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x111"           FEDId="582"             GOHId="2"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x110"           FEDId="582"             GOHId="2"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x11F"           FEDId="582"             GOHId="2"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x11E"           FEDId="583"             GOHId="2"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x11D"           FEDId="583"             GOHId="2"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x11C"           FEDId="583"             GOHId="2"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x11B"           FEDId="583"             GOHId="2"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="1?"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x205"           FEDId="583"             GOHId="1?"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x204"           FEDId="583"             GOHId="1?"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x203"           FEDId="583"             GOHId="1?"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x202"           FEDId="583"             GOHId="1?"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x201"           FEDId="582"             GOHId="1?"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x200"           FEDId="582"             GOHId="1?"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x20F"           FEDId="583"             GOHId="1?"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x20E"           FEDId="583"             GOHId="1?"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x20D"           FEDId="583"             GOHId="1?"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x20C"           FEDId="583"             GOHId="1?"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x20B"           FEDId="583"             GOHId="1?"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">  <!-- UFSD -->
+          <diamond_channel id="0"         hw_id="0x216"           FEDId="583"             GOHId="2?"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x215"           FEDId="583"             GOHId="2?"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x214"           FEDId="583"             GOHId="2?"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x213"           FEDId="583"             GOHId="2?"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x212"           FEDId="583"             GOHId="2?"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x211"           FEDId="582"             GOHId="2?"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x210"           FEDId="582"             GOHId="2?"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x21F"           FEDId="582"             GOHId="2?"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x21E"           FEDId="583"             GOHId="2?"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x21D"           FEDId="583"             GOHId="2?"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x21C"           FEDId="583"             GOHId="2?"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x21B"           FEDId="583"             GOHId="2?"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+      </rp_detector_set>
+    </station>
+  </arm>
+    <arm id="1">  <!-- 56 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x306"           FEDId="583"             GOHId="8"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x305"           FEDId="583"             GOHId="8"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x304"           FEDId="583"             GOHId="8"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x303"           FEDId="583"             GOHId="8"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x302"           FEDId="583"             GOHId="8"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x301"           FEDId="582"             GOHId="8"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x300"           FEDId="582"             GOHId="8"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x30F"           FEDId="583"             GOHId="8"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x30E"           FEDId="583"             GOHId="8"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x30D"           FEDId="583"             GOHId="8"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x30C"           FEDId="583"             GOHId="8"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x30B"           FEDId="583"             GOHId="8"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x316"           FEDId="583"             GOHId="7"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x315"           FEDId="583"             GOHId="7"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x314"           FEDId="583"             GOHId="7"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x313"           FEDId="583"             GOHId="7"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x312"           FEDId="583"             GOHId="7"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x311"           FEDId="582"             GOHId="7"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x310"           FEDId="582"             GOHId="7"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x31F"           FEDId="582"             GOHId="7"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x31E"           FEDId="583"             GOHId="7"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x31D"           FEDId="583"             GOHId="7"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x31C"           FEDId="583"             GOHId="7"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x31B"           FEDId="583"             GOHId="7"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x406"           FEDId="583"             GOHId="8?"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x405"           FEDId="583"             GOHId="8?"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x404"           FEDId="583"             GOHId="8?"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x403"           FEDId="583"             GOHId="8?"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x402"           FEDId="583"             GOHId="8?"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x401"           FEDId="582"             GOHId="8?"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x400"           FEDId="582"             GOHId="8?"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x40F"           FEDId="583"             GOHId="8?"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x40E"           FEDId="583"             GOHId="8?"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x40D"           FEDId="583"             GOHId="8?"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x40C"           FEDId="583"             GOHId="8?"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x40B"           FEDId="583"             GOHId="8?"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">  <!-- UFSD -->
+          <diamond_channel id="0"         hw_id="0x416"           FEDId="583"             GOHId="7?"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x415"           FEDId="583"             GOHId="7?"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x414"           FEDId="583"             GOHId="7?"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x413"           FEDId="583"             GOHId="7?"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x412"           FEDId="583"             GOHId="7?"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x411"           FEDId="582"             GOHId="7?"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x410"           FEDId="582"             GOHId="7?"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x41F"           FEDId="582"             GOHId="7?"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x41E"           FEDId="583"             GOHId="7?"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x41D"           FEDId="583"             GOHId="7?"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x41C"           FEDId="583"             GOHId="7?"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x41B"           FEDId="583"             GOHId="7?"               IdxInFiber="10"/>
+        </rp_plane_diamond>
+      </rp_detector_set>
+    </station>
+  </arm>
+</top>

--- a/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
+++ b/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
@@ -10,11 +10,11 @@
           <diamond_channel id="4"         hw_id="0x102"           FEDId="583"             GOHId="1"               IdxInFiber="2"/>
           <diamond_channel id="5"         hw_id="0x101"           FEDId="583"             GOHId="1"               IdxInFiber="1"/>
           <diamond_channel id="6"         hw_id="0x100"           FEDId="583"             GOHId="1"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x10F"           FEDId="583"             GOHId="1"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x10E"           FEDId="583"             GOHId="1"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x10D"           FEDId="583"             GOHId="1"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x10C"           FEDId="583"             GOHId="1"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x10B"           FEDId="583"             GOHId="1"               IdxInFiber="10"/>
+          <diamond_channel id="7"         hw_id="0x10E"           FEDId="583"             GOHId="1"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x10D"           FEDId="583"             GOHId="1"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x10C"           FEDId="583"             GOHId="1"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x10B"           FEDId="583"             GOHId="1"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x10A"           FEDId="583"             GOHId="1"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="1"> 
           <diamond_channel id="0"         hw_id="0x116"           FEDId="583"             GOHId="2"               IdxInFiber="6"/>
@@ -24,41 +24,41 @@
           <diamond_channel id="4"         hw_id="0x112"           FEDId="583"             GOHId="2"               IdxInFiber="2"/>
           <diamond_channel id="5"         hw_id="0x111"           FEDId="583"             GOHId="2"               IdxInFiber="1"/>
           <diamond_channel id="6"         hw_id="0x110"           FEDId="583"             GOHId="2"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x11E"           FEDId="583"             GOHId="2"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x11D"           FEDId="583"             GOHId="2"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x11C"           FEDId="583"             GOHId="2"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x11B"           FEDId="583"             GOHId="2"               IdxInFiber="10"/>
+          <diamond_channel id="7"         hw_id="0x11E"           FEDId="583"             GOHId="2"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x11D"           FEDId="583"             GOHId="2"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x11C"           FEDId="583"             GOHId="2"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x11B"           FEDId="583"             GOHId="2"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x11A"           FEDId="583"             GOHId="2"               IdxInFiber="10"/>
           <diamond_channel id="30"        hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="7"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x205"           FEDId="583"             GOHId="7"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x204"           FEDId="583"             GOHId="7"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x203"           FEDId="583"             GOHId="7"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x202"           FEDId="583"             GOHId="7"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x201"           FEDId="583"             GOHId="7"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x200"           FEDId="583"             GOHId="7"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x20F"           FEDId="583"             GOHId="7"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x20E"           FEDId="583"             GOHId="7"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x20D"           FEDId="583"             GOHId="7"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x20C"           FEDId="583"             GOHId="7"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x20B"           FEDId="583"             GOHId="7"               IdxInFiber="10"/>
+          <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x205"           FEDId="583"             GOHId="3"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x204"           FEDId="583"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x203"           FEDId="583"             GOHId="3"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x202"           FEDId="583"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x201"           FEDId="583"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x200"           FEDId="583"             GOHId="3"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x20E"           FEDId="583"             GOHId="3"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x20D"           FEDId="583"             GOHId="3"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x20C"           FEDId="583"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x20B"           FEDId="583"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x20A"           FEDId="583"             GOHId="3"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">  <!-- UFSD -->
-          <diamond_channel id="0"         hw_id="0x216"           FEDId="583"             GOHId="8"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x215"           FEDId="583"             GOHId="8"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x214"           FEDId="583"             GOHId="8"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x213"           FEDId="583"             GOHId="8"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x212"           FEDId="583"             GOHId="8"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x211"           FEDId="583"             GOHId="8"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x210"           FEDId="583"             GOHId="8"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x21F"           FEDId="583"             GOHId="8"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x21E"           FEDId="583"             GOHId="8"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x21D"           FEDId="583"             GOHId="8"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x21C"           FEDId="583"             GOHId="8"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x21B"           FEDId="583"             GOHId="8"               IdxInFiber="10"/>
-          <diamond_channel id="30"        hw_id="0x21F"           FEDId="583"             GOHId="8"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x216"           FEDId="583"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x215"           FEDId="583"             GOHId="4"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x214"           FEDId="583"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x213"           FEDId="583"             GOHId="4"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x212"           FEDId="583"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x211"           FEDId="583"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x210"           FEDId="583"             GOHId="4"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x21E"           FEDId="583"             GOHId="4"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x21D"           FEDId="583"             GOHId="4"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x21C"           FEDId="583"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x21B"           FEDId="583"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x21A"           FEDId="583"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x21F"           FEDId="583"             GOHId="4"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>
@@ -67,64 +67,63 @@
     <station id="1">        <!-- 215 m -->
       <rp_detector_set id="6">        <!-- Timing -->
         <rp_plane_diamond id="0"> 
-          <diamond_channel id="0"         hw_id="0x306"           FEDId="582"             GOHId="8"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x305"           FEDId="582"             GOHId="8"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x304"           FEDId="582"             GOHId="8"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x303"           FEDId="582"             GOHId="8"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x302"           FEDId="582"             GOHId="8"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x301"           FEDId="582"             GOHId="8"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x300"           FEDId="582"             GOHId="8"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x30F"           FEDId="582"             GOHId="8"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x30E"           FEDId="582"             GOHId="8"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x30D"           FEDId="582"             GOHId="8"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x30C"           FEDId="582"             GOHId="8"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x30B"           FEDId="582"             GOHId="8"               IdxInFiber="10"/>
+          <diamond_channel id="0"         hw_id="0x306"           FEDId="582"             GOHId="7"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x305"           FEDId="582"             GOHId="7"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x304"           FEDId="582"             GOHId="7"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x303"           FEDId="582"             GOHId="7"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x302"           FEDId="582"             GOHId="7"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x301"           FEDId="582"             GOHId="7"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x300"           FEDId="582"             GOHId="7"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x30E"           FEDId="582"             GOHId="7"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x30D"           FEDId="582"             GOHId="7"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x30C"           FEDId="582"             GOHId="7"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x30B"           FEDId="582"             GOHId="7"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x30A"           FEDId="582"             GOHId="7"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="1"> 
-          <diamond_channel id="0"         hw_id="0x316"           FEDId="582"             GOHId="7"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x315"           FEDId="582"             GOHId="7"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x314"           FEDId="582"             GOHId="7"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x313"           FEDId="582"             GOHId="7"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x312"           FEDId="582"             GOHId="7"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x311"           FEDId="582"             GOHId="7"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x310"           FEDId="582"             GOHId="7"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x31F"           FEDId="582"             GOHId="7"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x31E"           FEDId="582"             GOHId="7"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x31D"           FEDId="582"             GOHId="7"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x31C"           FEDId="582"             GOHId="7"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x31B"           FEDId="582"             GOHId="7"               IdxInFiber="10"/>
-          <diamond_channel id="30"        hw_id="0x31F"           FEDId="582"             GOHId="7"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x309"           FEDId="582"             GOHId="7"               IdxInFiber="9"/>      <!-- relocated for problem with HPTDC -->
+          <diamond_channel id="1"         hw_id="0x308"           FEDId="582"             GOHId="7"               IdxInFiber="8"/>      <!-- relocated for problem with HPTDC -->
+          <diamond_channel id="2"         hw_id="0x319"           FEDId="582"             GOHId="8"               IdxInFiber="9"/>      <!-- relocated for problem with HPTDC -->
+          <diamond_channel id="3"         hw_id="0x318"           FEDId="582"             GOHId="8"               IdxInFiber="8"/>      <!-- relocated for problem with HPTDC -->     
+          <diamond_channel id="4"         hw_id="0x409"           FEDId="582"             GOHId="3"               IdxInFiber="9"/>      <!-- relocated for problem with HPTDC -->
+          <diamond_channel id="5"         hw_id="0x408"           FEDId="582"             GOHId="3"               IdxInFiber="8"/>      <!-- relocated for problem with HPTDC -->
+          <diamond_channel id="6"         hw_id="0x310"           FEDId="582"             GOHId="8"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x31E"           FEDId="582"             GOHId="8"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x31D"           FEDId="582"             GOHId="8"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x31C"           FEDId="582"             GOHId="8"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x31B"           FEDId="582"             GOHId="8"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x31A"           FEDId="582"             GOHId="8"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x31F"           FEDId="582"             GOHId="8"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x406"           FEDId="582"             GOHId="9"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x405"           FEDId="582"             GOHId="9"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x404"           FEDId="582"             GOHId="9"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x403"           FEDId="582"             GOHId="9"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x402"           FEDId="582"             GOHId="9"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x401"           FEDId="582"             GOHId="9"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x400"           FEDId="582"             GOHId="9"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x40F"           FEDId="582"             GOHId="9"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x40E"           FEDId="582"             GOHId="9"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x40D"           FEDId="582"             GOHId="9"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x40C"           FEDId="582"             GOHId="9"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x40B"           FEDId="582"             GOHId="9"               IdxInFiber="10"/>
+          <diamond_channel id="0"         hw_id="0x406"           FEDId="582"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x405"           FEDId="582"             GOHId="3"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x404"           FEDId="582"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x403"           FEDId="582"             GOHId="3"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x402"           FEDId="582"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x401"           FEDId="582"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x400"           FEDId="582"             GOHId="3"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x40E"           FEDId="582"             GOHId="3"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x40D"           FEDId="582"             GOHId="3"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x40C"           FEDId="582"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x40B"           FEDId="582"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x40A"           FEDId="582"             GOHId="3"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">  <!-- UFSD -->
-          <diamond_channel id="0"         hw_id="0x416"           FEDId="582"             GOHId="10"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x415"           FEDId="582"             GOHId="10"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x414"           FEDId="582"             GOHId="10"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x413"           FEDId="582"             GOHId="10"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x412"           FEDId="582"             GOHId="10"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x411"           FEDId="582"             GOHId="10"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x410"           FEDId="582"             GOHId="10"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x41F"           FEDId="582"             GOHId="10"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x41E"           FEDId="582"             GOHId="10"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x41D"           FEDId="582"             GOHId="10"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x41C"           FEDId="582"             GOHId="10"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x41B"           FEDId="582"             GOHId="10"               IdxInFiber="10"/>
-          <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="10"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x416"           FEDId="582"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x415"           FEDId="582"             GOHId="4"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x414"           FEDId="582"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x413"           FEDId="582"             GOHId="4"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x412"           FEDId="582"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="5"         hw_id="0x411"           FEDId="582"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x410"           FEDId="582"             GOHId="4"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x41E"           FEDId="582"             GOHId="4"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x41D"           FEDId="582"             GOHId="4"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x41C"           FEDId="582"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x41B"           FEDId="582"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x41A"           FEDId="582"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="4"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>
   </arm>
-</top>

--- a/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
+++ b/CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml
@@ -8,8 +8,8 @@
           <diamond_channel id="2"         hw_id="0x104"           FEDId="583"             GOHId="1"               IdxInFiber="4"/>
           <diamond_channel id="3"         hw_id="0x103"           FEDId="583"             GOHId="1"               IdxInFiber="3"/>     
           <diamond_channel id="4"         hw_id="0x102"           FEDId="583"             GOHId="1"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x101"           FEDId="582"             GOHId="1"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x100"           FEDId="582"             GOHId="1"               IdxInFiber="0"/>
+          <diamond_channel id="5"         hw_id="0x101"           FEDId="583"             GOHId="1"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x100"           FEDId="583"             GOHId="1"               IdxInFiber="0"/>
           <diamond_channel id="7"         hw_id="0x10F"           FEDId="583"             GOHId="1"               IdxInFiber="14"/>
           <diamond_channel id="8"         hw_id="0x10E"           FEDId="583"             GOHId="1"               IdxInFiber="13"/>
           <diamond_channel id="9"         hw_id="0x10D"           FEDId="583"             GOHId="1"               IdxInFiber="12"/>
@@ -22,13 +22,14 @@
           <diamond_channel id="2"         hw_id="0x114"           FEDId="583"             GOHId="2"               IdxInFiber="4"/>
           <diamond_channel id="3"         hw_id="0x113"           FEDId="583"             GOHId="2"               IdxInFiber="3"/>     
           <diamond_channel id="4"         hw_id="0x112"           FEDId="583"             GOHId="2"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x111"           FEDId="582"             GOHId="2"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x110"           FEDId="582"             GOHId="2"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x11F"           FEDId="582"             GOHId="2"               IdxInFiber="14"/>
+          <diamond_channel id="5"         hw_id="0x111"           FEDId="583"             GOHId="2"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x110"           FEDId="583"             GOHId="2"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="14"/>
           <diamond_channel id="8"         hw_id="0x11E"           FEDId="583"             GOHId="2"               IdxInFiber="13"/>
           <diamond_channel id="9"         hw_id="0x11D"           FEDId="583"             GOHId="2"               IdxInFiber="12"/>
           <diamond_channel id="10"        hw_id="0x11C"           FEDId="583"             GOHId="2"               IdxInFiber="11"/>
           <diamond_channel id="11"        hw_id="0x11B"           FEDId="583"             GOHId="2"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
           <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="1?"               IdxInFiber="6"/>
@@ -36,8 +37,8 @@
           <diamond_channel id="2"         hw_id="0x204"           FEDId="583"             GOHId="1?"               IdxInFiber="4"/>
           <diamond_channel id="3"         hw_id="0x203"           FEDId="583"             GOHId="1?"               IdxInFiber="3"/>     
           <diamond_channel id="4"         hw_id="0x202"           FEDId="583"             GOHId="1?"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x201"           FEDId="582"             GOHId="1?"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x200"           FEDId="582"             GOHId="1?"               IdxInFiber="0"/>
+          <diamond_channel id="5"         hw_id="0x201"           FEDId="583"             GOHId="1?"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x200"           FEDId="583"             GOHId="1?"               IdxInFiber="0"/>
           <diamond_channel id="7"         hw_id="0x20F"           FEDId="583"             GOHId="1?"               IdxInFiber="14"/>
           <diamond_channel id="8"         hw_id="0x20E"           FEDId="583"             GOHId="1?"               IdxInFiber="13"/>
           <diamond_channel id="9"         hw_id="0x20D"           FEDId="583"             GOHId="1?"               IdxInFiber="12"/>
@@ -50,13 +51,14 @@
           <diamond_channel id="2"         hw_id="0x214"           FEDId="583"             GOHId="2?"               IdxInFiber="4"/>
           <diamond_channel id="3"         hw_id="0x213"           FEDId="583"             GOHId="2?"               IdxInFiber="3"/>     
           <diamond_channel id="4"         hw_id="0x212"           FEDId="583"             GOHId="2?"               IdxInFiber="2"/>
-          <diamond_channel id="5"         hw_id="0x211"           FEDId="582"             GOHId="2?"               IdxInFiber="1"/>
-          <diamond_channel id="6"         hw_id="0x210"           FEDId="582"             GOHId="2?"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x21F"           FEDId="582"             GOHId="2?"               IdxInFiber="14"/>
+          <diamond_channel id="5"         hw_id="0x211"           FEDId="583"             GOHId="2?"               IdxInFiber="1"/>
+          <diamond_channel id="6"         hw_id="0x210"           FEDId="583"             GOHId="2?"               IdxInFiber="0"/>
+          <diamond_channel id="7"         hw_id="0x21F"           FEDId="583"             GOHId="2?"               IdxInFiber="14"/>
           <diamond_channel id="8"         hw_id="0x21E"           FEDId="583"             GOHId="2?"               IdxInFiber="13"/>
           <diamond_channel id="9"         hw_id="0x21D"           FEDId="583"             GOHId="2?"               IdxInFiber="12"/>
           <diamond_channel id="10"        hw_id="0x21C"           FEDId="583"             GOHId="2?"               IdxInFiber="11"/>
           <diamond_channel id="11"        hw_id="0x21B"           FEDId="583"             GOHId="2?"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x21F"           FEDId="583"             GOHId="2?"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>
@@ -65,60 +67,62 @@
     <station id="1">        <!-- 215 m -->
       <rp_detector_set id="6">        <!-- Timing -->
         <rp_plane_diamond id="0"> 
-          <diamond_channel id="0"         hw_id="0x306"           FEDId="583"             GOHId="8"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x305"           FEDId="583"             GOHId="8"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x304"           FEDId="583"             GOHId="8"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x303"           FEDId="583"             GOHId="8"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x302"           FEDId="583"             GOHId="8"               IdxInFiber="2"/>
+          <diamond_channel id="0"         hw_id="0x306"           FEDId="582"             GOHId="8"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x305"           FEDId="582"             GOHId="8"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x304"           FEDId="582"             GOHId="8"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x303"           FEDId="582"             GOHId="8"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x302"           FEDId="582"             GOHId="8"               IdxInFiber="2"/>
           <diamond_channel id="5"         hw_id="0x301"           FEDId="582"             GOHId="8"               IdxInFiber="1"/>
           <diamond_channel id="6"         hw_id="0x300"           FEDId="582"             GOHId="8"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x30F"           FEDId="583"             GOHId="8"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x30E"           FEDId="583"             GOHId="8"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x30D"           FEDId="583"             GOHId="8"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x30C"           FEDId="583"             GOHId="8"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x30B"           FEDId="583"             GOHId="8"               IdxInFiber="10"/>
+          <diamond_channel id="7"         hw_id="0x30F"           FEDId="582"             GOHId="8"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x30E"           FEDId="582"             GOHId="8"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x30D"           FEDId="582"             GOHId="8"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x30C"           FEDId="582"             GOHId="8"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x30B"           FEDId="582"             GOHId="8"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="1"> 
-          <diamond_channel id="0"         hw_id="0x316"           FEDId="583"             GOHId="7"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x315"           FEDId="583"             GOHId="7"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x314"           FEDId="583"             GOHId="7"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x313"           FEDId="583"             GOHId="7"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x312"           FEDId="583"             GOHId="7"               IdxInFiber="2"/>
+          <diamond_channel id="0"         hw_id="0x316"           FEDId="582"             GOHId="7"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x315"           FEDId="582"             GOHId="7"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x314"           FEDId="582"             GOHId="7"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x313"           FEDId="582"             GOHId="7"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x312"           FEDId="582"             GOHId="7"               IdxInFiber="2"/>
           <diamond_channel id="5"         hw_id="0x311"           FEDId="582"             GOHId="7"               IdxInFiber="1"/>
           <diamond_channel id="6"         hw_id="0x310"           FEDId="582"             GOHId="7"               IdxInFiber="0"/>
           <diamond_channel id="7"         hw_id="0x31F"           FEDId="582"             GOHId="7"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x31E"           FEDId="583"             GOHId="7"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x31D"           FEDId="583"             GOHId="7"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x31C"           FEDId="583"             GOHId="7"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x31B"           FEDId="583"             GOHId="7"               IdxInFiber="10"/>
+          <diamond_channel id="8"         hw_id="0x31E"           FEDId="582"             GOHId="7"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x31D"           FEDId="582"             GOHId="7"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x31C"           FEDId="582"             GOHId="7"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x31B"           FEDId="582"             GOHId="7"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x31F"           FEDId="582"             GOHId="7"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x406"           FEDId="583"             GOHId="8?"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x405"           FEDId="583"             GOHId="8?"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x404"           FEDId="583"             GOHId="8?"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x403"           FEDId="583"             GOHId="8?"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x402"           FEDId="583"             GOHId="8?"               IdxInFiber="2"/>
+          <diamond_channel id="0"         hw_id="0x406"           FEDId="582"             GOHId="8?"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x405"           FEDId="582"             GOHId="8?"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x404"           FEDId="582"             GOHId="8?"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x403"           FEDId="582"             GOHId="8?"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x402"           FEDId="582"             GOHId="8?"               IdxInFiber="2"/>
           <diamond_channel id="5"         hw_id="0x401"           FEDId="582"             GOHId="8?"               IdxInFiber="1"/>
           <diamond_channel id="6"         hw_id="0x400"           FEDId="582"             GOHId="8?"               IdxInFiber="0"/>
-          <diamond_channel id="7"         hw_id="0x40F"           FEDId="583"             GOHId="8?"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x40E"           FEDId="583"             GOHId="8?"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x40D"           FEDId="583"             GOHId="8?"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x40C"           FEDId="583"             GOHId="8?"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x40B"           FEDId="583"             GOHId="8?"               IdxInFiber="10"/>
+          <diamond_channel id="7"         hw_id="0x40F"           FEDId="582"             GOHId="8?"               IdxInFiber="14"/>
+          <diamond_channel id="8"         hw_id="0x40E"           FEDId="582"             GOHId="8?"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x40D"           FEDId="582"             GOHId="8?"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x40C"           FEDId="582"             GOHId="8?"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x40B"           FEDId="582"             GOHId="8?"               IdxInFiber="10"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">  <!-- UFSD -->
-          <diamond_channel id="0"         hw_id="0x416"           FEDId="583"             GOHId="7?"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x415"           FEDId="583"             GOHId="7?"               IdxInFiber="5"/>
-          <diamond_channel id="2"         hw_id="0x414"           FEDId="583"             GOHId="7?"               IdxInFiber="4"/>
-          <diamond_channel id="3"         hw_id="0x413"           FEDId="583"             GOHId="7?"               IdxInFiber="3"/>     
-          <diamond_channel id="4"         hw_id="0x412"           FEDId="583"             GOHId="7?"               IdxInFiber="2"/>
+          <diamond_channel id="0"         hw_id="0x416"           FEDId="582"             GOHId="7?"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x415"           FEDId="582"             GOHId="7?"               IdxInFiber="5"/>
+          <diamond_channel id="2"         hw_id="0x414"           FEDId="582"             GOHId="7?"               IdxInFiber="4"/>
+          <diamond_channel id="3"         hw_id="0x413"           FEDId="582"             GOHId="7?"               IdxInFiber="3"/>     
+          <diamond_channel id="4"         hw_id="0x412"           FEDId="582"             GOHId="7?"               IdxInFiber="2"/>
           <diamond_channel id="5"         hw_id="0x411"           FEDId="582"             GOHId="7?"               IdxInFiber="1"/>
           <diamond_channel id="6"         hw_id="0x410"           FEDId="582"             GOHId="7?"               IdxInFiber="0"/>
           <diamond_channel id="7"         hw_id="0x41F"           FEDId="582"             GOHId="7?"               IdxInFiber="14"/>
-          <diamond_channel id="8"         hw_id="0x41E"           FEDId="583"             GOHId="7?"               IdxInFiber="13"/>
-          <diamond_channel id="9"         hw_id="0x41D"           FEDId="583"             GOHId="7?"               IdxInFiber="12"/>
-          <diamond_channel id="10"        hw_id="0x41C"           FEDId="583"             GOHId="7?"               IdxInFiber="11"/>
-          <diamond_channel id="11"        hw_id="0x41B"           FEDId="583"             GOHId="7?"               IdxInFiber="10"/>
+          <diamond_channel id="8"         hw_id="0x41E"           FEDId="582"             GOHId="7?"               IdxInFiber="13"/>
+          <diamond_channel id="9"         hw_id="0x41D"           FEDId="582"             GOHId="7?"               IdxInFiber="12"/>
+          <diamond_channel id="10"        hw_id="0x41C"           FEDId="582"             GOHId="7?"               IdxInFiber="11"/>
+          <diamond_channel id="11"        hw_id="0x41B"           FEDId="582"             GOHId="7?"               IdxInFiber="10"/>
+          <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="7?"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>

--- a/DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h
+++ b/DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h
@@ -86,7 +86,7 @@ class CTPPSDiamondDetId : public CTPPSDetId
         case nPath: rpName(name, flag); name += "/plane "; break;
       }
 
-      name += planeNames[plane()];
+      name += std::to_string(plane());
     }
 
     inline void channelName(std::string &name, NameFlag flag = nFull) const
@@ -98,12 +98,8 @@ class CTPPSDiamondDetId : public CTPPSDetId
         case nPath: planeName(name, flag); name += "/channel "; break;
       }
 
-      name += channelNames[channel()];
+      name += std::to_string(channel());
     }
-    
-  private:
-    static const std::string planeNames[];
-    static const std::string channelNames[];
 };
 
 std::ostream& operator<<(std::ostream& os, const CTPPSDiamondDetId& id);

--- a/DataFormats/CTPPSDetId/src/CTPPSDiamondDetId.cc
+++ b/DataFormats/CTPPSDetId/src/CTPPSDiamondDetId.cc
@@ -13,10 +13,7 @@ using namespace std;
 //----------------------------------------------------------------------------------------------------
 
 const uint32_t CTPPSDiamondDetId::startPlaneBit = 17, CTPPSDiamondDetId::maskPlane = 0x3, CTPPSDiamondDetId::maxPlane = 3, CTPPSDiamondDetId::lowMaskPlane = 0x1FFFF;
-const uint32_t CTPPSDiamondDetId::startDetBit = 12, CTPPSDiamondDetId::maskChannel = 0x1F, CTPPSDiamondDetId::maxChannel = 11, CTPPSDiamondDetId::lowMaskChannel = 0xFFF;
-
-const string CTPPSDiamondDetId::planeNames[] = { "0", "1", "2", "3" };
-const string CTPPSDiamondDetId::channelNames[] = { "0", "1", "2", "3", "4", "05", "06", "07", "08", "09", "10", "11" };
+const uint32_t CTPPSDiamondDetId::startDetBit = 12, CTPPSDiamondDetId::maskChannel = 0x1F, CTPPSDiamondDetId::maxChannel = 31, CTPPSDiamondDetId::lowMaskChannel = 0xFFF;
 
 //----------------------------------------------------------------------------------------------------
 

--- a/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
@@ -3,5 +3,9 @@ import FWCore.ParameterSet.Config as cms
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 ctppsDiamondRawToDigi = totemVFATRawToDigi.clone(
-    subSystem = cms.string('TimingDiamond')
+    subSystem = cms.string('TimingDiamond'),
+    RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
+        testCRC = cms.uint32(0), # no need to test CRC for diamond frames
+        testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
+    )
 )

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -54,19 +54,19 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
   verbosity = cms.untracked.uint32(0),
   subSystem = cms.untracked.string("TimingDiamond"),
   configuration = cms.VPSet(
-    # before diamonds inserted in DAQ
+    # 2016, before diamonds inserted in DAQ
     cms.PSet(
       validityRange = cms.EventRange("1:min - 283819:max"),
       mappingFileNames = cms.vstring(),
       maskFileNames = cms.vstring()
     ),
-    # after diamonds inserted in DAQ
+    # 2016, after diamonds inserted in DAQ
     cms.PSet(
       validityRange = cms.EventRange("283820:min - 292520:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond.xml"),
       maskFileNames = cms.vstring()
     ),
-    # 2017 configuration
+    # 2017
     cms.PSet(
       validityRange = cms.EventRange("292521:min - 999999999:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml"),

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -62,8 +62,14 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
     ),
     # after diamonds inserted in DAQ
     cms.PSet(
-      validityRange = cms.EventRange("283820:min - 999999999:max"),
+      validityRange = cms.EventRange("283820:min - 292527:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2016, diamonds inserted in DAQ
+    cms.PSet(
+      validityRange = cms.EventRange("292528:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml"),
       maskFileNames = cms.vstring()
     )
   )

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -78,8 +78,6 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
 from EventFilter.CTPPSRawToDigi.ctppsDiamondRawToDigi_cfi import ctppsDiamondRawToDigi
 ctppsDiamondRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 
-ctppsDiamondRawToDigi.RawToDigi.testCRC = 0 # no need to test CRC for diamonds
-
 
 
 # ---------- pixels ----------

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -62,13 +62,13 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
     ),
     # after diamonds inserted in DAQ
     cms.PSet(
-      validityRange = cms.EventRange("283820:min - 292527:max"),
+      validityRange = cms.EventRange("283820:min - 292520:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond.xml"),
       maskFileNames = cms.vstring()
     ),
-    # 2016, diamonds inserted in DAQ
+    # 2017 configuration
     cms.PSet(
-      validityRange = cms.EventRange("292528:min - 999999999:max"),
+      validityRange = cms.EventRange("292521:min - 999999999:max"),
       mappingFileNames = cms.vstring("CondFormats/CTPPSReadoutObjects/xml/mapping_timing_diamond_2017.xml"),
       maskFileNames = cms.vstring()
     )


### PR DESCRIPTION
This PR introduces the channels mapping for 2017 diamond detectors operations, along with a limited set of small changes:
* the `CTPPSDiamondDetId` object is modified to account for a "more trivial" list of channels.
* the CRC validity check for VFAT frames is directly disabled (along with the events counter check) in the `ctppsDiamondRawToDigi` object definition.