### PR TITLE
Stop compiler warning for CaloCluster's operator<<

### DIFF
--- a/DataFormats/CaloRecHit/interface/CaloCluster.h
+++ b/DataFormats/CaloRecHit/interface/CaloCluster.h
@@ -25,6 +25,9 @@
 
 namespace reco {
 
+  class CaloCluster;
+  std::ostream& operator<<(std::ostream& out, 
+                           const CaloCluster& cluster);
 
   class CaloCluster {
   public:


### PR DESCRIPTION
gcc6 warned that operator<< for CaloCluster was not in the reco
namespace.