### PR TITLE
Phase2 workflow simplifications and updates for muon

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1904,6 +1904,15 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
         if '--era' in upgradeStepDict[stepName][k].keys() and not "_timing" in upgradeStepDict[stepName][k]['--era']:
             upgradeStepDict[stepName][k]['--era'] += "_timing"
 
+    for step in upgradeSteps['Neutron']['steps']:
+        custNew = "SLHCUpgradeSimulations/Configuration/customise_mixing.customise_Mix_LongLived_Neutrons"
+        stepName = step + upgradeSteps['Neutron']['suffix']
+        upgradeStepDict[stepName][k] = deepcopy(upgradeStepDict[step][k])
+        if '--customise' in upgradeStepDict[stepName][k].keys():
+            upgradeStepDict[stepName][k]['--customise'] += ","+custNew
+        else:
+            upgradeStepDict[stepName][k]['--customise'] = custNew
+
     # setup PU
     if k2 in PUDataSets:
         for stepType in upgradeSteps.keys():

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1758,8 +1758,13 @@ for ds in defaultDataSets:
 
 
 upgradeStepDict={}
-for step in upgradeSteps:
-    upgradeStepDict[step]={}
+for stepType in upgradeSteps.keys():
+    for step in upgradeSteps[stepType]['steps']:
+        stepName = step+upgradeSteps[stepType]['suffix']
+        upgradeStepDict[stepName]={}
+    for step in upgradeSteps[stepType]['PU']:
+        stepName = step+'PU'+upgradeSteps[stepType]['suffix']
+        upgradeStepDict[stepName]={}
 
 # just make all combinations - yes, some will be nonsense.. but then these are not used unless specified above
 # collapse upgradeKeys using list comprehension
@@ -1773,6 +1778,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     cust=upgradeProperties[year][k].get('Custom', None)
     era=upgradeProperties[year][k].get('Era', None)
     beamspot=upgradeProperties[year][k].get('BeamSpot', None)
+
+    # setup baseline steps
     upgradeStepDict['GenSimFull'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
@@ -1781,8 +1788,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom
                                        }
-    if cust!=None : upgradeStepDict['GenSimFull'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['GenSimFull'][k]['--era']=era
     if beamspot is not None: upgradeStepDict['GenSimFull'][k]['--beamspot']=beamspot
 
     upgradeStepDict['GenSimHLBeamSpotFull'][k]= {'-s' : 'GEN,SIM',
@@ -1793,8 +1798,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom
                                        }
-    if cust!=None : upgradeStepDict['GenSimHLBeamSpotFull'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['GenSimHLBeamSpotFull'][k]['--era']=era
 
     upgradeStepDict['GenSimHLBeamSpotFull14'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
@@ -1805,9 +1808,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--geometry' : geom
                                        }
     
-    if cust!=None : upgradeStepDict['GenSimHLBeamSpotFull14'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['GenSimHLBeamSpotFull14'][k]['--era']=era
-    
     upgradeStepDict['DigiFull'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',
@@ -1816,13 +1816,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    if cust!=None : upgradeStepDict['DigiFull'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['DigiFull'][k]['--era']=era
- 
-    if k2 in PUDataSets:
-        upgradeStepDict['DigiFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['DigiFull'][k]])
-
-#Adding Track trigger step in step2 
+    # Adding Track trigger step in step2 
     upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',
@@ -1830,13 +1824,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--eventcontent':'FEVTDEBUGHLT',
                                       '--geometry' : geom
                                       }
-
-    if cust!=None : upgradeStepDict['DigiFullTrigger'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['DigiFullTrigger'][k]['--era']=era
- 
- 
-    if k2 in PUDataSets:
-        upgradeStepDict['DigiFullTriggerPU'][k]=merge([PUDataSets[k2],upgradeStepDict['DigiFullTrigger'][k]])
 
     upgradeStepDict['RecoFull'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@miniAODDQM',
                                       '--conditions':gt,
@@ -1846,19 +1833,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--eventcontent':'RECOSIM,MINIAODSIM,DQM',
                                       '--geometry' : geom
                                       }
-    if cust!=None : upgradeStepDict['RecoFull'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['RecoFull'][k]['--era']=era
-
-
-    if k2 in PUDataSets:
-        upgradeStepDict['RecoFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['RecoFull'][k]])
-
-
-    upgradeStepDict['RecoFull_trackingOnly'][k] = merge([step3_trackingOnly, upgradeStepDict['RecoFull'][k]]) 
-
-    if k2 in PUDataSets:
-        upgradeStepDict['RecoFull_trackingOnlyPU'][k]=merge([PUDataSets[k2],upgradeStepDict['RecoFull_trackingOnly'][k]])
-
 
     upgradeStepDict['RecoFullGlobal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM',
                                       '--conditions':gt,
@@ -1868,11 +1842,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--eventcontent':'FEVTDEBUGHLT,MINIAODSIM,DQM',
                                       '--geometry' : geom
                                       }
-    if cust!=None : upgradeStepDict['RecoFullGlobal'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['RecoFullGlobal'][k]['--era']=era
-
-    if k2 in PUDataSets:
-        upgradeStepDict['RecoFullGlobalPU'][k]=merge([PUDataSets[k2],upgradeStepDict['RecoFullGlobal'][k]])
 
     upgradeStepDict['RecoFullLocal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO:localreco',
                                       '--conditions':gt,
@@ -1881,12 +1850,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--eventcontent':'FEVTDEBUGHLT',
                                       '--geometry' : geom
                                       }
-    if cust!=None : upgradeStepDict['RecoFullLocal'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['RecoFullLocal'][k]['--era']=era
-
-    if k2 in PUDataSets:
-        upgradeStepDict['RecoFullLocalPU'][k]=merge([PUDataSets[k2],upgradeStepDict['RecoFullLocal'][k]])
-
 
     upgradeStepDict['HARVESTFull'][k]={'-s':'HARVESTING:@standardValidation+@standardDQM+@miniAODValidation+@miniAODDQM',
                                     '--conditions':gt,
@@ -1896,20 +1859,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                     '--filetype':'DQM',
 				    '--filein':'file:step3_inDQM.root'
                                     }
-    if cust!=None : upgradeStepDict['HARVESTFull'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['HARVESTFull'][k]['--era']=era
 
-    if k2 in PUDataSets:
-        upgradeStepDict['HARVESTFullPU'][k]=merge([PUDataSets[k2],upgradeStepDict['HARVESTFull'][k]])
-
-    upgradeStepDict['HARVESTFull_trackingOnly'][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, upgradeStepDict['HARVESTFull'][k]])
     upgradeStepDict['HARVESTFullGlobal'][k] = merge([{'-s': 'HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM'}, upgradeStepDict['HARVESTFull'][k]])
-
-    if k2 in PUDataSets:
-        upgradeStepDict['HARVESTFull_trackingOnlyPU'][k]=merge([PUDataSets[k2],upgradeStepDict['HARVESTFull_trackingOnly'][k]])
-        upgradeStepDict['HARVESTFullGlobalPU'][k]=merge([PUDataSets[k2],upgradeStepDict['HARVESTFullGlobal'][k]])
-
-
 
     upgradeStepDict['ALCAFull'][k] = {'-s':'ALCA:TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+HcalCalHBHEMuonFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu',
                                       '--conditions':gt,
@@ -1918,10 +1869,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--eventcontent':'ALCARECO',
                                       '--geometry' : geom
                                       }
-    if cust!=None : upgradeStepDict['ALCAFull'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['ALCAFull'][k]['--era']=era
-
-
 
     upgradeStepDict['FastSim'][k]={'-s':'GEN,SIM,RECO,VALIDATION',
                                    '--eventcontent':'FEVTDEBUGHLT,DQM',
@@ -1930,8 +1877,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                    '--fast':'',
                                    '--geometry' : geom,
                                    '--relval':'27000,3000'}
-    if cust!=None : upgradeStepDict['FastSim'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['FastSim'][k]['--era']=era
 
     upgradeStepDict['HARVESTFast'][k]={'-s':'HARVESTING:validationHarvesting',
                                     '--conditions':gt,
@@ -1939,17 +1884,33 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                     '--geometry' : geom,
                                     '--scenario' : 'pp'
                                     }
-    if cust!=None : upgradeStepDict['HARVESTFast'][k]['--customise']=cust
-    if era is not None: upgradeStepDict['HARVESTFast'][k]['--era']=era
 
-# add Timing variations
-for step in upgradeStepDict.keys():
-    if not "_Timing" in step:
-        upgradeStepDict[step+"_Timing"] = deepcopy(upgradeStepDict[step])
-        for key in upgradeStepDict[step+"_Timing"].keys():
-            # avoid some nonsense
-            if not "_timing" in upgradeStepDict[step+"_Timing"][key]['--era']:
-                upgradeStepDict[step+"_Timing"][key]['--era'] += "_timing"
+    # setup baseline customizations and PU
+    for step in upgradeSteps['baseline']['steps']:
+        if cust is not None: upgradeStepDict[step][k]['--customise']=cust
+        if era is not None: upgradeStepDict[step][k]['--era']=era
+
+    # setup variations (manually)
+
+    for step in upgradeSteps['trackingOnly']['steps']:
+        stepName = step + upgradeSteps['trackingOnly']['suffix']
+        if 'Reco' in step: upgradeStepDict[stepName][k] = merge([step3_trackingOnly, upgradeStepDict[step][k]])
+        elif 'HARVEST' in step: upgradeStepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, upgradeStepDict[step][k]])
+
+    for step in upgradeSteps['Timing']['steps']:
+        stepName = step + upgradeSteps['Timing']['suffix']
+        upgradeStepDict[stepName][k] = deepcopy(upgradeStepDict[step][k])
+        # avoid some nonsense
+        if '--era' in upgradeStepDict[stepName][k].keys() and not "_timing" in upgradeStepDict[stepName][k]['--era']:
+            upgradeStepDict[stepName][k]['--era'] += "_timing"
+
+    # setup PU
+    if k2 in PUDataSets:
+        for stepType in upgradeSteps.keys():
+            for step in upgradeSteps[stepType]['PU']:
+                stepName = step + upgradeSteps[stepType]['suffix']
+                stepNamePU = step + 'PU' + upgradeSteps[stepType]['suffix']
+                upgradeStepDict[stepNamePU][k]=merge([PUDataSets[k2],upgradeStepDict[stepName][k]])
 
 for step in upgradeStepDict.keys():
     # we need to do this for each fragment

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -9,55 +9,47 @@ workflows = Matrix()
 # if no explicit name/label given for the workflow (first arg),
 # the name of step1 will be used
 
+def makeStepNameSim(key,frag,step,suffix):
+    return frag+'_'+key+'_'+step+suffix
+
+def makeStepName(key,frag,step,suffix):
+   return step+suffix+'_'+key
 
 
 #just define all of them
-
-# special offsets
-trackingOnlyOffset = 0.1
-timingOffset = 0.2
 
 for year in upgradeKeys:
     for i,key in enumerate(upgradeKeys[year]):
         numWF=numWFAll[year][i]
         for frag in upgradeFragments:
-            k=frag[:-4]+'_'+key
-            stepList=[]
-            stepListTiming=[]
+            stepList={}
+            for stepType in upgradeSteps.keys():
+                stepList[stepType] = []
+            hasHarvest = False
             for step in upgradeProperties[year][key]['ScenToRun']:                    
+                stepMaker = makeStepName
                 if 'Sim' in step:
                     if 'HLBeamSpotFull' in step and '14TeV' in frag:
                         step = 'GenSimHLBeamSpotFull14'
-                    stepList.append(k+'_'+step)
-                    stepListTiming.append(k+'_'+step+'_Timing')
-                else:
-                    stepList.append(step+'_'+key)
-                    stepListTiming.append(step+'_Timing'+'_'+key)
-            workflows[numWF] = [ upgradeDatasetFromFragment[frag], stepList]
+                    stepMaker = makeStepNameSim
+                
+                if 'HARVEST' in step: hasHarvest = True
+
+                for stepType in upgradeSteps.keys():
+                    # use variation only when available
+                    if (stepType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in upgradeSteps[stepType]['PU']) or (step in upgradeSteps[stepType]['steps']) ):
+                        stepList[stepType].append(stepMaker(key,frag[:-4],step,upgradeSteps[stepType]['suffix']))
+                    else:
+                        stepList[stepType].append(stepMaker(key,frag[:-4],step,upgradeSteps['baseline']['suffix']))
+
+            workflows[numWF] = [ upgradeDatasetFromFragment[frag], stepList['baseline']]
 
             # only keep some special workflows for timing
             if upgradeDatasetFromFragment[frag]=="TTbar_14TeV" and '2023' in key:
-                workflows[numWF+timingOffset] = [ upgradeDatasetFromFragment[frag], stepListTiming]
+                workflows[numWF+upgradeSteps['Timing']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['Timing']]
 
             # special workflows for tracker
-            if (upgradeDatasetFromFragment[frag]=="TTbar_13" or upgradeDatasetFromFragment[frag]=="TTbar_14TeV") and not 'PU' in key:
-                stepListTk=[]
-                hasHarvest = False
-                for step in upgradeProperties[year][key]['ScenToRun']:
-                    if 'Reco' in step:
-                        step = 'RecoFull_trackingOnly'
-                    if 'HARVEST' in step:
-                        step = 'HARVESTFull_trackingOnly'
-                        hasHarvest = True
-
-                    if 'Sim' in step:
-                        if 'HLBeamSpotFull' in step and '14TeV' in frag:
-                            step = 'GenSimHLBeamSpotFull14'
-                        stepListTk.append(k+'_'+step)
-                    else:
-                        stepListTk.append(step+'_'+key)
-                 
-                if hasHarvest:
-                    workflows[numWF+trackingOnlyOffset] = [ upgradeDatasetFromFragment[frag], stepListTk]
+            if (upgradeDatasetFromFragment[frag]=="TTbar_13" or upgradeDatasetFromFragment[frag]=="TTbar_14TeV") and not 'PU' in key and hasHarvest:
+                workflows[numWF+upgradeSteps['trackingOnly']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['trackingOnly']]
 
             numWF+=1

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -48,6 +48,10 @@ for year in upgradeKeys:
             if upgradeDatasetFromFragment[frag]=="TTbar_14TeV" and '2023' in key:
                 workflows[numWF+upgradeSteps['Timing']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['Timing']]
 
+            # special workflows for neutron bkg sim
+            if upgradeDatasetFromFragment[frag]=="ZMM_14" and ('2023D12' in key or '2023D14' in key):
+                workflows[numWF+upgradeSteps['Neutron']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['Neutron']]
+
             # special workflows for tracker
             if (upgradeDatasetFromFragment[frag]=="TTbar_13" or upgradeDatasetFromFragment[frag]=="TTbar_14TeV") and not 'PU' in key and hasHarvest:
                 workflows[numWF+upgradeSteps['trackingOnly']['offset']] = [ upgradeDatasetFromFragment[frag], stepList['trackingOnly']]

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -59,32 +59,53 @@ for year in upgradeKeys:
                 break
         numWFAll[year].append(numWFtmp)
 
-upgradeSteps=[
-    'GenSimFull',
-    'GenSimHLBeamSpotFull',
-    'GenSimHLBeamSpotFull14',
-    'DigiFull',
-    'DigiFullTrigger',
-    'DigiFullTriggerPU',
-    'RecoFullLocal',
-    'RecoFullLocalPU',
-    'RecoFull',
-    'RecoFullGlobal',
-    'RecoFullGlobalPU',
-    'HARVESTFull',
-    'FastSim',
-    'HARVESTFast',
-    'DigiFullPU',
-    'RecoFullPU',
-    'HARVESTFullPU',
-    'RecoFull_trackingOnly',
-    'RecoFull_trackingOnlyPU',
-    'HARVESTFull_trackingOnly',
-    'HARVESTFull_trackingOnlyPU',
-    'HARVESTFullGlobal',
-    'HARVESTFullGlobalPU',
-    'ALCAFull'
-]
+# steps for baseline and for variations
+upgradeSteps={}
+upgradeSteps['baseline'] = {
+    'steps' : [
+        'GenSimFull',
+        'GenSimHLBeamSpotFull',
+        'GenSimHLBeamSpotFull14',
+        'DigiFull',
+        'DigiFullTrigger',
+        'RecoFullLocal',
+        'RecoFull',
+        'RecoFullGlobal',
+        'HARVESTFull',
+        'FastSim',
+        'HARVESTFast',
+        'HARVESTFullGlobal',
+        'ALCAFull',
+    ],
+    'PU' : [
+        'DigiFullTrigger',
+        'RecoFullLocal',
+        'RecoFullGlobal',
+        'DigiFull',
+        'RecoFull',
+        'HARVESTFull',
+        'HARVESTFullGlobal',
+    ],
+    'suffix' : '',
+    'offset' : 0.0,
+}
+upgradeSteps['trackingOnly'] = {
+    'steps' : [
+        'RecoFull',
+        'HARVESTFull',
+        'RecoFullGlobal',
+        'HARVESTFullGlobal',
+    ],
+    'PU' : [],
+    'suffix' : '_trackingOnly',
+    'offset' : 0.1,
+}
+upgradeSteps['Timing'] = {
+    'steps' : upgradeSteps['baseline']['steps'],
+    'PU' : upgradeSteps['baseline']['PU'],
+    'suffix' : '_Timing',
+    'offset' : 0.2,
+}
 
 upgradeProperties = {}
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -106,6 +106,12 @@ upgradeSteps['Timing'] = {
     'suffix' : '_Timing',
     'offset' : 0.2,
 }
+upgradeSteps['Neutron'] = {
+    'steps' : upgradeSteps['baseline']['steps'],
+    'PU' : upgradeSteps['baseline']['PU'],
+    'suffix' : '_Neutron',
+    'offset' : 0.3,
+}
 
 upgradeProperties = {}
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -329,6 +329,7 @@ upgradeFragments=['FourMuPt_1_200_pythia8_cfi',
                   'WprimeToENu_M-2000_TuneCUETP8M1_13TeV-pythia8_cff',
                   'DisplacedSUSY_stopToBottom_M_300_1000mm_TuneCUETP8M1_13TeV_pythia8_cff',
                   'TenE_E_0_200_pythia8_cfi',
+                  'FlatRandomPtAndDxyGunProducer_cfi',
 ]
 
 howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
@@ -417,6 +418,7 @@ howMuches={'FourMuPt_1_200_pythia8_cfi':Kby(10,100),
            'WprimeToENu_M-2000_TuneCUETP8M1_13TeV-pythia8_cff':Kby(9,50),
            'DisplacedSUSY_stopToBottom_M_300_1000mm_TuneCUETP8M1_13TeV_pythia8_cff':Kby(9,50),
            'TenE_E_0_200_pythia8_cfi':Kby(9,100),
+           'FlatRandomPtAndDxyGunProducer_cfi':Kby(9,100),
 }
 
 upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
@@ -505,4 +507,5 @@ upgradeDatasetFromFragment={'FourMuPt_1_200_pythia8_cfi': 'FourMuPt1_200',
                             'WprimeToENu_M-2000_TuneCUETP8M1_13TeV-pythia8_cff': 'WpToENu_M-2000_13',
                             'DisplacedSUSY_stopToBottom_M_300_1000mm_TuneCUETP8M1_13TeV_pythia8_cff': 'DisplacedSUSY_stopToBottom_M_300_1000mm_13',
                             'TenE_E_0_200_pythia8_cfi': 'TenE_0_200',
+                            'FlatRandomPtAndDxyGunProducer_cfi': 'DisplacedMuonsDxy_0_500',
 }


### PR DESCRIPTION
Following discussion with @davidlange6 re: #18373, I simplified several areas of Python code in `Configuration/PyReleaseValidation` to reduce code duplication and to make it easier to add specific workflow variations (e.g. 2XXXX.Y where Y!=1).

This PR also contains a few requests from @calabria for workflows related to #18456. It adds a displaced muon gen fragment, and the following few neutron bkg simulation workflows (you can see how easy it was to add these in 216c9da, after the changes in e52b0ad):
```
24450.3 ZMM_14TeV_TuneCUETP8M1_2023D12_GenSimHLBeamSpotFull14_Neutron+DigiFullTrigger_Neutron_2023D12+RecoFullGlobal_Neutron_2023D12+HARVESTFullGlobal_Neutron_2023D12
24650.3 ZMM_14TeV_TuneCUETP8M1_2023D12PU_GenSimHLBeamSpotFull14_Neutron+DigiFullTriggerPU_Neutron_2023D12PU+RecoFullGlobalPU_Neutron_2023D12PU+HARVESTFullGlobalPU_Neutron_2023D12PU
26250.3 ZMM_14TeV_TuneCUETP8M1_2023D14_GenSimHLBeamSpotFull14_Neutron+DigiFullTrigger_Neutron_2023D14+RecoFullGlobal_Neutron_2023D14+HARVESTFullGlobal_Neutron_2023D14
26450.3 ZMM_14TeV_TuneCUETP8M1_2023D14PU_GenSimHLBeamSpotFull14_Neutron+DigiFullTriggerPU_Neutron_2023D14PU+RecoFullGlobalPU_Neutron_2023D14PU+HARVESTFullGlobalPU_Neutron_2023D14PU 
```