### PR TITLE
Digi collection getByToken call moved

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -91,34 +91,56 @@ private:
   MonitorElement * bookMETrend(DQMStore::IBooker & , const char*);
   // internal evaluation of monitorables
   void AllClusters(const edm::Event& ev, const edm::EventSetup& es);
-  void trackStudyFromTrack(edm::Handle<reco::TrackCollection > trackCollectionHandle, const edm::Event&ev, const edm::EventSetup& es);
-  void trackStudyFromTrajectory(edm::Handle<reco::TrackCollection > trackCollectionHandle, const edm::Event& ev, const edm::EventSetup& es);
-  void trajectoryStudy(const reco::Track& track, const edm::Event& ev, const edm::EventSetup& es, bool track_ok);
+
+  void trackStudyFromTrack(
+    edm::Handle<reco::TrackCollection >   trackCollectionHandle,
+    const edm::DetSetVector<SiStripDigi>& digilist,
+    const edm::Event&                     ev, 
+    const edm::EventSetup&                es);
+  void trackStudyFromTrajectory(
+    edm::Handle<reco::TrackCollection >   trackCollectionHandle, 
+    const edm::DetSetVector<SiStripDigi>& digilist,
+    const edm::Event&                     ev, 
+    const edm::EventSetup&                es);
+  void trajectoryStudy(
+    const reco::Track&                    track, 
+    const edm::DetSetVector<SiStripDigi>& digilist,
+    const edm::Event&                     ev, 
+    const edm::EventSetup&                es, 
+    bool                                  track_ok);
   void trackStudy(const edm::Event& ev, const edm::EventSetup& es);
   bool trackFilter(const reco::Track& track);
   //  LocalPoint project(const GeomDet *det,const GeomDet* projdet,LocalPoint position,LocalVector trackdirection)const;
   void hitStudy(
-    const edm::Event&      ev,
-    const edm::EventSetup& es,
-		const ProjectedSiStripRecHit2D* projhit,
-		const SiStripMatchedRecHit2D*   matchedhit,
-		const SiStripRecHit2D*          hit2D,
-		const SiStripRecHit1D*          hit1D,
-		      LocalVector               localMomentum,
-		const bool                      track_ok);
+    const edm::Event&                      ev,
+    const edm::EventSetup&                 es,
+    const edm::DetSetVector<SiStripDigi>&  digilist,
+	  const ProjectedSiStripRecHit2D*        projhit,
+	  const SiStripMatchedRecHit2D*          matchedhit,
+	  const SiStripRecHit2D*                 hit2D,
+	  const SiStripRecHit1D*                 hit1D,
+	 	      LocalVector                      localMomentum,
+	  const bool                             track_ok);
   bool clusterInfos(
     SiStripClusterInfo* cluster,
-    const uint32_t detid,
-    enum ClusterFlags flags,
-    bool track_ok,
-    LocalVector LV,
-    const Det2MEs& MEs ,
-    const TrackerTopology* tTopo,
-    const SiStripGain*     stripGain,
-    const SiStripQuality*  stripQuality,
+    const uint32_t                        detid,
+    enum ClusterFlags                     flags,
+    bool                                  track_ok,
+    LocalVector                           LV,
+    const Det2MEs&                        MEs ,
+    const TrackerTopology*                tTopo,
+    const SiStripGain*                    stripGain,
+    const SiStripQuality*                 stripQuality,
     const edm::DetSetVector<SiStripDigi>& digilist
   );
-  template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::Event&, const edm::EventSetup&, bool ok);
+  template <class T> void RecHitInfo(
+    const T*                              tkrecHit, 
+          LocalVector                     LV, 
+    const edm::DetSetVector<SiStripDigi>& digilist,
+    const edm::Event&                     ev, 
+    const edm::EventSetup&                es,
+    bool ok
+  );
 
   // fill monitorables
 //  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, const uint32_t detid, const LocalVector LV);

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -691,10 +691,11 @@ MonitorElement* SiStripMonitorTrack::bookMETrend(DQMStore::IBooker & ibooker , c
 
 //------------------------------------------------------------------------------------------
 void SiStripMonitorTrack::trajectoryStudy(
-  const reco::Track & track,
-  const edm::Event&      ev,
-  const edm::EventSetup& es,
-  bool track_ok
+  const reco::Track &                   track,
+  const edm::DetSetVector<SiStripDigi>& digilist,
+  const edm::Event&                     ev,
+  const edm::EventSetup&                es,
+  bool                                  track_ok
 ) {
 
   auto const & trajParams = track.extra()->trajParams();
@@ -740,13 +741,13 @@ void SiStripMonitorTrack::trajectoryStudy(
       statedirection=monodet->toLocal(gtrkdirup);
       SiStripRecHit2D m = matchedhit->monoHit();
       //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,trackref,es);
-      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,ev,es,track_ok);
+      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,digilist,ev,es,track_ok);
       //stereo side
       const GeomDetUnit * stereodet=gdet->stereoDet();
       statedirection=stereodet->toLocal(gtrkdirup);
       SiStripRecHit2D s = matchedhit->stereoHit();
       //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,trackref,es);
-      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,ev,es,track_ok);
+      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,digilist,ev,es,track_ok);
     }
     else if(projhit){
       LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found"<< std::endl;
@@ -761,19 +762,19 @@ void SiStripMonitorTrack::trajectoryStudy(
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found  MONO"<< std::endl;
 	det=gdet->monoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,ev,es,track_ok);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,digilist,ev,es,track_ok);
       }
       else{
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found STEREO"<< std::endl;
 	//stereo side
 	det=gdet->stereoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,ev,es,track_ok);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,digilist,ev,es,track_ok);
       }
     }else if (hit2D){
-      if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,ev,es,track_ok);
+      if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,digilist,ev,es,track_ok);
     } else if (hit1D) {
-      if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,ev,es,track_ok);
+      if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,digilist,ev,es,track_ok);
     } else {
       LogDebug ("SiStripMonitorTrack")
 	<< " LocalMomentum: "<<statedirection
@@ -785,14 +786,15 @@ void SiStripMonitorTrack::trajectoryStudy(
 }
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::hitStudy(
-  const edm::Event& ev,
-  const edm::EventSetup& es,
-	const ProjectedSiStripRecHit2D* projhit,
-	const SiStripMatchedRecHit2D*   matchedhit,
-	const SiStripRecHit2D*          hit2D,
-	const SiStripRecHit1D*          hit1D,
-	      LocalVector               localMomentum,
-	const bool                      track_ok
+  const edm::Event&                     ev,
+  const edm::EventSetup&                es,
+  const edm::DetSetVector<SiStripDigi>& digilist,
+	const ProjectedSiStripRecHit2D*       projhit,
+	const SiStripMatchedRecHit2D*         matchedhit,
+	const SiStripRecHit2D*                hit2D,
+	const SiStripRecHit1D*                hit1D,
+	      LocalVector                     localMomentum,
+	const bool                            track_ok
 ) {
   LocalVector statedirection;
   if(matchedhit){     // type=Matched;
@@ -806,13 +808,13 @@ void SiStripMonitorTrack::hitStudy(
     const GeomDetUnit * monodet=gdet->monoDet();
     statedirection=monodet->toLocal(gtrkdirup);
     SiStripRecHit2D m = matchedhit->monoHit();
-    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,ev,es,track_ok);
+    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,digilist,ev,es,track_ok);
 
     //stereo side
     const GeomDetUnit * stereodet=gdet->stereoDet();
     statedirection=stereodet->toLocal(gtrkdirup);
     SiStripRecHit2D s = matchedhit->stereoHit();
-    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,ev,es,track_ok);
+    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,digilist,ev,es,track_ok);
   }
   else if(projhit){    // type=Projected;
       LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found"<< std::endl;
@@ -828,21 +830,21 @@ void SiStripMonitorTrack::hitStudy(
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found  MONO"<< std::endl;
 	det=gdet->monoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,ev,es,track_ok);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,digilist,ev,es,track_ok);
       }
       else{
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found STEREO"<< std::endl;
 	//stereo side
 	det=gdet->stereoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,ev,es,track_ok);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,digilist,ev,es,track_ok);
       }
   } else if (hit2D){ // type=2D
     statedirection=localMomentum;
-    if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,ev,es,track_ok);
+    if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,digilist,ev,es,track_ok);
   } else if (hit1D) { // type=1D
     statedirection=localMomentum;
-    if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,ev,es,track_ok);
+    if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,digilist,ev,es,track_ok);
   } else {
     LogDebug ("SiStripMonitorTrack")
       << " LocalMomentum: "<<statedirection
@@ -864,8 +866,14 @@ using namespace reco;
   // track input
   edm::Handle<reco::TrackCollection > trackCollectionHandle;
   ev.getByToken(trackToken_, trackCollectionHandle);//takes the track collection
+
+  // digis list
+  edm::Handle<edm::DetSetVector<SiStripDigi>> digihandle;
+  ev.getByToken( digiToken_, digihandle );
+  auto& digilist  = *(digihandle.product());
+
   if (trackCollectionHandle.isValid()){
-    trackStudyFromTrajectory(trackCollectionHandle,ev, es);
+    trackStudyFromTrajectory(trackCollectionHandle,digilist,ev, es);
   } else {
     edm::LogError("SiStripMonitorTrack")<<"also Track Collection is not valid !! " << TrackLabel_<<std::endl;
     return;
@@ -884,6 +892,7 @@ bool SiStripMonitorTrack::trackFilter(const reco::Track& track) {
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::trackStudyFromTrack(
   edm::Handle<reco::TrackCollection > trackCollectionHandle,
+  const edm::DetSetVector<SiStripDigi>& digilist,
   const edm::Event& ev,
   const edm::EventSetup& es
 ) {
@@ -928,7 +937,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(
       //      reco::TrajectoryStateOnSurface stateOnSurface = transientTrack->stateOnSurface(globalPoint);
 
       LocalVector localMomentum;
-      hitStudy(ev,es,projhit,matchedhit,hit2D,hit1D,localMomentum,track_ok);
+      hitStudy(ev,es,digilist,projhit,matchedhit,hit2D,hit1D,localMomentum,track_ok);
     }
 
     // hit pattern of the track
@@ -967,6 +976,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::trackStudyFromTrajectory(
   edm::Handle<reco::TrackCollection > trackCollectionHandle,
+  const edm::DetSetVector<SiStripDigi>& digilist,
   const edm::Event& ev,
   const edm::EventSetup& es
 ) {
@@ -990,12 +1000,19 @@ void SiStripMonitorTrack::trackStudyFromTrajectory(
 
     //    trajectoryStudy(traj_iterator,trackref,es);
     bool track_ok = trackFilter(*track);
-    trajectoryStudy(*track,ev,es,track_ok);
+    trajectoryStudy(*track,digilist,ev,es,track_ok);
 
   }
 }
 //------------------------------------------------------------------------
-template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::Event& ev,  const edm::EventSetup& es, bool track_ok){
+template <class T> void SiStripMonitorTrack::RecHitInfo(
+  const T*                              tkrecHit,
+  LocalVector                           LV,
+  const edm::DetSetVector<SiStripDigi>& digilist,
+  const edm::Event&                     ev,
+  const edm::EventSetup&                es,
+  bool                                  track_ok)
+  {
 
     if(!tkrecHit->isValid()){
       LogTrace("SiStripMonitorTrack") <<"\t\t Invalid Hit " << std::endl;
@@ -1024,12 +1041,6 @@ template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, Local
     edm::ESHandle<SiStripQuality> qualityHandle;
     es.get<SiStripQualityRcd>().get("",qualityHandle);
     const SiStripQuality* stripQuality = qualityHandle.product();
-
-    edm::Handle<edm::DetSetVector<SiStripDigi>> digihandle;
-    if (Digi_On_)
-      ev.getByToken( digiToken_, digihandle );
-    const edm::DetSetVector<SiStripDigi> dummy;
-    auto digilist = ( digihandle.isValid() ? *digihandle : dummy );
 
     //Get SiStripCluster from SiStripRecHit
     if ( tkrecHit != NULL ){
@@ -1182,7 +1193,7 @@ bool SiStripMonitorTrack::clusterInfos(
     clustergain += stripGain->getStripGain(cluster->firstStrip()+chidx, stripGain->getRange(detid));
     // Getting raw adc charge from digi collections
     if( digi_it == digilist.end() ){
-      continue; 
+      continue;
     } // skipping if not found
     for( const auto& digiobj : *digi_it ){
       if( digiobj.strip() == cluster->firstStrip() + chidx  ){


### PR DESCRIPTION
Originally the `getByToken` call for the digi collection when analyzing the on track clusters was listed in the `RecHitInfo` method. Since this is called per track, this makes the plugin very slow. 
This change proposes to move the `getByToken` call up in the stack to `trackStudy` method. For subsequent function calls, a `const edm::DetSetVector<SiStripDigis>&` is passed down the stack. 

Another proposed (but not implemented) change is to removed the methods `trackStudyFromTrack` and `hitStudy`, since these methods are never called. 