### PR TITLE
Work around: allow production of LHERunInfoProduct at begin Run

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -136,7 +136,8 @@ ExternalLHEProducer::ExternalLHEProducer(const edm::ParameterSet& iConfig) :
   produces<LHEXMLStringProduct, edm::Transition::BeginRun>("LHEScriptOutput"); 
 
   produces<LHEEventProduct>();
-  produces<LHERunInfoProduct, edm::Transition::EndRun>();
+  produces<LHERunInfoProduct, edm::Transition::BeginRun>();
+  //produces<LHERunInfoProduct, edm::Transition::EndRun>();
 }
 
 


### PR DESCRIPTION
Other modules in the schedule require that LHERunInfoProduct be
available in the Run at begin run time even though the data product
is mergeable.
ExternalLHEProducer also puts the product in at both begin and end
run time which is not a behavior expected by the framework and
just happens to work.