### PR TITLE
Ecalpedestal pcl improved

### DIFF
--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLHarvester.h
@@ -43,6 +43,12 @@ class ECALpedestalPCLHarvester : public  DQMEDHarvester {
       const EcalPedestals * currentPedestals_;
       const EcalChannelStatus * channelStatus_;
       bool  checkStatusCode(const DetId& id);
+      bool  checkVariation(const EcalPedestalsMap& oldPedestals, const EcalPedestalsMap& newPedestals);
       std::vector<int> chStatusToExclude_;
       int minEntries_;
+          
+      bool   checkAnomalies_ ;    // whether or not to avoid creating sqlite file in case of many changed pedestals
+      double nSigma_;             // threshold in sigmas to define a pedestal as changed
+      double thresholdAnomalies_; // threshold (fraction of changed pedestals) to avoid creation of sqlite file 
+      std::string dqmDir_;         // DQM directory where histograms are stored
 };

--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
@@ -53,9 +53,16 @@ private:
     std::vector<MonitorElement *> meEB_;
     std::vector<MonitorElement *> meEE_;
 
-    static const int kPedestalSamples = 3;
-    static const int kThreshold = 10; // threshold (in adc count) above which we'll assume 
-                                      // there's signal and not just pedestal
+    uint32_t pedestalSamples_ ; // number of presamples to be used for pedestal determination    
+    bool     checkSignal_;      // avoid frames containing a signal
+    uint32_t  sThreshold_ ;     // if checkSignal = true threshold (in adc count) above which we'll assume 
+                                // there's signal and not just pedestal
+
+    bool dynamicBooking_;       // use old pedestal to book histograms
+    int fixedBookingCenterBin_; // if dynamicBooking_ = false, use this as bin center
+    int nBins_ ;                // number of bins per histogram
+    std::string dqmDir_;         // DQM directory where histograms are stored
+    
 
     // compare ADC values  
     static bool adc_compare(uint16_t a, uint16_t b) { return ( a&0xFFF )  < (b&0xFFF);}

--- a/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
+++ b/Calibration/EcalCalibAlgos/interface/ECALpedestalPCLworker.h
@@ -55,8 +55,10 @@ private:
 
     uint32_t pedestalSamples_ ; // number of presamples to be used for pedestal determination    
     bool     checkSignal_;      // avoid frames containing a signal
-    uint32_t  sThreshold_ ;     // if checkSignal = true threshold (in adc count) above which we'll assume 
+    uint32_t  sThresholdEB_  ;  // if checkSignal = true threshold (in adc count) above which we'll assume 
                                 // there's signal and not just pedestal
+
+    uint32_t  sThresholdEE_  ;
 
     bool dynamicBooking_;       // use old pedestal to book histograms
     int fixedBookingCenterBin_; // if dynamicBooking_ = false, use this as bin center

--- a/Calibration/EcalCalibAlgos/python/ecalPedestalPCLHarvester_cfi.py
+++ b/Calibration/EcalCalibAlgos/python/ecalPedestalPCLHarvester_cfi.py
@@ -1,14 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 ECALpedestalPCLHarvester = cms.EDAnalyzer('ECALpedestalPCLHarvester',
                                           MinEntries = cms.int32(100), #skip channel if stat is low
-                                          ChannelStatusToExclude = cms.vstring('kDAC',
-                                                                               'kNoisy',
-                                                                               'kNNoisy',
-                                                                               'kFixedG6',
-                                                                               'kFixedG1',
-                                                                               'kFixedG0',
-                                                                               'kNonRespondingIsolated',
-                                                                               'kDeadVFE',
-                                                                               'kDeadFE',
-                                                                               'kNoDataNoTP',)
+                                          ChannelStatusToExclude = cms.vstring(), # db statuses to exclude
+                                          checkAnomalies  = cms.bool(False), # whether or not to avoid creating sqlite file in case of many changed pedestals
+                                          nSigma          = cms.double(5.0), #  threshold in sigmas to define a pedestal as anomally changed
+                                          thresholdAnomalies = cms.double(0.1),# threshold (fraction of changed pedestals) to avoid creation of sqlite file 
+                                          dqmDir      = cms.string('AlCaReco/EcalPedestalsPCL') 
                                           )

--- a/Calibration/EcalCalibAlgos/python/ecalPedestalPCLworker_cfi.py
+++ b/Calibration/EcalCalibAlgos/python/ecalPedestalPCLworker_cfi.py
@@ -2,4 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 ecalpedestalPCL =cms.EDAnalyzer('ECALpedestalPCLworker',
                                 BarrelDigis=cms.InputTag('ecalDigis','ebDigis'),
-                                EndcapDigis=cms.InputTag('ecalDigis','eeDigis'))
+                                EndcapDigis=cms.InputTag('ecalDigis','eeDigis'),
+                                pedestalSamples=cms.uint32(2),    # number of presamples to be used for pedestal determination
+                                checkSignal = cms.bool(False), # whether or not to exclude digis containing a signal
+                                sThreshold  = cms.uint32(10),     # threshold to define a digi as containing signal
+                                dqmDir      = cms.string('AlCaReco/EcalPedestalsPCL'), 
+                                dynamicBooking = cms.bool(True), # use old pedestal to book histograms (central bin)
+                                fixedBookingCenterBin = cms.int32(200), # if dynamicBooking = false, use this as center bin 
+                                nBins       = cms.int32(40)      # number of bins per histogram
+)

--- a/Calibration/EcalCalibAlgos/python/ecalPedestalPCLworker_cfi.py
+++ b/Calibration/EcalCalibAlgos/python/ecalPedestalPCLworker_cfi.py
@@ -3,9 +3,10 @@ import FWCore.ParameterSet.Config as cms
 ecalpedestalPCL =cms.EDAnalyzer('ECALpedestalPCLworker',
                                 BarrelDigis=cms.InputTag('ecalDigis','ebDigis'),
                                 EndcapDigis=cms.InputTag('ecalDigis','eeDigis'),
-                                pedestalSamples=cms.uint32(2),    # number of presamples to be used for pedestal determination
-                                checkSignal = cms.bool(False), # whether or not to exclude digis containing a signal
-                                sThreshold  = cms.uint32(10),     # threshold to define a digi as containing signal
+                                pedestalSamples=cms.uint32(2),   # number of presamples to be used for pedestal determination
+                                checkSignal = cms.bool(False),   # whether or not to exclude digis containing a signal
+                                sThresholdEB  = cms.uint32(10),  # threshold to define a digi as containing signal
+                                sThresholdEE  = cms.uint32(15),
                                 dqmDir      = cms.string('AlCaReco/EcalPedestalsPCL'), 
                                 dynamicBooking = cms.bool(True), # use old pedestal to book histograms (central bin)
                                 fixedBookingCenterBin = cms.int32(200), # if dynamicBooking = false, use this as center bin 

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -182,9 +182,9 @@ bool ECALpedestalPCLHarvester::checkVariation(const EcalPedestalsMap& oldPedesta
     
     if (nAnomaliesEB > thresholdAnomalies_ *  EBDetId::kSizeForDenseIndexing || 
         nAnomaliesEE > thresholdAnomalies_ *  EEDetId::kSizeForDenseIndexing)  
-        return false;
+        return true;
 
-    return true;
+    return false;
 
 
 }

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -166,7 +166,7 @@ bool ECALpedestalPCLHarvester::checkVariation(const EcalPedestalsMap& oldPedesta
         const EcalPedestal& newped=* newPedestals.find(id.rawId());   
         const EcalPedestal& oldped=* oldPedestals.find(id.rawId());
 
-        if  (abs(newped.mean_x12 -oldped.mean_x12)  >  nSigma_ * oldped.rms_x12) nAnomaliesEB++;
+        if  (std::abs(newped.mean_x12 -oldped.mean_x12)  >  nSigma_ * oldped.rms_x12) nAnomaliesEB++;
 
     }
 
@@ -176,7 +176,7 @@ bool ECALpedestalPCLHarvester::checkVariation(const EcalPedestalsMap& oldPedesta
         const EcalPedestal& newped=* newPedestals.find(id.rawId());   
         const EcalPedestal& oldped=* oldPedestals.find(id.rawId());
 
-        if  (abs(newped.mean_x12 -oldped.mean_x12)  >  nSigma_ * oldped.rms_x12) nAnomaliesEE++;
+        if  (std::abs(newped.mean_x12 -oldped.mean_x12)  >  nSigma_ * oldped.rms_x12) nAnomaliesEE++;
 
     }
     

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLworker.cc
@@ -22,7 +22,8 @@ ECALpedestalPCLworker::ECALpedestalPCLworker(const edm::ParameterSet& iConfig)
 
     pedestalSamples_ = iConfig.getParameter<uint32_t>("pedestalSamples");
     checkSignal_     = iConfig.getParameter<bool>("checkSignal");
-    sThreshold_      = iConfig.getParameter<uint32_t>("sThreshold");
+    sThresholdEB_      = iConfig.getParameter<uint32_t>("sThresholdEB");
+    sThresholdEE_      = iConfig.getParameter<uint32_t>("sThresholdEE");
 
     dynamicBooking_ = iConfig.getParameter<bool>("dynamicBooking");
     fixedBookingCenterBin_ = iConfig.getParameter<int>("fixedBookingCenterBin");
@@ -56,7 +57,7 @@ ECALpedestalPCLworker::analyze(const edm::Event& iEvent, const edm::EventSetup& 
         if (checkSignal_){
             uint16_t maxdiff = *std::max_element(digi.frame().begin(), digi.frame().end(), adc_compare )  -
                                *std::min_element(digi.frame().begin(), digi.frame().end(), adc_compare );
-            if ( maxdiff> sThreshold_ ) continue; // assume there is signal in this frame
+            if ( maxdiff> sThresholdEB_ ) continue; // assume there is signal in this frame
         }
 
         //for (auto& mgpasample : digi.frame()) meEB_[hashedId]->Fill(mgpasample&0xFFF);
@@ -79,7 +80,7 @@ ECALpedestalPCLworker::analyze(const edm::Event& iEvent, const edm::EventSetup& 
         if (checkSignal_){
             uint16_t maxdiff = *std::max_element(digi.frame().begin(), digi.frame().end(), adc_compare )  -
                                *std::min_element(digi.frame().begin(), digi.frame().end(), adc_compare );
-            if ( maxdiff> sThreshold_ ) continue; // assume there is signal in this frame
+            if ( maxdiff> sThresholdEE_ ) continue; // assume there is signal in this frame
         }
 
         //for (auto& mgpasample : digi.frame()) meEE_[hashedId]->Fill(mgpasample&0xFFF);


### PR DESCRIPTION
Adding  flexibility:

1. dynamic booking of histograms
2. configurable number of presamples
3. option to exclude signal frames
4. option to avoid payload creation when a configurable fraction of channels has large pedestal variations

changed default on channels to be excluded