### PR TITLE
B-tag DQM/Val.: Add efficiency plots vs. eta and phi for cut on discriminators

### DIFF
--- a/DQMOffline/RecoB/interface/BTagDifferentialPlot.h
+++ b/DQMOffline/RecoB/interface/BTagDifferentialPlot.h
@@ -19,84 +19,84 @@ class BTagDifferentialPlot {
 
   enum ConstVarType {constPT, constETA };
 
-  BTagDifferentialPlot (const double& bEff, const ConstVarType& constVariable, const std::string & tagName, const unsigned int& mc) ;
+  BTagDifferentialPlot(double bEff, const ConstVarType& constVariable, const std::string & tagName, unsigned int mc);
 
-  ~BTagDifferentialPlot () ;
+  ~BTagDifferentialPlot();
 
-  void addBinPlotter ( JetTagPlotter * aPlotter ) { theBinPlotters.push_back ( aPlotter ) ; }
+  void addBinPlotter(std::shared_ptr<JetTagPlotter> aPlotter) { theBinPlotters.push_back(aPlotter); }
 
-  void process (DQMStore::IBooker & ibook) ;
+  void process(DQMStore::IBooker & ibook);
 
 
   void epsPlot(const std::string & name);
 
   void psPlot(const std::string & name);
 
-  void plot (TCanvas & theCanvas) ;
+  void plot(TCanvas & theCanvas);
 
   void plot(const std::string & name, const std::string & ext);
 
-//   void print () const ;
+//   void print() const;
 
-  TH1F * getDifferentialHistoB_d    () { return theDifferentialHistoB_d ->getTH1F()   ; }
-  TH1F * getDifferentialHistoB_u    () { return theDifferentialHistoB_u ->getTH1F()   ; }
-  TH1F * getDifferentialHistoB_s    () { return theDifferentialHistoB_s ->getTH1F()   ; }
-  TH1F * getDifferentialHistoB_c    () { return theDifferentialHistoB_c ->getTH1F()   ; }
-  TH1F * getDifferentialHistoB_b    () { return theDifferentialHistoB_b ->getTH1F()   ; }
-  TH1F * getDifferentialHistoB_g    () { return theDifferentialHistoB_g ->getTH1F()   ; }
-  TH1F * getDifferentialHistoB_ni   () { return theDifferentialHistoB_ni->getTH1F()   ; }
-  TH1F * getDifferentialHistoB_dus  () { return theDifferentialHistoB_dus->getTH1F()  ; }
-  TH1F * getDifferentialHistoB_dusg () { return theDifferentialHistoB_dusg->getTH1F() ; }
-  TH1F * getDifferentialHistoB_pu   () { return theDifferentialHistoB_pu->getTH1F()   ; }
+  TH1F * getDifferentialHistoB_d   () { return theDifferentialHistoB_d ->getTH1F()  ; }
+  TH1F * getDifferentialHistoB_u   () { return theDifferentialHistoB_u ->getTH1F()  ; }
+  TH1F * getDifferentialHistoB_s   () { return theDifferentialHistoB_s ->getTH1F()  ; }
+  TH1F * getDifferentialHistoB_c   () { return theDifferentialHistoB_c ->getTH1F()  ; }
+  TH1F * getDifferentialHistoB_b   () { return theDifferentialHistoB_b ->getTH1F()  ; }
+  TH1F * getDifferentialHistoB_g   () { return theDifferentialHistoB_g ->getTH1F()  ; }
+  TH1F * getDifferentialHistoB_ni  () { return theDifferentialHistoB_ni->getTH1F()  ; }
+  TH1F * getDifferentialHistoB_dus () { return theDifferentialHistoB_dus->getTH1F() ; }
+  TH1F * getDifferentialHistoB_dusg() { return theDifferentialHistoB_dusg->getTH1F(); }
+  TH1F * getDifferentialHistoB_pu  () { return theDifferentialHistoB_pu->getTH1F()  ; }
   
  private:
   
-  void setVariableName () ;
+  void setVariableName();
   
-  void bookHisto (DQMStore::IBooker & ibook) ;
+  void bookHisto(DQMStore::IBooker & ibook);
 
 
-  void fillHisto () ;
+  void fillHisto();
   std::pair<double, double> getMistag(const double& fixedBEfficiency, TH1F * effPurHist);
 
 
-  // the fixed b-efficiency (later: allow more than one) for which the misids have to be plotted
-  double fixedBEfficiency ;
+  // the fixed b-efficiency(later: allow more than one) for which the misids have to be plotted
+  double fixedBEfficiency;
   
   // flag if processing should be skipped
-  bool noProcessing ;
+  bool noProcessing;
   bool processed;
 
   ConstVarType constVar;
   // the name for the variable with constant value
-  std::string constVariableName ;
-  // the name of the variable to be plotted on the x-axis (e.g. "eta", "pt")
-  std::string diffVariableName ;
+  std::string constVariableName;
+  // the name of the variable to be plotted on the x-axis(e.g. "eta", "pt")
+  std::string diffVariableName;
 
-  // value of the constant variable (lower/upper edge of interval)
-  std::pair<double,double> constVariableValue ;
+  // value of the constant variable(lower/upper edge of interval)
+  std::pair<double,double> constVariableValue;
 
   // the common name to describe histograms
-  std::string commonName ;
+  std::string commonName;
 
   // the input
-  std::vector<JetTagPlotter *> theBinPlotters ;
+  std::vector<std::shared_ptr<JetTagPlotter>> theBinPlotters;
 
   // the histo to create/fill
-  MonitorElement * theDifferentialHistoB_d    ;
-  MonitorElement * theDifferentialHistoB_u    ;
-  MonitorElement * theDifferentialHistoB_s    ;
-  MonitorElement * theDifferentialHistoB_c    ;
-  MonitorElement * theDifferentialHistoB_b    ;
-  MonitorElement * theDifferentialHistoB_g    ;
-  MonitorElement * theDifferentialHistoB_ni   ;
-  MonitorElement * theDifferentialHistoB_dus  ;
-  MonitorElement * theDifferentialHistoB_dusg ;
-  MonitorElement * theDifferentialHistoB_pu   ;
+  MonitorElement * theDifferentialHistoB_d   ;
+  MonitorElement * theDifferentialHistoB_u   ;
+  MonitorElement * theDifferentialHistoB_s   ;
+  MonitorElement * theDifferentialHistoB_c   ;
+  MonitorElement * theDifferentialHistoB_b   ;
+  MonitorElement * theDifferentialHistoB_g   ;
+  MonitorElement * theDifferentialHistoB_ni  ;
+  MonitorElement * theDifferentialHistoB_dus ;
+  MonitorElement * theDifferentialHistoB_dusg;
+  MonitorElement * theDifferentialHistoB_pu  ;
 
   //flavour histograms choice
   unsigned int mcPlots_;
-} ;
+};
 
 
 #endif

--- a/DQMOffline/RecoB/interface/BaseBTagPlotter.h
+++ b/DQMOffline/RecoB/interface/BaseBTagPlotter.h
@@ -10,11 +10,11 @@ class BaseBTagPlotter {
 
  public:
 
-  BaseBTagPlotter ( const std::string & tagName, const EtaPtBin & etaPtBin) :
+  BaseBTagPlotter(const std::string & tagName, const EtaPtBin & etaPtBin):
 	etaPtBin_(etaPtBin), tagName_(tagName),
-	theExtensionString ("_"+tagName+etaPtBin.getDescriptionString()) {};
+	theExtensionString("_" + tagName + etaPtBin.getDescriptionString()) {};
 
-  virtual ~BaseBTagPlotter () {};
+  virtual ~BaseBTagPlotter() {};
   
   const EtaPtBin& etaPtBin() { return etaPtBin_ ;}
   
@@ -30,6 +30,6 @@ class BaseBTagPlotter {
   // the extension string to be used in histograms etc.
   const EtaPtBin etaPtBin_;
   const std::string tagName_, theExtensionString;
-} ;
+};
 
 #endif

--- a/DQMOffline/RecoB/interface/BaseTagInfoPlotter.h
+++ b/DQMOffline/RecoB/interface/BaseTagInfoPlotter.h
@@ -8,18 +8,16 @@
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 #include "DQMOffline/RecoB/interface/BaseBTagPlotter.h"
 
-class BaseTagInfoPlotter : public BaseBTagPlotter {
+class BaseTagInfoPlotter: public BaseBTagPlotter {
 
  public:
 
-  BaseTagInfoPlotter ( const std::string & tagName, const EtaPtBin & etaPtBin) :
+  BaseTagInfoPlotter(const std::string & tagName, const EtaPtBin & etaPtBin) :
 	    BaseBTagPlotter(tagName, etaPtBin) {};
 
-  virtual ~BaseTagInfoPlotter () {};
-  virtual void analyzeTag(const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour);
-  virtual void analyzeTag(const std::vector<const reco::BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour);
-  virtual void analyzeTag(const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour, const float & w);
-  virtual void analyzeTag(const std::vector<const reco::BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour, const float & w);
+  virtual ~BaseTagInfoPlotter() {};
+  virtual void analyzeTag(const reco::BaseTagInfo * tagInfo, double jec, int jetFlavour, float w=1);
+  virtual void analyzeTag(const std::vector<const reco::BaseTagInfo *> &tagInfos, double jec, int jetFlavour, float w=1);
 
   virtual void setEventSetup(const edm::EventSetup & setup);
   virtual std::vector<std::string> tagInfoRequirements() const;

--- a/DQMOffline/RecoB/interface/EffPurFromHistos.h
+++ b/DQMOffline/RecoB/interface/EffPurFromHistos.h
@@ -14,16 +14,16 @@ class EffPurFromHistos {
 
  public:
 
-  EffPurFromHistos ( const std::string & ext, TH1F * h_d, TH1F * h_u,
-		     TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
-		     TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
-		     const std::string& label, const unsigned int& mc,
-		     int nBin = 100 , double startO = 0.005 , double endO = 1.005 ) ;
+  EffPurFromHistos(const std::string & ext, TH1F * h_d, TH1F * h_u,
+             TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g, TH1F * h_ni,
+             TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
+             const std::string& label, unsigned int mc,
+             int nBin = 100, double startO = 0.005, double endO = 1.005);
 
-  EffPurFromHistos (const FlavourHistograms<double> * dDiscriminatorFC, const std::string& label, const unsigned int& mc, 
-		    DQMStore::IBooker & ibook, int nBin = 100 , double startO = 0.005 , double endO = 1.005 ) ;
+  EffPurFromHistos(const FlavourHistograms<double>& dDiscriminatorFC, const std::string& label, unsigned int mc, 
+            DQMStore::IBooker & ibook, int nBin = 100, double startO = 0.005, double endO = 1.005);
 
-  ~EffPurFromHistos () ;
+  ~EffPurFromHistos();
 
   // do the computation
   void compute (DQMStore::IBooker & ibook) ;
@@ -44,27 +44,27 @@ class EffPurFromHistos {
   void epsPlot(const std::string & name);
   void psPlot(const std::string & name);
 
-  void plot(TPad * theCanvas = 0) ;
+  void plot(TPad * theCanvas = 0);
   void plot(const std::string & name, const std::string & ext);
 
-  FlavourHistograms<double> * discriminatorNoCutEffic() const {return discrNoCutEffic.get();}
-  FlavourHistograms<double> * discriminatorCutEfficScan() const {return discrCutEfficScan.get();}
+  FlavourHistograms<double>& discriminatorNoCutEffic() const { return *discrNoCutEffic; }
+  FlavourHistograms<double>& discriminatorCutEfficScan() const { return *discrCutEfficScan; }
 
-  bool doCTagPlots(bool Ctag) {doCTagPlots_ = Ctag; return doCTagPlots_;};
+  bool doCTagPlots(bool Ctag) { doCTagPlots_ = Ctag; return doCTagPlots_; }
  
  private:
 
   // consistency check (same binning)
-  void check () ;
+  void check();
   bool fromDiscriminatorDistr;
 
   unsigned int mcPlots_;
   bool doCTagPlots_;
   std::string label_;
   // the string for the histo name extension
-  std::string histoExtension ;
+  std::string histoExtension;
 
-  std::unique_ptr<FlavourHistograms<double> > discrNoCutEffic, discrCutEfficScan;
+  std::unique_ptr<FlavourHistograms<double>> discrNoCutEffic, discrCutEfficScan;
 
   // the input histograms (efficiency versus discriminator cut)
   // IMPORTANT: IT'S ASSUMED THAT ALL HISTOS HAVE THE SAME BINNING!!
@@ -84,9 +84,9 @@ class EffPurFromHistos {
   // the corresponding output histograms (flavour-eff vs. b-efficiency)
 
   // binning for output histograms
-  int   nBinOutput ;
-  double startOutput ;
-  double endOutput ;
+  int nBinOutput;
+  double startOutput;
+  double endOutput;
 
   MonitorElement * EffFlavVsXEff_d    ;
   MonitorElement * EffFlavVsXEff_u    ;

--- a/DQMOffline/RecoB/interface/EffPurFromHistos2D.h
+++ b/DQMOffline/RecoB/interface/EffPurFromHistos2D.h
@@ -14,63 +14,63 @@ class EffPurFromHistos2D {
 
  public:
 
-  EffPurFromHistos2D ( const std::string & ext, TH2F * h_d, TH2F * h_u,
-                     TH2F * h_s, TH2F * h_c, TH2F * h_b, TH2F * h_g, TH2F * h_ni,
-                     TH2F * h_dus, TH2F * h_dusg, TH2F * h_pu,
-		     const std::string& label, const unsigned int& mc,
-		     int nBinX = 100 , double startOX = 0.05 , double endOX = 1.05) ;
+  EffPurFromHistos2D(const std::string & ext, TH2F * h_d, TH2F * h_u,
+                        TH2F * h_s, TH2F * h_c, TH2F * h_b, TH2F * h_g, TH2F * h_ni,
+                        TH2F * h_dus, TH2F * h_dusg, TH2F * h_pu,
+                        const std::string& label, unsigned int mc,
+                        int nBinX = 100, double startOX = 0.05, double endOX = 1.05);
 
-  EffPurFromHistos2D (const FlavourHistograms2D<double, double> * dDiscriminatorFC,  
-                      const std::string& label, const unsigned int& mc, 
-		      DQMStore::IBooker & ibook,
-		      int nBinX = 100 , double startOX = 0.05 , double endOX = 1.05) ;
+  EffPurFromHistos2D(const FlavourHistograms2D<double, double>& dDiscriminatorFC,  
+                        const std::string& label, unsigned int mc, 
+                        DQMStore::IBooker & ibook,
+                        int nBinX = 100, double startOX = 0.05, double endOX = 1.05);
 
-  ~EffPurFromHistos2D () ;
+  ~EffPurFromHistos2D();
 
   // do the computation
-  void compute (DQMStore::IBooker & ibook, std::vector<double> fixedEff) ;
+  void compute(DQMStore::IBooker & ibook, std::vector<double> fixedEff);
    
   void epsPlot(const std::string & name);
   void psPlot(const std::string & name);
 
-  void plot(TPad * theCanvas = 0) ;
+  void plot(TPad * theCanvas = 0);
   void plot(const std::string & name, const std::string & ext);
 
-  FlavourHistograms2D<double,double> * discriminatorNoCutEffic() const {return discrNoCutEffic.get();}
-  FlavourHistograms2D<double,double> * discriminatorCutEfficScan() const {return discrCutEfficScan.get();}
+  FlavourHistograms2D<double,double>& discriminatorNoCutEffic() const { return *discrNoCutEffic; }
+  FlavourHistograms2D<double,double>& discriminatorCutEfficScan() const { return *discrCutEfficScan; }
 
-  bool doCTagPlots(bool Ctag) {doCTagPlots_ = Ctag; return doCTagPlots_;};
+  bool doCTagPlots(bool Ctag) { doCTagPlots_ = Ctag; return doCTagPlots_; }
  
  private:
 
-  // consistency check (same binning)
-  void check () ;
+  // consistency check(same binning)
+  void check();
   bool fromDiscriminatorDistr;
 
   unsigned int mcPlots_;
   bool doCTagPlots_;
   std::string label_;
   // the string for the histo name extension
-  std::string histoExtension ;
+  std::string histoExtension;
 
-  std::unique_ptr<FlavourHistograms2D<double, double> > discrNoCutEffic, discrCutEfficScan;
+  std::unique_ptr< FlavourHistograms2D<double, double> > discrNoCutEffic, discrCutEfficScan;
 
-  // the input histograms (efficiency versus discriminator cut)
+  // the input histograms(efficiency versus discriminator cut)
   // IMPORTANT: IT'S ASSUMED THAT ALL HISTOS HAVE THE SAME BINNING!!
-  // (can in principle be relaxed by checking explicitely for the discriminator value
+  //(can in principle be relaxed by checking explicitely for the discriminator value
   //  instead of bin index)
-  TH2F * effVersusDiscr_d    ;
-  TH2F * effVersusDiscr_u    ;
-  TH2F * effVersusDiscr_s    ;
-  TH2F * effVersusDiscr_c    ;
-  TH2F * effVersusDiscr_b    ;
-  TH2F * effVersusDiscr_g    ;
-  TH2F * effVersusDiscr_ni   ;
-  TH2F * effVersusDiscr_dus  ;
-  TH2F * effVersusDiscr_dusg ;
-  TH2F * effVersusDiscr_pu   ;
+  TH2F * effVersusDiscr_d   ;
+  TH2F * effVersusDiscr_u   ;
+  TH2F * effVersusDiscr_s   ;
+  TH2F * effVersusDiscr_c   ;
+  TH2F * effVersusDiscr_b   ;
+  TH2F * effVersusDiscr_g   ;
+  TH2F * effVersusDiscr_ni  ;
+  TH2F * effVersusDiscr_dus ;
+  TH2F * effVersusDiscr_dusg;
+  TH2F * effVersusDiscr_pu  ;
 
-  // the corresponding output histograms (flavour-eff vs. b-efficiency)
+  // the corresponding output histograms(flavour-eff vs. b-efficiency)
 
   // binning for output histograms
   int nBinOutputX;

--- a/DQMOffline/RecoB/interface/EtaPtBin.h
+++ b/DQMOffline/RecoB/interface/EtaPtBin.h
@@ -8,7 +8,7 @@
 
 /** \class EtaPtBin
  *
- *  Decide if jet/parton lie within desired rapidity/pt range.
+ *  Decide if jet/parton lie within desired abs(pseudo-rapidity)/pt range.
  *
  */
 

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -30,15 +30,15 @@ class FlavourHistograms {
 
 public:
   FlavourHistograms (const std::string& baseNameTitle_ , const std::string& baseNameDescription_ ,
-		     const int& nBins_ , const double& lowerBound_ , const double& upperBound_ , 
-		     const std::string& plotFirst_ , const std::string& folder, 
-		     const unsigned int& mc, DQMStore::IGetter & iget) ;
+             const int& nBins_ , const double& lowerBound_ , const double& upperBound_ , 
+             const std::string& plotFirst_ , const std::string& folder, 
+             const unsigned int& mc, DQMStore::IGetter & iget) ;
 
   FlavourHistograms (const std::string& baseNameTitle_ , const std::string& baseNameDescription_ ,
-		     const int& nBins_ , const double& lowerBound_ , const double& upperBound_ ,
-		     const bool& statistics_ , const bool& plotLog_ , const bool& plotNormalized_ ,
-		     const std::string& plotFirst_ , const std::string& folder, 
-		     const unsigned int& mc, DQMStore::IBooker & ibook) ;
+             const int& nBins_ , const double& lowerBound_ , const double& upperBound_ ,
+             const bool& statistics_ , const bool& plotLog_ , const bool& plotNormalized_ ,
+             const std::string& plotFirst_ , const std::string& folder, 
+             const unsigned int& mc, DQMStore::IBooker & ibook) ;
 
   virtual ~FlavourHistograms () ;
 
@@ -149,9 +149,9 @@ protected:
 
 template <class T>
 FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_, const std::string& baseNameDescription_ ,
-					 const int& nBins_ , const double& lowerBound_ , const double& upperBound_ ,
-					 const std::string& plotFirst_, const std::string& folder, 
-					 const unsigned int& mc, DQMStore::IGetter & iget) :
+                     const int& nBins_ , const double& lowerBound_ , const double& upperBound_ ,
+                     const std::string& plotFirst_, const std::string& folder, 
+                     const unsigned int& mc, DQMStore::IGetter & iget) :
   theMaxDimension(-1), theIndexToPlot(-1), theBaseNameTitle ( baseNameTitle_ ) , theBaseNameDescription ( baseNameDescription_ ) ,
   theNBins ( nBins_ ) , theLowerBound ( lowerBound_ ) , theUpperBound ( upperBound_ ) ,
   theStatistics ( false ) , thePlotLog ( false ) , thePlotNormalized ( false ) ,
@@ -212,10 +212,10 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_, cons
 
 template <class T>
 FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , const std::string& baseNameDescription_ ,
-					 const int& nBins_ , const double& lowerBound_ , const double& upperBound_ ,
-					 const bool& statistics_ , const bool& plotLog_ , const bool& plotNormalized_ ,
-					 const std::string& plotFirst_, const std::string& folder, 
-					 const unsigned int& mc, DQMStore::IBooker & ibook) :
+                     const int& nBins_ , const double& lowerBound_ , const double& upperBound_ ,
+                     const bool& statistics_ , const bool& plotLog_ , const bool& plotNormalized_ ,
+                     const std::string& plotFirst_, const std::string& folder, 
+                     const unsigned int& mc, DQMStore::IBooker & ibook) :
   theMaxDimension(-1), theIndexToPlot(-1), theBaseNameTitle ( baseNameTitle_ ) , theBaseNameDescription ( baseNameDescription_ ) ,
   theNBins ( nBins_ ) , theLowerBound ( lowerBound_ ) , theUpperBound ( upperBound_ ) ,
   theStatistics ( statistics_ ) , thePlotLog ( plotLog_ ) , thePlotNormalized ( plotNormalized_ ) ,
@@ -277,11 +277,11 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
     if(theHisto_all) theHisto_all ->getTH1F()->Sumw2() ; 
     if (mcPlots_ ) {  
       if (mcPlots_>2 ) {
-	theHisto_d   ->getTH1F()->Sumw2() ; 
-	theHisto_u   ->getTH1F()->Sumw2() ; 
-	theHisto_s   ->getTH1F()->Sumw2() ;
-	theHisto_g   ->getTH1F()->Sumw2() ; 
-	theHisto_dus ->getTH1F()->Sumw2() ; 
+        theHisto_d   ->getTH1F()->Sumw2() ; 
+        theHisto_u   ->getTH1F()->Sumw2() ; 
+        theHisto_s   ->getTH1F()->Sumw2() ;
+        theHisto_g   ->getTH1F()->Sumw2() ; 
+        theHisto_dus ->getTH1F()->Sumw2() ; 
       } 
       theHisto_c   ->getTH1F()->Sumw2() ; 
       theHisto_b   ->getTH1F()->Sumw2() ; 
@@ -329,7 +329,7 @@ FlavourHistograms<T>::fill ( const int & flavour,  const T * variable) const
     for ( int i = 0 ; i != iMax ; ++i ) {
       // check if only one index to be plotted (<0: switched off -> plot all)
       if ( ( theIndexToPlot < 0 ) || ( i == theIndexToPlot ) ) { 
-	fillVariable ( flavour , *(variable+i) , 1.) ;
+        fillVariable ( flavour , *(variable+i) , 1.) ;
       }
     }
 
@@ -348,11 +348,11 @@ void FlavourHistograms<T>::settitle(const char* title) {
  if(theHisto_all) theHisto_all ->setAxisTitle(title) ;
     if (mcPlots_) {  
       if (mcPlots_>2 ) {
-	theHisto_d   ->setAxisTitle(title) ;
-	theHisto_u   ->setAxisTitle(title) ;
-	theHisto_s   ->setAxisTitle(title) ;
-	theHisto_g   ->setAxisTitle(title) ;
-	theHisto_dus ->setAxisTitle(title) ;
+        theHisto_d   ->setAxisTitle(title) ;
+        theHisto_u   ->setAxisTitle(title) ;
+        theHisto_s   ->setAxisTitle(title) ;
+        theHisto_g   ->setAxisTitle(title) ;
+        theHisto_dus ->setAxisTitle(title) ;
       }
       theHisto_c   ->setAxisTitle(title) ;
       theHisto_b   ->setAxisTitle(title) ;
@@ -379,7 +379,7 @@ void FlavourHistograms<T>::plot (TPad * theCanvas /* = 0 */) {
 //   
 //   // here: plot histograms in a canvas
 //   theCanvas = new TCanvas ( "C" + theBaseNameTitle , "C" + theBaseNameDescription ,
-// 			    btppXCanvas , btppYCanvas ) ;
+//                 btppXCanvas , btppYCanvas ) ;
 //   theCanvas->SetFillColor ( 0 ) ;
 //   theCanvas->cd  ( 1 ) ;
   gPad->SetLogy  ( 0 ) ;
@@ -482,8 +482,7 @@ void FlavourHistograms<T>::plot (TPad * theCanvas /* = 0 */) {
   }
 
   if ( thePlotNormalized ) {
-    if (histo[0]->getTH1F()->GetEntries() != 0) {histo[0]->getTH1F() ->DrawNormalized() ;} else {    histo[0]->getTH1F() ->SetMaximum(1.0);
-histo[0] ->getTH1F()->Draw() ;}
+    if (histo[0]->getTH1F()->GetEntries() != 0) {histo[0]->getTH1F() ->DrawNormalized() ;} else {    histo[0]->getTH1F() ->SetMaximum(1.0); histo[0] ->getTH1F()->Draw() ;}
     if (histo[1]->getTH1F()->GetEntries() != 0) histo[1] ->getTH1F()->DrawNormalized("Same") ;
     if (histo[2]->getTH1F()->GetEntries() != 0) histo[2]->getTH1F() ->DrawNormalized("Same") ;
     if ((histo[3] != 0) && (histo[3]->getTH1F()->GetEntries() != 0))  histo[3] ->getTH1F()->DrawNormalized("Same") ;
@@ -522,7 +521,7 @@ void FlavourHistograms<T>::ComputeEfficiency(TH1F* num, TH1F* den, int bin){
   double errVal = 0.;
   double numVal = num->GetBinContent(bin);
   double denVal = den->GetBinContent(bin);
-  if (denVal > 0 && numVal > 0 && numVal <= denVal) {
+  if (denVal > 0 && numVal <= denVal) {
     effVal = numVal / denVal; 
     errVal = ClopperPearsonUnc(numVal, denVal);
   }
@@ -536,11 +535,11 @@ void FlavourHistograms<T>::divide ( const FlavourHistograms<T> & bHD ) {
     if(theHisto_all) ComputeEfficiency(theHisto_all  ->getTH1F(), bHD.histo_all(), bin);
     if (mcPlots_) {
       if (mcPlots_>2 ) {
-	ComputeEfficiency(theHisto_d    ->getTH1F(), bHD.histo_d   (), bin) ;    
-	ComputeEfficiency(theHisto_u    ->getTH1F(), bHD.histo_u   (), bin) ;
-	ComputeEfficiency(theHisto_s    ->getTH1F(), bHD.histo_s   (), bin) ;
-	ComputeEfficiency(theHisto_g    ->getTH1F(), bHD.histo_g   (), bin) ;
-	ComputeEfficiency(theHisto_dus  ->getTH1F(), bHD.histo_dus (), bin) ;
+        ComputeEfficiency(theHisto_d    ->getTH1F(), bHD.histo_d   (), bin) ;    
+        ComputeEfficiency(theHisto_u    ->getTH1F(), bHD.histo_u   (), bin) ;
+        ComputeEfficiency(theHisto_s    ->getTH1F(), bHD.histo_s   (), bin) ;
+        ComputeEfficiency(theHisto_g    ->getTH1F(), bHD.histo_g   (), bin) ;
+        ComputeEfficiency(theHisto_dus  ->getTH1F(), bHD.histo_dus (), bin) ;
       }
       ComputeEfficiency(theHisto_c    ->getTH1F(), bHD.histo_c   (), bin) ;
       ComputeEfficiency(theHisto_b    ->getTH1F(), bHD.histo_b   (), bin) ;
@@ -583,22 +582,22 @@ void FlavourHistograms<T>::fillVariable ( const int & flavour , const T & var , 
   switch(flavour) {
     case 1:
       if (mcPlots_>2 ) {
-	theHisto_d->Fill( var ,w);
-	if(theBaseNameDescription != "Jet Multiplicity") theHisto_dus->Fill( var ,w);
+    theHisto_d->Fill( var ,w);
+    if(theBaseNameDescription != "Jet Multiplicity") theHisto_dus->Fill( var ,w);
       }
       if(theBaseNameDescription != "Jet Multiplicity") theHisto_dusg->Fill( var ,w);
       return;
     case 2:
       if (mcPlots_>2 ) {
-	theHisto_u->Fill( var ,w);
-	if(theBaseNameDescription != "Jet Multiplicity") theHisto_dus->Fill( var ,w);
+    theHisto_u->Fill( var ,w);
+    if(theBaseNameDescription != "Jet Multiplicity") theHisto_dus->Fill( var ,w);
       }
       if(theBaseNameDescription != "Jet Multiplicity") theHisto_dusg->Fill( var ,w);
       return;
     case 3:
       if (mcPlots_>2 ) {
-	theHisto_s->Fill( var ,w);
-	if(theBaseNameDescription != "Jet Multiplicity") theHisto_dus->Fill( var ,w);
+    theHisto_s->Fill( var ,w);
+    if(theBaseNameDescription != "Jet Multiplicity") theHisto_dus->Fill( var ,w);
       }
       if(theBaseNameDescription != "Jet Multiplicity") theHisto_dusg->Fill( var ,w);
       return;
@@ -634,11 +633,11 @@ std::vector<TH1F*> FlavourHistograms<T>::getHistoVector() const
   if(theHisto_all) histoVector.push_back ( theHisto_all->getTH1F() );
     if (mcPlots_) {  
       if (mcPlots_>2 ) {
-	histoVector.push_back ( theHisto_d->getTH1F()   );
-	histoVector.push_back ( theHisto_u->getTH1F()   );
-	histoVector.push_back ( theHisto_s->getTH1F()   );
-	histoVector.push_back ( theHisto_g ->getTH1F()  );
-	histoVector.push_back ( theHisto_dus->getTH1F() );
+        histoVector.push_back ( theHisto_d->getTH1F()   );
+        histoVector.push_back ( theHisto_u->getTH1F()   );
+        histoVector.push_back ( theHisto_s->getTH1F()   );
+        histoVector.push_back ( theHisto_g ->getTH1F()  );
+        histoVector.push_back ( theHisto_dus->getTH1F() );
       }
       histoVector.push_back ( theHisto_c->getTH1F()   );
       histoVector.push_back ( theHisto_b->getTH1F()   );

--- a/DQMOffline/RecoB/interface/HistoProviderDQM.h
+++ b/DQMOffline/RecoB/interface/HistoProviderDQM.h
@@ -10,30 +10,30 @@ class MonitorElement;
 class HistoProviderDQM  {
  public:
   HistoProviderDQM(const std::string& prefix, const std::string& label, DQMStore::IBooker & ibook);
-  virtual ~HistoProviderDQM(){}
+  virtual ~HistoProviderDQM() {}
 
-  virtual MonitorElement* book1D       (const std::string &name,
+  virtual MonitorElement* book1D(const std::string &name,
                       const std::string &title,
-                      const int& nchX, const double& lowX, const double& highX) ;
+                      const int& nchX, const double& lowX, const double& highX);
   
-  virtual MonitorElement* book1D       (const std::string &name,
+  virtual MonitorElement* book1D(const std::string &name,
                       const std::string &title,
-                      const int& nchX, float *xbinsize) ;
+                      const int& nchX, float *xbinsize);
 
-  virtual MonitorElement* book2D       (const std::string &name,
+  virtual MonitorElement* book2D(const std::string &name,
                       const std::string &title,
                       const int& nchX, const double& lowX, const double& highX,
-                      const int& nchY, const double& lowY, const double& highY) ;
+                      const int& nchY, const double& lowY, const double& highY);
   
-  virtual MonitorElement* book2D       (const std::string &name,
+  virtual MonitorElement* book2D(const std::string &name,
                       const std::string &title,
                       const int& nchX, float *xbinsize,
-                      const int& nchY, float *ybinsize) ;
+                      const int& nchY, float *ybinsize);
 
-  virtual MonitorElement* bookProfile       (const std::string &name,
+  virtual MonitorElement* bookProfile(const std::string &name,
                       const std::string &title,
                       int nchX, double lowX, double highX,
-                      int nchY, double lowY, double highY) ;
+                      int nchY, double lowY, double highY);
 
   void setDir(const std::string&);
 

--- a/DQMOffline/RecoB/interface/HistoShifter.h
+++ b/DQMOffline/RecoB/interface/HistoShifter.h
@@ -5,8 +5,8 @@
 
 class HistoShifter {
  public:
-  HistoShifter (){}
-  ~HistoShifter(){}
+  HistoShifter() {}
+  ~HistoShifter() {}
   bool insertAndShift(TH1F * in, const float& value);
   bool insertAndShift(TH1F * in, const float& value, const float& error);
 };

--- a/DQMOffline/RecoB/interface/IPTagPlotter.h
+++ b/DQMOffline/RecoB/interface/IPTagPlotter.h
@@ -13,13 +13,12 @@ class IPTagPlotter : public BaseTagInfoPlotter {
 
  public:
   IPTagPlotter (const std::string & tagName, const EtaPtBin & etaPtBin,
-		     const edm::ParameterSet& pSet, const unsigned int& mc, 
-		     const bool& wf, DQMStore::IBooker & ibook);
+		     const edm::ParameterSet& pSet, unsigned int mc, 
+		     bool wf, DQMStore::IBooker & ibook);
 
-  ~IPTagPlotter () ;
+  ~IPTagPlotter ();
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, double jec, int jetFlavour, float w=1);
 
   virtual void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
 
@@ -31,52 +30,55 @@ class IPTagPlotter : public BaseTagInfoPlotter {
 
  private:
 
-  int	nBinEffPur_ ;
-  double startEffPur_ ; 
-  double endEffPur_ ; 
+  int nBinEffPur_;
+  double startEffPur_; 
+  double endEffPur_; 
   unsigned int mcPlots_;
   bool willFinalize_;
   bool makeQualityPlots_;
 
-  TrackIPHistograms<double> * tkcntHistosSig3D[5];
-  TrackIPHistograms<double> * tkcntHistosSig2D[5];
-  TrackIPHistograms<double> * tkcntHistosErr3D[5];
-  TrackIPHistograms<double> * tkcntHistosErr2D[5];
-  TrackIPHistograms<double> * tkcntHistosVal3D[5];
-  TrackIPHistograms<double> * tkcntHistosVal2D[5];
-  TrackIPHistograms<double> * tkcntHistosDecayLengthVal2D[5];
-  TrackIPHistograms<double> * tkcntHistosDecayLengthVal3D[5];
-  TrackIPHistograms<double> * tkcntHistosJetDistVal2D[5];
-  TrackIPHistograms<double> * tkcntHistosJetDistVal3D[5];
-  TrackIPHistograms<double> * tkcntHistosJetDistSign2D[5];
-  TrackIPHistograms<double> * tkcntHistosJetDistSign3D[5];
-  TrackIPHistograms<double> * tkcntHistosTkNChiSqr2D[5];
-  TrackIPHistograms<double> * tkcntHistosTkNChiSqr3D[5];
-  TrackIPHistograms<double> * tkcntHistosTkPt2D[5];
-  TrackIPHistograms<double> * tkcntHistosTkPt3D[5];
-  TrackIPHistograms<int> * tkcntHistosTkNHits2D[5];
-  TrackIPHistograms<int> * tkcntHistosTkNHits3D[5];
-  TrackIPHistograms<int> * tkcntHistosTkNPixelHits2D[5];
-  TrackIPHistograms<int> * tkcntHistosTkNPixelHits3D[5];
-  FlavourHistograms<int> * trkNbr3D, * trkNbr2D;
-  double lowerIPSBound, upperIPSBound,lowerIPBound, upperIPBound,lowerIPEBound, upperIPEBound ;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosSig3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosSig2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosErr3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosErr2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosVal3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosVal2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosDecayLengthVal2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosDecayLengthVal3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosJetDistVal2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosJetDistVal3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosJetDistSign2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosJetDistSign3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosTkNChiSqr2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosTkNChiSqr3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosTkPt2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<double>> > tkcntHistosTkPt3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<int>> >    tkcntHistosTkNHits2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<int>> >    tkcntHistosTkNHits3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<int>> >    tkcntHistosTkNPixelHits2D;
+  std::vector< std::unique_ptr<TrackIPHistograms<int>> >    tkcntHistosTkNPixelHits3D;
+  
+  std::unique_ptr<FlavourHistograms<int>> trkNbr3D, trkNbr2D;
+  
+  double lowerIPSBound, upperIPSBound,lowerIPBound, upperIPBound,lowerIPEBound, upperIPEBound;
   int nBinsIPS, nBinsIP, nBinsIPE;
   double minDecayLength, maxDecayLength, minJetDistance, maxJetDistance;
 
-  EffPurFromHistos * effPurFromHistos[4] ;
+  std::vector< std::unique_ptr<EffPurFromHistos> > effPurFromHistos;
 
-  TrackIPHistograms<float> * tkcntHistosProb3D[5];
-  TrackIPHistograms<float> * tkcntHistosProb2D[5];
-  TrackIPHistograms<float> * tkcntHistosTkProbIPneg2D, * tkcntHistosTkProbIPpos2D;
-  TrackIPHistograms<float> * tkcntHistosTkProbIPneg3D, * tkcntHistosTkProbIPpos3D;
-  TrackIPHistograms<double> * ghostTrackWeightHisto;
-  TrackIPHistograms<double> * ghostTrackDistanceValuHisto, * ghostTrackDistanceSignHisto;
+  std::vector< std::unique_ptr<TrackIPHistograms<float>> > tkcntHistosProb3D;
+  std::vector< std::unique_ptr<TrackIPHistograms<float>> > tkcntHistosProb2D;
+  
+  std::unique_ptr<TrackIPHistograms<float>> tkcntHistosTkProbIPneg2D, tkcntHistosTkProbIPpos2D;
+  std::unique_ptr<TrackIPHistograms<float>> tkcntHistosTkProbIPneg3D, tkcntHistosTkProbIPpos3D;
+  std::unique_ptr<TrackIPHistograms<double>> ghostTrackWeightHisto;
+  std::unique_ptr<TrackIPHistograms<double>> ghostTrackDistanceValuHisto, ghostTrackDistanceSignHisto;
 
-  FlavourHistograms<int> * trackQualHisto;
-  FlavourHistograms<int> * selectedTrackQualHisto;
-  FlavourHistograms2D<double, int> * trackMultVsJetPtHisto;
-  FlavourHistograms2D<double, int> * selectedTrackMultVsJetPtHisto;
-} ;
+  std::unique_ptr<FlavourHistograms<int>> trackQualHisto;
+  std::unique_ptr<FlavourHistograms<int>> selectedTrackQualHisto;
+  std::unique_ptr<FlavourHistograms2D<double, int>> trackMultVsJetPtHisto;
+  std::unique_ptr<FlavourHistograms2D<double, int>> selectedTrackMultVsJetPtHisto;
+};
 
 #include "DQMOffline/RecoB/interface/IPTagPlotter_cc.h"
 

--- a/DQMOffline/RecoB/interface/IPTagPlotter_cc.h
+++ b/DQMOffline/RecoB/interface/IPTagPlotter_cc.h
@@ -6,8 +6,8 @@
 
 template <class Container, class Base>
 IPTagPlotter<Container, Base>::IPTagPlotter(const std::string & tagName,
-						      const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
-						      const unsigned int& mc, const bool& wf, DQMStore::IBooker & ibook_) :
+                              const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
+                              unsigned int mc, bool wf, DQMStore::IBooker & ibook_):
   BaseTagInfoPlotter(tagName, etaPtBin),
   nBinEffPur_(pSet.getParameter<int>("nBinEffPur")),
   startEffPur_(pSet.getParameter<double>("startEffPur")),
@@ -32,584 +32,298 @@ IPTagPlotter<Container, Base>::IPTagPlotter(const std::string & tagName,
 
   if (willFinalize_) return;
 
-  trkNbr3D = new TrackIPHistograms<int>
-	("selTrksNbr_3D" + theExtensionString, "Number of selected tracks for 3D IPS", 31, -0.5, 30.5,
-	 false, true, true, "b", trackIPDir ,mc, makeQualityPlots_, ibook_);
+  // Number of tracks
+  // 3D
+  trkNbr3D = std::make_unique<TrackIPHistograms<int>>
+    ("selTrksNbr_3D" + theExtensionString, "Number of selected tracks for 3D IPS", 31, -0.5, 30.5,
+     false, true, true, "b", trackIPDir ,mc, makeQualityPlots_, ibook_);
 
-  trkNbr2D = new TrackIPHistograms<int>
-	("selTrksNbr_2D" + theExtensionString, "Number of selected tracks for 2D IPS", 31, -0.5, 30.5,
-	 false, true, true, "b", trackIPDir ,mc, makeQualityPlots_, ibook_);
+  // 2D
+  trkNbr2D = std::make_unique<TrackIPHistograms<int>>
+    ("selTrksNbr_2D" + theExtensionString, "Number of selected tracks for 2D IPS", 31, -0.5, 30.5,
+     false, true, true, "b", trackIPDir ,mc, makeQualityPlots_, ibook_);
 
   // IP significance
   // 3D
-  tkcntHistosSig3D[4] = new TrackIPHistograms<double>
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosSig3D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("ips" + std::to_string(i) + "_3D" + theExtensionString, "3D IP significance " + std::to_string(i) + ".trk",
+            nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+  tkcntHistosSig3D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("ips_3D" + theExtensionString, "3D IP significance",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig3D[0] = new TrackIPHistograms<double>
-       ("ips1_3D" + theExtensionString, "3D IP significance 1.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir,mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig3D[1] = new TrackIPHistograms<double>
-       ("ips2_3D" + theExtensionString, "3D IP significance 2.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig3D[2] = new TrackIPHistograms<double>
-       ("ips3_3D" + theExtensionString, "3D IP significance 3.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig3D[3] = new TrackIPHistograms<double>
-       ("ips4_3D" + theExtensionString, "3D IP significance 4.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
   //2D
-  tkcntHistosSig2D[4] = new TrackIPHistograms<double>
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosSig2D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("ips" + std::to_string(i) + "_2D" + theExtensionString, "2D IP significance " + std::to_string(i) + ".trk",
+            nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosSig2D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("ips_2D" + theExtensionString, "2D IP significance",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig2D[0] = new TrackIPHistograms<double>
-       ("ips1_2D" + theExtensionString, "2D IP significance 1.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig2D[1] = new TrackIPHistograms<double>
-       ("ips2_2D" + theExtensionString, "2D IP significance 2.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig2D[2] = new TrackIPHistograms<double>
-       ("ips3_2D" + theExtensionString, "2D IP significance 3.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosSig2D[3] = new TrackIPHistograms<double>
-       ("ips4_2D" + theExtensionString, "2D IP significance 4.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        nBinsIPS, lowerIPSBound, upperIPSBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
   // IP value
   //3D
-  tkcntHistosVal3D[4] = new TrackIPHistograms<double>
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosVal3D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("ip" + std::to_string(i) + "_3D" + theExtensionString, "3D IP value " + std::to_string(i) + ".trk",
+            nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosVal3D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("ip_3D" + theExtensionString, "3D IP value",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal3D[0] = new TrackIPHistograms<double>
-       ("ip1_3D" + theExtensionString, "3D IP value 1.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal3D[1] = new TrackIPHistograms<double>
-       ("ip2_3D" + theExtensionString, "3D IP value 2.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal3D[2] = new TrackIPHistograms<double>
-       ("ip3_3D" + theExtensionString, "3D IP value 3.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal3D[3] = new TrackIPHistograms<double>
-       ("ip4_3D" + theExtensionString, "3D IP value 4.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
   //2D
-  tkcntHistosVal2D[4] = new TrackIPHistograms<double>
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosVal2D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("ip" + std::to_string(i) + "_2D" + theExtensionString, "2D IP value " + std::to_string(i) + ".trk",
+            nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosVal2D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("ip_2D" + theExtensionString, "2D IP value",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal2D[0] = new TrackIPHistograms<double>
-       ("ip1_2D" + theExtensionString, "2D IP value 1.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal2D[1] = new TrackIPHistograms<double>
-       ("ip2_2D" + theExtensionString, "2D IP value 2.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal2D[2] = new TrackIPHistograms<double>
-       ("ip3_2D" + theExtensionString, "2D IP value 3.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosVal2D[3] = new TrackIPHistograms<double>
-       ("ip4_2D" + theExtensionString, "2D IP value 4.trk",
-	nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        nBinsIP, lowerIPBound, upperIPBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
 
   // IP error
   // 3D
-  tkcntHistosErr3D[4] = new TrackIPHistograms<double>
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosErr3D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("ipe" + std::to_string(i) + "_3D" + theExtensionString, "3D IP error " + std::to_string(i) + ".trk",
+            nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosErr3D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("ipe_3D" + theExtensionString, "3D IP error",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr3D[0] = new TrackIPHistograms<double>
-       ("ipe1_3D" + theExtensionString, "3D IP error 1.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr3D[1] = new TrackIPHistograms<double>
-       ("ipe2_3D" + theExtensionString, "3D IP error 2.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr3D[2] = new TrackIPHistograms<double>
-       ("ipe3_3D" + theExtensionString, "3D IP error 3.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr3D[3] = new TrackIPHistograms<double>
-       ("ipe4_3D" + theExtensionString, "3D IP error 4.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
   //2D
-  tkcntHistosErr2D[4] = new TrackIPHistograms<double>
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosErr2D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("ipe" + std::to_string(i) + "_2D" + theExtensionString, "2D IP error " + std::to_string(i) + ".trk",
+            nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosErr2D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("ipe_2D" + theExtensionString, "2D IP error",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr2D[0] = new TrackIPHistograms<double>
-       ("ipe1_2D" + theExtensionString, "2D IP error 1.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr2D[1] = new TrackIPHistograms<double>
-       ("ipe2_2D" + theExtensionString, "2D IP error 2.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr2D[2] = new TrackIPHistograms<double>
-       ("ipe3_2D" + theExtensionString, "2D IP error 3.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosErr2D[3] = new TrackIPHistograms<double>
-       ("ipe4_2D" + theExtensionString, "2D IP error 4.trk",
-	nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        nBinsIPE, lowerIPEBound, upperIPEBound, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
   // decay length
-  tkcntHistosDecayLengthVal2D[4] = new TrackIPHistograms<double>
+  //2D
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosDecayLengthVal2D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("decLen" + std::to_string(i) + "_2D" + theExtensionString, "2D Decay Length " + std::to_string(i) + ".trk",
+            50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosDecayLengthVal2D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("decLen_2D" + theExtensionString, "Decay Length 2D",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosDecayLengthVal2D[0] = new TrackIPHistograms<double>
-       ("decLen1_2D" + theExtensionString, "2D Decay Length 1.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+  // 3D
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosDecayLengthVal3D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("decLen" + std::to_string(i) + "_3D" + theExtensionString, "3D Decay Length " + std::to_string(i) + ".trk",
+            50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
 
-  tkcntHistosDecayLengthVal2D[1] = new TrackIPHistograms<double>
-       ("decLen2_2D" + theExtensionString, "2D Decay Length 2.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosDecayLengthVal2D[2] = new TrackIPHistograms<double>
-       ("decLen3_2D" + theExtensionString, "2D Decay Length 3.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosDecayLengthVal2D[3] = new TrackIPHistograms<double>
-       ("decLen4_2D" + theExtensionString, "2D Decay Length 4.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosDecayLengthVal3D[4] = new TrackIPHistograms<double>
+  tkcntHistosDecayLengthVal3D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("decLen_3D" + theExtensionString, "3D Decay Length",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosDecayLengthVal3D[0] = new TrackIPHistograms<double>
-       ("decLen1_3D" + theExtensionString, "3D Decay Length 1.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosDecayLengthVal3D[1] = new TrackIPHistograms<double>
-       ("decLen2_3D" + theExtensionString, "3D Decay Length 2.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosDecayLengthVal3D[2] = new TrackIPHistograms<double>
-       ("decLen3_3D" + theExtensionString, "3D Decay Length 3.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosDecayLengthVal3D[3] = new TrackIPHistograms<double>
-       ("decLen4_3D" + theExtensionString, "3D Decay Length 4.trk",
-	50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, 0.0, 5.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
   // jet distance
-  tkcntHistosJetDistVal2D[4] = new TrackIPHistograms<double>
+  //2D
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosJetDistVal2D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("jetDist" + std::to_string(i) + "_2D" + theExtensionString, "JetDistance 2D " + std::to_string(i) + ".trk",
+            50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosJetDistVal2D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("jetDist_2D" + theExtensionString, "JetDistance 2D",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosJetDistVal2D[0] = new TrackIPHistograms<double>
-       ("jetDist1_2D" + theExtensionString, "JetDistance 2D 1.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+  // 3D
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosJetDistVal3D.push_back(std::make_unique<TrackIPHistograms<double>>
+           ("jetDist" + std::to_string(i) + "_3D" + theExtensionString, "JetDistance 3D " + std::to_string(i) + ".trk",
+            50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
 
-  tkcntHistosJetDistVal2D[1] = new TrackIPHistograms<double>
-       ("jetDist2_2D" + theExtensionString, "JetDistance 2D 2.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistVal2D[2] = new TrackIPHistograms<double>
-       ("jetDist3_2D" + theExtensionString, "JetDistance 2D 3.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistVal2D[3] = new TrackIPHistograms<double>
-       ("jetDist4_2D" + theExtensionString, "JetDistance 2D 4.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistVal3D[4] = new TrackIPHistograms<double>
+  tkcntHistosJetDistVal3D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("jetDist_3D" + theExtensionString, "JetDistance 3D",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosJetDistVal3D[0] = new TrackIPHistograms<double>
-       ("jetDist1_3D" + theExtensionString, "JetDistance 3D 1.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistVal3D[1] = new TrackIPHistograms<double>
-       ("jetDist2_3D" + theExtensionString, "JetDistance 3D 2.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistVal3D[2] = new TrackIPHistograms<double>
-       ("jetDist3_3D" + theExtensionString, "JetDistance 3D 3.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistVal3D[3] = new TrackIPHistograms<double>
-       ("jetDist4_3D" + theExtensionString, "JetDistance 3D 4.trk",
-	50, -0.1, 0.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-  /* // the jet distance significance return always 0 => disabled
-  tkcntHistosJetDistSign2D[4] = new TrackIPHistograms<double>
-       ("jetDistSig_2D" + theExtensionString, "JetDistance Sign 2D",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign2D[0] = new TrackIPHistograms<double>
-       ("jetDistSig1_2D" + theExtensionString, "JetDistance Sign 2D 1.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign2D[1] = new TrackIPHistograms<double>
-       ("jetDistSig2_2D" + theExtensionString, "JetDistance Sign 2D 2.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign2D[2] = new TrackIPHistograms<double>
-       ("jetDistSig3_2D" + theExtensionString, "JetDistance Sign 2D 3.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign2D[3] = new TrackIPHistograms<double>
-       ("jetDistSig4_2D" + theExtensionString, "JetDistance Sign 2D 4.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign3D[4] = new TrackIPHistograms<double>
-       ("jetDistSig_3D" + theExtensionString, "JetDistance Sign 3D",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign3D[0] = new TrackIPHistograms<double>
-       ("jetDistSig1_3D" + theExtensionString, "JetDistance Sign 3D 1.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign3D[1] = new TrackIPHistograms<double>
-       ("jetDistSig2_3D" + theExtensionString, "JetDistance Sign 3D 2.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign3D[2] = new TrackIPHistograms<double>
-       ("jetDistSig3_3D" + theExtensionString, "JetDistance Sign 3D 3.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosJetDistSign3D[3] = new TrackIPHistograms<double>
-       ("jetDistSig4_3D" + theExtensionString, "JetDistance Sign 3D 4.trk",
-	100, -0.001, 0.001, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-  */
   // track chi-squared
-  tkcntHistosTkNChiSqr2D[4] = new TrackIPHistograms<double>
+  // 2D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkNChiSqr2D.push_back(std::make_unique<TrackIPHistograms<double>>
+         ("tkNChiSqr" + std::to_string(i) + "_2D" + theExtensionString, "Normalized Chi Squared 2D " + std::to_string(i) + ".trk",
+          50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosTkNChiSqr2D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("tkNChiSqr_2D" + theExtensionString, "Normalized Chi Squared 2D",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosTkNChiSqr2D[0] = new TrackIPHistograms<double>
-       ("tkNChiSqr1_2D" + theExtensionString, "Normalized Chi Squared 2D 1.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+  // 3D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkNChiSqr3D.push_back(std::make_unique<TrackIPHistograms<double>>
+         ("tkNChiSqr" + std::to_string(i) + "_3D" + theExtensionString, "Normalized Chi Squared 3D " + std::to_string(i) + ".trk",
+          50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
 
-  tkcntHistosTkNChiSqr2D[1] = new TrackIPHistograms<double>
-       ("tkNChiSqr2_2D" + theExtensionString, "Normalized Chi Squared 2D 2.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNChiSqr2D[2] = new TrackIPHistograms<double>
-       ("tkNChiSqr3_2D" + theExtensionString, "Normalized Chi Squared 2D 3.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNChiSqr2D[3] = new TrackIPHistograms<double>
-       ("tkNChiSqr4_2D" + theExtensionString, "Normalized Chi Squared 2D 4.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNChiSqr3D[4] = new TrackIPHistograms<double>
+  tkcntHistosTkNChiSqr3D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("tkNChiSqr_3D" + theExtensionString, "Normalized Chi Squared 3D",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNChiSqr3D[0] = new TrackIPHistograms<double>
-       ("tkNChiSqr1_3D" + theExtensionString, "Normalized Chi Squared 3D 1.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNChiSqr3D[1] = new TrackIPHistograms<double>
-       ("tkNChiSqr2_3D" + theExtensionString, "Normalized Chi Squared 3D 2.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNChiSqr3D[2] = new TrackIPHistograms<double>
-       ("tkNChiSqr3_3D" + theExtensionString, "Normalized Chi Squared 3D 3.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNChiSqr3D[3] = new TrackIPHistograms<double>
-       ("tkNChiSqr4_3D" + theExtensionString, "Normalized Chi Squared 3D 4.trk",
-        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, -0.1, 10.0, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
   // track pT
-  tkcntHistosTkPt2D[4] = new TrackIPHistograms<double>
+  // 2D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkPt2D.push_back(std::make_unique<TrackIPHistograms<double>>
+         ("tkPt" + std::to_string(i) + "_2D" + theExtensionString, "Track Pt 2D " + std::to_string(i) + ".trk",
+          50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosTkPt2D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("tkPt_2D" + theExtensionString, "Track Pt 2D",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosTkPt2D[0] = new TrackIPHistograms<double>
-       ("tkPt1_2D" + theExtensionString, "Track Pt 2D 1.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+  // 3D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkPt3D.push_back(std::make_unique<TrackIPHistograms<double>>
+         ("tkPt" + std::to_string(i) + "_3D" + theExtensionString, "Track Pt 3D " + std::to_string(i) + ".trk",
+          50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
 
-  tkcntHistosTkPt2D[1] = new TrackIPHistograms<double>
-       ("tkPt2_2D" + theExtensionString, "Track Pt 2D 2.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkPt2D[2] = new TrackIPHistograms<double>
-       ("tkPt3_2D" + theExtensionString, "Track Pt 2D 3.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkPt2D[3] = new TrackIPHistograms<double>
-       ("tkPt4_2D" + theExtensionString, "Track Pt 2D 4.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkPt3D[4] = new TrackIPHistograms<double>
+  tkcntHistosTkPt3D.push_back(std::make_unique<TrackIPHistograms<double>>
        ("tkPt_3D" + theExtensionString, "Track Pt 3D",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkPt3D[0] = new TrackIPHistograms<double>
-       ("tkPt1_3D" + theExtensionString, "Track Pt 3D 1.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkPt3D[1] = new TrackIPHistograms<double>
-       ("tkPt2_3D" + theExtensionString, "Track Pt 3D 2.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkPt3D[2] = new TrackIPHistograms<double>
-       ("tkPt3_3D" + theExtensionString, "Track Pt 3D 3.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkPt3D[3] = new TrackIPHistograms<double>
-       ("tkPt4_3D" + theExtensionString, "Track Pt 3D 4.trk",
-        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, -0.1, 50.1, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
   // track nHits
-  tkcntHistosTkNHits2D[4] = new TrackIPHistograms<int>
+  // 2D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkNHits2D.push_back(std::make_unique<TrackIPHistograms<int>>
+         ("tkNHits" + std::to_string(i) + "_2D" + theExtensionString, "Track NHits 2D " + std::to_string(i) + ".trk",
+          31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosTkNHits2D.push_back(std::make_unique<TrackIPHistograms<int>>
        ("tkNHits_2D" + theExtensionString, "Track NHits 2D",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosTkNHits2D[0] = new TrackIPHistograms<int>
-       ("tkNHits1_2D" + theExtensionString, "Track NHits 2D 1.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+  // 3D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkNHits3D.push_back(std::make_unique<TrackIPHistograms<int>>
+         ("tkNHits" + std::to_string(i) + "_3D" + theExtensionString, "Track NHits 3D " + std::to_string(i) + ".trk",
+          31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
 
-  tkcntHistosTkNHits2D[1] = new TrackIPHistograms<int>
-       ("tkNHits2_2D" + theExtensionString, "Track NHits 2D 2.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNHits2D[2] = new TrackIPHistograms<int>
-       ("tkNHits3_2D" + theExtensionString, "Track NHits 2D 3.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNHits2D[3] = new TrackIPHistograms<int>
-       ("tkNHits4_2D" + theExtensionString, "Track NHits 2D 4.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNHits3D[4] = new TrackIPHistograms<int>
+  tkcntHistosTkNHits3D.push_back(std::make_unique<TrackIPHistograms<int>>
        ("tkNHits_3D" + theExtensionString, "Track NHits 3D",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNHits3D[0] = new TrackIPHistograms<int>
-       ("tkNHits1_3D" + theExtensionString, "Track NHits 3D 1.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNHits3D[1] = new TrackIPHistograms<int>
-       ("tkNHits2_3D" + theExtensionString, "Track NHits 3D 2.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNHits3D[2] = new TrackIPHistograms<int>
-       ("tkNHits3_3D" + theExtensionString, "Track NHits 3D 3.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNHits3D[3] = new TrackIPHistograms<int>
-       ("tkNHits4_3D" + theExtensionString, "Track NHits 3D 4.trk",
-        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        31, -0.5, 30.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
   //Pixel hits
-  tkcntHistosTkNPixelHits2D[4] = new TrackIPHistograms<int>
+  // 2D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkNPixelHits2D.push_back(std::make_unique<TrackIPHistograms<int>>
+         ("tkNPixelHits" + std::to_string(i) + "_2D" + theExtensionString, "Track NPixelHits 2D " + std::to_string(i) + ".trk",
+          11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosTkNPixelHits2D.push_back(std::make_unique<TrackIPHistograms<int>>
        ("tkNPixelHits_2D" + theExtensionString, "Track NPixelHits 2D",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosTkNPixelHits2D[0] = new TrackIPHistograms<int>
-       ("tkNPixelHits1_2D" + theExtensionString, "Track NPixelHits 2D 1.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+  // 3D
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosTkNPixelHits3D.push_back(std::make_unique<TrackIPHistograms<int>>
+         ("tkNPixelHits" + std::to_string(i) + "_3D" + theExtensionString, "Track NPixelHits 3D " + std::to_string(i) + ".trk",
+          11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
 
-  tkcntHistosTkNPixelHits2D[1] = new TrackIPHistograms<int>
-       ("tkNPixelHits2_2D" + theExtensionString, "Track NPixelHits 2D 2.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNPixelHits2D[2] = new TrackIPHistograms<int>
-       ("tkNPixelHits3_2D" + theExtensionString, "Track NPixelHits 2D 3.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNPixelHits2D[3] = new TrackIPHistograms<int>
-       ("tkNPixelHits4_2D" + theExtensionString, "Track NPixelHits 2D 4.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNPixelHits3D[4] = new TrackIPHistograms<int>
+  tkcntHistosTkNPixelHits3D.push_back(std::make_unique<TrackIPHistograms<int>>
        ("tkNPixelHits_3D" + theExtensionString, "Track NPixelHits 3D",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNPixelHits3D[0] = new TrackIPHistograms<int>
-       ("tkNPixelHits1_3D" + theExtensionString, "Track NPixelHits 3D 1.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNPixelHits3D[1] = new TrackIPHistograms<int>
-       ("tkNPixelHits2_3D" + theExtensionString, "Track NPixelHits 3D 2.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNPixelHits3D[2] = new TrackIPHistograms<int>
-       ("tkNPixelHits3_3D" + theExtensionString, "Track NPixelHits 3D 3.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosTkNPixelHits3D[3] = new TrackIPHistograms<int>
-       ("tkNPixelHits4_3D" + theExtensionString, "Track NPixelHits 3D 4.trk",
-        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        11, -0.5, 10.5, false, true, true, "b",  trackIPDir, mc, makeQualityPlots_, ibook_));
 
   // probability
-  tkcntHistosProb3D[4] = new TrackIPHistograms<float>
+  // 3D
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosProb3D.push_back(std::make_unique<TrackIPHistograms<float>>
+           ("prob" + std::to_string(i) + "_3D" + theExtensionString, "3D IP probability " + std::to_string(i) + ".trk",
+            52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
+
+  tkcntHistosProb3D.push_back(std::make_unique<TrackIPHistograms<float>>
        ("prob_3D" + theExtensionString, "3D IP probability",
-	50, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+    50, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosProb3D[0] = new TrackIPHistograms<float>
-       ("prob1_3D" + theExtensionString, "3D IP probability 1.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+  // 2D
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosProb2D.push_back(std::make_unique<TrackIPHistograms<float>>
+           ("prob" + std::to_string(i) + "_2D" + theExtensionString, "2D IP probability " + std::to_string(i) + ".trk",
+            52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
+  }
 
-  tkcntHistosProb3D[1] = new TrackIPHistograms<float>
-       ("prob2_3D" + theExtensionString, "3D IP probability 2.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosProb3D[2] = new TrackIPHistograms<float>
-       ("prob3_3D" + theExtensionString, "3D IP probability 3.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosProb3D[3] = new TrackIPHistograms<float>
-       ("prob4_3D" + theExtensionString, "3D IP probability 4.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosProb2D[4] = new TrackIPHistograms<float>
+  tkcntHistosProb2D.push_back(std::make_unique<TrackIPHistograms<float>>
        ("prob_2D" + theExtensionString, "2D IP probability",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_));
 
-  tkcntHistosProb2D[0] = new TrackIPHistograms<float>
-       ("prob1_2D" + theExtensionString, "2D IP probability 1.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosProb2D[1] = new TrackIPHistograms<float>
-       ("prob2_2D" + theExtensionString, "2D IP probability 2.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosProb2D[2] = new TrackIPHistograms<float>
-       ("prob3_2D" + theExtensionString, "2D IP probability 3.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  tkcntHistosProb2D[3] = new TrackIPHistograms<float>
-       ("prob4_2D" + theExtensionString, "2D IP probability 4.trk",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-
-  //probability for tracks with IP value < 0 or IP value > 0
-  tkcntHistosTkProbIPneg2D = new TrackIPHistograms<float>
+  // probability for tracks with IP value < 0 or IP value >> 0
+  tkcntHistosTkProbIPneg2D = std::make_unique<TrackIPHistograms<float>>
        ("probIPneg_2D" + theExtensionString, "2D negative IP probability",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-  tkcntHistosTkProbIPpos2D = new TrackIPHistograms<float>
+        52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_);
+  tkcntHistosTkProbIPpos2D = std::make_unique<TrackIPHistograms<float>>
        ("probIPpos_2D" + theExtensionString, "2D positive IP probability",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-  tkcntHistosTkProbIPneg3D = new TrackIPHistograms<float>
+        52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_);
+  tkcntHistosTkProbIPneg3D = std::make_unique<TrackIPHistograms<float>>
        ("probIPneg_3D" + theExtensionString, "3D negative IP probability",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-  tkcntHistosTkProbIPpos3D = new TrackIPHistograms<float>
+        52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_);
+  tkcntHistosTkProbIPpos3D = std::make_unique<TrackIPHistograms<float>>
        ("probIPpos_3D" + theExtensionString, "3D positive IP probability",
-	52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        52, -1.04, 1.04, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_);
 
-  //ghost Tracks and others
-  ghostTrackDistanceValuHisto = new TrackIPHistograms<double>
+  // ghost Tracks and others
+  ghostTrackDistanceValuHisto = std::make_unique<TrackIPHistograms<double>>
        ("ghostTrackDist" + theExtensionString, "GhostTrackDistance",
-	50, 0.0, 0.1, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-  ghostTrackDistanceSignHisto = new TrackIPHistograms<double>
+        50, 0.0, 0.1, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_);
+  ghostTrackDistanceSignHisto = std::make_unique<TrackIPHistograms<double>>
        ("ghostTrackDistSign" + theExtensionString, "GhostTrackDistance significance",
-	50, -5.0, 15.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
-  ghostTrackWeightHisto = new TrackIPHistograms<double>
+        50, -5.0, 15.0, false, true, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_);
+  ghostTrackWeightHisto = std::make_unique<TrackIPHistograms<double>>
        ("ghostTrackWeight" + theExtensionString, "GhostTrack fit participation weight",
-	50, 0.0, 1.0, false, false, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_) ;
+        50, 0.0, 1.0, false, false, true, "b", trackIPDir, mc, makeQualityPlots_, ibook_);
 
-  trackQualHisto = new FlavourHistograms<int>
+  trackQualHisto = std::make_unique<FlavourHistograms<int>>
        ("trackQual" + theExtensionString, "Track Quality of Tracks Associated to Jets",
         4, -1.5, 2.5, false, true, true, "b",  trackIPDir, mc, ibook_);
 
-  selectedTrackQualHisto = new FlavourHistograms<int>
+  selectedTrackQualHisto = std::make_unique<FlavourHistograms<int>>
        ("selectedTrackQual" + theExtensionString, "Track Quality of Selected Tracks Associated to Jets",
         4, -1.5, 2.5, false, true, true, "b",  trackIPDir, mc, ibook_);
 
-  trackMultVsJetPtHisto = new FlavourHistograms2D<double, int>
+  trackMultVsJetPtHisto = std::make_unique<FlavourHistograms2D<double, int>>
        ("trackMultVsJetPt" + theExtensionString, "Track Multiplicity vs Jet Pt for Tracks Associated to Jets",
         50, 0.0, 250.0, 21, -0.5, 30.5, false,  trackIPDir, mc, true, ibook_);
 
-  selectedTrackMultVsJetPtHisto = new FlavourHistograms2D<double, int>
+  selectedTrackMultVsJetPtHisto = std::make_unique<FlavourHistograms2D<double, int>>
        ("selectedTrackMultVsJetPt" + theExtensionString, "Track Multiplicity vs Jet Pt for Selected Tracks Associated to Jets",
         50, 0.0, 250.0, 21, -0.5, 20.5, false, trackIPDir, mc, true, ibook_);
 
 }
 
 template <class Container, class Base> 
-IPTagPlotter<Container, Base>::~IPTagPlotter ()
-{
-  if (willFinalize_) {
-    for(int n=1; n != 3; ++n) {
-      delete tkcntHistosSig3D[n];      
-      delete effPurFromHistos[n-1];
-    }
-    for(int n=1; n != 3; ++n) {
-      delete tkcntHistosSig2D[n];      
-      delete effPurFromHistos[n+1];
-    }
-    return;
-  }
-
-  delete trkNbr3D;
-  delete trkNbr2D;
-  delete tkcntHistosTkProbIPneg2D;
-  delete tkcntHistosTkProbIPpos2D;
-  delete tkcntHistosTkProbIPneg3D;
-  delete tkcntHistosTkProbIPpos3D;
-  delete ghostTrackDistanceValuHisto;
-  delete ghostTrackDistanceSignHisto;
-  delete ghostTrackWeightHisto;
-  delete trackQualHisto;
-  delete selectedTrackQualHisto;
-  delete trackMultVsJetPtHisto;
-  delete selectedTrackMultVsJetPtHisto;
-
-  for(int n=0; n != 5; ++n) {
-    delete tkcntHistosSig2D[n];
-    delete tkcntHistosSig3D[n];
-    delete tkcntHistosVal2D[n];
-    delete tkcntHistosVal3D[n];
-    delete tkcntHistosErr2D[n];
-    delete tkcntHistosErr3D[n];
-    delete tkcntHistosDecayLengthVal2D[n];
-    delete tkcntHistosDecayLengthVal3D[n];
-    delete tkcntHistosJetDistVal2D[n];
-    delete tkcntHistosJetDistVal3D[n];
-    //delete tkcntHistosJetDistSign2D[n];
-    //delete tkcntHistosJetDistSign3D[n];
-    delete tkcntHistosTkNChiSqr2D[n];
-    delete tkcntHistosTkNChiSqr3D[n];
-    delete tkcntHistosTkPt2D[n];
-    delete tkcntHistosTkPt3D[n];
-    delete tkcntHistosTkNHits2D[n];
-    delete tkcntHistosTkNHits3D[n];  
-    delete tkcntHistosTkNPixelHits2D[n];
-    delete tkcntHistosTkNPixelHits3D[n];
-    delete tkcntHistosProb2D[n];
-    delete tkcntHistosProb3D[n];
-  }
-}
+IPTagPlotter<Container, Base>::~IPTagPlotter() { }
 
 template <class Container, class Base> 
-void IPTagPlotter<Container, Base>::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
-				    const double & jec,
-				    const int & jetFlavour)
-{
-  analyzeTag(baseTagInfo, jec, jetFlavour, 1.);
-}
-
-template <class Container, class Base> 
-void IPTagPlotter<Container, Base>::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
-				    const double & jec,
-				    const int & jetFlavour, const float & w)
+void IPTagPlotter<Container, Base>::analyzeTag (const reco::BaseTagInfo * baseTagInfo, double jec, int jetFlavour, float w/*=1*/)
 {
   //  const reco::TrackIPTagInfo * tagInfo = 
-  //	dynamic_cast<const reco::TrackIPTagInfo *>(baseTagInfo);
+  //    dynamic_cast<const reco::TrackIPTagInfo *>(baseTagInfo);
   const reco::IPTagInfo<Container, Base> * tagInfo = 
     dynamic_cast<const reco::IPTagInfo<Container, Base> *>(baseTagInfo);
 
@@ -626,18 +340,18 @@ void IPTagPlotter<Container, Base>::analyzeTag (const reco::BaseTagInfo * baseTa
 
   std::vector<float> prob2d, prob3d;
   if (tagInfo->hasProbabilities()) {
-    prob2d = tagInfo->probabilities(0);	
-    prob3d = tagInfo->probabilities(1);	
+    prob2d = tagInfo->probabilities(0);    
+    prob3d = tagInfo->probabilities(1);    
   }
 
   std::vector<std::size_t> sortedIndices = tagInfo->sortedIndexes(reco::btag::IP2DSig);
   std::vector<std::size_t> selectedIndices;
   Container sortedTracks = tagInfo->sortedTracks(sortedIndices);
   Container selectedTracks;
-  for(unsigned int n = 0; n != sortedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != sortedIndices.size(); ++n) {
     double decayLength = (ip[sortedIndices[n]].closestToJetAxis - pv).mag();
     double jetDistance = ip[sortedIndices[n]].distanceToJetAxis.value();
-    if(decayLength > minDecayLength && decayLength < maxDecayLength &&
+    if (decayLength > minDecayLength && decayLength < maxDecayLength &&
        fabs(jetDistance) >= minJetDistance && fabs(jetDistance) < maxJetDistance ) {
       selectedIndices.push_back(sortedIndices[n]);
       selectedTracks.push_back(sortedTracks[n]);
@@ -646,147 +360,143 @@ void IPTagPlotter<Container, Base>::analyzeTag (const reco::BaseTagInfo * baseTa
 
   trkNbr2D->fill(jetFlavour, selectedIndices.size(),w);
 
-  for(unsigned int n=0; n != selectedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != selectedIndices.size(); ++n) {
     const reco::Track * track =  reco::btag::toTrack(selectedTracks[n]);
     const reco::TrackBase::TrackQuality& trackQual = highestTrackQual(track);
-    tkcntHistosSig2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.significance(), true,w);
-    tkcntHistosVal2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.value(), true,w);
-    tkcntHistosErr2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.error(), true,w);
+    tkcntHistosSig2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.significance(), true, w);
+    tkcntHistosVal2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.value(), true, w);
+    tkcntHistosErr2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.error(), true, w);
     const double& decayLen = (ip[selectedIndices[n]].closestToJetAxis - pv).mag();
-    tkcntHistosDecayLengthVal2D[4]->fill(jetFlavour, trackQual, decayLen, true,w);
-    tkcntHistosJetDistVal2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true,w);
-    //tkcntHistosJetDistSign2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.significance(), true,w);
-    tkcntHistosTkNChiSqr2D[4]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
-    tkcntHistosTkPt2D[4]->fill(jetFlavour, trackQual, track->pt(), true,w);
-    tkcntHistosTkNHits2D[4]->fill(jetFlavour, trackQual, track->found(), true,w);
-    tkcntHistosTkNPixelHits2D[4]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
-    if(n >= 4) continue;
-    tkcntHistosSig2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.significance(), true,w);
-    tkcntHistosVal2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.value(), true,w);
-    tkcntHistosErr2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.error(), true,w);
-    tkcntHistosDecayLengthVal2D[n]->fill(jetFlavour, trackQual, decayLen, true,w);
-    tkcntHistosJetDistVal2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true,w);
-    //tkcntHistosJetDistSign2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.significance(), true,w);
-    tkcntHistosTkNChiSqr2D[n]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
-    tkcntHistosTkPt2D[n]->fill(jetFlavour, trackQual, track->pt(), true,w);
-    tkcntHistosTkNHits2D[n]->fill(jetFlavour, trackQual, track->found(), true,w);
-    tkcntHistosTkNPixelHits2D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
+    tkcntHistosDecayLengthVal2D[4]->fill(jetFlavour, trackQual, decayLen, true, w);
+    tkcntHistosJetDistVal2D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true, w);
+    tkcntHistosTkNChiSqr2D[4]->fill(jetFlavour, trackQual, track->normalizedChi2(), true, w);
+    tkcntHistosTkPt2D[4]->fill(jetFlavour, trackQual, track->pt(), true, w);
+    tkcntHistosTkNHits2D[4]->fill(jetFlavour, trackQual, track->found(), true, w);
+    tkcntHistosTkNPixelHits2D[4]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true, w);
+    if (n >= 4) continue;
+    tkcntHistosSig2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.significance(), true, w);
+    tkcntHistosVal2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.value(), true, w);
+    tkcntHistosErr2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip2d.error(), true, w);
+    tkcntHistosDecayLengthVal2D[n]->fill(jetFlavour, trackQual, decayLen, true, w);
+    tkcntHistosJetDistVal2D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true, w);
+    tkcntHistosTkNChiSqr2D[n]->fill(jetFlavour, trackQual, track->normalizedChi2(), true, w);
+    tkcntHistosTkPt2D[n]->fill(jetFlavour, trackQual, track->pt(), true, w);
+    tkcntHistosTkNHits2D[n]->fill(jetFlavour, trackQual, track->found(), true, w);
+    tkcntHistosTkNPixelHits2D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true, w);
   }
   sortedIndices = tagInfo->sortedIndexes(reco::btag::Prob2D);
   selectedIndices.clear();
   sortedTracks = tagInfo->sortedTracks(sortedIndices);
   selectedTracks.clear();
-  for(unsigned int n = 0; n != sortedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != sortedIndices.size(); ++n) {
     double decayLength = (ip[sortedIndices[n]].closestToJetAxis - pv).mag();
     double jetDistance = ip[sortedIndices[n]].distanceToJetAxis.value();
-    if(decayLength > minDecayLength && decayLength < maxDecayLength &&
+    if (decayLength > minDecayLength && decayLength < maxDecayLength &&
        fabs(jetDistance) >= minJetDistance && fabs(jetDistance) < maxJetDistance ) {
       selectedIndices.push_back(sortedIndices[n]);
       selectedTracks.push_back(sortedTracks[n]);
     }
   }
-  for(unsigned int n=0; n != selectedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != selectedIndices.size(); ++n) {
     const reco::Track * track = reco::btag::toTrack(selectedTracks[n]);
     const reco::TrackBase::TrackQuality& trackQual = highestTrackQual(track);
-    tkcntHistosProb2D[4]->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true,w);
-    if(ip[selectedIndices[n]].ip2d.value() < 0) tkcntHistosTkProbIPneg2D->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true,w);
-    else tkcntHistosTkProbIPpos2D->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true,w);
-    if(n >= 4) continue;
-    tkcntHistosProb2D[n]->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true,w);
+    tkcntHistosProb2D[4]->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true, w);
+    if (ip[selectedIndices[n]].ip2d.value() < 0) tkcntHistosTkProbIPneg2D->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true, w);
+    else tkcntHistosTkProbIPpos2D->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true, w);
+    if (n >= 4) continue;
+    tkcntHistosProb2D[n]->fill(jetFlavour, trackQual, prob2d[selectedIndices[n]], true, w);
   }
-  for(unsigned int n=selectedIndices.size(); n < 4; ++n){
+  for (unsigned int n = selectedIndices.size(); n < 4; ++n){
     const reco::TrackBase::TrackQuality trackQual = reco::TrackBase::undefQuality;
-    tkcntHistosSig2D[n]->fill(jetFlavour, trackQual, lowerIPSBound-1.0, false,w);
-    tkcntHistosVal2D[n]->fill(jetFlavour, trackQual, lowerIPBound-1.0, false,w);
-    tkcntHistosErr2D[n]->fill(jetFlavour, trackQual, lowerIPEBound-1.0, false,w);
+    tkcntHistosSig2D[n]->fill(jetFlavour, trackQual, lowerIPSBound-1.0, false, w);
+    tkcntHistosVal2D[n]->fill(jetFlavour, trackQual, lowerIPBound-1.0, false, w);
+    tkcntHistosErr2D[n]->fill(jetFlavour, trackQual, lowerIPEBound-1.0, false, w);
   }
   sortedIndices = tagInfo->sortedIndexes(reco::btag::IP3DSig);
   selectedIndices.clear();
   sortedTracks = tagInfo->sortedTracks(sortedIndices);
   selectedTracks.clear();
-  for(unsigned int n = 0; n != sortedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != sortedIndices.size(); ++n) {
     double decayLength = (ip[sortedIndices[n]].closestToJetAxis - pv).mag();
     double jetDistance = ip[sortedIndices[n]].distanceToJetAxis.value();
-    if(decayLength > minDecayLength && decayLength < maxDecayLength &&
+    if (decayLength > minDecayLength && decayLength < maxDecayLength &&
        fabs(jetDistance) >= minJetDistance && fabs(jetDistance) < maxJetDistance ) {
       selectedIndices.push_back(sortedIndices[n]);
       selectedTracks.push_back(sortedTracks[n]);
     }
   }
 
-  trkNbr3D->fill(jetFlavour, selectedIndices.size(),w);
+  trkNbr3D->fill(jetFlavour, selectedIndices.size(), w);
   int nSelectedTracks = selectedIndices.size();
 
-  for(unsigned int n=0; n != selectedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != selectedIndices.size(); ++n) {
     const reco::Track * track = reco::btag::toTrack(selectedTracks[n]);
     const reco::TrackBase::TrackQuality& trackQual = highestTrackQual(track);
-    tkcntHistosSig3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.significance(), true,w);
-    tkcntHistosVal3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.value(), true,w);
-    tkcntHistosErr3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.error(), true,w);
+    tkcntHistosSig3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.significance(), true, w);
+    tkcntHistosVal3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.value(), true, w);
+    tkcntHistosErr3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.error(), true, w);
     const double& decayLen = (ip[selectedIndices[n]].closestToJetAxis - pv).mag();
-    tkcntHistosDecayLengthVal3D[4]->fill(jetFlavour, trackQual, decayLen, true,w);
-    tkcntHistosJetDistVal3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true,w);
-    //tkcntHistosJetDistSign3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.significance(), true,w);
-    tkcntHistosTkNChiSqr3D[4]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
+    tkcntHistosDecayLengthVal3D[4]->fill(jetFlavour, trackQual, decayLen, true, w);
+    tkcntHistosJetDistVal3D[4]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true, w);
+    tkcntHistosTkNChiSqr3D[4]->fill(jetFlavour, trackQual, track->normalizedChi2(), true, w);
     tkcntHistosTkPt3D[4]->fill(jetFlavour, trackQual, track->pt(), true,w);
     tkcntHistosTkNHits3D[4]->fill(jetFlavour, trackQual, track->found(), true,w);
     tkcntHistosTkNPixelHits3D[4]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
     //ghostTrack infos  
-    ghostTrackDistanceValuHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToGhostTrack.value(), true,w);
-    ghostTrackDistanceSignHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToGhostTrack.significance(), true,w);
-    ghostTrackWeightHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ghostTrackWeight, true,w);
-    selectedTrackQualHisto->fill(jetFlavour, trackQual,w);
-    if(n >= 4) continue;
-    tkcntHistosSig3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.significance(), true,w);
-    tkcntHistosVal3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.value(), true,w);
-    tkcntHistosErr3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.error(), true,w);
-    tkcntHistosDecayLengthVal3D[n]->fill(jetFlavour, trackQual, decayLen, true,w);
-    tkcntHistosJetDistVal3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true,w);
-    //tkcntHistosJetDistSign3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.significance(), true,w);
-    tkcntHistosTkNChiSqr3D[n]->fill(jetFlavour, trackQual, track->normalizedChi2(), true,w);
-    tkcntHistosTkPt3D[n]->fill(jetFlavour, trackQual, track->pt(), true,w);
-    tkcntHistosTkNHits3D[n]->fill(jetFlavour, trackQual, track->found(), true,w);
-    tkcntHistosTkNPixelHits3D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true,w);
+    ghostTrackDistanceValuHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToGhostTrack.value(), true, w);
+    ghostTrackDistanceSignHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToGhostTrack.significance(), true, w);
+    ghostTrackWeightHisto->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ghostTrackWeight, true, w);
+    selectedTrackQualHisto->fill(jetFlavour, trackQual, w);
+    if (n >= 4) continue;
+    tkcntHistosSig3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.significance(), true, w);
+    tkcntHistosVal3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.value(), true, w);
+    tkcntHistosErr3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].ip3d.error(), true, w);
+    tkcntHistosDecayLengthVal3D[n]->fill(jetFlavour, trackQual, decayLen, true, w);
+    tkcntHistosJetDistVal3D[n]->fill(jetFlavour, trackQual, ip[selectedIndices[n]].distanceToJetAxis.value(), true, w);
+    tkcntHistosTkNChiSqr3D[n]->fill(jetFlavour, trackQual, track->normalizedChi2(), true, w);
+    tkcntHistosTkPt3D[n]->fill(jetFlavour, trackQual, track->pt(), true, w);
+    tkcntHistosTkNHits3D[n]->fill(jetFlavour, trackQual, track->found(), true, w);
+    tkcntHistosTkNPixelHits3D[n]->fill(jetFlavour, trackQual, track->hitPattern().numberOfValidPixelHits(), true, w);
   }
   sortedIndices = tagInfo->sortedIndexes(reco::btag::Prob3D);
   selectedIndices.clear();
   sortedTracks = tagInfo->sortedTracks(sortedIndices);
   selectedTracks.clear();
-  for(unsigned int n = 0; n != sortedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != sortedIndices.size(); ++n) {
     double decayLength = (ip[sortedIndices[n]].closestToJetAxis - pv).mag();
     double jetDistance = ip[sortedIndices[n]].distanceToJetAxis.value();
-    if(decayLength > minDecayLength && decayLength < maxDecayLength &&
-       fabs(jetDistance) >= minJetDistance && fabs(jetDistance) < maxJetDistance ) {
+    if (decayLength > minDecayLength && decayLength < maxDecayLength &&
+       fabs(jetDistance) >= minJetDistance && fabs(jetDistance) < maxJetDistance) {
       selectedIndices.push_back(sortedIndices[n]);
       selectedTracks.push_back(sortedTracks[n]);
     }
   }
-  for(unsigned int n=0; n != selectedIndices.size(); ++n) {
+  for (unsigned int n = 0; n != selectedIndices.size(); ++n) {
     const reco::Track * track = reco::btag::toTrack(selectedTracks[n]);
     const reco::TrackBase::TrackQuality& trackQual = highestTrackQual(track);
-    tkcntHistosProb3D[4]->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true,w);
-    if(ip[selectedIndices[n]].ip3d.value() < 0) tkcntHistosTkProbIPneg3D->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true,w);
-    else tkcntHistosTkProbIPpos3D->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true,w);
-    if(n >= 4) continue;
-    tkcntHistosProb3D[n]->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true,w);
+    tkcntHistosProb3D[4]->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true, w);
+    if (ip[selectedIndices[n]].ip3d.value() < 0) tkcntHistosTkProbIPneg3D->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true, w);
+    else tkcntHistosTkProbIPpos3D->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true, w);
+    if (n >= 4) continue;
+    tkcntHistosProb3D[n]->fill(jetFlavour, trackQual, prob3d[selectedIndices[n]], true, w);
   }
-  for(unsigned int n=selectedIndices.size(); n < 4; ++n){
+  for (unsigned int n = selectedIndices.size(); n < 4; ++n){
     const reco::TrackBase::TrackQuality trackQual = reco::TrackBase::undefQuality;
-    tkcntHistosSig3D[n]->fill(jetFlavour, trackQual, lowerIPSBound-1.0, false,w);
-    tkcntHistosVal3D[n]->fill(jetFlavour, trackQual, lowerIPBound-1.0, false,w);
-    tkcntHistosErr3D[n]->fill(jetFlavour, trackQual, lowerIPEBound-1.0, false,w);
+    tkcntHistosSig3D[n]->fill(jetFlavour, trackQual, lowerIPSBound-1.0, false, w);
+    tkcntHistosVal3D[n]->fill(jetFlavour, trackQual, lowerIPBound-1.0, false, w);
+    tkcntHistosErr3D[n]->fill(jetFlavour, trackQual, lowerIPEBound-1.0, false, w);
   }
-  for(unsigned int n = 0; n != sortedTracks.size(); ++n) {
-    trackQualHisto->fill(jetFlavour, highestTrackQual(reco::btag::toTrack(sortedTracks[n])),w);
+  for (unsigned int n = 0; n != sortedTracks.size(); ++n) {
+    trackQualHisto->fill(jetFlavour, highestTrackQual(reco::btag::toTrack(sortedTracks[n])), w);
   }
 
   //still need to implement weights in FlavourHistograms2D
-  trackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt()*jec, sortedTracks.size());
-  selectedTrackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt()*jec, nSelectedTracks); //tagInfo->selectedTracks().size());
+  trackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt() * jec, sortedTracks.size());
+  selectedTrackMultVsJetPtHisto->fill(jetFlavour, tagInfo->jet()->pt() * jec, nSelectedTracks); //tagInfo->selectedTracks().size());
 }
 
 template <class Container, class Base> 
-void IPTagPlotter<Container, Base>::finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_)
+void IPTagPlotter<Container, Base>::finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_)
 {
   //
   // final processing:
@@ -794,35 +504,31 @@ void IPTagPlotter<Container, Base>::finalize (DQMStore::IBooker & ibook_, DQMSto
   //
   const std::string trackIPDir(theExtensionString.substr(1));
 
-  tkcntHistosSig3D[1] = new TrackIPHistograms<double>
-       ("ips2_3D" + theExtensionString, "3D IP significance 2.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, "b", trackIPDir, mcPlots_, makeQualityPlots_, igetter_) ;
-  effPurFromHistos[0] = new EffPurFromHistos (tkcntHistosSig3D[1],trackIPDir, mcPlots_, ibook_,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
+  tkcntHistosSig3D.clear();
+  tkcntHistosSig2D.clear();
+  effPurFromHistos.clear();
+  
+  for (unsigned int i = 2; i <= 3; i++) {
+    tkcntHistosSig3D.push_back(
+            std::make_unique<TrackIPHistograms<double>>
+                        ("ips" + std::to_string(i) + "_3D" + theExtensionString, "3D IP significance " + std::to_string(i) + ".trk",
+                        nBinsIPS, lowerIPSBound, upperIPSBound, "b", trackIPDir, mcPlots_, makeQualityPlots_, igetter_));
+    effPurFromHistos.push_back(
+            std::make_unique<EffPurFromHistos>(*tkcntHistosSig3D.back(), trackIPDir, mcPlots_, ibook_,
+                            nBinEffPur_, startEffPur_, endEffPur_));
+  }
 
-  tkcntHistosSig3D[2] = new TrackIPHistograms<double>
-       ("ips3_3D" + theExtensionString, "3D IP significance 3.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, "b", trackIPDir, mcPlots_, makeQualityPlots_, igetter_) ;
-  effPurFromHistos[1] = new EffPurFromHistos (tkcntHistosSig3D[2],trackIPDir, mcPlots_, ibook_,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
+  for (unsigned int i = 2; i <= 3; i++) {
+    tkcntHistosSig2D.push_back(
+            std::make_unique<TrackIPHistograms<double>>
+                    ("ips" + std::to_string(i) + "_2D" + theExtensionString, "2D IP significance " + std::to_string(i) + ".trk",
+                    nBinsIPS, lowerIPSBound, upperIPSBound, "b", trackIPDir, mcPlots_, makeQualityPlots_, igetter_));
+    effPurFromHistos.push_back(
+            std::make_unique<EffPurFromHistos>(*tkcntHistosSig2D.back(), trackIPDir, mcPlots_, ibook_,
+                            nBinEffPur_, startEffPur_, endEffPur_));
+  }
 
-  tkcntHistosSig2D[1] = new TrackIPHistograms<double>
-       ("ips2_2D" + theExtensionString, "2D IP significance 2.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, "b", trackIPDir, mcPlots_, makeQualityPlots_, igetter_) ;
-  effPurFromHistos[2] = new EffPurFromHistos (tkcntHistosSig2D[1],trackIPDir, mcPlots_, ibook_,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
-
-  tkcntHistosSig2D[2] = new TrackIPHistograms<double>
-       ("ips3_2D" + theExtensionString, "2D IP significance 3.trk",
-	nBinsIPS, lowerIPSBound, upperIPSBound, "b", trackIPDir, mcPlots_, makeQualityPlots_, igetter_) ;
-  effPurFromHistos[3] = new EffPurFromHistos (tkcntHistosSig2D[2],trackIPDir, mcPlots_, ibook_,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
-
-  for(int n=0; n != 4; ++n) effPurFromHistos[n]->compute(ibook_);
+  for (int n = 0; n != 4; ++n) effPurFromHistos[n]->compute(ibook_);
 }
 
 
@@ -834,20 +540,20 @@ void IPTagPlotter<Container, Base>::psPlot(const std::string & name)
   TCanvas canvas(cName.c_str(), cName.c_str(), 600, 900);
   canvas.UseCurrentStyle();
   if (willFinalize_) {
-    for(int n=0; n != 2; ++n) {
+    for (int n = 0; n != 2; ++n) {
       canvas.Print((name + cName + ".ps").c_str());
       canvas.Clear();
       canvas.Divide(2,3);
       canvas.cd(1);
-      effPurFromHistos[0+n]->discriminatorNoCutEffic()->plot();
+      effPurFromHistos[0+n]->discriminatorNoCutEffic().plot();
       canvas.cd(2);
-      effPurFromHistos[0+n]->discriminatorCutEfficScan()->plot();
+      effPurFromHistos[0+n]->discriminatorCutEfficScan().plot();
       canvas.cd(3);
       effPurFromHistos[0+n]->plot();
       canvas.cd(4);
-      effPurFromHistos[1+n]->discriminatorNoCutEffic()->plot();
+      effPurFromHistos[1+n]->discriminatorNoCutEffic().plot();
       canvas.cd(5);
-      effPurFromHistos[1+n]->discriminatorCutEfficScan()->plot();
+      effPurFromHistos[1+n]->discriminatorCutEfficScan().plot();
       canvas.cd(6);
       effPurFromHistos[1+n]->plot();
     }
@@ -862,7 +568,7 @@ void IPTagPlotter<Container, Base>::psPlot(const std::string & name)
   trkNbr3D->plot();
   canvas.cd(2);
   tkcntHistosSig3D[4]->plot();
-  for(int n=0; n < 4; n++) {
+  for (int n = 0; n < 4; n++) {
     canvas.cd(3+n);
     tkcntHistosSig3D[n]->plot();
   }
@@ -875,7 +581,7 @@ void IPTagPlotter<Container, Base>::psPlot(const std::string & name)
   trkNbr3D->plot();
   canvas.cd(2);
   tkcntHistosProb3D[4]->plot();
-  for(int n=0; n < 4; n++) {
+  for (int n = 0; n < 4; n++) {
     canvas.cd(3+n);
     tkcntHistosProb3D[n]->plot();
   }
@@ -887,7 +593,7 @@ void IPTagPlotter<Container, Base>::psPlot(const std::string & name)
   trkNbr2D->plot();
   canvas.cd(2);
   tkcntHistosSig2D[4]->plot();
-  for(int n=0; n != 4; ++n) {
+  for (int n = 0; n != 4; ++n) {
     canvas.cd(3+n);
     tkcntHistosSig2D[n]->plot();
   }
@@ -899,7 +605,7 @@ void IPTagPlotter<Container, Base>::psPlot(const std::string & name)
   trkNbr2D->plot();
   canvas.cd(2);
   tkcntHistosProb2D[4]->plot();
-  for(int n=0; n != 4; ++n) {
+  for (int n = 0; n != 4; ++n) {
     canvas.cd(3+n);
     tkcntHistosProb2D[n]->plot();
   }
@@ -923,7 +629,7 @@ template <class Container, class Base>
 void IPTagPlotter<Container, Base>::epsPlot(const std::string & name)
 {
   if (willFinalize_) {
-    for(int n=0; n != 4; ++n) effPurFromHistos[n]->epsPlot(name);
+    for (int n = 0; n != 4; ++n) effPurFromHistos[n]->epsPlot(name);
     return;
   }
   trkNbr2D->epsPlot(name);
@@ -935,7 +641,7 @@ void IPTagPlotter<Container, Base>::epsPlot(const std::string & name)
   ghostTrackDistanceValuHisto->epsPlot(name);
   ghostTrackDistanceSignHisto->epsPlot(name);
   ghostTrackWeightHisto->epsPlot(name);
-  for(int n=0; n != 5; ++n) {
+  for (int n = 0; n != 5; ++n) {
     tkcntHistosSig2D[n]->epsPlot(name);
     tkcntHistosSig3D[n]->epsPlot(name);
     tkcntHistosVal2D[n]->epsPlot(name);
@@ -948,8 +654,6 @@ void IPTagPlotter<Container, Base>::epsPlot(const std::string & name)
     tkcntHistosDecayLengthVal3D[n]->epsPlot(name);
     tkcntHistosJetDistVal2D[n]->epsPlot(name);
     tkcntHistosJetDistVal3D[n]->epsPlot(name);
-    //tkcntHistosJetDistSign2D[n]->epsPlot(name);
-    //tkcntHistosJetDistSign3D[n]->epsPlot(name);
     tkcntHistosTkNChiSqr2D[n]->epsPlot(name);
     tkcntHistosTkNChiSqr3D[n]->epsPlot(name);
     tkcntHistosTkPt2D[n]->epsPlot(name);
@@ -964,9 +668,9 @@ void IPTagPlotter<Container, Base>::epsPlot(const std::string & name)
 
 template <class Container, class Base> 
 reco::TrackBase::TrackQuality IPTagPlotter<Container, Base>::highestTrackQual(const reco::Track * track) const {
-  for(reco::TrackBase::TrackQuality i = reco::TrackBase::highPurity; i != reco::TrackBase::undefQuality; i = reco::TrackBase::TrackQuality(i - 1))
+  for (reco::TrackBase::TrackQuality i = reco::TrackBase::highPurity; i != reco::TrackBase::undefQuality; i = reco::TrackBase::TrackQuality(i - 1))
   {
-    if(track->quality(i))
+    if (track->quality(i))
       return i;
   }
 

--- a/DQMOffline/RecoB/interface/JetTagPlotter.h
+++ b/DQMOffline/RecoB/interface/JetTagPlotter.h
@@ -17,7 +17,7 @@ class JetTagPlotter : public BaseBTagPlotter {
 
   JetTagPlotter (const std::string & tagName, const EtaPtBin & etaPtBin,
 		 const edm::ParameterSet& pSet, const unsigned int& mc , 
-		 const bool& willFinalize, DQMStore::IBooker & ibook, const bool & doCTagPlots = false);
+		 const bool& willFinalize, DQMStore::IBooker & ibook, const bool & doCTagPlots = false, bool doDifferentialPlots=false, double discrCut=-999.);
 
   virtual ~JetTagPlotter () ;
 
@@ -45,17 +45,21 @@ class JetTagPlotter : public BaseBTagPlotter {
 
   // binning and bounds
   // 1) for 'efficiency' versus discriminator cut histos
-  int    discrBins  ;
-  double discrStart_ ;
-  double discrEnd_   ;
-  int	nBinEffPur_ ;
-  double startEffPur_ ; 
-  double endEffPur_ ; 
+  int discrBins;
+  double discrStart_;
+  double discrEnd_;
+  int nBinEffPur_;
+  double startEffPur_; 
+  double endEffPur_; 
 
   unsigned int mcPlots_;
   bool willFinalize_;
 
   bool doCTagPlots_;
+  
+  // Differential plots: efficiency vs. variable for cut on discrimator > cutValue_
+  bool doDifferentialPlots_;
+  double cutValue_;
 
   int *nJets;
   // jet multiplicity
@@ -80,6 +84,12 @@ class JetTagPlotter : public BaseBTagPlotter {
 
   // reconstructed jet phi
   FlavourHistograms<double> * dJetRecPhi;
+  
+  // jet Phi larger than requested discrimnator cut
+  FlavourHistograms<double> * dJetPhiDiscrCut;
+  
+  // jet Eta larger than requested discrimnator cut
+  FlavourHistograms<double> * dJetPseudoRapidityDiscrCut;
 };
 
 #endif

--- a/DQMOffline/RecoB/interface/JetTagPlotter.h
+++ b/DQMOffline/RecoB/interface/JetTagPlotter.h
@@ -61,7 +61,7 @@ class JetTagPlotter : public BaseBTagPlotter {
   bool doDifferentialPlots_;
   double cutValue_;
 
-  int *nJets_;
+  std::vector<int> nJets_;
   
   // jet multiplicity
   FlavourHistograms<int> * jetMultiplicity_;

--- a/DQMOffline/RecoB/interface/JetTagPlotter.h
+++ b/DQMOffline/RecoB/interface/JetTagPlotter.h
@@ -29,17 +29,17 @@ class JetTagPlotter : public BaseBTagPlotter {
   void analyzeTag (const reco::Jet & jet, const double & jec, const float& discriminator, const int& jetFlavour, const float & w);
 
   // final computation, plotting, printing .......
-  void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_) ;
+  void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
 
   // get "2d" histograms for misid. vs. b-eff
-  EffPurFromHistos * getEffPurFromHistos () { return effPurFromHistos ; }
+  EffPurFromHistos * getEffPurFromHistos () { return effPurFromHistos_ ; }
 
   void epsPlot(const std::string & name);
   void psPlot(const std::string & name);
 
-  int nBinEffPur() const {return nBinEffPur_;}
-  double startEffPur() const {return startEffPur_;}
-  double endEffPur() const {return endEffPur_;}
+  int nBinEffPur() const { return nBinEffPur_; }
+  double startEffPur() const { return startEffPur_; }
+  double endEffPur() const { return endEffPur_; }
 
  protected:
 
@@ -61,35 +61,36 @@ class JetTagPlotter : public BaseBTagPlotter {
   bool doDifferentialPlots_;
   double cutValue_;
 
-  int *nJets;
+  int *nJets_;
+  
   // jet multiplicity
-  FlavourHistograms<int> * JetMultiplicity;
+  FlavourHistograms<int> * jetMultiplicity_;
 
   // for the misid vs. eff plots
-  EffPurFromHistos * effPurFromHistos ;
+  EffPurFromHistos * effPurFromHistos_;
 
-  FlavourHistograms<int> * dJetFlav;
+  FlavourHistograms<int> * dJetFlav_;
   
   // Discriminator: again with reasonable binning
-  FlavourHistograms<double> * dDiscriminator;
+  FlavourHistograms<double> * dDiscriminator_;
   
   // reconstructed jet momentum
-  FlavourHistograms<double> * dJetRecMomentum;
+  FlavourHistograms<double> * dJetRecMomentum_;
 
   // reconstructed jet transverse momentum
-  FlavourHistograms<double> * dJetRecPt;
+  FlavourHistograms<double> * dJetRecPt_;
 
   // reconstructed jet eta
-  FlavourHistograms<double> * dJetRecPseudoRapidity;
+  FlavourHistograms<double> * dJetRecPseudoRapidity_;
 
   // reconstructed jet phi
-  FlavourHistograms<double> * dJetRecPhi;
+  FlavourHistograms<double> * dJetRecPhi_;
   
   // jet Phi larger than requested discrimnator cut
-  FlavourHistograms<double> * dJetPhiDiscrCut;
+  FlavourHistograms<double> * dJetPhiDiscrCut_;
   
   // jet Eta larger than requested discrimnator cut
-  FlavourHistograms<double> * dJetPseudoRapidityDiscrCut;
+  FlavourHistograms<double> * dJetPseudoRapidityDiscrCut_;
 };
 
 #endif

--- a/DQMOffline/RecoB/interface/JetTagPlotter.h
+++ b/DQMOffline/RecoB/interface/JetTagPlotter.h
@@ -11,28 +11,28 @@
 #include "DataFormats/BTauReco/interface/JetTag.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-class JetTagPlotter : public BaseBTagPlotter {
+class JetTagPlotter: public BaseBTagPlotter {
 
  public:
 
   JetTagPlotter (const std::string & tagName, const EtaPtBin & etaPtBin,
-		 const edm::ParameterSet& pSet, const unsigned int& mc , 
-		 const bool& willFinalize, DQMStore::IBooker & ibook, const bool & doCTagPlots = false, bool doDifferentialPlots=false, double discrCut=-999.);
+         const edm::ParameterSet& pSet, unsigned int mc, 
+         bool willFinalize, DQMStore::IBooker & ibook, bool doCTagPlots = false, bool doDifferentialPlots=false, double discrCut=-999.);
 
-  virtual ~JetTagPlotter () ;
+  virtual ~JetTagPlotter() ;
 
-  void analyzeTag (); //added to fill the jet multiplicity on data 
-  void analyzeTag (const float & w); //added to fill the jet multiplicity on mc 
-  void analyzeTag (const reco::JetTag & jetTag, const double & jec, const int & jetFlavour);
-  void analyzeTag (const reco::JetTag & jetTag, const double & jec, const int & jetFlavour, const float & w);
-  void analyzeTag (const reco::Jet & jet, const double & jec, const float& discriminator, const int& jetFlavour);
-  void analyzeTag (const reco::Jet & jet, const double & jec, const float& discriminator, const int& jetFlavour, const float & w);
+  void analyzeTag(); //added to fill the jet multiplicity on data 
+  void analyzeTag(float w); //added to fill the jet multiplicity on mc 
+  //void analyzeTag (const reco::JetTag & jetTag, const double & jec, const int & jetFlavour);
+  void analyzeTag(const reco::JetTag & jetTag, double jec, int jetFlavour, float w=1);
+  //void analyzeTag (const reco::Jet & jet, const double & jec, const float& discriminator, const int& jetFlavour);
+  void analyzeTag(const reco::Jet & jet, double jec, float discriminator, int jetFlavour, float w=1);
 
   // final computation, plotting, printing .......
   void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
 
   // get "2d" histograms for misid. vs. b-eff
-  EffPurFromHistos * getEffPurFromHistos () { return effPurFromHistos_ ; }
+  EffPurFromHistos& getEffPurFromHistos() { return *effPurFromHistos_; }
 
   void epsPlot(const std::string & name);
   void psPlot(const std::string & name);
@@ -45,7 +45,6 @@ class JetTagPlotter : public BaseBTagPlotter {
 
   // binning and bounds
   // 1) for 'efficiency' versus discriminator cut histos
-  int discrBins;
   double discrStart_;
   double discrEnd_;
   int nBinEffPur_;
@@ -64,33 +63,33 @@ class JetTagPlotter : public BaseBTagPlotter {
   std::vector<int> nJets_;
   
   // jet multiplicity
-  FlavourHistograms<int> * jetMultiplicity_;
+  std::unique_ptr<FlavourHistograms<int>> jetMultiplicity_;
 
   // for the misid vs. eff plots
-  EffPurFromHistos * effPurFromHistos_;
+  std::unique_ptr<EffPurFromHistos> effPurFromHistos_;
 
-  FlavourHistograms<int> * dJetFlav_;
+  std::unique_ptr<FlavourHistograms<int>> dJetFlav_;
   
   // Discriminator: again with reasonable binning
-  FlavourHistograms<double> * dDiscriminator_;
+  std::unique_ptr<FlavourHistograms<double>> dDiscriminator_;
   
   // reconstructed jet momentum
-  FlavourHistograms<double> * dJetRecMomentum_;
+  std::unique_ptr<FlavourHistograms<double>> dJetRecMomentum_;
 
   // reconstructed jet transverse momentum
-  FlavourHistograms<double> * dJetRecPt_;
+  std::unique_ptr<FlavourHistograms<double>> dJetRecPt_;
 
   // reconstructed jet eta
-  FlavourHistograms<double> * dJetRecPseudoRapidity_;
+  std::unique_ptr<FlavourHistograms<double>> dJetRecPseudoRapidity_;
 
   // reconstructed jet phi
-  FlavourHistograms<double> * dJetRecPhi_;
+  std::unique_ptr<FlavourHistograms<double>> dJetRecPhi_;
   
   // jet Phi larger than requested discrimnator cut
-  FlavourHistograms<double> * dJetPhiDiscrCut_;
+  std::unique_ptr<FlavourHistograms<double>> dJetPhiDiscrCut_;
   
   // jet Eta larger than requested discrimnator cut
-  FlavourHistograms<double> * dJetPseudoRapidityDiscrCut_;
+  std::unique_ptr<FlavourHistograms<double>> dJetPseudoRapidityDiscrCut_;
 };
 
 #endif

--- a/DQMOffline/RecoB/interface/MVAJetTagPlotter.h
+++ b/DQMOffline/RecoB/interface/MVAJetTagPlotter.h
@@ -13,18 +13,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-class MVAJetTagPlotter : public BaseTagInfoPlotter {
+class MVAJetTagPlotter: public BaseTagInfoPlotter {
 
  public:
 
   MVAJetTagPlotter (const std::string & tagName, const EtaPtBin & etaPtBin,
 		    const edm::ParameterSet& pSet, const std::string& folderName, 
-		    const unsigned int& mc, const bool& willFinalize, DQMStore::IBooker & ibook);
+		    unsigned int mc, bool willFinalize, DQMStore::IBooker & ibook);
 
   ~MVAJetTagPlotter ();
 
-  virtual void analyzeTag (const std::vector<const reco::BaseTagInfo *> & baseTagInfos, const double & jec, const int & jetFlavour);
-  virtual void analyzeTag (const std::vector<const reco::BaseTagInfo *> & baseTagInfos, const double & jec, const int & jetFlavour, const float & w);
+  virtual void analyzeTag (const std::vector<const reco::BaseTagInfo *> & baseTagInfos, double jec, int jetFlavour, float w=1);
 
   virtual void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
 
@@ -41,7 +40,7 @@ class MVAJetTagPlotter : public BaseTagInfoPlotter {
   const GenericMVAJetTagComputer *computer;
 
   reco::TaggingVariableName categoryVariable;
-  std::vector<TaggingVariablePlotter*> categoryPlotters;
+  std::vector<std::unique_ptr<TaggingVariablePlotter>> categoryPlotters;
 };
 
 #endif

--- a/DQMOffline/RecoB/interface/SoftLeptonTagPlotter.h
+++ b/DQMOffline/RecoB/interface/SoftLeptonTagPlotter.h
@@ -11,38 +11,37 @@ class SoftLeptonTagPlotter : public BaseTagInfoPlotter {
 public:
 
   SoftLeptonTagPlotter(const std::string & tagName, const EtaPtBin & etaPtBin,
-		       const edm::ParameterSet& pSet, const unsigned int& mc, 
-		       const bool& willFinalize, DQMStore::IBooker & ibook);
+		       const edm::ParameterSet& pSet, unsigned int mc, 
+		       bool willFinalize, DQMStore::IBooker & ibook);
   
-  ~SoftLeptonTagPlotter( void ) ;
+  ~SoftLeptonTagPlotter(void) ;
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
+  void analyzeTag(const reco::BaseTagInfo * baseTagInfo, double jec, int jetFlavour, float w/*=1*/);
 
   virtual void finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_) {}
 
-  void psPlot( const std::string & name );
-  void epsPlot( const std::string & name );
+  void psPlot(const std::string & name);
+  void epsPlot(const std::string & name);
 
 private:
 
   unsigned int mcPlots_;
   bool willFinalize_;
 
-  // keep plots for up to 3 leptons per jet
+  // keep plots for up to 2 leptons per jet
   static const int s_leptons = 2;
-  FlavourHistograms<double> * m_leptonId[s_leptons];   // lepton identification discriminant
-  FlavourHistograms<double> * m_leptonPt[s_leptons];   // lepton transverse momentum
-  FlavourHistograms<double> * m_sip2dsig[s_leptons];      // 2D signed inpact parameter significance
-  FlavourHistograms<double> * m_sip3dsig[s_leptons];      // 3D signed inpact parameter significance
-  FlavourHistograms<double> * m_sip2d[s_leptons];      // 2D signed inpact parameter
-  FlavourHistograms<double> * m_sip3d[s_leptons];      // 3D signed inpact parameter
-  FlavourHistograms<double> * m_ptRel[s_leptons];      // transverse momentum wrt. jet axis
-  FlavourHistograms<double> * m_p0Par[s_leptons];      // parallel momentum wrt. jet axis in the B rest frame
-  FlavourHistograms<double> * m_etaRel[s_leptons];     // (pseudo)rapidity along jet axis
-  FlavourHistograms<double> * m_deltaR[s_leptons];     // (pseudo)angular distance to jet axis
-  FlavourHistograms<double> * m_ratio[s_leptons];      // momentum over jet energy
-  FlavourHistograms<double> * m_ratioRel[s_leptons];   // momentum parallel to jet axis over jet energy
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_leptonId;   // lepton identification discriminant
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_leptonPt;   // lepton transverse momentum
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_sip2dsig;      // 2D signed inpact parameter significance
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_sip3dsig;      // 3D signed inpact parameter significance
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_sip2d;      // 2D signed inpact parameter
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_sip3d;      // 3D signed inpact parameter
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_ptRel;      // transverse momentum wrt. jet axis
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_p0Par;      // parallel momentum wrt. jet axis in the B rest frame
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_etaRel;     // (pseudo)rapidity along jet axis
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_deltaR;     // (pseudo)angular distance to jet axis
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_ratio;      // momentum over jet energy
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > m_ratioRel;   // momentum parallel to jet axis over jet energy
   
 };
 

--- a/DQMOffline/RecoB/interface/TagCorrelationPlotter.h
+++ b/DQMOffline/RecoB/interface/TagCorrelationPlotter.h
@@ -9,30 +9,27 @@
 #include "DataFormats/BTauReco/interface/JetTag.h"
 #include "DQMOffline/RecoB/interface/EffPurFromHistos2D.h"
 
-class TagCorrelationPlotter : public BaseBTagPlotter {
+class TagCorrelationPlotter: public BaseBTagPlotter {
   public:
     TagCorrelationPlotter(const std::string& tagName1, const std::string& tagName2, const EtaPtBin& etaPtBin,
-	                  const edm::ParameterSet& pSet, const unsigned int& mc, const bool doCTagPlots, const bool finalize, DQMStore::IBooker & ibook);
+	                  const edm::ParameterSet& pSet, unsigned int mc, bool doCTagPlots, bool finalize, DQMStore::IBooker & ibook);
 
     virtual ~TagCorrelationPlotter();
 
     void finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
 
     void epsPlot(const std::string & name);
-    void psPlot (const std::string& name) {}
+    void psPlot(const std::string& name) {}
 
-    void analyzeTags(const reco::JetTag& jetTag1, const reco::JetTag& jetTag2, const int& jetFlavour);
-    void analyzeTags(const reco::JetTag& jetTag1, const reco::JetTag& jetTag2, const int& jetFlavour, const float & w);
-
-    void analyzeTags(const float& discr1, const float& discr2, const int& jetFlavour);
-    void analyzeTags(const float& discr1, const float& discr2, const int& jetFlavour, const float & w);
+    void analyzeTags(const reco::JetTag& jetTag1, const reco::JetTag& jetTag2, int jetFlavour, float w=1);
+    void analyzeTags(float discr1, float discr2, int jetFlavour, float w=1);
 
   protected:
     double lowerBound1_, lowerBound2_;
     double upperBound1_, upperBound2_;
-    int   nBinEffPur_ ;
-    double startEffPur_ ;
-    double endEffPur_ ;
+    int nBinEffPur_;
+    double startEffPur_;
+    double endEffPur_;
     bool createProfile_;
 
     std::vector<double> fixedEff_;
@@ -41,9 +38,9 @@ class TagCorrelationPlotter : public BaseBTagPlotter {
     bool doCTagPlots_;
     bool finalize_;
 
-    FlavourHistograms2D<double, double> * correlationHisto_;
+    std::unique_ptr<FlavourHistograms2D<double, double>> correlationHisto_;
 
-    EffPurFromHistos2D * effPurFromHistos2D ;
+    std::unique_ptr<EffPurFromHistos2D> effPurFromHistos2D;
 };
 
 #endif

--- a/DQMOffline/RecoB/interface/TagInfoPlotterFactory.h
+++ b/DQMOffline/RecoB/interface/TagInfoPlotterFactory.h
@@ -8,10 +8,10 @@
 
 class TagInfoPlotterFactory  {
  public:
-   BaseTagInfoPlotter* buildPlotter(const std::string& dataFormatType, const std::string & tagName,
-				    const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
-				    const std::string& folderName, const unsigned int& mc,
-				    const bool& wf, DQMStore::IBooker & ibook);
+     std::unique_ptr<BaseTagInfoPlotter> buildPlotter(const std::string& dataFormatType, const std::string & tagName,
+                    const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
+                    const std::string& folderName, unsigned int mc,
+                    bool wf, DQMStore::IBooker & ibook);
 };
 
 

--- a/DQMOffline/RecoB/interface/TaggingVariablePlotter.h
+++ b/DQMOffline/RecoB/interface/TaggingVariablePlotter.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
-
 #include "DQMOffline/RecoB/interface/BaseTagInfoPlotter.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
@@ -13,26 +11,21 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-class TaggingVariablePlotter : public BaseTagInfoPlotter {
+class TaggingVariablePlotter: public BaseTagInfoPlotter {
 
  public:
 
-  TaggingVariablePlotter (const std::string & tagName, const EtaPtBin & etaPtBin,
-			  const edm::ParameterSet& pSet,
-			  const unsigned int& mc, const bool& willFinalize, DQMStore::IBooker & ibook,
-			  const std::string &category = std::string());
+  TaggingVariablePlotter(const std::string & tagName, const EtaPtBin & etaPtBin,
+              const edm::ParameterSet& pSet,
+              unsigned int mc, bool willFinalize, DQMStore::IBooker & ibook,
+              const std::string &category = std::string());
 
-  ~TaggingVariablePlotter () ;
+  ~TaggingVariablePlotter ();
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
+  void analyzeTag(const reco::BaseTagInfo * baseTagInfo, double jec, int jetFlavour, float w=1);
+  void analyzeTag(const reco::TaggingVariableList & variables, int jetFlavour, float w=1);
 
-  void analyzeTag (const reco::TaggingVariableList & variables, const int & jetFlavour);
-
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
-
-  void analyzeTag (const reco::TaggingVariableList & variables, const int & jetFlavour, const float & w);
-
-  virtual void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_) {}
+  virtual void finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_) {}
 
   void epsPlot(const std::string & name) {}
 
@@ -45,23 +38,23 @@ class TaggingVariablePlotter : public BaseTagInfoPlotter {
   struct VariableConfig {
     VariableConfig(const std::string &name, const edm::ParameterSet& pSet,
                    const std::string &category, const std::string& label, 
-		   const unsigned int& mc, DQMStore::IBooker & ibook);
+                   unsigned int mc, DQMStore::IBooker & ibook);
 
-    reco::TaggingVariableName	var;
-    unsigned int		nBins;
-    double			min, max;
-    bool			logScale;
+    reco::TaggingVariableName var;
+    unsigned int nBins;
+    double min, max;
+    bool logScale;
 
     struct Plot {
-      boost::shared_ptr< FlavourHistograms<double> >	histo;
-      unsigned int					index;
-    } ;
+      std::shared_ptr< FlavourHistograms<double> > histo;
+      unsigned int index;
+    };
 
     std::vector<Plot> plots;
     std::string label;
-  } ;
+  };
 
-  std::vector<VariableConfig>	variables;
-} ;
+  std::vector<VariableConfig> variables;
+};
 
 #endif

--- a/DQMOffline/RecoB/interface/TrackCountingTagPlotter.h
+++ b/DQMOffline/RecoB/interface/TrackCountingTagPlotter.h
@@ -13,14 +13,13 @@ class TrackCountingTagPlotter : public BaseTagInfoPlotter {
 
  public:
 
-  TrackCountingTagPlotter (const std::string & tagName, const EtaPtBin & etaPtBin,
-			   const edm::ParameterSet& pSet, 
-			   const unsigned int& mc, const bool& willfinalize, DQMStore::IBooker & ibook);
+  TrackCountingTagPlotter(const std::string & tagName, const EtaPtBin & etaPtBin,
+               const edm::ParameterSet& pSet, 
+               unsigned int mc, bool willfinalize, DQMStore::IBooker & ibook);
 
-  ~TrackCountingTagPlotter () ;
+  ~TrackCountingTagPlotter ();
 
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour);
-  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, const int & jetFlavour, const float & w);
+  void analyzeTag (const reco::BaseTagInfo * baseTagInfo, double jec, int jetFlavour, float w/*=1*/);
 
   virtual void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
 
@@ -30,18 +29,18 @@ class TrackCountingTagPlotter : public BaseTagInfoPlotter {
 
  private:
   unsigned int mcPlots_;
-  int	nBinEffPur_ ;
-  double startEffPur_ ; 
-  double endEffPur_ ; 
+  int nBinEffPur_;
+  double startEffPur_; 
+  double endEffPur_; 
 
   bool willFinalize_;
 
-  FlavourHistograms<double> * tkcntHistosSig3D[5];
-  FlavourHistograms<double> * tkcntHistosSig2D[5];
-  FlavourHistograms<int> * trkNbr3D, * trkNbr2D;
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > tkcntHistosSig3D;
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > tkcntHistosSig2D;
+  std::unique_ptr<FlavourHistograms<int>> trkNbr3D, trkNbr2D;
   double lowerIPSBound, upperIPSBound;
 
-  EffPurFromHistos * effPurFromHistos[4] ;
-} ;
+  std::vector< std::unique_ptr<EffPurFromHistos> > effPurFromHistos;
+};
 
 #endif

--- a/DQMOffline/RecoB/interface/TrackProbabilityTagPlotter.h
+++ b/DQMOffline/RecoB/interface/TrackProbabilityTagPlotter.h
@@ -9,22 +9,20 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-class TrackProbabilityTagPlotter : public BaseTagInfoPlotter {
+class TrackProbabilityTagPlotter: public BaseTagInfoPlotter {
 
 
  public:
 
-  TrackProbabilityTagPlotter (const std::string & tagName, const EtaPtBin & etaPtBin,
-			      const edm::ParameterSet& pSet, 
-			      const unsigned int& mc, const bool& wf, DQMStore::IBooker & ibook);
+  TrackProbabilityTagPlotter(const std::string & tagName, const EtaPtBin & etaPtBin,
+                  const edm::ParameterSet& pSet, 
+                  const unsigned int& mc, const bool& wf, DQMStore::IBooker & ibook);
 
-  ~TrackProbabilityTagPlotter () ;
+  ~TrackProbabilityTagPlotter();
 
-  void analyzeTag (const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour);
+  void analyzeTag(const reco::BaseTagInfo * tagInfo, double jec, int jetFlavour, float w=1);
 
-  void analyzeTag (const reco::BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour, const float & w);
-
-  virtual void finalize (DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
+  virtual void finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_);
 
   void epsPlot(const std::string & name);
 
@@ -32,14 +30,14 @@ class TrackProbabilityTagPlotter : public BaseTagInfoPlotter {
 
  private:
 
-  int	nBinEffPur_ ;
-  double startEffPur_ ; 
-  double endEffPur_ ; 
-  FlavourHistograms<double> * tkcntHistosSig3D[5];
-  FlavourHistograms<double> * tkcntHistosSig2D[5];
-  EffPurFromHistos * effPurFromHistos[4] ;
+  int nBinEffPur_;
+  double startEffPur_; 
+  double endEffPur_; 
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > tkcntHistosSig3D_;
+  std::vector< std::unique_ptr<FlavourHistograms<double>> > tkcntHistosSig2D_;
+  std::vector< std::unique_ptr<EffPurFromHistos> > effPurFromHistos_;
   unsigned int mcPlots_;  
   bool willFinalize_;
-} ;
+};
 
 #endif

--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
@@ -99,6 +99,13 @@ void BTagPerformanceAnalyzerOnData::bookHistograms(DQMStore::IBooker & ibook, ed
       iTag++;
       const string& folderName    = iModule->getParameter<string>("folder");
       
+      bool doDifferentialPlots = false;
+      double discrCut = -999.;
+      if (iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true) {
+          doDifferentialPlots = true;
+          discrCut = iModule->getParameter<double>("discrCut");
+      }
+      
       // eta loop
       for ( int iEta = iEtaStart ; iEta < iEtaEnd ; ++iEta ) {
         // pt loop
@@ -107,12 +114,6 @@ void BTagPerformanceAnalyzerOnData::bookHistograms(DQMStore::IBooker & ibook, ed
           const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
           
           // Instantiate the genertic b tag plotter
-          bool doDifferentialPlots = false;
-          double discrCut = -999.;
-          if (iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true) {
-              doDifferentialPlots = true;
-              discrCut = iModule->getParameter<double>("discrCut");
-          }
           JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), 0, false, ibook, false, doDifferentialPlots, discrCut);
           binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
           

--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
@@ -43,24 +43,24 @@ BTagPerformanceAnalyzerOnData::BTagPerformanceAnalyzerOnData(const edm::Paramete
     if (dataFormatType == "JetTag") {
       const InputTag& moduleLabel = iModule->getParameter<InputTag>("label");
       jetTagInputTags.push_back(moduleLabel);
-      binJetTagPlotters.push_back(vector<JetTagPlotter*>()) ;
+      binJetTagPlotters.push_back(vector<std::unique_ptr<JetTagPlotter>>()) ;
       jetTagToken.push_back(consumes<JetTagCollection>(moduleLabel));
     }
     else if(dataFormatType == "TagCorrelation") {
       const InputTag& label1 = iModule->getParameter<InputTag>("label1");
       const InputTag& label2 = iModule->getParameter<InputTag>("label2");
       tagCorrelationInputTags.push_back(std::pair<edm::InputTag, edm::InputTag>(label1, label2));
-      binTagCorrelationPlotters.push_back(vector<TagCorrelationPlotter*>());
+      binTagCorrelationPlotters.push_back(vector<std::unique_ptr<TagCorrelationPlotter>>());
       tagCorrelationToken.push_back(std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >(consumes<JetTagCollection>(label1), consumes<JetTagCollection>(label2)));
     }
     else {
       vector<edm::InputTag> vIP;
       tiDataFormatType.push_back(dataFormatType);
-      binTagInfoPlotters.push_back(vector<BaseTagInfoPlotter*>()) ;
+      binTagInfoPlotters.push_back(vector<std::unique_ptr<BaseTagInfoPlotter>>()) ;
       std::vector< edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> > tokens;
       if(dataFormatType == "GenericMVA") {
         const std::vector<InputTag> listInfo = iModule->getParameter<vector<InputTag>>("listTagInfos"); 
-        for(unsigned int ITi=0; ITi<listInfo.size(); ITi++){ 
+        for(unsigned int ITi=0; ITi<listInfo.size(); ITi++) { 
           tokens.push_back(consumes< View<BaseTagInfo> >(listInfo[ITi]));
           vIP.push_back(listInfo[ITi]);
         }
@@ -107,34 +107,34 @@ void BTagPerformanceAnalyzerOnData::bookHistograms(DQMStore::IBooker & ibook, ed
       }
       
       // eta loop
-      for ( int iEta = iEtaStart ; iEta < iEtaEnd ; ++iEta ) {
+      for (int iEta = iEtaStart ; iEta < iEtaEnd ; ++iEta) {
         // pt loop
-        for ( int iPt = iPtStart ; iPt < iPtEnd ; ++iPt ) {
+        for (int iPt = iPtStart ; iPt < iPtEnd ; ++iPt) {
           
           const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
           
-          // Instantiate the genertic b tag plotter
-          JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), 0, false, ibook, false, doDifferentialPlots, discrCut);
-          binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
+          // Instantiate the generic b tag plotter
+          binJetTagPlotters.at(iTag).push_back(std::make_unique<JetTagPlotter>(folderName, etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), 0, false, ibook, false, doDifferentialPlots, discrCut));
           
         }
       }
       
-    } else if(dataFormatType == "TagCorrelation") { 
+    } else if (dataFormatType == "TagCorrelation") { 
         iTagCorr++;
         const InputTag& label1 = iModule->getParameter<InputTag>("label1");
         const InputTag& label2 = iModule->getParameter<InputTag>("label2");
 
         // eta loop
-        for ( int iEta = iEtaStart ; iEta != iEtaEnd ; ++iEta) {
+        for (int iEta = iEtaStart ; iEta != iEtaEnd ; ++iEta) {
           // pt loop
-          for( int iPt = iPtStart ; iPt != iPtEnd ; ++iPt) {
+          for(int iPt = iPtStart ; iPt != iPtEnd ; ++iPt) {
             const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
             // Instantiate the generic b tag correlation plotter
-            TagCorrelationPlotter* tagCorrelationPlotter = new TagCorrelationPlotter(label1.label(), label2.label(), etaPtBin,
-                                                                                     iModule->getParameter<edm::ParameterSet>("parameters"),
-                                                                                     0, false, false, ibook);
-            binTagCorrelationPlotters.at(iTagCorr).push_back(tagCorrelationPlotter);
+            binTagCorrelationPlotters.at(iTagCorr).push_back(
+                    std::make_unique<TagCorrelationPlotter>(label1.label(), label2.label(), etaPtBin,
+                                                            iModule->getParameter<edm::ParameterSet>("parameters"),
+                                                            0, false, false, ibook)
+                        );
           }
         }
     } else {
@@ -144,19 +144,17 @@ void BTagPerformanceAnalyzerOnData::bookHistograms(DQMStore::IBooker & ibook, ed
       const string& folderName    = iModule->getParameter<string>("folder");
       
       // eta loop
-      for ( int iEta = iEtaStart ; iEta < iEtaEnd ; ++iEta ) {
-    // pt loop
-    for ( int iPt = iPtStart ; iPt < iPtEnd ; ++iPt ) {
-      const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
-      
-      // Instantiate the tagInfo plotter
-      
-      BaseTagInfoPlotter *jetTagPlotter = theFactory.buildPlotter(dataFormatType, moduleLabel.label(),
-                                      etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), folderName,
-                                      0, false, ibook);
-      binTagInfoPlotters.at(iInfoTag).push_back ( jetTagPlotter ) ;
-          binTagInfoPlottersToModuleConfig.insert(make_pair(jetTagPlotter, iModule - moduleConfig.begin()));
-    }
+      for (int iEta = iEtaStart ; iEta < iEtaEnd ; ++iEta) {
+        // pt loop
+        for (int iPt = iPtStart ; iPt < iPtEnd ; ++iPt) {
+          const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
+          
+          // Instantiate the tagInfo plotter
+          binTagInfoPlotters.at(iInfoTag).push_back(theFactory.buildPlotter(dataFormatType, moduleLabel.label(),
+                                          etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), folderName,
+                                          0, false, ibook)
+                  );
+        }
       }
     }
   }
@@ -194,7 +192,7 @@ EtaPtBin BTagPerformanceAnalyzerOnData::getEtaPtBin(const int& iEta, const int& 
 
 BTagPerformanceAnalyzerOnData::~BTagPerformanceAnalyzerOnData()
 {
-  for (unsigned int iJetLabel = 0; iJetLabel != binJetTagPlotters.size(); ++iJetLabel) {
+  /*for (unsigned int iJetLabel = 0; iJetLabel != binJetTagPlotters.size(); ++iJetLabel) {
     int plotterSize =  binJetTagPlotters[iJetLabel].size();
     for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
       delete binJetTagPlotters[iJetLabel][iPlotter];
@@ -211,7 +209,7 @@ BTagPerformanceAnalyzerOnData::~BTagPerformanceAnalyzerOnData()
     for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
       delete binTagInfoPlotters[iJetLabel][iPlotter];
     }
-  }
+  }*/
 }
 
 void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
@@ -221,17 +219,17 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
   iEvent.getByToken(slInfoToken, infoHandle);
 
   //Get JEC
-  const JetCorrector* corrector = 0;
+  const JetCorrector* corrector = nullptr;
   if(doJEC) {
     edm::Handle<GenEventInfoProduct> genInfoHandle; //check if data or MC                                                                                                                                 
     iEvent.getByToken(genToken, genInfoHandle);
     edm::Handle<JetCorrector> corrHandle;
-    if( !genInfoHandle.isValid() ) iEvent.getByToken( jecDataToken, corrHandle);
-    else iEvent.getByToken( jecMCToken, corrHandle);
+    if( !genInfoHandle.isValid() ) iEvent.getByToken(jecDataToken, corrHandle);
+    else iEvent.getByToken(jecMCToken, corrHandle);
     corrector = corrHandle.product();
   }
 
-// Look first at the jetTags
+  // Look first at the jetTags
 
   for (unsigned int iJetLabel = 0; iJetLabel != jetTagInputTags.size(); ++iJetLabel) {
     edm::Handle<reco::JetTagCollection> tagHandle;
@@ -240,7 +238,7 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
     // insert check on the presence of the collections
     //
 
-    if (!tagHandle.isValid()){
+    if (!tagHandle.isValid()) {
       edm::LogWarning("BTagPerformanceAnalyzerOnData")<<" Collection "<<jetTagInputTags[iJetLabel]<<" not present. Skipping it for this event.";
       continue;
     }
@@ -273,7 +271,7 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
     }
   }
 
-// Now look at Tag Correlations
+  // Now look at Tag Correlations
   for (unsigned int iJetLabel = 0; iJetLabel != tagCorrelationInputTags.size(); ++iJetLabel) {
     const std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >& inputTokens = tagCorrelationToken[iJetLabel];
     edm::Handle<reco::JetTagCollection> tagHandle1;
@@ -307,8 +305,8 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
       }
     }
   }
-// Now look at the TagInfos
 
+  // Now look at the TagInfos
   for (unsigned int iJetLabel = 0; iJetLabel != tiDataFormatType.size(); ++iJetLabel) {
     int plotterSize = binTagInfoPlotters[iJetLabel].size();
     for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter)
@@ -316,11 +314,10 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
 
     vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> > & tokens = tagInfoToken[iJetLabel];
     //check number of tag infos = expected number of tag infos
-    BaseTagInfoPlotter *firstPlotter = binTagInfoPlotters[iJetLabel][0];
-    vector<string> labels = firstPlotter->tagInfoRequirements();
+    vector<string> labels = binTagInfoPlotters[iJetLabel][0]->tagInfoRequirements();
     if (labels.empty())
       labels.push_back("label");
-    if(labels.size()!=tokens.size()) throw cms::Exception("Configuration") << "Different number of Tag Infos than expected" << labels.size() << tokens.size() << endl;
+    if (labels.size() != tokens.size()) throw cms::Exception("Configuration") << "Different number of Tag Infos than expected" << labels.size() << tokens.size() << endl;
 
     unsigned int nInputTags = tokens.size();
     vector< edm::Handle< View<BaseTagInfo> > > tagInfoHandles(nInputTags);
@@ -332,7 +329,7 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
       //
       // protect against missing products
       //
-      if (tagInfoHandle.isValid() == false){
+      if (tagInfoHandle.isValid() == false) {
         edm::LogWarning("BTagPerformanceAnalyzerOnData")<<" Collection "<<tagInfoInputTags[iJetLabel][iInputTags]<<" not present. Skipping it for this event.";
         continue;
       }

--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
@@ -46,15 +46,14 @@ class BTagPerformanceAnalyzerOnData : public DQMEDAnalyzer {
   bool doJEC;
   edm::InputTag slInfoTag;
 
-  std::vector< std::vector<JetTagPlotter*> > binJetTagPlotters;
-  std::vector< std::vector<TagCorrelationPlotter*> > binTagCorrelationPlotters;
-  std::vector< std::vector<BaseTagInfoPlotter*> > binTagInfoPlotters;
+  std::vector< std::vector<std::unique_ptr<JetTagPlotter>> > binJetTagPlotters;
+  std::vector< std::vector<std::unique_ptr<TagCorrelationPlotter>> > binTagCorrelationPlotters;
+  std::vector< std::vector<std::unique_ptr<BaseTagInfoPlotter>> > binTagInfoPlotters;
   std::vector<edm::InputTag> jetTagInputTags;
   std::vector< std::pair<edm::InputTag, edm::InputTag> > tagCorrelationInputTags;
   std::vector< std::vector<edm::InputTag> > tagInfoInputTags;
   // Contains plots for each bin of rapidity and pt.
   std::vector<edm::ParameterSet> moduleConfig;
-  std::map<BaseTagInfoPlotter*, size_t> binTagInfoPlottersToModuleConfig;
 
   //add consumes
   edm::EDGetTokenT<reco::JetCorrector> jecMCToken;

--- a/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.cc
@@ -9,7 +9,7 @@ using namespace edm;
 using namespace std;
 using namespace RecoBTag;
 
-BTagPerformanceHarvester::BTagPerformanceHarvester(const edm::ParameterSet& pSet) :
+BTagPerformanceHarvester::BTagPerformanceHarvester(const edm::ParameterSet& pSet):
   etaRanges(pSet.getParameter< vector<double> >("etaRanges")),
   ptRanges(pSet.getParameter< vector<double> >("ptRanges")),
   produceEps(pSet.getParameter< bool >("produceEps")),
@@ -19,15 +19,18 @@ BTagPerformanceHarvester::BTagPerformanceHarvester(const edm::ParameterSet& pSet
   makeDiffPlots_(pSet.getParameter< bool >("differentialPlots"))
 {
   //mcPlots_ : 1=b+c+l+ni; 2=all+1; 3=1+d+u+s+g; 4=3+all . Default is 2. Don't use 0.
-  if(flavPlots_.find("dusg")<15){
-    if(flavPlots_.find("all")<15) mcPlots_ = 4;
-    else mcPlots_ = 3;
-  }
-  else if(flavPlots_.find("bcl")<15){
-    if(flavPlots_.find("all")<15) mcPlots_ = 2;
-    else mcPlots_ = 1;
-  }
-  else mcPlots_ = 0;
+  if (flavPlots_.find("dusg")<15) {
+    if (flavPlots_.find("all")<15)
+        mcPlots_ = 4;
+    else
+        mcPlots_ = 3;
+  } else if (flavPlots_.find("bcl")<15) {
+    if (flavPlots_.find("all")<15)
+        mcPlots_ = 2;
+    else
+        mcPlots_ = 1;
+  } else
+      mcPlots_ = 0;
 
   for (vector<edm::ParameterSet>::const_iterator iModule = moduleConfig.begin();
        iModule != moduleConfig.end(); ++iModule) {
@@ -37,21 +40,19 @@ BTagPerformanceHarvester::BTagPerformanceHarvester(const edm::ParameterSet& pSet
     if (dataFormatType == "JetTag") {
       const InputTag& moduleLabel = iModule->getParameter<InputTag>("label");
       jetTagInputTags.push_back(moduleLabel);
-      binJetTagPlotters.push_back(vector<JetTagPlotter*>()) ;
-      if (mcPlots_ && makeDiffPlots_){
-        differentialPlots.push_back(vector<BTagDifferentialPlot*>());
+      binJetTagPlotters.push_back(vector<std::shared_ptr<JetTagPlotter>>());
+      if (mcPlots_ && makeDiffPlots_) {
+        differentialPlots.push_back(vector<std::unique_ptr<BTagDifferentialPlot>>());
       }
-    }
-    else if(dataFormatType == "TagCorrelation") {
+    } else if (dataFormatType == "TagCorrelation") {
       const InputTag& label1 = iModule->getParameter<InputTag>("label1");
       const InputTag& label2 = iModule->getParameter<InputTag>("label2");
       tagCorrelationInputTags.push_back(std::pair<edm::InputTag, edm::InputTag>(label1, label2));
-      binTagCorrelationPlotters.push_back(vector<TagCorrelationPlotter*>());
-    }
-    else {
+      binTagCorrelationPlotters.push_back(vector<std::unique_ptr<TagCorrelationPlotter>>());
+    } else {
       tagInfoInputTags.push_back(vector<edm::InputTag>());
       tiDataFormatType.push_back(dataFormatType);
-      binTagInfoPlotters.push_back(vector<BaseTagInfoPlotter*>()) ;
+      binTagInfoPlotters.push_back(vector<std::unique_ptr<BaseTagInfoPlotter>>());
     }
   }
 
@@ -63,7 +64,7 @@ EtaPtBin BTagPerformanceHarvester::getEtaPtBin(const int& iEta, const int& iPt)
   bool    etaActive_ , ptActive_;
   double  etaMin_, etaMax_, ptMin_, ptMax_;
 
-  if ( iEta != -1 ) {
+  if (iEta != -1) {
     etaActive_ = true;
     etaMin_    = etaRanges[iEta];
     etaMax_    = etaRanges[iEta+1];
@@ -74,8 +75,8 @@ EtaPtBin BTagPerformanceHarvester::getEtaPtBin(const int& iEta, const int& iPt)
     etaMax_    = etaRanges[etaRanges.size() - 1];
   }
 
-  if ( iPt != -1 ) {
-    ptActive_ = true ;
+  if (iPt != -1) {
+    ptActive_ = true;
     ptMin_    = ptRanges[iPt];
     ptMax_    = ptRanges[iPt+1];
   }
@@ -87,43 +88,17 @@ EtaPtBin BTagPerformanceHarvester::getEtaPtBin(const int& iEta, const int& iPt)
   return EtaPtBin(etaActive_, etaMin_, etaMax_, ptActive_, ptMin_, ptMax_);
 }
 
-BTagPerformanceHarvester::~BTagPerformanceHarvester()
-{
-  for (vector<vector<JetTagPlotter*> >::iterator iJetLabel = binJetTagPlotters.begin();
-       iJetLabel != binJetTagPlotters.end(); ++iJetLabel) 
-    for (vector<JetTagPlotter*>::iterator iPlotter = iJetLabel->begin(); iPlotter != iJetLabel->end(); ++iPlotter) 
-      delete *iPlotter;
-
-  if (mcPlots_ && makeDiffPlots_) {
-    for(vector<vector<BTagDifferentialPlot*> >::iterator iJetLabel = differentialPlots.begin();
-        iJetLabel != differentialPlots.end(); ++iJetLabel)
-      for (vector<BTagDifferentialPlot *>::iterator iPlotter = iJetLabel->begin();
-           iPlotter != iJetLabel->end(); ++ iPlotter) 
-    delete *iPlotter;
-  }
-
-  for (vector<vector<TagCorrelationPlotter*> >::iterator iJetLabel = binTagCorrelationPlotters.begin(); 
-       iJetLabel != binTagCorrelationPlotters.end(); ++iJetLabel) 
-    for (vector<TagCorrelationPlotter* >::iterator iPlotter = iJetLabel->begin(); iPlotter != iJetLabel->end(); ++iPlotter) 
-      delete *iPlotter;
-    
-  
-  for (vector<vector<BaseTagInfoPlotter*> >::iterator iJetLabel = binTagInfoPlotters.begin(); 
-       iJetLabel != binTagInfoPlotters.end(); ++iJetLabel) 
-    for (vector<BaseTagInfoPlotter*>::iterator iPlotter = iJetLabel->begin(); iPlotter != iJetLabel->end(); ++iPlotter) 
-      delete *iPlotter;
-    
-}
+BTagPerformanceHarvester::~BTagPerformanceHarvester() {}
 
 void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IGetter & iget)
 {
   // Book all histograms.
 
   // iterate over ranges:
-  const int iEtaStart = -1                   ;  // this will be the inactive one
-  const int iEtaEnd   = etaRanges.size() - 1 ;
-  const int iPtStart  = -1                   ;  // this will be the inactive one
-  const int iPtEnd    = ptRanges.size() - 1  ;
+  const int iEtaStart = -1                  ;  // this will be the inactive one
+  const int iEtaEnd   = etaRanges.size() - 1;
+  const int iPtStart  = -1                  ;  // this will be the inactive one
+  const int iPtEnd    = ptRanges.size() - 1 ;
   setTDRStyle();
 
   TagInfoPlotterFactory theFactory;
@@ -140,98 +115,91 @@ void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IG
              
     if (dataFormatType == "JetTag") {
       iTag++;
-      const string& folderName    = iModule->getParameter<string>("folder");
+      const string& folderName = iModule->getParameter<string>("folder");
 
       // Contains plots for each bin of rapidity and pt.
-      vector<BTagDifferentialPlot*> * differentialPlotsConstantEta = new vector<BTagDifferentialPlot*> () ;
-      vector<BTagDifferentialPlot*> * differentialPlotsConstantPt  = new vector<BTagDifferentialPlot*> () ;
-      if (mcPlots_ && makeDiffPlots_){
+      auto differentialPlotsConstantEta = std::make_unique< std::vector<std::unique_ptr<BTagDifferentialPlot>> >();
+      auto differentialPlotsConstantPt  = std::make_unique< std::vector<std::unique_ptr<BTagDifferentialPlot>> >();
+      if (mcPlots_ && makeDiffPlots_) {
         // the constant b-efficiency for the differential plots versus pt and eta
         const double& effBConst =
                       iModule->getParameter<edm::ParameterSet>("parameters").getParameter<double>("effBConst");
 
         // the objects for the differential plots vs. eta,pt for
-        for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
-          BTagDifferentialPlot * etaConstDifferentialPlot = new BTagDifferentialPlot
-            (effBConst, BTagDifferentialPlot::constETA, folderName, mcPlots_);
-          differentialPlotsConstantEta->push_back ( etaConstDifferentialPlot );
+        for (int iEta = iEtaStart; iEta < iEtaEnd; iEta++) {
+            std::unique_ptr<BTagDifferentialPlot> etaConstDifferentialPlot = std::make_unique<BTagDifferentialPlot>(effBConst, BTagDifferentialPlot::constETA, folderName, mcPlots_);
+          differentialPlotsConstantEta->push_back(std::move(etaConstDifferentialPlot));
         }
 
-        for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
+        for (int iPt = iPtStart; iPt < iPtEnd; iPt++) {
           // differentialPlots for this pt bin
-          BTagDifferentialPlot * ptConstDifferentialPlot = new BTagDifferentialPlot
-            (effBConst, BTagDifferentialPlot::constPT, folderName, mcPlots_);
-          differentialPlotsConstantPt->push_back ( ptConstDifferentialPlot );
+          std::unique_ptr<BTagDifferentialPlot> ptConstDifferentialPlot = std::make_unique<BTagDifferentialPlot>(effBConst, BTagDifferentialPlot::constPT, folderName, mcPlots_);
+          differentialPlotsConstantPt->push_back(std::move(ptConstDifferentialPlot));
         }
       }
       // eta loop
-      for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
-    // pt loop
-    for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
+      for (int iEta = iEtaStart; iEta < iEtaEnd; iEta++) {
+        // pt loop
+        for (int iPt = iPtStart; iPt < iPtEnd; iPt++) {
 
-      const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
+          const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
 
-      // Instantiate the genertic b tag plotter
-      bool doDifferentialPlots = iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true;
-      JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin,
-                               iModule->getParameter<edm::ParameterSet>("parameters"),mcPlots_,true, ibook, doCTagPlots, doDifferentialPlots);
-      binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
+          // Instantiate the generic b tag plotter
+          bool doDifferentialPlots = iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true;
+          std::shared_ptr<JetTagPlotter> jetTagPlotter = std::make_shared<JetTagPlotter>(folderName, etaPtBin,
+                                   iModule->getParameter<edm::ParameterSet>("parameters"),mcPlots_,true, ibook, doCTagPlots, doDifferentialPlots);
+          binJetTagPlotters.at(iTag).push_back(jetTagPlotter);
 
-      // Add to the corresponding differential plotters
-      if (mcPlots_ && makeDiffPlots_){
-        (*differentialPlotsConstantEta)[iEta+1]->addBinPlotter ( jetTagPlotter ) ;
-        (*differentialPlotsConstantPt )[iPt+1] ->addBinPlotter ( jetTagPlotter ) ;
-      }
-    }
+          // Add to the corresponding differential plotters
+          if (mcPlots_ && makeDiffPlots_) {
+            (*differentialPlotsConstantEta)[iEta+1]->addBinPlotter(jetTagPlotter);
+            (*differentialPlotsConstantPt)[iPt+1] ->addBinPlotter(jetTagPlotter);
+          }
+        }
       }
       // the objects for the differential plots vs. eta, pt: collect all from constant eta and constant pt
-      if (mcPlots_ && makeDiffPlots_){
-        differentialPlots.at(iTag).reserve(differentialPlotsConstantEta->size()+differentialPlotsConstantPt->size()) ;
-        differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), differentialPlotsConstantEta->begin(), differentialPlotsConstantEta->end());
-        differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), differentialPlotsConstantPt->begin(), differentialPlotsConstantPt->end());
+      if (mcPlots_ && makeDiffPlots_) {
+        differentialPlots.at(iTag).reserve(differentialPlotsConstantEta->size() + differentialPlotsConstantPt->size());
+        differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), std::make_move_iterator(differentialPlotsConstantEta->begin()), std::make_move_iterator(differentialPlotsConstantEta->end()));
+        differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), std::make_move_iterator(differentialPlotsConstantPt->begin()), std::make_move_iterator(differentialPlotsConstantPt->end()));
 
         edm::LogInfo("Info")
           << "====>>>> ## sizeof differentialPlots = " << differentialPlots.size();
-
-        // the intermediate ones are no longer needed
-        delete differentialPlotsConstantEta ;
-        delete differentialPlotsConstantPt  ;
       }
-    } else if(dataFormatType == "TagCorrelation") {
+    } else if (dataFormatType == "TagCorrelation") {
         iTagCorr++;
         const InputTag& label1 = iModule->getParameter<InputTag>("label1");
         const InputTag& label2 = iModule->getParameter<InputTag>("label2");
 
         // eta loop
-        for ( int iEta = iEtaStart ; iEta != iEtaEnd ; ++iEta) {
+        for (int iEta = iEtaStart; iEta != iEtaEnd; ++iEta) {
           // pt loop
-          for( int iPt = iPtStart ; iPt != iPtEnd ; ++iPt) {
+          for (int iPt = iPtStart; iPt != iPtEnd; ++iPt) {
             const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
             // Instantiate the generic b tag correlation plotter
-            TagCorrelationPlotter* tagCorrelationPlotter = new TagCorrelationPlotter(label1.label(), label2.label(), etaPtBin,
+            std::unique_ptr<TagCorrelationPlotter> tagCorrelationPlotter = std::make_unique<TagCorrelationPlotter>(label1.label(), label2.label(), etaPtBin,
                                                                                      iModule->getParameter<edm::ParameterSet>("parameters"),
                                                                                      mcPlots_, doCTagPlots, true, ibook);
-            binTagCorrelationPlotters.at(iTagCorr).push_back(tagCorrelationPlotter);
+            binTagCorrelationPlotters.at(iTagCorr).push_back(std::move(tagCorrelationPlotter));
           }
         }
     } else {
       iInfoTag++;
-      // tag info retrievel is deferred (needs availability of EventSetup)
+      // tag info retrievel is deferred(needs availability of EventSetup)
       const InputTag& moduleLabel = iModule->getParameter<InputTag>("label");
       const string& folderName    = iModule->getParameter<string>("folder");
       // eta loop
-      for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
+      for (int iEta = iEtaStart; iEta < iEtaEnd; iEta++) {
         // pt loop
-        for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
-          const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
+        for (int iPt = iPtStart; iPt < iPtEnd; iPt++) {
+            const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
 
-          // Instantiate the tagInfo plotter
+            // Instantiate the tagInfo plotter
 
-          BaseTagInfoPlotter *jetTagPlotter = theFactory.buildPlotter(dataFormatType, moduleLabel.label(), 
+            std::unique_ptr<BaseTagInfoPlotter> jetTagPlotter = theFactory.buildPlotter(dataFormatType, moduleLabel.label(), 
                                           etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), folderName, 
                                           mcPlots_, true, ibook);
-          binTagInfoPlotters.at(iInfoTag).push_back ( jetTagPlotter ) ;
-              binTagInfoPlottersToModuleConfig.insert(make_pair(jetTagPlotter, iModule - moduleConfig.begin()));
+            binTagInfoPlotters.at(iInfoTag).push_back(std::move(jetTagPlotter));
         }
       }
       edm::LogInfo("Info")
@@ -244,35 +212,34 @@ void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IG
     int plotterSize =  binJetTagPlotters[iJetLabel].size();
     for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
       binJetTagPlotters[iJetLabel][iPlotter]->finalize(ibook, iget);
-      if (producePs)  (*binJetTagPlotters[iJetLabel][iPlotter]).psPlot(psBaseName);
-      if (produceEps) (*binJetTagPlotters[iJetLabel][iPlotter]).epsPlot(epsBaseName);
+      if (producePs) (*binJetTagPlotters[iJetLabel][iPlotter]).psPlot(psBaseName);
+      if (produceEps)(*binJetTagPlotters[iJetLabel][iPlotter]).epsPlot(epsBaseName);
     }
    
-      if(makeDiffPlots_) { 
-        for (vector<BTagDifferentialPlot *>::iterator iPlotter = differentialPlots[iJetLabel].begin();
-         iPlotter != differentialPlots[iJetLabel].end(); ++ iPlotter) {
-          (*iPlotter)->process(ibook);
-          if (producePs)  (*iPlotter)->psPlot(psBaseName);
-          if (produceEps) (*iPlotter)->epsPlot(epsBaseName);
+    if (makeDiffPlots_) {
+        for (auto& iPlotter: differentialPlots[iJetLabel]) {
+          iPlotter->process(ibook);
+          if (producePs)  iPlotter->psPlot(psBaseName);
+          if (produceEps) iPlotter->epsPlot(epsBaseName);
         }
-      }
-  }
-  for (vector<vector<BaseTagInfoPlotter*> >::iterator iJetLabel = binTagInfoPlotters.begin();
-       iJetLabel != binTagInfoPlotters.end(); ++iJetLabel) {
-    for (vector<BaseTagInfoPlotter*>::iterator iPlotter = iJetLabel->begin(); iPlotter != iJetLabel->end(); ++iPlotter) {
-      (*iPlotter)->finalize(ibook, iget);
-      if (producePs)  (*iPlotter)->psPlot(psBaseName);
-      if (produceEps) (*iPlotter)->epsPlot(epsBaseName);
     }
   }
-   for (unsigned int iJetLabel = 0; iJetLabel != binTagCorrelationPlotters.size(); ++iJetLabel) {
+  
+  for (auto& iJetLabel: binTagInfoPlotters) {
+    for (auto& iPlotter: iJetLabel) {
+      iPlotter->finalize(ibook, iget);
+      if (producePs)  iPlotter->psPlot(psBaseName);
+      if (produceEps) iPlotter->epsPlot(epsBaseName);
+    }
+  }
+  for (unsigned int iJetLabel = 0; iJetLabel != binTagCorrelationPlotters.size(); ++iJetLabel) {
     int plotterSize =  binTagCorrelationPlotters[iJetLabel].size();
     for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
       binTagCorrelationPlotters[iJetLabel][iPlotter]->finalize(ibook, iget);
-      if (producePs)  (*binTagCorrelationPlotters[iJetLabel][iPlotter]).psPlot(psBaseName);
-      if (produceEps) (*binTagCorrelationPlotters[iJetLabel][iPlotter]).epsPlot(epsBaseName);
+      if (producePs) (*binTagCorrelationPlotters[iJetLabel][iPlotter]).psPlot(psBaseName);
+      if (produceEps)(*binTagCorrelationPlotters[iJetLabel][iPlotter]).epsPlot(epsBaseName);
     }
-   } 
+  } 
 
 }
 

--- a/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.cc
@@ -61,31 +61,30 @@ EtaPtBin BTagPerformanceHarvester::getEtaPtBin(const int& iEta, const int& iPt)
 {
   // DEFINE BTagBin:
   bool    etaActive_ , ptActive_;
-  double  etaMin_, etaMax_, ptMin_, ptMax_ ;
+  double  etaMin_, etaMax_, ptMin_, ptMax_;
 
   if ( iEta != -1 ) {
-    etaActive_ = true ;
-    etaMin_    = etaRanges[iEta]   ;
-    etaMax_    = etaRanges[iEta+1] ;
+    etaActive_ = true;
+    etaMin_    = etaRanges[iEta];
+    etaMax_    = etaRanges[iEta+1];
   }
   else {
-    etaActive_ = false ;
-    etaMin_    = etaRanges[0]   ;
-    etaMax_    = etaRanges[etaRanges.size() - 1]   ;
+    etaActive_ = false;
+    etaMin_    = etaRanges[0];
+    etaMax_    = etaRanges[etaRanges.size() - 1];
   }
 
   if ( iPt != -1 ) {
     ptActive_ = true ;
-    ptMin_    = ptRanges[iPt]   ;
-    ptMax_    = ptRanges[iPt+1] ;
+    ptMin_    = ptRanges[iPt];
+    ptMax_    = ptRanges[iPt+1];
   }
   else {
-    ptActive_ = false ;
-    ptMin_    = ptRanges[0]	;
-    ptMax_    = ptRanges[ptRanges.size() - 1]	;
+    ptActive_ = false;
+    ptMin_    = ptRanges[0];
+    ptMax_    = ptRanges[ptRanges.size() - 1];
   }
-  return EtaPtBin(etaActive_ , etaMin_ , etaMax_ ,
-			ptActive_  , ptMin_  , ptMax_ );
+  return EtaPtBin(etaActive_, etaMin_, etaMax_, ptActive_, ptMin_, ptMax_);
 }
 
 BTagPerformanceHarvester::~BTagPerformanceHarvester()
@@ -100,7 +99,7 @@ BTagPerformanceHarvester::~BTagPerformanceHarvester()
         iJetLabel != differentialPlots.end(); ++iJetLabel)
       for (vector<BTagDifferentialPlot *>::iterator iPlotter = iJetLabel->begin();
            iPlotter != iJetLabel->end(); ++ iPlotter) 
-	delete *iPlotter;
+    delete *iPlotter;
   }
 
   for (vector<vector<TagCorrelationPlotter*> >::iterator iJetLabel = binTagCorrelationPlotters.begin(); 
@@ -135,10 +134,10 @@ void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IG
     const string& dataFormatType = iModule->exists("type") ?
                                    iModule->getParameter<string>("type") :
                                    "JetTag";
-		const bool& doCTagPlots = iModule->exists("doCTagPlots") ?
+    const bool& doCTagPlots = iModule->exists("doCTagPlots") ?
                                    iModule->getParameter<bool>("doCTagPlots") :
                                    false;
-			 
+             
     if (dataFormatType == "JetTag") {
       iTag++;
       const string& folderName    = iModule->getParameter<string>("folder");
@@ -147,55 +146,56 @@ void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IG
       vector<BTagDifferentialPlot*> * differentialPlotsConstantEta = new vector<BTagDifferentialPlot*> () ;
       vector<BTagDifferentialPlot*> * differentialPlotsConstantPt  = new vector<BTagDifferentialPlot*> () ;
       if (mcPlots_ && makeDiffPlots_){
-	// the constant b-efficiency for the differential plots versus pt and eta
-	const double& effBConst =
-	  			iModule->getParameter<edm::ParameterSet>("parameters").getParameter<double>("effBConst");
+        // the constant b-efficiency for the differential plots versus pt and eta
+        const double& effBConst =
+                      iModule->getParameter<edm::ParameterSet>("parameters").getParameter<double>("effBConst");
 
-	// the objects for the differential plots vs. eta,pt for
-	for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
-	  BTagDifferentialPlot * etaConstDifferentialPlot = new BTagDifferentialPlot
-	    (effBConst, BTagDifferentialPlot::constETA, folderName, mcPlots_);
-	  differentialPlotsConstantEta->push_back ( etaConstDifferentialPlot );
-	}
+        // the objects for the differential plots vs. eta,pt for
+        for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
+          BTagDifferentialPlot * etaConstDifferentialPlot = new BTagDifferentialPlot
+            (effBConst, BTagDifferentialPlot::constETA, folderName, mcPlots_);
+          differentialPlotsConstantEta->push_back ( etaConstDifferentialPlot );
+        }
 
-	for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
-	  // differentialPlots for this pt bin
-	  BTagDifferentialPlot * ptConstDifferentialPlot = new BTagDifferentialPlot
-	    (effBConst, BTagDifferentialPlot::constPT, folderName, mcPlots_);
-	  differentialPlotsConstantPt->push_back ( ptConstDifferentialPlot );
-	}
+        for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
+          // differentialPlots for this pt bin
+          BTagDifferentialPlot * ptConstDifferentialPlot = new BTagDifferentialPlot
+            (effBConst, BTagDifferentialPlot::constPT, folderName, mcPlots_);
+          differentialPlotsConstantPt->push_back ( ptConstDifferentialPlot );
+        }
       }
       // eta loop
       for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
-	// pt loop
-	for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
+    // pt loop
+    for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
 
-	  const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
+      const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
 
-	  // Instantiate the genertic b tag plotter
-	  JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin,
-							   iModule->getParameter<edm::ParameterSet>("parameters"),mcPlots_,true, ibook, doCTagPlots);
-	  binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
+      // Instantiate the genertic b tag plotter
+      bool doDifferentialPlots = iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true;
+      JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin,
+                               iModule->getParameter<edm::ParameterSet>("parameters"),mcPlots_,true, ibook, doCTagPlots, doDifferentialPlots);
+      binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
 
-	  // Add to the corresponding differential plotters
-	  if (mcPlots_ && makeDiffPlots_){
-	    (*differentialPlotsConstantEta)[iEta+1]->addBinPlotter ( jetTagPlotter ) ;
-	    (*differentialPlotsConstantPt )[iPt+1] ->addBinPlotter ( jetTagPlotter ) ;
-	  }
-	}
+      // Add to the corresponding differential plotters
+      if (mcPlots_ && makeDiffPlots_){
+        (*differentialPlotsConstantEta)[iEta+1]->addBinPlotter ( jetTagPlotter ) ;
+        (*differentialPlotsConstantPt )[iPt+1] ->addBinPlotter ( jetTagPlotter ) ;
+      }
+    }
       }
       // the objects for the differential plots vs. eta, pt: collect all from constant eta and constant pt
       if (mcPlots_ && makeDiffPlots_){
-	differentialPlots.at(iTag).reserve(differentialPlotsConstantEta->size()+differentialPlotsConstantPt->size()) ;
-	differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), differentialPlotsConstantEta->begin(), differentialPlotsConstantEta->end());
-	differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), differentialPlotsConstantPt->begin(), differentialPlotsConstantPt->end());
+        differentialPlots.at(iTag).reserve(differentialPlotsConstantEta->size()+differentialPlotsConstantPt->size()) ;
+        differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), differentialPlotsConstantEta->begin(), differentialPlotsConstantEta->end());
+        differentialPlots.at(iTag).insert(differentialPlots.at(iTag).end(), differentialPlotsConstantPt->begin(), differentialPlotsConstantPt->end());
 
-	edm::LogInfo("Info")
-	  << "====>>>> ## sizeof differentialPlots = " << differentialPlots.size();
+        edm::LogInfo("Info")
+          << "====>>>> ## sizeof differentialPlots = " << differentialPlots.size();
 
-	// the intermediate ones are no longer needed
-	delete differentialPlotsConstantEta ;
-	delete differentialPlotsConstantPt  ;
+        // the intermediate ones are no longer needed
+        delete differentialPlotsConstantEta ;
+        delete differentialPlotsConstantPt  ;
       }
     } else if(dataFormatType == "TagCorrelation") {
         iTagCorr++;
@@ -221,21 +221,21 @@ void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IG
       const string& folderName    = iModule->getParameter<string>("folder");
       // eta loop
       for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
-	// pt loop
-	for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
-	  const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
+        // pt loop
+        for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
+          const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
 
-	  // Instantiate the tagInfo plotter
+          // Instantiate the tagInfo plotter
 
-	  BaseTagInfoPlotter *jetTagPlotter = theFactory.buildPlotter(dataFormatType, moduleLabel.label(), 
-								      etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), folderName, 
-								      mcPlots_, true, ibook);
-	  binTagInfoPlotters.at(iInfoTag).push_back ( jetTagPlotter ) ;
-          binTagInfoPlottersToModuleConfig.insert(make_pair(jetTagPlotter, iModule - moduleConfig.begin()));
-	}
+          BaseTagInfoPlotter *jetTagPlotter = theFactory.buildPlotter(dataFormatType, moduleLabel.label(), 
+                                          etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), folderName, 
+                                          mcPlots_, true, ibook);
+          binTagInfoPlotters.at(iInfoTag).push_back ( jetTagPlotter ) ;
+              binTagInfoPlottersToModuleConfig.insert(make_pair(jetTagPlotter, iModule - moduleConfig.begin()));
+        }
       }
       edm::LogInfo("Info")
-	<< "====>>>> ## sizeof differentialPlots = " << differentialPlots.size();
+    << "====>>>> ## sizeof differentialPlots = " << differentialPlots.size();
     }
   }
 
@@ -250,10 +250,10 @@ void BTagPerformanceHarvester::dqmEndJob(DQMStore::IBooker & ibook, DQMStore::IG
    
       if(makeDiffPlots_) { 
         for (vector<BTagDifferentialPlot *>::iterator iPlotter = differentialPlots[iJetLabel].begin();
-	     iPlotter != differentialPlots[iJetLabel].end(); ++ iPlotter) {
-	  (*iPlotter)->process(ibook);
-	  if (producePs)  (*iPlotter)->psPlot(psBaseName);
-	  if (produceEps) (*iPlotter)->epsPlot(epsBaseName);
+         iPlotter != differentialPlots[iJetLabel].end(); ++ iPlotter) {
+          (*iPlotter)->process(ibook);
+          if (producePs)  (*iPlotter)->psPlot(psBaseName);
+          if (produceEps) (*iPlotter)->epsPlot(epsBaseName);
         }
       }
   }

--- a/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.h
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceHarvester.h
@@ -15,7 +15,7 @@
  *
  */
 
-class BTagPerformanceHarvester : public DQMEDHarvester {
+class BTagPerformanceHarvester: public DQMEDHarvester {
    public:
       explicit BTagPerformanceHarvester(const edm::ParameterSet& pSet);
       ~BTagPerformanceHarvester();
@@ -30,16 +30,15 @@ class BTagPerformanceHarvester : public DQMEDHarvester {
       std::string psBaseName, epsBaseName;
       std::vector<std::string> tiDataFormatType;
 
-      std::vector< std::vector<JetTagPlotter*> > binJetTagPlotters;
-      std::vector< std::vector<TagCorrelationPlotter*> > binTagCorrelationPlotters;
-      std::vector< std::vector<BaseTagInfoPlotter*> > binTagInfoPlotters;
+      std::vector< std::vector<std::shared_ptr<JetTagPlotter>> > binJetTagPlotters;
+      std::vector< std::vector<std::unique_ptr<TagCorrelationPlotter>> > binTagCorrelationPlotters;
+      std::vector< std::vector<std::unique_ptr<BaseTagInfoPlotter>> > binTagInfoPlotters;
       std::vector<edm::InputTag> jetTagInputTags;
       std::vector< std::pair<edm::InputTag, edm::InputTag> > tagCorrelationInputTags;
       std::vector< std::vector<edm::InputTag> > tagInfoInputTags;
       // Contains plots for each bin of rapidity and pt.
-      std::vector< std::vector<BTagDifferentialPlot*> > differentialPlots;
+      std::vector< std::vector<std::unique_ptr<BTagDifferentialPlot>> > differentialPlots;
       std::vector<edm::ParameterSet> moduleConfig;
-      std::map<BaseTagInfoPlotter*, size_t> binTagInfoPlottersToModuleConfig;
       
       std::string flavPlots_;
       unsigned int mcPlots_;

--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -77,12 +77,12 @@ bTagCommonBlock = cms.PSet(
             label = cms.InputTag("pfJetBProbabilityBJetTags"),
             folder = cms.string("JBP")
         ),
-	cms.PSet(
+        cms.PSet(
             bTagSimpleSVAnalysisBlock,
             label = cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
             folder = cms.string("SSVHE")
         ),
-	cms.PSet(
+        cms.PSet(
             bTagSimpleSVAnalysisBlock,
             label = cms.InputTag("pfSimpleInclusiveSecondaryVertexHighEffBJetTags"),
             folder = cms.string("SISVHE")
@@ -90,12 +90,16 @@ bTagCommonBlock = cms.PSet(
         cms.PSet(
             bTagGenericAnalysisBlock,
             label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-            folder = cms.string("CSVv2")
+            folder = cms.string("CSVv2"),
+            differentialPlots = cms.bool(True),
+            discrCut = cms.double(0.5426)
         ),
         cms.PSet(
             bTagSymmetricAnalysisBlock,
             label = cms.InputTag("pfCombinedMVAV2BJetTags"),
-            folder = cms.string("combMVAv2")
+            folder = cms.string("combMVAv2"),
+            differentialPlots = cms.bool(True),
+            discrCut = cms.double(-0.5884)
         ), 
         cms.PSet(
             bTagGenericAnalysisBlock,
@@ -147,31 +151,35 @@ bTagCommonBlock = cms.PSet(
             label = cms.InputTag("softPFElectronBJetTags"),
             folder = cms.string("SET")
         ),
-	cms.PSet(
+        cms.PSet(
            cTagCombinedSVAnalysisBlock,
            listTagInfos = cms.VInputTag(
-           	cms.InputTag("pfImpactParameterTagInfos"),
-           	cms.InputTag("pfInclusiveSecondaryVertexFinderCvsLTagInfos"),                
-           	cms.InputTag("softPFMuonsTagInfos"),
-           	cms.InputTag("softPFElectronsTagInfos")
+               cms.InputTag("pfImpactParameterTagInfos"),
+               cms.InputTag("pfInclusiveSecondaryVertexFinderCvsLTagInfos"),                
+               cms.InputTag("softPFMuonsTagInfos"),
+               cms.InputTag("softPFElectronsTagInfos")
            ),
            type = cms.string('GenericMVA'),
            label = cms.InputTag("candidateCombinedSecondaryVertexSoftLeptonCvsLComputer"),
            folder = cms.string("CtaggerTag")
         ),
-	cms.PSet(
+        cms.PSet(
             cTagGenericAnalysisBlock,
             label = cms.InputTag("pfCombinedCvsLJetTags"),
             folder = cms.string("Ctagger_CvsL"),
-            doCTagPlots = cms.bool(True)
+            doCTagPlots = cms.bool(True),
+            differentialPlots = cms.bool(True),
+            discrCut = cms.double(-0.48)
         ),
         cms.PSet(
             cTagGenericAnalysisBlock,
             label = cms.InputTag("pfCombinedCvsBJetTags"),
             folder = cms.string("Ctagger_CvsB"),
-            doCTagPlots = cms.bool(True)
+            doCTagPlots = cms.bool(True),
+            differentialPlots = cms.bool(True),
+            discrCut = cms.double(-0.17)
         ),
-	cms.PSet(
+        cms.PSet(
             cTagCorrelationAnalysisBlock,
             type = cms.string('TagCorrelation'),
             label1 = cms.InputTag("pfCombinedCvsLJetTags"),

--- a/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
+++ b/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
@@ -13,31 +13,31 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
-using namespace std ;
+using namespace std;
 
 
 
-BTagDifferentialPlot::BTagDifferentialPlot (const double& bEff, const ConstVarType& constVariable,
-					    const std::string & tagName, const unsigned int& mc) :
-	fixedBEfficiency     ( bEff )  ,
-	noProcessing         ( false ) , processed(false), constVar(constVariable),
-	constVariableName    ( "" )    , diffVariableName     ( "" )    ,
-	constVariableValue   ( 999.9 , 999.9 ) , commonName( "MisidForBEff_" + tagName+"_"),
-	theDifferentialHistoB_d    ( 0 ) ,
-	theDifferentialHistoB_u    ( 0 ) ,
-	theDifferentialHistoB_s    ( 0 ) ,
-	theDifferentialHistoB_c    ( 0 ) ,
-	theDifferentialHistoB_b    ( 0 ) ,
-	theDifferentialHistoB_g    ( 0 ) ,
-	theDifferentialHistoB_ni   ( 0 ) ,
-	theDifferentialHistoB_dus  ( 0 ) ,
-	theDifferentialHistoB_dusg ( 0 ) ,
-	theDifferentialHistoB_pu   ( 0 ) ,
-	mcPlots_ (mc)
+BTagDifferentialPlot::BTagDifferentialPlot(double bEff, const ConstVarType& constVariable,
+					    const std::string & tagName, unsigned int mc) :
+	fixedBEfficiency   (bEff),
+	noProcessing       (false), processed(false), constVar(constVariable),
+	constVariableName  ("")  , diffVariableName   ("")  ,
+	constVariableValue (999.9, 999.9), commonName("MisidForBEff_" + tagName+"_"),
+	theDifferentialHistoB_d  (0),
+	theDifferentialHistoB_u  (0),
+	theDifferentialHistoB_s  (0),
+	theDifferentialHistoB_c  (0),
+	theDifferentialHistoB_b  (0),
+	theDifferentialHistoB_g  (0),
+	theDifferentialHistoB_ni (0),
+	theDifferentialHistoB_dus(0),
+	theDifferentialHistoB_dusg(0),
+	theDifferentialHistoB_pu (0),
+	mcPlots_(mc)
 {}
 
 
-BTagDifferentialPlot::~BTagDifferentialPlot () {
+BTagDifferentialPlot::~BTagDifferentialPlot() {
 }
 
 
@@ -45,114 +45,114 @@ BTagDifferentialPlot::~BTagDifferentialPlot () {
 
 
 
-void BTagDifferentialPlot::plot (TCanvas & thePlotCanvas ) {
+void BTagDifferentialPlot::plot(TCanvas & thePlotCanvas) {
 
-//   thePlotCanvas = new TCanvas(  commonName ,
-// 				commonName ,
-// 				btppXCanvas , btppYCanvas ) ;
+//   thePlotCanvas = new TCanvas( commonName,
+// 				commonName,
+// 				btppXCanvas, btppYCanvas);
 //
-//   if ( !btppTitle ) gStyle->SetOptTitle ( 0 ) ;
+//   if (!btppTitle) gStyle->SetOptTitle(0);
 
   if (!processed) return;
 //fixme:
   bool btppNI = false;
   bool btppColour = true;
 
-  thePlotCanvas.SetFillColor ( 0 ) ;
-  thePlotCanvas.cd ( 1 ) ;
-  gPad->SetLogy  ( 1 ) ;
-  gPad->SetGridx ( 1 ) ;
-  gPad->SetGridy ( 1 ) ;
+  thePlotCanvas.SetFillColor(0);
+  thePlotCanvas.cd(1);
+  gPad->SetLogy(1);
+  gPad->SetGridx(1);
+  gPad->SetGridy(1);
 
-//  int col_b   ;
-  int col_c   ;
-  int col_g   ;
-  int col_dus ;
-  int col_ni  ;
+//  int col_b;
+  int col_c;
+  int col_g;
+  int col_dus;
+  int col_ni;
 
-//  int mStyle_b   ;
-  int mStyle_c   ;
-  int mStyle_g   ;
-  int mStyle_dus ;
-  int mStyle_ni  ;
+//  int mStyle_b;
+  int mStyle_c;
+  int mStyle_g;
+  int mStyle_dus;
+  int mStyle_ni;
 
-  // marker size (same for all)
-  float mSize = 1.5 ;
+  // marker size(same for all)
+  float mSize = 1.5;
 
-  if ( btppColour ) {
-//    col_b    = 2 ;
-    col_c    = 6 ;
-    col_g    = 3 ;
-    col_dus  = 4 ;
-    col_ni   = 5 ;
-//    mStyle_b   = 20 ;
-    mStyle_c   = 20 ;
-    mStyle_g   = 20 ;
-    mStyle_dus = 20 ;
-    mStyle_ni  = 20 ;
+  if (btppColour) {
+//    col_b    = 2;
+    col_c    = 6;
+    col_g    = 3;
+    col_dus  = 4;
+    col_ni   = 5;
+//    mStyle_b   = 20;
+    mStyle_c   = 20;
+    mStyle_g   = 20;
+    mStyle_dus = 20;
+    mStyle_ni  = 20;
   }
   else {
-//    col_b    = 1 ;
-    col_c    = 1 ;
-    col_g    = 1 ;
-    col_dus  = 1 ;
-    col_ni   = 1 ;
-//    mStyle_b   = 12 ;
-    mStyle_c   = 22 ;
-    mStyle_g   = 29 ;
-    mStyle_dus = 20 ;
-    mStyle_ni  = 27 ;
+//    col_b    = 1;
+    col_c    = 1;
+    col_g    = 1;
+    col_dus  = 1;
+    col_ni   = 1;
+//    mStyle_b   = 12;
+    mStyle_c   = 22;
+    mStyle_g   = 29;
+    mStyle_dus = 20;
+    mStyle_ni  = 27;
   }
 
-  // for the moment: plot b (to see what the constant b-efficiency is), c, g, uds
+  // for the moment: plot b(to see what the constant b-efficiency is), c, g, uds
   // b in red
-  // No, do not plot b (because only visible for the soft leptons)
-  // theDifferentialHistoB_b   -> GetXaxis()->SetTitle ( diffVariableName ) ;
-  // theDifferentialHistoB_b   -> GetYaxis()->SetTitle ( "non b-jet efficiency" ) ;
-  // theDifferentialHistoB_b   -> GetYaxis()->SetTitleOffset ( 1.25 ) ;
-  // theDifferentialHistoB_b   -> SetMaximum ( 0.4 )  ;
-  // theDifferentialHistoB_b   -> SetMinimum ( 1.e-4 )  ;
-  // theDifferentialHistoB_b   -> SetMarkerColor ( col_b ) ;
-  // theDifferentialHistoB_b   -> SetLineColor   ( col_b ) ;
-  // theDifferentialHistoB_b   -> SetMarkerSize  ( mSize ) ;
-  // theDifferentialHistoB_b   -> SetMarkerStyle ( mStyle_b ) ;
-  // theDifferentialHistoB_b   -> SetStats ( false ) ;
-  // theDifferentialHistoB_b   -> Draw ( "pe" ) ;
+  // No, do not plot b(because only visible for the soft leptons)
+  // theDifferentialHistoB_b   -> GetXaxis()->SetTitle(diffVariableName);
+  // theDifferentialHistoB_b   -> GetYaxis()->SetTitle("non b-jet efficiency");
+  // theDifferentialHistoB_b   -> GetYaxis()->SetTitleOffset(1.25);
+  // theDifferentialHistoB_b   -> SetMaximum(0.4);
+  // theDifferentialHistoB_b   -> SetMinimum(1.e-4);
+  // theDifferentialHistoB_b   -> SetMarkerColor(col_b);
+  // theDifferentialHistoB_b   -> SetLineColor (col_b);
+  // theDifferentialHistoB_b   -> SetMarkerSize(mSize);
+  // theDifferentialHistoB_b   -> SetMarkerStyle(mStyle_b);
+  // theDifferentialHistoB_b   -> SetStats(false);
+  // theDifferentialHistoB_b   -> Draw("pe");
   // c in magenta
-  theDifferentialHistoB_c ->getTH1F()  -> SetMaximum ( 0.4 )  ;
-  theDifferentialHistoB_c ->getTH1F()  -> SetMinimum ( 1.e-4 )  ;
-  theDifferentialHistoB_c ->getTH1F()  -> SetMarkerColor ( col_c ) ;
-  theDifferentialHistoB_c ->getTH1F()  -> SetLineColor   ( col_c ) ;
-  theDifferentialHistoB_c ->getTH1F()  -> SetMarkerSize  ( mSize ) ;
-  theDifferentialHistoB_c ->getTH1F()  -> SetMarkerStyle ( mStyle_c ) ;
-  theDifferentialHistoB_c ->getTH1F()  -> SetStats     ( false ) ;
-  //  theDifferentialHistoB_c   -> Draw("peSame") ;
-  theDifferentialHistoB_c   ->getTH1F()-> Draw("pe") ;
-  if(mcPlots_>2){
+  theDifferentialHistoB_c ->getTH1F()  -> SetMaximum(0.4);
+  theDifferentialHistoB_c ->getTH1F()  -> SetMinimum(1.e-4);
+  theDifferentialHistoB_c ->getTH1F()  -> SetMarkerColor(col_c);
+  theDifferentialHistoB_c ->getTH1F()  -> SetLineColor (col_c);
+  theDifferentialHistoB_c ->getTH1F()  -> SetMarkerSize(mSize);
+  theDifferentialHistoB_c ->getTH1F()  -> SetMarkerStyle(mStyle_c);
+  theDifferentialHistoB_c ->getTH1F()  -> SetStats   (false);
+  //  theDifferentialHistoB_c   -> Draw("peSame");
+  theDifferentialHistoB_c   ->getTH1F()-> Draw("pe");
+  if (mcPlots_>2) {
     // uds in blue
-    theDifferentialHistoB_dus ->getTH1F()-> SetMarkerColor ( col_dus ) ;
-    theDifferentialHistoB_dus ->getTH1F()-> SetLineColor   ( col_dus ) ;
-    theDifferentialHistoB_dus ->getTH1F()-> SetMarkerSize  ( mSize ) ;
-    theDifferentialHistoB_dus ->getTH1F()-> SetMarkerStyle ( mStyle_dus ) ;
-    theDifferentialHistoB_dus ->getTH1F()-> SetStats     ( false ) ;
-    theDifferentialHistoB_dus ->getTH1F()-> Draw("peSame") ;
+    theDifferentialHistoB_dus ->getTH1F()-> SetMarkerColor(col_dus);
+    theDifferentialHistoB_dus ->getTH1F()-> SetLineColor (col_dus);
+    theDifferentialHistoB_dus ->getTH1F()-> SetMarkerSize(mSize);
+    theDifferentialHistoB_dus ->getTH1F()-> SetMarkerStyle(mStyle_dus);
+    theDifferentialHistoB_dus ->getTH1F()-> SetStats   (false);
+    theDifferentialHistoB_dus ->getTH1F()-> Draw("peSame");
     // g in green
     // only uds not to confuse
-    theDifferentialHistoB_g   ->getTH1F()-> SetMarkerColor ( col_g ) ;
-    theDifferentialHistoB_g   ->getTH1F()-> SetLineColor   ( col_g ) ;
-    theDifferentialHistoB_g   ->getTH1F()-> SetMarkerSize  ( mSize ) ;
-    theDifferentialHistoB_g   ->getTH1F()-> SetMarkerStyle ( mStyle_g ) ;
-    theDifferentialHistoB_g   ->getTH1F()-> SetStats     ( false ) ;
-    theDifferentialHistoB_g   ->getTH1F()-> Draw("peSame") ;
+    theDifferentialHistoB_g   ->getTH1F()-> SetMarkerColor(col_g);
+    theDifferentialHistoB_g   ->getTH1F()-> SetLineColor (col_g);
+    theDifferentialHistoB_g   ->getTH1F()-> SetMarkerSize(mSize);
+    theDifferentialHistoB_g   ->getTH1F()-> SetMarkerStyle(mStyle_g);
+    theDifferentialHistoB_g   ->getTH1F()-> SetStats   (false);
+    theDifferentialHistoB_g   ->getTH1F()-> Draw("peSame");
   }
   // NI if wanted
-  if ( btppNI ) {
-    theDifferentialHistoB_ni ->getTH1F()-> SetMarkerColor ( col_ni ) ;
-    theDifferentialHistoB_ni ->getTH1F()-> SetLineColor   ( col_ni ) ;
-    theDifferentialHistoB_ni ->getTH1F()-> SetMarkerSize  ( mSize ) ;
-    theDifferentialHistoB_ni ->getTH1F()-> SetMarkerStyle ( mStyle_ni ) ;
-    theDifferentialHistoB_ni ->getTH1F()-> SetStats     ( false ) ;
-    theDifferentialHistoB_ni ->getTH1F()-> Draw("peSame") ;
+  if (btppNI) {
+    theDifferentialHistoB_ni ->getTH1F()-> SetMarkerColor(col_ni);
+    theDifferentialHistoB_ni ->getTH1F()-> SetLineColor (col_ni);
+    theDifferentialHistoB_ni ->getTH1F()-> SetMarkerSize(mSize);
+    theDifferentialHistoB_ni ->getTH1F()-> SetMarkerStyle(mStyle_ni);
+    theDifferentialHistoB_ni ->getTH1F()-> SetStats   (false);
+    theDifferentialHistoB_ni ->getTH1F()-> Draw("peSame");
   }
 }
 
@@ -175,140 +175,140 @@ void BTagDifferentialPlot::plot(const std::string & name, const std::string & ex
 }
 
 
-void BTagDifferentialPlot::process (DQMStore::IBooker & ibook) {
-  setVariableName () ; // also sets noProcessing if not OK
-  if ( noProcessing ) return ;
-  bookHisto (ibook) ;
-  fillHisto () ;
+void BTagDifferentialPlot::process(DQMStore::IBooker & ibook) {
+  setVariableName(); // also sets noProcessing if not OK
+  if (noProcessing) return;
+  bookHisto(ibook);
+  fillHisto();
   processed = true;
 }
 
 
-void BTagDifferentialPlot::setVariableName ()
+void BTagDifferentialPlot::setVariableName()
 {
-  if ( constVar==constETA ) {
-    constVariableName  = "eta" ;
-    diffVariableName   = "pt"  ;
-    constVariableValue = make_pair ( theBinPlotters[0]->etaPtBin().getEtaMin() , theBinPlotters[0]->etaPtBin().getEtaMax() ) ;
+  if (constVar==constETA) {
+    constVariableName  = "eta";
+    diffVariableName   = "pt";
+    constVariableValue = make_pair(theBinPlotters[0]->etaPtBin().getEtaMin(), theBinPlotters[0]->etaPtBin().getEtaMax());
   }
-  if ( constVar==constPT  ) {
-    constVariableName = "pt"  ;
-    diffVariableName  = "eta" ;
-    constVariableValue = make_pair ( theBinPlotters[0]->etaPtBin().getPtMin() , theBinPlotters[0]->etaPtBin().getPtMax() ) ;
+  if (constVar==constPT ) {
+    constVariableName = "pt";
+    diffVariableName  = "eta";
+    constVariableValue = make_pair(theBinPlotters[0]->etaPtBin().getPtMin(), theBinPlotters[0]->etaPtBin().getPtMax());
   }
 }
 
 
 
-void BTagDifferentialPlot::bookHisto (DQMStore::IBooker & ibook) {
+void BTagDifferentialPlot::bookHisto(DQMStore::IBooker & ibook) {
 
   // vector with ranges
-  vector<float> variableRanges ;
+  vector<float> variableRanges;
 
-  for ( vector<JetTagPlotter *>::const_iterator iP = theBinPlotters.begin() ; 
-        iP != theBinPlotters.end() ; ++iP ) {
-    const EtaPtBin & currentBin = (*iP)->etaPtBin()  ;
-    if ( diffVariableName == "eta" ) {
+  for (vector<std::shared_ptr<JetTagPlotter>>::const_iterator iP = theBinPlotters.begin(); 
+        iP != theBinPlotters.end(); ++iP) {
+    const EtaPtBin & currentBin =(*iP)->etaPtBin();
+    if (diffVariableName == "eta") {
       // only active bins in the variable on x-axis
-      if ( currentBin.getEtaActive() ) {
-	variableRanges.push_back ( currentBin.getEtaMin() ) ;
+      if (currentBin.getEtaActive()) {
+	variableRanges.push_back(currentBin.getEtaMin());
 	// also max if last one
-	if ( iP == --theBinPlotters.end() ) variableRanges.push_back ( currentBin.getEtaMax() ) ;
+	if (iP == --theBinPlotters.end()) variableRanges.push_back(currentBin.getEtaMax());
       }
     }
-    if ( diffVariableName == "pt" ) {
+    if (diffVariableName == "pt") {
       // only active bins in the variable on x-axis
-      if ( currentBin.getPtActive() ) {
-	variableRanges.push_back ( currentBin.getPtMin() ) ;
+      if (currentBin.getPtActive()) {
+	variableRanges.push_back(currentBin.getPtMin());
 	// also max if last one
-	if ( iP == --theBinPlotters.end() ) variableRanges.push_back ( currentBin.getPtMax() ) ;
+	if (iP == --theBinPlotters.end()) variableRanges.push_back(currentBin.getPtMax());
       }
     }
   }
 
   // to book histo with variable binning -> put into array
-  int      nBins    = variableRanges.size() - 1 ;
+  int      nBins    = variableRanges.size() - 1;
   float * binArray = &variableRanges[0];
 
   // part of the name common to all flavours
   std::stringstream stream("");
-  stream << fixedBEfficiency << "_Const_" << constVariableName << "_" << constVariableValue.first << "-" ;
-  stream << constVariableValue.second << "_" << "_Vs_" << diffVariableName ;
+  stream << fixedBEfficiency << "_Const_" << constVariableName << "_" << constVariableValue.first << "-";
+  stream << constVariableValue.second << "_" << "_Vs_" << diffVariableName;
   commonName += stream.str();
-  std::remove(commonName.begin(), commonName.end(), ' ') ;
-  std::replace(commonName.begin(), commonName.end(), '.' , 'v' ) ;
+  std::remove(commonName.begin(), commonName.end(), ' ');
+  std::replace(commonName.begin(), commonName.end(), '.', 'v');
 
   std::string label(commonName);
-  HistoProviderDQM prov ("Btag",label,ibook);
+  HistoProviderDQM prov("Btag",label,ibook);
 
-  theDifferentialHistoB_b    = (prov.book1D ( "B_"    + commonName , "B_"    + commonName , nBins , binArray )) ;
-  theDifferentialHistoB_c    = (prov.book1D ( "C_"    + commonName , "C_"    + commonName , nBins , binArray )) ;
-  theDifferentialHistoB_dusg = (prov.book1D ( "DUSG_" + commonName , "DUSG_" + commonName , nBins , binArray )) ;
-  theDifferentialHistoB_ni   = (prov.book1D ( "NI_"   + commonName , "NI_"   + commonName , nBins , binArray )) ;
-  theDifferentialHistoB_pu   = (prov.book1D ( "PU_"   + commonName , "PU_"   + commonName , nBins , binArray )) ;
+  theDifferentialHistoB_b    =(prov.book1D("B_"    + commonName, "B_"    + commonName, nBins, binArray));
+  theDifferentialHistoB_c    =(prov.book1D("C_"    + commonName, "C_"    + commonName, nBins, binArray));
+  theDifferentialHistoB_dusg =(prov.book1D("DUSG_" + commonName, "DUSG_" + commonName, nBins, binArray));
+  theDifferentialHistoB_ni   =(prov.book1D("NI_"   + commonName, "NI_"   + commonName, nBins, binArray));
+  theDifferentialHistoB_pu   =(prov.book1D("PU_"   + commonName, "PU_"   + commonName, nBins, binArray));
 
-  if(mcPlots_>2){
-    theDifferentialHistoB_d    = (prov.book1D ( "D_"    + commonName , "D_"    + commonName , nBins , binArray )) ;
-    theDifferentialHistoB_u    = (prov.book1D ( "U_"    + commonName , "U_"    + commonName , nBins , binArray )) ;
-    theDifferentialHistoB_s    = (prov.book1D ( "S_"    + commonName , "S_"    + commonName , nBins , binArray )) ;
-    theDifferentialHistoB_g    = (prov.book1D ( "G_"    + commonName , "G_"    + commonName , nBins , binArray )) ;
-    theDifferentialHistoB_dus  = (prov.book1D ( "DUS_"  + commonName , "DUS_"  + commonName , nBins , binArray )) ;
+  if (mcPlots_>2) {
+    theDifferentialHistoB_d    =(prov.book1D("D_"    + commonName, "D_"    + commonName, nBins, binArray));
+    theDifferentialHistoB_u    =(prov.book1D("U_"    + commonName, "U_"    + commonName, nBins, binArray));
+    theDifferentialHistoB_s    =(prov.book1D("S_"    + commonName, "S_"    + commonName, nBins, binArray));
+    theDifferentialHistoB_g    =(prov.book1D("G_"    + commonName, "G_"    + commonName, nBins, binArray));
+    theDifferentialHistoB_dus  =(prov.book1D("DUS_"  + commonName, "DUS_"  + commonName, nBins, binArray));
   }
 }
 
 
-void BTagDifferentialPlot::fillHisto () {
+void BTagDifferentialPlot::fillHisto() {
   // loop over bins and find corresponding misid. in the MisIdVs..... histo
-  for ( vector<JetTagPlotter *>::const_iterator iP = theBinPlotters.begin() ;
-        iP != theBinPlotters.end() ; ++iP ) {
-    const EtaPtBin   & currentBin              = (*iP)->etaPtBin() ;
-    EffPurFromHistos * currentEffPurFromHistos = (*iP)->getEffPurFromHistos() ;
+  for (vector<std::shared_ptr<JetTagPlotter>>::const_iterator iP = theBinPlotters.begin();
+        iP != theBinPlotters.end(); ++iP) {
+    const EtaPtBin & currentBin =(*iP)->etaPtBin();
+    EffPurFromHistos & currentEffPurFromHistos =(*iP)->getEffPurFromHistos();
     //
-    bool   isActive   = true ;
-    double valueXAxis = -999.99 ;
+    bool   isActive   = true;
+    double valueXAxis = -999.99;
     // find right bin based on middle of the interval
-    if ( diffVariableName == "eta" ) {
-      isActive = currentBin.getEtaActive() ;
-      valueXAxis = 0.5 * ( currentBin.getEtaMin() + currentBin.getEtaMax() ) ;
-    } else if ( diffVariableName == "pt"  ) {
-      isActive = currentBin.getPtActive() ;
-      valueXAxis = 0.5 * ( currentBin.getPtMin() + currentBin.getPtMax() ) ;
+    if (diffVariableName == "eta") {
+      isActive = currentBin.getEtaActive();
+      valueXAxis = 0.5 *(currentBin.getEtaMin() + currentBin.getEtaMax());
+    } else if (diffVariableName == "pt" ) {
+      isActive = currentBin.getPtActive();
+      valueXAxis = 0.5 *(currentBin.getPtMin() + currentBin.getPtMax());
     } else {
       throw cms::Exception("Configuration")
 	<< "====>>>> BTagDifferentialPlot::fillHisto() : illegal diffVariableName = " << diffVariableName << endl;
     }
 
     // for the moment: ignore inactive bins
-    // (maybe later: if a Bin is inactive -> set value to fill well below left edge of histogram to have it in the underflow)
+    //(maybe later: if a Bin is inactive -> set value to fill well below left edge of histogram to have it in the underflow)
 
-    if ( !isActive ) continue ;
+    if (!isActive) continue;
 
     // to have less lines of code ....
-    vector< pair<TH1F*,TH1F*> > effPurDifferentialPairs ;
+    vector< pair<TH1F*,TH1F*> > effPurDifferentialPairs;
 
-    // all flavours (b is a good cross check! must be constant and = fixed b-efficiency)
+    // all flavours(b is a good cross check! must be constant and = fixed b-efficiency)
     // get histo; find the bin of the fixed b-efficiency in the histo and get misid; fill
 
 
-    effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_b()    , theDifferentialHistoB_b  ->getTH1F()  ) ) ;
-    effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_c()    , theDifferentialHistoB_c  ->getTH1F()  ) ) ;
-    effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_dusg() , theDifferentialHistoB_dusg->getTH1F() ) ) ;
-    effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_ni()   , theDifferentialHistoB_ni ->getTH1F()  ) ) ;
-    effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_pu()   , theDifferentialHistoB_pu->getTH1F()   ) ) ;
-    if(mcPlots_>2){
-      effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_d()    , theDifferentialHistoB_d ->getTH1F()   ) ) ;
-      effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_u()    , theDifferentialHistoB_u ->getTH1F()   ) ) ;
-      effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_s()    , theDifferentialHistoB_s ->getTH1F()   ) ) ;
-      effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_g()    , theDifferentialHistoB_g  ->getTH1F()  ) ) ;
-      effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_dus()  , theDifferentialHistoB_dus->getTH1F()  ) ) ;
+    effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_b()  , theDifferentialHistoB_b  ->getTH1F() ));
+    effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_c()  , theDifferentialHistoB_c  ->getTH1F() ));
+    effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_dusg(), theDifferentialHistoB_dusg->getTH1F()));
+    effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_ni() , theDifferentialHistoB_ni ->getTH1F() ));
+    effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_pu() , theDifferentialHistoB_pu->getTH1F()  ));
+    if (mcPlots_>2) {
+      effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_d()  , theDifferentialHistoB_d ->getTH1F()  ));
+      effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_u()  , theDifferentialHistoB_u ->getTH1F()  ));
+      effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_s()  , theDifferentialHistoB_s ->getTH1F()  ));
+      effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_g()  , theDifferentialHistoB_g  ->getTH1F() ));
+      effPurDifferentialPairs.push_back(make_pair(currentEffPurFromHistos.getEffFlavVsBEff_dus(), theDifferentialHistoB_dus->getTH1F() ));
     }
 
-    for ( vector< pair<TH1F*,TH1F*> >::const_iterator itP  = effPurDifferentialPairs.begin() ;
-	                                              itP != effPurDifferentialPairs.end()   ; ++itP ) {
-      TH1F * effPurHist = itP->first  ;
-      TH1F * diffHist   = itP->second ;
+    for (vector< pair<TH1F*,TH1F*> >::const_iterator itP  = effPurDifferentialPairs.begin();
+	                                              itP != effPurDifferentialPairs.end(); ++itP) {
+      TH1F * effPurHist = itP->first;
+      TH1F * diffHist   = itP->second;
       pair<double, double> mistag = getMistag(fixedBEfficiency, effPurHist);
-      int iBinSet = diffHist->FindBin(valueXAxis) ;
+      int iBinSet = diffHist->FindBin(valueXAxis);
       diffHist->SetBinContent(iBinSet, mistag.first);
       diffHist->SetBinError(iBinSet, mistag.second);
     }
@@ -319,9 +319,9 @@ void BTagDifferentialPlot::fillHisto () {
 pair<double, double>
 BTagDifferentialPlot::getMistag(const double& fixedBEfficiency, TH1F * effPurHist)
 {
-  int iBinGet = effPurHist->FindBin ( fixedBEfficiency ) ;
-  double effForBEff    = effPurHist->GetBinContent ( iBinGet ) ;
-  double effForBEffErr = effPurHist->GetBinError   ( iBinGet ) ;
+  int iBinGet = effPurHist->FindBin(fixedBEfficiency);
+  double effForBEff    = effPurHist->GetBinContent(iBinGet);
+  double effForBEffErr = effPurHist->GetBinError (iBinGet);
 
   if (effForBEff==0. && effForBEffErr==0.) {
     // The bin was empty. Could be that it was not filled, as the scan-plot
@@ -333,11 +333,11 @@ BTagDifferentialPlot::getMistag(const double& fixedBEfficiency, TH1F * effPurHis
     TF1 myfunc("myfunc","pol4");
     try {
       fitStatus = effPurHist->Fit(&myfunc, "q");
-    }catch (cms::Exception& iException){
+    }catch(cms::Exception& iException) {
       return pair<double, double>(effForBEff, effForBEffErr);
     }
     if (fitStatus != 0) {
-      edm::LogWarning("BTagDifferentialPlot")<<"Fit failed to hisogram " << effPurHist->GetTitle() << " , perhaps because too few entries = " << effPurHist->GetEntries() <<". This bin will be missing in plots at fixed b efficiency.";
+      edm::LogWarning("BTagDifferentialPlot")<<"Fit failed to hisogram " << effPurHist->GetTitle() << ", perhaps because too few entries = " << effPurHist->GetEntries() <<". This bin will be missing in plots at fixed b efficiency.";
       //    } else {
       //      edm::LogInfo("BTagDifferentialPlot")<<"Fit OK to hisogram " << effPurHist->GetTitle() << " entries = " << effPurHist->GetEntries();
       return pair<double, double>(effForBEff, effForBEffErr);

--- a/DQMOffline/RecoB/src/BaseTagInfoPlotter.cc
+++ b/DQMOffline/RecoB/src/BaseTagInfoPlotter.cc
@@ -3,25 +3,18 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
-// #include "RecoBTag/MCTools/interface/JetFlavour.h"
 #include "DQMOffline/RecoB/interface/BaseTagInfoPlotter.h"
 
 using namespace std;
 using namespace reco;
 
-void BaseTagInfoPlotter::analyzeTag(const BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour)
+void BaseTagInfoPlotter::analyzeTag(const BaseTagInfo * tagInfo, double jec, int jetFlavour, float w/*=1*/)
 {
   throw cms::Exception("MissingVirtualMethod")
   	<< "No analyzeTag method overloaded from BaseTagInfoPlotter." << endl;
 }
 
-void BaseTagInfoPlotter::analyzeTag(const BaseTagInfo * tagInfo, const double & jec, const int & jetFlavour, const float & w)
-{
-  throw cms::Exception("MissingVirtualMethod")
-  	<< "No analyzeTag method overloaded from BaseTagInfoPlotter." << endl;
-}
-
-void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour, const float & w)
+void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos, double jec, int jetFlavour, float w/*=1*/)
 {
 
   if (tagInfos.size() != 1)
@@ -30,15 +23,6 @@ void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos,
 
   analyzeTag(tagInfos.front(), jec, jetFlavour, w);
 
-}
-
-void BaseTagInfoPlotter::analyzeTag(const vector<const BaseTagInfo *> &tagInfos, const double & jec, const int & jetFlavour)
-{
-  if (tagInfos.size() != 1)
-    throw cms::Exception("MismatchedTagInfos")
-      << tagInfos.size() << " BaseTagInfos passed, but only one expected." << endl;
-  
-  analyzeTag(tagInfos.front(), jec, jetFlavour);
 }
 
 void BaseTagInfoPlotter::setEventSetup(const edm::EventSetup & setup)

--- a/DQMOffline/RecoB/src/EffPurFromHistos.cc
+++ b/DQMOffline/RecoB/src/EffPurFromHistos.cc
@@ -14,106 +14,104 @@
 using namespace std;
 using namespace RecoBTag;
 
-EffPurFromHistos::EffPurFromHistos ( const std::string & ext, TH1F * h_d, TH1F * h_u,
-				     TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g, TH1F * h_ni,
-				     TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
-				     const std::string& label, const unsigned int& mc, 
-				     int nBin, double startO, double endO) :
+EffPurFromHistos::EffPurFromHistos(const std::string & ext, TH1F * h_d, TH1F * h_u,
+                     TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g, TH1F * h_ni,
+                     TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
+                     const std::string& label, unsigned int mc, 
+                     int nBin, double startO, double endO):
         fromDiscriminatorDistr(false),
-	mcPlots_(mc), doCTagPlots_(false), label_(label),
-	histoExtension(ext), effVersusDiscr_d(h_d), effVersusDiscr_u(h_u),
-	effVersusDiscr_s(h_s), effVersusDiscr_c(h_c), effVersusDiscr_b(h_b),
-	effVersusDiscr_g(h_g), effVersusDiscr_ni(h_ni), effVersusDiscr_dus(h_dus),
-	effVersusDiscr_dusg(h_dusg), effVersusDiscr_pu(h_pu), 
-	nBinOutput(nBin), startOutput(startO), endOutput(endO)
+        mcPlots_(mc), doCTagPlots_(false), label_(label),
+        histoExtension(ext), effVersusDiscr_d(h_d), effVersusDiscr_u(h_u),
+        effVersusDiscr_s(h_s), effVersusDiscr_c(h_c), effVersusDiscr_b(h_b),
+        effVersusDiscr_g(h_g), effVersusDiscr_ni(h_ni), effVersusDiscr_dus(h_dus),
+        effVersusDiscr_dusg(h_dusg), effVersusDiscr_pu(h_pu), 
+        nBinOutput(nBin), startOutput(startO), endOutput(endO)
 {
   // consistency check
   check();
 }
 
-EffPurFromHistos::EffPurFromHistos (const FlavourHistograms<double> * dDiscriminatorFC, const std::string& label, 
-				    const unsigned int& mc, DQMStore::IBooker & ibook, int nBin,
-				    double startO, double endO) :
-	  fromDiscriminatorDistr(true), 
-	  mcPlots_(mc), doCTagPlots_(false), label_(label),
-	  nBinOutput(nBin), startOutput(startO), endOutput(endO)  
+EffPurFromHistos::EffPurFromHistos(const FlavourHistograms<double>& dDiscriminatorFC, const std::string& label, 
+                    unsigned int mc, DQMStore::IBooker & ibook, int nBin,
+                    double startO, double endO) :
+      fromDiscriminatorDistr(true), 
+      mcPlots_(mc), doCTagPlots_(false), label_(label),
+      nBinOutput(nBin), startOutput(startO), endOutput(endO)  
 {
-  histoExtension = "_"+dDiscriminatorFC->baseNameTitle();
+  histoExtension = "_" + dDiscriminatorFC.baseNameTitle();
 
 
-  discrNoCutEffic.reset( new FlavourHistograms<double> (
-	"totalEntries" + histoExtension, "Total Entries: " + dDiscriminatorFC->baseNameDescription(),
-	dDiscriminatorFC->nBins(), dDiscriminatorFC->lowerBound(),
-	dDiscriminatorFC->upperBound(), false, true, false, "b", label, mcPlots_, ibook ));
+  discrNoCutEffic.reset( new FlavourHistograms<double>(
+    "totalEntries" + histoExtension, "Total Entries: " + dDiscriminatorFC.baseNameDescription(),
+    dDiscriminatorFC.nBins(), dDiscriminatorFC.lowerBound(),
+    dDiscriminatorFC.upperBound(), false, true, false, "b", label, mcPlots_, ibook ));
 
   // conditional discriminator cut for efficiency histos
 
-  discrCutEfficScan.reset( new FlavourHistograms<double> (
-	"effVsDiscrCut" + histoExtension, "Eff. vs Disc. Cut: " + dDiscriminatorFC->baseNameDescription(),
-	dDiscriminatorFC->nBins(), dDiscriminatorFC->lowerBound(),
-	dDiscriminatorFC->upperBound(), false, true, false, "b", label , mcPlots_, ibook ));
+  discrCutEfficScan.reset( new FlavourHistograms<double>(
+    "effVsDiscrCut" + histoExtension, "Eff. vs Disc. Cut: " + dDiscriminatorFC.baseNameDescription(),
+    dDiscriminatorFC.nBins(), dDiscriminatorFC.lowerBound(),
+    dDiscriminatorFC.upperBound(), false, true, false, "b", label, mcPlots_, ibook ));
   discrCutEfficScan->SetMinimum(1E-4);
-  if (mcPlots_){ 
+  if (mcPlots_) { 
 
-    if(mcPlots_>2){
-      effVersusDiscr_d =    discrCutEfficScan->histo_d   ();
-      effVersusDiscr_u =    discrCutEfficScan->histo_u   ();
-      effVersusDiscr_s =    discrCutEfficScan->histo_s   ();
-      effVersusDiscr_g =    discrCutEfficScan->histo_g   ();
-      effVersusDiscr_dus =  discrCutEfficScan->histo_dus ();
+    if (mcPlots_ > 2) {
+      effVersusDiscr_d =    discrCutEfficScan->histo_d  ();
+      effVersusDiscr_u =    discrCutEfficScan->histo_u  ();
+      effVersusDiscr_s =    discrCutEfficScan->histo_s  ();
+      effVersusDiscr_g =    discrCutEfficScan->histo_g  ();
+      effVersusDiscr_dus =  discrCutEfficScan->histo_dus();
+    } else {
+      effVersusDiscr_d   =  nullptr;
+      effVersusDiscr_u   =  nullptr; 
+      effVersusDiscr_s   =  nullptr;
+      effVersusDiscr_g   =  nullptr;
+      effVersusDiscr_dus =  nullptr;
     }
-    else{
-      effVersusDiscr_d   =  0;
-      effVersusDiscr_u   =  0; 
-      effVersusDiscr_s   =  0;
-      effVersusDiscr_g   =  0;
-      effVersusDiscr_dus =  0;
-    }
-    effVersusDiscr_c =    discrCutEfficScan->histo_c   ();
-    effVersusDiscr_b =    discrCutEfficScan->histo_b   ();
-    effVersusDiscr_ni =   discrCutEfficScan->histo_ni  ();
+    effVersusDiscr_c =    discrCutEfficScan->histo_c  ();
+    effVersusDiscr_b =    discrCutEfficScan->histo_b  ();
+    effVersusDiscr_ni =   discrCutEfficScan->histo_ni ();
     effVersusDiscr_dusg = discrCutEfficScan->histo_dusg();
     effVersusDiscr_pu = discrCutEfficScan->histo_pu();
 
   
-    if(mcPlots_>2){
-      effVersusDiscr_d->SetXTitle ( "Discriminant" );
-      effVersusDiscr_d->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_u->SetXTitle ( "Discriminant" );
-      effVersusDiscr_u->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_s->SetXTitle ( "Discriminant" );
-      effVersusDiscr_s->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_g->SetXTitle ( "Discriminant" );
-      effVersusDiscr_g->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_dus->SetXTitle ( "Discriminant" );
-      effVersusDiscr_dus->GetXaxis()->SetTitleOffset ( 0.75 );
+    if ( mcPlots_ > 2) {
+      effVersusDiscr_d->SetXTitle( "Discriminant" );
+      effVersusDiscr_d->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_u->SetXTitle( "Discriminant" );
+      effVersusDiscr_u->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_s->SetXTitle( "Discriminant" );
+      effVersusDiscr_s->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_g->SetXTitle( "Discriminant" );
+      effVersusDiscr_g->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_dus->SetXTitle( "Discriminant" );
+      effVersusDiscr_dus->GetXaxis()->SetTitleOffset( 0.75 );
     }
-    effVersusDiscr_c->SetXTitle ( "Discriminant" );
-    effVersusDiscr_c->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_b->SetXTitle ( "Discriminant" );
-    effVersusDiscr_b->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_ni->SetXTitle ( "Discriminant" );
-    effVersusDiscr_ni->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_dusg->SetXTitle ( "Discriminant" );
-    effVersusDiscr_dusg->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_pu->SetXTitle ( "Discriminant" );
-    effVersusDiscr_pu->GetXaxis()->SetTitleOffset ( 0.75 );
-  }
-  else{
-    effVersusDiscr_d =    0;
-    effVersusDiscr_u =    0; 
-    effVersusDiscr_s =    0;
-    effVersusDiscr_c =    0; 
-    effVersusDiscr_b =    0;
-    effVersusDiscr_g =    0;
-    effVersusDiscr_ni =   0;
-    effVersusDiscr_dus =  0;
-    effVersusDiscr_dusg = 0;
-    effVersusDiscr_pu = 0;
+    effVersusDiscr_c->SetXTitle( "Discriminant" );
+    effVersusDiscr_c->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_b->SetXTitle( "Discriminant" );
+    effVersusDiscr_b->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_ni->SetXTitle( "Discriminant" );
+    effVersusDiscr_ni->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_dusg->SetXTitle( "Discriminant" );
+    effVersusDiscr_dusg->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_pu->SetXTitle( "Discriminant" );
+    effVersusDiscr_pu->GetXaxis()->SetTitleOffset( 0.75 );
+  } else {
+    effVersusDiscr_d =    nullptr;
+    effVersusDiscr_u =    nullptr; 
+    effVersusDiscr_s =    nullptr;
+    effVersusDiscr_c =    nullptr; 
+    effVersusDiscr_b =    nullptr;
+    effVersusDiscr_g =    nullptr;
+    effVersusDiscr_ni =   nullptr;
+    effVersusDiscr_dus =  nullptr;
+    effVersusDiscr_dusg = nullptr;
+    effVersusDiscr_pu = nullptr;
   }
 
   // discr. for computation
-  vector<TH1F*> discrCfHistos = dDiscriminatorFC->getHistoVector();
+  vector<TH1F*> discrCfHistos = dDiscriminatorFC.getHistoVector();
 
   // discr no cut
   vector<TH1F*> discrNoCutHistos = discrNoCutEffic->getHistoVector();
@@ -127,36 +125,36 @@ EffPurFromHistos::EffPurFromHistos (const FlavourHistograms<double> * dDiscrimin
   // fill the histos for eff-pur computations by scanning the discriminatorFC histogram
 
   // better to loop over bins -> discrCut no longer needed
-  const int& nBins = dDiscriminatorFC->nBins();
+  const int& nBins = dDiscriminatorFC.nBins();
 
   // loop over flavours
   for ( int iFlav = 0; iFlav < dimHistos; iFlav++ ) {
     if (discrCfHistos[iFlav] == 0) continue;
-    discrNoCutHistos[iFlav]->SetXTitle ( "Discriminant" );
-    discrNoCutHistos[iFlav]->GetXaxis()->SetTitleOffset ( 0.75 );
+    discrNoCutHistos[iFlav]->SetXTitle( "Discriminant" );
+    discrNoCutHistos[iFlav]->GetXaxis()->SetTitleOffset( 0.75 );
 
     // In Root histos, bin counting starts at 1 to nBins.
     // bin 0 is the underflow, and nBins+1 is the overflow.
-    const double& nJetsFlav = discrCfHistos[iFlav]->GetEntries ();
+    const double& nJetsFlav = discrCfHistos[iFlav]->GetEntries();
     double sum = discrCfHistos[iFlav]->GetBinContent( nBins+1 ); //+1 to get the overflow.
     
     for ( int iDiscr = nBins; iDiscr > 0 ; --iDiscr ) {
       // fill all jets into NoCut histo
-      discrNoCutHistos[iFlav]->SetBinContent ( iDiscr, nJetsFlav );
-      discrNoCutHistos[iFlav]->SetBinError   ( iDiscr, sqrt(nJetsFlav) );
+      discrNoCutHistos[iFlav]->SetBinContent( iDiscr, nJetsFlav );
+      discrNoCutHistos[iFlav]->SetBinError  ( iDiscr, sqrt(nJetsFlav) );
       sum += discrCfHistos[iFlav]->GetBinContent( iDiscr );
-      discrCutHistos[iFlav]->SetBinContent ( iDiscr, sum );
-      discrCutHistos[iFlav]->SetBinError   ( iDiscr, sqrt(sum) );
+      discrCutHistos[iFlav]->SetBinContent( iDiscr, sum );
+      discrCutHistos[iFlav]->SetBinError  ( iDiscr, sqrt(sum) );
     }
   }
 
 
   // divide to get efficiency vs. discriminator cut from absolute numbers
-  discrCutEfficScan->divide ( *discrNoCutEffic );  // does: histos including discriminator cut / flat histo
+  discrCutEfficScan->divide(*discrNoCutEffic);  // does: histos including discriminator cut / flat histo
   discrCutEfficScan->setEfficiencyFlag();
 }
 
-EffPurFromHistos::~EffPurFromHistos () {}
+EffPurFromHistos::~EffPurFromHistos() {}
 
 void EffPurFromHistos::epsPlot(const std::string & name)
 {
@@ -175,38 +173,38 @@ void EffPurFromHistos::psPlot(const std::string & name)
 void EffPurFromHistos::plot(const std::string & name, const std::string & ext)
 {
    std::string hX = "";
-	 std::string Title = "";
-   if(!doCTagPlots_){
-	   hX = "FlavEffVsBEff";
-		 Title = "b";
+     std::string Title = "";
+   if (!doCTagPlots_) {
+       hX = "FlavEffVsBEff";
+         Title = "b";
    }
    else{
      hX = "FlavEffVsCEff";
-		 Title = "c";
+         Title = "c";
    }
-   TCanvas tc ((hX +histoExtension).c_str() ,
-	("Flavour misidentification vs. " + Title + "-tagging efficiency " + histoExtension).c_str());
+   TCanvas tc((hX +histoExtension).c_str(),
+   ("Flavour misidentification vs. " + Title + "-tagging efficiency " + histoExtension).c_str());
    plot(&tc);
    tc.Print((name + hX + histoExtension + ext).c_str());
 }
 
-void EffPurFromHistos::plot (TPad * plotCanvas /* = 0 */) {
+void EffPurFromHistos::plot(TPad * plotCanvas /* = 0 */) {
 
 //fixme:
   bool btppNI = false;
   bool btppColour = true;
 
-//   if ( !btppTitle ) gStyle->SetOptTitle ( 0 );
+//   if ( !btppTitle ) gStyle->SetOptTitle( 0 );
   setTDRStyle()->cd();
 
   if (plotCanvas)
     plotCanvas->cd();
   
   gPad->UseCurrentStyle();
-  gPad->SetFillColor ( 0 );
-  gPad->SetLogy  ( 1 );
-  gPad->SetGridx ( 1 );
-  gPad->SetGridy ( 1 );
+  gPad->SetFillColor( 0 );
+  gPad->SetLogy ( 1 );
+  gPad->SetGridx( 1 );
+  gPad->SetGridy( 1 );
 
   int col_c  ;
   int col_g  ;
@@ -218,7 +216,7 @@ void EffPurFromHistos::plot (TPad * plotCanvas /* = 0 */) {
   int mStyle_dus;
   int mStyle_ni ;
 
-  // marker size (same for all)
+  // marker size(same for all)
   float mSize = gPad->GetWh() * gPad->GetHNDC() / 500.; //1.2;
 
   if ( btppColour ) {
@@ -243,7 +241,7 @@ void EffPurFromHistos::plot (TPad * plotCanvas /* = 0 */) {
   }
   
   TString Title = "";
-  if(!doCTagPlots_){
+  if (!doCTagPlots_) {
         Title = "b";
   }
   else{
@@ -251,34 +249,34 @@ void EffPurFromHistos::plot (TPad * plotCanvas /* = 0 */) {
   } 
  
   // for the moment: plot c,dus,g
-  if(mcPlots_>2){
-    EffFlavVsXEff_dus ->getTH1F()->GetXaxis()->SetTitle ( Title + "-jet efficiency" );
-    EffFlavVsXEff_dus ->getTH1F()->GetYaxis()->SetTitle ( "non " + Title + "-jet efficiency");
-    EffFlavVsXEff_dus ->getTH1F()->GetYaxis()->SetTitleOffset ( 0.25 );
-    EffFlavVsXEff_dus ->getTH1F()->SetMaximum     ( 1.1 );
-    EffFlavVsXEff_dus ->getTH1F()->SetMinimum     ( 1.e-5 );
-    EffFlavVsXEff_dus ->getTH1F()->SetMarkerColor ( col_dus );
-    EffFlavVsXEff_dus ->getTH1F()->SetLineColor   ( col_dus );
-    EffFlavVsXEff_dus ->getTH1F()->SetMarkerSize  ( mSize );
-    EffFlavVsXEff_dus ->getTH1F()->SetMarkerStyle ( mStyle_dus );
-    EffFlavVsXEff_dus ->getTH1F()->SetStats     ( false );
+  if (mcPlots_>2) {
+    EffFlavVsXEff_dus ->getTH1F()->GetXaxis()->SetTitle( Title + "-jet efficiency" );
+    EffFlavVsXEff_dus ->getTH1F()->GetYaxis()->SetTitle( "non " + Title + "-jet efficiency");
+    EffFlavVsXEff_dus ->getTH1F()->GetYaxis()->SetTitleOffset( 0.25 );
+    EffFlavVsXEff_dus ->getTH1F()->SetMaximum    ( 1.1 );
+    EffFlavVsXEff_dus ->getTH1F()->SetMinimum    ( 1.e-5 );
+    EffFlavVsXEff_dus ->getTH1F()->SetMarkerColor( col_dus );
+    EffFlavVsXEff_dus ->getTH1F()->SetLineColor  ( col_dus );
+    EffFlavVsXEff_dus ->getTH1F()->SetMarkerSize ( mSize );
+    EffFlavVsXEff_dus ->getTH1F()->SetMarkerStyle( mStyle_dus );
+    EffFlavVsXEff_dus ->getTH1F()->SetStats    ( false );
     EffFlavVsXEff_dus ->getTH1F()->Draw("pe");
 
-    EffFlavVsXEff_g   ->getTH1F()->SetMarkerColor ( col_g );
-    EffFlavVsXEff_g   ->getTH1F()->SetLineColor   ( col_g );
-    EffFlavVsXEff_g   ->getTH1F()->SetMarkerSize  ( mSize );
-    EffFlavVsXEff_g   ->getTH1F()->SetMarkerStyle ( mStyle_g );
-    EffFlavVsXEff_g   ->getTH1F()->SetStats     ( false );
+    EffFlavVsXEff_g   ->getTH1F()->SetMarkerColor( col_g );
+    EffFlavVsXEff_g   ->getTH1F()->SetLineColor  ( col_g );
+    EffFlavVsXEff_g   ->getTH1F()->SetMarkerSize ( mSize );
+    EffFlavVsXEff_g   ->getTH1F()->SetMarkerStyle( mStyle_g );
+    EffFlavVsXEff_g   ->getTH1F()->SetStats    ( false );
     EffFlavVsXEff_g   ->getTH1F()->Draw("peSame");
   }
-  EffFlavVsXEff_c   ->getTH1F()->SetMarkerColor ( col_c );
-  EffFlavVsXEff_c   ->getTH1F()->SetLineColor   ( col_c );
-  EffFlavVsXEff_c   ->getTH1F()->SetMarkerSize  ( mSize );
-  EffFlavVsXEff_c   ->getTH1F()->SetMarkerStyle ( mStyle_c );
-  EffFlavVsXEff_c   ->getTH1F()->SetStats     ( false );
+  EffFlavVsXEff_c   ->getTH1F()->SetMarkerColor( col_c );
+  EffFlavVsXEff_c   ->getTH1F()->SetLineColor  ( col_c );
+  EffFlavVsXEff_c   ->getTH1F()->SetMarkerSize ( mSize );
+  EffFlavVsXEff_c   ->getTH1F()->SetMarkerStyle( mStyle_c );
+  EffFlavVsXEff_c   ->getTH1F()->SetStats    ( false );
   EffFlavVsXEff_c   ->getTH1F()->Draw("peSame");
 
-  if(mcPlots_>2){
+  if (mcPlots_>2) {
     EffFlavVsXEff_d ->getTH1F()-> SetMinimum(0.01);
     EffFlavVsXEff_u ->getTH1F()-> SetMinimum(0.01);
     EffFlavVsXEff_s ->getTH1F()-> SetMinimum(0.01);
@@ -292,45 +290,45 @@ void EffPurFromHistos::plot (TPad * plotCanvas /* = 0 */) {
   EffFlavVsXEff_pu ->getTH1F()-> SetMinimum(0.01);
 
   // plot separately u,d and s
-//  EffFlavVsXEff_d ->GetXaxis()->SetTitle ( Title + "-jet efficiency" );
-//  EffFlavVsXEff_d ->GetYaxis()->SetTitle ( "non " + Title + "-jet efficiency" );
-//  EffFlavVsXEff_d ->GetYaxis()->SetTitleOffset ( 1.25 );
-//  EffFlavVsXEff_d ->SetMaximum     ( 1.1 );
-//  EffFlavVsXEff_d ->SetMinimum     ( 1.e-5 );
-//  EffFlavVsXEff_d ->SetMarkerColor ( col_dus );
-//  EffFlavVsXEff_d ->SetLineColor   ( col_dus );
-//  EffFlavVsXEff_d ->SetMarkerSize  ( mSize );
-//  EffFlavVsXEff_d ->SetMarkerStyle ( mStyle_dus );
-//  EffFlavVsXEff_d ->SetStats     ( false );
+//  EffFlavVsXEff_d ->GetXaxis()->SetTitle( Title + "-jet efficiency" );
+//  EffFlavVsXEff_d ->GetYaxis()->SetTitle( "non " + Title + "-jet efficiency" );
+//  EffFlavVsXEff_d ->GetYaxis()->SetTitleOffset( 1.25 );
+//  EffFlavVsXEff_d ->SetMaximum    ( 1.1 );
+//  EffFlavVsXEff_d ->SetMinimum    ( 1.e-5 );
+//  EffFlavVsXEff_d ->SetMarkerColor( col_dus );
+//  EffFlavVsXEff_d ->SetLineColor  ( col_dus );
+//  EffFlavVsXEff_d ->SetMarkerSize ( mSize );
+//  EffFlavVsXEff_d ->SetMarkerStyle( mStyle_dus );
+//  EffFlavVsXEff_d ->SetStats    ( false );
 //  EffFlavVsXEff_d ->Draw("pe");
 //
-//  EffFlavVsXEff_u   ->SetMarkerColor ( col_g );
-//  EffFlavVsXEff_u   ->SetLineColor   ( col_g );
-//  EffFlavVsXEff_u   ->SetMarkerSize  ( mSize );
-//  EffFlavVsXEff_u   ->SetMarkerStyle ( mStyle_g );
-//  EffFlavVsXEff_u   ->SetStats     ( false );
+//  EffFlavVsXEff_u   ->SetMarkerColor( col_g );
+//  EffFlavVsXEff_u   ->SetLineColor  ( col_g );
+//  EffFlavVsXEff_u   ->SetMarkerSize ( mSize );
+//  EffFlavVsXEff_u   ->SetMarkerStyle( mStyle_g );
+//  EffFlavVsXEff_u   ->SetStats    ( false );
 //  EffFlavVsXEff_u   ->Draw("peSame");
 //
-//  EffFlavVsXEff_s   ->SetMarkerColor ( col_c );
-//  EffFlavVsXEff_s   ->SetLineColor   ( col_c );
-//  EffFlavVsXEff_s   ->SetMarkerSize  ( mSize );
-//  EffFlavVsXEff_s   ->SetMarkerStyle ( mStyle_c );
-//  EffFlavVsXEff_s   ->SetStats     ( false );
+//  EffFlavVsXEff_s   ->SetMarkerColor( col_c );
+//  EffFlavVsXEff_s   ->SetLineColor  ( col_c );
+//  EffFlavVsXEff_s   ->SetMarkerSize ( mSize );
+//  EffFlavVsXEff_s   ->SetMarkerStyle( mStyle_c );
+//  EffFlavVsXEff_s   ->SetStats    ( false );
 //  EffFlavVsXEff_s   ->Draw("peSame");
 
   // only if asked: NI
   if ( btppNI ) {
-    EffFlavVsXEff_ni   ->getTH1F()->SetMarkerColor ( col_ni );
-    EffFlavVsXEff_ni   ->getTH1F()->SetLineColor   ( col_ni );
-    EffFlavVsXEff_ni   ->getTH1F()->SetMarkerSize  ( mSize );
-    EffFlavVsXEff_ni   ->getTH1F()->SetMarkerStyle ( mStyle_ni );
-    EffFlavVsXEff_ni   ->getTH1F()->SetStats     ( false );
+    EffFlavVsXEff_ni   ->getTH1F()->SetMarkerColor( col_ni );
+    EffFlavVsXEff_ni   ->getTH1F()->SetLineColor  ( col_ni );
+    EffFlavVsXEff_ni   ->getTH1F()->SetMarkerSize ( mSize );
+    EffFlavVsXEff_ni   ->getTH1F()->SetMarkerStyle( mStyle_ni );
+    EffFlavVsXEff_ni   ->getTH1F()->SetStats    ( false );
     EffFlavVsXEff_ni   ->getTH1F()->Draw("peSame");
   }
 }
 
 
-void EffPurFromHistos::check () {
+void EffPurFromHistos::check() {
   // number of bins
 
   int nBins_d    = 0;
@@ -338,7 +336,7 @@ void EffPurFromHistos::check () {
   int nBins_s    = 0;
   int nBins_g    = 0;
   int nBins_dus  = 0;
-  if(mcPlots_>2){
+  if (mcPlots_>2) {
     nBins_d    = effVersusDiscr_d    -> GetNbinsX();
     nBins_u    = effVersusDiscr_u    -> GetNbinsX();
     nBins_s    = effVersusDiscr_s    -> GetNbinsX();
@@ -352,7 +350,7 @@ void EffPurFromHistos::check () {
   const int& nBins_pu   = effVersusDiscr_pu   -> GetNbinsX();
 
   const bool& lNBins =
-    ( (nBins_d == nBins_u    &&
+   ((nBins_d == nBins_u    &&
        nBins_d == nBins_s    &&
        nBins_d == nBins_c    &&
        nBins_d == nBins_b    &&
@@ -360,7 +358,7 @@ void EffPurFromHistos::check () {
        nBins_d == nBins_ni   &&
        nBins_d == nBins_dus  &&
        nBins_d == nBins_dusg)||
-      (nBins_c == nBins_b    &&
+     (nBins_c == nBins_b    &&
        nBins_c == nBins_dusg &&
        nBins_c == nBins_ni   &&
        nBins_c == nBins_pu)    );
@@ -377,7 +375,7 @@ void EffPurFromHistos::check () {
   float sBin_s    = 0;
   float sBin_g    = 0;
   float sBin_dus  = 0;
-  if(mcPlots_>2){
+  if (mcPlots_>2) {
     sBin_d    = effVersusDiscr_d    -> GetBinCenter(1);
     sBin_u    = effVersusDiscr_u    -> GetBinCenter(1);
     sBin_s    = effVersusDiscr_s    -> GetBinCenter(1);
@@ -391,7 +389,7 @@ void EffPurFromHistos::check () {
   const float& sBin_pu   = effVersusDiscr_pu   -> GetBinCenter(1);
 
   const bool& lSBin =
-    ( (sBin_d == sBin_u    &&
+   ((sBin_d == sBin_u    &&
        sBin_d == sBin_s    &&
        sBin_d == sBin_c    &&
        sBin_d == sBin_b    &&
@@ -399,7 +397,7 @@ void EffPurFromHistos::check () {
        sBin_d == sBin_ni   &&
        sBin_d == sBin_dus  &&
        sBin_d == sBin_dusg)||
-      (sBin_c == sBin_b    &&
+     (sBin_c == sBin_b    &&
        sBin_c == sBin_dusg &&
        sBin_c == sBin_ni   &&
        sBin_c == sBin_pu)    );
@@ -416,7 +414,7 @@ void EffPurFromHistos::check () {
   float eBin_s    = 0;
   float eBin_g    = 0;
   float eBin_dus  = 0;
-  if(mcPlots_>2){
+  if (mcPlots_>2) {
     eBin_d    = effVersusDiscr_d    -> GetBinCenter( nBins_d - 1 );
     eBin_u    = effVersusDiscr_u    -> GetBinCenter( nBins_d - 1 );
     eBin_s    = effVersusDiscr_s    -> GetBinCenter( nBins_d - 1 );
@@ -430,7 +428,7 @@ void EffPurFromHistos::check () {
   const float& eBin_pu   = effVersusDiscr_pu   -> GetBinCenter( nBins_d - 1 );
 
   const bool& lEBin =
-    ( (eBin_d == eBin_u    &&
+   ((eBin_d == eBin_u    &&
        eBin_d == eBin_s    &&
        eBin_d == eBin_c    &&
        eBin_d == eBin_b    &&
@@ -438,7 +436,7 @@ void EffPurFromHistos::check () {
        eBin_d == eBin_ni   &&
        eBin_d == eBin_dus  &&
        eBin_d == eBin_dusg)||
-      (eBin_c == eBin_b    &&
+     (eBin_c == eBin_b    &&
        eBin_c == eBin_dusg &&
        eBin_c == eBin_ni   &&
        eBin_c == eBin_pu)     );
@@ -450,7 +448,7 @@ void EffPurFromHistos::check () {
 }
 
 
-void EffPurFromHistos::compute (DQMStore::IBooker & ibook)
+void EffPurFromHistos::compute(DQMStore::IBooker & ibook)
 {
   if (!mcPlots_) {
 
@@ -471,92 +469,91 @@ void EffPurFromHistos::compute (DQMStore::IBooker & ibook)
   // to have shorter names ......
   const std::string & hE = histoExtension;
   std::string hX = "";
-	TString Title = "";
-	if(!doCTagPlots_){
-	   hX = "FlavEffVsBEff_";
-	   Title = "b";
-	}
+    TString Title = "";
+    if (!doCTagPlots_) {
+       hX = "FlavEffVsBEff_";
+       Title = "b";
+    }
   else{
      hX = "FlavEffVsCEff_";
      Title = "c";
   }
-	
+    
   // create histograms from base name and extension as given from user
   // BINNING MUST BE IDENTICAL FOR ALL OF THEM!!
   HistoProviderDQM prov("Btag",label_,ibook);
-  if(mcPlots_>2){
-    EffFlavVsXEff_d    = (prov.book1D ( hX + "D"    + hE , hX + "D"    + hE , nBinOutput , startOutput , endOutput ));
+  if (mcPlots_>2) {
+    EffFlavVsXEff_d    =(prov.book1D( hX + "D"    + hE, hX + "D"    + hE, nBinOutput, startOutput, endOutput ));
     EffFlavVsXEff_d->setEfficiencyFlag();
-    EffFlavVsXEff_u    = (prov.book1D ( hX + "U"    + hE , hX + "U"    + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsXEff_u    =(prov.book1D( hX + "U"    + hE, hX + "U"    + hE, nBinOutput, startOutput, endOutput )) ;
     EffFlavVsXEff_u->setEfficiencyFlag();
-    EffFlavVsXEff_s    = (prov.book1D ( hX + "S"    + hE , hX + "S"    + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsXEff_s    =(prov.book1D( hX + "S"    + hE, hX + "S"    + hE, nBinOutput, startOutput, endOutput )) ;
     EffFlavVsXEff_s->setEfficiencyFlag();
-    EffFlavVsXEff_g    = (prov.book1D ( hX + "G"    + hE , hX + "G"    + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsXEff_g    =(prov.book1D( hX + "G"    + hE, hX + "G"    + hE, nBinOutput, startOutput, endOutput )) ;
     EffFlavVsXEff_g->setEfficiencyFlag();
-    EffFlavVsXEff_dus  = (prov.book1D ( hX + "DUS"  + hE , hX + "DUS"  + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsXEff_dus  =(prov.book1D( hX + "DUS"  + hE, hX + "DUS"  + hE, nBinOutput, startOutput, endOutput )) ;
     EffFlavVsXEff_dus->setEfficiencyFlag();
-  }
-  else {
+  } else {
     EffFlavVsXEff_d = 0;
     EffFlavVsXEff_u = 0;
     EffFlavVsXEff_s = 0;
     EffFlavVsXEff_g = 0;
     EffFlavVsXEff_dus = 0;
   }
-  EffFlavVsXEff_c    = (prov.book1D ( hX + "C"    + hE , hX + "C"    + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsXEff_c    =(prov.book1D( hX + "C"    + hE, hX + "C"    + hE, nBinOutput, startOutput, endOutput )) ;
   EffFlavVsXEff_c->setEfficiencyFlag();
-  EffFlavVsXEff_b    = (prov.book1D ( hX + "B"    + hE , hX + "B"    + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsXEff_b    =(prov.book1D( hX + "B"    + hE, hX + "B"    + hE, nBinOutput, startOutput, endOutput )) ;
   EffFlavVsXEff_b->setEfficiencyFlag();
-  EffFlavVsXEff_ni   = (prov.book1D ( hX + "NI"   + hE , hX + "NI"   + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsXEff_ni   =(prov.book1D( hX + "NI"   + hE, hX + "NI"   + hE, nBinOutput, startOutput, endOutput )) ;
   EffFlavVsXEff_ni->setEfficiencyFlag();
-  EffFlavVsXEff_dusg = (prov.book1D ( hX + "DUSG" + hE , hX + "DUSG" + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsXEff_dusg =(prov.book1D( hX + "DUSG" + hE, hX + "DUSG" + hE, nBinOutput, startOutput, endOutput )) ;
   EffFlavVsXEff_dusg->setEfficiencyFlag();
-  EffFlavVsXEff_pu   = (prov.book1D ( hX + "PU"   + hE , hX + "PU"   + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsXEff_pu   =(prov.book1D( hX + "PU"   + hE, hX + "PU"   + hE, nBinOutput, startOutput, endOutput )) ;
   EffFlavVsXEff_pu->setEfficiencyFlag();
-	
+    
 
-  if(mcPlots_>2){
-    EffFlavVsXEff_d->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-    EffFlavVsXEff_d->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-    EffFlavVsXEff_d->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_d->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_u->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-    EffFlavVsXEff_u->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-    EffFlavVsXEff_u->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_u->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_s->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-    EffFlavVsXEff_s->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-    EffFlavVsXEff_s->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_s->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_g->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-    EffFlavVsXEff_g->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-    EffFlavVsXEff_g->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_g->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_dus->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-    EffFlavVsXEff_dus->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-    EffFlavVsXEff_dus->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-    EffFlavVsXEff_dus->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
+  if (mcPlots_ > 2) {
+    EffFlavVsXEff_d->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+    EffFlavVsXEff_d->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+    EffFlavVsXEff_d->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_d->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_u->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+    EffFlavVsXEff_u->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+    EffFlavVsXEff_u->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_u->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_s->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+    EffFlavVsXEff_s->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+    EffFlavVsXEff_s->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_s->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_g->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+    EffFlavVsXEff_g->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+    EffFlavVsXEff_g->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_g->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_dus->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+    EffFlavVsXEff_dus->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+    EffFlavVsXEff_dus->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+    EffFlavVsXEff_dus->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
   }
-  EffFlavVsXEff_c->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-  EffFlavVsXEff_c->getTH1F()->SetYTitle ( "c-jet efficiency" );
-  EffFlavVsXEff_c->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_c->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_b->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-  EffFlavVsXEff_b->getTH1F()->SetYTitle ( "b-jet efficiency" );
-  EffFlavVsXEff_b->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_b->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_ni->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-  EffFlavVsXEff_ni->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-  EffFlavVsXEff_ni->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_ni->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_dusg->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-  EffFlavVsXEff_dusg->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-  EffFlavVsXEff_dusg->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_dusg->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_pu->getTH1F()->SetXTitle ( Title + "-jet efficiency" );
-  EffFlavVsXEff_pu->getTH1F()->SetYTitle ( "non " + Title + "-jet efficiency" );
-  EffFlavVsXEff_pu->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-  EffFlavVsXEff_pu->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
+  EffFlavVsXEff_c->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+  EffFlavVsXEff_c->getTH1F()->SetYTitle( "c-jet efficiency" );
+  EffFlavVsXEff_c->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_c->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_b->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+  EffFlavVsXEff_b->getTH1F()->SetYTitle( "b-jet efficiency" );
+  EffFlavVsXEff_b->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_b->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_ni->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+  EffFlavVsXEff_ni->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+  EffFlavVsXEff_ni->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_ni->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_dusg->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+  EffFlavVsXEff_dusg->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+  EffFlavVsXEff_dusg->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_dusg->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_pu->getTH1F()->SetXTitle( Title + "-jet efficiency" );
+  EffFlavVsXEff_pu->getTH1F()->SetYTitle( "non " + Title + "-jet efficiency" );
+  EffFlavVsXEff_pu->getTH1F()->GetXaxis()->SetTitleOffset( 0.75 );
+  EffFlavVsXEff_pu->getTH1F()->GetYaxis()->SetTitleOffset( 0.75 );
 
   // loop over eff. vs. discriminator cut b-histo and look in which bin the closest entry is;
   // use fact that eff decreases monotonously
@@ -568,49 +565,48 @@ void EffPurFromHistos::compute (DQMStore::IBooker & ibook)
 
   for ( int iBinX = 1; iBinX <= nBinX; iBinX++ ) {  // loop over the bins on the x-axis of the histograms to be filled
 
-    const float& effXBinWidth = EffFlavVsXEff->getTH1F()->GetBinWidth  ( iBinX );
-    const float& effXMid      = EffFlavVsXEff->getTH1F()->GetBinCenter ( iBinX ); // middle of b-efficiency bin
+    const float& effXBinWidth = EffFlavVsXEff->getTH1F()->GetBinWidth ( iBinX );
+    const float& effXMid      = EffFlavVsXEff->getTH1F()->GetBinCenter( iBinX ); // middle of b-efficiency bin
     const float& effXLeft     = effXMid - 0.5*effXBinWidth;              // left edge of bin
     const float& effXRight    = effXMid + 0.5*effXBinWidth;              // right edge of bin
     // find the corresponding bin in the efficiency versus discriminator cut histo: closest one in efficiency
 
     int binClosest = -1;
-    if(!doCTagPlots_){
-      binClosest = findBinClosestYValue ( effVersusDiscr_b , effXMid , effXLeft , effXRight );
-    }
-    else{
-      binClosest = findBinClosestYValue ( effVersusDiscr_c , effXMid , effXLeft , effXRight );
+    if (!doCTagPlots_) {
+      binClosest = findBinClosestYValue( effVersusDiscr_b, effXMid, effXLeft, effXRight );
+    } else {
+      binClosest = findBinClosestYValue( effVersusDiscr_c, effXMid, effXLeft, effXRight );
     }
 
-    const bool&  binFound   = ( binClosest > 0 ) ;
+    const bool&  binFound   =( binClosest > 0 ) ;
     //
-    if ( binFound ) {
+    if (binFound) {
       // fill the histos
-      if(mcPlots_>2){
-	EffFlavVsXEff_d    -> Fill ( effXMid , effVersusDiscr_d   ->GetBinContent ( binClosest ) );
-	EffFlavVsXEff_u    -> Fill ( effXMid , effVersusDiscr_u   ->GetBinContent ( binClosest ) );
-	EffFlavVsXEff_s    -> Fill ( effXMid , effVersusDiscr_s   ->GetBinContent ( binClosest ) );
-	EffFlavVsXEff_g    -> Fill ( effXMid , effVersusDiscr_g   ->GetBinContent ( binClosest ) );
-	EffFlavVsXEff_dus  -> Fill ( effXMid , effVersusDiscr_dus ->GetBinContent ( binClosest ) );
+      if (mcPlots_ > 2) {
+        EffFlavVsXEff_d    -> Fill( effXMid, effVersusDiscr_d   ->GetBinContent( binClosest ) );
+        EffFlavVsXEff_u    -> Fill( effXMid, effVersusDiscr_u   ->GetBinContent( binClosest ) );
+        EffFlavVsXEff_s    -> Fill( effXMid, effVersusDiscr_s   ->GetBinContent( binClosest ) );
+        EffFlavVsXEff_g    -> Fill( effXMid, effVersusDiscr_g   ->GetBinContent( binClosest ) );
+        EffFlavVsXEff_dus  -> Fill( effXMid, effVersusDiscr_dus ->GetBinContent( binClosest ) );
       }
-      EffFlavVsXEff_c    -> Fill ( effXMid , effVersusDiscr_c   ->GetBinContent ( binClosest ) );
-      EffFlavVsXEff_b    -> Fill ( effXMid , effVersusDiscr_b   ->GetBinContent ( binClosest ) );
-      EffFlavVsXEff_ni   -> Fill ( effXMid , effVersusDiscr_ni  ->GetBinContent ( binClosest ) );
-      EffFlavVsXEff_dusg -> Fill ( effXMid , effVersusDiscr_dusg->GetBinContent ( binClosest ) );
-      EffFlavVsXEff_pu   -> Fill ( effXMid , effVersusDiscr_pu  ->GetBinContent ( binClosest ) );
+      EffFlavVsXEff_c    -> Fill( effXMid, effVersusDiscr_c   ->GetBinContent( binClosest ) );
+      EffFlavVsXEff_b    -> Fill( effXMid, effVersusDiscr_b   ->GetBinContent( binClosest ) );
+      EffFlavVsXEff_ni   -> Fill( effXMid, effVersusDiscr_ni  ->GetBinContent( binClosest ) );
+      EffFlavVsXEff_dusg -> Fill( effXMid, effVersusDiscr_dusg->GetBinContent( binClosest ) );
+      EffFlavVsXEff_pu   -> Fill( effXMid, effVersusDiscr_pu  ->GetBinContent( binClosest ) );
 
-      if(mcPlots_>2){
-	EffFlavVsXEff_d  ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_d   ->GetBinError ( binClosest ) );
-	EffFlavVsXEff_u  ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_u   ->GetBinError ( binClosest ) );
-	EffFlavVsXEff_s  ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_s   ->GetBinError ( binClosest ) );
-	EffFlavVsXEff_g  ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_g   ->GetBinError ( binClosest ) );
-	EffFlavVsXEff_dus->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_dus ->GetBinError ( binClosest ) );
+      if (mcPlots_>2) {
+        EffFlavVsXEff_d  ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_d   ->GetBinError( binClosest ) );
+        EffFlavVsXEff_u  ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_u   ->GetBinError( binClosest ) );
+        EffFlavVsXEff_s  ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_s   ->GetBinError( binClosest ) );
+        EffFlavVsXEff_g  ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_g   ->GetBinError( binClosest ) );
+        EffFlavVsXEff_dus->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_dus ->GetBinError( binClosest ) );
       }
-      EffFlavVsXEff_c  ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_c   ->GetBinError ( binClosest ) );
-      EffFlavVsXEff_b  ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_b   ->GetBinError ( binClosest ) );
-      EffFlavVsXEff_ni ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_ni  ->GetBinError ( binClosest ) );
-      EffFlavVsXEff_dusg->getTH1F() -> SetBinError ( iBinX , effVersusDiscr_dusg->GetBinError ( binClosest ) );
-      EffFlavVsXEff_pu ->getTH1F()  -> SetBinError ( iBinX , effVersusDiscr_pu  ->GetBinError ( binClosest ) );
+      EffFlavVsXEff_c  ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_c   ->GetBinError( binClosest ) );
+      EffFlavVsXEff_b  ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_b   ->GetBinError( binClosest ) );
+      EffFlavVsXEff_ni ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_ni  ->GetBinError( binClosest ) );
+      EffFlavVsXEff_dusg->getTH1F() -> SetBinError( iBinX, effVersusDiscr_dusg->GetBinError( binClosest ) );
+      EffFlavVsXEff_pu ->getTH1F()  -> SetBinError( iBinX, effVersusDiscr_pu  ->GetBinError( binClosest ) );
     }
   }
 }

--- a/DQMOffline/RecoB/src/EffPurFromHistos2D.cc
+++ b/DQMOffline/RecoB/src/EffPurFromHistos2D.cc
@@ -14,108 +14,106 @@
 using namespace std;
 using namespace RecoBTag;
 
-EffPurFromHistos2D::EffPurFromHistos2D ( const std::string & ext, TH2F * h_d, TH2F * h_u,
+EffPurFromHistos2D::EffPurFromHistos2D(const std::string & ext, TH2F * h_d, TH2F * h_u,
                                      TH2F * h_s, TH2F * h_c, TH2F * h_b, TH2F * h_g, TH2F * h_ni,
                                      TH2F * h_dus, TH2F * h_dusg, TH2F * h_pu,
-				     const std::string& label, const unsigned int& mc, 
-				     int nBinX, double startOX, double endOX) :
+                                     const std::string& label, unsigned int mc, 
+                                     int nBinX, double startOX, double endOX) :
         fromDiscriminatorDistr(false),
         mcPlots_(mc), doCTagPlots_(false), label_(label),
-	histoExtension(ext), effVersusDiscr_d(h_d), effVersusDiscr_u(h_u),
+        histoExtension(ext), effVersusDiscr_d(h_d), effVersusDiscr_u(h_u),
         effVersusDiscr_s(h_s), effVersusDiscr_c(h_c), effVersusDiscr_b(h_b),
         effVersusDiscr_g(h_g), effVersusDiscr_ni(h_ni), effVersusDiscr_dus(h_dus),
         effVersusDiscr_dusg(h_dusg), effVersusDiscr_pu(h_pu),
-	nBinOutputX(nBinX), startOutputX(startOX), endOutputX(endOX)
+        nBinOutputX(nBinX), startOutputX(startOX), endOutputX(endOX)
 {
   // consistency check
   check();
 }
 
-EffPurFromHistos2D::EffPurFromHistos2D (const FlavourHistograms2D<double, double> * dDiscriminatorFC, 
-				    const std::string& label, const unsigned int& mc, 
+EffPurFromHistos2D::EffPurFromHistos2D(const FlavourHistograms2D<double, double>& dDiscriminatorFC, 
+                                    const std::string& label, unsigned int mc, 
                                     DQMStore::IBooker & ibook, 
-                                    int nBinX, double startOX, double endOX) :
+                                    int nBinX, double startOX, double endOX):
   fromDiscriminatorDistr(true), 
   mcPlots_(mc), doCTagPlots_(false), label_(label),
   nBinOutputX(nBinX), startOutputX(startOX), endOutputX(endOX)
 {
-  histoExtension = "_"+dDiscriminatorFC->baseNameTitle();
+  histoExtension = "_" + dDiscriminatorFC.baseNameTitle();
 
-  discrNoCutEffic.reset( new FlavourHistograms2D<double, double> (
-        "totalEntries" + histoExtension, "Total Entries: " + dDiscriminatorFC->baseNameDescription(),
-        dDiscriminatorFC->nBinsX(), dDiscriminatorFC->lowerBoundX(), dDiscriminatorFC->upperBoundX(), dDiscriminatorFC->nBinsY(), 
-        dDiscriminatorFC->lowerBoundY(), dDiscriminatorFC->upperBoundY(), 
-        false, label, mcPlots_, false, ibook));
+  discrNoCutEffic = std::make_unique<FlavourHistograms2D<double, double>>(
+        "totalEntries" + histoExtension, "Total Entries: " + dDiscriminatorFC.baseNameDescription(),
+        dDiscriminatorFC.nBinsX(), dDiscriminatorFC.lowerBoundX(), dDiscriminatorFC.upperBoundX(), dDiscriminatorFC.nBinsY(), 
+        dDiscriminatorFC.lowerBoundY(), dDiscriminatorFC.upperBoundY(), 
+        false, label, mcPlots_, false, ibook);
+  
   // conditional discriminator cut for efficiency histos
-
-  discrCutEfficScan.reset( new FlavourHistograms2D<double, double> (
-	"effVsDiscrCut" + histoExtension, "Eff. vs Disc. Cut: " + dDiscriminatorFC->baseNameDescription(),
-	dDiscriminatorFC->nBinsX(), dDiscriminatorFC->lowerBoundX(), dDiscriminatorFC->upperBoundX(), dDiscriminatorFC->nBinsY(),
-        dDiscriminatorFC->lowerBoundY(), dDiscriminatorFC->upperBoundY(),
-        false, label, mcPlots_, false, ibook));
+  discrCutEfficScan = std::make_unique<FlavourHistograms2D<double, double>>(
+        "effVsDiscrCut" + histoExtension, "Eff. vs Disc. Cut: " + dDiscriminatorFC.baseNameDescription(),
+        dDiscriminatorFC.nBinsX(), dDiscriminatorFC.lowerBoundX(), dDiscriminatorFC.upperBoundX(), dDiscriminatorFC.nBinsY(),
+        dDiscriminatorFC.lowerBoundY(), dDiscriminatorFC.upperBoundY(),
+        false, label, mcPlots_, false, ibook);
   discrCutEfficScan->SetMinimum(1E-4);
 
-  if (mcPlots_){
+  if (mcPlots_) {
 
-    if(mcPlots_>2){
-      effVersusDiscr_d =    discrCutEfficScan->histo_d   ();
-      effVersusDiscr_u =    discrCutEfficScan->histo_u   ();
-      effVersusDiscr_s =    discrCutEfficScan->histo_s   ();
-      effVersusDiscr_g =    discrCutEfficScan->histo_g   ();
-      effVersusDiscr_dus =  discrCutEfficScan->histo_dus ();
+    if (mcPlots_ > 2) {
+      effVersusDiscr_d =    discrCutEfficScan->histo_d  ();
+      effVersusDiscr_u =    discrCutEfficScan->histo_u  ();
+      effVersusDiscr_s =    discrCutEfficScan->histo_s  ();
+      effVersusDiscr_g =    discrCutEfficScan->histo_g  ();
+      effVersusDiscr_dus =  discrCutEfficScan->histo_dus();
+    } else {
+      effVersusDiscr_d   =  nullptr;
+      effVersusDiscr_u   =  nullptr;
+      effVersusDiscr_s   =  nullptr;
+      effVersusDiscr_g   =  nullptr;
+      effVersusDiscr_dus =  nullptr;
     }
-    else{
-      effVersusDiscr_d   =  0;
-      effVersusDiscr_u   =  0;
-      effVersusDiscr_s   =  0;
-      effVersusDiscr_g   =  0;
-      effVersusDiscr_dus =  0;
-    }
-    effVersusDiscr_c =    discrCutEfficScan->histo_c   ();
-    effVersusDiscr_b =    discrCutEfficScan->histo_b   ();
-    effVersusDiscr_ni =   discrCutEfficScan->histo_ni  ();
+    effVersusDiscr_c =    discrCutEfficScan->histo_c  ();
+    effVersusDiscr_b =    discrCutEfficScan->histo_b  ();
+    effVersusDiscr_ni =   discrCutEfficScan->histo_ni ();
     effVersusDiscr_dusg = discrCutEfficScan->histo_dusg();
     effVersusDiscr_pu = discrCutEfficScan->histo_pu();
 
 
-    if(mcPlots_>2){
-      effVersusDiscr_d->SetXTitle ( "Discriminant" );
-      effVersusDiscr_d->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_u->SetXTitle ( "Discriminant" );
-      effVersusDiscr_u->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_s->SetXTitle ( "Discriminant" );
-      effVersusDiscr_s->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_g->SetXTitle ( "Discriminant" );
-      effVersusDiscr_g->GetXaxis()->SetTitleOffset ( 0.75 );
-      effVersusDiscr_dus->SetXTitle ( "Discriminant" );
-      effVersusDiscr_dus->GetXaxis()->SetTitleOffset ( 0.75 );
+    if (mcPlots_ > 2) {
+      effVersusDiscr_d->SetXTitle( "Discriminant" );
+      effVersusDiscr_d->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_u->SetXTitle( "Discriminant" );
+      effVersusDiscr_u->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_s->SetXTitle( "Discriminant" );
+      effVersusDiscr_s->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_g->SetXTitle( "Discriminant" );
+      effVersusDiscr_g->GetXaxis()->SetTitleOffset( 0.75 );
+      effVersusDiscr_dus->SetXTitle( "Discriminant" );
+      effVersusDiscr_dus->GetXaxis()->SetTitleOffset( 0.75 );
     }
-    effVersusDiscr_c->SetXTitle ( "Discriminant" );
-    effVersusDiscr_c->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_b->SetXTitle ( "Discriminant" );
-    effVersusDiscr_b->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_ni->SetXTitle ( "Discriminant" );
-    effVersusDiscr_ni->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_dusg->SetXTitle ( "Discriminant" );
-    effVersusDiscr_dusg->GetXaxis()->SetTitleOffset ( 0.75 );
-    effVersusDiscr_pu->SetXTitle ( "Discriminant" );
-    effVersusDiscr_pu->GetXaxis()->SetTitleOffset ( 0.75 );
-  }
-  else{
-    effVersusDiscr_d =    0;
-    effVersusDiscr_u =    0;
-    effVersusDiscr_s =    0;
-    effVersusDiscr_c =    0;
-    effVersusDiscr_b =    0;
-    effVersusDiscr_g =    0;
-    effVersusDiscr_ni =   0;
-    effVersusDiscr_dus =  0;
-    effVersusDiscr_dusg = 0;
-    effVersusDiscr_pu = 0;
+    effVersusDiscr_c->SetXTitle( "Discriminant" );
+    effVersusDiscr_c->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_b->SetXTitle( "Discriminant" );
+    effVersusDiscr_b->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_ni->SetXTitle( "Discriminant" );
+    effVersusDiscr_ni->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_dusg->SetXTitle( "Discriminant" );
+    effVersusDiscr_dusg->GetXaxis()->SetTitleOffset( 0.75 );
+    effVersusDiscr_pu->SetXTitle( "Discriminant" );
+    effVersusDiscr_pu->GetXaxis()->SetTitleOffset( 0.75 );
+  } else {
+    effVersusDiscr_d    = nullptr;
+    effVersusDiscr_u    = nullptr;
+    effVersusDiscr_s    = nullptr;
+    effVersusDiscr_c    = nullptr;
+    effVersusDiscr_b    = nullptr;
+    effVersusDiscr_g    = nullptr;
+    effVersusDiscr_ni   = nullptr;
+    effVersusDiscr_dus  = nullptr;
+    effVersusDiscr_dusg = nullptr;
+    effVersusDiscr_pu   = nullptr;
   }
 
   // discr. for computation
-  vector<TH2F*> discrCfHistos = dDiscriminatorFC->getHistoVector();
+  vector<TH2F*> discrCfHistos = dDiscriminatorFC.getHistoVector();
   // discr no cut
   vector<TH2F*> discrNoCutHistos = discrNoCutEffic->getHistoVector();
   // discr no cut
@@ -127,43 +125,43 @@ EffPurFromHistos2D::EffPurFromHistos2D (const FlavourHistograms2D<double, double
   // fill the histos for eff-pur computations by scanning the discriminatorFC histogram
 
   // better to loop over bins -> discrCut no longer needed
-  const int& nBinsX = dDiscriminatorFC->nBinsX();
-  const int& nBinsY = dDiscriminatorFC->nBinsY();
+  const int& nBinsX = dDiscriminatorFC.nBinsX();
+  const int& nBinsY = dDiscriminatorFC.nBinsY();
 
   // loop over flavours
-  for ( int iFlav = 0; iFlav < dimHistos; iFlav++ ) {
+  for (int iFlav = 0; iFlav < dimHistos; iFlav++) {
     if (discrCfHistos[iFlav] == 0) continue;
-    discrNoCutHistos[iFlav]->SetXTitle ( "Discriminant A" );
-    discrNoCutHistos[iFlav]->GetXaxis()->SetTitleOffset ( 0.75 );
-    discrNoCutHistos[iFlav]->SetYTitle ( "Discriminant B" );
-    discrNoCutHistos[iFlav]->GetYaxis()->SetTitleOffset ( 0.75 );
+    discrNoCutHistos[iFlav]->SetXTitle("Discriminant A");
+    discrNoCutHistos[iFlav]->GetXaxis()->SetTitleOffset(0.75);
+    discrNoCutHistos[iFlav]->SetYTitle("Discriminant B");
+    discrNoCutHistos[iFlav]->GetYaxis()->SetTitleOffset(0.75);
 
     // In Root histos, bin counting starts at 1 to nBins.
     // bin 0 is the underflow, and nBins+1 is the overflow.
-    const double& nJetsFlav = discrCfHistos[iFlav]->GetEntries ();
+    const double& nJetsFlav = discrCfHistos[iFlav]->GetEntries();
 
-    for ( int iDiscrX = nBinsX; iDiscrX > 0 ; --iDiscrX ) {
-	for ( int iDiscrY = nBinsY; iDiscrY > 0 ; --iDiscrY ) {
-	  // fill all jets into NoCut histo
-	  discrNoCutHistos[iFlav]->SetBinContent ( iDiscrX, iDiscrY, nJetsFlav );
-	  discrNoCutHistos[iFlav]->SetBinError   ( iDiscrX, iDiscrY, sqrt(nJetsFlav) );
-	  const double& sum = nJetsFlav - discrCfHistos[iFlav]->Integral( 0, iDiscrX-1, 0, iDiscrY-1 );
-	  discrCutHistos[iFlav]->SetBinContent ( iDiscrX, iDiscrY, sum );
-	  discrCutHistos[iFlav]->SetBinError   ( iDiscrX, iDiscrY, sqrt(sum) );
-	}
+    for (int iDiscrX = nBinsX; iDiscrX > 0; --iDiscrX) {
+        for (int iDiscrY = nBinsY; iDiscrY > 0; --iDiscrY) {
+          // fill all jets into NoCut histo
+          discrNoCutHistos[iFlav]->SetBinContent(iDiscrX, iDiscrY, nJetsFlav);
+          discrNoCutHistos[iFlav]->SetBinError(iDiscrX, iDiscrY, sqrt(nJetsFlav));
+          const double& sum = nJetsFlav - discrCfHistos[iFlav]->Integral( 0, iDiscrX-1, 0, iDiscrY-1);
+          discrCutHistos[iFlav]->SetBinContent(iDiscrX, iDiscrY, sum);
+          discrCutHistos[iFlav]->SetBinError(iDiscrX, iDiscrY, sqrt(sum));
+        }
     }
   }
 
   // divide to get efficiency vs. discriminator cut from absolute numbers
-  discrCutEfficScan->divide ( *discrNoCutEffic );  // does: histos including discriminator cut / flat histo
+  discrCutEfficScan->divide(*discrNoCutEffic);  // does: histos including discriminator cut / flat histo
   discrCutEfficScan->setEfficiencyFlag();
 }
 
-EffPurFromHistos2D::~EffPurFromHistos2D () {}
+EffPurFromHistos2D::~EffPurFromHistos2D() {}
 
 void EffPurFromHistos2D::epsPlot(const std::string & name)
 {
-  if ( fromDiscriminatorDistr) {
+  if (fromDiscriminatorDistr) {
     discrNoCutEffic->epsPlot(name);
     discrCutEfficScan->epsPlot(name);
   }
@@ -178,22 +176,20 @@ void EffPurFromHistos2D::psPlot(const std::string & name)
 void EffPurFromHistos2D::plot(const std::string & name, const std::string & ext)
 {
    std::string hX = "";
-	 std::string Title = "";
-   if(!doCTagPlots_){
-	   hX = "FlavEffVsBEff";
-		 Title = "b";
+   std::string Title = "";
+   if (!doCTagPlots_) {
+        hX = "FlavEffVsBEff";
+        Title = "b";
+   } else {
+        hX = "FlavEffVsCEff";
+        Title = "c";
    }
-   else{
-     hX = "FlavEffVsCEff";
-		 Title = "c";
-   }
-   TCanvas tc ((hX +histoExtension).c_str() ,
-	("Flavour misidentification vs. " + Title + "-tagging efficiency " + histoExtension).c_str());
+   TCanvas tc((hX +histoExtension).c_str(), ("Flavour misidentification vs. " + Title + "-tagging efficiency " + histoExtension).c_str());
    plot(&tc);
    tc.Print((name + hX + histoExtension + ext).c_str());
 }
 
-void EffPurFromHistos2D::plot (TPad * plotCanvas /* = 0 */) {
+void EffPurFromHistos2D::plot(TPad * plotCanvas /* = 0 */) {
 
   setTDRStyle()->cd();
 
@@ -201,14 +197,14 @@ void EffPurFromHistos2D::plot (TPad * plotCanvas /* = 0 */) {
     plotCanvas->cd();
   
   gPad->UseCurrentStyle();
-  gPad->SetFillColor ( 0 );
-  gPad->SetLogy  ( 1 );
-  gPad->SetGridx ( 1 );
-  gPad->SetGridy ( 1 );
+  gPad->SetFillColor( 0 );
+  gPad->SetLogy ( 1 );
+  gPad->SetGridx( 1 );
+  gPad->SetGridy( 1 );
 }
 
 
-void EffPurFromHistos2D::check () {
+void EffPurFromHistos2D::check() {
   // number of bins
   int nBinsX_d    = 0;
   int nBinsX_u    = 0;
@@ -220,7 +216,7 @@ void EffPurFromHistos2D::check () {
   int nBinsY_s    = 0;
   int nBinsY_g    = 0;
   int nBinsY_dus  = 0;
-  if(mcPlots_>2){
+  if (mcPlots_ > 2) {
     nBinsX_d    = effVersusDiscr_d    -> GetNbinsX();
     nBinsX_u    = effVersusDiscr_u    -> GetNbinsX();
     nBinsX_s    = effVersusDiscr_s    -> GetNbinsX();
@@ -244,7 +240,7 @@ void EffPurFromHistos2D::check () {
   const int& nBinsY_pu   = effVersusDiscr_pu   -> GetNbinsY();
 
   const bool& lNBinsX =
-    ( (nBinsX_d == nBinsX_u    &&
+   ((nBinsX_d == nBinsX_u    &&
        nBinsX_d == nBinsX_s    &&
        nBinsX_d == nBinsX_c    &&
        nBinsX_d == nBinsX_b    &&
@@ -252,13 +248,13 @@ void EffPurFromHistos2D::check () {
        nBinsX_d == nBinsX_ni   &&
        nBinsX_d == nBinsX_dus  &&
        nBinsX_d == nBinsX_dusg)||
-      (nBinsX_c == nBinsX_b    &&
+     (nBinsX_c == nBinsX_b    &&
        nBinsX_c == nBinsX_dusg &&
        nBinsX_c == nBinsX_ni   &&
        nBinsX_c == nBinsX_pu)    );
 
   const bool& lNBinsY =
-    ( (nBinsY_d == nBinsY_u    &&
+   ((nBinsY_d == nBinsY_u    &&
        nBinsY_d == nBinsY_s    &&
        nBinsY_d == nBinsY_c    &&
        nBinsY_d == nBinsY_b    &&
@@ -266,7 +262,7 @@ void EffPurFromHistos2D::check () {
        nBinsY_d == nBinsY_ni   &&
        nBinsY_d == nBinsY_dus  &&
        nBinsY_d == nBinsY_dusg)||
-      (nBinsY_c == nBinsY_b    &&
+     (nBinsY_c == nBinsY_b    &&
        nBinsY_c == nBinsY_dusg &&
        nBinsY_c == nBinsY_ni   &&
        nBinsY_c == nBinsY_pu)    );
@@ -282,7 +278,7 @@ void EffPurFromHistos2D::check () {
   float sBin_s    = 0;
   float sBin_g    = 0;
   float sBin_dus  = 0;
-  if(mcPlots_>2){
+  if (mcPlots_>2){
     sBin_d    = effVersusDiscr_d    -> GetBinCenter(1);
     sBin_u    = effVersusDiscr_u    -> GetBinCenter(1);
     sBin_s    = effVersusDiscr_s    -> GetBinCenter(1);
@@ -296,7 +292,7 @@ void EffPurFromHistos2D::check () {
   const float& sBin_pu   = effVersusDiscr_pu   -> GetBinCenter(1);
 
   const bool& lSBin =
-    ( (sBin_d == sBin_u    &&
+   ((sBin_d == sBin_u    &&
        sBin_d == sBin_s    &&
        sBin_d == sBin_c    &&
        sBin_d == sBin_b    &&
@@ -304,7 +300,7 @@ void EffPurFromHistos2D::check () {
        sBin_d == sBin_ni   &&
        sBin_d == sBin_dus  &&
        sBin_d == sBin_dusg)||
-      (sBin_c == sBin_b    &&
+     (sBin_c == sBin_b    &&
        sBin_c == sBin_dusg &&
        sBin_c == sBin_ni   &&
        sBin_c == sBin_pu)    );
@@ -321,7 +317,7 @@ void EffPurFromHistos2D::check () {
   float eBin_g    = 0;
   float eBin_dus  = 0;
   const int& binEnd = effVersusDiscr_b -> GetBin(nBinsX_b - 1, nBinsY_b - 1);
-  if(mcPlots_>2){
+  if (mcPlots_>2){
     eBin_d    = effVersusDiscr_d    -> GetBinCenter( binEnd );
     eBin_u    = effVersusDiscr_u    -> GetBinCenter( binEnd );
     eBin_s    = effVersusDiscr_s    -> GetBinCenter( binEnd );
@@ -335,7 +331,7 @@ void EffPurFromHistos2D::check () {
   const float& eBin_pu   = effVersusDiscr_pu   -> GetBinCenter( binEnd );
 
   const bool& lEBin =
-    ( (eBin_d == eBin_u    &&
+   ((eBin_d == eBin_u    &&
        eBin_d == eBin_s    &&
        eBin_d == eBin_c    &&
        eBin_d == eBin_b    &&
@@ -343,7 +339,7 @@ void EffPurFromHistos2D::check () {
        eBin_d == eBin_ni   &&
        eBin_d == eBin_dus  &&
        eBin_d == eBin_dusg)||
-      (eBin_c == eBin_b    &&
+     (eBin_c == eBin_b    &&
        eBin_c == eBin_dusg &&
        eBin_c == eBin_ni   &&
        eBin_c == eBin_pu)     );
@@ -354,7 +350,7 @@ void EffPurFromHistos2D::check () {
   } 
 }
 
-void EffPurFromHistos2D::compute (DQMStore::IBooker & ibook, vector<double> fixedEff)
+void EffPurFromHistos2D::compute(DQMStore::IBooker & ibook, vector<double> fixedEff)
 {
 
   if (!mcPlots_ || fixedEff.size()<1) {
@@ -364,22 +360,22 @@ void EffPurFromHistos2D::compute (DQMStore::IBooker & ibook, vector<double> fixe
   // to have shorter names ......
   const std::string & hE = histoExtension;
   std::string hX = "DUSG_vs_B_eff_at_fixedCeff_";
-  if(!doCTagPlots_) hX = "DUSG_vs_C_eff_at_fixedBeff_"; 
-	
+  if (!doCTagPlots_) hX = "DUSG_vs_C_eff_at_fixedBeff_"; 
+    
   // create histograms from base name and extension as given from user
-  HistoProviderDQM prov("Btag",label_,ibook);
+  HistoProviderDQM prov("Btag", label_, ibook);
  
-  for (unsigned int ieff=0; ieff<fixedEff.size(); ieff++){
+  for (unsigned int ieff = 0; ieff < fixedEff.size(); ieff++){
     std::string fixedEfficiency = std::to_string(fixedEff[ieff]);
-    fixedEfficiency.replace(1,1,"_");
-    X_vs_Y_eff_at_fixedZeff.push_back( (prov.book1D ( hX + fixedEfficiency + hE , hX + fixedEfficiency + hE , nBinOutputX , startOutputX , endOutputX )) );
+    fixedEfficiency.replace(1, 1, "_");
+    X_vs_Y_eff_at_fixedZeff.push_back((prov.book1D( hX + fixedEfficiency + hE, hX + fixedEfficiency + hE, nBinOutputX, startOutputX, endOutputX )) );
     X_vs_Y_eff_at_fixedZeff[ieff]->setEfficiencyFlag();
     
-    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetXTitle ( "Light mistag" );
-    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetYTitle ( "B mistag" );
-    if(!doCTagPlots_) X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetYTitle ( "C mistag" );
-    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
-    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
+    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetXTitle("Light mistag");
+    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetYTitle("B mistag");
+    if (!doCTagPlots_) X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetYTitle("C mistag");
+    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->GetXaxis()->SetTitleOffset(0.75);
+    X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->GetYaxis()->SetTitleOffset(0.75);
   }
   // loop over eff. vs. discriminator cut b-histo and look in which bin the closest entry is;
   // use fact that eff decreases monotonously
@@ -389,29 +385,30 @@ void EffPurFromHistos2D::compute (DQMStore::IBooker & ibook, vector<double> fixe
 
   const int& nBinX = EffFlavVsXEff->getTH1F()->GetNbinsX();
 
-  for ( int iBinX = 1; iBinX <= nBinX; iBinX++ ) {  // loop over the bins on the x-axis of the histograms to be filled
-    const float& effBinWidthX = EffFlavVsXEff->getTH1F()->GetBinWidth  ( iBinX );
-    const float& effMidX      = EffFlavVsXEff->getTH1F()->GetBinCenter ( iBinX ); // middle of efficiency bin
+  for (int iBinX = 1; iBinX <= nBinX; iBinX++) {  // loop over the bins on the x-axis of the histograms to be filled
+    const float& effBinWidthX = EffFlavVsXEff->getTH1F()->GetBinWidth (iBinX);
+    const float& effMidX      = EffFlavVsXEff->getTH1F()->GetBinCenter(iBinX); // middle of efficiency bin
     const float& effLeftX     = effMidX - 0.5*effBinWidthX;              // left edge of bin
     const float& effRightX    = effMidX + 0.5*effBinWidthX;              // right edge of bin
 
     vector<int> binClosest;
-    if(doCTagPlots_) binClosest = findBinClosestYValueAtFixedZ ( effVersusDiscr_dusg, effMidX , effLeftX , effRightX , effVersusDiscr_c, fixedEff );
-    else binClosest = findBinClosestYValueAtFixedZ ( effVersusDiscr_dusg, effMidX , effLeftX , effRightX , effVersusDiscr_b, fixedEff );
+    if (doCTagPlots_)
+        binClosest = findBinClosestYValueAtFixedZ(effVersusDiscr_dusg, effMidX, effLeftX, effRightX, effVersusDiscr_c, fixedEff);
+    else
+        binClosest = findBinClosestYValueAtFixedZ(effVersusDiscr_dusg, effMidX, effLeftX, effRightX, effVersusDiscr_b, fixedEff);
 
-    for (unsigned int ieff = 0; ieff < binClosest.size(); ieff++){
-      const bool&  binFound   = ( binClosest[ieff] > 0 ) ;
+    for (unsigned int ieff = 0; ieff < binClosest.size(); ieff++) {
+      const bool&  binFound   =( binClosest[ieff] > 0 );
       //
-      if ( binFound ) {
-	// fill the histos
-	if(doCTagPlots_) {
-	  X_vs_Y_eff_at_fixedZeff[ieff]->Fill(effMidX, effVersusDiscr_b->GetBinContent ( binClosest[ieff] ));
-	  X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetBinError(iBinX, effVersusDiscr_b->GetBinError ( binClosest[ieff] ));
-	}
-	else {
-	  X_vs_Y_eff_at_fixedZeff[ieff]->Fill(effMidX, effVersusDiscr_c->GetBinContent ( binClosest[ieff] ));
-	  X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetBinError(iBinX, effVersusDiscr_c->GetBinError ( binClosest[ieff] ));
-	}
+      if (binFound) {
+        // fill the histos
+        if (doCTagPlots_) {
+          X_vs_Y_eff_at_fixedZeff[ieff]->Fill(effMidX, effVersusDiscr_b->GetBinContent( binClosest[ieff] ));
+          X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetBinError(iBinX, effVersusDiscr_b->GetBinError( binClosest[ieff] ));
+        } else {
+          X_vs_Y_eff_at_fixedZeff[ieff]->Fill(effMidX, effVersusDiscr_c->GetBinContent( binClosest[ieff] ));
+          X_vs_Y_eff_at_fixedZeff[ieff]->getTH1F()->SetBinError(iBinX, effVersusDiscr_c->GetBinError( binClosest[ieff] ));
+        }
       }
     }
   } 

--- a/DQMOffline/RecoB/src/HistoProviderDQM.cc
+++ b/DQMOffline/RecoB/src/HistoProviderDQM.cc
@@ -5,9 +5,9 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 
-HistoProviderDQM::HistoProviderDQM(const std::string& prefix, const std::string& label, DQMStore::IBooker & ibook): ibook_(ibook){
-  //  get the store
-  label_ =prefix+"/"+label;
+HistoProviderDQM::HistoProviderDQM(const std::string& prefix, const std::string& label, DQMStore::IBooker & ibook): ibook_(ibook) {
+  // get the store
+  label_ = prefix + "/" + label;
   setDir(label_);
 }
 
@@ -18,34 +18,34 @@ void HistoProviderDQM::setDir(const std::string& name){
 MonitorElement* HistoProviderDQM::book1D(const std::string &name,
                                 const std::string &title,
                                 const int& nchX, const double& lowX, const double& highX) {
-  return (ibook_.book1D (name, title, nchX,lowX,highX));
+  return ibook_.book1D(name, title, nchX, lowX, highX);
 }
 
 
 MonitorElement* HistoProviderDQM::book1D (const std::string &name,
                                  const std::string &title,
-                                 const int& nchX, float *xbinsize){
-  return (ibook_.book1D (name, title,nchX, xbinsize));
+                                 const int& nchX, float *xbinsize) {
+  return ibook_.book1D(name, title, nchX, xbinsize);
 }        
 
 MonitorElement* HistoProviderDQM::book2D(const std::string &name,
                                 const std::string &title,
                                 const int& nchX, const double& lowX, const double& highX,
                                 const int& nchY, const double& lowY, const double& highY) {
-  return (ibook_.book2D (name, title, nchX,lowX,highX, nchY, lowY, highY));
+  return ibook_.book2D(name, title, nchX, lowX, highX, nchY, lowY, highY);
 }
 
-MonitorElement* HistoProviderDQM::book2D (const std::string &name,
+MonitorElement* HistoProviderDQM::book2D(const std::string &name,
                                  const std::string &title,
                                  const int& nchX, float *xbinsize,
-                                 const int& nchY, float *ybinsize){
-  return (ibook_.book2D (name, title,nchX, xbinsize, nchY, ybinsize));
+                                 const int& nchY, float *ybinsize) {
+  return ibook_.book2D(name, title, nchX, xbinsize, nchY, ybinsize);
 }
         
 MonitorElement* HistoProviderDQM::bookProfile(const std::string &name,
                                 const std::string &title,
                                 int nchX, double lowX, double highX,
                                 int nchY, double lowY, double highY) {
-  return (ibook_.bookProfile (name,title, nchX,lowX,highX, nchY, lowY, highY));
+  return ibook_.bookProfile(name, title, nchX, lowX, highX, nchY, lowY, highY);
 }
 

--- a/DQMOffline/RecoB/src/HistoShifter.cc
+++ b/DQMOffline/RecoB/src/HistoShifter.cc
@@ -5,17 +5,17 @@
 bool HistoShifter::insertAndShift(TH1F* in, const float& value){
   const int& nBins = in->GetNbinsX();
   
-  for (int i=2; i<nBins; ++i){
-    in->SetBinContent(i-1,in->GetBinContent(i));
-    in->SetBinError(i-1,in->GetBinError(i));
+  for (int i = 2; i < nBins; ++i){
+    in->SetBinContent(i-1, in->GetBinContent(i));
+    in->SetBinError(i-1, in->GetBinError(i));
   }
-  in->SetBinContent(nBins,value);
+  in->SetBinContent(nBins, value);
     
   return true;
 }
 
 bool HistoShifter::insertAndShift(TH1F* in, const float& value, const float& error){
   const bool& ok = insertAndShift(in, value);
-  in->SetBinError(in->GetNbinsX(),error);
+  in->SetBinError(in->GetNbinsX(), error);
   return ok;
 }

--- a/DQMOffline/RecoB/src/JetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/JetTagPlotter.cc
@@ -84,6 +84,9 @@ JetTagPlotter::JetTagPlotter (const std::string & tagName, const EtaPtBin & etaP
       // jet Eta larger than requested discrimnator cut
       dJetPseudoRapidityDiscrCut = new FlavourHistograms<double>("jetEta_diffEff" + es, "Efficiency vs. jet eta for discriminator above cut",
             20, -etaPtBin.getEtaMax(), etaPtBin.getEtaMax(), false, false, true, "b", jetTagDir, mcPlots_, ibook);
+  } else {
+      dJetPhiDiscrCut = nullptr;
+      dJetPseudoRapidityDiscrCut = nullptr;
   }
 }  
   

--- a/DQMOffline/RecoB/src/JetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/JetTagPlotter.cc
@@ -32,10 +32,7 @@ JetTagPlotter::JetTagPlotter (const std::string & tagName, const EtaPtBin & etaP
   //added to count the number of jets by event : 0=DATA or NI, 1to5=quarks u,d,s,c,b , 6=gluon
   int nFl = 1;
   if(mcPlots_) nFl = 8;
-  nJets_ = new int [nFl];
-  for(int i = 0; i < nFl; i++){
-    nJets_[i]=0;
-  }
+  nJets_.resize(nFl, 0);
   
   if (mcPlots_){
     // jet flavour
@@ -204,13 +201,11 @@ void JetTagPlotter::analyzeTag(const float& w)
     jetMultiplicity_->fill(-1, totNJets, w); //total number of jets in the event
     jetMultiplicity_->fill(123, udsNJets, w);
     jetMultiplicity_->fill(12321, udsgNJets, w);
-  }
-  else 
-    {
+  } else {
       int totNJets = 0;
-      for(int i = 0; i < 8; i++){
-	totNJets += nJets_[i];
-	nJets_[i] = 0;
+      for (int i = 0; i < 8; i++) {
+	    totNJets += nJets_[i];
+	    nJets_[i] = 0;
       }
       jetMultiplicity_->fill(-1, totNJets, w);
     }
@@ -227,8 +222,7 @@ void JetTagPlotter::analyzeTag(const reco::Jet & jet,
     else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
     else if(jetFlavour==20) nJets_[7]+=1; //PU
     else nJets_[0]+=1; //NI
-  }
-  else{
+  } else {
     nJets_[0]+=1;
   }
   if (edm::isNotFinite(discriminator) ) dDiscriminator_->fill(jetFlavour, -999.0 );
@@ -257,8 +251,7 @@ void JetTagPlotter::analyzeTag(const reco::Jet & jet,
     else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
     else if(jetFlavour==20) nJets_[7]+=1; //PU
     else nJets_[0]+=1; //NI
-  }
-  else{
+  } else {
     nJets_[0]+=1;
   }
   if (edm::isNotFinite(discriminator) ) dDiscriminator_->fill(jetFlavour, -999.0 , w );
@@ -282,13 +275,12 @@ void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
 {
   if (mcPlots_) {
   dJetFlav_->fill(jetFlavour, jetFlavour);
-  if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets_[abs(jetFlavour)]+=1; //quarks 1 to 5
-  else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
-  else if(jetFlavour==20) nJets_[7]+=1; //PU  
-  else nJets_[0]+=1; //NI
-  }
-  else{
-    nJets_[0]+=1;
+  if (abs(jetFlavour) > 0 && abs(jetFlavour) < 6) nJets_[abs(jetFlavour)] += 1; //quarks 1 to 5
+  else if(abs(jetFlavour) == 21) nJets_[6] +=1 ; //gluons
+  else if(jetFlavour == 20) nJets_[7] += 1; //PU  
+  else nJets_[0] += 1; //NI
+  } else {
+    nJets_[0] += 1;
   }
   if (edm::isNotFinite(jetTag.second) ) dDiscriminator_->fill(jetFlavour, -999.0 );
   else dDiscriminator_->fill(jetFlavour, jetTag.second);
@@ -305,13 +297,12 @@ void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
 {
   if (mcPlots_) {
     dJetFlav_->fill(jetFlavour, jetFlavour, w );
-    if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets_[abs(jetFlavour)]+=1; //quarks 1 to 5
-    else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
-    else if(jetFlavour==20) nJets_[7]+=1; //PU  
-    else nJets_[0]+=1; //NI
-  }
-  else{
-    nJets_[0]+=1;
+    if (abs(jetFlavour) > 0 && abs(jetFlavour) < 6) nJets_[abs(jetFlavour)] += 1; //quarks 1 to 5
+    else if (abs(jetFlavour) == 21) nJets_[6] += 1; //gluons
+    else if (jetFlavour == 20) nJets_[7] += 1; //PU  
+    else nJets_[0] += 1; //NI
+  } else {
+    nJets_[0] += 1;
   }
   if (edm::isNotFinite(jetTag.second) ) dDiscriminator_->fill(jetFlavour, -999.0 , w );
   else dDiscriminator_->fill(jetFlavour, jetTag.second , w );

--- a/DQMOffline/RecoB/src/JetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/JetTagPlotter.cc
@@ -32,98 +32,98 @@ JetTagPlotter::JetTagPlotter (const std::string & tagName, const EtaPtBin & etaP
   //added to count the number of jets by event : 0=DATA or NI, 1to5=quarks u,d,s,c,b , 6=gluon
   int nFl = 1;
   if(mcPlots_) nFl = 8;
-  nJets = new int [nFl];
+  nJets_ = new int [nFl];
   for(int i = 0; i < nFl; i++){
-    nJets[i]=0;
+    nJets_[i]=0;
   }
   
   if (mcPlots_){
     // jet flavour
-    dJetFlav = new FlavourHistograms<int>
+    dJetFlav_ = new FlavourHistograms<int>
       ("jetFlavour" + es, "Jet Flavour", 22, -0.5, 21.5,
        false, false, false, "b", jetTagDir, mcPlots_, ibook);
   }else {
-    dJetFlav=0;
+    dJetFlav_=0;
   }
   
   // jet multiplicity
-  JetMultiplicity = new FlavourHistograms<int>
+  jetMultiplicity_ = new FlavourHistograms<int>
     ("jetMultiplicity" + es, "Jet Multiplicity", 11, -0.5, 10.5,
      false, true, true, "b", jetTagDir, mcPlots_, ibook);
   
   // Discriminator: again with reasonable binning
-  dDiscriminator = new FlavourHistograms<double>
+  dDiscriminator_ = new FlavourHistograms<double>
     ("discr" + es, "Discriminator", 102, discrStart_, discrEnd_,
      false, true, true, "b", jetTagDir, mcPlots_, ibook);
-  dDiscriminator->settitle("Discriminant");
+  dDiscriminator_->settitle("Discriminant");
   // reconstructed jet momentum
-  dJetRecMomentum = new FlavourHistograms<double>
+  dJetRecMomentum_ = new FlavourHistograms<double>
     ("jetMomentum" + es, "jet momentum", 350, 0.0, 350.0,
      false, false, true, "b", jetTagDir, mcPlots_, ibook);
   
   // reconstructed jet transverse momentum
-  dJetRecPt = new FlavourHistograms<double>
+  dJetRecPt_ = new FlavourHistograms<double>
     ("jetPt" + es, "jet pt", 350, 0.0, 350.0,
      false, false, true, "b", jetTagDir, mcPlots_, ibook);
   
   // reconstructed jet eta
-  dJetRecPseudoRapidity = new FlavourHistograms<double>
+  dJetRecPseudoRapidity_ = new FlavourHistograms<double>
     ("jetEta" + es, "jet eta", 20, -etaPtBin.getEtaMax(), etaPtBin.getEtaMax(),
      false, false, true, "b", jetTagDir, mcPlots_, ibook);
   
   // reconstructed jet phi
-  dJetRecPhi = new FlavourHistograms<double>
+  dJetRecPhi_ = new FlavourHistograms<double>
     ("jetPhi" + es, "jet phi", 20, -M_PI, M_PI,
      false, false, true, "b", jetTagDir, mcPlots_, ibook); 
  
   if (doDifferentialPlots_) {
       // jet Phi larger than requested discrimnator cut
-      dJetPhiDiscrCut = new FlavourHistograms<double>("jetPhi_diffEff" + es, "Efficiency vs. jet Phi for discriminator above cut",
+      dJetPhiDiscrCut_ = new FlavourHistograms<double>("jetPhi_diffEff" + es, "Efficiency vs. jet Phi for discriminator above cut",
             20, -M_PI, M_PI, false, false, true, "b", jetTagDir, mcPlots_, ibook);
       
       // jet Eta larger than requested discrimnator cut
-      dJetPseudoRapidityDiscrCut = new FlavourHistograms<double>("jetEta_diffEff" + es, "Efficiency vs. jet eta for discriminator above cut",
+      dJetPseudoRapidityDiscrCut_ = new FlavourHistograms<double>("jetEta_diffEff" + es, "Efficiency vs. jet eta for discriminator above cut",
             20, -etaPtBin.getEtaMax(), etaPtBin.getEtaMax(), false, false, true, "b", jetTagDir, mcPlots_, ibook);
   } else {
-      dJetPhiDiscrCut = nullptr;
-      dJetPseudoRapidityDiscrCut = nullptr;
+      dJetPhiDiscrCut_ = nullptr;
+      dJetPseudoRapidityDiscrCut_ = nullptr;
   }
 }  
   
   
 JetTagPlotter::~JetTagPlotter () {
-  delete dDiscriminator;
+  delete dDiscriminator_;
   
   if (doDifferentialPlots_) {
-    delete dJetPhiDiscrCut;
-    delete dJetPseudoRapidityDiscrCut;
+    delete dJetPhiDiscrCut_;
+    delete dJetPseudoRapidityDiscrCut_;
   }
   
   if (!willFinalize_) {
-    delete dJetFlav;
-    delete JetMultiplicity;
-    delete dJetRecMomentum;
-    delete dJetRecPt;
-    delete dJetRecPseudoRapidity;
-    delete dJetRecPhi;
+    delete dJetFlav_;
+    delete jetMultiplicity_;
+    delete dJetRecMomentum_;
+    delete dJetRecPt_;
+    delete dJetRecPseudoRapidity_;
+    delete dJetRecPhi_;
   } else {
-    delete effPurFromHistos;
+    delete effPurFromHistos_;
   }
 }
 
 void JetTagPlotter::epsPlot(const std::string & name)
 {
   if (!willFinalize_) {
-    dJetFlav->epsPlot(name);
-    JetMultiplicity->epsPlot(name);
-    dDiscriminator->epsPlot(name);
-    dJetRecMomentum->epsPlot(name);
-    dJetRecPt->epsPlot(name);
-    dJetRecPseudoRapidity->epsPlot(name);
-    dJetRecPhi->epsPlot(name);
+    dJetFlav_->epsPlot(name);
+    jetMultiplicity_->epsPlot(name);
+    dDiscriminator_->epsPlot(name);
+    dJetRecMomentum_->epsPlot(name);
+    dJetRecPt_->epsPlot(name);
+    dJetRecPseudoRapidity_->epsPlot(name);
+    dJetRecPhi_->epsPlot(name);
   }
   else {
-    effPurFromHistos->epsPlot(name);
+    effPurFromHistos_->epsPlot(name);
   }
 }
 
@@ -138,40 +138,40 @@ void JetTagPlotter::psPlot(const std::string & name)
   canvas.Print((name + cName + ".ps[").c_str());
   if (!willFinalize_) {
     canvas.cd(1);
-    dJetFlav->plot();
+    dJetFlav_->plot();
     canvas.cd(2);
     canvas.cd(3);
-    dDiscriminator->plot();
+    dDiscriminator_->plot();
     canvas.cd(4);
-    dJetRecMomentum->plot();
+    dJetRecMomentum_->plot();
     canvas.cd(5);
-    dJetRecPt->plot();
+    dJetRecPt_->plot();
     canvas.cd(6);
-    dJetRecPseudoRapidity->plot();
+    dJetRecPseudoRapidity_->plot();
     canvas.Print((name + cName + ".ps").c_str());
     canvas.Clear();
     canvas.Divide(2,3);
     
-    JetMultiplicity->plot();
+    jetMultiplicity_->plot();
     canvas.Print((name + cName + ".ps").c_str());
     canvas.Clear();
     
     canvas.cd(1);
-    dJetRecPhi->plot();
+    dJetRecPhi_->plot();
     canvas.cd(2);
     canvas.cd(3);
     canvas.cd(4);
   }
   else {
     canvas.cd(5);
-    effPurFromHistos->discriminatorNoCutEffic()->plot();
+    effPurFromHistos_->discriminatorNoCutEffic()->plot();
     canvas.cd(6);
-    effPurFromHistos->discriminatorCutEfficScan()->plot();
+    effPurFromHistos_->discriminatorCutEfficScan()->plot();
     canvas.Print((name + cName + ".ps").c_str());
     canvas.Clear();
     canvas.Divide(2,3);
     canvas.cd(1);
-    effPurFromHistos->plot();
+    effPurFromHistos_->plot();
   }
   canvas.Print((name + cName + ".ps").c_str());
   canvas.Print((name + cName + ".ps]").c_str());
@@ -180,8 +180,8 @@ void JetTagPlotter::psPlot(const std::string & name)
 void JetTagPlotter::analyzeTag() //here jetFlavour not needed
 {
   //to use on data
-  JetMultiplicity->fill(-1, nJets[0]);
-  nJets[0] = 0; //reset to 0 before the next event
+  jetMultiplicity_->fill(-1, nJets_[0]);
+  nJets_[0] = 0; //reset to 0 before the next event
 }
 
 void JetTagPlotter::analyzeTag(const float& w)
@@ -192,27 +192,27 @@ void JetTagPlotter::analyzeTag(const float& w)
     int udsNJets = 0;
     int udsgNJets = 0;
     for(int i = 0; i < 8; i++){
-      totNJets += nJets[i];
-      if(i > 0 && i < 4) udsNJets += nJets[i];
-      if((i > 0 && i < 4) || i == 6) udsgNJets += nJets[i];
-      if(i <= 5 && i >= 1) JetMultiplicity->fill(i, nJets[i], w);
-      else if (i==6) JetMultiplicity->fill(21, nJets[i], w);
-      else if (i==7) JetMultiplicity->fill(20, nJets[i], w);
-      else JetMultiplicity->fill(0, nJets[i], w);
-      nJets[i] = 0; //reset to 0 before the next event
+      totNJets += nJets_[i];
+      if(i > 0 && i < 4) udsNJets += nJets_[i];
+      if((i > 0 && i < 4) || i == 6) udsgNJets += nJets_[i];
+      if(i <= 5 && i >= 1) jetMultiplicity_->fill(i, nJets_[i], w);
+      else if (i==6) jetMultiplicity_->fill(21, nJets_[i], w);
+      else if (i==7) jetMultiplicity_->fill(20, nJets_[i], w);
+      else jetMultiplicity_->fill(0, nJets_[i], w);
+      nJets_[i] = 0; //reset to 0 before the next event
     }
-    JetMultiplicity->fill(-1, totNJets, w); //total number of jets in the event
-    JetMultiplicity->fill(123, udsNJets, w);
-    JetMultiplicity->fill(12321, udsgNJets, w);
+    jetMultiplicity_->fill(-1, totNJets, w); //total number of jets in the event
+    jetMultiplicity_->fill(123, udsNJets, w);
+    jetMultiplicity_->fill(12321, udsgNJets, w);
   }
   else 
     {
       int totNJets = 0;
       for(int i = 0; i < 8; i++){
-	totNJets += nJets[i];
-	nJets[i] = 0;
+	totNJets += nJets_[i];
+	nJets_[i] = 0;
       }
-      JetMultiplicity->fill(-1, totNJets, w);
+      jetMultiplicity_->fill(-1, totNJets, w);
     }
 }
 
@@ -222,25 +222,25 @@ void JetTagPlotter::analyzeTag(const reco::Jet & jet,
                                const int& jetFlavour)  
 {
   if (mcPlots_) {
-    dJetFlav->fill(jetFlavour, jetFlavour);
-    if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
-    else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
-    else if(jetFlavour==20) nJets[7]+=1; //PU
-    else nJets[0]+=1; //NI
+    dJetFlav_->fill(jetFlavour, jetFlavour);
+    if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets_[abs(jetFlavour)]+=1; //quarks 1 to 5
+    else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
+    else if(jetFlavour==20) nJets_[7]+=1; //PU
+    else nJets_[0]+=1; //NI
   }
   else{
-    nJets[0]+=1;
+    nJets_[0]+=1;
   }
-  if (edm::isNotFinite(discriminator) ) dDiscriminator->fill(jetFlavour, -999.0 );
-  else dDiscriminator->fill(jetFlavour, discriminator );
-  dJetRecMomentum->fill(jetFlavour, jet.p()*jec );
-  dJetRecPt->fill(jetFlavour, jet.pt()*jec );
-  dJetRecPseudoRapidity->fill(jetFlavour, jet.eta() );
-  dJetRecPhi->fill(jetFlavour, jet.phi());
+  if (edm::isNotFinite(discriminator) ) dDiscriminator_->fill(jetFlavour, -999.0 );
+  else dDiscriminator_->fill(jetFlavour, discriminator );
+  dJetRecMomentum_->fill(jetFlavour, jet.p()*jec );
+  dJetRecPt_->fill(jetFlavour, jet.pt()*jec );
+  dJetRecPseudoRapidity_->fill(jetFlavour, jet.eta() );
+  dJetRecPhi_->fill(jetFlavour, jet.phi());
   if (doDifferentialPlots_) {
     if (edm::isFinite(discriminator) && discriminator > cutValue_) {
-      dJetPhiDiscrCut->fill(jetFlavour, jet.phi());
-      dJetPseudoRapidityDiscrCut->fill(jetFlavour, jet.eta());
+      dJetPhiDiscrCut_->fill(jetFlavour, jet.phi());
+      dJetPseudoRapidityDiscrCut_->fill(jetFlavour, jet.eta());
     }
   }
 }
@@ -252,25 +252,25 @@ void JetTagPlotter::analyzeTag(const reco::Jet & jet,
 			       const float& w)  
 {
   if (mcPlots_) {
-    dJetFlav->fill(jetFlavour, jetFlavour , w );
-    if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
-    else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
-    else if(jetFlavour==20) nJets[7]+=1; //PU
-    else nJets[0]+=1; //NI
+    dJetFlav_->fill(jetFlavour, jetFlavour , w );
+    if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets_[abs(jetFlavour)]+=1; //quarks 1 to 5
+    else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
+    else if(jetFlavour==20) nJets_[7]+=1; //PU
+    else nJets_[0]+=1; //NI
   }
   else{
-    nJets[0]+=1;
+    nJets_[0]+=1;
   }
-  if (edm::isNotFinite(discriminator) ) dDiscriminator->fill(jetFlavour, -999.0 , w );
-  else dDiscriminator->fill(jetFlavour, discriminator , w );
-  dJetRecMomentum->fill(jetFlavour, jet.p()*jec , w);
-  dJetRecPt->fill(jetFlavour, jet.pt()*jec , w);
-  dJetRecPseudoRapidity->fill(jetFlavour, jet.eta() , w );
-  dJetRecPhi->fill(jetFlavour, jet.phi() , w );
+  if (edm::isNotFinite(discriminator) ) dDiscriminator_->fill(jetFlavour, -999.0 , w );
+  else dDiscriminator_->fill(jetFlavour, discriminator , w );
+  dJetRecMomentum_->fill(jetFlavour, jet.p()*jec , w);
+  dJetRecPt_->fill(jetFlavour, jet.pt()*jec , w);
+  dJetRecPseudoRapidity_->fill(jetFlavour, jet.eta() , w );
+  dJetRecPhi_->fill(jetFlavour, jet.phi() , w );
   if (doDifferentialPlots_) {
     if (edm::isFinite(discriminator) && discriminator > cutValue_) {
-      dJetPhiDiscrCut->fill(jetFlavour, jet.phi());
-      dJetPseudoRapidityDiscrCut->fill(jetFlavour, jet.eta());
+      dJetPhiDiscrCut_->fill(jetFlavour, jet.phi());
+      dJetPseudoRapidityDiscrCut_->fill(jetFlavour, jet.eta());
     }
   }
 }
@@ -281,21 +281,21 @@ void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
 			       const int & jetFlavour)
 {
   if (mcPlots_) {
-  dJetFlav->fill(jetFlavour, jetFlavour);
-  if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
-  else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
-  else if(jetFlavour==20) nJets[7]+=1; //PU  
-  else nJets[0]+=1; //NI
+  dJetFlav_->fill(jetFlavour, jetFlavour);
+  if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets_[abs(jetFlavour)]+=1; //quarks 1 to 5
+  else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
+  else if(jetFlavour==20) nJets_[7]+=1; //PU  
+  else nJets_[0]+=1; //NI
   }
   else{
-    nJets[0]+=1;
+    nJets_[0]+=1;
   }
-  if (edm::isNotFinite(jetTag.second) ) dDiscriminator->fill(jetFlavour, -999.0 );
-  else dDiscriminator->fill(jetFlavour, jetTag.second);
-  dJetRecMomentum->fill(jetFlavour, jetTag.first->p()*jec );
-  dJetRecPt->fill(jetFlavour, jetTag.first->pt()*jec );
-  dJetRecPseudoRapidity->fill(jetFlavour, jetTag.first->eta() );
-  dJetRecPhi->fill(jetFlavour, jetTag.first->phi());
+  if (edm::isNotFinite(jetTag.second) ) dDiscriminator_->fill(jetFlavour, -999.0 );
+  else dDiscriminator_->fill(jetFlavour, jetTag.second);
+  dJetRecMomentum_->fill(jetFlavour, jetTag.first->p()*jec );
+  dJetRecPt_->fill(jetFlavour, jetTag.first->pt()*jec );
+  dJetRecPseudoRapidity_->fill(jetFlavour, jetTag.first->eta() );
+  dJetRecPhi_->fill(jetFlavour, jetTag.first->phi());
 }
 
 void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag, 
@@ -304,21 +304,21 @@ void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
 			       const float& w)
 {
   if (mcPlots_) {
-    dJetFlav->fill(jetFlavour, jetFlavour, w );
-    if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
-    else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
-    else if(jetFlavour==20) nJets[7]+=1; //PU  
-    else nJets[0]+=1; //NI
+    dJetFlav_->fill(jetFlavour, jetFlavour, w );
+    if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets_[abs(jetFlavour)]+=1; //quarks 1 to 5
+    else if(abs(jetFlavour)==21) nJets_[6]+=1; //gluons
+    else if(jetFlavour==20) nJets_[7]+=1; //PU  
+    else nJets_[0]+=1; //NI
   }
   else{
-    nJets[0]+=1;
+    nJets_[0]+=1;
   }
-  if (edm::isNotFinite(jetTag.second) ) dDiscriminator->fill(jetFlavour, -999.0 , w );
-  else dDiscriminator->fill(jetFlavour, jetTag.second , w );
-  dJetRecMomentum->fill(jetFlavour, jetTag.first->p()*jec , w );
-  dJetRecPt->fill(jetFlavour, jetTag.first->pt()*jec , w );
-  dJetRecPseudoRapidity->fill(jetFlavour, jetTag.first->eta() , w );
-  dJetRecPhi->fill(jetFlavour, jetTag.first->phi() , w );
+  if (edm::isNotFinite(jetTag.second) ) dDiscriminator_->fill(jetFlavour, -999.0 , w );
+  else dDiscriminator_->fill(jetFlavour, jetTag.second , w );
+  dJetRecMomentum_->fill(jetFlavour, jetTag.first->p()*jec , w );
+  dJetRecPt_->fill(jetFlavour, jetTag.first->pt()*jec , w );
+  dJetRecPseudoRapidity_->fill(jetFlavour, jetTag.first->eta() , w );
+  dJetRecPhi_->fill(jetFlavour, jetTag.first->phi() , w );
 }
 
 void JetTagPlotter::finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_)
@@ -329,24 +329,24 @@ void JetTagPlotter::finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & ige
   //
   const std::string & es = theExtensionString;
   const std::string jetTagDir(es.substr(1));
-  dDiscriminator = new FlavourHistograms<double>("discr" + es, "Discriminator", 102, discrStart_, discrEnd_, "b", jetTagDir, mcPlots_, igetter_);
+  dDiscriminator_ = new FlavourHistograms<double>("discr" + es, "Discriminator", 102, discrStart_, discrEnd_, "b", jetTagDir, mcPlots_, igetter_);
   
-  effPurFromHistos = new EffPurFromHistos ( dDiscriminator,theExtensionString.substr(1), mcPlots_, ibook_, 
+  effPurFromHistos_ = new EffPurFromHistos ( dDiscriminator_,theExtensionString.substr(1), mcPlots_, ibook_, 
 					    nBinEffPur_, startEffPur_, endEffPur_);
-  effPurFromHistos->doCTagPlots(doCTagPlots_);
-  effPurFromHistos->compute(ibook_);
+  effPurFromHistos_->doCTagPlots(doCTagPlots_);
+  effPurFromHistos_->compute(ibook_);
 
   // Produce the differentiel efficiency vs. kinematical variables
   if (doDifferentialPlots_) {
-    dJetRecPhi = new FlavourHistograms<double>("jetPhi" + es, "jet phi", 20, -M_PI, M_PI, "b", jetTagDir, mcPlots_, igetter_); 
-    dJetPhiDiscrCut = new FlavourHistograms<double>("jetPhi_diffEff" + es, "Efficiency vs. jet Phi for discriminator above cut", 20, -M_PI, M_PI, "b", jetTagDir, mcPlots_, igetter_); 
-    dJetPhiDiscrCut->divide(*dJetRecPhi);
-    dJetPhiDiscrCut->setEfficiencyFlag();
+    dJetRecPhi_ = new FlavourHistograms<double>("jetPhi" + es, "jet phi", 20, -M_PI, M_PI, "b", jetTagDir, mcPlots_, igetter_); 
+    dJetPhiDiscrCut_ = new FlavourHistograms<double>("jetPhi_diffEff" + es, "Efficiency vs. jet Phi for discriminator above cut", 20, -M_PI, M_PI, "b", jetTagDir, mcPlots_, igetter_); 
+    dJetPhiDiscrCut_->divide(*dJetRecPhi_);
+    dJetPhiDiscrCut_->setEfficiencyFlag();
   
-    dJetRecPseudoRapidity = new FlavourHistograms<double>("jetEta" + es, "jet eta", 20, -etaPtBin_.getEtaMax(), etaPtBin_.getEtaMax(), "b", jetTagDir, mcPlots_, igetter_); 
-    dJetPseudoRapidityDiscrCut = new FlavourHistograms<double>("jetEta_diffEff" + es, "Efficiency vs. jet eta for discriminator above cut", 20, -etaPtBin_.getEtaMax(), etaPtBin_.getEtaMax(), "b", jetTagDir, mcPlots_, igetter_); 
-    dJetPseudoRapidityDiscrCut->divide(*dJetRecPseudoRapidity);
-    dJetPseudoRapidityDiscrCut->setEfficiencyFlag();
+    dJetRecPseudoRapidity_ = new FlavourHistograms<double>("jetEta" + es, "jet eta", 20, -etaPtBin_.getEtaMax(), etaPtBin_.getEtaMax(), "b", jetTagDir, mcPlots_, igetter_); 
+    dJetPseudoRapidityDiscrCut_ = new FlavourHistograms<double>("jetEta_diffEff" + es, "Efficiency vs. jet eta for discriminator above cut", 20, -etaPtBin_.getEtaMax(), etaPtBin_.getEtaMax(), "b", jetTagDir, mcPlots_, igetter_); 
+    dJetPseudoRapidityDiscrCut_->divide(*dJetRecPseudoRapidity_);
+    dJetPseudoRapidityDiscrCut_->setEfficiencyFlag();
   }
 }
 

--- a/DQMOffline/RecoB/src/MVAJetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/MVAJetTagPlotter.cc
@@ -17,8 +17,8 @@ MVAJetTagPlotter::MVAJetTagPlotter(const std::string &tagName,
                                    const EtaPtBin &etaPtBin,
                                    const ParameterSet &pSet,
                                    const std::string& folderName,
-                                   const unsigned int& mc, const bool& willFinalize, 
-				   DQMStore::IBooker & ibook) :
+                                   unsigned int mc, bool willFinalize, 
+				   DQMStore::IBooker & ibook):
 	BaseTagInfoPlotter(folderName, etaPtBin),
 	jetTagComputer(tagName), computer(0),
 	categoryVariable(btau::lastTaggingVariable)
@@ -29,24 +29,20 @@ MVAJetTagPlotter::MVAJetTagPlotter(const std::string &tagName,
 		categoryVariable = getTaggingVariableName(
 			pSet.getParameter<string>("categoryVariable"));
 		pSets = pSet.getParameter<VParameterSet>("categories");
-	} 
-	else pSets.push_back(pSet);
+	} else pSets.push_back(pSet);
 
-	for(unsigned int i = 0; i != pSets.size(); ++i) {
-	  ostringstream ss;
-	  ss << "CAT" << i;
+	for (unsigned int i = 0; i != pSets.size(); ++i) {
+      std::string ss = "CAT";
+      ss += std::to_string(i);
 	  categoryPlotters.push_back(
-				     new TaggingVariablePlotter(folderName, etaPtBin,
+              std::make_unique<TaggingVariablePlotter>(folderName, etaPtBin,
 								pSets[i], mc, willFinalize, ibook,
-								i ? ss.str() : string()));
+								i ? ss : std::string())
+                     );
 	}
 }
 
-MVAJetTagPlotter::~MVAJetTagPlotter ()
-{
-	for_each(categoryPlotters.begin(), categoryPlotters.end(),
-	         bind(&::operator delete, _1));
-}
+MVAJetTagPlotter::~MVAJetTagPlotter() { }
 
 void MVAJetTagPlotter::setEventSetup(const edm::EventSetup &setup)
 {
@@ -61,26 +57,16 @@ void MVAJetTagPlotter::setEventSetup(const edm::EventSetup &setup)
 			   "GenericMVAJetTagComputer." << endl;
 }
 
-void MVAJetTagPlotter::analyzeTag (const vector<const BaseTagInfo*> &baseTagInfos, const double & jec, 
-                                   const int &jetFlavour)
-{
-  analyzeTag(baseTagInfos,jec,jetFlavour,1.);
-}
-
-void MVAJetTagPlotter::analyzeTag (const vector<const BaseTagInfo*> &baseTagInfos,
-				   const double & jec, 
-                                   const int &jetFlavour,
-				   const float & w)
+void MVAJetTagPlotter::analyzeTag(const vector<const BaseTagInfo*> &baseTagInfos, double jec, int jetFlavour, float w/*=1*/)
 {
 	const JetTagComputer::TagInfoHelper helper(baseTagInfos);
 	const TaggingVariableList& vars = computer->taggingVariables(helper);
 
-	categoryPlotters.front()->analyzeTag(vars, jetFlavour,w);
+	categoryPlotters.front()->analyzeTag(vars, jetFlavour, w);
 	if (categoryVariable != btau::lastTaggingVariable) {
-		unsigned int cat =
-			(unsigned int)(vars.get(categoryVariable, -1) + 1);
+		unsigned int cat = (unsigned int)(vars.get(categoryVariable, -1) + 1);
 		if (cat >= 1 && cat < categoryPlotters.size())
-		  categoryPlotters[cat]->analyzeTag(vars, jetFlavour,w);
+		  categoryPlotters[cat]->analyzeTag(vars, jetFlavour, w);
 	}
 }
 
@@ -95,14 +81,14 @@ void MVAJetTagPlotter::finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & 
 
 void MVAJetTagPlotter::psPlot(const std::string &name)
 {
-	for_each(categoryPlotters.begin(), categoryPlotters.end(),
-	         boost::bind(&TaggingVariablePlotter::psPlot, _1, boost::ref(name)));
+    for (const auto& plot: categoryPlotters)
+        plot->psPlot(name);
 }
 
 void MVAJetTagPlotter::epsPlot(const std::string &name)
 {
-	for_each(categoryPlotters.begin(), categoryPlotters.end(),
-	         boost::bind(&TaggingVariablePlotter::epsPlot, _1, boost::ref(name)));
+    for (const auto& plot: categoryPlotters)
+        plot->epsPlot(name);
 }
 
 vector<string> MVAJetTagPlotter::tagInfoRequirements() const

--- a/DQMOffline/RecoB/src/SoftLeptonTagPlotter.cc
+++ b/DQMOffline/RecoB/src/SoftLeptonTagPlotter.cc
@@ -12,7 +12,7 @@ static const string ordinal[9] = { "1st", "2nd", "3rd", "4th", "5th", "6th", "7t
 
 SoftLeptonTagPlotter::SoftLeptonTagPlotter(const std::string & tagName,
 					   const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
-					   const unsigned int& mc, const bool& wf, DQMStore::IBooker & ibook) :
+					   unsigned int mc, bool wf, DQMStore::IBooker & ibook) :
   BaseTagInfoPlotter(tagName, etaPtBin), mcPlots_(mc), willFinalize_(wf)
 {
   const std::string softLepDir(theExtensionString.substr(1));
@@ -20,91 +20,63 @@ SoftLeptonTagPlotter::SoftLeptonTagPlotter(const std::string & tagName,
   if(willFinalize_) return;
   
   for (int i = 0; i < s_leptons; i++) {
-    std::ostringstream s("");
-    s << ordinal[i] << " lepton ";
-    m_leptonId[i] = new FlavourHistograms<double> (
-						   s.str() + "id",
+    std::string s;
+    s += ordinal[i] + " lepton ";
+    m_leptonId.push_back(std::make_unique<FlavourHistograms<double>>(
+						   s + "id",
 						   "Lepton identification discriminaint",
-						   60, -0.1, 1.1, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_leptonPt[i] = new FlavourHistograms<double> (
-						   s.str() + "pT",
+						   60, -0.1, 1.1, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_leptonPt.push_back(std::make_unique<FlavourHistograms<double>>(
+						   s + "pT",
 						   "Lepton transverse moementum",
-						   100, 0.0, 20.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_sip2dsig[i] = new FlavourHistograms<double> (
-        s.str() + "sip2dsig",
+						   100, 0.0, 20.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_sip2dsig.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "sip2dsig",
         "Lepton signed 2D impact parameter significance",
-        100, -20.0, 30.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_sip3dsig[i] = new FlavourHistograms<double> (
-        s.str() + "sip3dsig",
+        100, -20.0, 30.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_sip3dsig.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "sip3dsig",
         "Lepton signed 3D impact parameter significance",
-        100, -20.0, 30.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_sip2d[i] = new FlavourHistograms<double> (
-        s.str() + "sip2d",
+        100, -20.0, 30.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_sip2d.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "sip2d",
         "Lepton signed 2D impact parameter",
-        100, -20.0, 30.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_sip3d[i] = new FlavourHistograms<double> (
-        s.str() + "sip3d",
+        100, -20.0, 30.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_sip3d.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "sip3d",
         "Lepton signed 3D impact parameter",
-        100, -20.0, 30.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_ptRel[i] = new FlavourHistograms<double> (
-        s.str() +  "pT rel",
-        "Lepton transverse moementum relative to jet axis",
-        100, 0.0, 10.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_p0Par[i] = new FlavourHistograms<double> (
-        s.str() + "p0 par",
+        100, -20.0, 30.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_ptRel.push_back(std::make_unique<FlavourHistograms<double>>(
+        s +  "pT rel",
+        "Lepton transverse momentum relative to jet axis",
+        100, 0.0, 10.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_p0Par.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "p0 par",
         "Lepton moementum along jet axis in the B rest frame",
-        100, 0.0, 10.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_etaRel[i] = new FlavourHistograms<double> (
-        s.str() + "eta rel",
+        100, 0.0, 10.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_etaRel.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "eta rel",
         "Lepton pseudorapidity relative to jet axis",
-        100, -5.0, 25.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_deltaR[i] = new FlavourHistograms<double> (
-        s.str() + "delta R",
+        100, -5.0, 25.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_deltaR.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "delta R",
         "Lepton pseudoangular distance from jet axis",
-        100, 0.0, 0.6, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_ratio[i] = new FlavourHistograms<double> (
-        s.str() + "energy ratio",
+        100, 0.0, 0.6, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_ratio.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "energy ratio",
         "Ratio of lepton momentum to jet energy",
-        100, 0.0, 2.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
-    m_ratioRel[i] = new FlavourHistograms<double> (
-        s.str() + "parallel energy ratio",
+        100, 0.0, 2.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
+    m_ratioRel.push_back(std::make_unique<FlavourHistograms<double>>(
+        s + "parallel energy ratio",
         "Ratio of lepton momentum along the jet axis to jet energy",
-        100, 0.0, 2.0, false, false, true, "b", softLepDir,mcPlots_, ibook);
+        100, 0.0, 2.0, false, false, true, "b", softLepDir, mcPlots_, ibook));
   }
 }
 
-SoftLeptonTagPlotter::~SoftLeptonTagPlotter ()
+SoftLeptonTagPlotter::~SoftLeptonTagPlotter() {}
+
+void SoftLeptonTagPlotter::analyzeTag( const reco::BaseTagInfo * baseTagInfo, double jec, int jetFlavour, float w/*=1*/)
 {
-  if(willFinalize_) return;
-
-  for (int i = 0; i != s_leptons; ++i) {
-    delete m_leptonId[i];
-    delete m_leptonPt[i];
-    delete m_sip2dsig[i];
-    delete m_sip3dsig[i];
-    delete m_sip2d[i];
-    delete m_sip3d[i];
-    delete m_ptRel[i];
-    delete m_p0Par[i];
-    delete m_etaRel[i];
-    delete m_deltaR[i];
-    delete m_ratio[i];
-    delete m_ratioRel[i];
-  }
-}
-
-void SoftLeptonTagPlotter::analyzeTag( const reco::BaseTagInfo * baseTagInfo, const double & jec, 
-    const int & jetFlavour )
-{
-  analyzeTag(baseTagInfo,jetFlavour,1.);
-}
-
-void SoftLeptonTagPlotter::analyzeTag( const reco::BaseTagInfo * baseTagInfo,
-				       const double & jec, 
-				       const int & jetFlavour,
-				       const float & w)
-{
-
   const reco::SoftLeptonTagInfo * tagInfo = 
 	dynamic_cast<const reco::SoftLeptonTagInfo *>(baseTagInfo);
 
@@ -117,18 +89,18 @@ void SoftLeptonTagPlotter::analyzeTag( const reco::BaseTagInfo * baseTagInfo,
 
   for (int i = 0; i != n_leptons && i != s_leptons; ++i) {
     const reco::SoftLeptonProperties& properties = tagInfo->properties(i);
-    m_leptonPt[i]->fill( jetFlavour, tagInfo->lepton(i)->pt() ,w);
-    m_leptonId[i]->fill( jetFlavour, properties.quality() ,w);
-    m_sip2dsig[i]->fill(    jetFlavour, properties.sip2dsig ,w);
-    m_sip3dsig[i]->fill(    jetFlavour, properties.sip3dsig ,w);
-    m_sip2d[i]->fill(    jetFlavour, properties.sip2d ,w);
-    m_sip3d[i]->fill(    jetFlavour, properties.sip3d ,w);
-    m_ptRel[i]->fill(    jetFlavour, properties.ptRel ,w);
-    m_p0Par[i]->fill(    jetFlavour, properties.p0Par ,w);
-    m_etaRel[i]->fill(   jetFlavour, properties.etaRel ,w);
-    m_deltaR[i]->fill(   jetFlavour, properties.deltaR ,w);
-    m_ratio[i]->fill(    jetFlavour, properties.ratio ,w);
-    m_ratioRel[i]->fill( jetFlavour, properties.ratioRel ,w);
+    m_leptonPt[i]->fill(jetFlavour, tagInfo->lepton(i)->pt(), w);
+    m_leptonId[i]->fill(jetFlavour, properties.quality(), w);
+    m_sip2dsig[i]->fill(jetFlavour, properties.sip2dsig, w);
+    m_sip3dsig[i]->fill(jetFlavour, properties.sip3dsig, w);
+    m_sip2d[i]->fill(jetFlavour, properties.sip2d, w);
+    m_sip3d[i]->fill(jetFlavour, properties.sip3d, w);
+    m_ptRel[i]->fill(jetFlavour, properties.ptRel, w);
+    m_p0Par[i]->fill(jetFlavour, properties.p0Par, w);
+    m_etaRel[i]->fill(jetFlavour, properties.etaRel, w);
+    m_deltaR[i]->fill(jetFlavour, properties.deltaR, w);
+    m_ratio[i]->fill(jetFlavour, properties.ratio, w);
+    m_ratioRel[i]->fill(jetFlavour, properties.ratioRel, w);
   }
 }
 

--- a/DQMOffline/RecoB/src/TagCorrelationPlotter.cc
+++ b/DQMOffline/RecoB/src/TagCorrelationPlotter.cc
@@ -8,61 +8,51 @@ using namespace RecoBTag;
 
 TagCorrelationPlotter::TagCorrelationPlotter(const std::string& tagName1, const std::string& tagName2,
                                              const EtaPtBin& etaPtBin, const edm::ParameterSet& pSet,
-                                             const unsigned int& mc, const bool doCTagPlots, const bool finalize, DQMStore::IBooker & ibook) :
-					     BaseBTagPlotter(tagName2 + "_vs_" + tagName1, etaPtBin),
-  					     lowerBound1_(pSet.getParameter<double>("Discr1Start")),
-  					     lowerBound2_(pSet.getParameter<double>("Discr2Start")),
-  					     upperBound1_(pSet.getParameter<double>("Discr1End")),
-  					     upperBound2_(pSet.getParameter<double>("Discr2End")),
-                                             nBinEffPur_(pSet.getParameter<int>("nBinEffPur")),
-					     startEffPur_(pSet.getParameter<double>("startEffPur")),
-					     endEffPur_(pSet.getParameter<double>("endEffPur")),
-					     createProfile_(pSet.getParameter<bool>("CreateProfile")),
-                                             fixedEff_(pSet.getParameter<vector<double>>("fixedEff")),
-					     mcPlots_(mc), doCTagPlots_(doCTagPlots), finalize_(finalize)
+                                             unsigned int mc, bool doCTagPlots, bool finalize, DQMStore::IBooker & ibook) :
+                         BaseBTagPlotter(tagName2 + "_vs_" + tagName1, etaPtBin),
+                         lowerBound1_(pSet.getParameter<double>("Discr1Start")),
+                         lowerBound2_(pSet.getParameter<double>("Discr2Start")),
+                         upperBound1_(pSet.getParameter<double>("Discr1End")),
+                         upperBound2_(pSet.getParameter<double>("Discr2End")),
+                         nBinEffPur_(pSet.getParameter<int>("nBinEffPur")),
+                         startEffPur_(pSet.getParameter<double>("startEffPur")),
+                         endEffPur_(pSet.getParameter<double>("endEffPur")),
+                         createProfile_(pSet.getParameter<bool>("CreateProfile")),
+                         fixedEff_(pSet.getParameter<vector<double>>("fixedEff")),
+                         mcPlots_(mc), doCTagPlots_(doCTagPlots), finalize_(finalize)
   {
-  if(finalize_) return;  
-  correlationHisto_ = new FlavourHistograms2D<double, double>("correlation" + theExtensionString, tagName2 + " discr vs " + tagName1 + " discr",
-                                                              102, lowerBound1_, upperBound1_, 102, lowerBound2_, upperBound2_, false, 
-                                                              "TagCorrelation" + theExtensionString, mc, createProfile_, ibook);
+  if (finalize_) return;  
+  correlationHisto_ = std::make_unique<FlavourHistograms2D<double, double>>(
+                            "correlation" + theExtensionString, tagName2 + " discr vs " + tagName1 + " discr",
+                            102, lowerBound1_, upperBound1_, 102, lowerBound2_, upperBound2_, false, 
+                            "TagCorrelation" + theExtensionString, mc, createProfile_, ibook);
   correlationHisto_->settitle(tagName1.c_str(), tagName2.c_str());
 }
 
-TagCorrelationPlotter::~TagCorrelationPlotter() {
-  if(finalize_) return;
-  delete correlationHisto_;
-}
+TagCorrelationPlotter::~TagCorrelationPlotter() {}
 
 void TagCorrelationPlotter::epsPlot(const std::string & name)
 {
   effPurFromHistos2D->epsPlot(name);
 }
 
-void TagCorrelationPlotter::analyzeTags(const reco::JetTag& jetTag1, const reco::JetTag& jetTag2, const int& jetFlavour, const float & w) {
+void TagCorrelationPlotter::analyzeTags(const reco::JetTag& jetTag1, const reco::JetTag& jetTag2, int jetFlavour, float w/*=1*/) {
   correlationHisto_->fill(jetFlavour, jetTag1.second, jetTag2.second, w);
 }
 
-void TagCorrelationPlotter::analyzeTags(const reco::JetTag& jetTag1, const reco::JetTag& jetTag2, const int& jetFlavour) {
-  analyzeTags(jetTag1, jetTag2, jetFlavour, 1.0);
-}
-
-void TagCorrelationPlotter::analyzeTags(const float& discr1, const float& discr2, const int& jetFlavour, const float & w) {
+void TagCorrelationPlotter::analyzeTags(float discr1, float discr2, int jetFlavour, float w/*=1*/) {
   correlationHisto_->fill(jetFlavour, discr1, discr2, w);
-}
-
-void TagCorrelationPlotter::analyzeTags(const float& discr1, const float& discr2, const int& jetFlavour) {
-  analyzeTags(discr1, discr2, jetFlavour, 1.0);
 }
 
 void TagCorrelationPlotter::finalize(DQMStore::IBooker & ibook_, DQMStore::IGetter & igetter_)
 {
 
-  correlationHisto_ = new FlavourHistograms2D<double, double>("correlation" + theExtensionString, " discr vs discr",
+  correlationHisto_ = std::make_unique<FlavourHistograms2D<double, double>>("correlation" + theExtensionString, " discr vs discr",
                                                               102, lowerBound1_, upperBound1_, 102, lowerBound2_, upperBound2_,
                                                               "TagCorrelation" + theExtensionString, mcPlots_, createProfile_, igetter_);
 
-  effPurFromHistos2D = new EffPurFromHistos2D ( correlationHisto_, "TagCorrelation" + theExtensionString, mcPlots_, ibook_, 
-						nBinEffPur_, startEffPur_, endEffPur_);
+  effPurFromHistos2D = std::make_unique<EffPurFromHistos2D>(*correlationHisto_, "TagCorrelation" + theExtensionString, mcPlots_, ibook_, 
+                        nBinEffPur_, startEffPur_, endEffPur_);
   effPurFromHistos2D->doCTagPlots(doCTagPlots_);
   effPurFromHistos2D->compute(ibook_, fixedEff_);  
 }

--- a/DQMOffline/RecoB/src/TagInfoPlotterFactory.cc
+++ b/DQMOffline/RecoB/src/TagInfoPlotterFactory.cc
@@ -14,25 +14,25 @@
 
 using namespace std;
 
-BaseTagInfoPlotter*  TagInfoPlotterFactory::buildPlotter(const string& dataFormatType, const std::string & tagName,
-							 const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
-							 const std::string& folderName, const unsigned int& mc, 
-							 const bool& wf, DQMStore::IBooker & ibook)
+std::unique_ptr<BaseTagInfoPlotter> TagInfoPlotterFactory::buildPlotter(const string& dataFormatType, const std::string & tagName,
+                             const EtaPtBin& etaPtBin, const edm::ParameterSet& pSet, 
+                             const std::string& folderName, unsigned int mc, 
+                             bool wf, DQMStore::IBooker & ibook)
 {
   if (dataFormatType == "TrackCounting") {
-    return new TrackCountingTagPlotter(folderName, etaPtBin, pSet,  mc, wf, ibook);
+    return std::make_unique<TrackCountingTagPlotter>(folderName, etaPtBin, pSet,  mc, wf, ibook);
   } else if (dataFormatType == "TrackProbability") {
-    return new TrackProbabilityTagPlotter(folderName, etaPtBin, pSet,  mc, wf, ibook);
+    return std::make_unique<TrackProbabilityTagPlotter>(folderName, etaPtBin, pSet,  mc, wf, ibook);
   } else if (dataFormatType == "SoftLepton") {
-    return new SoftLeptonTagPlotter(folderName, etaPtBin, pSet, mc, wf, ibook);
+    return std::make_unique<SoftLeptonTagPlotter>(folderName, etaPtBin, pSet, mc, wf, ibook);
   } else if (dataFormatType == "TrackIP") {
-    return new IPTagPlotter<reco::TrackRefVector,reco::JTATagInfo>(folderName, etaPtBin, pSet,  mc, wf, ibook);
+    return std::make_unique<IPTagPlotter<reco::TrackRefVector, reco::JTATagInfo>>(folderName, etaPtBin, pSet,  mc, wf, ibook);
   } else if (dataFormatType == "CandIP") {
-    return new IPTagPlotter<std::vector<reco::CandidatePtr>,reco::JetTagInfo>(folderName, etaPtBin, pSet,  mc, wf, ibook);
+    return std::make_unique<IPTagPlotter<std::vector<reco::CandidatePtr>, reco::JetTagInfo>>(folderName, etaPtBin, pSet,  mc, wf, ibook);
   } else if (dataFormatType == "TaggingVariable") {
-    return new TaggingVariablePlotter(folderName, etaPtBin, pSet,  mc, wf, ibook);
+    return std::make_unique<TaggingVariablePlotter>(folderName, etaPtBin, pSet,  mc, wf, ibook);
   } else if (dataFormatType == "GenericMVA") {
-    return new MVAJetTagPlotter(tagName, etaPtBin, pSet, folderName,  mc, wf, ibook);
+    return std::make_unique<MVAJetTagPlotter>(tagName, etaPtBin, pSet, folderName,  mc, wf, ibook);
   }
   throw cms::Exception("Configuration")
     << "BTagPerformanceAnalysis: Unknown ExtendedTagInfo " << dataFormatType << endl

--- a/DQMOffline/RecoB/src/TaggingVariablePlotter.cc
+++ b/DQMOffline/RecoB/src/TaggingVariablePlotter.cc
@@ -5,109 +5,84 @@ using namespace edm;
 using namespace reco;
 
 TaggingVariablePlotter::VariableConfig::VariableConfig(
-		const string &name, const ParameterSet &pSet,
-		const string &category, const string& label, const unsigned int& mc, DQMStore::IBooker & ibook) :
-	var(getTaggingVariableName(name)),
-	nBins(pSet.getParameter<unsigned int>("nBins")),
-	min(pSet.getParameter<double>("min")),
-	max(pSet.getParameter<double>("max"))
+        const string &name, const ParameterSet &pSet,
+        const string &category, const string& label, unsigned int mc, DQMStore::IBooker & ibook) :
+    var(getTaggingVariableName(name)),
+    nBins(pSet.getParameter<unsigned int>("nBins")),
+    min(pSet.getParameter<double>("min")),
+    max(pSet.getParameter<double>("max"))
 {
-	if (var == btau::lastTaggingVariable)
-		throw cms::Exception("Configuration")
-			<< "Tagging variable \"" << name
-			<< "\" does not exist." << endl;
+    if (var == btau::lastTaggingVariable)
+        throw cms::Exception("Configuration")
+            << "Tagging variable \"" << name
+            << "\" does not exist." << endl;
 
-	if (pSet.exists("logScale"))
-		logScale = pSet.getParameter<bool>("logScale");
-	else
-		logScale = false;
+    if (pSet.exists("logScale"))
+        logScale = pSet.getParameter<bool>("logScale");
+    else
+        logScale = false;
 
-	std::vector<unsigned int> indices;
-	if (pSet.exists("indices"))
-		indices = pSet.getParameter< vector<unsigned int> >("indices");
-	else
-		indices.push_back(0);
+    std::vector<unsigned int> indices;
+    if (pSet.exists("indices"))
+        indices = pSet.getParameter< vector<unsigned int> >("indices");
+    else
+        indices.push_back(0);
 
-	for(std::vector<unsigned int>::const_iterator iter = indices.begin();
-	    iter != indices.end(); ++iter) {
-		Plot plot;
-		plot.histo.reset(new FlavourHistograms<double>(
-							       name + (*iter ? Form("%d", *iter) : "")
-							       + (category.empty() ? "_" + label
-								  : ("_" + category) + "_" + label),
-							       TaggingVariableDescription[var], nBins, min, max,
-							       false, logScale, true, "b", label,mc,ibook));
-		plot.index = *iter;
-		plots.push_back(plot);
-	}
+    for (const unsigned int iter: indices) {
+        Plot plot;
+        plot.histo = std::make_shared<FlavourHistograms<double>>(
+                                   name + (iter ? Form("%d", iter) : "")
+                                   + (category.empty() ? "_" + label
+                                  : ("_" + category) + "_" + label),
+                                   TaggingVariableDescription[var], nBins, min, max,
+                                   false, logScale, true, "b", label,mc,ibook);
+        plot.index = iter;
+        plots.push_back(plot);
+    }
 }
 
 TaggingVariablePlotter::TaggingVariablePlotter(const std::string &tagName,
-					       const EtaPtBin &etaPtBin, const ParameterSet &pSet,
-					       const unsigned int& mc, const bool& willFinalize, DQMStore::IBooker & ibook,
-					       const string &category) : BaseTagInfoPlotter(tagName, etaPtBin), mcPlots_(mc)
+                           const EtaPtBin &etaPtBin, const ParameterSet &pSet,
+                           unsigned int mc, bool willFinalize, DQMStore::IBooker & ibook,
+                           const string &category): BaseTagInfoPlotter(tagName, etaPtBin), mcPlots_(mc)
 {
   const std::string tagVarDir(theExtensionString.substr(1));
   
-  if(willFinalize) return;
+  if (willFinalize) return;
 
   const vector<string>& pSets = pSet.getParameterNames();
-  for(vector<string>::const_iterator iter = pSets.begin();
-      iter != pSets.end(); ++iter) {
-    VariableConfig var(*iter,
-		       pSet.getParameter<ParameterSet>(*iter),
-		       category,tagVarDir, mcPlots_, ibook);
+  for (const std::string& iter: pSets) {
+    VariableConfig var(iter,
+               pSet.getParameter<ParameterSet>(iter),
+               category,tagVarDir, mcPlots_, ibook);
     variables.push_back(var);
   }
 }
 
 
-TaggingVariablePlotter::~TaggingVariablePlotter ()
-{
-}
+TaggingVariablePlotter::~TaggingVariablePlotter() {}
 
 
-void TaggingVariablePlotter::analyzeTag (const BaseTagInfo *baseTagInfo, const double & jec, 
-	const int &jetFlavour)
-{
-  analyzeTag(baseTagInfo->taggingVariables(), jetFlavour,1.);
-}
-
-void TaggingVariablePlotter::analyzeTag (const BaseTagInfo *baseTagInfo,
-					 const double & jec, 
-					 const int &jetFlavour,
-					 const float & w)
+void TaggingVariablePlotter::analyzeTag(const BaseTagInfo *baseTagInfo, double jec, int jetFlavour, float w/*=1*/)
 {
   analyzeTag(baseTagInfo->taggingVariables(), jetFlavour,w);
 }
 
-void TaggingVariablePlotter::analyzeTag (const TaggingVariableList &vars,
-	const int &jetFlavour)
+void TaggingVariablePlotter::analyzeTag(const TaggingVariableList &vars, int jetFlavour, float w/*=1*/)
 {
-  analyzeTag(vars,jetFlavour,1.);
-}
+    for (const VariableConfig& cfg: variables) {
+        const std::vector<TaggingValue> values(vars.getList(cfg.var, false));
+        if (values.empty())
+            continue;
 
-void TaggingVariablePlotter::analyzeTag (const TaggingVariableList &vars,
-					 const int &jetFlavour,
-					 const float & w)
-{
-	for(vector<VariableConfig>::const_iterator iter = variables.begin();
-	    iter != variables.end(); ++iter) {
-		const std::vector<TaggingValue> values(vars.getList(iter->var, false));
-		if (values.empty())
-			continue;
-
-		const unsigned int& size = values.size();
-		for(std::vector<VariableConfig::Plot>::const_iterator plot =
-						iter->plots.begin();
-		    plot != iter->plots.end(); plot++) {
-			if (plot->index == 0) {
-				for(std::vector<TaggingValue>::const_iterator iter = values.begin();
-                                    iter != values.end(); ++iter)
-				  plot->histo->fill(jetFlavour, *iter,w);
-			} else if (plot->index - 1 < size)
-				plot->histo->fill(jetFlavour,
-				                  values[plot->index - 1],w);
-		}
-	}
+        const unsigned int& size = values.size();
+        
+        for (const VariableConfig::Plot& plot: cfg.plots) {
+            if (plot.index == 0) {
+                for (const TaggingValue& val: values)
+                  plot.histo->fill(jetFlavour, val, w);
+            } else if (plot.index - 1 < size)
+                plot.histo->fill(jetFlavour, values[plot.index - 1], w);
+        }
+    }
 }

--- a/DQMOffline/RecoB/src/TrackCountingTagPlotter.cc
+++ b/DQMOffline/RecoB/src/TrackCountingTagPlotter.cc
@@ -5,9 +5,9 @@ using namespace std;
 using namespace RecoBTag;
 
 TrackCountingTagPlotter::TrackCountingTagPlotter(const std::string & tagName,
-						 const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
-						 const unsigned int& mc, 
-						 const bool& wf, DQMStore::IBooker & ibook) :
+                         const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet, 
+                         unsigned int mc, 
+                         bool wf, DQMStore::IBooker & ibook):
   BaseTagInfoPlotter(tagName, etaPtBin), mcPlots_(mc), 
   nBinEffPur_(pSet.getParameter<int>("nBinEffPur")),
   startEffPur_(pSet.getParameter<double>("startEffPur")),
@@ -17,155 +17,100 @@ TrackCountingTagPlotter::TrackCountingTagPlotter(const std::string & tagName,
   const std::string dir(theExtensionString.substr(1));
   if (willFinalize_) return;
 
-  trkNbr3D = new FlavourHistograms<int>
-	("selTrksNbr_3D" + theExtensionString, "Number of selected tracks for 3D IPS" + theExtensionString, 31, -0.5, 30.5,
-	false, true, true, "b",  dir, mc, ibook);
+  trkNbr3D = std::make_unique<FlavourHistograms<int>>
+    ("selTrksNbr_3D" + theExtensionString, "Number of selected tracks for 3D IPS" + theExtensionString, 31, -0.5, 30.5,
+    false, true, true, "b",  dir, mc, ibook);
 
-  trkNbr2D = new FlavourHistograms<int>
-	("selTrksNbr_2D" + theExtensionString, "Number of selected tracks for 2D IPS" + theExtensionString, 31, -0.5, 30.5,
-	false, true, true, "b",  dir, mc, ibook);
+  trkNbr2D = std::make_unique<FlavourHistograms<int>>
+    ("selTrksNbr_2D" + theExtensionString, "Number of selected tracks for 2D IPS" + theExtensionString, 31, -0.5, 30.5,
+    false, true, true, "b",  dir, mc, ibook);
 
-  tkcntHistosSig3D[4] = new FlavourHistograms<double>
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosSig3D.push_back(std::make_unique<FlavourHistograms<double>>
+         ("ips" + std::to_string(i) + "_3D" + theExtensionString, "3D Significance of impact parameter " + std::to_string(i) + ". trk",
+          50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook));
+  }
+  tkcntHistosSig3D.push_back(std::make_unique<FlavourHistograms<double>>
        ("ips_3D" + theExtensionString, "3D Significance of impact parameter",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
+        50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook));
 
-  tkcntHistosSig3D[0] = new FlavourHistograms<double>
-       ("ips1_3D" + theExtensionString, "3D Significance of impact parameter 1st trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
+  for (unsigned int i = 1; i <= 4; i++) {
+    tkcntHistosSig2D.push_back(std::make_unique<FlavourHistograms<double>>
+         ("ips" + std::to_string(i) + "_2D" + theExtensionString, "2D Significance of impact parameter " + std::to_string(i) + ". trk",
+          50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook));
+  }
 
-  tkcntHistosSig3D[1] = new FlavourHistograms<double>
-       ("ips2_3D" + theExtensionString, "3D Significance of impact parameter 2nd trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
-
-  tkcntHistosSig3D[2] = new FlavourHistograms<double>
-       ("ips3_3D" + theExtensionString, "3D Significance of impact parameter 3rd trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
-
-  tkcntHistosSig3D[3] = new FlavourHistograms<double>
-       ("ips4_3D" + theExtensionString, "3D Significance of impact parameter 4th trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
-
-  tkcntHistosSig2D[4] = new FlavourHistograms<double>
+  tkcntHistosSig2D.push_back(std::make_unique<FlavourHistograms<double>>
        ("ips_2D" + theExtensionString, "2D Significance of impact parameter",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
-
-  tkcntHistosSig2D[0] = new FlavourHistograms<double>
-       ("ips1_2D" + theExtensionString, "2D Significance of impact parameter 1st trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
-
-  tkcntHistosSig2D[1] = new FlavourHistograms<double>
-       ("ips2_2D" + theExtensionString, "2D Significance of impact parameter 2nd trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
-
-  tkcntHistosSig2D[2] = new FlavourHistograms<double>
-       ("ips3_2D" + theExtensionString, "2D Significance of impact parameter 3rd trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
-
-  tkcntHistosSig2D[3] = new FlavourHistograms<double>
-       ("ips4" + theExtensionString, "2D Significance of impact parameter 4th trk",
-	50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook) ;
+        50, lowerIPSBound, upperIPSBound, false, true, true, "b",  dir, mc, ibook));
 }
 
 
-TrackCountingTagPlotter::~TrackCountingTagPlotter ()
-{
+TrackCountingTagPlotter::~TrackCountingTagPlotter() {}
 
-  if (willFinalize_) {
-    for(int n=0; n != 4; ++n) {
-      if(n==1 || n==2){
-	delete tkcntHistosSig2D[n];
-	delete tkcntHistosSig3D[n];
-      }
-      delete effPurFromHistos[n];
-    }
-    return;
-  }
-
-  delete trkNbr3D;
-  delete trkNbr2D;
-
-  for(int n=0; n != 5; ++n) {
-    delete tkcntHistosSig2D[n];
-    delete tkcntHistosSig3D[n];
-  }
-}
-
-void TrackCountingTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, 
-	const int & jetFlavour)
-{
-  analyzeTag(baseTagInfo,jetFlavour,1.);
-}
-
-void TrackCountingTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
-					  const double & jec, 
-					  const int & jetFlavour,
-					  const float & w)
+void TrackCountingTagPlotter::analyzeTag(const reco::BaseTagInfo * baseTagInfo, double jec, int jetFlavour, float w)
 {
 
   const reco::TrackCountingTagInfo * tagInfo = 
-	dynamic_cast<const reco::TrackCountingTagInfo *>(baseTagInfo);
+    dynamic_cast<const reco::TrackCountingTagInfo *>(baseTagInfo);
 
   if (!tagInfo) {
     throw cms::Exception("Configuration")
       << "BTagPerformanceAnalyzer: Extended TagInfo not of type TrackCountingTagInfo. " << endl;
   }
 
-  trkNbr3D->fill(jetFlavour, tagInfo->selectedTracks(0),w);
-  trkNbr2D->fill(jetFlavour, tagInfo->selectedTracks(1),w);
+  trkNbr3D->fill(jetFlavour, tagInfo->selectedTracks(0), w);
+  trkNbr2D->fill(jetFlavour, tagInfo->selectedTracks(1), w);
 
-  for(int n=0; n != tagInfo->selectedTracks(1) && n != 4; ++n)
-    tkcntHistosSig2D[n]->fill(jetFlavour, tagInfo->significance(n,1),w);
-  for(int n=tagInfo->selectedTracks(1); n < 4; ++n)
-    tkcntHistosSig2D[n]->fill(jetFlavour, lowerIPSBound-1.0,w);
+  for (int n = 0; n != tagInfo->selectedTracks(1) && n != 4; ++n)
+    tkcntHistosSig2D[n]->fill(jetFlavour, tagInfo->significance(n, 1), w);
+  for (int n = tagInfo->selectedTracks(1); n < 4; ++n)
+    tkcntHistosSig2D[n]->fill(jetFlavour, lowerIPSBound - 1.0, w);
 
-  for(int n=0; n != tagInfo->selectedTracks(0) && n != 4; ++n)
-    tkcntHistosSig3D[n]->fill(jetFlavour, tagInfo->significance(n,0),w);
-  for(int n=tagInfo->selectedTracks(0); n < 4; ++n)
-    tkcntHistosSig3D[n]->fill(jetFlavour, lowerIPSBound-1.0,w);
+  for (int n = 0; n != tagInfo->selectedTracks(0) && n != 4; ++n)
+    tkcntHistosSig3D[n]->fill(jetFlavour, tagInfo->significance(n, 0), w);
+  for (int n = tagInfo->selectedTracks(0); n < 4; ++n)
+    tkcntHistosSig3D[n]->fill(jetFlavour, lowerIPSBound - 1.0, w);
 
-  for(int n=0; n != tagInfo->selectedTracks(1); ++n)
-    tkcntHistosSig2D[4]->fill(jetFlavour, tagInfo->significance(n,1),w);
-  for(int n=0; n != tagInfo->selectedTracks(0); ++n)
-    tkcntHistosSig3D[4]->fill(jetFlavour, tagInfo->significance(n,0),w);
+  for (int n = 0; n != tagInfo->selectedTracks(1); ++n)
+    tkcntHistosSig2D[4]->fill(jetFlavour, tagInfo->significance(n, 1), w);
+  for (int n = 0; n != tagInfo->selectedTracks(0); ++n)
+    tkcntHistosSig3D[4]->fill(jetFlavour, tagInfo->significance(n, 0), w);
 }
 
-void TrackCountingTagPlotter::finalize (DQMStore::IBooker & ibook, DQMStore::IGetter & igetter_)
+void TrackCountingTagPlotter::finalize(DQMStore::IBooker & ibook, DQMStore::IGetter & igetter_)
 {
   //
   // final processing:
   // produce the misid. vs. eff histograms
   //
-  const std::string dir("TrackCounting"+theExtensionString);
+  const std::string dir("TrackCounting" + theExtensionString);
 
-  tkcntHistosSig3D[1] = new FlavourHistograms<double>
-       ("ips2_3D" + theExtensionString, "3D Significance of impact parameter 2nd trk",
-	50, lowerIPSBound, upperIPSBound, "b",  dir, mcPlots_, igetter_) ;
-  effPurFromHistos[0] = new EffPurFromHistos (tkcntHistosSig3D[1],dir,mcPlots_, ibook,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
+  tkcntHistosSig3D.clear();
+  tkcntHistosSig2D.clear();
+  effPurFromHistos.clear();
+  
+  for (unsigned int i = 2; i <= 3; i++) {
+    tkcntHistosSig3D.push_back(
+            std::make_unique<FlavourHistograms<double>>
+                          ("ips" + std::to_string(i) + "_3D" + theExtensionString, "3D Significance of impact parameter " + std::to_string(i) + ". trk",
+                          50, lowerIPSBound, upperIPSBound, "b",  dir, mcPlots_, igetter_));
+    effPurFromHistos.push_back(
+            std::make_unique<EffPurFromHistos>(*tkcntHistosSig3D.back(), dir, mcPlots_, ibook,
+                            nBinEffPur_, startEffPur_, endEffPur_));
+  }
 
-  tkcntHistosSig3D[2] = new FlavourHistograms<double>
-       ("ips3_3D" + theExtensionString, "3D Significance of impact parameter 3rd trk",
-	50, lowerIPSBound, upperIPSBound, "b",  dir, mcPlots_, igetter_) ;
-  effPurFromHistos[1] = new EffPurFromHistos (tkcntHistosSig3D[2],dir,mcPlots_, ibook,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
+  for (unsigned int i = 2; i <= 3; i++) {
+    tkcntHistosSig2D.push_back(
+            std::make_unique<FlavourHistograms<double>>
+                          ("ips" + std::to_string(i) + "_2D" + theExtensionString, "2D Significance of impact parameter " + std::to_string(i) + ". trk",
+                          50, lowerIPSBound, upperIPSBound, "b",  dir, mcPlots_, igetter_));
+    effPurFromHistos.push_back(
+            std::make_unique<EffPurFromHistos>(*tkcntHistosSig2D.back(), dir, mcPlots_, ibook,
+                            nBinEffPur_, startEffPur_, endEffPur_));
+  }
 
-  tkcntHistosSig2D[1] = new FlavourHistograms<double>
-       ("ips2_2D" + theExtensionString, "2D Significance of impact parameter 2nd trk",
-	50, lowerIPSBound, upperIPSBound, "b",  dir, mcPlots_, igetter_) ;
-  effPurFromHistos[2] = new EffPurFromHistos (tkcntHistosSig2D[1],dir,mcPlots_, ibook,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
-
-  tkcntHistosSig2D[2] = new FlavourHistograms<double>
-       ("ips3_2D" + theExtensionString, "2D Significance of impact parameter 3rd trk",
-	50, lowerIPSBound, upperIPSBound, "b",  dir, mcPlots_, igetter_) ;
-  effPurFromHistos[3] = new EffPurFromHistos (tkcntHistosSig2D[2],dir,mcPlots_, ibook,
-					      nBinEffPur_, startEffPur_,
-					      endEffPur_);
-
-  for(int n=0; n != 4; ++n) effPurFromHistos[n]->compute(ibook);
+  for (int n = 0; n != 4; ++n) effPurFromHistos[n]->compute(ibook);
 }
 
 void TrackCountingTagPlotter::psPlot(const std::string & name)
@@ -175,20 +120,20 @@ void TrackCountingTagPlotter::psPlot(const std::string & name)
   TCanvas canvas(cName.c_str(), cName.c_str(), 600, 900);
   canvas.UseCurrentStyle();
   if (willFinalize_) {
-    for(int n=0; n != 2; ++n) {
+    for (int n = 0; n != 2; ++n) {
       canvas.Print((name + cName + ".ps").c_str());
       canvas.Clear();
       canvas.Divide(2,3);
       canvas.cd(1);
-      effPurFromHistos[0+n]->discriminatorNoCutEffic()->plot();
+      effPurFromHistos[0+n]->discriminatorNoCutEffic().plot();
       canvas.cd(2);
-      effPurFromHistos[0+n]->discriminatorCutEfficScan()->plot();
+      effPurFromHistos[0+n]->discriminatorCutEfficScan().plot();
       canvas.cd(3);
       effPurFromHistos[0+n]->plot();
       canvas.cd(4);
-      effPurFromHistos[1+n]->discriminatorNoCutEffic()->plot();
+      effPurFromHistos[1+n]->discriminatorNoCutEffic().plot();
       canvas.cd(5);
-      effPurFromHistos[1+n]->discriminatorCutEfficScan()->plot();
+      effPurFromHistos[1+n]->discriminatorCutEfficScan().plot();
       canvas.cd(6);
       effPurFromHistos[1+n]->plot();
     }
@@ -203,7 +148,7 @@ void TrackCountingTagPlotter::psPlot(const std::string & name)
   trkNbr3D->plot();
   canvas.cd(2);
   tkcntHistosSig3D[4]->plot();
-  for(int n=0; n < 4; n++) {
+  for (int n = 0; n < 4; n++) {
     canvas.cd(3+n);
     tkcntHistosSig3D[n]->plot();
   }
@@ -216,7 +161,7 @@ void TrackCountingTagPlotter::psPlot(const std::string & name)
   trkNbr2D->plot();
   canvas.cd(2);
   tkcntHistosSig2D[4]->plot();
-  for(int n=0; n != 4; ++n) {
+  for (int n = 0; n != 4; ++n) {
     canvas.cd(3+n);
     tkcntHistosSig2D[n]->plot();
   }
@@ -229,13 +174,14 @@ void TrackCountingTagPlotter::psPlot(const std::string & name)
 void TrackCountingTagPlotter::epsPlot(const std::string & name)
 {
   if (willFinalize_) {
-    for(int n=0; n != 4; ++n) effPurFromHistos[n]->epsPlot(name);
+    for (int n = 0; n != 4; ++n)
+        effPurFromHistos[n]->epsPlot(name);
     return;
   }
 
   trkNbr2D->epsPlot(name);
   trkNbr3D->epsPlot(name);
-  for(int n=0; n != 5; ++n) {
+  for (int n = 0; n != 5; ++n) {
     tkcntHistosSig2D[n]->epsPlot(name);
     tkcntHistosSig3D[n]->epsPlot(name);
   }

--- a/DQMOffline/RecoB/src/TrackProbabilityTagPlotter.cc
+++ b/DQMOffline/RecoB/src/TrackProbabilityTagPlotter.cc
@@ -5,8 +5,8 @@ using namespace std;
 using namespace RecoBTag;
 
 TrackProbabilityTagPlotter::TrackProbabilityTagPlotter(const std::string & tagName,
-						       const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet,
-						       const unsigned int& mc, const bool& wf, DQMStore::IBooker & ibook) :
+                               const EtaPtBin & etaPtBin, const edm::ParameterSet& pSet,
+                               const unsigned int& mc, const bool& wf, DQMStore::IBooker & ibook) :
   BaseTagInfoPlotter(tagName, etaPtBin),
   nBinEffPur_(pSet.getParameter<int>("nBinEffPur")),
   startEffPur_(pSet.getParameter<double>("startEffPur")),
@@ -14,134 +14,91 @@ TrackProbabilityTagPlotter::TrackProbabilityTagPlotter(const std::string & tagNa
   mcPlots_(mc), willFinalize_(wf)
 {
   const std::string dir(theExtensionString.substr(1));
+  
   if (willFinalize_) return;
+  
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosSig3D_.push_back(std::make_unique<FlavourHistograms<double>>
+           ("ips" + std::to_string(i) + "_3D" + theExtensionString, "3D Probability of impact parameter " + std::to_string(i) + ". trk",
+            50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook));
+  }
 
-  tkcntHistosSig3D[4] = new FlavourHistograms<double>
+  tkcntHistosSig3D_.push_back(std::make_unique<FlavourHistograms<double>>
        ("ips_3D" + theExtensionString, "3D Probability of impact parameter",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
+        50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook));
 
-  tkcntHistosSig3D[0] = new FlavourHistograms<double>
-       ("ips1_3D" + theExtensionString, "3D Probability of impact parameter 1st trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
+  
+  for (unsigned int i = 1; i <= 4; i++) {
+      tkcntHistosSig2D_.push_back(std::make_unique<FlavourHistograms<double>>
+           ("ips" + std::to_string(i) + "_2D" + theExtensionString, "2D Probability of impact parameter " + std::to_string(i) + ". trk",
+            50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook));
+  }
 
-  tkcntHistosSig3D[1] = new FlavourHistograms<double>
-       ("ips2_3D" + theExtensionString, "3D Probability of impact parameter 2nd trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
-
-  tkcntHistosSig3D[2] = new FlavourHistograms<double>
-       ("ips3_3D" + theExtensionString, "3D Probability of impact parameter 3rd trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
-
-  tkcntHistosSig3D[3] = new FlavourHistograms<double>
-       ("ips4_3D" + theExtensionString, "3D Probability of impact parameter 4th trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
-
-  tkcntHistosSig2D[4] = new FlavourHistograms<double>
+  tkcntHistosSig2D_.push_back(std::make_unique<FlavourHistograms<double>>
        ("ips_2D" + theExtensionString, "2D Probability of impact parameter",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
-
-  tkcntHistosSig2D[0] = new FlavourHistograms<double>
-       ("ips1_2D" + theExtensionString, "2D Probability of impact parameter 1st trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
-
-  tkcntHistosSig2D[1] = new FlavourHistograms<double>
-       ("ips2_2D" + theExtensionString, "2D Probability of impact parameter 2nd trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
-
-  tkcntHistosSig2D[2] = new FlavourHistograms<double>
-       ("ips3_2D" + theExtensionString, "2D Probability of impact parameter 3rd trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
-
-  tkcntHistosSig2D[3] = new FlavourHistograms<double>
-       ("ips4" + theExtensionString, "2D Probability of impact parameter 4th trk",
-	50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook) ;
+        50, -1.0, 1.0, false, true, true, "b", dir, mc, ibook));
 }
 
 
-TrackProbabilityTagPlotter::~TrackProbabilityTagPlotter ()
-{
+TrackProbabilityTagPlotter::~TrackProbabilityTagPlotter() { }
 
-  if (willFinalize_) {
-    for(int n=1; n != 3; ++n) {
-      delete tkcntHistosSig3D[n];
-      delete effPurFromHistos[n-1];
-    }
-    for(int n=1; n != 3; ++n) {
-      delete tkcntHistosSig2D[n];
-      delete effPurFromHistos[n+1];
-    }
-    return;
-  }
-  for(int n=0; n != 5; ++n) {
-    delete tkcntHistosSig2D[n];
-    delete tkcntHistosSig3D[n];
-  }
-}
-
-
-void TrackProbabilityTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo,
-					     const double & jec, 
-					     const int & jetFlavour,
-					     const float & w)
+void TrackProbabilityTagPlotter::analyzeTag(const reco::BaseTagInfo * baseTagInfo,
+                         double jec, 
+                         int jetFlavour,
+                         float w/*=1*/)
 {
   const reco::TrackProbabilityTagInfo * tagInfo = 
-	dynamic_cast<const reco::TrackProbabilityTagInfo *>(baseTagInfo);
+    dynamic_cast<const reco::TrackProbabilityTagInfo *>(baseTagInfo);
 
   if (!tagInfo) {
     throw cms::Exception("Configuration")
       << "BTagPerformanceAnalyzer: Extended TagInfo not of type TrackProbabilityTagInfo. " << endl;
   }
 
-  for(int n=0; n != tagInfo->selectedTracks(1) && n != 4; ++n)
-    tkcntHistosSig2D[n]->fill(jetFlavour, tagInfo->probability(n,1),w);
-  for(int n=0; n != tagInfo->selectedTracks(0) && n != 4; ++n)
-    tkcntHistosSig3D[n]->fill(jetFlavour, tagInfo->probability(n,0),w);
+  for (int n = 0; n != tagInfo->selectedTracks(1) && n != 4; ++n)
+    tkcntHistosSig2D_[n]->fill(jetFlavour, tagInfo->probability(n, 1), w);
+  for (int n = 0; n != tagInfo->selectedTracks(0) && n != 4; ++n)
+    tkcntHistosSig3D_[n]->fill(jetFlavour, tagInfo->probability(n, 0), w);
 
-  for(int n=0; n != tagInfo->selectedTracks(1); ++n)
-    tkcntHistosSig2D[4]->fill(jetFlavour, tagInfo->probability(n,1),w);
-  for(int n=0; n != tagInfo->selectedTracks(0); ++n)
-    tkcntHistosSig3D[4]->fill(jetFlavour, tagInfo->probability(n,0),w);
+  for (int n = 0; n != tagInfo->selectedTracks(1); ++n)
+    tkcntHistosSig2D_[4]->fill(jetFlavour, tagInfo->probability(n, 1), w);
+  for (int n = 0; n != tagInfo->selectedTracks(0); ++n)
+    tkcntHistosSig3D_[4]->fill(jetFlavour, tagInfo->probability(n, 0), w);
 }
 
-void TrackProbabilityTagPlotter::analyzeTag (const reco::BaseTagInfo * baseTagInfo, const double & jec, 
-					     const int & jetFlavour)
-{
-  analyzeTag(baseTagInfo,jetFlavour,1.);
-}
-
-void TrackProbabilityTagPlotter::finalize (DQMStore::IBooker & ibook, DQMStore::IGetter & igetter_)
+void TrackProbabilityTagPlotter::finalize(DQMStore::IBooker & ibook, DQMStore::IGetter & igetter_)
 {
   //
   // final processing:
   // produce the misid. vs. eff histograms
   //
-  const std::string dir("TrackProbability"+theExtensionString);
+  const std::string dir("TrackProbability" + theExtensionString);
 
-  tkcntHistosSig3D[1] = new FlavourHistograms<double>
-       ("ips2_3D" + theExtensionString, "3D Probability of impact parameter 2nd trk",
-	50, -1.0, 1.0, "b", dir, mcPlots_, igetter_) ;
-  effPurFromHistos[0] = new EffPurFromHistos (tkcntHistosSig3D[1],dir,mcPlots_, ibook, 
-					      nBinEffPur_, startEffPur_, endEffPur_);
+  tkcntHistosSig3D_.clear();
+  tkcntHistosSig2D_.clear();
+  effPurFromHistos_.clear();
+  
+  for (unsigned int i = 2; i <= 3; i++) {
+    tkcntHistosSig3D_.push_back(
+            std::make_unique<FlavourHistograms<double>>
+                    ("ips" + std::to_string(i) + "_3D" + theExtensionString, "3D Probability of impact parameter " + std::to_string(i) + ". trk",
+                    50, -1.0, 1.0, "b", dir, mcPlots_, igetter_));
+    effPurFromHistos_.push_back(
+            std::make_unique<EffPurFromHistos>(*tkcntHistosSig3D_.back(), dir, mcPlots_, ibook, 
+                nBinEffPur_, startEffPur_, endEffPur_));
+  }
 
-  tkcntHistosSig3D[2] = new FlavourHistograms<double>
-       ("ips3_3D" + theExtensionString, "3D Probability of impact parameter 3rd trk",
-	50, -1.0, 1.0, "b", dir, mcPlots_, igetter_) ;
-  effPurFromHistos[1] = new EffPurFromHistos (tkcntHistosSig3D[2],dir,mcPlots_, ibook, 
-					      nBinEffPur_, startEffPur_, endEffPur_);
+  for (unsigned int i = 2; i <= 3; i++) {
+    tkcntHistosSig2D_.push_back(
+            std::make_unique<FlavourHistograms<double>>
+                    ("ips" + std::to_string(i) + "_2D" + theExtensionString, "2D Probability of impact parameter " + std::to_string(i) + ". trk",
+                    50, -1.0, 1.0, "b", dir, mcPlots_, igetter_));
+    effPurFromHistos_.push_back(
+            std::make_unique<EffPurFromHistos>(*tkcntHistosSig2D_.back(), dir, mcPlots_, ibook, 
+                nBinEffPur_, startEffPur_, endEffPur_));
+  }
 
-  tkcntHistosSig2D[1] = new FlavourHistograms<double>
-       ("ips2_2D" + theExtensionString, "2D Probability of impact parameter 2nd trk",
-	50, -1.0, 1.0, "b", dir, mcPlots_, igetter_) ;
-  effPurFromHistos[2] = new EffPurFromHistos (tkcntHistosSig2D[1],dir,mcPlots_, ibook, 
-					      nBinEffPur_, startEffPur_, endEffPur_);
-
-  tkcntHistosSig2D[2] = new FlavourHistograms<double>
-       ("ips3_2D" + theExtensionString, "2D Probability of impact parameter 3rd trk",
-	50, -1.0, 1.0, "b", dir, mcPlots_, igetter_) ;
-  effPurFromHistos[3] = new EffPurFromHistos (tkcntHistosSig2D[2],dir,mcPlots_, ibook, 
-					      nBinEffPur_, startEffPur_, endEffPur_);
-
-  for(int n=0; n != 4; ++n) effPurFromHistos[n]->compute(ibook);
+  for (int n = 0; n != 4; ++n) effPurFromHistos_[n]->compute(ibook);
 }
 
 void TrackProbabilityTagPlotter::psPlot(const std::string & name)
@@ -151,22 +108,22 @@ void TrackProbabilityTagPlotter::psPlot(const std::string & name)
   TCanvas canvas(cName.c_str(), cName.c_str(), 600, 900);
   canvas.UseCurrentStyle();
   if (willFinalize_) {
-    for(int n=0; n != 2; ++n) {
+    for (int n=0; n != 2; ++n) {
       canvas.Print((name + cName + ".ps").c_str());
       canvas.Clear();
       canvas.Divide(2,3);
       canvas.cd(1);
-      effPurFromHistos[0+n]->discriminatorNoCutEffic()->plot();
+      effPurFromHistos_[0+n]->discriminatorNoCutEffic().plot();
       canvas.cd(2);
-      effPurFromHistos[0+n]->discriminatorCutEfficScan()->plot();
+      effPurFromHistos_[0+n]->discriminatorCutEfficScan().plot();
       canvas.cd(3);
-      effPurFromHistos[0+n]->plot();
+      effPurFromHistos_[0+n]->plot();
       canvas.cd(4);
-      effPurFromHistos[1+n]->discriminatorNoCutEffic()->plot();
+      effPurFromHistos_[1+n]->discriminatorNoCutEffic().plot();
       canvas.cd(5);
-      effPurFromHistos[1+n]->discriminatorCutEfficScan()->plot();
+      effPurFromHistos_[1+n]->discriminatorCutEfficScan().plot();
       canvas.cd(6);
-      effPurFromHistos[1+n]->plot();
+      effPurFromHistos_[1+n]->plot();
     }
     return;
   }
@@ -176,10 +133,10 @@ void TrackProbabilityTagPlotter::psPlot(const std::string & name)
   canvas.Print((name + cName + ".ps[").c_str());
   canvas.cd(1);
 
-  tkcntHistosSig3D[4]->plot();
-  for(int n=0; n != 4; ++n) {
+  tkcntHistosSig3D_[4]->plot();
+  for (int n = 0; n != 4; ++n) {
     canvas.cd(2+n);
-    tkcntHistosSig3D[n]->plot();
+    tkcntHistosSig3D_[n]->plot();
   }
 
   canvas.Print((name + cName + ".ps").c_str());
@@ -187,10 +144,10 @@ void TrackProbabilityTagPlotter::psPlot(const std::string & name)
   canvas.Divide(2,3);
 
   canvas.cd(1);
-  tkcntHistosSig2D[4]->plot();
-  for(int n=0; n != 4; ++n) {
+  tkcntHistosSig2D_[4]->plot();
+  for (int n = 0; n != 4; ++n) {
     canvas.cd(2+n);
-    tkcntHistosSig2D[n]->plot();
+    tkcntHistosSig2D_[n]->plot();
   }
 
   canvas.Print((name + cName + ".ps").c_str());
@@ -201,11 +158,11 @@ void TrackProbabilityTagPlotter::psPlot(const std::string & name)
 void TrackProbabilityTagPlotter::epsPlot(const std::string & name)
 {
   if (willFinalize_) {
-    for(int n=0; n != 4; ++n) effPurFromHistos[n]->epsPlot(name);
+    for (int n = 0; n != 4; ++n) effPurFromHistos_[n]->epsPlot(name);
     return;
   }
-  for(int n=0; n != 5; ++n) {
-    tkcntHistosSig2D[n]->epsPlot(name);
-    tkcntHistosSig3D[n]->epsPlot(name);
+  for (int n = 0; n != 5; ++n) {
+    tkcntHistosSig2D_[n]->epsPlot(name);
+    tkcntHistosSig3D_[n]->epsPlot(name);
   }
 }

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -48,6 +48,11 @@ BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pS
     case 15: tauPlots = true; electronPlots = false; tauPlots = false; break;
     default: electronPlots = false; muonPlots = false; tauPlots = false;
   }
+
+  if (etaRanges.size() == 0)
+      etaRanges = { pSet.getParameter<double>("etaMin"), pSet.getParameter<double>("etaMax") };
+  if (ptRanges.size() == 0)
+      ptRanges = { pSet.getParameter<double>("ptRecJetMin"), pSet.getParameter<double>("ptRecJetMax") };
   
   genToken = mayConsume<GenEventInfoProduct>(edm::InputTag("generator"));
   genJetsMatchedToken = mayConsume<edm::Association<reco::GenJetCollection>>(pSet.getParameter<InputTag>("genJetsMatched"));
@@ -81,16 +86,16 @@ BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pS
       binTagInfoPlotters.push_back(vector<BaseTagInfoPlotter*>()) ;
       std::vector< edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> > tokens; 
       if(dataFormatType == "GenericMVA") {
-	const std::vector<InputTag> listInfo = iModule->getParameter<vector<InputTag>>("listTagInfos"); 
+        const std::vector<InputTag> listInfo = iModule->getParameter<vector<InputTag>>("listTagInfos"); 
         for(unsigned int ITi=0; ITi<listInfo.size(); ITi++){ 
           tokens.push_back(consumes< View<BaseTagInfo> >(listInfo[ITi]));
-	  vIP.push_back(listInfo[ITi]);
-	}
+          vIP.push_back(listInfo[ITi]);
+        }
       }
       else {
-	const InputTag& moduleLabel = iModule->getParameter<InputTag>("label");
-	tokens.push_back(consumes< View<BaseTagInfo> >(moduleLabel));
-	vIP.push_back(moduleLabel);
+        const InputTag& moduleLabel = iModule->getParameter<InputTag>("label");
+        tokens.push_back(consumes< View<BaseTagInfo> >(moduleLabel));
+        vIP.push_back(moduleLabel);
       }
       tagInfoToken.push_back(tokens);
       tagInfoInputTags.push_back(vIP);
@@ -125,17 +130,22 @@ void BTagPerformanceAnalyzerMC::bookHistograms(DQMStore::IBooker & ibook, edm::R
 
       // eta loop
       for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
-	// pt loop
-	for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
+        // pt loop
+        for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
 
-	  const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
+          const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
 
-	  // Instantiate the genertic b tag plotter
-	  JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin,
-							   iModule->getParameter<edm::ParameterSet>("parameters"),mcPlots_,false, ibook);
-	  binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
+          // Instantiate the genertic b tag plotter
+          bool doDifferentialPlots = false;
+          double discrCut = -999.;
+          if (iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true) {
+              doDifferentialPlots = true;
+              discrCut = iModule->getParameter<double>("discrCut");
+          }
+          JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), mcPlots_, false, ibook, false, doDifferentialPlots, discrCut);
+          binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
 
-	}
+        }
       }
     } else if(dataFormatType == "TagCorrelation") {
         iTagCorr++;
@@ -161,18 +171,18 @@ void BTagPerformanceAnalyzerMC::bookHistograms(DQMStore::IBooker & ibook, edm::R
       const string& folderName    = iModule->getParameter<string>("folder");
       // eta loop
       for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
-	// pt loop
-	for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
-	  const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
+        // pt loop
+        for ( int iPt = iPtStart ; iPt < iPtEnd ; iPt++ ) {
+          const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
 
-	  // Instantiate the tagInfo plotter
+          // Instantiate the tagInfo plotter
 
-	  BaseTagInfoPlotter *jetTagPlotter = theFactory.buildPlotter(dataFormatType, moduleLabel.label(), 
-								      etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), folderName, 
-								       mcPlots_,false, ibook);
-	  binTagInfoPlotters.at(iInfoTag).push_back ( jetTagPlotter ) ;
-          binTagInfoPlottersToModuleConfig.insert(make_pair(jetTagPlotter, iModule - moduleConfig.begin()));
-	}
+          BaseTagInfoPlotter *jetTagPlotter = theFactory.buildPlotter(dataFormatType, moduleLabel.label(), 
+                                          etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), folderName, 
+                                           mcPlots_,false, ibook);
+          binTagInfoPlotters.at(iInfoTag).push_back ( jetTagPlotter ) ;
+              binTagInfoPlottersToModuleConfig.insert(make_pair(jetTagPlotter, iModule - moduleConfig.begin()));
+        }
       }
     }
   }
@@ -186,27 +196,26 @@ EtaPtBin BTagPerformanceAnalyzerMC::getEtaPtBin(const int& iEta, const int& iPt)
 
   if ( iEta != -1 ) {
     etaActive_ = true ;
-    etaMin_    = etaRanges[iEta]   ;
-    etaMax_    = etaRanges[iEta+1] ;
+    etaMin_    = etaRanges[iEta];
+    etaMax_    = etaRanges[iEta+1];
   }
   else {
-    etaActive_ = false ;
-    etaMin_    = etaRanges[0]   ;
-    etaMax_    = etaRanges[etaRanges.size() - 1]   ;
+    etaActive_ = false;
+    etaMin_    = etaRanges[0];
+    etaMax_    = etaRanges[etaRanges.size() - 1];
   }
 
   if ( iPt != -1 ) {
-    ptActive_ = true ;
-    ptMin_    = ptRanges[iPt]   ;
-    ptMax_    = ptRanges[iPt+1] ;
+    ptActive_ = true;
+    ptMin_    = ptRanges[iPt];
+    ptMax_    = ptRanges[iPt+1];
   }
   else {
-    ptActive_ = false ;
-    ptMin_    = ptRanges[0]	;
-    ptMax_    = ptRanges[ptRanges.size() - 1]	;
+    ptActive_ = false;
+    ptMin_    = ptRanges[0];
+    ptMax_    = ptRanges[ptRanges.size() - 1];
   }
-  return EtaPtBin(etaActive_ , etaMin_ , etaMax_ ,
-			ptActive_  , ptMin_  , ptMax_ );
+  return EtaPtBin(etaActive_, etaMin_, etaMax_, ptActive_, ptMin_, ptMax_);
 }
 
 BTagPerformanceAnalyzerMC::~BTagPerformanceAnalyzerMC()
@@ -256,16 +265,15 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
   if(!useOldFlavourTool) {
     edm::Handle<JetFlavourInfoMatchingCollection> jetMC;
     iEvent.getByToken(jetToken, jetMC); 
-    for (JetFlavourInfoMatchingCollection::const_iterator iter = jetMC->begin(); 
-	 iter != jetMC->end(); ++iter) {
+    for (JetFlavourInfoMatchingCollection::const_iterator iter = jetMC->begin(); iter != jetMC->end(); ++iter) {
       unsigned int fl = std::abs(iter->second.getPartonFlavour());
       flavours.insert(std::make_pair(iter->first, fl));
       const GenParticleRefVector &lep = iter->second.getLeptons();
       reco::JetFlavour::Leptons lepCount;
       for (unsigned int i=0; i<lep.size(); i++){
-	if(abs(lep[i]->pdgId())==11) lepCount.electron++;
-	else if(abs(lep[i]->pdgId())==13) lepCount.muon++;
-	else if(abs(lep[i]->pdgId())==15) lepCount.tau++;
+        if(abs(lep[i]->pdgId())==11) lepCount.electron++;
+        else if(abs(lep[i]->pdgId())==13) lepCount.muon++;
+        else if(abs(lep[i]->pdgId())==15) lepCount.tau++;
       }
       leptons.insert(std::make_pair(iter->first, lepCount));
     }
@@ -273,8 +281,7 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
   else {
     edm::Handle<JetFlavourMatchingCollection> jetMC;
     iEvent.getByToken(caloJetToken, jetMC); 
-    for (JetFlavourMatchingCollection::const_iterator iter = jetMC->begin(); 
-	 iter != jetMC->end(); ++iter) {
+    for (JetFlavourMatchingCollection::const_iterator iter = jetMC->begin(); iter != jetMC->end(); ++iter) {
       unsigned int fl = std::abs(iter->second.getFlavour());
       flavours.insert(std::make_pair(iter->first, fl));
       const reco::JetFlavour::Leptons &lep = iter->second.getLeptons();
@@ -311,7 +318,7 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
 
     int plotterSize =  binJetTagPlotters[iJetLabel].size();
     for (JetTagCollection::const_iterator tagI = tagColl.begin();
-	 tagI != tagColl.end(); ++tagI) {
+      tagI != tagColl.end(); ++tagI) {
       // Identify parton associated to jet.
 
       /// needed for lepton specific plots
@@ -334,11 +341,11 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
         continue;
 
       for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
-	      bool inBin = false;
-	      inBin = binJetTagPlotters[iJetLabel][iPlotter]->etaPtBin().inBin(jetWithFlavour.first, jec);
-	      // Fill histograms if in desired pt/rapidity bin.
-	      if (inBin)
-	        binJetTagPlotters[iJetLabel][iPlotter]->analyzeTag(jetWithFlavour.first, jec, tagI->second, std::abs(jetWithFlavour.second.getPartonFlavour()),weight);
+          bool inBin = false;
+          inBin = binJetTagPlotters[iJetLabel][iPlotter]->etaPtBin().inBin(jetWithFlavour.first, jec);
+          // Fill histograms if in desired pt/rapidity bin.
+          if (inBin)
+            binJetTagPlotters[iJetLabel][iPlotter]->analyzeTag(jetWithFlavour.first, jec, tagI->second, std::abs(jetWithFlavour.second.getPartonFlavour()),weight);
       }
     }
     for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
@@ -381,10 +388,9 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
 
       for(int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
         bool inBin = false;
-	inBin = binTagCorrelationPlotters[iJetLabel][iPlotter]->etaPtBin().inBin(jetWithFlavour.first, jec);
+        inBin = binTagCorrelationPlotters[iJetLabel][iPlotter]->etaPtBin().inBin(jetWithFlavour.first, jec);
 
-        if(inBin)
-        {
+        if(inBin) {
           double discr2 = tagColl2[tagI->first];
           binTagCorrelationPlotters[iJetLabel][iPlotter]->analyzeTags(tagI->second, discr2, std::abs(jetWithFlavour.second.getPartonFlavour()),weight);
         }
@@ -414,9 +420,9 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
     for (unsigned int iInputTags = 0; iInputTags < tokens.size(); ++iInputTags) {
       edm::Handle< View<BaseTagInfo> > & tagInfoHandle = tagInfoHandles[iInputTags];
       iEvent.getByToken(tokens[iInputTags], tagInfoHandle); 
-       if (tagInfoHandle.isValid() == false){
-	edm::LogWarning("BTagPerformanceAnalyzerMC")<<" Collection "<<tagInfoInputTags[iJetLabel][iInputTags]<<" not present. Skipping it for this event.";
-	continue;
+      if (tagInfoHandle.isValid() == false){
+        edm::LogWarning("BTagPerformanceAnalyzerMC")<<" Collection "<<tagInfoInputTags[iJetLabel][iInputTags]<<" not present. Skipping it for this event.";
+        continue;
       }
 
       unsigned int size = tagInfoHandle->size();
@@ -466,11 +472,11 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
         continue;
 
       for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter) {
-	      bool inBin = false;
-	      inBin = binTagInfoPlotters[iJetLabel][iPlotter]->etaPtBin().inBin(*jetRef, jec);
-	      // Fill histograms if in desired pt/rapidity bin.
-	      if (inBin)
-	        binTagInfoPlotters[iJetLabel][iPlotter]->analyzeTag(baseTagInfos, jec, std::abs(jetWithFlavour.second.getPartonFlavour()),weight);
+          bool inBin = false;
+          inBin = binTagInfoPlotters[iJetLabel][iPlotter]->etaPtBin().inBin(*jetRef, jec);
+          // Fill histograms if in desired pt/rapidity bin.
+          if (inBin)
+            binTagInfoPlotters[iJetLabel][iPlotter]->analyzeTag(baseTagInfos, jec, std::abs(jetWithFlavour.second.getPartonFlavour()),weight);
       }
     }
   }
@@ -485,9 +491,9 @@ bool BTagPerformanceAnalyzerMC::getJetWithGenJet(edm::RefToBase<Jet> jetRef, edm
 }
 
 bool  BTagPerformanceAnalyzerMC::getJetWithFlavour(const edm::Event& iEvent,
-						   edm::RefToBase<Jet> jetRef, const FlavourMap& flavours,
-						   JetWithFlavour & jetWithFlavour, const JetCorrector * corrector, 
-						   edm::Handle<edm::Association<reco::GenJetCollection> > genJetsMatched)
+                           edm::RefToBase<Jet> jetRef, const FlavourMap& flavours,
+                           JetWithFlavour & jetWithFlavour, const JetCorrector * corrector, 
+                           edm::Handle<edm::Association<reco::GenJetCollection> > genJetsMatched)
 {
   edm::ProductID recProdId = jetRef.id();
   edm::ProductID refProdId = (flavours.begin() == flavours.end())

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -128,6 +128,13 @@ void BTagPerformanceAnalyzerMC::bookHistograms(DQMStore::IBooker & ibook, edm::R
       iTag++;
       const string& folderName    = iModule->getParameter<string>("folder");
 
+      bool doDifferentialPlots = false;
+      double discrCut = -999.;
+      if (iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true) {
+          doDifferentialPlots = true;
+          discrCut = iModule->getParameter<double>("discrCut");
+      }
+      
       // eta loop
       for ( int iEta = iEtaStart ; iEta < iEtaEnd ; iEta++ ) {
         // pt loop
@@ -136,12 +143,6 @@ void BTagPerformanceAnalyzerMC::bookHistograms(DQMStore::IBooker & ibook, edm::R
           const EtaPtBin& etaPtBin = getEtaPtBin(iEta, iPt);
 
           // Instantiate the genertic b tag plotter
-          bool doDifferentialPlots = false;
-          double discrCut = -999.;
-          if (iModule->exists("differentialPlots") && iModule->getParameter<bool>("differentialPlots") == true) {
-              doDifferentialPlots = true;
-              discrCut = iModule->getParameter<double>("discrCut");
-          }
           JetTagPlotter *jetTagPlotter = new JetTagPlotter(folderName, etaPtBin, iModule->getParameter<edm::ParameterSet>("parameters"), mcPlots_, false, ibook, false, doDifferentialPlots, discrCut);
           binJetTagPlotters.at(iTag).push_back ( jetTagPlotter ) ;
 

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -69,15 +69,14 @@ class BTagPerformanceAnalyzerMC : public DQMEDAnalyzer {
   edm::InputTag slInfoTag;
   edm::InputTag genJetsMatchedSrc;
 
-  std::vector< std::vector<JetTagPlotter*> > binJetTagPlotters;
-  std::vector< std::vector<TagCorrelationPlotter*> > binTagCorrelationPlotters;
-  std::vector< std::vector<BaseTagInfoPlotter*> > binTagInfoPlotters;
+  std::vector< std::vector<std::unique_ptr<JetTagPlotter>> > binJetTagPlotters;
+  std::vector< std::vector<std::unique_ptr<TagCorrelationPlotter>> > binTagCorrelationPlotters;
+  std::vector< std::vector<std::unique_ptr<BaseTagInfoPlotter>> > binTagInfoPlotters;
   std::vector<edm::InputTag> jetTagInputTags;
   std::vector< std::pair<edm::InputTag, edm::InputTag> > tagCorrelationInputTags;
   std::vector< std::vector<edm::InputTag> > tagInfoInputTags;
   //  JetFlavourIdentifier jfi;
   std::vector<edm::ParameterSet> moduleConfig;
-  std::map<BaseTagInfoPlotter*, size_t> binTagInfoPlottersToModuleConfig;
 
   std::string flavPlots_;
   unsigned int mcPlots_;


### PR DESCRIPTION
This PR adds a few monitored quantities to the b-tagging offline DQM and validation: differential efficiencies versus jet Eta and Phi, for a cut on the CSVv2, cMVAv2, CvsL and CvsB discriminators corresponding to the present Loose working points.

This is similar to #18413, where those quantities were added to the HLT DQM. 

I've removed some tabs and fixed the indentation where I encountered eye-piercing inconsistencies, hence the large diff when the actual changes are small.