### PR TITLE
Add isolated charged hadron raw energies to MiniAOD

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -620,14 +620,6 @@ namespace pat {
         uint16_t dphidphi;
     };
 
-  private:
-    void unpackCovarianceElement(reco::TrackBase::CovarianceMatrix & m, uint16_t packed, int i,int j) const {
-      m(i,j)= covarianceParameterization().unpack(packed,covarianceSchema_,i,j,pt(),eta(),numberOfHits(), numberOfPixelHits());
-    }
-    uint16_t packCovarianceElement(const reco::TrackBase::CovarianceMatrix &m,int i,int j) const {
-      return covarianceParameterization().pack(m(i,j),covarianceSchema_,i,j,pt(),eta(),numberOfHits(), numberOfPixelHits());
-    }
-
     // for the neutral fractions
     void setRawCaloFraction(float p);                      /// Set the fraction of Ecal needed for HF and neutral isolated charged hadrons
     float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
@@ -637,6 +629,14 @@ namespace pat {
      // isolated charged hadrons
     void setIsIsolatedChargedHadron(bool p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
     bool isIsolatedChargedHadron() const { return isIsolatedChargedHadron_; }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
+
+  private:
+    void unpackCovarianceElement(reco::TrackBase::CovarianceMatrix & m, uint16_t packed, int i,int j) const {
+      m(i,j)= covarianceParameterization().unpack(packed,covarianceSchema_,i,j,pt(),eta(),numberOfHits(), numberOfPixelHits());
+    }
+    uint16_t packCovarianceElement(const reco::TrackBase::CovarianceMatrix &m,int i,int j) const {
+      return covarianceParameterization().pack(m(i,j),covarianceSchema_,i,j,pt(),eta(),numberOfHits(), numberOfPixelHits());
+    }
 
   protected:
     friend class ::testPackedCandidate;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -42,7 +42,9 @@ namespace pat {
       packedCovariance_(),
       packedPuppiweight_(0),
       packedPuppiweightNoLepDiff_(0),
+      rawCaloFraction_(0),
       hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_(new PolarLorentzVector(0,0,0,0)), p4c_( new LorentzVector(0,0,0,0)), 
       vertex_(new Point(0,0,0)), dphi_(0), deta_(0), dtrkpt_(0),track_(nullptr), pdgId_(0),
       qualityFlags_(0), pvRefKey_(reco::VertexRef::invalidKey()),
@@ -51,7 +53,8 @@ namespace pat {
     explicit PackedCandidate( const reco::Candidate & c,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_( new PolarLorentzVector(c.pt(), c.eta(), c.phi(), c.mass())), 
       p4c_( new LorentzVector(*p4_)), vertex_( new Point(c.vertex())), 
       dphi_(0), deta_(0), dtrkpt_(0),
@@ -65,7 +68,8 @@ namespace pat {
                               float trkPt,float etaAtVtx,float phiAtVtx,int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_( new PolarLorentzVector(p4) ), p4c_( new LorentzVector(*p4_)), 
       vertex_( new Point(vtx) ), 
       dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
@@ -81,7 +85,8 @@ namespace pat {
                               float trkPt, float etaAtVtx, float phiAtVtx, int pdgId,
                               const reco::VertexRefProd &pvRefProd,
                               reco::VertexRef::key_type pvRefKey) :
-      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), hcalFraction_(0),
+      packedPuppiweight_(0), packedPuppiweightNoLepDiff_(0), rawCaloFraction_(0), hcalFraction_(0),
+      isIsolatedChargedHadron_(0),
       p4_(new PolarLorentzVector(p4.Pt(), p4.Eta(), p4.Phi(), p4.M())), 
       p4c_( new LorentzVector(p4)), vertex_( new Point(vtx) ) ,
       dphi_(reco::deltaPhi(phiAtVtx,p4_.load()->phi())), 
@@ -101,7 +106,9 @@ namespace pat {
       packedCovariance_(iOther.packedCovariance_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      rawCaloFraction_(iOther.rawCaloFraction_),
       hcalFraction_(iOther.hcalFraction_),
+      isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
       //Need to trigger unpacking in iOther
       p4_( new PolarLorentzVector(iOther.polarP4() ) ),
       p4c_( new LorentzVector(iOther.p4())), vertex_( new Point(iOther.vertex())),
@@ -123,7 +130,9 @@ namespace pat {
       packedCovariance_(iOther.packedCovariance_),
       packedPuppiweight_(iOther.packedPuppiweight_), 
       packedPuppiweightNoLepDiff_(iOther.packedPuppiweightNoLepDiff_),
+      rawCaloFraction_(iOther.rawCaloFraction_),
       hcalFraction_(iOther.hcalFraction_),
+      isIsolatedChargedHadron_(iOther.isIsolatedChargedHadron_),
       p4_( iOther.p4_.exchange(nullptr) ) ,
       p4c_( iOther.p4c_.exchange(nullptr)), vertex_(iOther.vertex_.exchange(nullptr)),
       dxy_(iOther.dxy_), dz_(iOther.dz_),
@@ -153,7 +162,9 @@ namespace pat {
       packedCovariance_=iOther.packedCovariance_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      rawCaloFraction_=iOther.rawCaloFraction_;
       hcalFraction_=iOther.hcalFraction_;
+      isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
       //Need to trigger unpacking in iOther
       if(p4_) {
         *p4_ = iOther.polarP4();
@@ -225,7 +236,9 @@ namespace pat {
       packedCovariance_=iOther.packedCovariance_;
       packedPuppiweight_=iOther.packedPuppiweight_; 
       packedPuppiweightNoLepDiff_=iOther.packedPuppiweightNoLepDiff_;
+      rawCaloFraction_=iOther.rawCaloFraction_;
       hcalFraction_=iOther.hcalFraction_;
+      isIsolatedChargedHadron_=iOther.isIsolatedChargedHadron_;
       delete p4_.exchange(iOther.p4_.exchange(nullptr));
       delete p4c_.exchange(iOther.p4c_.exchange(nullptr));
       delete vertex_.exchange(iOther.vertex_.exchange(nullptr));
@@ -592,10 +605,6 @@ namespace pat {
     float puppiWeight() const;                          /// Weight from full PUPPI
     float puppiWeightNoLep() const;                     /// Weight from PUPPI removing leptons
     
-    // for teh neutral fraction
-    void setHcalFraction(float p);                      /// Set the fraction of Ecal and Hcal needed for HF and neutral hadrons
-    float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons
-    
     struct PackedCovariance {
         PackedCovariance(): dxydxy(0),dxydz(0),dzdz(0),dlambdadz(0),dphidxy(0),dptdpt(0),detadeta(0),dphidphi(0) {}
         //3D IP covariance
@@ -618,6 +627,16 @@ namespace pat {
     uint16_t packCovarianceElement(const reco::TrackBase::CovarianceMatrix &m,int i,int j) const {
       return covarianceParameterization().pack(m(i,j),covarianceSchema_,i,j,pt(),eta(),numberOfHits(), numberOfPixelHits());
     }
+
+    // for the neutral fractions
+    void setRawCaloFraction(float p);                      /// Set the fraction of Ecal needed for HF and neutral isolated charged hadrons
+    float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
+    void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
+    float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
+
+     // isolated charged hadrons
+    void setIsIsolatedChargedHadron(bool p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
+    bool isIsolatedChargedHadron() const { return isIsolatedChargedHadron_; }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
 
   protected:
     friend class ::testPackedCandidate;
@@ -643,7 +662,10 @@ namespace pat {
 
     int8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
+    int8_t rawCaloFraction_;
     int8_t hcalFraction_;
+
+    bool isIsolatedChargedHadron_;
 
     /// the four vector                                                 
     mutable std::atomic<PolarLorentzVector*> p4_;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -605,6 +605,16 @@ namespace pat {
     float puppiWeight() const;                          /// Weight from full PUPPI
     float puppiWeightNoLep() const;                     /// Weight from PUPPI removing leptons
     
+    // for the neutral fractions
+    void setRawCaloFraction(float p);                      /// Set the raw ECAL+HCAL energy for isolated charged hadrons
+    float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Raw ECAL+HCAL energy for isolated charged hadrons
+    void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
+    float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
+
+     // isolated charged hadrons
+    void setIsIsolatedChargedHadron(bool p);                      /// Set isolation (as in particle flow, i.e. at calorimeter surface rather than at PV) flat for charged hadrons
+    bool isIsolatedChargedHadron() const { return isIsolatedChargedHadron_; }    /// Flag isolation (as in particle flow, i.e. at calorimeter surface rather than at PV) flag for charged hadrons
+
     struct PackedCovariance {
         PackedCovariance(): dxydxy(0),dxydz(0),dzdz(0),dlambdadz(0),dphidxy(0),dptdpt(0),detadeta(0),dphidphi(0) {}
         //3D IP covariance
@@ -619,16 +629,6 @@ namespace pat {
         uint16_t detadeta;
         uint16_t dphidphi;
     };
-
-    // for the neutral fractions
-    void setRawCaloFraction(float p);                      /// Set the fraction of Ecal needed for HF and neutral isolated charged hadrons
-    float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
-    void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
-    float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
-
-     // isolated charged hadrons
-    void setIsIsolatedChargedHadron(bool p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
-    bool isIsolatedChargedHadron() const { return isIsolatedChargedHadron_; }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
 
   private:
     void unpackCovarianceElement(reco::TrackBase::CovarianceMatrix & m, uint16_t packed, int i,int j) const {

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -606,8 +606,8 @@ namespace pat {
     float puppiWeightNoLep() const;                     /// Weight from PUPPI removing leptons
     
     // for the neutral fractions
-    void setRawCaloFraction(float p);                      /// Set the raw ECAL+HCAL energy for isolated charged hadrons
-    float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Raw ECAL+HCAL energy for isolated charged hadrons
+    void setRawCaloFraction(float p);                      /// Set the raw ECAL+HCAL energy over candidate energy for isolated charged hadrons
+    float rawCaloFraction() const { return (rawCaloFraction_/100.); }    /// Raw ECAL+HCAL energy over candidate energy for isolated charged hadrons
     void setHcalFraction(float p);                      /// Set the fraction of Hcal needed for HF and neutral hadrons and isolated charged hadrons
     float hcalFraction() const { return (hcalFraction_/100.); }    /// Fraction of Ecal and Hcal for HF and neutral hadrons and isolated charged hadrons
 

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -662,7 +662,7 @@ namespace pat {
 
     int8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_; // storing the DIFFERENCE of (all - "no lep") for compression optimization
-    int8_t rawCaloFraction_;
+    uint8_t rawCaloFraction_;
     int8_t hcalFraction_;
 
     bool isIsolatedChargedHadron_;

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -335,6 +335,14 @@ float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packed
 
 float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
 
+void pat::PackedCandidate::setRawCaloFraction(float p) {
+  rawCaloFraction_ = 100*p;
+}
+
 void pat::PackedCandidate::setHcalFraction(float p) {
   hcalFraction_ = 100*p;
+}
+
+void pat::PackedCandidate::setIsIsolatedChargedHadron(bool p) {
+  isIsolatedChargedHadron_ = p;
 }

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -336,7 +336,10 @@ float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packed
 float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
 
 void pat::PackedCandidate::setRawCaloFraction(float p) {
-  rawCaloFraction_ = 100*p;
+  if(p>1)
+    rawCaloFraction_ = 250; // Set to overflow value of 250 (since uint8 only goes up to 256)
+  else
+    rawCaloFraction_ = 100*p;
 }
 
 void pat::PackedCandidate::setHcalFraction(float p) {

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -336,8 +336,8 @@ float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packed
 float pat::PackedCandidate::puppiWeightNoLep() const { return unpack8logClosed(packedPuppiweightNoLepDiff_+packedPuppiweight_,-2,0,64)/2. + 0.5;}
 
 void pat::PackedCandidate::setRawCaloFraction(float p) {
-  if(p>1)
-    rawCaloFraction_ = 250; // Set to overflow value of 250 (since uint8 only goes up to 256)
+  if(100*p>std::numeric_limits<uint8_t>::max())
+    rawCaloFraction_ = std::numeric_limits<uint8_t>::max(); // Set to overflow value
   else
     rawCaloFraction_ = 100*p;
 }

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -290,7 +290,8 @@
   <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="3">
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
-  <class name="pat::PackedCandidate" ClassVersion="29">
+  <class name="pat::PackedCandidate" ClassVersion="30">
+   <version ClassVersion="30" checksum="2047798346"/>
    <version ClassVersion="29" checksum="649303924"/>
    <version ClassVersion="28" checksum="1956349111"/>
     <version ClassVersion="27" checksum="2418936168"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -291,7 +291,7 @@
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
   <class name="pat::PackedCandidate" ClassVersion="30">
-   <version ClassVersion="30" checksum="2047798346"/>
+   <version ClassVersion="30" checksum="3338823671"/>
    <version ClassVersion="29" checksum="649303924"/>
    <version ClassVersion="28" checksum="1956349111"/>
     <version ClassVersion="27" checksum="2418936168"/>

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -115,7 +115,7 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   PuppiCandsNoLep_(usePuppi_ ? consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc")) : edm::EDGetTokenT<std::vector< reco::PFCandidate > >()),
   ChargedHadronIsolation_(consumes<edm::ValueMap<bool> >(iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
   minPtForChargedHadronProperties_(iConfig.getParameter<double>("minPtForChargedHadronProperties")),
-  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
+  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
   covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
   covariancePackingSchemas_(iConfig.getParameter<std::vector<int> >("covariancePackingSchemas"))
 {

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -83,7 +83,9 @@ namespace pat {
             const edm::EDGetTokenT<std::vector< reco::PFCandidate >  >    PuppiCands_;
             const edm::EDGetTokenT<std::vector< reco::PFCandidate >  >    PuppiCandsNoLep_;
             std::vector< edm::EDGetTokenT<edm::View<reco::Candidate> > > SVWhiteLists_;
+            const edm::EDGetTokenT<edm::ValueMap<bool> >            ChargedHadronIsolation_;
 
+            const double minPtForChargedHadronProperties_;
             const double minPtForTrackProperties_;
             const int covarianceVersion_;
             const std::vector<int> covariancePackingSchemas_;
@@ -111,10 +113,11 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   PuppiCandsMap_(usePuppi_ ? consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc")) : edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr> >() ),
   PuppiCands_(usePuppi_ ? consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiSrc")) : edm::EDGetTokenT<std::vector< reco::PFCandidate > >() ),
   PuppiCandsNoLep_(usePuppi_ ? consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiNoLepSrc")) : edm::EDGetTokenT<std::vector< reco::PFCandidate > >()),
-  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties")),
+  ChargedHadronIsolation_(consumes<edm::ValueMap<bool> >(iConfig.getParameter<edm::InputTag>("chargedHadronIsolation"))),
+  minPtForChargedHadronProperties_(iConfig.getParameter<double>("minPtForChargedHadronProperties")),
+  minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
   covarianceVersion_(iConfig.getParameter<int >("covarianceVersion")),
   covariancePackingSchemas_(iConfig.getParameter<std::vector<int> >("covariancePackingSchemas"))
-
 {
   std::vector<edm::InputTag> sv_tags = iConfig.getParameter<std::vector<edm::InputTag> >("secondaryVerticesForWhiteList");
   for(auto itag : sv_tags){
@@ -166,6 +169,9 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
     const edm::Association<reco::VertexCollection> &  associatedPV=*(assoHandle.product());
     const edm::ValueMap<int>  &  associationQuality=*(assoQualityHandle.product());
            
+    edm::Handle<edm::ValueMap<bool> > chargedHadronIsolationHandle;
+    iEvent.getByToken(ChargedHadronIsolation_,chargedHadronIsolationHandle);
+    const edm::ValueMap<bool>  &  chargedHadronIsolation=*(chargedHadronIsolationHandle.product());
 
     std::set<unsigned int> whiteList;
     std::set<reco::TrackRef> whiteListTk;
@@ -288,10 +294,16 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent,
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
         }
 
-	// neutrals
+	// neutrals and isolated charged hadrons
+
+        bool isIsolatedChargedHadron = ((cand.pt()>minPtForChargedHadronProperties_)&&(chargedHadronIsolation[reco::PFCandidateRef(cands,ic)]));
+        outPtrP->back().setIsIsolatedChargedHadron(isIsolatedChargedHadron);
 
 	if(abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 130) {
 	  outPtrP->back().setHcalFraction(cand.hcalEnergy()/(cand.ecalEnergy()+cand.hcalEnergy()));
+        } else if(isIsolatedChargedHadron) {
+          outPtrP->back().setRawCaloFraction((cand.rawEcalEnergy()+cand.rawHcalEnergy())/cand.energy());
+          outPtrP->back().setHcalFraction(cand.rawHcalEnergy()/(cand.rawEcalEnergy()+cand.rawHcalEnergy()));
 	} else {
 	  outPtrP->back().setHcalFraction(0);
 	}

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -8,6 +8,8 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     vertexAssociator = cms.InputTag("primaryVertexAssociation","original"),
     PuppiSrc = cms.InputTag("puppi"),
     PuppiNoLepSrc = cms.InputTag("puppiNoLep"),    
+    chargedHadronIsolation = cms.InputTag("chargedHadronPFTrackIsolation"),
+    minPtForChargedHadronProperties = cms.double(3.0),
     secondaryVerticesForWhiteList = cms.VInputTag(
       cms.InputTag("inclusiveCandidateSecondaryVertices"),
       cms.InputTag("inclusiveCandidateSecondaryVerticesCvsL"),

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py
@@ -1,0 +1,89 @@
+# import ROOT in batch mode
+import sys
+oldargv = sys.argv[:]
+sys.argv = [ '-b-' ]
+import ROOT
+ROOT.gROOT.SetBatch(True)
+sys.argv = oldargv
+
+# load FWLite C++ libraries
+ROOT.gSystem.Load("libFWCoreFWLite.so");
+ROOT.gSystem.Load("libDataFormatsFWLite.so");
+ROOT.FWLiteEnabler.enable()
+
+# load FWlite python libraries
+from DataFormats.FWLite import Handle, Events
+
+# define deltaR
+from math import hypot, pi
+def deltaR(a,b):
+    dphi = abs(a.phi()-b.phi());
+    if dphi < pi: dphi = 2*pi-dphi
+    return hypot(a.eta()-b.eta(),dphi)
+
+muons, muonLabel = Handle("std::vector<pat::Muon>"), "slimmedMuons"
+electrons, electronLabel = Handle("std::vector<pat::Electron>"), "slimmedElectrons"
+jets, jetLabel = Handle("std::vector<pat::Jet>"), "slimmedJets"
+pfs, pfLabel = Handle("std::vector<pat::PackedCandidate>"), "packedPFCandidates"
+
+# open file (you can use 'edmFileUtil -d /store/whatever.root' to get the physical file name)
+events = Events("patMiniAOD_standard.root")
+
+for iev,event in enumerate(events):
+    event.getByLabel(muonLabel, muons)
+    event.getByLabel(electronLabel, electrons)
+    event.getByLabel(pfLabel, pfs)
+    event.getByLabel(jetLabel, jets)
+
+    print "\nEvent %d: run %6d, lumi %4d, event %12d" % (iev,event.eventAuxiliary().run(), event.eventAuxiliary().luminosityBlock(),event.eventAuxiliary().event())
+
+    # Let's compute lepton PF Isolation with R=0.2, 0.5 GeV threshold on neutrals, and deltaBeta corrections
+    leps  = [ p for p in muons.product() ] + [ p for p in electrons.product() ]
+    for lep in leps:
+        # skip those below 5 GeV, which we don't care about
+        if lep.pt() < 5: continue
+        # initialize sums
+        charged = 0
+        neutral = 0
+        pileup  = 0
+        # now get a list of the PF candidates used to build this lepton, so to exclude them
+        footprint = set()
+        for i in xrange(lep.numberOfSourceCandidatePtrs()):
+            footprint.add(lep.sourceCandidatePtr(i).key()) # the key is the index in the pf collection
+        # now loop on pf candidates
+        for ipf,pf in enumerate(pfs.product()):
+            if deltaR(pf,lep) < 0.2:
+                # pfcandidate-based footprint removal
+                if ipf in footprint: continue
+                # add up
+                if (pf.charge() == 0):
+                    if pf.pt() > 0.5: neutral += pf.pt()
+                elif pf.fromPV() >= 2:
+                    charged += pf.pt()
+                else:
+                    if pf.pt() > 0.5: pileup += pf.pt()
+        # do deltaBeta
+        iso = charged + max(0, neutral-0.5*pileup)
+        print "%-8s of pt %6.1f, eta %+4.2f: relIso = %5.2f" % (
+                    "muon" if abs(lep.pdgId())==13 else "electron",
+                    lep.pt(), lep.eta(), iso/lep.pt())
+
+    # Let's compute the fraction of charged pt from particles with dz < 0.1 cm
+    for i,j in enumerate(jets.product()):
+        if j.pt() < 40 or abs(j.eta()) > 2.4: continue
+        sums = [0,0]
+        for id in xrange(j.numberOfDaughters()):
+            dau = j.daughter(id)
+            if (dau.charge() == 0): continue
+            sums[ abs(dau.dz())<0.1 ] += dau.pt()
+        sum = sums[0]+sums[1]
+        print "Jet with pt %6.1f, eta %+4.2f, beta(0.1) = %+5.3f, pileup mva disc %+.2f" % (
+                j.pt(),j.eta(), sums[1]/sum if sum else 0, j.userFloat("pileupJetId:fullDiscriminant"))
+
+    # Let's check the calorimeter response for hadrons (after PF hadron calibration)
+    for i,j in enumerate(pfs.product()):
+        if not j.isIsolatedChargedHadron(): continue
+        print "Isolated charged hadron candidate with pt %6.1f, eta %+4.2f, calo/track energy = %+5.3f, hcal/calo energy %+5.3f" % (
+                j.pt(),j.eta(), j.rawCaloFraction(), j.hcalFraction())
+    
+    if iev > 10: break


### PR DESCRIPTION
This PR adds "isIsolatedChargedHadron", "rawCaloFraction" and "hcalFraction" to the packedCandidates which are isolated charged hadrons in MiniAOD.
Charged hadrons with track pT > 3 GeV and rawCaloEnergy > 0.5 GeV tagged on RECO are saved in MiniAOD.
With these variables for isolated charged hadrons, calorimeter response can be measured in data and simulation with fine granularity, enabling PF hadron calibration at MiniAOD level.

runTheMatrix -l limited works.

It was checked that the variables in MiniAOD are filled correctly with reasonable values. A test config for the MiniAOD content was added here:
PhysicsTools/PatAlgos/test/miniAOD/example_packedCandidates.py

The size increase in the ttbar relval with 35PU is:
WITHOUT isolated charged hadron info:
patPackedCandidates_packedPFCandidates__PAT. 101067 18431.8
WITH isolated charged hadron info:
patPackedCandidates_packedPFCandidates__PAT. 105030 18513
--> 0.4% increase of packedCandidate collection

This was discussed at xPOG meeting: https://indico.cern.ch/event/631884/
@arizzi @gpetruc Please have a look.

Followup of #18308