### PR TITLE
Adding OutIn Muon Step in Phase-2 tracking

### DIFF
--- a/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
@@ -64,7 +64,7 @@ trackingPhase2PU140.toReplaceWith(preDuplicateMergingGeneralTracks, _trackListMe
         cms.InputTag("muonSeededTracksInOutSelector","MVAVals"),
         cms.InputTag("muonSeededTracksOutInSelector","MVAVals"),
     ),
-    setsToMerge = cms.VPSet(cms.PSet(pQual = cms.bool(False), tLists = cms.vint32(0, 1))),
+    setsToMerge = cms.VPSet(cms.PSet(pQual = cms.bool(False), tLists = cms.vint32(0, 1, 2))),
     FoundHitBonus  = 100.0,
     LostHitPenalty =   1.0,
     indivShareFrac = cms.vdouble(1.0, 0.16, 0.095, 0.09, 0.095,0.095, 0.095, 0.08),

--- a/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/preDuplicateMergingGeneralTracks_cfi.py
@@ -50,18 +50,18 @@ trackingPhase2PU140.toReplaceWith(preDuplicateMergingGeneralTracks, _trackListMe
     TrackProducers = cms.VInputTag(
         cms.InputTag("earlyGeneralTracks"),
         cms.InputTag("muonSeededTracksInOut"),
-        #cms.InputTag("muonSeededTracksOutIn"),
+        cms.InputTag("muonSeededTracksOutIn"),
     ),
-    hasSelector = cms.vint32(0,1),
+    hasSelector = cms.vint32(0,1,1),
     selectedTrackQuals = cms.VInputTag(
         cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"), # not used but needed
-        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity")
-        #cms.InputTag("muonSeededTracksOutInSelector","muonSeededTracksOutInHighPurity"),
+        cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity"),
+        cms.InputTag("muonSeededTracksOutInSelector","muonSeededTracksOutInHighPurity"),
     ),
     mvaValueTags = cms.VInputTag(
         cms.InputTag("earlyGeneralTracks","MVAVals"),
         cms.InputTag("muonSeededTracksInOutSelector","MVAVals"),
-    #    cms.InputTag("muonSeededTracksOutInSelector","MVAVals"),
+        cms.InputTag("muonSeededTracksOutInSelector","MVAVals"),
     ),
     setsToMerge = cms.VPSet(cms.PSet(pQual = cms.bool(False), tLists = cms.vint32(0, 1))),
     FoundHitBonus  = 100.0,

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -232,12 +232,15 @@ muonSeededTracksOutInSelector = RecoTracker.FinalTrackSelectors.multiTrackSelect
 muonSeededStepCoreInOut = cms.Sequence(
     muonSeededSeedsInOut + muonSeededTrackCandidatesInOut + muonSeededTracksInOut
 )
-muonSeededStepCore = cms.Sequence(
-    muonSeededStepCoreInOut +
+muonSeededStepCoreOutIn = cms.Sequence(
     muonSeededSeedsOutIn + muonSeededTrackCandidatesOutIn + muonSeededTracksOutIn
 )
+muonSeededStepCore = cms.Sequence(
+    muonSeededStepCoreInOut +
+    muonSeededStepCoreOutIn
+)
 #Phase2 : just muon Seed InOut is used in this moment
-trackingPhase2PU140.toReplaceWith(muonSeededStepCore, muonSeededStepCoreInOut)
+#trackingPhase2PU140.toReplaceWith(muonSeededStepCore, muonSeededStepCoreInOut)
 muonSeededStepExtraInOut = cms.Sequence(
     muonSeededTracksInOutClassifier
 )
@@ -256,7 +259,8 @@ trackingPhase1PU70.toReplaceWith(muonSeededStepExtra, cms.Sequence(
     muonSeededTracksOutInSelector
 ))
 trackingPhase2PU140.toReplaceWith(muonSeededStepExtra, cms.Sequence(
-    muonSeededStepExtraInOut
+    muonSeededStepExtraInOut +
+    muonSeededTracksOutInSelector
 ))
 
 muonSeededStep = cms.Sequence(

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -68,9 +68,10 @@ _iterations_muonSeeded = [
     "MuonSeededStepInOut",
     "MuonSeededStepOutIn",
 ]
-#Phase2 : just muon Seed InOut is used in this moment
+#Phase2
 _iterations_muonSeeded_trackingPhase2PU140 = [
     "MuonSeededStepInOut",
+    "MuonSeededStepOutIn",
 ]
 _multipleSeedProducers = {
     "MixedTripletStep": ["A", "B"],

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -153,7 +153,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         std::unique_ptr<Propagator> ptracker_cloned = SetPropagationDirection(*trackerPropagator_, alongMomentum);
 
         int sizeBefore = out->size();
-        if (debug_) std::cout << "\n\n\nSeeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << std::endl;
+        std::cout << "\n\n\nSeeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << std::endl;
         const reco::Track &tk = *mu.outerTrack();
 
         TrajectoryStateOnSurface state;
@@ -203,7 +203,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
                 }
             }
         }
-        if (debug_) std::cout << "Outcome of seeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << ": found " << (out->size() - sizeBefore) << " seeds."<< std::endl;
+        std::cout << "Outcome of seeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << ": found " << (out->size() - sizeBefore) << " seeds."<< std::endl;
 
     }
 

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -179,7 +179,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         }
         if (tk.eta() > minEtaForTEC_) {
             int iLayer = 9, found = 0;
-            std::vector< ForwardDetLayer const* > const & tec = measurementTracker->geometricSearchTracker()->posTecLayers();
+            std::vector< ForwardDetLayer const* > const & tec = measurementTracker->geometricSearchTracker()->posForwardLayers();
             for (auto it = tec.rbegin(), ed = tec.rend(); it != ed; ++it, --iLayer) {
                 if (debug_) std::cout << "\n ==== Trying TEC " << +iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
@@ -192,7 +192,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         }
         if (tk.eta() < -minEtaForTEC_) {
             int iLayer = 9, found = 0;
-            std::vector< ForwardDetLayer const* > const & tec = measurementTracker->geometricSearchTracker()->negTecLayers();
+            std::vector< ForwardDetLayer const* > const & tec = measurementTracker->geometricSearchTracker()->negForwardLayers();
             for (auto it = tec.rbegin(), ed = tec.rend(); it != ed; ++it, --iLayer) {
                 if (debug_) std::cout << "\n ==== Trying TEC " << -iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -227,7 +227,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
                 }
             }
         }
-        std::cout << "Outcome of seeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << ": found " << (out->size() - sizeBefore) << " seeds."<< std::endl;
+        if (debug_) std::cout << "Outcome of seeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << ": found " << (out->size() - sizeBefore) << " seeds."<< std::endl;
 
     }
 

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -156,7 +156,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         std::unique_ptr<Propagator> ptracker_cloned = SetPropagationDirection(*trackerPropagator_, alongMomentum);
 
         int sizeBefore = out->size();
-        if (debug_) std::cout << "\n\n\nSeeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << std::endl;
+        if (debug_) LogDebug("OutsideInMuonSeeder") << "\n\n\nSeeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << std::endl;
         const reco::Track &tk = *mu.outerTrack();
 
         TrajectoryStateOnSurface state;
@@ -174,7 +174,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
             if(iLayer==0) LogError("OutsideInMuonSeeder") << "TOB has no layers." ;
 
             for (auto it = tob.rbegin(), ed = tob.rend(); it != ed; ++it, --iLayer) {
-                if (debug_) std::cout << "\n ==== Trying TOB " << iLayer << " ====" << std::endl;
+                if (debug_) LogDebug("OutsideInMuonSeeder") << "\n ==== Trying TOB " << iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
                             *(pmuon_cloned.get()),
                             *(ptracker_cloned.get()),
@@ -184,19 +184,19 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
             }
         }
         if (tk.eta() > minEtaForTEC_) {
-            auto forwLayers = measurementTracker->geometricSearchTracker()->posTecLayers();
+            const auto& forwLayers = tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                     measurementTracker->geometricSearchTracker()->posTidLayers() : measurementTracker->geometricSearchTracker()->posTecLayers();
             if (tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC)) {
-              LogDebug("OutsideInMuonSeeder") << "\n We are using the Phase2 Outer Tracker (defined as a TID). ";
-              forwLayers = (measurementTracker->geometricSearchTracker()->posTidLayers());
+              LogDebug("OutsideInMuonSeeder") << "\n We are using the Phase2 Outer Tracker (defined as a TID+). ";
             }
-            LogTrace("OutsideInMuonSeeder") << "\n ==== TEC tot layers " << forwLayers.size() << " ====" << std::endl;
+            LogTrace("OutsideInMuonSeeder") << "\n ==== TEC+ tot layers " << forwLayers.size() << " ====" << std::endl;
             int found = 0;
             int iLayer = forwLayers.size(); 
             if(iLayer==0) LogError("OutsideInMuonSeeder") << "TEC+ has no layers." ;
 
-            if (debug_) std::cout << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
+            if (debug_) LogDebug("OutsideInMuonSeeder") << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
             for (auto it = forwLayers.rbegin(), ed = forwLayers.rend(); it != ed; ++it, --iLayer) {
-                if (debug_) std::cout << "\n ==== Trying Forward Layer +" << +iLayer << " ====" << std::endl;
+                if (debug_) LogDebug("OutsideInMuonSeeder") << "\n ==== Trying Forward Layer +" << +iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
                             *(pmuon_cloned.get()),
                             *(ptracker_cloned.get()),
@@ -206,19 +206,19 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
             }
         }
         if (tk.eta() < -minEtaForTEC_) {
-            auto forwLayers = measurementTracker->geometricSearchTracker()->negTecLayers();
+            const auto& forwLayers = tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC) ? 
+                                     measurementTracker->geometricSearchTracker()->negTidLayers() : measurementTracker->geometricSearchTracker()->negTecLayers();
             if (tmpTkGeometry->isThere(GeomDetEnumerators::P2OTEC)) {
-              LogDebug("OutsideInMuonSeeder") << "\n We are using the Phase2 Outer Tracker (defined as a TID). ";
-              forwLayers = (measurementTracker->geometricSearchTracker()->negTidLayers());
+              LogDebug("OutsideInMuonSeeder") << "\n We are using the Phase2 Outer Tracker (defined as a TID-). ";
             }
             LogTrace("OutsideInMuonSeeder") << "\n ==== TEC- tot layers " << forwLayers.size() << " ====" << std::endl;
             int found = 0;
             int iLayer = forwLayers.size(); 
             if(iLayer==0) LogError("OutsideInMuonSeeder") << "TEC- has no layers." ;
 
-            if (debug_) std::cout << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
+            if (debug_) LogDebug("OutsideInMuonSeeder") << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
             for (auto it = forwLayers.rbegin(), ed = forwLayers.rend(); it != ed; ++it, --iLayer) {
-                if (debug_) std::cout << "\n ==== Trying Forward Layer -" << -iLayer << " ====" << std::endl;
+                if (debug_) LogDebug("OutsideInMuonSeeder") << "\n ==== Trying Forward Layer -" << -iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
                             *(pmuon_cloned.get()),
                             *(ptracker_cloned.get()),
@@ -227,7 +227,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
                 }
             }
         }
-        if (debug_) std::cout << "Outcome of seeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << ": found " << (out->size() - sizeBefore) << " seeds."<< std::endl;
+        if (debug_) LogDebug("OutsideInMuonSeeder") << "Outcome of seeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << ": found " << (out->size() - sizeBefore) << " seeds."<< std::endl;
 
     }
 
@@ -247,7 +247,7 @@ OutsideInMuonSeeder::doLayer(const GeometricSearchDet &layer,
     layer.compatibleDetsV(onLayer, muon_propagator, *estimator_, dets);
 
     if (debug_) {
-        std::cout << "Query on layer around x = " << onLayer.globalPosition() <<
+        LogDebug("OutsideInMuonSeeder") << "Query on layer around x = " << onLayer.globalPosition() <<
             " with local pos error " << sqrt(onLayer.localError().positionError().xx()) << " ,  " << sqrt(onLayer.localError().positionError().yy()) << " ,  " <<
             " returned " << dets.size() << " compatible detectors" << std::endl;
     }
@@ -258,7 +258,7 @@ OutsideInMuonSeeder::doLayer(const GeometricSearchDet &layer,
         if (det.isNull()) { std::cerr << "BOGUS detid " << it->first->geographicalId().rawId() << std::endl; continue; }
         if (!it->second.isValid()) continue;
         std::vector < TrajectoryMeasurement > mymeas = det.fastMeasurements(it->second, state, tracker_propagator, *estimator_);
-        if (debug_) std::cout << "Query on detector " << it->first->geographicalId().rawId() << " returned " << mymeas.size() << " measurements." << std::endl;
+        if (debug_) LogDebug("OutsideInMuonSeeder") << "Query on detector " << it->first->geographicalId().rawId() << " returned " << mymeas.size() << " measurements." << std::endl;
         for (std::vector<TrajectoryMeasurement>::const_iterator it2 = mymeas.begin(), ed2 = mymeas.end(); it2 != ed2; ++it2) {
             if (it2->recHit()->isValid()) meas.push_back(*it2);
         }
@@ -267,13 +267,13 @@ OutsideInMuonSeeder::doLayer(const GeometricSearchDet &layer,
     std::sort(meas.begin(), meas.end(), TrajMeasLessEstim());
     for (std::vector<TrajectoryMeasurement>::const_iterator it2 = meas.begin(), ed2 = meas.end(); it2 != ed2; ++it2) {
         if (debug_) {
-            std::cout << "  inspecting Hit with chi2 = " << it2->estimate() << std::endl;
-            std::cout << "        track state     " << it2->forwardPredictedState().globalPosition() << std::endl;
-            std::cout << "        rechit position " << it2->recHit()->globalPosition() << std::endl;
+            LogDebug("OutsideInMuonSeeder") << "  inspecting Hit with chi2 = " << it2->estimate() << std::endl;
+            LogDebug("OutsideInMuonSeeder") << "        track state     " << it2->forwardPredictedState().globalPosition() << std::endl;
+            LogDebug("OutsideInMuonSeeder") << "        rechit position " << it2->recHit()->globalPosition() << std::endl;
         }
         TrajectoryStateOnSurface updated = updator_->update(it2->forwardPredictedState(), *it2->recHit());
         if (updated.isValid()) {
-            if (debug_) std::cout << "          --> updated state: x = " << updated.globalPosition() << ", p = " << updated.globalMomentum() << std::endl;
+            if (debug_) LogDebug("OutsideInMuonSeeder") << "          --> updated state: x = " << updated.globalPosition() << ", p = " << updated.globalMomentum() << std::endl;
             edm::OwnVector<TrackingRecHit> seedHits;
             seedHits.push_back(*it2->recHit()->hit());
             PTrajectoryStateOnDet const & pstate = trajectoryStateTransform::persistentState(updated, it2->recHit()->geographicalId().rawId());
@@ -295,11 +295,11 @@ OutsideInMuonSeeder::doDebug(const reco::Track &tk) const {
         if (det == 0) continue;
         if (i != 0) tsos = pmuon_cloned->propagate(tsos, det->surface());
         if (!tsos.isValid()) continue;
-        std::cout << "  state " << i << " at x = " << tsos.globalPosition() << ", p = " << tsos.globalMomentum() << std::endl;
+        LogDebug("OutsideInMuonSeeder") << "  state " << i << " at x = " << tsos.globalPosition() << ", p = " << tsos.globalMomentum() << std::endl;
         if (hit->isValid()) {
-            std::cout << "         valid   rechit on detid " << hit->geographicalId().rawId() << std::endl;
+            LogDebug("OutsideInMuonSeeder") << "         valid   rechit on detid " << hit->geographicalId().rawId() << std::endl;
         } else {
-            std::cout << "         invalid rechit on detid " << hit->geographicalId().rawId() << std::endl;
+            LogDebug("OutsideInMuonSeeder") << "         invalid rechit on detid " << hit->geographicalId().rawId() << std::endl;
         }
     }
 }

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -156,7 +156,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         std::unique_ptr<Propagator> ptracker_cloned = SetPropagationDirection(*trackerPropagator_, alongMomentum);
 
         int sizeBefore = out->size();
-        std::cout << "\n\n\nSeeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << std::endl;
+        if (debug_) std::cout << "\n\n\nSeeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << std::endl;
         const reco::Track &tk = *mu.outerTrack();
 
         TrajectoryStateOnSurface state;
@@ -174,7 +174,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
             if(iLayer==0) LogError("OutsideInMuonSeeder") << "TOB has no layers." ;
 
             for (auto it = tob.rbegin(), ed = tob.rend(); it != ed; ++it, --iLayer) {
-                std::cout << "\n ==== Trying TOB " << iLayer << " ====" << std::endl;
+                if (debug_) std::cout << "\n ==== Trying TOB " << iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
                             *(pmuon_cloned.get()),
                             *(ptracker_cloned.get()),
@@ -194,7 +194,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
             int iLayer = forwLayers.size(); 
             if(iLayer==0) LogError("OutsideInMuonSeeder") << "TEC+ has no layers." ;
 
-            std::cout << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
+            if (debug_) std::cout << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
             for (auto it = forwLayers.rbegin(), ed = forwLayers.rend(); it != ed; ++it, --iLayer) {
                 if (debug_) std::cout << "\n ==== Trying Forward Layer +" << +iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,
@@ -216,7 +216,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
             int iLayer = forwLayers.size(); 
             if(iLayer==0) LogError("OutsideInMuonSeeder") << "TEC- has no layers." ;
 
-            std::cout << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
+            if (debug_) std::cout << "\n ==== Tot layers " << forwLayers.size() << " ====" << std::endl;
             for (auto it = forwLayers.rbegin(), ed = forwLayers.rend(); it != ed; ++it, --iLayer) {
                 if (debug_) std::cout << "\n ==== Trying Forward Layer -" << -iLayer << " ====" << std::endl;
                 if (doLayer(**it, state, *out,

--- a/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.cc
@@ -97,13 +97,15 @@ Phase2OTtiltedBarrelLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurfac
   vector<DetGroup> closestResultNeg;
   vector<DetGroup> closestResultPos;
   Phase2OTBarrelLayer::groupedCompatibleDetsV(tsos, prop, est, closestResultRods);
-  for(auto ring : theNegativeRingsComps){
-    ring->groupedCompatibleDetsV(tsos, prop, est, closestResultNeg);
+  if(tsos.globalPosition().z()<0){
+    for(auto ring : theNegativeRingsComps){
+      ring->groupedCompatibleDetsV(tsos, prop, est, closestResultNeg);
+    }
+  } else {
+    for(auto ring : thePositiveRingsComps){
+      ring->groupedCompatibleDetsV(tsos, prop, est, closestResultPos);
+    }
   }
-  for(auto ring : thePositiveRingsComps){
-    ring->groupedCompatibleDetsV(tsos, prop, est, closestResultPos);
-  }
-
   result.assign(closestResultRods.begin(),closestResultRods.end());
   result.insert(result.end(),closestResultPos.begin(),closestResultPos.end());
   result.insert(result.end(),closestResultNeg.begin(),closestResultNeg.end());

--- a/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTtiltedBarrelLayer.cc
@@ -98,11 +98,11 @@ Phase2OTtiltedBarrelLayer::groupedCompatibleDetsV( const TrajectoryStateOnSurfac
   vector<DetGroup> closestResultPos;
   Phase2OTBarrelLayer::groupedCompatibleDetsV(tsos, prop, est, closestResultRods);
   if(tsos.globalPosition().z()<0){
-    for(auto ring : theNegativeRingsComps){
+    for(auto& ring : theNegativeRingsComps){
       ring->groupedCompatibleDetsV(tsos, prop, est, closestResultNeg);
     }
   } else {
-    for(auto ring : thePositiveRingsComps){
+    for(auto& ring : thePositiveRingsComps){
       ring->groupedCompatibleDetsV(tsos, prop, est, closestResultPos);
     }
   }

--- a/Validation/RecoTrack/python/plotting/ntuplePrintersDiff.py
+++ b/Validation/RecoTrack/python/plotting/ntuplePrintersDiff.py
@@ -1125,7 +1125,7 @@ class TrackingParticlePrinter(_IndentPrinter):
             self._trackPrinter.indent(2)
             for track in tracks:
                 lst.extend(self._trackPrinter.printTrack(track))
-                self._trackPrinter.restoreIndent()
+            self._trackPrinter.restoreIndent()
         return lst
 
     def printMatchedTracks(self, tp, useTrackPrinter=True):


### PR DESCRIPTION
With this PR, the OutIn iteration has been added back into the tracking iteration sequence - which was cut out after the updating on the OT local reconstruction.
It has been tested in 910pre2 release and with single muon 0PU the gain is already pretty clear (blue - baseline; red - baseline+PR):
![screenshot from 2017-05-03 13 50 41](https://cloud.githubusercontent.com/assets/5331004/25659351/b07acdf0-3007-11e7-9193-d48767f9190c.png)
Fakes have been tested using high PU events and changes are minor.

In principle, no change is expected in current tracking, but since `OutsideInMuonSeeder.cc` has been touched, it would be wise to double check.