### PR TITLE
Have cmsRun return the proper value when an exception is raised

### DIFF
--- a/DataFormats/Common/src/HandleBase.cc
+++ b/DataFormats/Common/src/HandleBase.cc
@@ -6,7 +6,7 @@ namespace edm {
   void const*
   HandleBase::productStorage() const {
     if (whyFailedFactory_) {
-      throw *whyFailedFactory_->make();
+      whyFailedFactory_->make()->raise();
     }
     return product_;
   }
@@ -14,7 +14,7 @@ namespace edm {
   ProductID
   HandleBase::id() const {
     if (whyFailedFactory_) {
-      throw *whyFailedFactory_->make();
+      whyFailedFactory_->make()->raise();
     }
     return prov_->productID();
   }

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -99,7 +99,8 @@ namespace edm {
               e.addAdditionalInfo(ost.str());
             }
 	  }
-          throw e;
+          //throw will copy which will slice the object
+          e.raise();
       }
     }
 
@@ -228,7 +229,7 @@ namespace edm {
       try {
         std::rethrow_exception(*iException);
       } catch(cms::Exception& oldEx) {
-        pEx = std::make_unique<cms::Exception>(oldEx);
+        pEx = std::unique_ptr<cms::Exception>(oldEx.clone());
       }
       try {
         std::ostringstream ost;

--- a/FWCore/Framework/test/run_unscheduled.sh
+++ b/FWCore/Framework/test/run_unscheduled.sh
@@ -14,7 +14,8 @@ F5=${LOCAL_TEST_DIR}/test_onPath_wrongOrder_unscheduled_fail_cfg.py
 (cmsRun $F1 ) > test_deepCall_unscheduled.log || die "Failure using $F1" $?
 diff ${LOCAL_TEST_DIR}/unit_test_outputs/test_deepCall_unscheduled.log test_deepCall_unscheduled.log || die "comparing test_deepCall_unscheduled.log" $?
 
-!(cmsRun $F2 ) || die "Failure using $F2" $?
+!(cmsRun -j test_deepCall_fail_fjr.xml $F2 ) || die "Failure using $F2" $?
+(grep '<FrameworkError ExitStatus="8006" Type="Fatal Exception" >' test_deepCall_fail_fjr.xml) || die "Failed to return proper exit code $F2" $?
 (cmsRun $F3 ) || die "Failure using $F3" $?
 
 (cmsRun $F4 )  > test_onPath_unscheduled.log || die "Failure using $F4" $?

--- a/FWCore/Utilities/src/ExceptionCollector.cc
+++ b/FWCore/Utilities/src/ExceptionCollector.cc
@@ -6,6 +6,25 @@
 
 namespace edm {
 
+  class MultipleException : public cms::Exception {
+  public:
+    MultipleException(int iReturnValue,
+                      std::string const& iMessage):
+    cms::Exception("MultipleExceptions", iMessage),
+    returnValue_(iReturnValue) {}
+    
+    virtual Exception* clone() const override {
+      return new MultipleException(*this);
+    }
+
+  private:
+    int returnCode_() const override {
+      return returnValue_;
+    }
+
+    int returnValue_;
+  };
+  
   ExceptionCollector::ExceptionCollector(std::string const& initialMessage) :
     initialMessage_(initialMessage),
     firstException_(),
@@ -42,7 +61,7 @@ namespace edm {
       ++nExceptions_;
       if (nExceptions_ == 1) {
         firstException_.reset(ex.clone());
-        accumulatedExceptions_.reset(new cms::Exception("MultipleExceptions", initialMessage_));
+        accumulatedExceptions_.reset(new MultipleException(ex.returnCode(), initialMessage_));
       }
       *accumulatedExceptions_ << nExceptions_ << "\n"
                               << ex.explainSelf();
@@ -54,7 +73,7 @@ namespace edm {
     ++nExceptions_;
     if (nExceptions_ == 1) {
       firstException_.reset(exception.clone());
-      accumulatedExceptions_.reset(new cms::Exception("MultipleExceptions", initialMessage_));
+      accumulatedExceptions_.reset(new MultipleException(exception.returnCode(), initialMessage_));
     }
     *accumulatedExceptions_ << "----- Exception " << nExceptions_ << " -----"
                             << "\n"


### PR DESCRIPTION
cmsRun was sometimes not returning the proper exit code when an exception was thrown. This pull request fixes the cases seen.