### PR TITLE
Reset the path in DQMStore for each module

### DIFF
--- a/DQMServices/Core/src/DQMEDAnalyzer.cc
+++ b/DQMServices/Core/src/DQMEDAnalyzer.cc
@@ -19,6 +19,7 @@ void DQMEDAnalyzer::beginRun(edm::Run const &iRun,
   dqmBeginRun(iRun, iSetup);
   DQMStore * store = edm::Service<DQMStore>().operator->();
   store->bookTransaction([this, &iRun, &iSetup](DQMStore::IBooker &b) {
+                           b.cd();
                            this->bookHistograms(b, iRun, iSetup);
                          },
                          iRun.run(),
@@ -99,6 +100,7 @@ void thread_unsafe::DQMEDAnalyzer::beginRun(edm::Run const &iRun,
   dqmBeginRun(iRun, iSetup);
   DQMStore * store = edm::Service<DQMStore>().operator->();
   store->bookTransaction([this, &iRun, &iSetup](DQMStore::IBooker &b) {
+      b.cd();
       this->bookHistograms(b, iRun, iSetup);
     },
     iRun.run(),


### PR DESCRIPTION
When modules book the monitor elements, they have to set the path first.

However, for several modules, it is not done.
In such case, the folder they book histograms in is neither predictable nor consistent.
And the monitor elements appear not they were belong...
(and depends on the last module who acquired the booking lock)

First commit to see how bad it really is,
I will add more commits once I identity the modules without this path set.
