### PR TITLE
uGMT online DQM muon copy validation

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -67,7 +67,12 @@ process.l1tMonitorPath = cms.Path(
     process.l1tStage2OnlineDQM +
     process.hltFatEventFilter +
 #    process.selfFatEventFilter +
-    process.l1tStage2uGMTZeroSuppFatEvts
+    process.l1tStage2uGMTZeroSuppFatEvts +
+    process.l1tStage2uGMTMuonVsuGMTMuonCopy1 +
+    process.l1tStage2uGMTMuonVsuGMTMuonCopy2 +
+    process.l1tStage2uGMTMuonVsuGMTMuonCopy3 +
+    process.l1tStage2uGMTMuonVsuGMTMuonCopy4 +
+    process.l1tStage2uGMTMuonVsuGMTMuonCopy5
 )
 
 # Remove DQM Modules

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -117,3 +117,41 @@ l1tStage2uGMTOutVsuGTIn = cms.EDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
+# The five modules below compare the primary unpacked uGMT muon collection to goes to uGT board 0
+# to the unpacked uGMT muon collections that are sent to uGT boards 1 to 5.
+# Only muons that do not match are filled in the histograms
+l1tStage2uGMTMuonVsuGMTMuonCopy1 = cms.EDAnalyzer(
+    "L1TStage2MuonComp",
+    muonCollection1 = cms.InputTag("gmtStage2Digis", "Muon"),
+    muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy1"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1"),
+    muonCollection1Title = cms.untracked.string("uGMT muons"),
+    muonCollection2Title = cms.untracked.string("uGMT muons copy 1"),
+    summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 1"),
+    verbose = cms.untracked.bool(False),
+)
+
+l1tStage2uGMTMuonVsuGMTMuonCopy2 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy2.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy2")
+l1tStage2uGMTMuonVsuGMTMuonCopy2.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2")
+l1tStage2uGMTMuonVsuGMTMuonCopy2.muonCollection2Title = cms.untracked.string("uGMT muons copy 2")
+l1tStage2uGMTMuonVsuGMTMuonCopy2.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 2")
+
+l1tStage2uGMTMuonVsuGMTMuonCopy3 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy3.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy3")
+l1tStage2uGMTMuonVsuGMTMuonCopy3.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3")
+l1tStage2uGMTMuonVsuGMTMuonCopy3.muonCollection2Title = cms.untracked.string("uGMT muons copy 3")
+l1tStage2uGMTMuonVsuGMTMuonCopy3.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 3")
+
+l1tStage2uGMTMuonVsuGMTMuonCopy4 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy4.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy4")
+l1tStage2uGMTMuonVsuGMTMuonCopy4.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4")
+l1tStage2uGMTMuonVsuGMTMuonCopy4.muonCollection2Title = cms.untracked.string("uGMT muons copy 4")
+l1tStage2uGMTMuonVsuGMTMuonCopy4.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 4")
+
+l1tStage2uGMTMuonVsuGMTMuonCopy5 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy5.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy5")
+l1tStage2uGMTMuonVsuGMTMuonCopy5.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5")
+l1tStage2uGMTMuonVsuGMTMuonCopy5.muonCollection2Title = cms.untracked.string("uGMT muons copy 5")
+l1tStage2uGMTMuonVsuGMTMuonCopy5.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 5")
+

--- a/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
+++ b/DQM/L1TMonitor/src/L1TMP7ZeroSupp.cc
@@ -92,7 +92,7 @@ void L1TMP7ZeroSupp::bookCapIdHistograms(DQMStore::IBooker& ibooker, const unsig
   zeroSuppValMap_[id]->setBinLabel(ZSBLKSBADFALSEPOS+1, "false pos.", 1);
   zeroSuppValMap_[id]->setBinLabel(ZSBLKSBADFALSENEG+1, "false neg.", 1);
 
-  readoutSizeNoZSMap_[id] = ibooker.book1D("readoutSizeNoZS", (sizeTitleText + "size without zero suppression").c_str(), 100, 0, maxFedReadoutSize_);
+  readoutSizeNoZSMap_[id] = ibooker.book1D("readoutSize", (sizeTitleText + "size").c_str(), 100, 0, maxFedReadoutSize_);
   readoutSizeNoZSMap_[id]->setAxisTitle("size (byte)", 1);
   readoutSizeZSMap_[id] = ibooker.book1D("readoutSizeZS", (sizeTitleText + "size with zero suppression").c_str(), 100, 0, maxFedReadoutSize_);
   readoutSizeZSMap_[id]->setAxisTitle("size (byte)", 1);


### PR DESCRIPTION
Online DQM histograms to validate the uGMT muon copies 1-5 against uGMT muons.
The additional copies are sent to uGT boards 1-5 and will be read out for validation events.
This checks that the collections contain the same muons.

Additionally, a histogram title is corrected.