### PR TITLE
remove tmp patch in the configuration of association thresholds for P…

### DIFF
--- a/Validation/RecoMuon/python/NewAssociators_cff.py
+++ b/Validation/RecoMuon/python/NewAssociators_cff.py
@@ -36,11 +36,6 @@ MABH.EfficiencyCut_muon = 0.     # for high pt muons this is a better choice
 MABH.PurityCut_muon = 0.75
 MABH.includeZeroHitMuons = False
 #
-# temporary fix for Phase2
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify( MABH, EfficiencyCut_track = 0. )
-phase2_tracker.toModify( MABH, PurityCut_track = 0. )
-#
 MABHhlt = MABH.clone()
 MABHhlt.EfficiencyCut_track = 0. # backup solution as UseGrouped/UseSplitting are always assumed to be true
 MABHhlt.DTrechitTag = 'hltDt1DRecHits'


### PR DESCRIPTION
Fix the configuration for phase2 New muon validation, removing the previous temporary patch.
This restores the desired defaults and is possible after the integration of the fix to the TrackerHitAssociator (PR #18354).
Git could not take that PR as wished (the file NewAssociators_cff.py was the wanted one in the submitted branch) as there was a previous PR (#18290 ) branched from the same base release which was integrated previously, containing the temporary patch, so it had to be expected. I realized it after checking the latest IB. sorry...
