### PR TITLE
Fix input source and enable 'inputFiles' option

### DIFF
--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -6,6 +6,7 @@ from dqmPythonTypes import *
 
 options = VarParsing.VarParsing('analysis')
 
+# options.inputFiles are inherited from 'analysis'
 options.register('runNumber',
                  111,
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -50,33 +51,34 @@ if not options.runkey.strip():
 
 runType.setRunType(options.runkey.strip())
 
-# Input source
-nextLumiTimeoutMillis = 90000
-endOfRunKills = True
-
-if options.scanOnce:
-    endOfRunKills = False
-    nextLumiTimeoutMillis = 0
-
-#source = cms.Source("DQMStreamerReader",
-#    runNumber = cms.untracked.uint32(options.runNumber),
-#    runInputDir = cms.untracked.string(options.runInputDir),
-#    SelectEvents = cms.untracked.vstring('*'),
-#    streamLabel = cms.untracked.string('streamDQM'),
-#    scanOnce = cms.untracked.bool(options.scanOnce),
-#    minEventsPerLumi = cms.untracked.int32(1),
-#    delayMillis = cms.untracked.uint32(500),
-#    nextLumiTimeoutMillis = cms.untracked.int32(nextLumiTimeoutMillis),
-#    skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
-#    deleteDatFiles = cms.untracked.bool(False),
-#    endOfRunKills  = cms.untracked.bool(endOfRunKills),
-#)
-
-source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-       '/store/user/tosi/STEAM/DQM/online/outputDQM_3.root'
-    ),
-    secondaryFileNames = cms.untracked.vstring()
-)
+if not options.inputFiles:
+    # Input source
+    nextLumiTimeoutMillis = 90000
+    endOfRunKills = True
+    
+    if options.scanOnce:
+        endOfRunKills = False
+        nextLumiTimeoutMillis = 0
+    
+    source = cms.Source("DQMStreamerReader",
+        runNumber = cms.untracked.uint32(options.runNumber),
+        runInputDir = cms.untracked.string(options.runInputDir),
+        SelectEvents = cms.untracked.vstring('*'),
+        streamLabel = cms.untracked.string('streamDQM'),
+        scanOnce = cms.untracked.bool(options.scanOnce),
+        minEventsPerLumi = cms.untracked.int32(1),
+        delayMillis = cms.untracked.uint32(500),
+        nextLumiTimeoutMillis = cms.untracked.int32(nextLumiTimeoutMillis),
+        skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
+        deleteDatFiles = cms.untracked.bool(False),
+        endOfRunKills  = cms.untracked.bool(endOfRunKills),
+    )
+else:
+    print "The list of input files is provided. Disabling discovery and running on everything."
+    files = map(lambda x: "file://" + x, options.inputFiles)
+    source = cms.Source("PoolSource",
+        fileNames = cms.untracked.vstring(files),
+        secondaryFileNames = cms.untracked.vstring()
+    )
 
 print "Source:", source


### PR DESCRIPTION
This PR fixes the error introduced by https://github.com/cms-sw/cmssw/pull/18264

And adds an option so users no longer need to hack this file, but rather and simply provide `inputFiles` option.

For example, `cmsRun <my_online_dqm_client> inputFiles="a.root,b.root"`