### PR TITLE
Remove mutables from HCAL DB objects and reduce code duplication

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
@@ -97,7 +97,6 @@ namespace HcalDbASCIIIO {
   bool dumpObject (std::ostream& fOutput, const HcalLutMetadata& fObject);
   bool getObject (std::istream& fInput, HcalDcsValues* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalDcsValues& fObject);
-  bool getObject (std::istream& fInput, HcalDcsMap* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalDcsMap& fObject);
 
   bool getObject (std::istream& fInput, HcalRecoParams* fObject);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
@@ -88,7 +88,6 @@ namespace HcalDbASCIIIO {
   bool dumpObject (std::ostream& fOutput, const HcalZSThresholds& fObject);
   bool getObject (std::istream& fInput, HcalL1TriggerObjects* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalL1TriggerObjects& fObject);
-  bool getObject (std::istream& fInput, HcalFrontEndMap* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalFrontEndMap& fObject);
 
   bool getObject (std::istream& fInput, HcalValidationCorrs* fObject);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
@@ -52,6 +52,13 @@ Text file formats for different data types is as following:
   eta(int)  phi(int) depth(int) det(HB,HE,HF) cap1_pedw(float) cap2_pedw(float) cap3_pedw(float) cap4_pedw(float) cap1_gainw(float) cap2_gainw(float) cap3_gainw(float) cap4_gainw(float) HcalDetId(int,optional)
 */
 namespace HcalDbASCIIIO {
+  //alternate function for creating certain objects
+  template <class T>
+  std::unique_ptr<T> createObject (std::istream& fInput){
+    assert(0); //no general case, relies on specializations defined in cc file
+    return std::make_unique<T>();
+  }
+
   bool getObject (std::istream& fInput, HcalPedestals* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalPedestals& fObject);
   bool getObject (std::istream& fInput, HcalPedestalWidths* fObject);
@@ -66,7 +73,6 @@ namespace HcalDbASCIIIO {
   bool dumpObject (std::ostream& fOutput, const HcalCalibrationQIEData& fObject);
   bool getObject (std::istream& fInput, HcalQIETypes* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalQIETypes& fObject);
-  bool getObject (std::istream& fInput, HcalElectronicsMap* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalElectronicsMap& fObject);
   bool getObject (std::istream& fInput, HcalChannelQuality* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalChannelQuality& fObject);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h
@@ -118,7 +118,6 @@ namespace HcalDbASCIIIO {
 
   bool getObject (std::istream& fInput, HcalSiPMParameters* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalSiPMParameters& fObject);
-  bool getObject (std::istream& fInput, HcalSiPMCharacteristics* fObject);
   bool dumpObject (std::ostream& fOutput, const HcalSiPMCharacteristics& fObject);
 
   bool getObject (std::istream& fInput, HcalTPParameters* fObject);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -86,7 +86,7 @@ class HcalDbHardcode {
     HcalMCParam makeMCParam (HcalGenericDetId fId);
     HcalTimingParam makeTimingParam (HcalGenericDetId fId);
     std::unique_ptr<HcalElectronicsMap> makeHardcodeMap(const std::vector<HcalGenericDetId>& cells);
-    void makeHardcodeDcsMap(HcalDcsMap& dcs_map);
+    std::unique_ptr<HcalDcsMap> makeHardcodeDcsMap();
     void makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::vector<HcalGenericDetId>& cells);
     HcalSiPMParameter makeHardcodeSiPMParameter (HcalGenericDetId fId, const HcalTopology* topo, double intlumi);
     void makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -90,7 +90,7 @@ class HcalDbHardcode {
     void makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::vector<HcalGenericDetId>& cells);
     std::unique_ptr<HcalFrontEndMap> makeHardcodeFrontEndMap(const std::vector<HcalGenericDetId>& cells);
     HcalSiPMParameter makeHardcodeSiPMParameter (HcalGenericDetId fId, const HcalTopology* topo, double intlumi);
-    void makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm);
+    std::unique_ptr<HcalSiPMCharacteristics> makeHardcodeSiPMCharacteristics ();
     HcalTPChannelParameter makeHardcodeTPChannelParameter (HcalGenericDetId fId);
     void makeHardcodeTPParameters (HcalTPParameters& tppar);
     int getLayersInDepth(int ieta, int depth, const HcalTopology* topo);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -85,7 +85,7 @@ class HcalDbHardcode {
     HcalRecoParam makeRecoParam (HcalGenericDetId fId);
     HcalMCParam makeMCParam (HcalGenericDetId fId);
     HcalTimingParam makeTimingParam (HcalGenericDetId fId);
-    void makeHardcodeMap(HcalElectronicsMap& emap, const std::vector<HcalGenericDetId>& cells);
+    std::unique_ptr<HcalElectronicsMap> makeHardcodeMap(const std::vector<HcalGenericDetId>& cells);
     void makeHardcodeDcsMap(HcalDcsMap& dcs_map);
     void makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::vector<HcalGenericDetId>& cells);
     HcalSiPMParameter makeHardcodeSiPMParameter (HcalGenericDetId fId, const HcalTopology* topo, double intlumi);

--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -88,6 +88,7 @@ class HcalDbHardcode {
     std::unique_ptr<HcalElectronicsMap> makeHardcodeMap(const std::vector<HcalGenericDetId>& cells);
     std::unique_ptr<HcalDcsMap> makeHardcodeDcsMap();
     void makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::vector<HcalGenericDetId>& cells);
+    std::unique_ptr<HcalFrontEndMap> makeHardcodeFrontEndMap(const std::vector<HcalGenericDetId>& cells);
     HcalSiPMParameter makeHardcodeSiPMParameter (HcalGenericDetId fId, const HcalTopology* topo, double intlumi);
     void makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm);
     HcalTPChannelParameter makeHardcodeTPChannelParameter (HcalGenericDetId fId);

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1887,8 +1887,10 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalSiPMParameters&
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalSiPMCharacteristics* fObject) {
+namespace HcalDbASCIIIO {
+template<> std::unique_ptr<HcalSiPMCharacteristics> createObject<HcalSiPMCharacteristics>(std::istream& fInput) {
   char buffer [1024];
+  HcalSiPMCharacteristics::Helper fObjectHelper;
   unsigned int all(0), good(0);
   while (fInput.getline(buffer, 1024)) {
     ++all;
@@ -1908,11 +1910,12 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalSiPMCharacteristics* fO
     float cTalk  = atof (items [5].c_str());
     int   auxi1  = atoi (items [6].c_str());
     float auxi2  = atof (items [7].c_str());
-    fObject->loadObject (type, pixels, parL0, parL1, parL2, cTalk, auxi1, auxi2);
+    fObjectHelper.loadObject (type, pixels, parL0, parL1, parL2, cTalk, auxi1, auxi2);
   }
-  fObject->sort ();
   edm::LogInfo("MapFormat") << "HcalSiPMCharacteristics:: processed " << good << " records in " << all << " record" << std::endl;
-  return true;
+  auto fObject = std::make_unique<HcalSiPMCharacteristics>(fObjectHelper);
+  return fObject;
+}
 }
 
 bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalSiPMCharacteristics& fObject) {

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1791,8 +1791,10 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalFlagHFDigiTimeP
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalFrontEndMap* fObject) {
+namespace HcalDbASCIIIO {
+template<> std::unique_ptr<HcalFrontEndMap> createObject<HcalFrontEndMap>(std::istream& fInput) {
   char buffer [1024];
+  HcalFrontEndMap::Helper fObjectHelper;
   unsigned int all(0), good(0);
   while (fInput.getline(buffer, 1024)) {
     ++all;
@@ -1803,14 +1805,14 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalFrontEndMap* fObject) {
       continue;
     }
     ++good;
-    //    std::cout << "HcalFrontEndMap-> processing line: " << buffer << std::endl;
     DetId id = HcalDbASCIIIO::getId (items);
     int   rm = atoi (items [5].c_str());
-    fObject->loadObject (id, rm, items[4]);
+    fObjectHelper.loadObject (id, rm, items[4]);
   }
-  fObject->sort ();
   edm::LogInfo("MapFormat") << "HcalFrontEndMap:: processed " << good << " records in " << all << " record" << std::endl;
-  return true;
+  auto fObject = std::make_unique<HcalFrontEndMap>(fObjectHelper);
+  return fObject;
+}
 }
 
 bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalFrontEndMap& fObject) {

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1629,8 +1629,10 @@ bool HcalDbASCIIIO::dumpObject(std::ostream& fOutput,
 // Format of the ASCII file:
 // line# Ring Slice Subchannel Subdetector Eta Phi Depth
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalDcsMap* fObject) {
+namespace HcalDbASCIIIO {
+template <> std::unique_ptr<HcalDcsMap> createObject<HcalDcsMap>(std::istream& fInput) {
   char buffer [1024];
+  HcalDcsMap::Helper fObjectHelper;
   while (fInput.getline(buffer, 1024)) {
     if (buffer [0] == '#') continue; //ignore comment
     std::vector <std::string> items = splitString (std::string (buffer));
@@ -1642,55 +1644,10 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalDcsMap* fObject) {
 	continue;
       }
     }
-    //    std::cout << "HcalDcsMap-> processing line: " << buffer << std::endl;
-    //int ring = atoi (items [1].c_str());
     int ring = atoi(items[1].c_str());
     unsigned int slice = atoi (items [2].c_str());
     unsigned int subchannel = atoi (items [3].c_str());
     HcalDcsDetId::DcsType type = HcalDcsDetId::DCSUNKNOWN;
-//    if(items[4].find("HV")!=std::string::npos){
-//      type = HcalDcsDetId::HV;
-//    }
-//    else if (items[4].find("BV")!=std::string::npos){
-//      type = HcalDcsDetId::BV;
-//    }
-//    else if (items[4].find("CATH")!=std::string::npos){
-//      type = HcalDcsDetId::CATH;
-//    }
-//    else if (items[4].find("DYN7")!=std::string::npos){
-//      type = HcalDcsDetId::DYN7;
-//    }
-//    else if (items[4].find("DYN8")!=std::string::npos){
-//      type = HcalDcsDetId::DYN8;
-//    }
-//    else if (items[4].find("RM_TEMP")!=std::string::npos){
-//      type = HcalDcsDetId::RM_TEMP;
-//    }
-//    else if (items[4].find("CCM_TEMP")!=std::string::npos){
-//      type = HcalDcsDetId::CCM_TEMP;
-//    }
-//    else if (items[4].find("CALIB_TEMP")!=std::string::npos){
-//      type = HcalDcsDetId::CALIB_TEMP;
-//    }
-//    else if (items[4].find("LVTTM_TEMP")!=std::string::npos){
-//      type = HcalDcsDetId::LVTTM_TEMP;
-//    }
-//    else if (items[4].find("TEMP")!=std::string::npos){
-//      type = HcalDcsDetId::TEMP;
-//    }
-//    else if (items[4].find("QPLL_LOCK")!=std::string::npos){
-//      type = HcalDcsDetId::QPLL_LOCK;
-//    }
-//    else if (items[4].find("STATUS")!=std::string::npos){
-//      type = HcalDcsDetId::STATUS;
-//    }
-//    else if (items[4].find("DCS_MAX")!=std::string::npos){
-//      type = HcalDcsDetId::DCS_MAX;
-//    }
-//    else{
-//      edm::LogError("MapFormat") << "HcalDcsMap-> Unknown DCS Type, line is not accepted: " << items[4];
-//      continue;
-//    }
     HcalOtherSubdetector subdet = HcalOtherEmpty;
     if (items[4].find("CALIB")!=std::string::npos){
       subdet = HcalCalibration;
@@ -1725,10 +1682,11 @@ bool HcalDbASCIIIO::getObject (std::istream& fInput, HcalDcsMap* fObject) {
 					      << items [7] << std::endl; 
       continue;
     }
-    fObject->mapGeomId2DcsId(id, dcsId);
+    fObjectHelper.mapGeomId2DcsId(id, dcsId);
   }
-  fObject->sort ();
-  return true;
+  auto fObject = std::make_unique<HcalDcsMap>(fObjectHelper);
+  return fObject;
+}
 }
 
 // Format of the ASCII file:

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbASCIIIO.cc
@@ -1295,7 +1295,7 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalCalibrationQIED
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 namespace HcalDbASCIIIO {
 template<> std::unique_ptr<HcalElectronicsMap> createObject<HcalElectronicsMap>(std::istream& fInput) {
-  HcalElectronicsMap::Helper fObjectHelper;
+  HcalElectronicsMapAddons::Helper fObjectHelper;
   char buffer [1024];
   while (fInput.getline(buffer, 1024)) {
     if (buffer [0] == '#') continue; //ignore comment
@@ -1632,7 +1632,7 @@ bool HcalDbASCIIIO::dumpObject(std::ostream& fOutput,
 namespace HcalDbASCIIIO {
 template <> std::unique_ptr<HcalDcsMap> createObject<HcalDcsMap>(std::istream& fInput) {
   char buffer [1024];
-  HcalDcsMap::Helper fObjectHelper;
+  HcalDcsMapAddons::Helper fObjectHelper;
   while (fInput.getline(buffer, 1024)) {
     if (buffer [0] == '#') continue; //ignore comment
     std::vector <std::string> items = splitString (std::string (buffer));
@@ -1794,7 +1794,7 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalFlagHFDigiTimeP
 namespace HcalDbASCIIIO {
 template<> std::unique_ptr<HcalFrontEndMap> createObject<HcalFrontEndMap>(std::istream& fInput) {
   char buffer [1024];
-  HcalFrontEndMap::Helper fObjectHelper;
+  HcalFrontEndMapAddons::Helper fObjectHelper;
   unsigned int all(0), good(0);
   while (fInput.getline(buffer, 1024)) {
     ++all;
@@ -1890,7 +1890,7 @@ bool HcalDbASCIIIO::dumpObject (std::ostream& fOutput, const HcalSiPMParameters&
 namespace HcalDbASCIIIO {
 template<> std::unique_ptr<HcalSiPMCharacteristics> createObject<HcalSiPMCharacteristics>(std::istream& fInput) {
   char buffer [1024];
-  HcalSiPMCharacteristics::Helper fObjectHelper;
+  HcalSiPMCharacteristicsAddons::Helper fObjectHelper;
   unsigned int all(0), good(0);
   while (fInput.getline(buffer, 1024)) {
     ++all;

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -614,14 +614,15 @@ HcalSiPMParameter HcalDbHardcode::makeHardcodeSiPMParameter (HcalGenericDetId fI
   return HcalSiPMParameter(fId.rawId(), theType, thePe2fC, theDC, 0, 0);
 }
 
-void HcalDbHardcode::makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& sipm) {
+std::unique_ptr<HcalSiPMCharacteristics> HcalDbHardcode::makeHardcodeSiPMCharacteristics () {
   // SiPMCharacteristics are constants for each type of SiPM:
   // Type, # of pixels, 3 parameters for non-linearity, cross talk parameter, ..
   // Obtained from data sheet and measurements
   // types (in order): HcalHOZecotek=1, HcalHOHamamatsu, HcalHEHamamatsu1, HcalHEHamamatsu2, HcalHBHamamatsu1, HcalHBHamamatsu2, HcalHPD
+  HcalSiPMCharacteristics::Helper sipmHelper;
   for(unsigned ip = 0; ip < theSiPMCharacteristics_.size(); ++ip){
     auto& ps = theSiPMCharacteristics_[ip];
-    sipm.loadObject(ip+1,
+    sipmHelper.loadObject(ip+1,
       ps.getParameter<int>("pixels"),
       ps.getParameter<double>("nonlin1"),
       ps.getParameter<double>("nonlin2"),
@@ -630,6 +631,7 @@ void HcalDbHardcode::makeHardcodeSiPMCharacteristics (HcalSiPMCharacteristics& s
       0,0
     );
   }
+  return std::make_unique<HcalSiPMCharacteristics>(sipmHelper);
 }
 
 HcalTPChannelParameter HcalDbHardcode::makeHardcodeTPChannelParameter (HcalGenericDetId fId) {

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -474,8 +474,8 @@ std::unique_ptr<HcalElectronicsMap> HcalDbHardcode::makeHardcodeMap(const std::v
   return std::make_unique<HcalElectronicsMap>(emapHelper);
 }
 
-void HcalDbHardcode::makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::vector<HcalGenericDetId>& cells) {
-
+std::unique_ptr<HcalFrontEndMap> HcalDbHardcode::makeHardcodeFrontEndMap(const std::vector<HcalGenericDetId>& cells) {
+  HcalFrontEndMap::Helper emapHelper;
   std::stringstream mystream;
   std::string detector[5] = {"XX","HB","HE","HO","HF"};
   for (const auto& fId : cells) {
@@ -502,7 +502,7 @@ void HcalDbHardcode::makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::v
 	mystream << tempbuff;
 	rbx = mystream.str();
 	mystream.str("");
-	emap.loadObject(id,irm,rbx);
+	emapHelper.loadObject(id,irm,rbx);
       } else if (subdet == HcalForward) {
 	det = detector[subdet];
 	int  hfphi(0);
@@ -518,7 +518,7 @@ void HcalDbHardcode::makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::v
 	mystream << tempbuff;
 	rbx = mystream.str();
 	mystream.str("");
-	emap.loadObject(id,irm,rbx);
+	emapHelper.loadObject(id,irm,rbx);
       } else if (subdet == HcalOuter) {
 	det = detector[subdet];
 	int ring(0), sector(0);
@@ -536,11 +536,11 @@ void HcalDbHardcode::makeHardcodeFrontEndMap(HcalFrontEndMap& emap, const std::v
         mystream << tempbuff;
 	rbx = mystream.str();
         mystream.str("");
-	emap.loadObject(id,irm,rbx);
+	emapHelper.loadObject(id,irm,rbx);
       }
     }
   }
-  emap.sort();
+  return std::make_unique<HcalFrontEndMap>(emapHelper);
 }
 
 int HcalDbHardcode::getLayersInDepth(int ieta, int depth, const HcalTopology* topo){

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -425,7 +425,7 @@ HcalTimingParam HcalDbHardcode::makeTimingParam (HcalGenericDetId fId) {
 #define EMAP_NHSETSHO 3
 
 std::unique_ptr<HcalDcsMap> HcalDbHardcode::makeHardcodeDcsMap() {
-  HcalDcsMap::Helper dcs_map_helper;
+  HcalDcsMapAddons::Helper dcs_map_helper;
   dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalBarrel, -16, 1, 1), 
 			  HcalDcsDetId(HcalDcsBarrel, -1, 1, HcalDcsDetId::HV, 2));
   dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalForward, -41, 3, 1), 
@@ -447,7 +447,7 @@ std::unique_ptr<HcalElectronicsMap> HcalDbHardcode::makeHardcodeMap(const std::v
   static const int kTriggerBitMask = 0x02000000; //2^25
   uint32_t counter = 0;
   uint32_t counterTrig = 0;
-  HcalElectronicsMap::Helper emapHelper;
+  HcalElectronicsMapAddons::Helper emapHelper;
   for(const auto& fId : cells){
     if(fId.genericSubdet() == HcalGenericDetId::HcalGenBarrel ||
        fId.genericSubdet() == HcalGenericDetId::HcalGenEndcap ||
@@ -475,7 +475,7 @@ std::unique_ptr<HcalElectronicsMap> HcalDbHardcode::makeHardcodeMap(const std::v
 }
 
 std::unique_ptr<HcalFrontEndMap> HcalDbHardcode::makeHardcodeFrontEndMap(const std::vector<HcalGenericDetId>& cells) {
-  HcalFrontEndMap::Helper emapHelper;
+  HcalFrontEndMapAddons::Helper emapHelper;
   std::stringstream mystream;
   std::string detector[5] = {"XX","HB","HE","HO","HF"};
   for (const auto& fId : cells) {
@@ -619,7 +619,7 @@ std::unique_ptr<HcalSiPMCharacteristics> HcalDbHardcode::makeHardcodeSiPMCharact
   // Type, # of pixels, 3 parameters for non-linearity, cross talk parameter, ..
   // Obtained from data sheet and measurements
   // types (in order): HcalHOZecotek=1, HcalHOHamamatsu, HcalHEHamamatsu1, HcalHEHamamatsu2, HcalHBHamamatsu1, HcalHBHamamatsu2, HcalHPD
-  HcalSiPMCharacteristics::Helper sipmHelper;
+  HcalSiPMCharacteristicsAddons::Helper sipmHelper;
   for(unsigned ip = 0; ip < theSiPMCharacteristics_.size(); ++ip){
     auto& ps = theSiPMCharacteristics_[ip];
     sipmHelper.loadObject(ip+1,

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -424,19 +424,21 @@ HcalTimingParam HcalDbHardcode::makeTimingParam (HcalGenericDetId fId) {
 #define EMAP_NHTRSHO 4
 #define EMAP_NHSETSHO 3
 
-void HcalDbHardcode::makeHardcodeDcsMap(HcalDcsMap& dcs_map) {
-  dcs_map.mapGeomId2DcsId(HcalDetId(HcalBarrel, -16, 1, 1), 
+std::unique_ptr<HcalDcsMap> HcalDbHardcode::makeHardcodeDcsMap() {
+  HcalDcsMap::Helper dcs_map_helper;
+  dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalBarrel, -16, 1, 1), 
 			  HcalDcsDetId(HcalDcsBarrel, -1, 1, HcalDcsDetId::HV, 2));
-  dcs_map.mapGeomId2DcsId(HcalDetId(HcalForward, -41, 3, 1), 
+  dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalForward, -41, 3, 1), 
 			  HcalDcsDetId(HcalDcsForward, -1, 1, HcalDcsDetId::DYN8, 1));
-  dcs_map.mapGeomId2DcsId(HcalDetId(HcalForward, -26, 25, 2), 
+  dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalForward, -26, 25, 2), 
 			  HcalDcsDetId(HcalDcsForward, -1, 7, HcalDcsDetId::HV, 1));
-  dcs_map.mapGeomId2DcsId(HcalDetId(HcalBarrel, -15, 68, 1), 
+  dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalBarrel, -15, 68, 1), 
 			  HcalDcsDetId(HcalDcsBarrel, -1, 18, HcalDcsDetId::HV, 3));
-  dcs_map.mapGeomId2DcsId(HcalDetId(HcalOuter, -14, 1, 4), 
+  dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalOuter, -14, 1, 4), 
 			  HcalDcsDetId(HcalDcsOuter, -2, 2, HcalDcsDetId::HV, 4));
-  dcs_map.mapGeomId2DcsId(HcalDetId(HcalForward, 41, 71, 2), 
+  dcs_map_helper.mapGeomId2DcsId(HcalDetId(HcalForward, 41, 71, 2), 
 			  HcalDcsDetId(HcalDcsForward, 1, 4, HcalDcsDetId::DYN8, 3));
+  return std::make_unique<HcalDcsMap>(dcs_map_helper);
 }
 
 std::unique_ptr<HcalElectronicsMap> HcalDbHardcode::makeHardcodeMap(const std::vector<HcalGenericDetId>& cells) {

--- a/CalibCalorimetry/HcalAlgos/test/MapTester.cc
+++ b/CalibCalorimetry/HcalAlgos/test/MapTester.cc
@@ -109,11 +109,10 @@ MapTester::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup)
     sprintf(buf,"#file creation series : %s",tempbuff);
     outStream<<buf<< std::endl;
 
-    HcalElectronicsMap myemap;
     edm::LogInfo( "MapTester") <<"generating the emap..."<<std::endl;
-    myemap = mymap.generateHcalElectronicsMap();
+    auto myemap = mymap.generateHcalElectronicsMap();
     edm::LogInfo( "MapTester") <<"dumping the emap..."<<std::endl;
-    HcalDbASCIIIO::dumpObject(outStream,myemap);}
+    HcalDbASCIIIO::dumpObject(outStream,*myemap);}
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -702,9 +702,7 @@ std::unique_ptr<HcalDcsValues> HcalHardcodeCalibrations::produceDcsValues (const
 std::unique_ptr<HcalDcsMap> HcalHardcodeCalibrations::produceDcsMap (const HcalDcsMapRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceDcsMap-> ...";
 
-  auto result = std::make_unique<HcalDcsMap>();
-  dbHardcode.makeHardcodeDcsMap(*result);
-  return result;
+  return dbHardcode.makeHardcodeDcsMap();
 }
 
 std::unique_ptr<HcalRecoParams> HcalHardcodeCalibrations::produceRecoParams (const HcalRecoParamsRcd& rec) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -832,9 +832,7 @@ std::unique_ptr<HcalFrontEndMap> HcalHardcodeCalibrations::produceFrontEndMap (c
   const HcalTopology* topo=&(*htopo);
   std::vector <HcalGenericDetId> cells = allCells(*topo, dbHardcode.killHE());
 
-  auto result = std::make_unique<HcalFrontEndMap>();
-  dbHardcode.makeHardcodeFrontEndMap(*result, cells);
-  return result;
+  return dbHardcode.makeHardcodeFrontEndMap(cells);
 }
 
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -854,9 +854,7 @@ std::unique_ptr<HcalSiPMParameters> HcalHardcodeCalibrations::produceSiPMParamet
 std::unique_ptr<HcalSiPMCharacteristics> HcalHardcodeCalibrations::produceSiPMCharacteristics (const HcalSiPMCharacteristicsRcd& rcd) {
   edm::LogInfo("HCAL") << "HcalHardcodeCalibrations::produceSiPMCharacteristics-> ...";
 
-  auto result = std::make_unique<HcalSiPMCharacteristics>();
-  dbHardcode.makeHardcodeSiPMCharacteristics(*result);
-  return result;
+  return dbHardcode.makeHardcodeSiPMCharacteristics();
 }
 
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -602,9 +602,7 @@ std::unique_ptr<HcalElectronicsMap> HcalHardcodeCalibrations::produceElectronics
   const HcalTopology* topo=&(*htopo);
 
   std::vector <HcalGenericDetId> cells = allCells(*topo, dbHardcode.killHE());
-  auto result = std::make_unique<HcalElectronicsMap>();
-  dbHardcode.makeHardcodeMap(*result,cells);
-  return result;
+  return dbHardcode.makeHardcodeMap(cells);
 }
 
 std::unique_ptr<HcalValidationCorrs> HcalHardcodeCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -294,7 +294,7 @@ std::unique_ptr<HcalElectronicsMap> HcalTextCalibrations::produceElectronicsMap 
 }
 
 std::unique_ptr<HcalFrontEndMap> HcalTextCalibrations::produceFrontEndMap (const HcalFrontEndMapRcd& rcd) {
-  return get_impl<HcalFrontEndMap> (mInputs ["FrontEndMap"]);
+  return create_impl<HcalFrontEndMap> (mInputs ["FrontEndMap"]);
 }
 
 std::unique_ptr<HcalValidationCorrs> HcalTextCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -369,7 +369,7 @@ std::unique_ptr<HcalSiPMParameters> HcalTextCalibrations::produceSiPMParameters 
 }
 
 std::unique_ptr<HcalSiPMCharacteristics> HcalTextCalibrations::produceSiPMCharacteristics (const HcalSiPMCharacteristicsRcd& rcd) {
-  return get_impl<HcalSiPMCharacteristics> (mInputs ["SiPMCharacteristics"]);
+  return create_impl<HcalSiPMCharacteristics> (mInputs ["SiPMCharacteristics"]);
 }
 
 std::unique_ptr<HcalTPChannelParameters> HcalTextCalibrations::produceTPChannelParameters (const HcalTPChannelParametersRcd& rcd) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -13,7 +13,6 @@
 
 #include "FWCore/Framework/interface/ValidityInterval.h"
 
-#include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 #include "CondFormats/DataRecord/interface/HcalAllRcds.h"
@@ -159,7 +158,7 @@ HcalTextCalibrations::HcalTextCalibrations ( const edm::ParameterSet& iConfig )
 		<< "FrontEndMap ZSThresholds RespCorrs LUTCorrs PFCorrs TimeCorrs L1TriggerObjects "
 		<< "ValidationCorrs LutMetadata DcsValues DcsMap "
 		<< "RecoParams LongRecoParams ZDCLowGainFraction FlagHFDigiTimeParams MCParams "
-		<< "SiPMParameters SiPMCharacteristics" << std::endl;
+		<< "SiPMParameters SiPMCharacteristics TPChannelParameters TPParameters" << std::endl;
     }
   }
   //  setWhatProduced(this);
@@ -180,38 +179,23 @@ HcalTextCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRecordKey
   oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
 }
 
-template <class T>
-std::unique_ptr<T> produce_impl (const HcalTopology* topo, const std::string& fFile) {
-  auto result = std::make_unique<T>(topo);
-  //  std::unique_ptr<T> result;
+template <class T, template <class> class F>
+std::unique_ptr<T> produce_impl (const std::string& fFile, const HcalTopology* topo=nullptr) {
   std::ifstream inStream (fFile.c_str ());
   if (!inStream.good ()) {
     std::cerr << "HcalTextCalibrations-> Unable to open file '" << fFile << "'" << std::endl;
     throw cms::Exception("FileNotFound") << "Unable to open '" << fFile << "'" << std::endl;
   }
-  if (!HcalDbASCIIIO::getObject (inStream, &*result)) {
+  auto result = F<T>(topo)(inStream);
+  if (!result) {
     std::cerr << "HcalTextCalibrations-> Can not read object from file '" << fFile << "'" << std::endl;
     throw cms::Exception("ReadError") << "Can not read object from file '" << fFile << "'" << std::endl;
   }
   return result;
 }
-
-template <class T>
-std::unique_ptr<T> produce_impl (const std::string& fFile) {
-  auto result = std::make_unique<T>();
-  //  std::unique_ptr<T> result;
-  std::ifstream inStream (fFile.c_str ());
-  if (!inStream.good ()) {
-    std::cerr << "HcalTextCalibrations-> Unable to open file '" << fFile << "'" << std::endl;
-    throw cms::Exception("FileNotFound") << "Unable to open '" << fFile << "'" << std::endl;
-  }
-  if (!HcalDbASCIIIO::getObject (inStream, &*result)) {
-    std::cerr << "HcalTextCalibrations-> Can not read object from file '" << fFile << "'" << std::endl;
-    throw cms::Exception("ReadError") << "Can not read object from file '" << fFile << "'" << std::endl;
-  }
-  return result;
-}
-
+template <class T> std::unique_ptr<T> get_impl (const std::string& fFile) { return produce_impl<T,HcalTextCalibrations::CheckGetObject>(fFile); }
+template <class T> std::unique_ptr<T> get_impl_topo (const std::string& fFile, const HcalTopology* topo) { return produce_impl<T,HcalTextCalibrations::CheckGetObjectTopo>(fFile,topo); }
+template <class T> std::unique_ptr<T> create_impl (const std::string& fFile) { return produce_impl<T,HcalTextCalibrations::CheckCreateObject>(fFile); }
 
 
 std::unique_ptr<HcalPedestals> HcalTextCalibrations::producePedestals (const HcalPedestalsRcd& rcd) {
@@ -219,182 +203,182 @@ std::unique_ptr<HcalPedestals> HcalTextCalibrations::producePedestals (const Hca
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
 
-  return produce_impl<HcalPedestals> (topo,mInputs ["Pedestals"]);
+  return get_impl_topo<HcalPedestals> (mInputs ["Pedestals"],topo);
 }
 
 std::unique_ptr<HcalPedestalWidths> HcalTextCalibrations::producePedestalWidths (const HcalPedestalWidthsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalPedestalWidths> (topo,mInputs ["PedestalWidths"]);
+  return get_impl_topo<HcalPedestalWidths> (mInputs ["PedestalWidths"],topo);
 }
 
 std::unique_ptr<HcalGains> HcalTextCalibrations::produceGains (const HcalGainsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalGains> (topo,mInputs ["Gains"]);
+  return get_impl_topo<HcalGains> (mInputs ["Gains"],topo);
 }
 
 std::unique_ptr<HcalGainWidths> HcalTextCalibrations::produceGainWidths (const HcalGainWidthsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalGainWidths> (topo,mInputs ["GainWidths"]);
+  return get_impl_topo<HcalGainWidths> (mInputs ["GainWidths"],topo);
 }
 
 std::unique_ptr<HcalQIEData> HcalTextCalibrations::produceQIEData (const HcalQIEDataRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalQIEData> (topo,mInputs ["QIEData"]);
+  return get_impl_topo<HcalQIEData> (mInputs ["QIEData"],topo);
 }
 
 std::unique_ptr<HcalQIETypes> HcalTextCalibrations::produceQIETypes (const HcalQIETypesRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalQIETypes> (topo,mInputs ["QIETypes"]);
+  return get_impl_topo<HcalQIETypes> (mInputs ["QIETypes"],topo);
 }
 
 std::unique_ptr<HcalChannelQuality> HcalTextCalibrations::produceChannelQuality (const HcalChannelQualityRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalChannelQuality> (topo,mInputs ["ChannelQuality"]);
+  return get_impl_topo<HcalChannelQuality> (mInputs ["ChannelQuality"],topo);
 }
 
 std::unique_ptr<HcalZSThresholds> HcalTextCalibrations::produceZSThresholds (const HcalZSThresholdsRcd& rcd) {  edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalZSThresholds> (topo,mInputs ["ZSThresholds"]);
+  return get_impl_topo<HcalZSThresholds> (mInputs ["ZSThresholds"],topo);
 }
 
 std::unique_ptr<HcalRespCorrs> HcalTextCalibrations::produceRespCorrs (const HcalRespCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalRespCorrs> (topo,mInputs ["RespCorrs"]);
+  return get_impl_topo<HcalRespCorrs> (mInputs ["RespCorrs"],topo);
 }
 
 std::unique_ptr<HcalLUTCorrs> HcalTextCalibrations::produceLUTCorrs (const HcalLUTCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalLUTCorrs> (topo,mInputs ["LUTCorrs"]);
+  return get_impl_topo<HcalLUTCorrs> (mInputs ["LUTCorrs"],topo);
 }
 
 std::unique_ptr<HcalPFCorrs> HcalTextCalibrations::producePFCorrs (const HcalPFCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalPFCorrs> (topo,mInputs ["PFCorrs"]);
+  return get_impl_topo<HcalPFCorrs> (mInputs ["PFCorrs"],topo);
 }
 
 std::unique_ptr<HcalTimeCorrs> HcalTextCalibrations::produceTimeCorrs (const HcalTimeCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalTimeCorrs> (topo,mInputs ["TimeCorrs"]);
+  return get_impl_topo<HcalTimeCorrs> (mInputs ["TimeCorrs"],topo);
 }
 
 std::unique_ptr<HcalL1TriggerObjects> HcalTextCalibrations::produceL1TriggerObjects (const HcalL1TriggerObjectsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalL1TriggerObjects> (topo,mInputs ["L1TriggerObjects"]);
+  return get_impl_topo<HcalL1TriggerObjects> (mInputs ["L1TriggerObjects"],topo);
 }
 
 std::unique_ptr<HcalElectronicsMap> HcalTextCalibrations::produceElectronicsMap (const HcalElectronicsMapRcd& rcd) {
-  return produce_impl<HcalElectronicsMap> (mInputs ["ElectronicsMap"]);
+  return create_impl<HcalElectronicsMap> (mInputs ["ElectronicsMap"]);
 }
 
 std::unique_ptr<HcalFrontEndMap> HcalTextCalibrations::produceFrontEndMap (const HcalFrontEndMapRcd& rcd) {
-  return produce_impl<HcalFrontEndMap> (mInputs ["FrontEndMap"]);
+  return get_impl<HcalFrontEndMap> (mInputs ["FrontEndMap"]);
 }
 
 std::unique_ptr<HcalValidationCorrs> HcalTextCalibrations::produceValidationCorrs (const HcalValidationCorrsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalValidationCorrs> (topo,mInputs ["ValidationCorrs"]);
+  return get_impl_topo<HcalValidationCorrs> (mInputs ["ValidationCorrs"],topo);
 }
 
 std::unique_ptr<HcalLutMetadata> HcalTextCalibrations::produceLutMetadata (const HcalLutMetadataRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalLutMetadata> (topo,mInputs ["LutMetadata"]);
+  return get_impl_topo<HcalLutMetadata> (mInputs ["LutMetadata"],topo);
 }
 
 std::unique_ptr<HcalDcsValues>
   HcalTextCalibrations::produceDcsValues(HcalDcsRcd const & rcd) {
-  return produce_impl<HcalDcsValues> (mInputs ["DcsValues"]);
+  return get_impl<HcalDcsValues> (mInputs ["DcsValues"]);
 }
 
 std::unique_ptr<HcalDcsMap> HcalTextCalibrations::produceDcsMap (const HcalDcsMapRcd& rcd) {
-  return produce_impl<HcalDcsMap> (mInputs ["DcsMap"]);
+  return get_impl<HcalDcsMap> (mInputs ["DcsMap"]);
 }
 
 std::unique_ptr<HcalRecoParams> HcalTextCalibrations::produceRecoParams (const HcalRecoParamsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalRecoParams> (topo,mInputs ["RecoParams"]);
+  return get_impl_topo<HcalRecoParams> (mInputs ["RecoParams"],topo);
 }
 
 std::unique_ptr<HcalLongRecoParams> HcalTextCalibrations::produceLongRecoParams (const HcalLongRecoParamsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalLongRecoParams> (topo,mInputs ["LongRecoParams"]);
+  return get_impl_topo<HcalLongRecoParams> (mInputs ["LongRecoParams"],topo);
 }
 
 std::unique_ptr<HcalZDCLowGainFractions> HcalTextCalibrations::produceZDCLowGainFractions (const HcalZDCLowGainFractionsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalZDCLowGainFractions> (topo,mInputs ["ZDCLowGainFractions"]);
+  return get_impl_topo<HcalZDCLowGainFractions> (mInputs ["ZDCLowGainFractions"],topo);
 }
 
 std::unique_ptr<HcalTimingParams> HcalTextCalibrations::produceTimingParams (const HcalTimingParamsRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalTimingParams> (topo,mInputs ["TimingParams"]);
+  return get_impl_topo<HcalTimingParams> (mInputs ["TimingParams"],topo);
 }
 std::unique_ptr<HcalMCParams> HcalTextCalibrations::produceMCParams (const HcalMCParamsRcd& rcd) {  
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalMCParams> (topo,mInputs ["MCParams"]);
+  return get_impl_topo<HcalMCParams> (mInputs ["MCParams"],topo);
 }
 
 std::unique_ptr<HcalFlagHFDigiTimeParams> HcalTextCalibrations::produceFlagHFDigiTimeParams (const HcalFlagHFDigiTimeParamsRcd& rcd) {  
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalFlagHFDigiTimeParams> (topo,mInputs ["FlagHFDigiTimeParams"]);
+  return get_impl_topo<HcalFlagHFDigiTimeParams> (mInputs ["FlagHFDigiTimeParams"],topo);
 }
 
 std::unique_ptr<HcalSiPMParameters> HcalTextCalibrations::produceSiPMParameters (const HcalSiPMParametersRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalSiPMParameters> (topo,mInputs ["SiPMParameters"]);
+  return get_impl_topo<HcalSiPMParameters> (mInputs ["SiPMParameters"],topo);
 }
 
 std::unique_ptr<HcalSiPMCharacteristics> HcalTextCalibrations::produceSiPMCharacteristics (const HcalSiPMCharacteristicsRcd& rcd) {
-  return produce_impl<HcalSiPMCharacteristics> (mInputs ["SiPMCharacteristics"]);
+  return get_impl<HcalSiPMCharacteristics> (mInputs ["SiPMCharacteristics"]);
 }
 
 std::unique_ptr<HcalTPChannelParameters> HcalTextCalibrations::produceTPChannelParameters (const HcalTPChannelParametersRcd& rcd) {
   edm::ESHandle<HcalTopology> htopo;
   rcd.getRecord<HcalRecNumberingRecord>().get(htopo);
   const HcalTopology* topo=&(*htopo);
-  return produce_impl<HcalTPChannelParameters> (topo,mInputs ["TPChannelParameters"]);
+  return get_impl_topo<HcalTPChannelParameters> (mInputs ["TPChannelParameters"],topo);
 }
 
 std::unique_ptr<HcalTPParameters> HcalTextCalibrations::produceTPParameters (const HcalTPParametersRcd& rcd) {
-  return produce_impl<HcalTPParameters> (mInputs ["TPParameters"]);
+  return get_impl<HcalTPParameters> (mInputs ["TPParameters"]);
 }

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -317,7 +317,7 @@ std::unique_ptr<HcalDcsValues>
 }
 
 std::unique_ptr<HcalDcsMap> HcalTextCalibrations::produceDcsMap (const HcalDcsMapRcd& rcd) {
-  return get_impl<HcalDcsMap> (mInputs ["DcsMap"]);
+  return create_impl<HcalDcsMap> (mInputs ["DcsMap"]);
 }
 
 std::unique_ptr<HcalRecoParams> HcalTextCalibrations::produceRecoParams (const HcalRecoParamsRcd& rcd) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
@@ -50,6 +50,36 @@ public:
   ~HcalTextCalibrations ();
 
   void produce () {};
+
+  template<class T>
+  class CheckGetObject {
+    public:
+      CheckGetObject(const HcalTopology* topo) {}
+      std::unique_ptr<T> operator()(std::istream& inStream){
+        auto result = makeResult();
+        if(!HcalDbASCIIIO::getObject(inStream, &*result)) result.reset(nullptr);
+        return result;
+      }
+    protected:
+      virtual std::unique_ptr<T> makeResult(){ return std::make_unique<T>(); }
+  };
+  template<class T>
+  class CheckGetObjectTopo : public CheckGetObject<T> {
+    public:
+      CheckGetObjectTopo(const HcalTopology* topo) : CheckGetObject<T>(topo_), topo_(topo) {}
+    protected:
+      std::unique_ptr<T> makeResult() override { return std::make_unique<T>(topo_); }
+    private:
+      const HcalTopology* topo_;
+  };
+  template<class T>
+  class CheckCreateObject {
+    public:
+      CheckCreateObject(const HcalTopology* topo) {}
+      std::unique_ptr<T> operator()(std::istream& inStream){
+        return HcalDbASCIIIO::createObject<T>(inStream);
+      }
+  };
   
 protected:
   virtual void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
@@ -89,36 +119,6 @@ protected:
   std::unique_ptr<HcalSiPMCharacteristics> produceSiPMCharacteristics (const HcalSiPMCharacteristicsRcd& rcd);
   std::unique_ptr<HcalTPChannelParameters> produceTPChannelParameters (const HcalTPChannelParametersRcd& rcd);
   std::unique_ptr<HcalTPParameters> produceTPParameters (const HcalTPParametersRcd& rcd);
-
-  template<class T>
-  class CheckGetObject {
-    public:
-      CheckGetObject(const HcalTopology* topo) {}
-      std::unique_ptr<T> operator()(std::istream& inStream){
-        auto result = makeResult();
-        if(!HcalDbASCIIIO::getObject(inStream, &*result)) result.reset(nullptr);
-        return result;
-      }
-    protected:
-      virtual std::unique_ptr<T> makeResult(){ return std::make_unique<T>(); }
-  };
-  template<class T>
-  class CheckGetObjectTopo : public CheckGetObject<T> {
-    public:
-      CheckGetObjectTopo(const HcalTopology* topo) : CheckGetObject<T>(topo_), topo_(topo) {}
-    protected:
-      std::unique_ptr<T> makeResult() override { return std::make_unique<T>(topo_); }
-    private:
-      const HcalTopology* topo_;
-  };
-  template<class T>
-  class CheckCreateObject {
-    public:
-      CheckCreateObject(const HcalTopology* topo) {}
-      std::unique_ptr<T> operator()(std::istream& inStream){
-        return HcalDbASCIIIO::createObject<T>(inStream);
-      }
-  };
 
 private:
   std::map <std::string, std::string> mInputs;

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
@@ -8,7 +8,7 @@
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
 #include "CondFormats/HcalObjects/interface/AllObjects.h"
 class ParameterSet;
 
@@ -90,7 +90,38 @@ protected:
   std::unique_ptr<HcalTPChannelParameters> produceTPChannelParameters (const HcalTPChannelParametersRcd& rcd);
   std::unique_ptr<HcalTPParameters> produceTPParameters (const HcalTPParametersRcd& rcd);
 
+  template<class T>
+  class CheckGetObject {
+    public:
+      CheckGetObject(const HcalTopology* topo) {}
+      std::unique_ptr<T> operator()(std::istream& inStream){
+        auto result = makeResult();
+        if(!HcalDbASCIIIO::getObject(inStream, &*result)) result.reset(nullptr);
+        return result;
+      }
+    protected:
+      virtual std::unique_ptr<T> makeResult(){ return std::make_unique<T>(); }
+  };
+  template<class T>
+  class CheckGetObjectTopo : public CheckGetObject<T> {
+    public:
+      CheckGetObjectTopo(const HcalTopology* topo) : CheckGetObject<T>(topo_), topo_(topo) {}
+    protected:
+      std::unique_ptr<T> makeResult() override { return std::make_unique<T>(topo_); }
+    private:
+      const HcalTopology* topo_;
+  };
+  template<class T>
+  class CheckCreateObject {
+    public:
+      CheckCreateObject(const HcalTopology* topo) {}
+      std::unique_ptr<T> operator()(std::istream& inStream){
+        return HcalDbASCIIIO::createObject<T>(inStream);
+      }
+  };
+
 private:
   std::map <std::string, std::string> mInputs;
 };
+
 

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
@@ -66,7 +66,7 @@ public:
   template<class T>
   class CheckGetObjectTopo : public CheckGetObject<T> {
     public:
-      CheckGetObjectTopo(const HcalTopology* topo) : CheckGetObject<T>(topo_), topo_(topo) {}
+      CheckGetObjectTopo(const HcalTopology* topo) : CheckGetObject<T>(topo), topo_(topo) {}
     protected:
       std::unique_ptr<T> makeResult() override { return std::make_unique<T>(topo_); }
     private:

--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -42,11 +42,15 @@ namespace cond {
 
 }
 
+namespace {
+  struct InitHcalElectronicsMap {void operator()(HcalElectronicsMap& e){ e.initialize();}};
+}
+
 REGISTER_PLUGIN(HcalPedestalsRcd,HcalPedestals);
 REGISTER_PLUGIN(HcalPedestalWidthsRcd,HcalPedestalWidths);
 REGISTER_PLUGIN(HcalGainsRcd,HcalGains);
 REGISTER_PLUGIN(HcalGainWidthsRcd,HcalGainWidths);
-REGISTER_PLUGIN(HcalElectronicsMapRcd,HcalElectronicsMap);
+REGISTER_PLUGIN_INIT(HcalElectronicsMapRcd,HcalElectronicsMap,InitHcalElectronicsMap);
 REGISTER_PLUGIN(HcalFrontEndMapRcd,HcalFrontEndMap);
 REGISTER_PLUGIN(HcalChannelQualityRcd,HcalChannelQuality);
 REGISTER_PLUGIN(HcalQIEDataRcd,HcalQIEData);

--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -51,6 +51,9 @@ namespace {
 namespace {
   struct InitHcalFrontEndMap {void operator()(HcalFrontEndMap& e){ e.initialize();}};
 }
+namespace {
+  struct InitHcalSiPMCharacteristics {void operator()(HcalSiPMCharacteristics& e){ e.initialize();}};
+}
 
 REGISTER_PLUGIN(HcalPedestalsRcd,HcalPedestals);
 REGISTER_PLUGIN(HcalPedestalWidthsRcd,HcalPedestalWidths);
@@ -84,7 +87,7 @@ REGISTER_PLUGIN(HcalOOTPileupCorrectionMapCollRcd,OOTPileupCorrectionMapColl);
 REGISTER_PLUGIN(HcalInterpolatedPulseCollRcd,HcalInterpolatedPulseColl);
 REGISTER_PLUGIN(HBHENegativeEFilterRcd,HBHENegativeEFilter);
 REGISTER_PLUGIN(HcalSiPMParametersRcd,HcalSiPMParameters);
-REGISTER_PLUGIN(HcalSiPMCharacteristicsRcd,HcalSiPMCharacteristics);
+REGISTER_PLUGIN_INIT(HcalSiPMCharacteristicsRcd,HcalSiPMCharacteristics,InitHcalSiPMCharacteristics);
 REGISTER_PLUGIN(HcalTPParametersRcd,HcalTPParameters);
 REGISTER_PLUGIN(HcalTPChannelParametersRcd,HcalTPChannelParameters);
 REGISTER_PLUGIN(HFPhase1PMTParamsRcd,HcalItemCollById<HFPhase1PMTData>);

--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -45,6 +45,9 @@ namespace cond {
 namespace {
   struct InitHcalElectronicsMap {void operator()(HcalElectronicsMap& e){ e.initialize();}};
 }
+namespace {
+  struct InitHcalDcsMap {void operator()(HcalDcsMap& e){ e.initialize();}};
+}
 
 REGISTER_PLUGIN(HcalPedestalsRcd,HcalPedestals);
 REGISTER_PLUGIN(HcalPedestalWidthsRcd,HcalPedestalWidths);
@@ -64,8 +67,8 @@ REGISTER_PLUGIN(HcalTimeCorrsRcd,HcalTimeCorrs);
 REGISTER_PLUGIN(HcalL1TriggerObjectsRcd,HcalL1TriggerObjects);
 REGISTER_PLUGIN(HcalValidationCorrsRcd,HcalValidationCorrs);
 REGISTER_PLUGIN(HcalLutMetadataRcd,HcalLutMetadata);
-REGISTER_PLUGIN(HcalDcsRcd, HcalDcsValues);
-REGISTER_PLUGIN(HcalDcsMapRcd,HcalDcsMap);
+REGISTER_PLUGIN(HcalDcsRcd,HcalDcsValues);
+REGISTER_PLUGIN_INIT(HcalDcsMapRcd,HcalDcsMap,InitHcalDcsMap);
 REGISTER_PLUGIN(HcalRecoParamsRcd,HcalRecoParams);
 REGISTER_PLUGIN(HcalLongRecoParamsRcd,HcalLongRecoParams);
 REGISTER_PLUGIN(HcalZDCLowGainFractionsRcd,HcalZDCLowGainFractions);

--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -48,13 +48,16 @@ namespace {
 namespace {
   struct InitHcalDcsMap {void operator()(HcalDcsMap& e){ e.initialize();}};
 }
+namespace {
+  struct InitHcalFrontEndMap {void operator()(HcalFrontEndMap& e){ e.initialize();}};
+}
 
 REGISTER_PLUGIN(HcalPedestalsRcd,HcalPedestals);
 REGISTER_PLUGIN(HcalPedestalWidthsRcd,HcalPedestalWidths);
 REGISTER_PLUGIN(HcalGainsRcd,HcalGains);
 REGISTER_PLUGIN(HcalGainWidthsRcd,HcalGainWidths);
 REGISTER_PLUGIN_INIT(HcalElectronicsMapRcd,HcalElectronicsMap,InitHcalElectronicsMap);
-REGISTER_PLUGIN(HcalFrontEndMapRcd,HcalFrontEndMap);
+REGISTER_PLUGIN_INIT(HcalFrontEndMapRcd,HcalFrontEndMap,InitHcalFrontEndMap);
 REGISTER_PLUGIN(HcalChannelQualityRcd,HcalChannelQuality);
 REGISTER_PLUGIN(HcalQIEDataRcd,HcalQIEData);
 REGISTER_PLUGIN(HcalQIETypesRcd,HcalQIETypes);

--- a/CondFormats/HcalObjects/interface/HcalDcsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalDcsMap.h
@@ -107,32 +107,12 @@ class HcalDcsMap {
 
   void initialize();
 
-  template <class Less>
-  static const Item * findByIdT (unsigned long fId, const std::vector<const HcalDcsMap::Item*>& itemsByIdT){
-    Item target (fId, 0);
-
-    auto item = std::lower_bound (itemsByIdT.begin(), itemsByIdT.end(), &target, Less());
-    if (item == itemsByIdT.end() || (*item)->mId != fId){
-      //    throw cms::Exception ("Conditions not found") << "Unavailable Dcs map for cell " << fId;
-      return 0;
-    }
-    return *item;
-  }
-  static const Item * findById (unsigned long fId, const std::vector<const HcalDcsMap::Item*>& itemsById);
-  static const Item * findByDcsId (unsigned long fDcsId, const std::vector<const HcalDcsMap::Item*>& itemsByDcsId);
+  const Item * findById (unsigned long fId) const;
+  const Item * findByDcsId (unsigned long fDcsId) const;
 
   //sorting
-  template <class Less>
-  static void sortByIdT(const std::vector<Item>& items, std::vector<const Item*>& itemsByIdT){
-    itemsByIdT.clear();
-    itemsByIdT.reserve(items.size());
-    for(const auto& i : items){
-      if (i.mDcsId) itemsByIdT.push_back(&i);
-    }
-    std::sort (itemsByIdT.begin(), itemsByIdT.end(), Less());
-  }
-  static void sortById(const std::vector<Item>& items, std::vector<const Item*>& itemsById);
-  static void sortByDcsId(const std::vector<Item>& items, std::vector<const Item*>& itemsByDcsId);
+  void sortById();
+  void sortByDcsId();
 
  protected:
   // these are inspired by the emap. Not clear if they are needed
@@ -149,21 +129,33 @@ class HcalDcsMap {
 
 namespace HcalDcsMapAddons {
   class LessById {
-  public:
+   public:
     bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
       return a->mId < b->mId;
     }
     bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) {
       return a.mId < b.mId;
     }
+    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+      return a->mId == b->mId;
+    }
+    bool good (const HcalDcsMap::Item& a) {
+      return a.mDcsId;
+    }
   };
   class LessByDcsId {
-  public:
+   public:
     bool operator () (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
       return a->mDcsId < b->mDcsId;
     }
     bool operator () (const HcalDcsMap::Item& a, const HcalDcsMap::Item& b) {
       return a.mDcsId < b.mDcsId;
+    }
+    bool equal (const HcalDcsMap::Item* a, const HcalDcsMap::Item* b) {
+      return a->mDcsId == b->mDcsId;
+    }
+    bool good (const HcalDcsMap::Item& a) {
+      return a.mDcsId;
     }
   };
   class Helper {

--- a/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
@@ -117,8 +117,18 @@ class HcalElectronicsMap {
 };
 
 namespace HcalElectronicsMapAddons {
-  class LessById {public: bool operator () (const HcalElectronicsMap::PrecisionItem* a, const HcalElectronicsMap::PrecisionItem* b) {return a->mId < b->mId;}};
-  class LessByTrigId {public: bool operator () (const HcalElectronicsMap::TriggerItem* a, const HcalElectronicsMap::TriggerItem* b) {return a->mTrigId < b->mTrigId;}};
+  class LessById {
+   public:
+    bool operator () (const HcalElectronicsMap::PrecisionItem* a, const HcalElectronicsMap::PrecisionItem* b) {return a->mId < b->mId;}
+    bool equal (const HcalElectronicsMap::PrecisionItem* a, const HcalElectronicsMap::PrecisionItem* b) {return a->mId == b->mId;}
+    bool good (const HcalElectronicsMap::PrecisionItem& a) {return a.mId;}
+  };
+  class LessByTrigId {
+   public:
+    bool operator () (const HcalElectronicsMap::TriggerItem* a, const HcalElectronicsMap::TriggerItem* b) {return a->mTrigId < b->mTrigId;}
+    bool equal (const HcalElectronicsMap::TriggerItem* a, const HcalElectronicsMap::TriggerItem* b) {return a->mTrigId == b->mTrigId;}
+    bool good (const HcalElectronicsMap::TriggerItem& a) {return a.mTrigId;}
+  };
   class Helper {
    public:
     Helper();

--- a/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
@@ -15,9 +15,6 @@ $Revision: 1.16 $
 #include <vector>
 #include <algorithm>
 #include <boost/cstdint.hpp>
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-#include <atomic>
-#endif
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -28,7 +25,44 @@ $Revision: 1.16 $
 // 
 class HcalElectronicsMap {
  public:
-  HcalElectronicsMap();
+
+  class PrecisionItem { 
+   public:
+    PrecisionItem () {mId = mElId = 0;}
+    PrecisionItem (uint32_t fId, uint32_t fElId) 
+      : mId (fId), mElId (fElId) {}
+    uint32_t mId;
+    uint32_t mElId;
+  
+   COND_SERIALIZABLE;
+  };
+  
+  class TriggerItem { 
+   public:
+    TriggerItem () {mElId = mTrigId = 0;}
+    TriggerItem (uint32_t fTrigId, uint32_t fElId) 
+      : mTrigId (fTrigId), mElId (fElId) { }
+    uint32_t mTrigId;
+    uint32_t mElId;
+  
+   COND_SERIALIZABLE;
+  };
+
+  class Helper {
+   public:
+    Helper();
+    // map channels
+    bool mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId);
+    bool mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId);
+
+    std::vector<PrecisionItem> mPItems;
+    std::vector<TriggerItem> mTItems;
+
+   COND_TRANSIENT;
+  };
+
+  HcalElectronicsMap() {}
+  HcalElectronicsMap(const Helper& helper);
   ~HcalElectronicsMap();
 
   // swap function
@@ -69,34 +103,8 @@ class HcalElectronicsMap {
   std::vector <HcalGenericDetId> allPrecisionId () const;
   std::vector <HcalTrigTowerDetId> allTriggerId () const;
 
-  // map channels
-  bool mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId);
-  bool mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId);
-  // sorting
-  void sortById () const;
-  void sortByTriggerId () const;
-  void sort() {}
+  void initialize();
 
-  class PrecisionItem { 
-  public:
-    PrecisionItem () {mId = mElId = 0;}
-    PrecisionItem (uint32_t fId, uint32_t fElId) 
-      : mId (fId), mElId (fElId) {}
-    uint32_t mId;
-    uint32_t mElId;
-  
-  COND_SERIALIZABLE;
-};
-  class TriggerItem { 
-  public:
-    TriggerItem () {mElId = mTrigId = 0;}
-    TriggerItem (uint32_t fTrigId, uint32_t fElId) 
-      : mTrigId (fTrigId), mElId (fElId) { }
-    uint32_t mTrigId;
-    uint32_t mElId;
-  
-  COND_SERIALIZABLE;
-};
  protected:
   const PrecisionItem* findById (unsigned long fId) const;
   const PrecisionItem* findPByElId (unsigned long fElId) const;
@@ -105,13 +113,13 @@ class HcalElectronicsMap {
   
   std::vector<PrecisionItem> mPItems;
   std::vector<TriggerItem> mTItems;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-  mutable std::atomic<std::vector<const PrecisionItem*>*> mPItemsById COND_TRANSIENT;
-  mutable std::atomic<std::vector<const TriggerItem*>*> mTItemsByTrigId COND_TRANSIENT;
-#else
-  mutable std::vector<const PrecisionItem*>* mPItemsById COND_TRANSIENT;
-  mutable std::vector<const TriggerItem*>* mTItemsByTrigId COND_TRANSIENT;
-#endif
+  std::vector<const PrecisionItem*> mPItemsById COND_TRANSIENT;
+  std::vector<const TriggerItem*> mTItemsByTrigId COND_TRANSIENT;
+
+ private:
+  // sorting
+  void sortById ();
+  void sortByTriggerId ();
 
  COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
+++ b/CondFormats/HcalObjects/interface/HcalElectronicsMap.h
@@ -22,7 +22,12 @@ $Revision: 1.16 $
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalElectronicsId.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
-// 
+
+//forward declaration
+namespace HcalElectronicsMapAddons {
+  class Helper;
+}
+ 
 class HcalElectronicsMap {
  public:
 
@@ -48,21 +53,8 @@ class HcalElectronicsMap {
    COND_SERIALIZABLE;
   };
 
-  class Helper {
-   public:
-    Helper();
-    // map channels
-    bool mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId);
-    bool mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId);
-
-    std::vector<PrecisionItem> mPItems;
-    std::vector<TriggerItem> mTItems;
-
-   COND_TRANSIENT;
-  };
-
   HcalElectronicsMap() {}
-  HcalElectronicsMap(const Helper& helper);
+  HcalElectronicsMap(const HcalElectronicsMapAddons::Helper& helper);
   ~HcalElectronicsMap();
 
   // swap function
@@ -123,5 +115,21 @@ class HcalElectronicsMap {
 
  COND_SERIALIZABLE;
 };
+
+namespace HcalElectronicsMapAddons {
+  class LessById {public: bool operator () (const HcalElectronicsMap::PrecisionItem* a, const HcalElectronicsMap::PrecisionItem* b) {return a->mId < b->mId;}};
+  class LessByTrigId {public: bool operator () (const HcalElectronicsMap::TriggerItem* a, const HcalElectronicsMap::TriggerItem* b) {return a->mTrigId < b->mTrigId;}};
+  class Helper {
+   public:
+    Helper();
+    // map channels
+    bool mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId);
+    bool mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId);
+
+    std::vector<HcalElectronicsMap::PrecisionItem> mPItems;
+    std::vector<HcalElectronicsMap::TriggerItem> mTItems;
+  };
+}
+
 
 #endif

--- a/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
+++ b/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
@@ -65,10 +65,10 @@ public:
   std::vector <int>         allRMs() const;
   std::vector <std::string> allRBXs() const;
 
-  static const PrecisionItem* findById (uint32_t fId, const std::vector<const PrecisionItem*>& mPItemsById);
+  const PrecisionItem* findById (uint32_t fId) const;
 
   // sorting
-  static void sortById (const std::vector<PrecisionItem>& items, std::vector<const PrecisionItem*>& itemsById);
+  void sortById ();
   void initialize();
   
 protected:
@@ -84,6 +84,8 @@ namespace HcalFrontEndMapAddons {
    public: 
     bool operator () (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) {return a->mId < b->mId;}
     bool operator () (const HcalFrontEndMap::PrecisionItem& a, const HcalFrontEndMap::PrecisionItem& b) {return a.mId < b.mId;}
+    bool equal (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) {return a->mId == b->mId;}
+    bool good (const HcalFrontEndMap::PrecisionItem& a) {return a.mId;}
   };
   class Helper {
    public:

--- a/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
+++ b/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
@@ -3,6 +3,7 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include <set>
 #include <vector>
 #include <algorithm>
 #include <boost/cstdint.hpp>
@@ -13,7 +14,12 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalFrontEndId.h"
-// 
+
+//forward declaration
+namespace HcalFrontEndMapAddons {
+  class Helper;
+}
+ 
 class HcalFrontEndMap {
 public:
 
@@ -29,20 +35,8 @@ public:
     COND_SERIALIZABLE;
   };
 
-  class Helper {
-   public:
-    Helper();
-    /// load a new entry
-    bool loadObject(DetId fId, int rm, std::string rbx);
-    
-    std::vector<PrecisionItem> mPItems;
-    std::vector<const PrecisionItem*> mPItemsById;
-    
-   COND_TRANSIENT;
-  };
-
   HcalFrontEndMap() {}
-  HcalFrontEndMap(const Helper& helper);
+  HcalFrontEndMap(const HcalFrontEndMapAddons::Helper& helper);
   ~HcalFrontEndMap();
 
   // swap function
@@ -84,5 +78,21 @@ protected:
 
   COND_SERIALIZABLE;
 };
+
+namespace HcalFrontEndMapAddons {
+  class LessById {
+   public: 
+    bool operator () (const HcalFrontEndMap::PrecisionItem* a, const HcalFrontEndMap::PrecisionItem* b) {return a->mId < b->mId;}
+    bool operator () (const HcalFrontEndMap::PrecisionItem& a, const HcalFrontEndMap::PrecisionItem& b) {return a.mId < b.mId;}
+  };
+  class Helper {
+   public:
+    Helper();
+    /// load a new entry
+    bool loadObject(DetId fId, int rm, std::string rbx);
+    
+    std::set<HcalFrontEndMap::PrecisionItem,LessById> mPItems;
+  };
+}
 
 #endif

--- a/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
+++ b/CondFormats/HcalObjects/interface/HcalFrontEndMap.h
@@ -16,7 +16,33 @@
 // 
 class HcalFrontEndMap {
 public:
-  HcalFrontEndMap();
+
+  class PrecisionItem { 
+   public:
+    PrecisionItem () {mId = mRM = 0; mRBX = "";}
+    PrecisionItem (uint32_t fId, int fRM, std::string fRBX) 
+      : mId (fId), mRM (fRM), mRBX (fRBX) {}
+    uint32_t    mId;
+    int         mRM;
+    std::string mRBX;
+    
+    COND_SERIALIZABLE;
+  };
+
+  class Helper {
+   public:
+    Helper();
+    /// load a new entry
+    bool loadObject(DetId fId, int rm, std::string rbx);
+    
+    std::vector<PrecisionItem> mPItems;
+    std::vector<const PrecisionItem*> mPItemsById;
+    
+   COND_TRANSIENT;
+  };
+
+  HcalFrontEndMap() {}
+  HcalFrontEndMap(const Helper& helper);
   ~HcalFrontEndMap();
 
   // swap function
@@ -29,9 +55,6 @@ public:
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   HcalFrontEndMap(HcalFrontEndMap&& other);
 #endif
-
-  /// load a new entry
-  bool loadObject(DetId fId, int rm, std::string rbx);
 
   /// brief lookup the RM associated with the given logical id
   //return Null item if no such mapping
@@ -48,30 +71,16 @@ public:
   std::vector <int>         allRMs() const;
   std::vector <std::string> allRBXs() const;
 
+  static const PrecisionItem* findById (uint32_t fId, const std::vector<const PrecisionItem*>& mPItemsById);
+
   // sorting
-  void sortById () const;
-  void sort() {}
+  static void sortById (const std::vector<PrecisionItem>& items, std::vector<const PrecisionItem*>& itemsById);
+  void initialize();
   
-  class PrecisionItem { 
-  public:
-    PrecisionItem () {mId = mRM = 0; mRBX = "";}
-    PrecisionItem (uint32_t fId, int fRM, std::string fRBX) 
-      : mId (fId), mRM (fRM), mRBX (fRBX) {}
-    uint32_t    mId;
-    int         mRM;
-    std::string mRBX;
-    
-    COND_SERIALIZABLE;
-  };
 protected:
-  const PrecisionItem* findById (uint32_t fId) const;
   
   std::vector<PrecisionItem> mPItems;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-  mutable std::atomic<std::vector<const PrecisionItem*>*> mPItemsById COND_TRANSIENT;
-#else
-  mutable std::vector<const PrecisionItem*>* mPItemsById COND_TRANSIENT;
-#endif
+  std::vector<const PrecisionItem*> mPItemsById COND_TRANSIENT;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/interface/HcalLogicalMap.h
+++ b/CondFormats/HcalObjects/interface/HcalLogicalMap.h
@@ -30,7 +30,7 @@ class HcalLogicalMap {
     void checkElectronicsHashIds() ;
     void checkIdFunctions();
     void printMap( unsigned int mapIOV );
-    HcalElectronicsMap generateHcalElectronicsMap();
+    std::unique_ptr<HcalElectronicsMap> generateHcalElectronicsMap();
     const DetId getDetId(const HcalElectronicsId&);
     const HcalFrontEndId getHcalFrontEndId(const DetId&);
     uint32_t static makeEntryNumber(bool,int,int);

--- a/CondFormats/HcalObjects/interface/HcalObjectAddons.h
+++ b/CondFormats/HcalObjects/interface/HcalObjectAddons.h
@@ -1,0 +1,33 @@
+#ifndef CondFormats_HcalObjects_HcalObjectAddons
+#define CondFormats_HcalObjects_HcalObjectAddons
+
+#include <vector>
+#include <algorithm>
+
+// functions with common forms
+namespace HcalObjectAddons {
+  template <class Item, class Less>
+  const Item * findByT (const Item* target, const std::vector<const Item*>& itemsByT){
+    Less less;
+    auto item = std::lower_bound (itemsByT.begin(), itemsByT.end(), target, less);
+    if (item == itemsByT.end() || !less.equal(*item,target)){
+      return 0;
+    }
+    return *item;
+  }
+
+  //sorting
+  template <class Item, class Less>
+  static void sortByT(const std::vector<Item>& items, std::vector<const Item*>& itemsByT){
+    itemsByT.clear();
+    itemsByT.reserve(items.size());
+    Less less;
+    for(const auto& i : items){
+      if (less.good(i)) itemsByT.push_back(&i);
+    }
+    std::sort (itemsByT.begin(), itemsByT.end(), less);
+  }
+
+}
+
+#endif

--- a/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
@@ -4,11 +4,17 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <vector>
+#include <set>
 #include <algorithm>
 #include <boost/cstdint.hpp>
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #endif
+
+//forward declarations
+namespace HcalSiPMCharacteristicsAddons {
+  class Helper;
+}
 
 class HcalSiPMCharacteristics {
 
@@ -36,22 +42,8 @@ public:
     COND_SERIALIZABLE;
   };
 
-  class Helper {
-   public:
-    Helper();
-    // Load a new entry
-    bool loadObject(int type, int pixels, float parLin1, 
-				float parLin2, float parLin3, float crossTalk,
-				int auxi1=0,  float auxi2=0);
-    
-    std::vector<PrecisionItem> mPItems;
-    std::vector<const PrecisionItem*> mPItemsByType;
-
-   COND_TRANSIENT;
-  };
-
   HcalSiPMCharacteristics() {}
-  HcalSiPMCharacteristics(const Helper& helper);
+  HcalSiPMCharacteristics(const HcalSiPMCharacteristicsAddons::Helper& helper);
   ~HcalSiPMCharacteristics();
 
   // swap function
@@ -91,5 +83,23 @@ protected:
 
   COND_SERIALIZABLE;
 };
+
+namespace HcalSiPMCharacteristicsAddons {
+  class LessByType {
+   public: 
+    bool operator () (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ < b->type_;}
+    bool operator () (const HcalSiPMCharacteristics::PrecisionItem& a, const HcalSiPMCharacteristics::PrecisionItem& b) {return a.type_ < b.type_;}
+  };
+  class Helper {
+   public:
+    Helper();
+    // Load a new entry
+    bool loadObject(int type, int pixels, float parLin1, 
+				float parLin2, float parLin3, float crossTalk,
+				int auxi1=0,  float auxi2=0);
+    
+    std::set<HcalSiPMCharacteristics::PrecisionItem,LessByType> mPItems;
+  };
+}
 
 #endif

--- a/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
@@ -13,44 +13,9 @@
 class HcalSiPMCharacteristics {
 
 public:
-  HcalSiPMCharacteristics();
-  ~HcalSiPMCharacteristics();
-
-  // swap function
-  void swap(HcalSiPMCharacteristics& other);
-  // copy-ctor
-  HcalSiPMCharacteristics(const HcalSiPMCharacteristics& src);
-  // copy assignment operator
-  HcalSiPMCharacteristics& operator=(const HcalSiPMCharacteristics& rhs);
-  // move constructor
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-  HcalSiPMCharacteristics(HcalSiPMCharacteristics&& other);
-#endif
-
-  // Load a new entry
-  bool               loadObject(int type, int pixels, float parLin1, 
-				float parLin2, float parLin3, float crossTalk,
-				int auxi1=0,  float auxi2=0);
-
-  /// get # of types
-  unsigned int       getTypes()                  const {return mPItems.size();}
-  int                getType(unsigned int k)     const {return mPItems[k].type_;}
-  /// get # of pixels
-  int                getPixels(int type)         const;
-  /// get nonlinearity constants
-  std::vector<float> getNonLinearities(int type) const;
-  /// get cross talk
-  float              getCrossTalk(int type)      const;
-  /// get auxiliary words
-  int                getAuxi1(int type)          const;
-  float              getAuxi2(int type)          const;
-
-  // sorting
-  void sortByType() const;
-  void sort() {}
 
   class PrecisionItem { 
-  public:
+   public:
     PrecisionItem () {type_=auxi1_=pixels_=0;
       parLin1_= parLin2_=parLin3_=crossTalk_=auxi2_=0;
     }
@@ -71,15 +36,58 @@ public:
     COND_SERIALIZABLE;
   };
 
+  class Helper {
+   public:
+    Helper();
+    // Load a new entry
+    bool loadObject(int type, int pixels, float parLin1, 
+				float parLin2, float parLin3, float crossTalk,
+				int auxi1=0,  float auxi2=0);
+    
+    std::vector<PrecisionItem> mPItems;
+    std::vector<const PrecisionItem*> mPItemsByType;
+
+   COND_TRANSIENT;
+  };
+
+  HcalSiPMCharacteristics() {}
+  HcalSiPMCharacteristics(const Helper& helper);
+  ~HcalSiPMCharacteristics();
+
+  // swap function
+  void swap(HcalSiPMCharacteristics& other);
+  // copy-ctor
+  HcalSiPMCharacteristics(const HcalSiPMCharacteristics& src);
+  // copy assignment operator
+  HcalSiPMCharacteristics& operator=(const HcalSiPMCharacteristics& rhs);
+  // move constructor
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+  HcalSiPMCharacteristics(HcalSiPMCharacteristics&& other);
+#endif
+
+  /// get # of types
+  unsigned int       getTypes()                  const {return mPItems.size();}
+  int                getType(unsigned int k)     const {return mPItems[k].type_;}
+  /// get # of pixels
+  int                getPixels(int type)         const;
+  /// get nonlinearity constants
+  std::vector<float> getNonLinearities(int type) const;
+  /// get cross talk
+  float              getCrossTalk(int type)      const;
+  /// get auxiliary words
+  int                getAuxi1(int type)          const;
+  float              getAuxi2(int type)          const;
+
+  static const PrecisionItem* findByType (int type, const std::vector<const PrecisionItem*>& itemsByType);
+
+  // sorting
+  static void sortByType(const std::vector<PrecisionItem>& items, std::vector<const PrecisionItem*>& itemsByType);
+  void initialize();
+
 protected:
-  const PrecisionItem* findByType (int type) const;
   
   std::vector<PrecisionItem> mPItems;
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-  mutable std::atomic<std::vector<const PrecisionItem*>*> mPItemsByType COND_TRANSIENT;
-#else
-  mutable std::vector<const PrecisionItem*>* mPItemsByType COND_TRANSIENT;
-#endif
+  std::vector<const PrecisionItem*> mPItemsByType COND_TRANSIENT;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
+++ b/CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h
@@ -70,10 +70,10 @@ public:
   int                getAuxi1(int type)          const;
   float              getAuxi2(int type)          const;
 
-  static const PrecisionItem* findByType (int type, const std::vector<const PrecisionItem*>& itemsByType);
+  const PrecisionItem* findByType (int type) const;
 
   // sorting
-  static void sortByType(const std::vector<PrecisionItem>& items, std::vector<const PrecisionItem*>& itemsByType);
+  void sortByType();
   void initialize();
 
 protected:
@@ -89,6 +89,8 @@ namespace HcalSiPMCharacteristicsAddons {
    public: 
     bool operator () (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ < b->type_;}
     bool operator () (const HcalSiPMCharacteristics::PrecisionItem& a, const HcalSiPMCharacteristics::PrecisionItem& b) {return a.type_ < b.type_;}
+    bool equal (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ == b->type_;}
+    bool good (const HcalSiPMCharacteristics::PrecisionItem& a) {return a.type_;}
   };
   class Helper {
    public:

--- a/CondFormats/HcalObjects/src/HcalDcsMap.cc
+++ b/CondFormats/HcalObjects/src/HcalDcsMap.cc
@@ -12,6 +12,7 @@ $Revision: 1.1 $
 #include <set>
 
 #include "CondFormats/HcalObjects/interface/HcalDcsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalObjectAddons.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 HcalDcsMap::HcalDcsMap(const HcalDcsMapAddons::Helper& helper) :
@@ -98,12 +99,14 @@ HcalDetId HcalDcsMap::const_iterator::getHcalDetId(void){
   return (*fIter)->mId;
 }
 
-const HcalDcsMap::Item * HcalDcsMap::findById (unsigned long fId, const std::vector<const HcalDcsMap::Item*>& itemsById) {
-  return HcalDcsMap::findByIdT<HcalDcsMapAddons::LessById>(fId,itemsById);
+const HcalDcsMap::Item * HcalDcsMap::findById (unsigned long fId) const {
+  Item target(fId,0);
+  return HcalObjectAddons::findByT<Item,HcalDcsMapAddons::LessById>(&target,mItemsById);
 }
 
-const HcalDcsMap::Item * HcalDcsMap::findByDcsId (unsigned long fId, const std::vector<const HcalDcsMap::Item*>& itemsByDcsId) {
-  return HcalDcsMap::findByIdT<HcalDcsMapAddons::LessByDcsId>(fId,itemsByDcsId);
+const HcalDcsMap::Item * HcalDcsMap::findByDcsId (unsigned long fDcsId) const {
+  Item target(0,fDcsId);
+  return HcalObjectAddons::findByT<Item,HcalDcsMapAddons::LessByDcsId>(&target,mItemsByDcsId);
 }
 
 HcalDetId HcalDcsMap::lookup(HcalDcsDetId fId ) const{
@@ -115,12 +118,12 @@ HcalDetId HcalDcsMap::lookup(HcalDcsDetId fId ) const{
 			     fId.slice(),
 			     HcalDcsDetId::DCSUNKNOWN,
 			     fId.subchannel());
-  auto item = HcalDcsMap::findByDcsId (fDcsId_notype.rawId (), mItemsByDcsId);
+  auto item = HcalDcsMap::findByDcsId (fDcsId_notype.rawId ());
   return item ? item->mId : 0;
 }
 
 HcalDcsDetId HcalDcsMap::lookup(HcalDetId fId, HcalDcsDetId::DcsType type) const {
-  auto item = HcalDcsMap::findById (fId.rawId (), mItemsById);
+  auto item = HcalDcsMap::findById (fId.rawId ());
   HcalDcsDetId _id(item ? item->mId : 0);
   return HcalDcsDetId(_id.subdet(),
 				 _id.zside()*_id.ring(),
@@ -175,14 +178,14 @@ bool HcalDcsMapAddons::Helper::mapGeomId2DcsId (HcalDetId fId, HcalDcsDetId fDcs
   return true;
 }
 
-void HcalDcsMap::sortById(const std::vector<Item>& items, std::vector<const Item*>& itemsById){
-  HcalDcsMap::sortByIdT<HcalDcsMapAddons::LessById>(items,itemsById);
+void HcalDcsMap::sortById(){
+  HcalObjectAddons::sortByT<Item,HcalDcsMapAddons::LessById>(mItems,mItemsById);
 }
-void HcalDcsMap::sortByDcsId(const std::vector<Item>& items, std::vector<const Item*>& itemsByDcsId){
-  HcalDcsMap::sortByIdT<HcalDcsMapAddons::LessByDcsId>(items,itemsByDcsId);
+void HcalDcsMap::sortByDcsId(){
+  HcalObjectAddons::sortByT<Item,HcalDcsMapAddons::LessByDcsId>(mItems,mItemsByDcsId);
 }
 
 void HcalDcsMap::initialize() {
-  HcalDcsMap::sortById(mItems,mItemsById);
-  HcalDcsMap::sortByDcsId(mItems,mItemsByDcsId);
+  sortById();
+  sortByDcsId();
 }

--- a/CondFormats/HcalObjects/src/HcalDcsMap.cc
+++ b/CondFormats/HcalObjects/src/HcalDcsMap.cc
@@ -14,21 +14,18 @@ $Revision: 1.1 $
 #include "CondFormats/HcalObjects/interface/HcalDcsMap.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HcalDcsMap::HcalDcsMap()
-  //FIXME mItems(HcalDcsDetId::maxLinearIndex+1),
-  //: mItems(0x7FFF),
-    : mItemsById(nullptr), mItemsByDcsId(nullptr)
+HcalDcsMap::HcalDcsMap(const HcalDcsMap::Helper& helper) :
+  mItems(helper.mItems)
 {
+  initialize();
 }
 
 HcalDcsMap::~HcalDcsMap(){
-    delete mItemsById.load();
-    delete mItemsByDcsId.load();
 }
 // copy-ctor
 HcalDcsMap::HcalDcsMap(const HcalDcsMap& src)
     : mItems(src.mItems),
-      mItemsById(nullptr), mItemsByDcsId(nullptr) {}
+      mItemsById(src.mItemsById), mItemsByDcsId(src.mItemsByDcsId) {}
 // copy assignment operator
 HcalDcsMap&
 HcalDcsMap::operator=(const HcalDcsMap& rhs) {
@@ -39,12 +36,8 @@ HcalDcsMap::operator=(const HcalDcsMap& rhs) {
 // public swap function
 void HcalDcsMap::swap(HcalDcsMap& other) {
     std::swap(mItems, other.mItems);
-    other.mItemsByDcsId.exchange(
-            mItemsByDcsId.exchange(other.mItemsByDcsId.load(std::memory_order_acquire), std::memory_order_acq_rel),
-            std::memory_order_acq_rel);
-    other.mItemsById.exchange(
-            mItemsById.exchange(other.mItemsById.load(std::memory_order_acquire), std::memory_order_acq_rel),
-            std::memory_order_acq_rel);
+    std::swap(mItemsById, other.mItemsById);
+    std::swap(mItemsByDcsId, other.mItemsByDcsId);
 }
 // move constructor
 HcalDcsMap::HcalDcsMap(HcalDcsMap&& other) 
@@ -72,29 +65,25 @@ namespace hcal_impl {
 
 HcalDcsMap::const_iterator HcalDcsMap::beginById(void) const{
   const_iterator _iter;
-  sortById();
-  _iter.fIter = (*mItemsById.load(std::memory_order_acquire)).begin();
+  _iter.fIter = mItemsById.begin();
   return _iter;
 }
 
 HcalDcsMap::const_iterator HcalDcsMap::beginByDcsId(void) const{
   const_iterator _iter;
-  sortByDcsId();
-  _iter.fIter = (*mItemsByDcsId.load(std::memory_order_acquire)).begin();
+  _iter.fIter = mItemsByDcsId.begin();
   return _iter;
 }
 
 HcalDcsMap::const_iterator HcalDcsMap::endById(void) const{
   const_iterator _iter;
-  sortById();
-  _iter.fIter = (*mItemsById.load(std::memory_order_acquire)).end();
+  _iter.fIter = mItemsById.end();
   return _iter;
 }
 
 HcalDcsMap::const_iterator HcalDcsMap::endByDcsId(void) const{
   const_iterator _iter;
-  sortByDcsId();
-  _iter.fIter = (*mItemsByDcsId.load(std::memory_order_acquire)).end();
+  _iter.fIter = mItemsByDcsId.end();
   return _iter;
 }
 
@@ -116,7 +105,7 @@ HcalDcsMap::const_iterator HcalDcsMap::const_iterator::operator++(int){
 }
 
 void HcalDcsMap::const_iterator::next(void){
-    ++fIter;
+  ++fIter;
 }
 
 HcalDcsDetId HcalDcsMap::const_iterator::getHcalDcsDetId(void){
@@ -127,51 +116,12 @@ HcalDetId HcalDcsMap::const_iterator::getHcalDetId(void){
   return (*fIter)->mId;
 }
 
-
-const std::vector<const HcalDcsMap::Item *> HcalDcsMap::findById (unsigned long fId) const {
-  Item target (fId, 0);
-  std::vector<const HcalDcsMap::Item*>::const_iterator item;
-  std::vector<const HcalDcsMap::Item *> result;
-
-  sortById();
-  
-  hcal_impl::LessById lessById;
-  auto const& ptr = (*mItemsById.load(std::memory_order_acquire));
-  item = std::lower_bound (ptr.begin(), ptr.end(), &target, lessById);
-  if (item == ptr.end() || (*item)->mId != fId){
-    //    throw cms::Exception ("Conditions not found") << "Unavailable Dcs map for cell " << fId;
-    return result;
-  }
-  else{
-    if(item != ptr.end() && !lessById(&target, *item)){
-      result.push_back( *item );
-      ++item;
-    }
-  }
-  return result;
+const std::vector<const HcalDcsMap::Item *> HcalDcsMap::findById (unsigned long fId, const std::vector<const HcalDcsMap::Item*>& itemsById) {
+  return HcalDcsMap::findByIdT<hcal_impl::LessById>(fId,itemsById);
 }
 
-const std::vector<const HcalDcsMap::Item *> HcalDcsMap::findByDcsId (unsigned long fDcsId) const {
-  Item target (0, fDcsId);
-  std::vector<const HcalDcsMap::Item*>::const_iterator item;
-  std::vector<const HcalDcsMap::Item *> result;
-
-  sortByDcsId();
-
-  hcal_impl::LessByDcsId lessByDcsId;  
-  auto const& ptr = (*mItemsByDcsId.load(std::memory_order_acquire));
-  item = std::lower_bound (ptr.begin(), ptr.end(), &target, lessByDcsId);
-  if (item == ptr.end() || (*item)->mDcsId != fDcsId) {
-    //    throw cms::Exception ("Conditions not found") << "Unavailable Dcs map for cell " << fDcsId;
-    return result;
-  }
-  else{
-    if(item != ptr.end() && !lessByDcsId(&target, *item)){
-      result.push_back( *item );
-      ++item;
-    }
-  }
-  return result;
+const std::vector<const HcalDcsMap::Item *> HcalDcsMap::findByDcsId (unsigned long fId, const std::vector<const HcalDcsMap::Item*>& itemsByDcsId) {
+  return HcalDcsMap::findByIdT<hcal_impl::LessByDcsId>(fId,itemsByDcsId);
 }
 
 const std::vector<HcalDetId> HcalDcsMap::lookup(HcalDcsDetId fId ) const{
@@ -183,7 +133,7 @@ const std::vector<HcalDetId> HcalDcsMap::lookup(HcalDcsDetId fId ) const{
 			     fId.slice(),
 			     HcalDcsDetId::DCSUNKNOWN,
 			     fId.subchannel());
-  const std::vector<const Item *> items = findByDcsId (fDcsId_notype.rawId ());
+  const std::vector<const Item *> items = HcalDcsMap::findByDcsId (fDcsId_notype.rawId (), mItemsByDcsId);
   std::vector<HcalDetId> _ids;
   for (std::vector<const Item *>::const_iterator item = items.begin();
        item != items.end();
@@ -194,7 +144,7 @@ const std::vector<HcalDetId> HcalDcsMap::lookup(HcalDcsDetId fId ) const{
 }
 
 const std::vector<HcalDcsDetId> HcalDcsMap::lookup(HcalDetId fId, HcalDcsDetId::DcsType type) const {
-  const std::vector<const Item *> items = findById (fId.rawId ());
+  const std::vector<const Item *> items = HcalDcsMap::findById (fId.rawId (), mItemsById);
   std::vector<HcalDcsDetId> _ids;
   for (std::vector<const Item *>::const_iterator item = items.begin();
        item != items.end();
@@ -231,8 +181,12 @@ std::vector <HcalGenericDetId> HcalDcsMap::allHcalDetId () const {
   return result;
 }
 
+HcalDcsMap::Helper::Helper()
+  //FIXME : mItems(HcalDcsDetId::maxLinearIndex+1)
+{
+}
 
-bool HcalDcsMap::mapGeomId2DcsId (HcalDetId fId, HcalDcsDetId fDcsId) {
+bool HcalDcsMap::Helper::mapGeomId2DcsId (HcalDetId fId, HcalDcsDetId fDcsId) {
   // DCS type is a part of DcsDetId but it does not make sense to keep
   // duplicate records in the map for DCS channels where only type is different.
   // Hence, the type in HcalDcsDetId is always forced to DCSUNKNOWN
@@ -241,7 +195,7 @@ bool HcalDcsMap::mapGeomId2DcsId (HcalDetId fId, HcalDcsDetId fDcsId) {
 			     fDcsId.slice(),
 			     HcalDcsDetId::DCSUNKNOWN,
 			     fDcsId.subchannel());
-  const std::vector<const Item *> items = findByDcsId(fDcsId_notype);
+  const std::vector<const Item *> items = HcalDcsMap::findByDcsId(fDcsId_notype,mItemsByDcsId);
   for (std::vector<const Item *>::const_iterator item = items.begin();
        item != items.end();
        ++item){
@@ -253,44 +207,20 @@ bool HcalDcsMap::mapGeomId2DcsId (HcalDetId fId, HcalDcsDetId fDcsId) {
   }
   Item _item(fId, fDcsId_notype);
   mItems.push_back(_item);
-  delete mItemsById.load();
-  mItemsById = nullptr;
-  delete mItemsByDcsId.load();
-  mItemsByDcsId = nullptr;
+  //re-sort
+  HcalDcsMap::sortByDcsId(mItems,mItemsByDcsId);
+
   return true;
 }
 
-
-void HcalDcsMap::sortById () const {
-  if (!mItemsById.load(std::memory_order_acquire)) {
-      auto ptr = new std::vector<const Item*>;
-      for (auto i=mItems.begin(); i!=mItems.end(); ++i) {
-          if (i->mDcsId) ptr->push_back(&(*i));
-      }
-
-      std::sort (ptr->begin(), ptr->end(), hcal_impl::LessById ());
-      //atomically try to swap this to become mItemsById
-      std::vector<const Item*>* expect = nullptr;
-      bool exchanged = mItemsById.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
-      if(!exchanged) {
-          delete ptr;
-      }
-  }
+void HcalDcsMap::sortById(const std::vector<Item>& items, std::vector<const Item*>& itemsById){
+  HcalDcsMap::sortByIdT<hcal_impl::LessById>(items,itemsById);
+}
+void HcalDcsMap::sortByDcsId(const std::vector<Item>& items, std::vector<const Item*>& itemsByDcsId){
+  HcalDcsMap::sortByIdT<hcal_impl::LessByDcsId>(items,itemsByDcsId);
 }
 
-void HcalDcsMap::sortByDcsId () const {
-  if (!mItemsByDcsId.load(std::memory_order_acquire)) {
-      auto ptr = new std::vector<const Item*>;
-      for (auto i=mItems.begin(); i!=mItems.end(); ++i) {
-          if (i->mDcsId) ptr->push_back(&(*i));
-      }
-    
-      std::sort (ptr->begin(), ptr->end(), hcal_impl::LessByDcsId ());
-      //atomically try to swap this to become mItemsByDcsId
-      std::vector<const Item*>* expect = nullptr;
-      bool exchanged = mItemsByDcsId.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
-      if(!exchanged) {
-          delete ptr;
-      }
-  }
+void HcalDcsMap::initialize() {
+  HcalDcsMap::sortById(mItems,mItemsById);
+  HcalDcsMap::sortByDcsId(mItems,mItemsByDcsId);
 }

--- a/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
+++ b/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
@@ -13,25 +13,22 @@ $Revision: 1.22 $
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HcalElectronicsMap::HcalElectronicsMap() : 
-  mPItems(HcalElectronicsId::maxLinearIndex+1),
-  mTItems(HcalElectronicsId::maxLinearIndex+1),
-  mPItemsById(nullptr), mTItemsByTrigId(nullptr)
-{}
+HcalElectronicsMap::HcalElectronicsMap(const HcalElectronicsMap::Helper& helper) :
+  mPItems(helper.mPItems), mTItems(helper.mTItems)
+{
+  initialize();
+}
 
 namespace hcal_impl {
   class LessById {public: bool operator () (const HcalElectronicsMap::PrecisionItem* a, const HcalElectronicsMap::PrecisionItem* b) {return a->mId < b->mId;}};
   class LessByTrigId {public: bool operator () (const HcalElectronicsMap::TriggerItem* a, const HcalElectronicsMap::TriggerItem* b) {return a->mTrigId < b->mTrigId;}};
 }
 
-HcalElectronicsMap::~HcalElectronicsMap() {
-    delete mPItemsById.load();
-    delete mTItemsByTrigId.load();
-}
+HcalElectronicsMap::~HcalElectronicsMap() {}
 // copy-ctor
 HcalElectronicsMap::HcalElectronicsMap(const HcalElectronicsMap& src)
     : mPItems(src.mPItems), mTItems(src.mTItems),
-      mPItemsById(nullptr), mTItemsByTrigId(nullptr) {}
+      mPItemsById(src.mPItemsById), mTItemsByTrigId(src.mTItemsByTrigId) {}
 // copy assignment operator
 HcalElectronicsMap&
 HcalElectronicsMap::operator=(const HcalElectronicsMap& rhs) {
@@ -43,28 +40,21 @@ HcalElectronicsMap::operator=(const HcalElectronicsMap& rhs) {
 void HcalElectronicsMap::swap(HcalElectronicsMap& other) {
     std::swap(mPItems, other.mPItems);
     std::swap(mTItems, other.mTItems);
-    other.mTItemsByTrigId.exchange(
-            mTItemsByTrigId.exchange(other.mTItemsByTrigId.load(std::memory_order_acquire), std::memory_order_acq_rel),
-            std::memory_order_acq_rel);
-    other.mPItemsById.exchange(
-            mPItemsById.exchange(other.mPItemsById.load(std::memory_order_acquire), std::memory_order_acq_rel),
-            std::memory_order_acq_rel);
+    std::swap(mPItemsById, other.mPItemsById);
+    std::swap(mTItemsByTrigId, other.mTItemsByTrigId);
 }
 // move constructor
 HcalElectronicsMap::HcalElectronicsMap(HcalElectronicsMap&& other) 
-    : HcalElectronicsMap() {
+{
     other.swap(*this);
 }
 
 const HcalElectronicsMap::PrecisionItem* HcalElectronicsMap::findById (unsigned long fId) const {
   PrecisionItem target (fId, 0);
   std::vector<const HcalElectronicsMap::PrecisionItem*>::const_iterator item;
-
-  sortById();
   
-  auto const& ptr = (*mPItemsById.load(std::memory_order_acquire));
-  item = std::lower_bound (ptr.begin(), ptr.end(), &target, hcal_impl::LessById());
-  if (item == ptr.end() || (*item)->mId != fId)
+  item = std::lower_bound (mPItemsById.begin(), mPItemsById.end(), &target, hcal_impl::LessById());
+  if (item == mPItemsById.end() || (*item)->mId != fId)
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
     return 0;
   return *item;
@@ -90,12 +80,9 @@ const HcalElectronicsMap::TriggerItem* HcalElectronicsMap::findTByElId (unsigned
 const HcalElectronicsMap::TriggerItem* HcalElectronicsMap::findByTrigId (unsigned long fTrigId) const {
   TriggerItem target (fTrigId,0);
   std::vector<const HcalElectronicsMap::TriggerItem*>::const_iterator item;
-
-  sortByTriggerId();
   
-  auto const& ptr = (*mTItemsByTrigId.load(std::memory_order_acquire));
-  item = std::lower_bound (ptr.begin(), ptr.end(), &target, hcal_impl::LessByTrigId());
-  if (item == (*mTItemsByTrigId).end() || (*item)->mTrigId != fTrigId)
+  item = std::lower_bound (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), &target, hcal_impl::LessByTrigId());
+  if (item == mTItemsByTrigId.end() || (*item)->mTrigId != fTrigId)
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
     return 0;
   return *item;
@@ -186,74 +173,65 @@ std::vector <HcalTrigTowerDetId> HcalElectronicsMap::allTriggerId () const {
   return result;
 }
 
-bool HcalElectronicsMap::mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId) {
-  TriggerItem& item = mTItems[fElectronicsId.linearIndex()];
+//use helper to do mapping
+HcalElectronicsMap::Helper::Helper() :
+  mPItems(HcalElectronicsId::maxLinearIndex+1),
+  mTItems(HcalElectronicsId::maxLinearIndex+1)
+{}
 
-  if (mTItemsByTrigId) {
-      delete mTItemsByTrigId.load();
-      mTItemsByTrigId = nullptr;
-  }
+bool HcalElectronicsMap::Helper::mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId) {
+  TriggerItem& item = mTItems[fElectronicsId.linearIndex()];
 
   if (item.mElId==0) item.mElId=fElectronicsId.rawId();
   if (item.mTrigId == 0) {
     item.mTrigId = fTriggerId.rawId (); // just cast avoiding long machinery
   } 
   else if (item.mTrigId != fTriggerId.rawId ()) {
-    edm::LogWarning("HCAL") << "HcalElectronicsMap::mapEId2tId-> Electronics channel " <<  fElectronicsId  << " already mapped to trigger channel " 
+    edm::LogWarning("HCAL") << "HcalElectronicsMap::Helper::mapEId2tId-> Electronics channel " <<  fElectronicsId  << " already mapped to trigger channel " 
 	      << (HcalTrigTowerDetId(item.mTrigId)) << ". New value " << fTriggerId << " is ignored" ;
     return false;
   }
   return true;
 }
 
-bool HcalElectronicsMap::mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId) {
+bool HcalElectronicsMap::Helper::mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId) {
   PrecisionItem& item = mPItems[fElectronicsId.linearIndex()];
-
-  delete mPItemsById.load();
-  mPItemsById = nullptr;
 
   if (item.mElId==0) item.mElId=fElectronicsId.rawId();
   if (item.mId == 0) {
     item.mId = fId.rawId ();
   } 
   else if (item.mId != fId.rawId ()) {
-     edm::LogWarning("HCAL") << "HcalElectronicsMap::mapEId2tId-> Electronics channel " <<  fElectronicsId << " already mapped to channel " 
+     edm::LogWarning("HCAL") << "HcalElectronicsMap::Helper::mapEId2tId-> Electronics channel " <<  fElectronicsId << " already mapped to channel " 
 			     << HcalGenericDetId(item.mId) << ". New value " << HcalGenericDetId(fId) << " is ignored" ;
        return false;
   }
   return true;
 }
 
-void HcalElectronicsMap::sortById () const {
-  if (!mPItemsById.load(std::memory_order_acquire)) {
-      auto ptr = new std::vector<const PrecisionItem*>;
-      for (auto i=mPItems.begin(); i!=mPItems.end(); ++i) {
-          if (i->mElId) (*ptr).push_back(&(*i));
-      }
-    
-      std::sort ((*ptr).begin(), (*ptr).end(), hcal_impl::LessById ());
-      //atomically try to swap this to become mPItemsById
-      std::vector<const PrecisionItem*>* expect = nullptr;
-      bool exchanged = mPItemsById.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
-      if(!exchanged) {
-          delete ptr;
-      }
+void HcalElectronicsMap::sortById () {
+  mPItemsById.clear();
+  mPItemsById.reserve(mPItems.size());
+
+  for (auto i=mPItems.begin(); i!=mPItems.end(); ++i) {
+    if (i->mElId) mPItemsById.push_back(&(*i));
   }
+
+  std::sort (mPItemsById.begin(), mPItemsById.end(), hcal_impl::LessById ());
 }
 
-void HcalElectronicsMap::sortByTriggerId () const {
-  if (!mTItemsByTrigId.load(std::memory_order_acquire)) {
-      auto ptr = new std::vector<const TriggerItem*>;
-      for (auto i=mTItems.begin(); i!=mTItems.end(); ++i) {
-          if (i->mElId) (*ptr).push_back(&(*i));
-      }
-    
-      std::sort ((*ptr).begin(), (*ptr).end(), hcal_impl::LessByTrigId ());
-      //atomically try to swap this to become mTItemsByTrigId
-      std::vector<const TriggerItem*>* expect = nullptr;
-      bool exchanged = mTItemsByTrigId.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
-      if(!exchanged) {
-          delete ptr;
-      }
+void HcalElectronicsMap::sortByTriggerId () {
+  mTItemsByTrigId.clear();
+  mTItemsByTrigId.reserve(mTItems.size());
+
+  for (auto i=mTItems.begin(); i!=mTItems.end(); ++i) {
+    if (i->mElId) mTItemsByTrigId.push_back(&(*i));
   }
+
+  std::sort (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), hcal_impl::LessByTrigId ());
+}
+
+void HcalElectronicsMap::initialize() {
+  sortById();
+  sortByTriggerId();
 }

--- a/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
+++ b/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
@@ -13,15 +13,10 @@ $Revision: 1.22 $
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HcalElectronicsMap::HcalElectronicsMap(const HcalElectronicsMap::Helper& helper) :
+HcalElectronicsMap::HcalElectronicsMap(const HcalElectronicsMapAddons::Helper& helper) :
   mPItems(helper.mPItems), mTItems(helper.mTItems)
 {
   initialize();
-}
-
-namespace hcal_impl {
-  class LessById {public: bool operator () (const HcalElectronicsMap::PrecisionItem* a, const HcalElectronicsMap::PrecisionItem* b) {return a->mId < b->mId;}};
-  class LessByTrigId {public: bool operator () (const HcalElectronicsMap::TriggerItem* a, const HcalElectronicsMap::TriggerItem* b) {return a->mTrigId < b->mTrigId;}};
 }
 
 HcalElectronicsMap::~HcalElectronicsMap() {}
@@ -53,7 +48,7 @@ const HcalElectronicsMap::PrecisionItem* HcalElectronicsMap::findById (unsigned 
   PrecisionItem target (fId, 0);
   std::vector<const HcalElectronicsMap::PrecisionItem*>::const_iterator item;
   
-  item = std::lower_bound (mPItemsById.begin(), mPItemsById.end(), &target, hcal_impl::LessById());
+  item = std::lower_bound (mPItemsById.begin(), mPItemsById.end(), &target, HcalElectronicsMapAddons::LessById());
   if (item == mPItemsById.end() || (*item)->mId != fId)
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
     return 0;
@@ -81,7 +76,7 @@ const HcalElectronicsMap::TriggerItem* HcalElectronicsMap::findByTrigId (unsigne
   TriggerItem target (fTrigId,0);
   std::vector<const HcalElectronicsMap::TriggerItem*>::const_iterator item;
   
-  item = std::lower_bound (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), &target, hcal_impl::LessByTrigId());
+  item = std::lower_bound (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), &target, HcalElectronicsMapAddons::LessByTrigId());
   if (item == mTItemsByTrigId.end() || (*item)->mTrigId != fTrigId)
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
     return 0;
@@ -174,13 +169,13 @@ std::vector <HcalTrigTowerDetId> HcalElectronicsMap::allTriggerId () const {
 }
 
 //use helper to do mapping
-HcalElectronicsMap::Helper::Helper() :
+HcalElectronicsMapAddons::Helper::Helper() :
   mPItems(HcalElectronicsId::maxLinearIndex+1),
   mTItems(HcalElectronicsId::maxLinearIndex+1)
 {}
 
-bool HcalElectronicsMap::Helper::mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId) {
-  TriggerItem& item = mTItems[fElectronicsId.linearIndex()];
+bool HcalElectronicsMapAddons::Helper::mapEId2tId (HcalElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId) {
+  HcalElectronicsMap::TriggerItem& item = mTItems[fElectronicsId.linearIndex()];
 
   if (item.mElId==0) item.mElId=fElectronicsId.rawId();
   if (item.mTrigId == 0) {
@@ -194,8 +189,8 @@ bool HcalElectronicsMap::Helper::mapEId2tId (HcalElectronicsId fElectronicsId, H
   return true;
 }
 
-bool HcalElectronicsMap::Helper::mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId) {
-  PrecisionItem& item = mPItems[fElectronicsId.linearIndex()];
+bool HcalElectronicsMapAddons::Helper::mapEId2chId (HcalElectronicsId fElectronicsId, DetId fId) {
+  HcalElectronicsMap::PrecisionItem& item = mPItems[fElectronicsId.linearIndex()];
 
   if (item.mElId==0) item.mElId=fElectronicsId.rawId();
   if (item.mId == 0) {
@@ -217,7 +212,7 @@ void HcalElectronicsMap::sortById () {
     if (i->mElId) mPItemsById.push_back(&(*i));
   }
 
-  std::sort (mPItemsById.begin(), mPItemsById.end(), hcal_impl::LessById ());
+  std::sort (mPItemsById.begin(), mPItemsById.end(), HcalElectronicsMapAddons::LessById ());
 }
 
 void HcalElectronicsMap::sortByTriggerId () {
@@ -228,7 +223,7 @@ void HcalElectronicsMap::sortByTriggerId () {
     if (i->mElId) mTItemsByTrigId.push_back(&(*i));
   }
 
-  std::sort (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), hcal_impl::LessByTrigId ());
+  std::sort (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), HcalElectronicsMapAddons::LessByTrigId ());
 }
 
 void HcalElectronicsMap::initialize() {

--- a/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
+++ b/CondFormats/HcalObjects/src/HcalElectronicsMap.cc
@@ -11,6 +11,7 @@ $Revision: 1.22 $
 #include <set>
 
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalObjectAddons.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 HcalElectronicsMap::HcalElectronicsMap(const HcalElectronicsMapAddons::Helper& helper) :
@@ -46,13 +47,7 @@ HcalElectronicsMap::HcalElectronicsMap(HcalElectronicsMap&& other)
 
 const HcalElectronicsMap::PrecisionItem* HcalElectronicsMap::findById (unsigned long fId) const {
   PrecisionItem target (fId, 0);
-  std::vector<const HcalElectronicsMap::PrecisionItem*>::const_iterator item;
-  
-  item = std::lower_bound (mPItemsById.begin(), mPItemsById.end(), &target, HcalElectronicsMapAddons::LessById());
-  if (item == mPItemsById.end() || (*item)->mId != fId)
-    //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
-    return 0;
-  return *item;
+  return HcalObjectAddons::findByT<PrecisionItem,HcalElectronicsMapAddons::LessById>(&target,mPItemsById);
 }
 
 const HcalElectronicsMap::PrecisionItem* HcalElectronicsMap::findPByElId (unsigned long fElId) const {
@@ -74,13 +69,7 @@ const HcalElectronicsMap::TriggerItem* HcalElectronicsMap::findTByElId (unsigned
 
 const HcalElectronicsMap::TriggerItem* HcalElectronicsMap::findByTrigId (unsigned long fTrigId) const {
   TriggerItem target (fTrigId,0);
-  std::vector<const HcalElectronicsMap::TriggerItem*>::const_iterator item;
-  
-  item = std::lower_bound (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), &target, HcalElectronicsMapAddons::LessByTrigId());
-  if (item == mTItemsByTrigId.end() || (*item)->mTrigId != fTrigId)
-    //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
-    return 0;
-  return *item;
+  return HcalObjectAddons::findByT<TriggerItem,HcalElectronicsMapAddons::LessByTrigId>(&target,mTItemsByTrigId);
 }
 
 const DetId HcalElectronicsMap::lookup(HcalElectronicsId fId ) const {
@@ -205,25 +194,11 @@ bool HcalElectronicsMapAddons::Helper::mapEId2chId (HcalElectronicsId fElectroni
 }
 
 void HcalElectronicsMap::sortById () {
-  mPItemsById.clear();
-  mPItemsById.reserve(mPItems.size());
-
-  for (auto i=mPItems.begin(); i!=mPItems.end(); ++i) {
-    if (i->mElId) mPItemsById.push_back(&(*i));
-  }
-
-  std::sort (mPItemsById.begin(), mPItemsById.end(), HcalElectronicsMapAddons::LessById ());
+  HcalObjectAddons::sortByT<PrecisionItem,HcalElectronicsMapAddons::LessById>(mPItems,mPItemsById);
 }
 
 void HcalElectronicsMap::sortByTriggerId () {
-  mTItemsByTrigId.clear();
-  mTItemsByTrigId.reserve(mTItems.size());
-
-  for (auto i=mTItems.begin(); i!=mTItems.end(); ++i) {
-    if (i->mElId) mTItemsByTrigId.push_back(&(*i));
-  }
-
-  std::sort (mTItemsByTrigId.begin(), mTItemsByTrigId.end(), HcalElectronicsMapAddons::LessByTrigId ());
+  HcalObjectAddons::sortByT<TriggerItem,HcalElectronicsMapAddons::LessByTrigId>(mTItems,mTItemsByTrigId);
 }
 
 void HcalElectronicsMap::initialize() {

--- a/CondFormats/HcalObjects/src/HcalLogicalMap.cc
+++ b/CondFormats/HcalObjects/src/HcalLogicalMap.cc
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <stdio.h>
 #include <time.h>
+#include <memory>
 
 using namespace std;
 
@@ -153,22 +154,21 @@ void HcalLogicalMap::printMap( unsigned int mapIOV ){
 }
 
 /**************/
-HcalElectronicsMap HcalLogicalMap::generateHcalElectronicsMap()
+std::unique_ptr<HcalElectronicsMap> HcalLogicalMap::generateHcalElectronicsMap()
 {
-  HcalElectronicsMap* theemap = new HcalElectronicsMap();
+  HcalElectronicsMap::Helper theemapHelper;
   
   for (std::vector<HBHEHFLogicalMapEntry>::iterator it = HBHEHFEntries_.begin(); it!=HBHEHFEntries_.end(); ++it) {
-    theemap->mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
+    theemapHelper.mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
   for (std::vector<HOHXLogicalMapEntry>::iterator it = HOHXEntries_.begin(); it!=HOHXEntries_.end(); ++it) {
-    theemap->mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
+    theemapHelper.mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
   for (std::vector<CALIBLogicalMapEntry>::iterator it = CALIBEntries_.begin(); it!=CALIBEntries_.end(); ++it) {
-    theemap->mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
+    theemapHelper.mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
   for (std::vector<ZDCLogicalMapEntry>::iterator it = ZDCEntries_.begin(); it!=ZDCEntries_.end(); ++it) {
-    theemap->mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
+    theemapHelper.mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}
   for (std::vector<HTLogicalMapEntry>::iterator it = HTEntries_.begin(); it!=HTEntries_.end(); ++it) {
-    theemap->mapEId2tId( it->getHcalTrigElectronicsId(), it->getDetId() );}
-  theemap->sort();
-  return *theemap;
+    theemapHelper.mapEId2tId( it->getHcalTrigElectronicsId(), it->getDetId() );}
+  return std::make_unique<HcalElectronicsMap>(theemapHelper);
 }
 /**************/
 

--- a/CondFormats/HcalObjects/src/HcalLogicalMap.cc
+++ b/CondFormats/HcalObjects/src/HcalLogicalMap.cc
@@ -156,7 +156,7 @@ void HcalLogicalMap::printMap( unsigned int mapIOV ){
 /**************/
 std::unique_ptr<HcalElectronicsMap> HcalLogicalMap::generateHcalElectronicsMap()
 {
-  HcalElectronicsMap::Helper theemapHelper;
+  HcalElectronicsMapAddons::Helper theemapHelper;
   
   for (std::vector<HBHEHFLogicalMapEntry>::iterator it = HBHEHFEntries_.begin(); it!=HBHEHFEntries_.end(); ++it) {
     theemapHelper.mapEId2chId( it->getHcalElectronicsId(), it->getDetId() );}

--- a/CondFormats/HcalObjects/src/HcalSiPMCharacteristics.cc
+++ b/CondFormats/HcalObjects/src/HcalSiPMCharacteristics.cc
@@ -5,19 +5,22 @@
 #include "CondFormats/HcalObjects/interface/HcalSiPMCharacteristics.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HcalSiPMCharacteristics::HcalSiPMCharacteristics() : mPItemsByType(nullptr) {}
-
 namespace hcal_impl {
   class LessByType {public: bool operator () (const HcalSiPMCharacteristics::PrecisionItem* a, const HcalSiPMCharacteristics::PrecisionItem* b) {return a->type_ < b->type_;}};
 }
 
+HcalSiPMCharacteristics::HcalSiPMCharacteristics(const HcalSiPMCharacteristics::Helper& helper) :
+  mPItems(helper.mPItems)
+{
+  initialize();
+}
+
 HcalSiPMCharacteristics::~HcalSiPMCharacteristics() {
-  delete mPItemsByType.load();
 }
 
 // copy-ctor
 HcalSiPMCharacteristics::HcalSiPMCharacteristics(const HcalSiPMCharacteristics& src)
-  : mPItems(src.mPItems), mPItemsByType(nullptr) {}
+  : mPItems(src.mPItems), mPItemsByType(src.mPItemsByType) {}
 
 // copy assignment operator
 HcalSiPMCharacteristics& HcalSiPMCharacteristics::operator=(const HcalSiPMCharacteristics& rhs) {
@@ -29,9 +32,7 @@ HcalSiPMCharacteristics& HcalSiPMCharacteristics::operator=(const HcalSiPMCharac
 // public swap function
 void HcalSiPMCharacteristics::swap(HcalSiPMCharacteristics& other) {
   std::swap(mPItems, other.mPItems);
-  other.mPItemsByType.exchange(mPItemsByType.exchange(other.mPItemsByType.load(std::memory_order_acquire), 
-						      std::memory_order_acq_rel),
-			       std::memory_order_acq_rel);
+  std::swap(mPItemsByType, other.mPItemsByType);
 }
 
 // move constructor
@@ -39,24 +40,23 @@ HcalSiPMCharacteristics::HcalSiPMCharacteristics(HcalSiPMCharacteristics&& other
   other.swap(*this);
 }
 
-const HcalSiPMCharacteristics::PrecisionItem* HcalSiPMCharacteristics::findByType (int type) const {
+const HcalSiPMCharacteristics::PrecisionItem* HcalSiPMCharacteristics::findByType (int type, const std::vector<const PrecisionItem*>& itemsByType) {
   HcalSiPMCharacteristics::PrecisionItem target(type, 0, 0, 0, 0, 0, 0, 0);
-  std::vector<const HcalSiPMCharacteristics::PrecisionItem*>::const_iterator item;
 
-  sortByType();
-  auto const& ptr = (*mPItemsByType.load(std::memory_order_acquire));
-  item = std::lower_bound (ptr.begin(), ptr.end(), &target, hcal_impl::LessByType());
-  if (item == ptr.end() || (*item)->type_ != type)
+  auto item = std::lower_bound (itemsByType.begin(), itemsByType.end(), &target, hcal_impl::LessByType());
+  if (item == itemsByType.end() || (*item)->type_ != type)
     //    throw cms::Exception ("Conditions not found") << "Unavailable SiPMCharacteristics for type " << type;
     return 0;
   return *item;
 }
 
-bool HcalSiPMCharacteristics::loadObject(int type, int pixels, float parLin1, 
+HcalSiPMCharacteristics::Helper::Helper() {}
+
+bool HcalSiPMCharacteristics::Helper::loadObject(int type, int pixels, float parLin1, 
 					 float parLin2, float parLin3, 
 					 float crossTalk, int auxi1,
 					 float auxi2) {
-  const HcalSiPMCharacteristics::PrecisionItem* item = findByType(type);
+  const HcalSiPMCharacteristics::PrecisionItem* item = HcalSiPMCharacteristics::findByType(type,mPItemsByType);
   if (item) {
     edm::LogWarning("HCAL") << "HcalSiPMCharacteristics::loadObject type " 
 			    << type << " already exists with pixels "
@@ -73,21 +73,18 @@ bool HcalSiPMCharacteristics::loadObject(int type, int pixels, float parLin1,
 						  parLin2,parLin3,crossTalk,
 						  auxi1,auxi2);
     mPItems.push_back(target);
-    if (mPItemsByType) {
-      delete mPItemsByType.load();
-      mPItemsByType = nullptr;
-    }
+    HcalSiPMCharacteristics::sortByType(mPItems,mPItemsByType);
     return true;
   }
 }
 
 int HcalSiPMCharacteristics::getPixels(int type ) const {
-  const HcalSiPMCharacteristics::PrecisionItem* item = findByType(type);
+  const HcalSiPMCharacteristics::PrecisionItem* item = HcalSiPMCharacteristics::findByType(type,mPItemsByType);
   return (item ? item->pixels_ : 0);
 }
 
 std::vector<float> HcalSiPMCharacteristics::getNonLinearities(int type) const {
-  const HcalSiPMCharacteristics::PrecisionItem* item = findByType(type);
+  const HcalSiPMCharacteristics::PrecisionItem* item = HcalSiPMCharacteristics::findByType(type,mPItemsByType);
   std::vector<float> pars;
   if (item) {
     pars.push_back(item->parLin1_);
@@ -98,33 +95,29 @@ std::vector<float> HcalSiPMCharacteristics::getNonLinearities(int type) const {
 }
 
 float HcalSiPMCharacteristics::getCrossTalk(int type) const {
-  const PrecisionItem* item = findByType(type);
+  const PrecisionItem* item = HcalSiPMCharacteristics::findByType(type,mPItemsByType);
   return (item ? item->crossTalk_ : 0);
 }
 
 int HcalSiPMCharacteristics::getAuxi1(int type) const {
-  const HcalSiPMCharacteristics::PrecisionItem* item = findByType(type);
+  const HcalSiPMCharacteristics::PrecisionItem* item = HcalSiPMCharacteristics::findByType(type,mPItemsByType);
   return (item ? item->auxi1_ : 0);
 }
 
 float HcalSiPMCharacteristics::getAuxi2(int type) const {
-  const HcalSiPMCharacteristics::PrecisionItem* item = findByType(type);
+  const HcalSiPMCharacteristics::PrecisionItem* item = HcalSiPMCharacteristics::findByType(type,mPItemsByType);
   return (item ? item->auxi2_ : 0);
 }
 
-void HcalSiPMCharacteristics::sortByType () const {
-  if (!mPItemsByType.load(std::memory_order_acquire)) {
-    auto ptr = new std::vector<const PrecisionItem*>;
-    for (auto i=mPItems.begin(); i!=mPItems.end(); ++i) {
-      if (i->type_) (*ptr).push_back(&(*i));
-    }
-    
-    std::sort ((*ptr).begin(), (*ptr).end(), hcal_impl::LessByType());
-    //atomically try to swap this to become mPItemsByType
-    std::vector<const PrecisionItem*>* expect = nullptr;
-    bool exchanged = mPItemsByType.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
-    if(!exchanged) {
-      delete ptr;
-    }
+void HcalSiPMCharacteristics::sortByType (const std::vector<PrecisionItem>& items, std::vector<const PrecisionItem*>& itemsByType) {
+  itemsByType.clear();
+  itemsByType.reserve(items.size());
+  for(const auto& i : items){
+    if (i.type_) itemsByType.push_back(&i);
   }
+  std::sort (itemsByType.begin(), itemsByType.end(), hcal_impl::LessByType());
+}
+
+void HcalSiPMCharacteristics::initialize(){
+  HcalSiPMCharacteristics::sortByType(mPItems,mPItemsByType);
 }

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -10,7 +10,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include "EventFilter/CastorRawToDigi/interface/CastorRawCollections.h"
-#include "CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"


### PR DESCRIPTION
Several HCAL DB objects (`HcalElectronicsMap`, `HcalDcsMap`, `HcalFrontEndMap`, `HcalSiPMCharacteristics`) follow a common pattern: a serialized vector of items along with one or more transient vectors of the same items sorted in a different order. Because these objects were allowed to be constructed piecemeal (one item inserted at a time), it was necessary to declare the transient members as mutables (with the associated locking, etc.) in case the object was modified while being accessed by multiple threads and the transient members needed to be re-sorted. However, in practice this sort of modification would only occur when the objects were being constructed (usually for insertion into the conditions database), never during subsequent accesses by consumers.

To make the code simpler and easier to understand/maintain, I reorganized these four objects so they must be constructed in one shot. Each class has an associated `Helper` which collects all the inserted items. When the class is constructed, it automatically fills and sorts the transient members. If the class is initialized from the conditions database, the `REGISTER_PLUGIN_INIT` macro is used to ensure the transient members are properly instantiated. The requirement of one-shot construction led to a new function in `HcalDbASCIIIO` called `createObject()` which returns a `unique_ptr` (instead of `getObject()` which acts on the contents of a `unique_ptr` created elsewhere).

I also noticed some duplicate functionality (`sortById()` and `findById()` functions), which I simplified into common template functions in a new `HcalObjectAddons` namespace.

This PR should not change any physics results - code refactoring/improvement only.

attn: @abdoulline, @bsunanda, @Dr15Jones 