### PR TITLE
Getting the L1T O2O ready for data taking of 2017

### DIFF
--- a/L1Trigger/L1TCommon/src/Parameter.cc
+++ b/L1Trigger/L1TCommon/src/Parameter.cc
@@ -35,10 +35,16 @@ Parameter::Parameter(const char *id,
     unsigned long nItems = 0;
     char *saveptr;
     for(const char *item=strtok_r(copy.get(),delimeter,&saveptr); item != NULL; item = strtok_r(NULL,delimeter,&saveptr), nItems++){
-        colIndexToName.insert( make_pair(nItems,string(item)) );
-        columnNameToIndex.insert( make_pair(string(item),nItems) );
-        if( table.insert( make_pair(string(item),vector<string>(rows.size())) ).second == false )
-            throw runtime_error("Duplicate column name: '" + string(item) + "'");
+        // trim leading and trailing whitespaces
+        size_t pos=0, len = strlen(item);
+        while( pos<len && isspace(item[pos]) ) pos++;
+        while( len>0 && isspace(item[--len]) );
+        string str = (pos<len+1 ? string(item+pos,len+1-pos) : item);
+
+        colIndexToName.insert( make_pair(nItems,str) );
+        columnNameToIndex.insert( make_pair(str,nItems) );
+        if( table.insert( make_pair(str,vector<string>(rows.size())) ).second == false )
+            throw runtime_error("Duplicate column name: '" + str + "'");
     }
 
     for(unsigned int r=0; r<rows.size(); r++){
@@ -48,7 +54,12 @@ Parameter::Parameter(const char *id,
             if( item == NULL )
                 throw runtime_error("Too few elements in '" + rows[r] + "'");
 
-            table[ colIndexToName[pos] ][r] = item;
+            // trim leading and trailing whitespaces
+            size_t p=0, len = strlen(item);
+            while( p<len && isspace(item[p]) ) p++;
+            while( len>0 && isspace(item[--len]) );
+
+            table[ colIndexToName[pos] ][r] = (pos<len+1 ? string(item+p,len+1-p) : item);
         }
         if( strtok_r(NULL,delimeter,&saveptr) != NULL )
             throw runtime_error("Too many elements in '" + rows[r] + "', expected " + to_string(nItems));

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
@@ -6,5 +6,5 @@ L1TGlobalPrescalesVetosOnlineProd = cms.ESProducer("L1TGlobalPrescalesVetosOnlin
     onlineAuthentication = cms.string('.'),
     forceGeneration = cms.bool(False),
     onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
-    xmlModel = cms.int(2016)
+    xmlModel = cms.int32(2016)
 )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
@@ -6,5 +6,5 @@ L1TGlobalPrescalesVetosOnlineProd = cms.ESProducer("L1TGlobalPrescalesVetosOnlin
     onlineAuthentication = cms.string('.'),
     forceGeneration = cms.bool(False),
     onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
-    xmlModel = cms.int32(2016)
+    xmlModel = cms.int32(2017)
 )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
@@ -5,5 +5,6 @@ from L1Trigger.L1TGlobal.PrescalesVetos_cff import *
 L1TGlobalPrescalesVetosOnlineProd = cms.ESProducer("L1TGlobalPrescalesVetosOnlineProd",
     onlineAuthentication = cms.string('.'),
     forceGeneration = cms.bool(False),
-    onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R')
+    onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
+    xmlModel = cms.int(2016)
 )

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -166,8 +166,8 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
 
     edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Producing L1TCaloParamsOnlineProd with TSC key = " << tscKey << " and RS key = " << rsKey ;
 
-    std::string calol1_top_key, calol1_algo_key;
-    std::string calol1_algo_payload;
+    std::string calol1_top_key, calol1_algo_key, calol1_hw_key;
+    std::string calol1_hw_payload, calol1_algo_payload;
     std::string calol2_top_key, calol2_algo_key, calol2_hw_key;
     std::string calol2_hw_payload;
     std::map<std::string,std::string> calol2_algo_payloads;  // key -> XML payload
@@ -180,11 +180,21 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
                                            );
         calol1_top_key = topKeys["CALOL1_KEY"];
 
-        calol1_algo_key = l1t::OnlineDBqueryHelper::fetch( {"ALGO"},
-                                                           "CALOL1_KEYS",
-                                                           calol1_top_key,
-                                                           m_omdsReader
-                                                         ) ["ALGO"];
+        std::map<std::string,std::string> calol1_keys =
+            l1t::OnlineDBqueryHelper::fetch( {"ALGO","HW"},
+                                             "CALOL1_KEYS",
+                                             calol1_top_key,
+                                             m_omdsReader
+                                           );
+
+        calol1_hw_key = calol1_keys["HW"];
+        calol1_hw_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
+                                                             "CALOL1_CLOBS",
+                                                              calol1_hw_key,
+                                                              m_omdsReader
+                                                           ) ["CONF"];
+
+        calol1_algo_key = calol1_keys["ALGO"];
 
         calol1_algo_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
                                                                "CALOL1_CLOBS",
@@ -248,16 +258,61 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
     }
 
 
-
     l1t::XmlConfigParser xmlReader1;
-    xmlReader1.readDOMFromString( calol1_algo_payload );
-
     l1t::TriggerSystem calol1;
-    calol1.addProcessor("processors", "processors","-1","-1");
+
+if( true ){
+    xmlReader1.readDOMFromString( calol1_hw_payload );
+    xmlReader1.readRootElement  ( calol1, "calol1"  );
+} else {
+    // explicitly make the parser aware of the processors
+    calol1.addProcessor("CTP7_Phi0", "Layer1Processor","-2","-0");
+    calol1.addProcessor("CTP7_Phi1", "Layer1Processor","-2","-1");
+    calol1.addProcessor("CTP7_Phi2", "Layer1Processor","-2","-2");
+    calol1.addProcessor("CTP7_Phi3", "Layer1Processor","-2","-3");
+    calol1.addProcessor("CTP7_Phi4", "Layer1Processor","-2","-4");
+    calol1.addProcessor("CTP7_Phi5", "Layer1Processor","-2","-5");
+    calol1.addProcessor("CTP7_Phi6", "Layer1Processor","-2","-6");
+    calol1.addProcessor("CTP7_Phi7", "Layer1Processor","-2","-7");
+    calol1.addProcessor("CTP7_Phi8", "Layer1Processor","-2","-8");
+    calol1.addProcessor("CTP7_Phi9", "Layer1Processor","-2","-9");
+    calol1.addProcessor("CTP7_Phi10","Layer1Processor","-2","-10");
+    calol1.addProcessor("CTP7_Phi11","Layer1Processor","-2","-11");
+    calol1.addProcessor("CTP7_Phi12","Layer1Processor","-2","-12");
+    calol1.addProcessor("CTP7_Phi13","Layer1Processor","-2","-13");
+    calol1.addProcessor("CTP7_Phi14","Layer1Processor","-2","-14");
+    calol1.addProcessor("CTP7_Phi15","Layer1Processor","-2","-15");
+    calol1.addProcessor("CTP7_Phi16","Layer1Processor","-2","-16");
+}
+    calol1.addProcessor("defaultProc", "processors","-2","0");
+
+    //// the block of lines below allows to manage broken CaloL1 configurations
+    calol1.addProcessor("processor0", "processors","-1","-1");
+    calol1.addProcessor("processor1", "processors","-1","-2");
+    calol1.addProcessor("processor2", "processors","-1","-3");
+    calol1.addProcessor("processor3", "processors","-1","-4");
+    calol1.addProcessor("processor4", "processors","-1","-5");
+    calol1.addProcessor("processor5", "processors","-1","-6");
+    calol1.addProcessor("processor6", "processors","-1","-7");
+    calol1.addProcessor("processor7", "processors","-1","-8");
+    calol1.addProcessor("processor8", "processors","-1","-9");
+    calol1.addProcessor("processor9", "processors","-1","-10");
+    calol1.addProcessor("processor10", "processors","-1","-11");
+    calol1.addProcessor("processor11", "processors","-1","-12");
+    calol1.addProcessor("processor12", "processors","-1","-13");
+    calol1.addProcessor("processor13", "processors","-1","-14");
+    calol1.addProcessor("processor14", "processors","-1","-15");
+    calol1.addProcessor("processor15", "processors","-1","-16");
+    calol1.addProcessor("processor16", "processors","-1","-17");
+    calol1.addProcessor("processor17", "processors","-1","-18");
+    ////
+
+    xmlReader1.readDOMFromString( calol1_algo_payload );
     xmlReader1.readRootElement( calol1, "calol1" );
+
     calol1.setConfigured();
 
-    std::map<std::string, l1t::Parameter> calol1_conf = calol1.getParameters("processors");
+    std::map<std::string, l1t::Parameter> calol1_conf = calol1.getParameters("defaultProc");
     std::map<std::string, l1t::Mask>      calol1_rs   ;//= calol1.getMasks   ("processors");
 
     l1t::TriggerSystem calol2;

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosObjectKeysOnlineProd.cc
@@ -21,11 +21,9 @@ void L1TGlobalPrescalesVetosObjectKeysOnlineProd::fillObjectKeys( ReturnType pL1
 
     std::string uGTKey = pL1TriggerKey->subsystemKey( L1TriggerKeyExt::kuGT ) ;
 
-    std::string uGTrsKey = uGTKey.substr( uGTKey.find(":")+1 );
-
     pL1TriggerKey->add( "L1TGlobalPrescalesVetosO2ORcd",
                         "L1TGlobalPrescalesVetos",
-                         uGTrsKey) ;
+                         uGTKey) ;
 }
 
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -2,6 +2,17 @@
 #include <fstream>
 #include <stdexcept>
 
+#include "tmEventSetup/tmEventSetup.hh"
+#include "tmEventSetup/esTriggerMenu.hh"
+#include "tmEventSetup/esAlgorithm.hh"
+#include "tmEventSetup/esCondition.hh"
+#include "tmEventSetup/esObject.hh"
+#include "tmEventSetup/esCut.hh"
+#include "tmEventSetup/esScale.hh"
+#include "tmGrammar/Algorithm.hh"
+
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+
 #include "CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h"
 #include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetos.h"
 #include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h"
@@ -25,14 +36,82 @@ L1TGlobalPrescalesVetosOnlineProd::L1TGlobalPrescalesVetosOnlineProd(const edm::
 std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newObject(const std::string& objectKey, const L1TGlobalPrescalesVetosO2ORcd& record) {
     using namespace edm::es;
 
-    edm::LogInfo( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "Producing L1TGlobalPrescalesVetos with RS key = " << objectKey ;
+    edm::LogInfo( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "Producing L1TGlobalPrescalesVetos with TSC:RS key = " << objectKey ;
 
     if( objectKey.empty() ){
         edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "Key is empty";
         throw std::runtime_error("Empty objecKey");
     }
 
-    std::vector< std::string > queryColumns ;
+
+    std::string uGTtscKey = objectKey.substr(0, objectKey.find(":"));
+    std::string uGTrsKey  = objectKey.substr(objectKey.find(":")+1, std::string::npos);
+
+    std::string stage2Schema = "CMS_TRG_L1_CONF" ;
+
+    std::string l1_menu_key;
+    std::vector< std::string > queryStrings ;
+    queryStrings.push_back( "L1_MENU" ) ;
+
+    // select L1_MENU from CMS_TRG_L1_CONF.UGT_KEYS where ID = objectKey ;
+    l1t::OMDSReader::QueryResults queryResult =
+            m_omdsReader.basicQuery( queryStrings,
+                                     stage2Schema,
+                                     "UGT_KEYS",
+                                     "UGT_KEYS.ID",
+                                     m_omdsReader.singleAttribute(uGTtscKey)
+                                   ) ;
+
+    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
+        edm::LogError( "L1-O2O" ) << "Cannot get UGT_KEYS.L1_MENU for ID = " << uGTtscKey << " " ;
+        throw std::runtime_error("Broken key");
+    }
+
+    if( !queryResult.fillVariable( "L1_MENU", l1_menu_key) ) l1_menu_key = "";
+
+    edm::LogInfo( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "Producing L1TUtmTriggerMenu with key =" << uGTtscKey;
+
+    if( uGTtscKey.empty() ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "TSC key is empty, returning";
+        throw std::runtime_error("Empty objectKey");
+    }
+
+    std::vector< std::string > queryColumns;
+    queryColumns.push_back( "CONF" ) ;
+
+    queryResult =
+            m_omdsReader.basicQuery( queryColumns,
+                                     stage2Schema,
+                                     "UGT_L1_MENU",
+                                     "UGT_L1_MENU.ID",
+                                     m_omdsReader.singleAttribute(uGTtscKey)
+                                   ) ;
+
+    if( queryResult.queryFailed() || queryResult.numberRows() != 1 ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" ) << "Cannot get UGT_L1_MENU.CONF for ID = " << uGTtscKey;
+        throw std::runtime_error("Broken key");
+    }
+
+    std::string l1Menu;
+    queryResult.fillVariable( "CONF", l1Menu );
+///
+    std::istringstream iss(l1Menu);
+
+    std::shared_ptr<L1TUtmTriggerMenu> pMenu(
+        const_cast<L1TUtmTriggerMenu*>(
+            reinterpret_cast<const L1TUtmTriggerMenu*>(tmeventsetup::getTriggerMenu(iss))
+        )
+    );
+
+    std::map<std::string,int> algoName2bit;
+
+    const std::map<std::string, L1TUtmAlgorithm>& algoMap = pMenu->getAlgorithmMap();
+
+    for(auto algo : algoMap)
+        algoName2bit[algo.first] = algo.second.getIndex();
+
+
+    queryColumns.clear() ;
     queryColumns.push_back( "ALGOBX_MASK"     ) ;
     queryColumns.push_back( "ALGO_FINOR_MASK" ) ;
     queryColumns.push_back( "ALGO_FINOR_VETO" ) ;
@@ -70,16 +149,16 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
     output4<<xmlPayload_mask_veto;
     output4.close();
 
-/// the code below is adopted from https://github.com/cms-l1t-offline/cmssw/blob/thomreis_o2o-dev_CMSSW_8_0_7/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosESProducer.cc#L124-L365
-
-  unsigned int m_numberPhysTriggers = 512;
-  unsigned int m_bx_mask_default = 1;
+//////////////////
 
 
-  std::vector<std::vector<int> > prescales;
-  std::vector<unsigned int> triggerMasks;
-  std::vector<int> triggerVetoMasks;
-  std::map<int, std::vector<int> > triggerAlgoBxMaskAlgoTrig;
+    unsigned int m_numberPhysTriggers = 512;
+
+
+    std::vector<std::vector<int> > prescales;
+    std::vector<unsigned int> triggerMasks;
+    std::vector<int> triggerVetoMasks;
+    std::map<int, std::vector<int> > triggerAlgoBxMaskAlgoTrig;
 
   // Prescales
     l1t::XmlConfigParser xmlReader_prescale;
@@ -95,91 +174,135 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
     std::map<std::string,unsigned int> prescaleColumns = settings_prescale.at("prescales").getColumnIndices();
 
     unsigned int numColumns_prescale = prescaleColumns.size();
-    
-    int NumPrescaleSets = numColumns_prescale - 1;
-///  there may be "missing" rows/bits in the xml description meaning that triggers are not unused, so go for max
-    std::vector<unsigned int> algoBits = settings_prescale.at("prescales").getTableColumn<unsigned int>("algo/prescale-index");
-    int NumAlgos_prescale = *std::max_element(algoBits.begin(), algoBits.end()) + 1;
+    int nPrescaleSets = numColumns_prescale - 1;
+    std::vector<std::string> algoNames = settings_prescale.at("prescales").getTableColumn<std::string>("algo/prescale-index");
 
-    if( NumPrescaleSets > 0 ){
-      // Fill default prescale set
-      for( int iSet=0; iSet<NumPrescaleSets; iSet++ ){
-	prescales.push_back(std::vector<int>());
-	for( int iBit = 0; iBit < NumAlgos_prescale; ++iBit ){
-	  int inputDefaultPrescale = 0; // only prescales that are set in the block below are used
-	  prescales[iSet].push_back(inputDefaultPrescale);
-	}
-      }
-
-      for(auto &col : prescaleColumns){
-        if( col.second<1 ) continue; // we don't care for the algorithms' indicies in 0th column
-        int iSet = col.second - 1;
-        std::vector<unsigned int> prescalesForSet = settings_prescale.at("prescales").getTableColumn<unsigned int>(col.first.c_str());
-        for(unsigned int row=0; row<prescalesForSet.size(); row++){
-          unsigned int prescale = prescalesForSet[row];
-          unsigned int algoBit  = algoBits[row];
-          prescales[iSet][algoBit] = prescale;
+    if( nPrescaleSets > 0 ){
+        // Fill default prescale set
+        for( int iSet=0; iSet<nPrescaleSets; iSet++ ){
+            prescales.push_back(std::vector<int>());
+            for(unsigned int iBit = 0; iBit < m_numberPhysTriggers; ++iBit ){
+                int inputDefaultPrescale = 0; // only prescales that are set in the block below are used
+                prescales[iSet].push_back(inputDefaultPrescale);
+            }
         }
-      }
+
+        for(auto &col : prescaleColumns){
+            if( col.second<1 ) continue; // we don't care for the algorithms' indicies in 0th column
+            int iSet = col.second - 1;
+            std::vector<unsigned int> prescalesForSet = settings_prescale.at("prescales").getTableColumn<unsigned int>(col.first.c_str());
+            for(unsigned int row=0; row<prescalesForSet.size(); row++){
+                unsigned int prescale = prescalesForSet[row];
+                std::string  algoName = algoNames[row];
+                unsigned int algoBit  = algoName2bit[algoName];
+                prescales[iSet][algoBit] = prescale;
+          }
+        }
     }
 
 
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  // finor mask
-  // Setting mask to default 1 (unmask)
-  for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
-    triggerMasks.push_back(1);
+    // finor mask
+    l1t::XmlConfigParser xmlReader_mask_finor;
+    l1t::TriggerSystem ts_mask_finor;
+    ts_mask_finor.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
 
-  l1t::XmlConfigParser xmlReader_mask_finor;
-  l1t::TriggerSystem ts_mask_finor;
-  ts_mask_finor.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
-  
-  // run the parser 
-  xmlReader_mask_finor.readDOMFromString( xmlPayload_mask_finor ); // initialize it
-  xmlReader_mask_finor.readRootElement( ts_mask_finor, "uGT" ); // extract all of the relevant context
-  ts_mask_finor.setConfigured();
-  
-  const std::map<std::string, l1t::Parameter>& settings_mask_finor = ts_mask_finor.getParameters("uGtProcessor");
-  
-  std::vector<unsigned int> algo_mask_finor = settings_mask_finor.at("finorMask").getTableColumn<unsigned int>("algo");
-  std::vector<unsigned int> mask_mask_finor = settings_mask_finor.at("finorMask").getTableColumn<unsigned int>("mask");
-  
-  for(unsigned int row=0; row<algo_mask_finor.size(); row++){
-    unsigned int algoBit = algo_mask_finor[row];
-    unsigned int mask    = mask_mask_finor[row];
-    if( algoBit < m_numberPhysTriggers ) triggerMasks[algoBit] = mask;
-  }
-  
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // run the parser 
+    xmlReader_mask_finor.readDOMFromString( xmlPayload_mask_finor ); // initialize it
+    xmlReader_mask_finor.readRootElement( ts_mask_finor, "uGT" ); // extract all of the relevant context
+    ts_mask_finor.setConfigured();
 
-  // veto mask
-  // Setting veto mask to default 0 (no veto)
-  for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
-    triggerVetoMasks.push_back(0);
-  
-  l1t::XmlConfigParser xmlReader_mask_veto;
-  l1t::TriggerSystem ts_mask_veto;
-  ts_mask_veto.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
-  
-  // run the parser 
-  xmlReader_mask_veto.readDOMFromString( xmlPayload_mask_veto ); // initialize it
-  xmlReader_mask_veto.readRootElement( ts_mask_veto, "uGT" ); // extract all of the relevant context
-  ts_mask_veto.setConfigured();
-  
-  const std::map<std::string, l1t::Parameter>& settings_mask_veto = ts_mask_veto.getParameters("uGtProcessor");
-  std::vector<unsigned int> algo_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<unsigned int>("algo");
-  std::vector<unsigned int> veto_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<unsigned int>("veto");
-  
-  for(unsigned int row=0; row<algo_mask_veto.size(); row++){
-    unsigned int algoBit = algo_mask_veto[row];
-    unsigned int veto    = veto_mask_veto[row];
-    if( algoBit < m_numberPhysTriggers ) triggerVetoMasks[algoBit] = int(veto);
-  }
+    const std::map<std::string, l1t::Parameter>& settings_mask_finor = ts_mask_finor.getParameters("uGtProcessor");
 
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    std::vector<std::string>  algo_mask_finor = settings_mask_finor.at("finorMask").getTableColumn<std::string>("algo");
+    std::vector<unsigned int> mask_mask_finor = settings_mask_finor.at("finorMask").getTableColumn<unsigned int>("mask");
 
-  // Algo bx mask
+    // mask (default=1 - unmask)
+    unsigned int default_finor_mask = 1;
+    auto default_finor_row =
+        std::find_if( algo_mask_finor.cbegin(),
+                      algo_mask_finor.cend(),
+                      [] (const std::string &s){
+                          // simpler than overweight std::tolower(s[], std::locale()) solution:
+                          return s == "all" || s == "All" || s == "ALl" ||
+                                 s == "ALL" || s == "aLL" || s == "alL" ||
+                                 s == "AlL" || s == "aLl";
+                      }
+        );
+    if( default_finor_row == algo_mask_finor.cend() ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+              << "\nWarning: No default found in FinOR mask xml, use 1 (unmasked) as default"
+              << std::endl;
+    } else {
+        default_finor_mask = mask_mask_finor[ std::distance( algo_mask_finor.cbegin(), default_finor_row ) ];
+    }
+
+    for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
+        triggerMasks.push_back(default_finor_mask);
+
+    for(unsigned int row=0; row<algo_mask_finor.size(); row++){
+        std::string  algoName = algo_mask_finor[row];
+        if( algoName == "all" || algoName == "All" || algoName == "ALl" ||
+            algoName == "ALL" || algoName == "aLL" || algoName == "alL" ||
+            algoName == "AlL" || algoName == "aLl" ) continue;
+        unsigned int algoBit  = algoName2bit[algoName];
+        unsigned int mask     = mask_mask_finor[row];
+        if( algoBit < m_numberPhysTriggers ) triggerMasks[algoBit] = mask;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // veto mask
+    l1t::XmlConfigParser xmlReader_mask_veto;
+    l1t::TriggerSystem ts_mask_veto;
+    ts_mask_veto.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
+
+    // run the parser 
+    xmlReader_mask_veto.readDOMFromString( xmlPayload_mask_veto ); // initialize it
+    xmlReader_mask_veto.readRootElement( ts_mask_veto, "uGT" ); // extract all of the relevant context
+    ts_mask_veto.setConfigured();
+
+    const std::map<std::string, l1t::Parameter>& settings_mask_veto = ts_mask_veto.getParameters("uGtProcessor");
+    std::vector<std::string>  algo_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<std::string>("algo");
+    std::vector<unsigned int> veto_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<unsigned int>("veto");
+
+    // veto mask (default=0 - no veto)
+    unsigned int default_veto_mask = 1;
+    auto default_veto_row =
+        std::find_if( algo_mask_veto.cbegin(),
+                      algo_mask_veto.cend(),
+                      [] (const std::string &s){
+                          // simpler than overweight std::tolower(s[], std::locale()) solution:
+                          return s == "all" || s == "All" || s == "ALl" ||
+                                 s == "ALL" || s == "aLL" || s == "alL" ||
+                                 s == "AlL" || s == "aLl";
+                      }
+        );
+    if( default_veto_row == algo_mask_veto.cend() ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+              << "\nWarning: No default found in Veto mask xml, use 0 (unvetoed) as default"
+              << std::endl;
+    } else {
+        default_veto_mask = veto_mask_veto[ std::distance( algo_mask_veto.cbegin(), default_veto_row ) ];
+    }
+
+    for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
+        triggerVetoMasks.push_back(default_veto_mask);
+
+    for(unsigned int row=0; row<algo_mask_veto.size(); row++){
+        std::string  algoName = algo_mask_veto[row];
+        if( algoName == "all" || algoName == "All" || algoName == "ALl" ||
+            algoName == "ALL" || algoName == "aLL" || algoName == "alL" ||
+            algoName == "AlL" || algoName == "aLl" ) continue;
+        unsigned int algoBit  = algoName2bit[algoName];
+        unsigned int veto    = veto_mask_veto[row];
+        if( algoBit < m_numberPhysTriggers ) triggerVetoMasks[algoBit] = int(veto);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Algo bx mask
     l1t::XmlConfigParser xmlReader_mask_algobx;
     l1t::TriggerSystem ts_mask_algobx;
     ts_mask_algobx.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
@@ -190,37 +313,249 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
     ts_mask_algobx.setConfigured();
 
     const std::map<std::string, l1t::Parameter>& settings_mask_algobx = ts_mask_algobx.getParameters("uGtProcessor");
-    std::map<std::string,unsigned int> mask_algobx_columns = settings_mask_algobx.at("algorithmBxMask").getColumnIndices();
-    std::vector<unsigned int> bunches = settings_mask_algobx.at("algorithmBxMask").getTableColumn<unsigned int>("bx/algo");
+    std::vector<std::string>  bx_algo_name = settings_mask_algobx.at("algorithmBxMask").getTableColumn<std::string>("algo");
+    std::vector<std::string>  bx_range     = settings_mask_algobx.at("algorithmBxMask").getTableColumn<std::string>("range");
+    std::vector<unsigned int> bx_mask      = settings_mask_algobx.at("algorithmBxMask").getTableColumn<unsigned int>("mask");
 
-    unsigned int numCol_mask_algobx = mask_algobx_columns.size();
+    int default_bxmask_row = -1;
+    unsigned int m_bx_mask_default = 1;
+    typedef std::pair<unsigned long,unsigned long> Range_t;
+    auto comp = [] (Range_t a, Range_t b){ return a.first < b.first; };
+    std::map<std::string, std::set<Range_t,decltype(comp)>> non_default_bx_ranges;
 
-    int NumAlgoBitsInMask = numCol_mask_algobx - 1;
-    for( int iBit=0; iBit<NumAlgoBitsInMask; iBit++ ){
-      std::vector<unsigned int> algo = settings_mask_algobx.at("algorithmBxMask").getTableColumn<unsigned int>(std::to_string(iBit).c_str());
-      for(unsigned int bx=0; bx<bunches.size(); bx++){
-          if( algo[bx]!=m_bx_mask_default ) triggerAlgoBxMaskAlgoTrig[ bunches[bx] ].push_back(iBit);
-      }
+    for(unsigned int row = 0; row < bx_algo_name.size(); row++){
+        const std::string &s1 = bx_algo_name[row];
+        const std::string &s2 = bx_range[row];
+        // find "all" broadcast keywords
+        bool broadcastAlgo  = false;
+        bool broadcastRange = false;
+        if( s1 == "all" || s1 == "All" || s1 == "ALl" ||
+            s1 == "ALL" || s1 == "aLL" || s1 == "alL" ||
+            s1 == "AlL" || s1 == "aLl" ) broadcastAlgo = true;
+        if( s2 == "all" || s2 == "All" || s2 == "ALl" ||
+            s2 == "ALL" || s2 == "aLL" || s2 == "alL" ||
+            s2 == "AlL" || s2 == "aLl" ) broadcastRange = true;
+        // ALL-ALL-default:
+        if( broadcastAlgo && broadcastRange ){
+            if( row != 0 ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                    << "\nWarning: ALL-ALL row is not the first one, ignore it assuming 1 (unmasked) as the default"
+                    << std::endl;
+                continue;
+            }
+            if( default_bxmask_row >= 0 ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                    << "\nWarning: multiple ALL-ALL rows found, using the first"
+                    << std::endl;
+                continue;
+            }
+            default_bxmask_row = row;
+            m_bx_mask_default = bx_mask[row];
+            continue;
+        }
+        // interpret the range
+        unsigned long first = 0, last = 0;
+        if( broadcastRange ){
+            first = 0;
+            last = 3563;
+        } else {
+            char *dash = 0;
+            first = strtoul(s2.data(), &dash, 0);
+            while( *dash != '\0' && *dash != '-' ) ++dash;
+            last  = (*dash != '\0' ? strtoul(++dash, &dash, 0) : first);
+            // what could possibly go wrong?
+            if( *dash != '\0' ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                        << "\nWarning: parsing " << s2 << " as [" << first << "," << last << "] range"
+                        << std::endl;
+            }
+            if( first > 3563 ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                        << "\nWarning: start of interval is out of range: " << s2 << ", skipping the row"
+                        << std::endl;
+                continue;
+            }
+            if( last > 3563 ){
+                last = 3563;
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                        << "\nWarning: end of interval is out of range: " << s2 << ", force [" << first << "," << last << "] range"
+                        << std::endl;
+            }
+            if( first > last ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                       << "\nWarning: inverse range "<< s2 << ", reordering as [" << last << "," << first << "]"
+                       << std::endl;
+                std::swap(first,last);
+            }
+        }
+        // {algo,ALL}-{range,ALL}-{0,1}:
+        std::vector<std::string> algos;
+        if( !broadcastAlgo )
+            algos.push_back( bx_algo_name[row] );
+        else
+            for(const auto &i: non_default_bx_ranges) algos.push_back(i.first);
+
+        for(const std::string &algoName : algos){
+
+           std::set<Range_t,decltype(comp)> &ranges = non_default_bx_ranges.insert
+           (
+               std::pair< std::string, std::set<Range_t,decltype(comp)> >
+               (
+                   algoName,  std::set<Range_t,decltype(comp)>(comp)
+               )
+           ).first->second; // I don't care if insert was successfull or if I've got a hold on existing range
+
+           // current range may or may not overlap with the already present ranges
+           // if end of the predecessor starts before begin of the current range and begin
+           //  of the successor starts after end of the current range there is no overlap
+           //  and I save this range only if it has mask different from the default
+           //  otherwise modify predecessor/successor ranges accordingly
+           std::set<Range_t>::iterator curr = ranges.end(); // inserted range
+           std::set<Range_t>::iterator succ = ranges.lower_bound(std::make_pair(first,last)); // successor starts at current or later
+           std::set<Range_t>::iterator pred = succ;
+           if( pred != ranges.begin() ) pred--; else pred = ranges.end();
+
+           if( (pred == ranges.end() || pred->second < first) &&
+               (succ == ranges.end() || succ->first > last) ){
+               // no overlap
+               if( m_bx_mask_default != bx_mask[row] )
+                   curr = ranges.insert(std::make_pair(first,last)).first;
+               // do nothing if this is a default-mask interval
+           } else {
+               // pred/succ iterators are read-only, create intermediate adjusted copies
+               Range_t newPred, newSucc;
+               bool modifiedPred = false, holeInPred = false, modifiedSucc = false, dropSucc = false;
+               // overlap found with predecessor range
+               if( pred != ranges.end() && pred->second >= first && pred->second <= last ){
+                   if( m_bx_mask_default != bx_mask[row] ){
+                       if( last == pred->second ){
+                           // both ranges end in the same place - nothing to do
+                           modifiedPred = false;
+                       } else {
+                           // extend predecessor range
+                           newPred.first  = pred->first;
+                           newPred.second = last;
+                           modifiedPred = true;
+                       }
+                   } else {
+                       // shrink predecessor range
+                       newPred.first  = pred->first;
+                       newPred.second = first-1; // non-negative for the predecessor by design
+                       // by design pred->first < first, so the interval above is always valid
+                       modifiedPred = true;
+                   }
+               }
+               // current range is fully contained in predecessor
+               if( pred != ranges.end() && pred->second > first && pred->second > last ){
+                   if( m_bx_mask_default != bx_mask[row] ){
+                       // no change to the predecessor range
+                       modifiedPred = false;
+                   } else {
+                       // make a "hole" in predecessor range
+                       newPred.first  = first;
+                       newPred.second = last;
+                       holeInPred = true;
+                       modifiedPred = true;
+                   }
+               }
+               // overlap found with successor range
+               if( succ != ranges.end() && succ->first <= last ){
+                   if( m_bx_mask_default != bx_mask[row] ){
+                       // extend successor range
+                       newSucc.first  = first;
+                       newSucc.second = succ->second;
+                   } else {
+                       // shrink successor range
+                       newSucc.first  = last+1;
+                       newSucc.second = succ->second;
+                       if( newSucc.first > 3563 || newSucc.first > newSucc.second )
+                           dropSucc = true;
+                   }
+                   modifiedSucc = true;
+               }
+               // overlap found with both, predecessor and successor, such that I need to merge them
+               if( modifiedPred && modifiedSucc && newPred.second >= newSucc.first ){
+                   // make newPred and newSucc identical just in case
+                   newPred.second = newSucc.second;
+                   newSucc.first  = newPred.first;
+                   ranges.erase(pred,++succ);
+                   curr = ranges.insert(newPred).first;
+               } else {
+                   // merging is not the case, but I still need to propagate the new ranges back to the source
+                   if( modifiedPred ){
+                       if( !holeInPred ){
+                           ranges.erase(pred);
+                           curr = ranges.insert(newPred).first;
+                       } else {
+                           // make a hole by splitting predecessor into two ranges
+                           Range_t r1(pred->first, newPred.first-1); // non-negative for the predecessor by design
+                           Range_t r2(newPred.second+1, pred->second);
+                           ranges.erase(pred);
+                           ranges.insert(r1).first;
+                           ranges.insert(r2).first;
+                           curr = ranges.end(); // hole cannot cover any additional ranges
+                       }
+                   }
+                   if( modifiedSucc ){
+                       ranges.erase(succ);
+                       if( !dropSucc )
+                           curr = ranges.insert(newSucc).first;
+                   }
+               }
+           }
+           // if current range spans over few more ranges after the successor
+           //  remove those from the consideration up until the last covered range
+           //  that may or may not extend beyond the current range end 
+           if( curr != ranges.end() ){ // insertion took place
+               std::set<Range_t,decltype(comp)>::iterator last_covered = ranges.upper_bound(std::make_pair(curr->second,0));
+               if( last_covered != ranges.begin() ) last_covered--; else last_covered = ranges.end();
+
+               if( last_covered != ranges.end() && last_covered->first != curr->first ){
+                   // ranges is not empty and last_covered is not current itself (i.e. it is different)
+                   if( curr->second < last_covered->second ){
+                       // the range needs to be extended
+                       Range_t newRange(curr->first, last_covered->second);
+                       ranges.erase(curr);
+                       curr = ranges.insert(newRange).first;
+                   }
+                   ranges.erase(++curr,last_covered);
+               }
+           }
+        }
+    }
+
+    if( default_bxmask_row < 0 ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+              << "\nWarning: No default found in BX mask xml, used 1 (unmasked) as default"
+              << std::endl;
+    }
+
+    for(const std::pair<std::string, std::set<Range_t,decltype(comp)>> &algo : non_default_bx_ranges){
+        const std::string &algoName = algo.first;
+        unsigned int algoBit  = algoName2bit[algoName];
+        for(auto range : algo.second)
+           for(unsigned int bx = range.first; bx <= range.second; bx++){
+               triggerAlgoBxMaskAlgoTrig[bx].push_back(algoBit);
+           }
     }
 
 
-  // Set prescales to zero if masked
-  for( unsigned int iSet=0; iSet < prescales.size(); iSet++ ){
-    for( unsigned int iBit=0; iBit < prescales[iSet].size(); iBit++ ){
-      // Add protection in case prescale table larger than trigger mask size
-      if( iBit >= triggerMasks.size() ){
+    // Set prescales to zero if masked
+    for( unsigned int iSet=0; iSet < prescales.size(); iSet++ ){
+        for( unsigned int iBit=0; iBit < prescales[iSet].size(); iBit++ ){
+        // Add protection in case prescale table larger than trigger mask size
+        if( iBit >= triggerMasks.size() ){
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
 	      << "\nWarning: algoBit in prescale table >= triggerMasks.size() "
 	      << "\nWarning: no information on masking bit or not, setting as unmasked "
 	      << std::endl;
-      }
-      else {
-	prescales[iSet][iBit] *= triggerMasks[iBit];
+        } else {
+            prescales[iSet][iBit] *= triggerMasks[iBit];
+        }
       }
     }
-  }
 
-//////////////////
+/////////////
 
   l1t::PrescalesVetosHelper data_( new L1TGlobalPrescalesVetos() );
 
@@ -230,8 +565,8 @@ std::shared_ptr<L1TGlobalPrescalesVetos> L1TGlobalPrescalesVetosOnlineProd::newO
   data_.setTriggerAlgoBxMask   ( triggerAlgoBxMaskAlgoTrig );
 
   using namespace edm::es;
-  std::shared_ptr<L1TGlobalPrescalesVetos> pMenu(data_.getWriteInstance());
-  return pMenu;
+  std::shared_ptr<L1TGlobalPrescalesVetos> payload(data_.getWriteInstance());
+  return payload;
 
 }
 

--- a/L1TriggerConfig/Utilities/test/bxmask.xml
+++ b/L1TriggerConfig/Utilities/test/bxmask.xml
@@ -1,0 +1,23 @@
+<run-settings id="uGT">
+  <context id="uGtProcessor">
+    <param id="algorithmBxMask" type="table">
+      <columns>algo, range, mask</columns>
+      <types>string, string, uint</types>
+      <rows>
+        <!-- Default bx mask value is 1 -->
+        <row>ALL, ALL, 1</row> <!-- mandatory row: set defaults -->
+        <row>L1_ZeroBias, 1-10, 0</row><!-- disable L1_ZeroBias in any BX -->
+        <row>L1_ZeroBias, 5-10, 1</row>
+        <row>L1_ZeroBias, 9, 1</row>
+        <row>L1_ZeroBias, 10-11, 1</row>
+        <row>L1_ZeroBias, 20-30, 0</row>
+        <row>L1_ZeroBias, 20, 1</row>
+        <row>L1_ZeroBias, 22, 1</row>
+        <row>L1_ZeroBias, 30, 1</row>
+        <row>ALL, 3500-3564, 0</row> <!-- set a gap for all algos -->
+        <row>L1_SingleMu10, ALL, 0</row> <!-- disable all BXs for algo -->
+      </rows>
+    </param>
+  </context>
+</run-settings>
+

--- a/L1TriggerConfig/Utilities/test/caloL1Dump.py
+++ b/L1TriggerConfig/Utilities/test/caloL1Dump.py
@@ -1,0 +1,97 @@
+# select CALOL1_KEY from CMS_TRG_L1_CONF.L1_TRG_CONF_KEYS where ID='collisions2016_TSC/v206' ;
+import re
+import os, sys, shutil
+import subprocess
+"""
+A simple helper script that provided with no arguments dumps a list of
+top-level keys, and provided with any key from this list as an argument,
+dumps a list of sub-keys and saves corresponding configuration to local
+files.
+"""
+
+# connection string
+sqlplusCmd = ['env',
+              'sqlplus',
+              '-S',
+              'cms_trg_r/X3lmdvu4@cms_omds_adg'
+             ]
+
+if hash( sqlplusCmd[-1] ) != 1687624727082866629:
+    print 'Do not forget to plug password to this script'
+    print 'Exiting.'
+    exit(0)
+
+myre = re.compile(r'(ID)|(-{80})')
+
+# if no arguments are given, query the top level keys only and exit
+if len(sys.argv) == 1:
+    sqlplus = subprocess.Popen(sqlplusCmd, shell=False, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+    print 'No args specified, querying and printing only top-level keys:'
+    for line in re.split('\n',sqlplus.communicate('select unique ID from CMS_TRG_L1_CONF.CALOL2_KEYS;')[0]):
+        if myre.search(line) == None :
+            print line
+    print 'Pick any of these keys as an argument next time you run this script'
+    exit(0)
+
+# if an argument is given query the whole content of the key
+key = sys.argv[1]
+
+sqlplus = subprocess.Popen(sqlplusCmd,
+                           shell=False,
+                           stdout=subprocess.PIPE,
+                           stdin=subprocess.PIPE
+                          )
+
+queryKey = "select CALOL1_KEY from CMS_TRG_L1_CONF.L1_TRG_CONF_KEYS where ID='{0}'".format(key)
+
+for line in re.split('\n',sqlplus.communicate(queryKey+';')[0]):
+    print line
+    if re.search('/v',line) :
+        key=line
+
+print key
+
+queryKeys = """
+            select
+                HW, ALGO, INFRA
+            from
+                CMS_TRG_L1_CONF.CALOL1_KEYS
+            where
+                ID = '{0}'
+            """.format(key)
+
+# write results for specific configs to the following files
+batch = {
+         'HW'    : 'hw.xml',
+         'ALGO'  : 'algo.xml',
+         'INFRA' : 'infra.xml'
+        }
+
+# do the main job here
+for config,fileName in batch.iteritems():
+    sqlplus = subprocess.Popen(sqlplusCmd, shell=False, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+
+    with open(fileName,'w') as f:
+        query = """
+                select
+                    CONF.CONF
+                from
+                    CMS_TRG_L1_CONF.CALOL1_CLOBS CONF, ({0}) KEY
+                where
+                    CONF.ID = KEY.{1}
+                """.format(queryKeys, config)
+
+        for line in re.split('\n',sqlplus.communicate('\n'.join(['set linesize 200', 'set longchunksize 2000000 long 2000000 pages 0',query+';']))[0]):
+            f.write('\n')
+            f.write(line)
+        f.close()
+
+sqlplus = subprocess.Popen(sqlplusCmd, shell=False, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+print 'Following keys were found:'
+for line in re.split('\n',sqlplus.communicate(queryKeys+';')[0]):
+    print line
+
+
+print 'Results are saved in ' + ' '.join(batch.values()) + ' files'
+
+

--- a/L1TriggerConfig/Utilities/test/dumpL1TGlobalPrescalesVetos.py
+++ b/L1TriggerConfig/Utilities/test/dumpL1TGlobalPrescalesVetos.py
@@ -66,7 +66,7 @@ else :
         cms.PSet(
             record = cms.string('L1TGlobalPrescalesVetosO2ORcd'),
             type = cms.string('L1TGlobalPrescalesVetos'),
-            key = cms.string( options.systemKey.split(':')[1] )
+            key = cms.string( options.systemKey )
         )
     )
 

--- a/L1TriggerConfig/Utilities/test/finor.xml
+++ b/L1TriggerConfig/Utilities/test/finor.xml
@@ -1,0 +1,16 @@
+<run-settings id="uGT">
+  <context id="uGtProcessor">
+    <param id="finorMask" type="table">
+      <columns>algo, mask</columns>
+      <types>string, uint</types>
+      <rows>
+        <!-- Default FinOR mask value is 1 -->
+        <row>ALL, 1</row> <!-- mandatory row: set defaults -->
+        <row>L1_ZeroBias, 0</row>
+        <row>L1_BptxMinus_NotBptxPlus2, 0</row>
+        <row>L1_DoubleMu10_Mass60to150_BptxAND, 0</row>
+      </rows>
+    </param>
+  </context>
+</run-settings>
+

--- a/L1TriggerConfig/Utilities/test/prescale.xml
+++ b/L1TriggerConfig/Utilities/test/prescale.xml
@@ -1,0 +1,22 @@
+<run-settings id="uGT">
+  <context id="uGtProcessor">
+    <!-- Initial prescale set -->
+    <param id="index" type="uint">2</param>
+    <!-- Prescales sets table -->
+    <param id="prescales" type="table">
+      <columns>algo/prescale-index, 0:0e00, 1:0e10, 2, 3, 4:emergency</columns>
+      <types>string, uint, uint, uint, uint, uint, uint</types>
+      <rows>
+      <!-- Algos must match with menu, thus no default row is needed -->
+        <row>L1_ZeroBias, 15923, 15923, 15923, 15923, 0</row>
+        <row>L1_BptxPlus_NotBptxMinus, 15923, 15923, 15923, 15923, 0</row>
+        <row>L1_BptxMinus_NotBptxPlus, 30000, 28000, 24000, 20000, 0</row>
+        <row>L1_MinimumBiasHF0_OR_BptxAND, 16000, 14000, 12000, 10000, 0</row>
+        <row>L1_MinimumBiasHF0_AND_BptxAND, 0, 0, 0, 0, 0</row>
+        <row>L1_MinimumBiasHF0_OR, 200, 170, 150, 120, 0</row>
+        <!-- ... -->
+      </rows>
+    </param>
+  </context>
+</run-settings>
+

--- a/L1TriggerConfig/Utilities/test/readcalol1.cpp
+++ b/L1TriggerConfig/Utilities/test/readcalol1.cpp
@@ -49,11 +49,11 @@ int main(int argc, char *argv[]){
     // parse the string using the XML reader
     XmlConfigParser xmlReader;
     l1t::TriggerSystem ts;
-if( false ){
+
     cout << "Parsing " << sequence.front() << endl;
+if( false ){
     xmlReader.readDOMFromString( xmlPayload[sequence.front()] );
     xmlReader.readRootElement  ( ts, "calol1" );
-    ts.addProcessor("defaultProc", "processors","-2","0");
 } else {
     ts.addProcessor("processor0", "processors","-1","-1");
     ts.addProcessor("processor1", "processors","-1","-2");
@@ -74,25 +74,23 @@ if( false ){
     ts.addProcessor("processor16", "processors","-1","-17");
     ts.addProcessor("processor17", "processors","-1","-18");
 
-    ts.addProcessor("CTP7_Phi0", "Layer1Processor","-2","-0");
-    ts.addProcessor("CTP7_Phi1", "Layer1Processor","-2","-1");
-    ts.addProcessor("CTP7_Phi2", "Layer1Processor","-2","-2");
-    ts.addProcessor("CTP7_Phi3", "Layer1Processor","-2","-3");
-    ts.addProcessor("CTP7_Phi4", "Layer1Processor","-2","-4");
-    ts.addProcessor("CTP7_Phi5", "Layer1Processor","-2","-5");
-    ts.addProcessor("CTP7_Phi6", "Layer1Processor","-2","-6");
-    ts.addProcessor("CTP7_Phi7", "Layer1Processor","-2","-7");
-    ts.addProcessor("CTP7_Phi8", "Layer1Processor","-2","-8");
-    ts.addProcessor("CTP7_Phi9", "Layer1Processor","-2","-9");
-    ts.addProcessor("CTP7_Phi10","Layer1Processor","-2","-10");
-    ts.addProcessor("CTP7_Phi11","Layer1Processor","-2","-11");
-    ts.addProcessor("CTP7_Phi12","Layer1Processor","-2","-12");
-    ts.addProcessor("CTP7_Phi13","Layer1Processor","-2","-13");
-    ts.addProcessor("CTP7_Phi14","Layer1Processor","-2","-14");
-    ts.addProcessor("CTP7_Phi15","Layer1Processor","-2","-15");
-    ts.addProcessor("CTP7_Phi16","Layer1Processor","-2","-16");
-
-    ts.addProcessor("defaultProc", "processors","-2","0");
+    ts.addProcessor("CTP7_Phi0", "processors","-2","-0");
+    ts.addProcessor("CTP7_Phi1", "processors","-2","-1");
+    ts.addProcessor("CTP7_Phi2", "processors","-2","-2");
+    ts.addProcessor("CTP7_Phi3", "processors","-2","-3");
+    ts.addProcessor("CTP7_Phi4", "processors","-2","-4");
+    ts.addProcessor("CTP7_Phi5", "processors","-2","-5");
+    ts.addProcessor("CTP7_Phi6", "processors","-2","-6");
+    ts.addProcessor("CTP7_Phi7", "processors","-2","-7");
+    ts.addProcessor("CTP7_Phi8", "processors","-2","-8");
+    ts.addProcessor("CTP7_Phi9", "processors","-2","-9");
+    ts.addProcessor("CTP7_Phi10","processors","-2","-10");
+    ts.addProcessor("CTP7_Phi11","processors","-2","-11");
+    ts.addProcessor("CTP7_Phi12","processors","-2","-12");
+    ts.addProcessor("CTP7_Phi13","processors","-2","-13");
+    ts.addProcessor("CTP7_Phi14","processors","-2","-14");
+    ts.addProcessor("CTP7_Phi15","processors","-2","-15");
+    ts.addProcessor("CTP7_Phi16","processors","-2","-16");
 }
 
     cout << "Parsing " << sequence.back() << endl;
@@ -104,7 +102,7 @@ if( false ){
 //    for(auto &q : ts.getProcToRoleAssignment()) cout << q.first << " - " << q.second << endl;
 
     // feel free to play with the containers:
-    map<string, l1t::Parameter> conf = ts.getParameters("defaultProc"); // use your context id here - Layer1Processor
+    map<string, l1t::Parameter> conf = ts.getParameters("CTP7_Phi15"); // use your context id here - Layer1Processor
 //    map<string, l1t::Mask>    rs   = ts.getMasks   ("processors"); // don't call a context that doesn't exist
 
     string layer1ECalScaleFactors= conf["layer1ECalScaleFactors"].getValueAsStr();

--- a/L1TriggerConfig/Utilities/test/readcalol1.cpp
+++ b/L1TriggerConfig/Utilities/test/readcalol1.cpp
@@ -1,57 +1,125 @@
-#include "L1Trigger/L1TCommon/src/Setting.cc"
+#include "L1Trigger/L1TCommon/src/Parameter.cc"
 #include "L1Trigger/L1TCommon/src/Mask.cc"
-#include "L1Trigger/L1TCommon/src/XmlConfigReader.cc"
-#include "L1Trigger/L1TCommon/src/TrigSystem.cc"
+#include "L1Trigger/L1TCommon/src/XmlConfigParser.cc"
+#include "L1Trigger/L1TCommon/src/TriggerSystem.cc"
 
 #include <iostream>
 #include <fstream>
+#include <string>
+#include <list>
+#include <map>
 
 // To compile run these lines in your CMSSW_X_Y_Z/src/ :
 /*
 cmsenv
-eval "export `scram tool info xerces-c | sed -n -e 's/INCLUDE=/XERC_INC=/gp'`"
-eval "export `scram tool info xerces-c | sed -n -e 's/LIBDIR=/XERC_LIB=/gp'`"
-eval "export `scram tool info boost    | sed -n -e 's/INCLUDE=/BOOST_INC=/gp'`"
-eval "export `scram tool info boost    | sed -n -e 's/LIBDIR=/BOOST_LIB=/gp'`"
+eval "setenv `scram tool info xerces-c | sed -n -e 's/INCLUDE=/XERC_INC /gp'`"
+eval "setenv `scram tool info xerces-c | sed -n -e 's/LIBDIR=/XERC_LIB /gp'`"
+eval "setenv `scram tool info boost    | sed -n -e 's/INCLUDE=/BOOST_INC /gp'`"
+eval "setenv `scram tool info boost    | sed -n -e 's/LIBDIR=/BOOST_LIB /gp'`"
 g++ -g -std=c++11 -o test readcalol1.cpp -I./ -I$CMSSW_RELEASE_BASE/src -I$XERC_INC -L$XERC_LIB -lxerces-c -I$BOOST_INC -L$BOOST_LIB -lboost_thread -lboost_signals -lboost_date_time -L$CMSSW_RELEASE_BASE/lib/$SCRAM_ARCH/ -lFWCoreMessageLogger -lCondFormatsL1TObjects
 */
 
 using namespace std;
 
 int main(int argc, char *argv[]){
-    // read the input xml file into a string
-    ifstream input( argv[1] );
-    if( !input ){ cout << "Cannot open " << argv[1] << " file" << endl; return 0; }
+    if( argc < 3 ) return 0;
+    // read the input xml files into a map of string
 
-    string xmlPayload;
-    size_t nLinesRead=0;
+    list<string> sequence;
+    map<string,string> xmlPayload;
+    for(int p=1; p<argc; p++){
 
-    while( !input.eof() ){
-        string tmp;
-        getline( input, tmp, '\n' );
-        xmlPayload.append( tmp );
-        nLinesRead++;
+        ifstream input( argv[p] );
+        if( !input ){ cout << "Cannot open " << argv[p] << " file" << endl; return 0; }
+        sequence.push_back( argv[p] );
+
+        size_t nLinesRead=0;
+
+        while( !input.eof() ){
+            string tmp;
+            getline( input, tmp, '\n' );
+            xmlPayload[ argv[p] ].append( tmp );
+            nLinesRead++;
+        }
+
+        cout << argv[p] << ": read " << nLinesRead << " lines" << endl;
+        input.close();
     }
 
-    cout << "read " << nLinesRead << " lines" << endl;
-    input.close();
-
     // parse the string using the XML reader
-    XmlConfigReader xmlReader;
-    xmlReader.readDOMFromString( xmlPayload ); // initialize it
+    XmlConfigParser xmlReader;
+    l1t::TriggerSystem ts;
+if( false ){
+    cout << "Parsing " << sequence.front() << endl;
+    xmlReader.readDOMFromString( xmlPayload[sequence.front()] );
+    xmlReader.readRootElement  ( ts, "calol1" );
+    ts.addProcessor("defaultProc", "processors","-2","0");
+} else {
+    ts.addProcessor("processor0", "processors","-1","-1");
+    ts.addProcessor("processor1", "processors","-1","-2");
+    ts.addProcessor("processor2", "processors","-1","-3");
+    ts.addProcessor("processor3", "processors","-1","-4");
+    ts.addProcessor("processor4", "processors","-1","-5");
+    ts.addProcessor("processor5", "processors","-1","-6");
+    ts.addProcessor("processor6", "processors","-1","-7");
+    ts.addProcessor("processor7", "processors","-1","-8");
+    ts.addProcessor("processor8", "processors","-1","-9");
+    ts.addProcessor("processor9", "processors","-1","-10");
+    ts.addProcessor("processor10", "processors","-1","-11");
+    ts.addProcessor("processor11", "processors","-1","-12");
+    ts.addProcessor("processor12", "processors","-1","-13");
+    ts.addProcessor("processor13", "processors","-1","-14");
+    ts.addProcessor("processor14", "processors","-1","-15");
+    ts.addProcessor("processor15", "processors","-1","-16");
+    ts.addProcessor("processor16", "processors","-1","-17");
+    ts.addProcessor("processor17", "processors","-1","-18");
 
-    l1t::TrigSystem ts;
-    ts.addProcRole("processors", "processors"); //
-    xmlReader.readRootElement( ts, "calol1" ); // extract all of the relevant context (labeled "calol1" here)
+    ts.addProcessor("CTP7_Phi0", "Layer1Processor","-2","-0");
+    ts.addProcessor("CTP7_Phi1", "Layer1Processor","-2","-1");
+    ts.addProcessor("CTP7_Phi2", "Layer1Processor","-2","-2");
+    ts.addProcessor("CTP7_Phi3", "Layer1Processor","-2","-3");
+    ts.addProcessor("CTP7_Phi4", "Layer1Processor","-2","-4");
+    ts.addProcessor("CTP7_Phi5", "Layer1Processor","-2","-5");
+    ts.addProcessor("CTP7_Phi6", "Layer1Processor","-2","-6");
+    ts.addProcessor("CTP7_Phi7", "Layer1Processor","-2","-7");
+    ts.addProcessor("CTP7_Phi8", "Layer1Processor","-2","-8");
+    ts.addProcessor("CTP7_Phi9", "Layer1Processor","-2","-9");
+    ts.addProcessor("CTP7_Phi10","Layer1Processor","-2","-10");
+    ts.addProcessor("CTP7_Phi11","Layer1Processor","-2","-11");
+    ts.addProcessor("CTP7_Phi12","Layer1Processor","-2","-12");
+    ts.addProcessor("CTP7_Phi13","Layer1Processor","-2","-13");
+    ts.addProcessor("CTP7_Phi14","Layer1Processor","-2","-14");
+    ts.addProcessor("CTP7_Phi15","Layer1Processor","-2","-15");
+    ts.addProcessor("CTP7_Phi16","Layer1Processor","-2","-16");
+
+    ts.addProcessor("defaultProc", "processors","-2","0");
+}
+
+    cout << "Parsing " << sequence.back() << endl;
+    xmlReader.readDOMFromString( xmlPayload[sequence.back()] );
+    xmlReader.readRootElement  ( ts, "calol1" );
+
     ts.setConfigured();
 
+//    for(auto &q : ts.getProcToRoleAssignment()) cout << q.first << " - " << q.second << endl;
+
     // feel free to play with the containers:
-    map<string, l1t::Setting> conf = ts.getSettings("processors"); // use your context id here
+    map<string, l1t::Parameter> conf = ts.getParameters("defaultProc"); // use your context id here - Layer1Processor
 //    map<string, l1t::Mask>    rs   = ts.getMasks   ("processors"); // don't call a context that doesn't exist
 
-    string tmp = conf["layer1ECalScaleETBins"].getValueAsStr();
-    cout << "layer1ECalScaleETBins =" << tmp << endl;
+    string layer1ECalScaleFactors= conf["layer1ECalScaleFactors"].getValueAsStr();
+    string layer1HCalScaleFactors= conf["layer1HCalScaleFactors"].getValueAsStr();
+    string layer1HFScaleFactors  = conf["layer1HFScaleFactors"].getValueAsStr();
+    string layer1ECalScaleETBins = conf["layer1ECalScaleETBins"].getValueAsStr();
+    string layer1HCalScaleETBins = conf["layer1HCalScaleETBins"].getValueAsStr();
+    string layer1HFScaleETBins   = conf["layer1HFScaleETBins"].getValueAsStr();
 
+    cout << "layer1ECalScaleFactors=" << layer1ECalScaleFactors << endl;
+    cout << "layer1HCalScaleFactors=" << layer1HCalScaleFactors << endl;
+    cout << "layer1HFScaleFactors  =" << layer1HFScaleFactors  << endl;
+    cout << "layer1ECalScaleETBins =" << layer1ECalScaleETBins << endl;
+    cout << "layer1HCalScaleETBins =" << layer1HCalScaleETBins << endl;
+    cout << "layer1HFScaleETBins   =" << layer1HFScaleETBins   << endl;
 
     return 0;
 }

--- a/L1TriggerConfig/Utilities/test/readgt.cpp
+++ b/L1TriggerConfig/Utilities/test/readgt.cpp
@@ -1,20 +1,19 @@
-#include "L1Trigger/L1TCommon/src/Setting.cc"
+#include "L1Trigger/L1TCommon/src/Parameter.cc"
 #include "L1Trigger/L1TCommon/src/Mask.cc"
-#include "L1Trigger/L1TCommon/src/Tools.cc"
-#include "L1Trigger/L1TCommon/src/XmlConfigReader.cc"
+#include "L1Trigger/L1TCommon/src/XmlConfigParser.cc"
 //#include "L1Trigger/L1TGlobal/interface/PrescalesVetosHelper.h"
-#include "L1Trigger/L1TCommon/interface/TrigSystem.h"
+#include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
 #include <iostream>
 #include <fstream>
 #include <algorithm>
 // To compile run these lines in your CMSSW_X_Y_Z/src/ :
 /*
 cmsenv
-eval "export `scram tool info xerces-c | sed -n -e 's/INCLUDE=/XERC_INC=/gp'`"
-eval "export `scram tool info xerces-c | sed -n -e 's/LIBDIR=/XERC_LIB=/gp'`"
-eval "export `scram tool info boost    | sed -n -e 's/INCLUDE=/BOOST_INC=/gp'`"
-eval "export `scram tool info boost    | sed -n -e 's/LIBDIR=/BOOST_LIB=/gp'`"
-g++ -g -std=c++11 -o test readgt.cpp -I./ -I$CMSSW_RELEASE_BASE/src -I$CMSSW_BASE/src -I$XERC_INC -L$XERC_LIB -lxerces-c -I$BOOST_INC -L$BOOST_LIB -lboost_thread -lboost_signals -lboost_date_time -L$CMSSW_RELEASE_BASE/lib/$SCRAM_ARCH/ -lFWCoreMessageLogger -L$CMSSW_BASE/lib/$SCRAM_ARCH/ -lL1TriggerL1TCommon -lCondFormatsL1TObjects
+eval "setenv `scram tool info xerces-c | sed -n -e 's/INCLUDE=/XERC_INC /gp'`"
+eval "setenv `scram tool info xerces-c | sed -n -e 's/LIBDIR=/XERC_LIB /gp'`"
+eval "setenv `scram tool info boost    | sed -n -e 's/INCLUDE=/BOOST_INC /gp'`"
+eval "setenv `scram tool info boost    | sed -n -e 's/LIBDIR=/BOOST_LIB /gp'`"
+g++ -g -std=c++11 -o test readgt.cpp -I./ -I$CMSSW_BASE/src -I$CMSSW_RELEASE_BASE/src -I$XERC_INC -L$XERC_LIB -lxerces-c -I$BOOST_INC -L$BOOST_LIB -lboost_thread -lboost_signals -lboost_date_time -L$CMSSW_BASE/lib/$SCRAM_ARCH/ -L$CMSSW_RELEASE_BASE/lib/$SCRAM_ARCH/ -lFWCoreMessageLogger -lCondFormatsL1TObjects -lL1TriggerL1TCommon
 */
 
 using namespace std;
@@ -42,6 +41,17 @@ int main(int argc, char *argv[]){
         input.close();
     }
 
+  std::map<std::string,int> algoName2bit;
+  algoName2bit["L1_ZeroBias"] = 0;
+  algoName2bit["L1_BptxMinus_NotBptxPlus2"] = 1;
+  algoName2bit["L1_DoubleMu10_Mass60to150_BptxAND"] = 2;
+  algoName2bit["L1_SingleMu10"] = 3;
+  algoName2bit["L1_BptxPlus_NotBptxMinus"] = 4;
+  algoName2bit["L1_BptxMinus_NotBptxPlus"] = 5;
+  algoName2bit["L1_MinimumBiasHF0_OR_BptxAND"] = 6;
+  algoName2bit["L1_MinimumBiasHF0_AND_BptxAND"] = 7;
+  algoName2bit["L1_MinimumBiasHF0_OR"] = 8;
+
   list<string>::const_iterator fname = sequence.begin();
   std::cout << "Prescales: " << *fname << std::endl;
   std::string xmlPayload_prescale    = xmlPayload[*fname++];
@@ -53,7 +63,6 @@ int main(int argc, char *argv[]){
   std::string xmlPayload_mask_algobx = xmlPayload[*fname++];
 
   unsigned int m_numberPhysTriggers = 512;
-  unsigned int m_bx_mask_default = 1;
 
 
   std::vector<std::vector<int> > prescales;
@@ -61,188 +70,358 @@ int main(int argc, char *argv[]){
   std::vector<int> triggerVetoMasks;
   std::map<int, std::vector<int> > triggerAlgoBxMaskAlgoTrig;
 
-
   // Prescales
-    l1t::XmlConfigReader xmlReader_prescale;
-    l1t::TrigSystem ts_prescale;
-    ts_prescale.addProcRole("uGtProcessor", "uGtProcessor");
+    l1t::XmlConfigParser xmlReader_prescale;
+    l1t::TriggerSystem ts_prescale;
+    ts_prescale.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
 
-std::cout<<"!!!!!!!!!!!!2"<<std::endl;
     // run the parser 
     xmlReader_prescale.readDOMFromString( xmlPayload_prescale ); // initialize it
     xmlReader_prescale.readRootElement( ts_prescale, "uGT" ); // extract all of the relevant context
     ts_prescale.setConfigured();
 
-std::cout<<"!!!!!!!!!!!!3"<<std::endl;
-    std::map<std::string, l1t::Setting> settings_prescale = ts_prescale.getSettings("uGtProcessor");
-    std::vector<l1t::TableRow> tRow_prescale = settings_prescale["prescales"].getTableRows();
+    const std::map<std::string, l1t::Parameter> &settings_prescale = ts_prescale.getParameters("uGtProcessor");
+    std::map<std::string,unsigned int> prescaleColumns = settings_prescale.at("prescales").getColumnIndices();
 
-    for(std::map<std::string, l1t::Setting>::const_iterator i=settings_prescale.begin(); i!=settings_prescale.end(); i++)
-        std::cout<<i->first<<std::endl;
+    unsigned int numColumns_prescale = prescaleColumns.size();
+    int nPrescaleSets = numColumns_prescale - 1;
+    std::vector<std::string> algoNames = settings_prescale.at("prescales").getTableColumn<std::string>("algo/prescale-index");
 
-std::cout<<"!!!!!!!!!!!!4"<<std::endl;
-    unsigned int numColumns_prescale = 0;
-    if( tRow_prescale.size()>0 ){
-      std::vector<std::string> firstRow_prescale = tRow_prescale[0].getRow();
-      numColumns_prescale = firstRow_prescale.size();
-    } else {
-      std::cout<<" tRow_prescale.size = 0"<<std::endl;
-    }
-    
-std::cout<<"!!!!!!!!!!!!5"<<std::endl;
-    int NumPrescaleSets = numColumns_prescale - 1;
-    int NumAlgos_prescale = 0;//*( std::max_element(std::begin(tRow_prescale), std::end(tRow_prescale)) );
-    for( auto it=tRow_prescale.begin(); it!=tRow_prescale.end(); it++ ){
-        unsigned int algoBit = it->getRowValue<unsigned int>("algo/prescale-index");
-        if( NumAlgos_prescale < algoBit+1 ) NumAlgos_prescale = algoBit+1;
-    }
+    if( nPrescaleSets > 0 ){
+        // Fill default prescale set
+        for( int iSet=0; iSet<nPrescaleSets; iSet++ ){
+            prescales.push_back(std::vector<int>());
+            for( int iBit = 0; iBit < m_numberPhysTriggers; ++iBit ){
+                int inputDefaultPrescale = 0; // only prescales that are set in the block below are used
+                prescales[iSet].push_back(inputDefaultPrescale);
+            }
+        }
 
-std::cout << "numColumns_prescale = " << numColumns_prescale << " NumAlgos_prescale = " << NumAlgos_prescale << std::endl;
-
-    if( NumPrescaleSets > 0 ){
-      // Fill default prescale set
-      for( int iSet=0; iSet<NumPrescaleSets; iSet++ ){
-	prescales.push_back(std::vector<int>());
-	for( int iBit = 0; iBit < NumAlgos_prescale; ++iBit ){
-	  int inputDefaultPrescale = 1;
-	  prescales[iSet].push_back(inputDefaultPrescale);
-	}
-      }
-
-std::cout<<"!!!!!!!!!!!!6"<<std::endl;
-      for( auto it=tRow_prescale.begin(); it!=tRow_prescale.end(); it++ ){
-	unsigned int algoBit = it->getRowValue<unsigned int>("algo/prescale-index");
-std::cout<<"algoBit = "<<algoBit<<std::endl;
-	for( int iSet=0; iSet<NumPrescaleSets; iSet++ ){
-	  int prescale = it->getRowValue<unsigned int>(std::to_string(iSet));
-	  prescales[iSet][algoBit] = prescale;
-	}
-      }
-    }
-
-
-std::cout<<"!!!!!!!!!!!!7"<<std::endl;
-
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  // finor mask
-  // Setting mask to default 1 (unmask)
-  for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
-    triggerMasks.push_back(1);
-
-std::cout<<"!!!!!!!!!!!!8"<<std::endl;
+        for(auto &col : prescaleColumns){
+            if( col.second<1 ) continue; // we don't care for the algorithms' indicies in 0th column
+            int iSet = col.second - 1;
+            std::vector<unsigned int> prescalesForSet = settings_prescale.at("prescales").getTableColumn<unsigned int>(col.first.c_str());
+            for(unsigned int row=0; row<prescalesForSet.size(); row++){
+                unsigned int prescale = prescalesForSet[row];
+                std::string  algoName = algoNames[row];
+                unsigned int algoBit  = algoName2bit[algoName];
+                prescales[iSet][algoBit] = prescale;
   
-    l1t::XmlConfigReader xmlReader_mask_finor;
-    l1t::TrigSystem ts_mask_finor;
-    ts_mask_finor.addProcRole("uGtProcessor", "uGtProcessor");
+std::cout << "prescales[" << iSet << "][" << algoBit << "(" << algoName << ")] " << prescale << std::endl;
+          }
+        }
+    }
 
-std::cout<<"!!!!!!!!!!!!9"<<std::endl;
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // finor mask
+    l1t::XmlConfigParser xmlReader_mask_finor;
+    l1t::TriggerSystem ts_mask_finor;
+    ts_mask_finor.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
+
     // run the parser 
     xmlReader_mask_finor.readDOMFromString( xmlPayload_mask_finor ); // initialize it
     xmlReader_mask_finor.readRootElement( ts_mask_finor, "uGT" ); // extract all of the relevant context
     ts_mask_finor.setConfigured();
 
-std::cout<<"!!!!!!!!!!!!10"<<std::endl;
-    std::map<std::string, l1t::Setting> settings_mask_finor = ts_mask_finor.getSettings("uGtProcessor");
+    const std::map<std::string, l1t::Parameter>& settings_mask_finor = ts_mask_finor.getParameters("uGtProcessor");
 
-std::cout<<"!!!!!!!!!!!!11"<<std::endl;
-    std::vector<l1t::TableRow> tRow_mask_finor = settings_mask_finor["finorMask"].getTableRows();
+    std::vector<std::string>  algo_mask_finor = settings_mask_finor.at("finorMask").getTableColumn<std::string>("algo");
+    std::vector<unsigned int> mask_mask_finor = settings_mask_finor.at("finorMask").getTableColumn<unsigned int>("mask");
 
-std::cout<<"!!!!!!!!!!!!12"<<std::endl;
-    for( auto it=tRow_mask_finor.begin(); it!=tRow_mask_finor.end(); it++ ){
-      unsigned int algoBit = it->getRowValue<unsigned int>("algo");
-      unsigned int mask = it->getRowValue<unsigned int>("mask");
-      if( algoBit < m_numberPhysTriggers ) triggerMasks[algoBit] = mask;
+    // mask (default=1 - unmask)
+    unsigned int default_finor_mask = 1;
+    auto default_finor_row =
+        std::find_if( algo_mask_finor.cbegin(),
+                      algo_mask_finor.cend(),
+                      [] (const std::string &s){
+                          // simpler than overweight std::tolower(s[], std::locale()) solution:
+                          return s == "all" || s == "All" || s == "ALl" ||
+                                 s == "ALL" || s == "aLL" || s == "alL" ||
+                                 s == "AlL" || s == "aLl";
+                      }
+        );
+    if( default_finor_row == algo_mask_finor.cend() ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+              << "\nWarning: No default found in FinOR mask xml, use 1 (unmasked) as default"
+              << std::endl;
+    } else {
+        default_finor_mask = mask_mask_finor[ std::distance( algo_mask_finor.cbegin(), default_finor_row ) ];
     }
 
-std::cout<<"!!!!!!!!!!!!13"<<std::endl;
-  
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
+        triggerMasks.push_back(default_finor_mask);
 
-  // veto mask
-  // Setting veto mask to default 0 (no veto)
-  for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
-    triggerVetoMasks.push_back(0);
-  
-std::cout<<"!!!!!!!!!!!!14"<<std::endl;
-    l1t::XmlConfigReader xmlReader_mask_veto;
-    l1t::TrigSystem ts_mask_veto;
-    ts_mask_veto.addProcRole("uGtProcessor", "uGtProcessor");
+    for(unsigned int row=0; row<algo_mask_finor.size(); row++){
+        std::string  algoName = algo_mask_finor[row];
+        if( algoName == "all" || algoName == "All" || algoName == "ALl" ||
+            algoName == "ALL" || algoName == "aLL" || algoName == "alL" ||
+            algoName == "AlL" || algoName == "aLl" ) continue;
+        unsigned int algoBit  = algoName2bit[algoName];
+        unsigned int mask     = mask_mask_finor[row];
+        if( algoBit < m_numberPhysTriggers ) triggerMasks[algoBit] = mask;
 
-std::cout<<"!!!!!!!!!!!!15"<<std::endl;
+std::cout << "triggerMasks[" << algoBit << "(" << algoName << ")] " << mask << std::endl;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // veto mask
+    l1t::XmlConfigParser xmlReader_mask_veto;
+    l1t::TriggerSystem ts_mask_veto;
+    ts_mask_veto.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
+
     // run the parser 
     xmlReader_mask_veto.readDOMFromString( xmlPayload_mask_veto ); // initialize it
     xmlReader_mask_veto.readRootElement( ts_mask_veto, "uGT" ); // extract all of the relevant context
     ts_mask_veto.setConfigured();
 
-std::cout<<"!!!!!!!!!!!!16"<<std::endl;
-    std::map<std::string, l1t::Setting> settings_mask_veto = ts_mask_veto.getSettings("uGtProcessor");
-    std::vector<l1t::TableRow> tRow_mask_veto = settings_mask_veto["vetoMask"].getTableRows();
+    const std::map<std::string, l1t::Parameter>& settings_mask_veto = ts_mask_veto.getParameters("uGtProcessor");
+    std::vector<std::string>  algo_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<std::string>("algo");
+    std::vector<unsigned int> veto_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<unsigned int>("veto");
 
-    for( auto it=tRow_mask_veto.begin(); it!=tRow_mask_veto.end(); it++ ){
-      unsigned int algoBit = it->getRowValue<unsigned int>("algo");
-      unsigned int veto = it->getRowValue<unsigned int>("veto");
-      if( algoBit < m_numberPhysTriggers ) triggerVetoMasks[algoBit] = int(veto);
+    // veto mask (default=0 - no veto)
+    unsigned int default_veto_mask = 1;
+    auto default_veto_row =
+        std::find_if( algo_mask_veto.cbegin(),
+                      algo_mask_veto.cend(),
+                      [] (const std::string &s){
+                          // simpler than overweight std::tolower(s[], std::locale()) solution:
+                          return s == "all" || s == "All" || s == "ALl" ||
+                                 s == "ALL" || s == "aLL" || s == "alL" ||
+                                 s == "AlL" || s == "aLl";
+                      }
+        );
+    if( default_veto_row == algo_mask_veto.cend() ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+              << "\nWarning: No default found in Veto mask xml, use 0 (unvetoed) as default"
+              << std::endl;
+    } else {
+        default_veto_mask = veto_mask_veto[ std::distance( algo_mask_veto.cbegin(), default_veto_row ) ];
     }
 
-std::cout<<"!!!!!!!!!!!!17"<<std::endl;
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    for( unsigned int iAlg=0; iAlg < m_numberPhysTriggers; iAlg++ )
+        triggerVetoMasks.push_back(default_veto_mask);
 
-  // Algo bx mask
-    l1t::XmlConfigReader xmlReader_mask_algobx;
-    l1t::TrigSystem ts_mask_algobx;
-    ts_mask_algobx.addProcRole("uGtProcessor", "uGtProcessor");
+    for(unsigned int row=0; row<algo_mask_veto.size(); row++){
+        std::string  algoName = algo_mask_veto[row];
+        if( algoName == "all" || algoName == "All" || algoName == "ALl" ||
+            algoName == "ALL" || algoName == "aLL" || algoName == "alL" ||
+            algoName == "AlL" || algoName == "aLl" ) continue;
+        unsigned int algoBit  = algoName2bit[algoName];
+        unsigned int veto    = veto_mask_veto[row];
+        if( algoBit < m_numberPhysTriggers ) triggerVetoMasks[algoBit] = int(veto);
 
-std::cout<<"!!!!!!!!!!!!18"<<std::endl;
+std::cout << "triggerVetoMasks[" << algoBit << "(" << algoName << ")] " << int(veto) << std::endl;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Algo bx mask
+    l1t::XmlConfigParser xmlReader_mask_algobx;
+    l1t::TriggerSystem ts_mask_algobx;
+    ts_mask_algobx.addProcessor("uGtProcessor", "uGtProcessor","-1","-1");
+
     // run the parser 
     xmlReader_mask_algobx.readDOMFromString( xmlPayload_mask_algobx ); // initialize it
     xmlReader_mask_algobx.readRootElement( ts_mask_algobx, "uGT" ); // extract all of the relevant context
     ts_mask_algobx.setConfigured();
 
-std::cout<<"!!!!!!!!!!!!19"<<std::endl;
-    std::map<std::string, l1t::Setting> settings_mask_algobx = ts_mask_algobx.getSettings("uGtProcessor");
-    std::vector<l1t::TableRow> tRow_mask_algobx = settings_mask_algobx["algorithmBxMask"].getTableRows();
+    const std::map<std::string, l1t::Parameter>& settings_mask_algobx = ts_mask_algobx.getParameters("uGtProcessor");
+    std::vector<std::string>  bx_algo_name = settings_mask_algobx.at("algorithmBxMask").getTableColumn<std::string>("algo");
+    std::vector<std::string>  bx_range     = settings_mask_algobx.at("algorithmBxMask").getTableColumn<std::string>("range");
+    std::vector<unsigned int> bx_mask      = settings_mask_algobx.at("algorithmBxMask").getTableColumn<unsigned int>("mask");
 
-std::cout<<"!!!!!!!!!!!!20"<<std::endl;
-    unsigned int numCol_mask_algobx = 0;
-    if( tRow_mask_algobx.size()>0 ){
-      std::vector<std::string> firstRow_mask_algobx = tRow_mask_algobx[0].getRow();
-      numCol_mask_algobx = firstRow_mask_algobx.size();
+    int default_bxmask_row = -1;
+    unsigned int m_bx_mask_default = 1;
+    typedef std::pair<unsigned long,unsigned long> Range_t;
+    auto comp = [] (Range_t a, Range_t b){ return a.first < b.first; };
+    std::map<std::string, std::set<Range_t,decltype(comp)>> non_default_bx_ranges;
+
+    for(unsigned int row = 0; row < bx_algo_name.size(); row++){
+        const std::string &s1 = bx_algo_name[row];
+        const std::string &s2 = bx_range[row];
+        // find "all" broadcast keywords
+        bool broadcastAlgo  = false;
+        bool broadcastRange = false;
+        if( s1 == "all" || s1 == "All" || s1 == "ALl" ||
+            s1 == "ALL" || s1 == "aLL" || s1 == "alL" ||
+            s1 == "AlL" || s1 == "aLl" ) broadcastAlgo = true;
+        if( s2 == "all" || s2 == "All" || s2 == "ALl" ||
+            s2 == "ALL" || s2 == "aLL" || s2 == "alL" ||
+            s2 == "AlL" || s2 == "aLl" ) broadcastRange = true;
+        // all-all-default:
+        if( broadcastAlgo && broadcastRange ){
+            if( row != 0 ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                    << "\nWarning: ALL-ALL row is not the first one, ignore it assuming 1 (unmasked) as the default"
+                    << std::endl;
+                continue;
+            }
+            if( default_bxmask_row >= 0 ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                    << "\nWarning: multiple ALL-ALL rows found, using the first"
+                    << std::endl;
+                continue;
+            }
+            default_bxmask_row = row;
+            m_bx_mask_default = bx_mask[row];
+        }
+        // to be implemented
+        if( broadcastAlgo && !broadcastRange ){
+        }
+        // algo-range-{0,1}:
+        if( !broadcastAlgo ){
+           unsigned long first = 0, last = 0;
+           if( broadcastRange ){
+               first = 0;
+               last = 3563;
+           } else {
+               char *dash = 0;
+               first = strtoul(s2.data(), &dash, 0);
+               while( *dash != '\0' && *dash != '-' ) ++dash;
+               last  = (*dash != '\0' ? strtoul(++dash, &dash, 0) : first);
+               // what could possibly go wrong?
+               if( *dash != '\0' ){
+                    edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                        << "\nWarning: parsing " << s2 << " as [" << first << "," << last << "] range"
+                        << std::endl;
+               }
+           }
+
+           // what else could possibly go wrong?
+           if( first > last ){
+                edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+                    << "\nWarning: inverse range "<< s2 << ", reordering as [" << last << "," << first << "]"
+                    << std::endl;
+                std::swap(first,last);
+           }
+
+           auto ranges = non_default_bx_ranges.insert
+           (
+               std::pair< std::string, std::set<Range_t,decltype(comp)> >
+               (
+                   bx_algo_name[row],  std::set<Range_t,decltype(comp)>(comp)
+               )
+           ).first->second; // I don't care if insert was successfull or if I've got a hold on existing range
+
+std::cout << bx_algo_name[row] << " " << first << "-" << last << " size=" << non_default_bx_ranges.size() << " and " << ranges.size() << std::endl;
+for(auto i : ranges) std::cout << i.first << "-" << i.second << std::endl;
+
+
+           // current range may or may not overlap with one of the already present ranges
+           // if end of the predecessor starts before begin of the current range and begin
+           //  of the successor starts after end of the current range there is no overlap
+           //  and we save this range only if it has mask different from the default
+           //  otherwise modify predecessor/successor ranges accordingly
+           std::set<Range_t>::iterator pred = ranges.lower_bound(std::make_pair(first,last));
+           std::set<Range_t>::iterator succ = ranges.upper_bound(std::make_pair(first,last));
+           std::set<Range_t>::iterator curr = ranges.end();
+
+           if( (pred == ranges.end() || pred->second < first) &&
+               (succ == ranges.end() || succ->first > last) ){
+               // no overlap
+               if( m_bx_mask_default != bx_mask[row] )
+                   curr = ranges.insert(std::make_pair(first,last)).first;
+               // do nothing if this is a default-mask interval
+           } else {
+               // pred/succ iterators are read-only, create intermediate adjusted copies
+               Range_t newPred, newSucc;
+               bool modifiedPred = false, modifiedSucc = false;
+               // overlap found with predecessor range
+               if( pred != ranges.end() && pred->second >= first ){
+                   if( m_bx_mask_default != bx_mask[row] ){
+                       // extend predecessor range
+                       newPred.first  = pred->first;
+                       newPred.second = last;
+                   } else {
+                       // shrink predecessor range
+                       newPred.first  = pred->first;
+                       newPred.second = first-1;
+                   }
+                   modifiedPred = true;
+               }
+               // overlap found with successor interval
+               if( succ != ranges.end() && succ->first <= last){
+                   if( m_bx_mask_default != bx_mask[row] ){
+                       // extend successor range
+                       newSucc.first  = first;
+                       newSucc.second = succ->second;
+                   } else {
+                       // shrink successor range
+                       newSucc.first  = last+1;
+                       newSucc.second = succ->second;
+                   }
+                   modifiedSucc = true;
+               }
+               // overlap found with both, predecessor and successor, such that I need to merge them
+               if( modifiedPred && modifiedSucc && newPred.second >= newSucc.first ){
+                   // make newPred and newSucc identical just in case
+                   newPred.second = newSucc.second;
+                   newSucc.first  = newPred.first;
+                   ranges.erase(pred,++succ);
+                   curr = ranges.insert(newPred).first;
+               } else {
+                   if( modifiedPred ){
+                       ranges.erase(pred);
+                       curr = ranges.insert(newPred).first;
+                   }
+                   if( modifiedSucc ){
+                       ranges.erase(succ);
+                       curr = ranges.insert(newSucc).first;
+                   }
+               }
+           }
+           // if current range spans over few more ranges after the successor
+           //  remove those from the consideration up until the last covered range
+           //  that may or may not extend beyond the current range end 
+           if( curr != ranges.end() ){ // insertion took place
+               std::set<Range_t>::iterator last_covered = ranges.lower_bound(std::make_pair(curr->second,0));
+               if( last_covered->first != curr->first ){ // last_covered is not current itself (i.e. it is different)
+                   if( curr->second < last_covered->second ){ // the range needs to be extended
+                       Range_t newRange(curr->first, last_covered->second);
+                       ranges.erase(curr);
+                       curr = ranges.insert(newRange).first;
+                   }
+                   ranges.erase(++curr,last_covered);
+               }
+           }
+        }
     }
-    
-std::cout<<"!!!!!!!!!!!!21"<<std::endl;
-    int NumAlgoBitsInMask = numCol_mask_algobx - 1;
-    if( NumAlgoBitsInMask > 0 ){
-      for( auto it=tRow_mask_algobx.begin(); it!=tRow_mask_algobx.end(); it++ ){
-	int bx = it->getRowValue<unsigned int>("bx/algo");
-	std::vector<int> maskedBits;
-	for( int iBit=0; iBit<NumAlgoBitsInMask; iBit++ ){
-	  unsigned int maskBit = it->getRowValue<unsigned int>(std::to_string(iBit));
-	  if( maskBit!=m_bx_mask_default ) maskedBits.push_back(iBit);
-	}
-	if( maskedBits.size()>0 ) triggerAlgoBxMaskAlgoTrig[bx] = maskedBits;
-      }
+
+    if( default_bxmask_row < 0 ){
+        edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
+              << "\nWarning: No default found in BX mask xml, used 1 (unmasked) as default"
+              << std::endl;
+    }
+
+    for(const std::pair<std::string, std::set<Range_t,decltype(comp)>> &algo : non_default_bx_ranges){
+        const std::string &algoName = algo.first;
+        unsigned int algoBit  = algoName2bit[algoName];
+        for(auto range : algo.second)
+           for(int bx = range.first; bx <= range.second; bx++){
+               triggerAlgoBxMaskAlgoTrig[bx].push_back(algoBit);
+
+std::cout << "triggerAlgoBxMaskAlgoTrig[" << bx << "] " << algoBit << std::endl;
+           }
     }
 
 
-std::cout<<"!!!!!!!!!!!!22"<<std::endl;
-  // Set prescales to zero if masked
-  for( unsigned int iSet=0; iSet < prescales.size(); iSet++ ){
-    for( unsigned int iBit=0; iBit < prescales[iSet].size(); iBit++ ){
-      // Add protection in case prescale table larger than trigger mask size
-      if( iBit >= triggerMasks.size() ){
+    // Set prescales to zero if masked
+    for( unsigned int iSet=0; iSet < prescales.size(); iSet++ ){
+        for( unsigned int iBit=0; iBit < prescales[iSet].size(); iBit++ ){
+        // Add protection in case prescale table larger than trigger mask size
+        if( iBit >= triggerMasks.size() ){
             edm::LogError( "L1-O2O: L1TGlobalPrescalesVetosOnlineProd" )
 	      << "\nWarning: algoBit in prescale table >= triggerMasks.size() "
 	      << "\nWarning: no information on masking bit or not, setting as unmasked "
 	      << std::endl;
-      }
-      else {
-	prescales[iSet][iBit] *= triggerMasks[iBit];
+        } else {
+            prescales[iSet][iBit] *= triggerMasks[iBit];
+        }
       }
     }
-  }
-
-
 
     return 0;
 }

--- a/L1TriggerConfig/Utilities/test/veto.xml
+++ b/L1TriggerConfig/Utilities/test/veto.xml
@@ -1,0 +1,14 @@
+<run-settings id="uGT">
+  <context id="uGtProcessor">
+    <param id="vetoMask" type="table">
+      <columns>algo, veto</columns>
+      <types>string, uint</types>
+      <rows>
+      <!-- Default veto mask value is 1 -->
+        <row>ALL, 0</row> <!-- mandatory row: set defaults -->
+        <row>L1_ZeroBias, 1</row>
+      </rows>
+    </param>
+  </context>
+</run-settings>
+

--- a/L1TriggerConfig/Utilities/test/viewL1TGlobalPrescalesVetos.py
+++ b/L1TriggerConfig/Utilities/test/viewL1TGlobalPrescalesVetos.py
@@ -22,14 +22,16 @@ process.l1conddb = cms.ESSource("PoolDBESSource",
        toGet   = cms.VPSet(
             cms.PSet(
                  record = cms.string('L1TGlobalPrescalesVetosRcd'),
-                 tag = cms.string("L1TGlobalPrescalesVetos_Stage2v0_hlt")
+                 tag = cms.string("L1TGlobalPrescalesVetos_passThrough_mc")
+#                 tag = cms.string("L1TGlobalPrescalesVetos_Stage2v0_hlt")
             )
        )
 )
 
 process.l1gpv = cms.EDAnalyzer("L1TGlobalPrescalesVetosViewer",
-    prescale_table_verbosity = cms.untracked.int32(2),
-    bxmask_map_verbosity     = cms.untracked.int32(0)
+    prescale_table_verbosity = cms.untracked.int32(0),
+    bxmask_map_verbosity     = cms.untracked.int32(0),
+    veto_verbosity           = cms.untracked.int32(0)
 )
 
 process.p = cms.Path(process.l1gpv)


### PR DESCRIPTION
1) Parser for the new XML format of Prescales-Masks has been implemented and tested at p5
2) Removing leading and railing whitespaces from the column names
3) Making CaloParams online producer fault-safe against a problem of inconsistency in some of the calo XMLs.
(from the https://github.com/kkotov/cmssw/tree/o2oFixesApr2017 branch developed in 90X)