### PR TITLE
Fixing race condition in EvFDaqDirector

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -66,7 +66,6 @@ namespace evf{
       void preBeginRun(edm::GlobalContext const& globalContext);
       void postEndRun(edm::GlobalContext const& globalContext);
       void preGlobalEndLumi(edm::GlobalContext const& globalContext);
-      void preSourceEvent(edm::StreamID const& streamID);
       //std::string &baseDir(){return base_dir_;}
       void overrideRunNumber(unsigned int run) {run_=run;}
       std::string &baseRunDir(){return run_dir_;}
@@ -110,8 +109,6 @@ namespace evf{
       void lockInitLock();
       void unlockInitLock();
       void setFMS(evf::FastMonitoringService* fms) {fms_=fms;}
-      void updateFileIndex(int const& fileIndex) {currentFileIndex_=fileIndex;}
-      std::vector<int>* getStreamFileTracker() {return &streamFileTracker_;}
       bool isSingleStreamThread() {return nStreams_==1 && nThreads_==1;}
       void lockFULocal();
       void unlockFULocal();
@@ -196,8 +193,6 @@ namespace evf{
       //struct flock fulocal_rw_fulk2;
 
       evf::FastMonitoringService * fms_ = nullptr;
-      std::vector<int> streamFileTracker_;
-      int currentFileIndex_ = -1;
 
       std::mutex *fileDeleteLockPtr_ = nullptr;
       std::list<std::pair<int,InputFile*>> *filesToDeletePtr_ = nullptr;

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -165,7 +165,7 @@ private:
   std::list<std::pair<int,InputFile*>> filesToDelete_;
   std::list<std::pair<int,std::string>> fileNamesToDelete_;
   std::mutex fileDeleteLock_;
-  std::vector<int> *streamFileTrackerPtr_ = nullptr;
+  std::vector<int> streamFileTracker_;
   unsigned int nStreams_ = 0;
   unsigned int checkEvery_ = 10;
 

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -95,7 +95,6 @@ namespace evf {
     reg.watchPreBeginJob(this, &EvFDaqDirector::preBeginJob);
     reg.watchPreGlobalBeginRun(this, &EvFDaqDirector::preBeginRun);
     reg.watchPostGlobalEndRun(this, &EvFDaqDirector::postEndRun);
-    reg.watchPreSourceEvent(this, &EvFDaqDirector::preSourceEvent);
     reg.watchPreGlobalEndLumi(this,&EvFDaqDirector::preGlobalEndLumi);
 
     //save hostname for later
@@ -276,9 +275,6 @@ namespace evf {
 
     initRun();
 
-    for (unsigned int i=0;i<bounds.maxNumberOfStreams();i++){
-      streamFileTracker_.push_back(-1);
-    }
     nThreads_=bounds.maxNumberOfStreams();
     nStreams_=bounds.maxNumberOfThreads();
   }
@@ -372,15 +368,9 @@ namespace evf {
     }
   }
 
-  inline void EvFDaqDirector::preSourceEvent(edm::StreamID const& streamID) {
-    streamFileTracker_[streamID]=currentFileIndex_;
-  }
-
-
   std::string EvFDaqDirector::getInputJsonFilePath(const unsigned int ls, const unsigned int index) const {
     return bu_run_dir_ + "/" + fffnaming::inputJsonFileName(run_,ls,index);
   }
-
 
   std::string EvFDaqDirector::getRawFilePath(const unsigned int ls, const unsigned int index) const {
     return bu_run_dir_ + "/" + fffnaming::inputRawFileName(run_,ls,index);

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -700,10 +700,6 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
 
   std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
 
-  //FWCore/Sources DaqProvenanceHelper before 7_1_0_pre3
-  //eventPrincipal.put(daqProvenanceHelper_.constBranchDescription_, edp,
-  //                   daqProvenanceHelper_.dummyProvenance_);
-
   eventPrincipal.put(daqProvenanceHelper_.branchDescription(), std::move(edp),
                      daqProvenanceHelper_.dummyProvenance());
 
@@ -711,7 +707,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   if (fms_) fms_->setInState(evf::FastMonitoringThread::inReadCleanup);
 
   //resize vector if needed
-  while (streamFileTracker_.size() =< eventPrincipal.streamID())
+  while (streamFileTracker_.size() <= eventPrincipal.streamID())
       streamFileTracker_.push_back(-1);
 
   streamFileTracker_[eventPrincipal.streamID()]=currentFileIndex_;
@@ -1085,12 +1081,6 @@ void FedRawDataInputSource::readSupervisor()
         assert( eventsInNewFile>=0 );
         assert((eventsInNewFile>0) == (fileSize>0));//file without events must be empty
       }
-      //int eventsInNewFile = fileListMode_ ? -1 : grabNextJsonFile(nextFile);
-      //if (fileListMode_ && fileSize==0) {eventsInNewFile=0;}
-      //if (!fileListMode_) {
-      //  assert( eventsInNewFile>=0 );
-      //  assert((eventsInNewFile>0) == (fileSize>0));//file without events must be empty
-      //}
 
       if (!singleBufferMode_) {
 	//calculate number of needed chunks
@@ -1160,7 +1150,7 @@ void FedRawDataInputSource::readSupervisor()
           readingFilesCount_++;
 	  fileQueue_.push(newInputFile);
 	  cvWakeup_.notify_one();
-	  return;
+	  break;
 	}
 	//in single-buffer mode put single chunk in the file and let the main thread read the file
 	InputChunk * newChunk;


### PR DESCRIPTION
DaqDirector was used to keep track of which file (based on which event) is being processed by which file.
This was not done in thread safe manner, as described in issue #18356 

This patch retrives event (file) stream ID from "read" in the input source instead of relying on preSourceEvent in DaqDirector, which can be executed in a different thread.