### PR TITLE
Add rhoCorr and energy-binned cuts

### DIFF
--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
@@ -35,29 +35,39 @@ class HLTEgammaGenericQuadraticEtaFilter : public HLTFilter {
       edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> varToken_;
       bool lessThan_;           // the cut is "<" or ">" ?
       bool useEt_;              // use E or Et in relative isolation cuts
-/*  Barrel quadratic threshold function:
+      /*  Barrel quadratic threshold function:
       vali (<= or >=) thrRegularEB_ + (E or Et)*thrOverEEB_ + (E or Et)*(E or Et)*thrOverE2EB_
     Endcap quadratic threshold function:
       vali (<= or >=) thrRegularEE_ + (E or Et)*thrOverEEE_ + (E or Et)*(E or Et)*thrOverE2EE_
-*/
+      */
+
+      std::vector<double> energyLowEdges_; // lower bin edges for energy-dependent cuts
       double etaBoundaryEB12_;     //eta Boundary between Regions 1 and 2 - ECAL barrel
       double etaBoundaryEE12_;     //eta Boundary between Regions 1 and 2 - ECAL endcap
-      double thrRegularEB1_;     // threshold value for zeroth order term - ECAL barrel region 1
-      double thrRegularEE1_;     // threshold value for zeroth order term - ECAL endcap region 1
-      double thrOverEEB1_;       // coefficient for first order term - ECAL barrel region 1
-      double thrOverEEE1_;       // coefficient for first order term - ECAL endcap region 1
-      double thrOverE2EB1_;      // coefficient for second order term - ECAL barrel region 1
-      double thrOverE2EE1_;      // coefficient for second order term - ECAL endcap region 1
-      double thrRegularEB2_;     // threshold value for zeroth order term - ECAL barrel region 2
-      double thrRegularEE2_;     // threshold value for zeroth order term - ECAL endcap region 2
-      double thrOverEEB2_;       // coefficient for first order term - ECAL barrel region 2
-      double thrOverEEE2_;       // coefficient for first order term - ECAL endcap region 2
-      double thrOverE2EB2_;      // coefficient for second order term - ECAL barrel region 2
-      double thrOverE2EE2_;      // coefficient for second order term - ECAL endcap region 2
+      std::vector<double> thrRegularEB1_;     // threshold value for zeroth order term - ECAL barrel region 1
+      std::vector<double> thrRegularEE1_;     // threshold value for zeroth order term - ECAL endcap region 1
+      std::vector<double> thrOverEEB1_;       // coefficient for first order term - ECAL barrel region 1
+      std::vector<double> thrOverEEE1_;       // coefficient for first order term - ECAL endcap region 1
+      std::vector<double> thrOverE2EB1_;      // coefficient for second order term - ECAL barrel region 1
+      std::vector<double> thrOverE2EE1_;      // coefficient for second order term - ECAL endcap region 1
+      std::vector<double> thrRegularEB2_;     // threshold value for zeroth order term - ECAL barrel region 2
+      std::vector<double> thrRegularEE2_;     // threshold value for zeroth order term - ECAL endcap region 2
+      std::vector<double> thrOverEEB2_;       // coefficient for first order term - ECAL barrel region 2
+      std::vector<double> thrOverEEE2_;       // coefficient for first order term - ECAL endcap region 2
+      std::vector<double> thrOverE2EB2_;      // coefficient for second order term - ECAL barrel region 2
+      std::vector<double> thrOverE2EE2_;      // coefficient for second order term - ECAL endcap region 2
       int    ncandcut_;        // number of candidates required
 
       bool   store_;
       edm::InputTag l1EGTag_;
+
+      edm::InputTag rhoTag_; // input tag identifying rho producer
+      edm::EDGetTokenT<double> rhoToken_;
+      bool doRhoCorrection_;
+      double rhoMax_;
+      double rhoScale_;
+      std::vector<double> effectiveAreas_;
+      std::vector<double> absEtaLowEdges_;
 };
 
 #endif //HLTEgammaGenericQuadraticEtaFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
@@ -36,20 +36,29 @@ class HLTEgammaGenericQuadraticFilter : public HLTFilter {
 
       bool lessThan_;           // the cut is "<" or ">" ?
       bool useEt_;              // use E or Et in relative isolation cuts
-/*  Barrel quadratic threshold function:
+      /*  Barrel quadratic threshold function:
       vali (<= or >=) thrRegularEB_ + (E or Et)*thrOverEEB_ + (E or Et)*(E or Et)*thrOverE2EB_
     Endcap quadratic threshold function:
       vali (<= or >=) thrRegularEE_ + (E or Et)*thrOverEEE_ + (E or Et)*(E or Et)*thrOverE2EE_
-*/
-      double thrRegularEB_;     // threshold value for zeroth order term - ECAL barrel
-      double thrRegularEE_;     // threshold value for zeroth order term - ECAL endcap
-      double thrOverEEB_;       // coefficient for first order term - ECAL barrel
-      double thrOverEEE_;       // coefficient for first order term - ECAL endcap
-      double thrOverE2EB_;      // coefficient for second order term - ECAL barrel
-      double thrOverE2EE_;      // coefficient for second order term - ECAL endcap
+      */
+      std::vector<double> energyLowEdges_;   // lower bin edges for energy-dependent cuts
+      std::vector<double> thrRegularEB_;     // threshold value for zeroth order term - ECAL barrel
+      std::vector<double> thrRegularEE_;     // threshold value for zeroth order term - ECAL endcap
+      std::vector<double> thrOverEEB_;       // coefficient for first order term - ECAL barrel
+      std::vector<double> thrOverEEE_;       // coefficient for first order term - ECAL endcap
+      std::vector<double> thrOverE2EB_;      // coefficient for second order term - ECAL barrel
+      std::vector<double> thrOverE2EE_;      // coefficient for second order term - ECAL endcap
       int    ncandcut_;        // number of candidates required
 
       edm::InputTag l1EGTag_;
+
+      edm::InputTag rhoTag_; // input tag identifying rho producer
+      edm::EDGetTokenT<double> rhoToken_;
+      bool doRhoCorrection_;
+      double rhoMax_;
+      double rhoScale_;
+      std::vector<double> effectiveAreas_;
+      std::vector<double> absEtaLowEdges_;
 };
 
 #endif //HLTEgammaGenericQuadraticFilter_h

--- a/HLTrigger/Egamma/interface/HLTGenericFilter.h
+++ b/HLTrigger/Egamma/interface/HLTGenericFilter.h
@@ -53,17 +53,27 @@ private:
     edm::InputTag varTag_; // input tag identifying product that contains variable map
     edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
     edm::EDGetTokenT<T1IsolationMap> varToken_;
-    bool lessThan_;           // the cut is "<" or ">" ?
-    bool useEt_;              // use E or Et in relative isolation cuts
-    double thrRegularEB_;     // threshold for regular cut (x < thr) - ECAL barrel
-    double thrRegularEE_;     // threshold for regular cut (x < thr) - ECAL endcap
-    double thrOverEEB_;       // threshold for x/E < thr cut (isolations) - ECAL barrel
-    double thrOverEEE_;       // threshold for x/E < thr cut (isolations) - ECAL endcap
-    double thrOverE2EB_;      // threshold for x/E^2 < thr cut (isolations) - ECAL barrel
-    double thrOverE2EE_;      // threshold for x/E^2 < thr cut (isolations) - ECAL endcap
-    int    ncandcut_;        // number of candidates required
+
+    std::vector<double> energyLowEdges_; // lower bin edges for energy-dependent cuts
+    bool lessThan_;                      // the cut is "<" or ">" ?
+    bool useEt_;                         // use E or Et in relative isolation cuts
+    std::vector<double> thrRegularEB_;   // threshold for regular cut (x < thr) - ECAL barrel
+    std::vector<double> thrRegularEE_;   // threshold for regular cut (x < thr) - ECAL endcap
+    std::vector<double> thrOverEEB_;     // threshold for x/E < thr cut (isolations) - ECAL barrel
+    std::vector<double> thrOverEEE_;     // threshold for x/E < thr cut (isolations) - ECAL endcap
+    std::vector<double> thrOverE2EB_;    // threshold for x/E^2 < thr cut (isolations) - ECAL barrel
+    std::vector<double> thrOverE2EE_;    // threshold for x/E^2 < thr cut (isolations) - ECAL endcap
+    int    ncandcut_;                    // number of candidates required
     
     edm::InputTag l1EGTag_;
+
+    edm::InputTag rhoTag_; // input tag identifying rho producer
+    edm::EDGetTokenT<double> rhoToken_;
+    bool doRhoCorrection_;
+    double rhoMax_;
+    double rhoScale_;
+    std::vector<double> effectiveAreas_;
+    std::vector<double> absEtaLowEdges_;
 };
 
 #endif //HLTGenericFilter_h

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -25,34 +25,72 @@
 HLTEgammaGenericQuadraticEtaFilter::HLTEgammaGenericQuadraticEtaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig){
   candTag_         = iConfig.getParameter< edm::InputTag > ("candTag");
   varTag_          = iConfig.getParameter< edm::InputTag > ("varTag");
+  rhoTag_          = iConfig.getParameter< edm::InputTag > ("rhoTag");
 
+  energyLowEdges_  = iConfig.getParameter<std::vector<double> > ("energyLowEdges");
   lessThan_        = iConfig.getParameter<bool> ("lessThan");
   useEt_           = iConfig.getParameter<bool> ("useEt");
 
   etaBoundaryEB12_ = iConfig.getParameter<double> ("etaBoundaryEB12");
   etaBoundaryEE12_ = iConfig.getParameter<double> ("etaBoundaryEE12");
 
-  thrRegularEB1_   = iConfig.getParameter<double> ("thrRegularEB1");
-  thrRegularEE1_   = iConfig.getParameter<double> ("thrRegularEE1");
-  thrOverEEB1_     = iConfig.getParameter<double> ("thrOverEEB1");
-  thrOverEEE1_     = iConfig.getParameter<double> ("thrOverEEE1");
-  thrOverE2EB1_    = iConfig.getParameter<double> ("thrOverE2EB1");
-  thrOverE2EE1_    = iConfig.getParameter<double> ("thrOverE2EE1");
-  thrRegularEB2_   = iConfig.getParameter<double> ("thrRegularEB2");
-  thrRegularEE2_   = iConfig.getParameter<double> ("thrRegularEE2");
-  thrOverEEB2_     = iConfig.getParameter<double> ("thrOverEEB2");
-  thrOverEEE2_     = iConfig.getParameter<double> ("thrOverEEE2");
-  thrOverE2EB2_    = iConfig.getParameter<double> ("thrOverE2EB2");
-  thrOverE2EE2_    = iConfig.getParameter<double> ("thrOverE2EE2");
+  thrRegularEB1_   = iConfig.getParameter<std::vector<double> > ("thrRegularEB1");
+  thrRegularEE1_   = iConfig.getParameter<std::vector<double> > ("thrRegularEE1");
+  thrOverEEB1_     = iConfig.getParameter<std::vector<double> > ("thrOverEEB1");
+  thrOverEEE1_     = iConfig.getParameter<std::vector<double> > ("thrOverEEE1");
+  thrOverE2EB1_    = iConfig.getParameter<std::vector<double> > ("thrOverE2EB1");
+  thrOverE2EE1_    = iConfig.getParameter<std::vector<double> > ("thrOverE2EE1");
+  thrRegularEB2_   = iConfig.getParameter<std::vector<double> > ("thrRegularEB2");
+  thrRegularEE2_   = iConfig.getParameter<std::vector<double> > ("thrRegularEE2");
+  thrOverEEB2_     = iConfig.getParameter<std::vector<double> > ("thrOverEEB2");
+  thrOverEEE2_     = iConfig.getParameter<std::vector<double> > ("thrOverEEE2");
+  thrOverE2EB2_    = iConfig.getParameter<std::vector<double> > ("thrOverE2EB2");
+  thrOverE2EE2_    = iConfig.getParameter<std::vector<double> > ("thrOverE2EE2");
 
   ncandcut_        = iConfig.getParameter<int> ("ncandcut");
-			     				
+
+  doRhoCorrection_ = iConfig.getParameter<bool> ("doRhoCorrection");
+  rhoMax_          = iConfig.getParameter<double> ("rhoMax");
+  rhoScale_        = iConfig.getParameter<double> ("rhoScale");
+  effectiveAreas_  = iConfig.getParameter<std::vector<double> > ("effectiveAreas");
+  absEtaLowEdges_  = iConfig.getParameter<std::vector<double> > ("absEtaLowEdges");
+
   l1EGTag_         = iConfig.getParameter< edm::InputTag > ("l1EGCand");
 
   candToken_       = consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
   varToken_        = consumes<reco::RecoEcalCandidateIsolationMap> (varTag_);
+  rhoToken_        = consumes<double> (rhoTag_);
 
-//register your products
+  if (energyLowEdges_.size() != thrRegularEB1_.size() or energyLowEdges_.size() != thrRegularEE1_.size() or
+      energyLowEdges_.size() != thrRegularEB2_.size() or energyLowEdges_.size() != thrRegularEE2_.size() or
+      energyLowEdges_.size() != thrOverEEB1_.size() or energyLowEdges_.size() != thrOverEEE1_.size() or
+      energyLowEdges_.size() != thrOverEEB2_.size() or energyLowEdges_.size() != thrOverEEE2_.size() or
+      energyLowEdges_.size() != thrOverE2EB1_.size() or energyLowEdges_.size() != thrOverE2EE1_.size() or
+      energyLowEdges_.size() != thrOverE2EB2_.size() or energyLowEdges_.size() != thrOverE2EE2_.size())
+    throw cms::Exception("IncompatibleVects") << "energyLowEdges and threshold vectors should be of the same size. \n";
+
+  if (energyLowEdges_.at(0) != 0.0)
+    throw cms::Exception("IncompleteCoverage") << "energyLowEdges should start from 0. \n";
+
+  for (unsigned int aIt = 0; aIt < energyLowEdges_.size() - 1; aIt++) {
+    if ( !(energyLowEdges_.at( aIt ) < energyLowEdges_.at( aIt + 1 )) )
+      throw cms::Exception("ImproperBinning") << "energyLowEdges entries should be in increasing order. \n";
+  }
+
+  if (doRhoCorrection_) {
+    if (absEtaLowEdges_.size() != effectiveAreas_.size())
+      throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
+
+    if (absEtaLowEdges_.at(0) != 0.0)
+      throw cms::Exception("IncompleteCoverage") << "absEtaLowEdges should start from 0. \n";
+
+    for (unsigned int bIt = 0; bIt < absEtaLowEdges_.size() - 1; bIt++) {
+      if ( !(absEtaLowEdges_.at( bIt ) < absEtaLowEdges_.at( bIt + 1 )) )
+        throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order. \n";
+    }
+  }
+
+  //register your products
   produces<trigger::TriggerFilterObjectWithRefs>();
 }
 
@@ -62,28 +100,35 @@ HLTEgammaGenericQuadraticEtaFilter::fillDescriptions(edm::ConfigurationDescripti
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("candTag", edm::InputTag("hltEGIsolFilter"));
   desc.add<edm::InputTag>("varTag", edm::InputTag("hltEGIsol"));
+  desc.add<edm::InputTag>("rhoTag", edm::InputTag("")); // No rho correction by default
+  desc.add<std::vector<double> >("energyLowEdges", {0.0}); // No energy-dependent cuts by default
   desc.add<bool>("lessThan", true);
   desc.add<bool>("useEt", true);
   desc.add<double>("etaBoundaryEB12", 1.0);
   desc.add<double>("etaBoundaryEE12", 2.0);
-  desc.add<double>("thrRegularEB1", 4.0);
-  desc.add<double>("thrRegularEE1", 6.0);
-  desc.add<double>("thrOverEEB1", 0.0020);
-  desc.add<double>("thrOverEEE1", 0.0020);
-  desc.add<double>("thrOverE2EB1", 0.0);
-  desc.add<double>("thrOverE2EE1", 0.0);
-  desc.add<double>("thrRegularEB2", 6.0);
-  desc.add<double>("thrRegularEE2", 4.0);
-  desc.add<double>("thrOverEEB2", 0.0020);
-  desc.add<double>("thrOverEEE2", 0.0020);
-  desc.add<double>("thrOverE2EB2", 0.0);
-  desc.add<double>("thrOverE2EE2", 0.0);
+  desc.add<std::vector<double> >("thrRegularEB1", {4.0});
+  desc.add<std::vector<double> >("thrRegularEE1", {6.0});
+  desc.add<std::vector<double> >("thrOverEEB1", {0.0020});
+  desc.add<std::vector<double> >("thrOverEEE1", {0.0020});
+  desc.add<std::vector<double> >("thrOverE2EB1", {0.0});
+  desc.add<std::vector<double> >("thrOverE2EE1", {0.0});
+  desc.add<std::vector<double> >("thrRegularEB2", {6.0});
+  desc.add<std::vector<double> >("thrRegularEE2", {4.0});
+  desc.add<std::vector<double> >("thrOverEEB2", {0.0020});
+  desc.add<std::vector<double> >("thrOverEEE2", {0.0020});
+  desc.add<std::vector<double> >("thrOverE2EB2", {0.0});
+  desc.add<std::vector<double> >("thrOverE2EE2", {0.0});
   desc.add<int>("ncandcut", 1);
+  desc.add<bool>("doRhoCorrection", false);
+  desc.add<double>("rhoMax", 9.9999999E7);
+  desc.add<double>("rhoScale", 1.0);
+  desc.add<std::vector<double> >("effectiveAreas", {0.0, 0.0});
+  desc.add<std::vector<double> >("absEtaLowEdges", {0.0, 1.479}); // EB, EE
   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
   descriptions.add("hltEgammaGenericQuadraticEtaFilter", desc);
 }
 
-HLTEgammaGenericQuadraticEtaFilter::~HLTEgammaGenericQuadraticEtaFilter()= default;
+HLTEgammaGenericQuadraticEtaFilter::~HLTEgammaGenericQuadraticEtaFilter(){}
 
 
 // ------------ method called to produce the data  ------------
@@ -113,64 +158,116 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;
   iEvent.getByToken (varToken_,depMap);
 
+  // Get rho if needed
+  edm::Handle<double> rhoHandle;
+  double rho = 0.0;
+  if (doRhoCorrection_) {
+    iEvent.getByToken(rhoToken_, rhoHandle);
+    rho = *(rhoHandle.product());
+  }
+
+  if (rho > rhoMax_)
+    rho = rhoMax_;
+  rho = rho * rhoScale_;
+
   // look at all photons, check cuts and add to filter object
   int n = 0;
+  for (unsigned int i=0; i<recoecalcands.size(); i++) {
 
-  for (auto & recoecalcand : recoecalcands) {
-
-    ref = recoecalcand;
+    ref = recoecalcands[i];
     reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
 
     float vali = mapi->val;
-    float energy = ref->superCluster()->energy();
     float EtaSC = ref->eta();
+
+    // Pick the right EA and do rhoCorr
+    if (doRhoCorrection_) {
+      int iEA = -1;
+      for (int cIt = absEtaLowEdges_.size() - 1; cIt > -1; cIt--) {
+        if ( std::abs(EtaSC) >= absEtaLowEdges_.at(cIt) ) {
+          iEA = cIt;
+          break;
+        }
+      }
+
+      vali = vali - (rho * effectiveAreas_.at(iEA));
+    }
+
+    float energy = ref->superCluster()->energy();
     if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));
-    if (energy < 0.) energy=0.; /* first and second order terms assume non-negative energies */
+    if (energy < 0.) energy = 0.; /* first and second order terms assume non-negative energies */
+
+    double cutRegularEB1_ = 9999., cutRegularEE1_ = 9999.;
+    double cutRegularEB2_ = 9999., cutRegularEE2_ = 9999.;
+    double cutOverEEB1_ = 9999., cutOverEEE1_ = 9999.;
+    double cutOverEEB2_ = 9999., cutOverEEE2_ = 9999.;
+    double cutOverE2EB1_ = 9999., cutOverE2EE1_ = 9999.;
+    double cutOverE2EB2_ = 9999., cutOverE2EE2_ = 9999.;
+
+    int iEn = -1;
+    for (int dIt = energyLowEdges_.size() - 1; dIt > -1; dIt--) {
+      if ( energy >= energyLowEdges_.at(dIt) ) {
+        iEn = dIt;
+        break;
+      }
+    }
+    cutRegularEB1_ = thrRegularEB1_.at(iEn);
+    cutRegularEB2_ = thrRegularEB2_.at(iEn);
+    cutRegularEE1_ = thrRegularEE1_.at(iEn);
+    cutRegularEE2_ = thrRegularEE2_.at(iEn);
+    cutOverEEB1_ = thrOverEEB1_.at(iEn);
+    cutOverEEB2_ = thrOverEEB2_.at(iEn);
+    cutOverEEE1_ = thrOverEEE1_.at(iEn);
+    cutOverEEE2_ = thrOverEEE2_.at(iEn);
+    cutOverE2EB1_ = thrOverE2EB1_.at(iEn);
+    cutOverE2EB2_ = thrOverE2EB2_.at(iEn);
+    cutOverE2EE1_ = thrOverE2EE1_.at(iEn);
+    cutOverE2EE2_ = thrOverE2EE2_.at(iEn);
 
     if ( lessThan_ ) {
-      if (fabs(EtaSC) < etaBoundaryEB12_) {
-          if ( vali <= thrRegularEB1_ + energy*thrOverEEB1_ + energy*energy*thrOverE2EB1_) {
+      if (std::abs(EtaSC) < etaBoundaryEB12_) {
+          if ( vali <= cutRegularEB1_ + energy*cutOverEEB1_ + energy*energy*cutOverE2EB1_) {
 	     n++;
 	     filterproduct.addObject(trigger_type, ref);
 	     continue;
           }
-      } else if (fabs(EtaSC) < 1.479) {
-          if ( vali <= thrRegularEB2_ + energy*thrOverEEB2_ + energy*energy*thrOverE2EB2_) {
+      } else if (std::abs(EtaSC) < 1.479) {
+          if ( vali <= cutRegularEB2_ + energy*cutOverEEB2_ + energy*energy*cutOverE2EB2_) {
 	     n++;
 	     filterproduct.addObject(trigger_type, ref);
 	     continue;
           }
-      } else if (fabs(EtaSC) < etaBoundaryEE12_) {
-          if ( vali <= thrRegularEE1_ + energy*thrOverEEE1_ + energy*energy*thrOverE2EE1_) {
+      } else if (std::abs(EtaSC) < etaBoundaryEE12_) {
+          if ( vali <= cutRegularEE1_ + energy*cutOverEEE1_ + energy*energy*cutOverE2EE1_) {
 	    n++;
 	    filterproduct.addObject(trigger_type, ref);
 	    continue;
           }
-      } else if (vali <= thrRegularEE2_ + energy*thrOverEEE2_ + energy*energy*thrOverE2EE2_) {
+      } else if (vali <= cutRegularEE2_ + energy*cutOverEEE2_ + energy*energy*cutOverE2EE2_) {
 	  n++;
 	  filterproduct.addObject(trigger_type, ref);
 	  continue;
       }
     } else {
-      if (fabs(EtaSC) < etaBoundaryEB12_) {
-          if ( vali >= thrRegularEB1_ + energy*thrOverEEB1_ + energy*energy*thrOverE2EB1_) {
+      if (std::abs(EtaSC) < etaBoundaryEB12_) {
+          if ( vali >= cutRegularEB1_ + energy*cutOverEEB1_ + energy*energy*cutOverE2EB1_) {
 	     n++;
 	     filterproduct.addObject(trigger_type, ref);
 	     continue;
           }
-      } else if (fabs(EtaSC) < 1.479) {
-          if ( vali >= thrRegularEB2_ + energy*thrOverEEB2_ + energy*energy*thrOverE2EB2_) {
+      } else if (std::abs(EtaSC) < 1.479) {
+          if ( vali >= cutRegularEB2_ + energy*cutOverEEB2_ + energy*energy*cutOverE2EB2_) {
 	     n++;
 	     filterproduct.addObject(trigger_type, ref);
 	     continue;
           }
-      } else if (fabs(EtaSC) < etaBoundaryEE12_) {
-          if ( vali >= thrRegularEE1_ + energy*thrOverEEE1_ + energy*energy*thrOverE2EE1_) {
+      } else if (std::abs(EtaSC) < etaBoundaryEE12_) {
+          if ( vali >= cutRegularEE1_ + energy*cutOverEEE1_ + energy*energy*cutOverE2EE1_) {
 	    n++;
 	    filterproduct.addObject(trigger_type, ref);
 	    continue;
           }
-      } else if (vali >= thrRegularEE2_ + energy*thrOverEEE2_ + energy*energy*thrOverE2EE2_) {
+      } else if (vali >= cutRegularEE2_ + energy*cutOverEEE2_ + energy*energy*cutOverE2EE2_) {
 	  n++;
 	  filterproduct.addObject(trigger_type, ref);
 	  continue;

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
@@ -25,23 +25,58 @@
 HLTEgammaGenericQuadraticFilter::HLTEgammaGenericQuadraticFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
   candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
   varTag_ = iConfig.getParameter< edm::InputTag > ("varTag");
+  rhoTag_ = iConfig.getParameter< edm::InputTag > ("rhoTag");
 
+  energyLowEdges_ = iConfig.getParameter<std::vector<double> > ("energyLowEdges");
   lessThan_ = iConfig.getParameter<bool> ("lessThan");
   useEt_ = iConfig.getParameter<bool> ("useEt");
 
-  thrRegularEB_ = iConfig.getParameter<double> ("thrRegularEB");
-  thrRegularEE_ = iConfig.getParameter<double> ("thrRegularEE");
-  thrOverEEB_ = iConfig.getParameter<double> ("thrOverEEB");
-  thrOverEEE_ = iConfig.getParameter<double> ("thrOverEEE");
-  thrOverE2EB_ = iConfig.getParameter<double> ("thrOverE2EB");
-  thrOverE2EE_ = iConfig.getParameter<double> ("thrOverE2EE");
+  thrRegularEB_ = iConfig.getParameter<std::vector<double> > ("thrRegularEB");
+  thrRegularEE_ = iConfig.getParameter<std::vector<double> > ("thrRegularEE");
+  thrOverEEB_ = iConfig.getParameter<std::vector<double> > ("thrOverEEB");
+  thrOverEEE_ = iConfig.getParameter<std::vector<double> > ("thrOverEEE");
+  thrOverE2EB_ = iConfig.getParameter<std::vector<double> > ("thrOverE2EB");
+  thrOverE2EE_ = iConfig.getParameter<std::vector<double> > ("thrOverE2EE");
   				     	
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
+
+  doRhoCorrection_ = iConfig.getParameter<bool> ("doRhoCorrection");
+  rhoMax_          = iConfig.getParameter<double> ("rhoMax");
+  rhoScale_        = iConfig.getParameter<double> ("rhoScale");
+  effectiveAreas_  = iConfig.getParameter<std::vector<double> > ("effectiveAreas");
+  absEtaLowEdges_  = iConfig.getParameter<std::vector<double> > ("absEtaLowEdges");
 			     				
   l1EGTag_= iConfig.getParameter< edm::InputTag > ("l1EGCand");
 
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
   varToken_ = consumes<reco::RecoEcalCandidateIsolationMap>(varTag_);
+  rhoToken_ = consumes<double> (rhoTag_);
+
+  if (energyLowEdges_.size() != thrRegularEB_.size() or energyLowEdges_.size() != thrRegularEE_.size() or
+      energyLowEdges_.size() != thrOverEEB_.size() or energyLowEdges_.size() != thrOverEEE_.size() or
+      energyLowEdges_.size() != thrOverE2EB_.size() or energyLowEdges_.size() != thrOverE2EE_.size())
+    throw cms::Exception("IncompatibleVects") << "energyLowEdges and threshold vectors should be of the same size. \n";
+
+  if (energyLowEdges_.at(0) != 0.0)
+    throw cms::Exception("IncompleteCoverage") << "energyLowEdges should start from 0. \n";
+
+  for (unsigned int aIt = 0; aIt < energyLowEdges_.size() - 1; aIt++) {
+    if ( !(energyLowEdges_.at( aIt ) < energyLowEdges_.at( aIt + 1 )) )
+      throw cms::Exception("ImproperBinning") << "energyLowEdges entries should be in increasing order. \n";
+  }
+
+  if (doRhoCorrection_) {
+    if (absEtaLowEdges_.size() != effectiveAreas_.size())
+      throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
+
+    if (absEtaLowEdges_.at(0) != 0.0)
+      throw cms::Exception("IncompleteCoverage") << "absEtaLowEdges should start from 0. \n";
+
+    for (unsigned int bIt = 0; bIt < absEtaLowEdges_.size() - 1; bIt++) {
+      if ( !(absEtaLowEdges_.at( bIt ) < absEtaLowEdges_.at( bIt + 1 )) )
+        throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order. \n";
+    }
+  }
 }
 
 void
@@ -50,20 +85,27 @@ HLTEgammaGenericQuadraticFilter::fillDescriptions(edm::ConfigurationDescriptions
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("candTag", edm::InputTag("hltSingleEgammaEtFilter"));
   desc.add<edm::InputTag>("varTag", edm::InputTag("hltSingleEgammaHcalIsol"));
+  desc.add<edm::InputTag>("rhoTag", edm::InputTag("")); // No rho correction by default
+  desc.add<std::vector<double> >("energyLowEdges", {0.0}); // No energy-dependent cuts by default
   desc.add<bool>("lessThan", true);
   desc.add<bool>("useEt", false);
-  desc.add<double>("thrRegularEB", 0.0);
-  desc.add<double>("thrRegularEE", 0.0);
-  desc.add<double>("thrOverEEB", 0.0);
-  desc.add<double>("thrOverEEE", 0.0);
-  desc.add<double>("thrOverE2EB", 0.0);
-  desc.add<double>("thrOverE2EE", 0.0);
+  desc.add<std::vector<double> >("thrRegularEB", {0.0});
+  desc.add<std::vector<double> >("thrRegularEE", {0.0});
+  desc.add<std::vector<double> >("thrOverEEB", {-1.0});
+  desc.add<std::vector<double> >("thrOverEEE", {-1.0});
+  desc.add<std::vector<double> >("thrOverE2EB", {-1.0});
+  desc.add<std::vector<double> >("thrOverE2EE", {-1.0});
   desc.add<int>("ncandcut",1);
+  desc.add<bool>("doRhoCorrection", false);
+  desc.add<double>("rhoMax", 9.9999999E7);
+  desc.add<double>("rhoScale", 1.0);
+  desc.add<std::vector<double> >("effectiveAreas", {0.0, 0.0});
+  desc.add<std::vector<double> >("absEtaLowEdges", {0.0, 1.479}); // EB, EE
   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
   descriptions.add("hltEgammaGenericQuadraticFilter", desc);
 }
 
-HLTEgammaGenericQuadraticFilter::~HLTEgammaGenericQuadraticFilter()= default;
+HLTEgammaGenericQuadraticFilter::~HLTEgammaGenericQuadraticFilter(){}
 
 
 // ------------ method called to produce the data  ------------
@@ -93,28 +135,72 @@ HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventS
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;
   iEvent.getByToken (varToken_,depMap);
 
+  // Get rho if needed
+  edm::Handle<double> rhoHandle;
+  double rho = 0.0;
+  if (doRhoCorrection_) {
+    iEvent.getByToken(rhoToken_, rhoHandle);
+    rho = *(rhoHandle.product());
+  }
+
+  if (rho > rhoMax_)
+    rho = rhoMax_;
+  rho = rho * rhoScale_;
+
   // look at all photons, check cuts and add to filter object
   int n = 0;
+  for (unsigned int i=0; i<recoecalcands.size(); i++) {
 
-  for (auto & recoecalcand : recoecalcands) {
-
-    ref = recoecalcand;
+    ref = recoecalcands[i];
     reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
 
     float vali = mapi->val;
-    float energy = ref->superCluster()->energy();
     float EtaSC = ref->eta();
+
+    // Pick the right EA and do rhoCorr
+    if (doRhoCorrection_) {
+      int iEA = -1;
+      for (int cIt = absEtaLowEdges_.size() - 1; cIt > -1; cIt--) {
+        if ( std::abs(EtaSC) >= absEtaLowEdges_.at(cIt) ) {
+          iEA = cIt;
+          break;
+        }
+      }
+
+      vali = vali - (rho * effectiveAreas_.at(iEA));
+    }
+
+    float energy = ref->superCluster()->energy();
     if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));
-    if (energy < 0.) energy=0.; /* first and second order terms assume non-negative energies */
+    if (energy < 0.) energy = 0.; /* first and second order terms assume non-negative energies */
+
+    // Pick the right cut threshold
+    double cutRegularEB_ = 9999., cutRegularEE_ = 9999.;
+    double cutOverEEB_ = 9999., cutOverEEE_ = 9999.;
+    double cutOverE2EB_ = 9999., cutOverE2EE_ = 9999.;
+
+    int iEn = -1;
+    for (int dIt = energyLowEdges_.size() - 1; dIt > -1; dIt--) {
+      if ( energy >= energyLowEdges_.at(dIt) ) {
+        iEn = dIt;
+        break;
+      }
+    }
+    cutRegularEB_ = thrRegularEB_.at(iEn);
+    cutRegularEE_ = thrRegularEE_.at(iEn);
+    cutOverEEB_ = thrOverEEB_.at(iEn);
+    cutOverEEE_ = thrOverEEE_.at(iEn);
+    cutOverE2EB_ = thrOverE2EB_.at(iEn);
+    cutOverE2EE_ = thrOverE2EE_.at(iEn);
 
     if ( lessThan_ ) {
-      if ((fabs(EtaSC) < 1.479 && vali <= thrRegularEB_ + energy*thrOverEEB_ + energy*energy*thrOverE2EB_) || (fabs(EtaSC) >= 1.479 && vali <= thrRegularEE_ + energy*thrOverEEE_ + energy*energy*thrOverE2EE_) ) {
+      if ((std::abs(EtaSC) < 1.479 && vali <= cutRegularEB_ + energy*cutOverEEB_ + energy*energy*cutOverE2EB_) || (std::abs(EtaSC) >= 1.479 && vali <= cutRegularEE_ + energy*cutOverEEE_ + energy*energy*cutOverE2EE_) ) {
 	  n++;
 	  filterproduct.addObject(trigger_type, ref);
 	  continue;
       }
     } else {
-      if ((fabs(EtaSC) < 1.479 && vali >= thrRegularEB_ + energy*thrOverEEB_ + energy*energy*thrOverE2EB_) || (fabs(EtaSC) >= 1.479 && vali >= thrRegularEE_ + energy*thrOverEEE_ + energy*energy*thrOverE2EE_) ) {
+      if ((std::abs(EtaSC) < 1.479 && vali >= cutRegularEB_ + energy*cutOverEEB_ + energy*energy*cutOverE2EB_) || (std::abs(EtaSC) >= 1.479 && vali >= cutRegularEE_ + energy*cutOverEEE_ + energy*energy*cutOverE2EE_) ) {
 	  n++;
 	  filterproduct.addObject(trigger_type, ref);
 	  continue;

--- a/HLTrigger/Egamma/src/HLTGenericFilter.cc
+++ b/HLTrigger/Egamma/src/HLTGenericFilter.cc
@@ -25,22 +25,57 @@
 //
 template<typename T1>
 HLTGenericFilter<T1>::HLTGenericFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
-    candTag_   = iConfig.template getParameter< edm::InputTag > ("candTag");
-    varTag_    = iConfig.template getParameter< edm::InputTag > ("varTag");
-    l1EGTag_   = iConfig.template getParameter< edm::InputTag > ("l1EGCand");
-    
+    candTag_  = iConfig.template getParameter< edm::InputTag > ("candTag");
+    varTag_   = iConfig.template getParameter< edm::InputTag > ("varTag");
+    l1EGTag_  = iConfig.template getParameter< edm::InputTag > ("l1EGCand");
+    rhoTag_   = iConfig.template getParameter< edm::InputTag > ("rhoTag");
+
+    energyLowEdges_  = iConfig.template getParameter<std::vector<double> > ("energyLowEdges");
     lessThan_        = iConfig.template getParameter<bool> ("lessThan");
     useEt_           = iConfig.template getParameter<bool> ("useEt");
-    thrRegularEB_    = iConfig.template getParameter<double> ("thrRegularEB");
-    thrRegularEE_    = iConfig.template getParameter<double> ("thrRegularEE");
-    thrOverEEB_      = iConfig.template getParameter<double> ("thrOverEEB");
-    thrOverEEE_      = iConfig.template getParameter<double> ("thrOverEEE");
-    thrOverE2EB_     = iConfig.template getParameter<double> ("thrOverE2EB");
-    thrOverE2EE_     = iConfig.template getParameter<double> ("thrOverE2EE");
+    thrRegularEB_    = iConfig.template getParameter<std::vector<double> > ("thrRegularEB");
+    thrRegularEE_    = iConfig.template getParameter<std::vector<double> > ("thrRegularEE");
+    thrOverEEB_      = iConfig.template getParameter<std::vector<double> > ("thrOverEEB");
+    thrOverEEE_      = iConfig.template getParameter<std::vector<double> > ("thrOverEEE");
+    thrOverE2EB_     = iConfig.template getParameter<std::vector<double> > ("thrOverE2EB");
+    thrOverE2EE_     = iConfig.template getParameter<std::vector<double> > ("thrOverE2EE");
     ncandcut_        = iConfig.template getParameter<int> ("ncandcut");
-    
+
+    doRhoCorrection_ = iConfig.template getParameter<bool> ("doRhoCorrection");
+    rhoMax_          = iConfig.template getParameter<double> ("rhoMax");
+    rhoScale_        = iConfig.template getParameter<double> ("rhoScale");
+    effectiveAreas_  = iConfig.template getParameter<std::vector<double> > ("effectiveAreas");
+    absEtaLowEdges_  = iConfig.template getParameter<std::vector<double> > ("absEtaLowEdges");
+
     candToken_ = consumes<trigger::TriggerFilterObjectWithRefs> (candTag_);
     varToken_  = consumes<T1IsolationMap> (varTag_);
+    rhoToken_  = consumes<double> (rhoTag_);
+
+    if (energyLowEdges_.size() != thrRegularEB_.size() or energyLowEdges_.size() != thrRegularEE_.size() or
+        energyLowEdges_.size() != thrOverEEB_.size() or energyLowEdges_.size() != thrOverEEE_.size() or
+        energyLowEdges_.size() != thrOverE2EB_.size() or energyLowEdges_.size() != thrOverE2EE_.size())
+      throw cms::Exception("IncompatibleVects") << "energyLowEdges and threshold vectors should be of the same size. \n";
+
+    if (energyLowEdges_.at(0) != 0.0)
+      throw cms::Exception("IncompleteCoverage") << "energyLowEdges should start from 0. \n";
+
+    for (unsigned int aIt = 0; aIt < energyLowEdges_.size() - 1; aIt++) {
+      if ( !(energyLowEdges_.at( aIt ) < energyLowEdges_.at( aIt + 1 )) )
+        throw cms::Exception("ImproperBinning") << "energyLowEdges entries should be in increasing order. \n";
+    }
+
+    if (doRhoCorrection_) {
+      if (absEtaLowEdges_.size() != effectiveAreas_.size())
+        throw cms::Exception("IncompatibleVects") << "absEtaLowEdges and effectiveAreas should be of the same size. \n";
+
+      if (absEtaLowEdges_.at(0) != 0.0)
+        throw cms::Exception("IncompleteCoverage") << "absEtaLowEdges should start from 0. \n";
+
+      for (unsigned int bIt = 0; bIt < absEtaLowEdges_.size() - 1; bIt++) {
+        if ( !(absEtaLowEdges_.at( bIt ) < absEtaLowEdges_.at( bIt + 1 )) )
+          throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order. \n";
+      }
+    }
 }
 
 template<typename T1>
@@ -50,15 +85,22 @@ HLTGenericFilter<T1>::fillDescriptions(edm::ConfigurationDescriptions& descripti
     makeHLTFilterDescription(desc);
     desc.add<edm::InputTag>("candTag", edm::InputTag("hltSingleEgammaEtFilter"));
     desc.add<edm::InputTag>("varTag", edm::InputTag("hltSingleEgammaHcalIsol"));
+    desc.add<edm::InputTag>("rhoTag", edm::InputTag("")); // No rho correction by default
+    desc.add<std::vector<double> >("energyLowEdges", {0.0}); // No energy-dependent cuts by default
     desc.add<bool>("lessThan", true);
     desc.add<bool>("useEt", false);
-    desc.add<double>("thrRegularEB", 0.0);
-    desc.add<double>("thrRegularEE", 0.0);
-    desc.add<double>("thrOverEEB", -1.0);
-    desc.add<double>("thrOverEEE", -1.0);
-    desc.add<double>("thrOverE2EB", -1.0);
-    desc.add<double>("thrOverE2EE", -1.0);
+    desc.add<std::vector<double> >("thrRegularEB", {0.0});
+    desc.add<std::vector<double> >("thrRegularEE", {0.0});
+    desc.add<std::vector<double> >("thrOverEEB", {-1.0});
+    desc.add<std::vector<double> >("thrOverEEE", {-1.0});
+    desc.add<std::vector<double> >("thrOverE2EB", {-1.0});
+    desc.add<std::vector<double> >("thrOverE2EE", {-1.0});
     desc.add<int>("ncandcut", 1);
+    desc.add<bool>("doRhoCorrection", false);
+    desc.add<double>("rhoMax", 9.9999999E7);
+    desc.add<double>("rhoScale", 1.0);
+    desc.add<std::vector<double> >("effectiveAreas", {0.0, 0.0});
+    desc.add<std::vector<double> >("absEtaLowEdges", {0.0, 1.479}); // EB, EE
     desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
     descriptions.add(defaultModuleLabel<HLTGenericFilter<T1>>(), desc);
 }
@@ -96,9 +138,7 @@ HLTGenericFilter<T1>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
     if (saveTags()) {
         filterproduct.addCollectionTag(l1EGTag_);
     }
-    
-    
-    
+
     // Set output format
     int trigger_type = trigger::TriggerCluster;
     if (saveTags()) trigger_type = trigger::TriggerPhoton;
@@ -116,53 +156,97 @@ HLTGenericFilter<T1>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
     //get hold of isolated association map
     edm::Handle<T1IsolationMap> depMap;
     iEvent.getByToken (varToken_,depMap);
-    
+
+    // Get rho if needed
+    edm::Handle<double> rhoHandle;
+    double rho = 0.0;
+    if (doRhoCorrection_) {
+      iEvent.getByToken(rhoToken_, rhoHandle);
+      rho = *(rhoHandle.product());
+    }
+
+    if (rho > rhoMax_)
+      rho = rhoMax_;
+    rho = rho * rhoScale_;
+
     // look at all photons, check cuts and add to filter object
     int n = 0;
-    
     for (unsigned int i=0; i<recoCands.size(); i++) {
-        
-        
+
         // Ref to Candidate object to be recorded in filter object
         T1Ref ref = recoCands[i];
         typename T1IsolationMap::const_iterator mapi = (*depMap).find( ref );
         
         float vali = mapi->val;
         float EtaSC = ref->eta();
+
+        // Pick the right EA and do rhoCorr
+        if (doRhoCorrection_) {
+          int iEA = -1;
+          for (int cIt = absEtaLowEdges_.size() - 1; cIt > -1; cIt--) {
+            if ( std::abs(EtaSC) >= absEtaLowEdges_.at(cIt) ) {
+              iEA = cIt;
+              break;
+            }
+          }
+
+          vali = vali - (rho * effectiveAreas_.at(iEA));
+        }
+
         float energy;
         if (useEt_) energy = getEt (ref);
         else energy = getEnergy( ref );
-        
+        //if (energy < 0.) energy = 0.; // require energy to be positive (needed?)
+
+        // Pick the right cut threshold
+        double cutRegularEB_ = 9999., cutRegularEE_ = 9999.;
+        double cutOverEEB_ = 9999., cutOverEEE_ = 9999.;
+        double cutOverE2EB_ = 9999., cutOverE2EE_ = 9999.;
+
+        int iEn = -1;
+        for (int dIt = energyLowEdges_.size() - 1; dIt > -1; dIt--) {
+          if ( energy >= energyLowEdges_.at(dIt) ) {
+            iEn = dIt;
+            break;
+          }
+        }
+        cutRegularEB_ = thrRegularEB_.at(iEn);
+        cutRegularEE_ = thrRegularEE_.at(iEn);
+        cutOverEEB_ = thrOverEEB_.at(iEn);
+        cutOverEEE_ = thrOverEEE_.at(iEn);
+        cutOverE2EB_ = thrOverE2EB_.at(iEn);
+        cutOverE2EE_ = thrOverE2EE_.at(iEn);
+
         if ( lessThan_ ) {
-            if ( (std::abs(EtaSC) < 1.479 && vali <= thrRegularEB_) || (std::abs(EtaSC) >= 1.479 && vali <= thrRegularEE_) ) {
+            if ( (std::abs(EtaSC) < 1.479 && vali <= cutRegularEB_) || (std::abs(EtaSC) >= 1.479 && vali <= cutRegularEE_) ) {
                 n++;
                 filterproduct.addObject(trigger_type, ref);
                 continue;
             }
-            if (energy > 0. && (thrOverEEB_ > 0. || thrOverEEE_ > 0. || thrOverE2EB_ > 0. || thrOverE2EE_ > 0.) ) {
-                if ((std::abs(EtaSC) < 1.479 && vali/energy <= thrOverEEB_) || (std::abs(EtaSC) >= 1.479 && vali/energy <= thrOverEEE_) ) {
+            if (energy > 0. && (cutOverEEB_ > 0. || cutOverEEE_ > 0. || cutOverE2EB_ > 0. || cutOverE2EE_ > 0.) ) {
+                if ((std::abs(EtaSC) < 1.479 && vali/energy <= cutOverEEB_) || (std::abs(EtaSC) >= 1.479 && vali/energy <= cutOverEEE_) ) {
                     n++;
                     filterproduct.addObject(trigger_type, ref);
                     continue;
                 }
-                if ((std::abs(EtaSC) < 1.479 && vali/(energy*energy) <= thrOverE2EB_) || (std::abs(EtaSC) >= 1.479 && vali/(energy*energy) <= thrOverE2EE_) ) {
+                if ((std::abs(EtaSC) < 1.479 && vali/(energy*energy) <= cutOverE2EB_) || (std::abs(EtaSC) >= 1.479 && vali/(energy*energy) <= cutOverE2EE_) ) {
                     n++;
                     filterproduct.addObject(trigger_type, ref);
                 }
             }
         } else {
-            if ( (std::abs(EtaSC) < 1.479 && vali >= thrRegularEB_) || (std::abs(EtaSC) >= 1.479 && vali >= thrRegularEE_) ) {
+            if ( (std::abs(EtaSC) < 1.479 && vali >= cutRegularEB_) || (std::abs(EtaSC) >= 1.479 && vali >= cutRegularEE_) ) {
                 n++;
                 filterproduct.addObject(trigger_type, ref);
                 continue;
             }
-            if (energy > 0. && (thrOverEEB_ > 0. || thrOverEEE_ > 0. || thrOverE2EB_ > 0. || thrOverE2EE_ > 0.) ) {
-                if ((std::abs(EtaSC) < 1.479 && vali/energy >= thrOverEEB_) || (std::abs(EtaSC) >= 1.479 && vali/energy >= thrOverEEE_) ) {
+            if (energy > 0. && (cutOverEEB_ > 0. || cutOverEEE_ > 0. || cutOverE2EB_ > 0. || cutOverE2EE_ > 0.) ) {
+                if ((std::abs(EtaSC) < 1.479 && vali/energy >= cutOverEEB_) || (std::abs(EtaSC) >= 1.479 && vali/energy >= cutOverEEE_) ) {
                     n++;
                     filterproduct.addObject(trigger_type, ref);
                     continue;
                 }
-                if ((std::abs(EtaSC) < 1.479 && vali/(energy*energy) >= thrOverE2EB_) || (std::abs(EtaSC) >= 1.479 && vali/(energy*energy) >= thrOverE2EE_) ) {
+                if ((std::abs(EtaSC) < 1.479 && vali/(energy*energy) >= cutOverE2EB_) || (std::abs(EtaSC) >= 1.479 && vali/(energy*energy) >= cutOverE2EE_) ) {
                     n++;
                     filterproduct.addObject(trigger_type, ref);
                 }


### PR DESCRIPTION
This PR adds 2 new features to the affected filters:
1 - ability to do rho correction on the variable being cut on, so that this can be applied at filter level instead of producer level as is done now
2 - energy or Et dependent cut thresholds for e.g. looser dPhi cut at low Et

The customization function coming very shortly will modify the affected filters such that they're compatible with this PR but with no change in behavior at all.

Cheers,
Afiq