### PR TITLE
Fix errors from Clang 4.0.0

### DIFF
--- a/MagneticField/Interpolation/test/BinaryTablesGeneration/GridFileReader.cpp
+++ b/MagneticField/Interpolation/test/BinaryTablesGeneration/GridFileReader.cpp
@@ -8,7 +8,8 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
-#include<cmath>
+#include <cmath>
+#include <stdlib.h>
 #include "DataFormats/Math/interface/approx_exp.h"
 inline
 int bits(int a) {
@@ -37,7 +38,7 @@ int main(int argc, char **argv)
   binary_ifstream inFile(filename);
   if (!inFile) {
     cout << "file open failed!" << endl;
-    return false;
+    return EXIT_FAILURE;
   }
 
   cout << "Data File: " << filename << endl;

--- a/SimG4CMS/Calo/src/HcalTestAnalysis.cc
+++ b/SimG4CMS/Calo/src/HcalTestAnalysis.cc
@@ -357,7 +357,7 @@ void HcalTestAnalysis::fill(const EndOfEvent * evt) {
   CaloG4HitCollection* theHCHC = (CaloG4HitCollection*) allHC->GetHC(HCHCid);
   LogDebug("HcalSim") << "HcalTestAnalysis :: Hit Collection for " << names[0] 
 		      << " of ID " << HCHCid << " is obtained at " << theHCHC;
-  if (HCHCid >= 0 && theHCHC > 0) {
+  if (HCHCid >= 0 && theHCHC != nullptr) {
     for (j = 0; j < theHCHC->entries(); j++) {
 
       CaloG4Hit* aHit = (*theHCHC)[j]; 
@@ -404,7 +404,7 @@ void HcalTestAnalysis::fill(const EndOfEvent * evt) {
   CaloG4HitCollection* theEBHC = (CaloG4HitCollection*) allHC->GetHC(EBHCid);
   LogDebug("HcalSim") << "HcalTestAnalysis :: Hit Collection for " << names[1]
 		      << " of ID " << EBHCid << " is obtained at " << theEBHC;
-  if (EBHCid >= 0 && theEBHC > 0) {
+  if (EBHCid >= 0 && theEBHC != nullptr) {
     for (j = 0; j < theEBHC->entries(); j++) {
 
       CaloG4Hit* aHit = (*theEBHC)[j]; 
@@ -442,7 +442,7 @@ void HcalTestAnalysis::fill(const EndOfEvent * evt) {
   CaloG4HitCollection* theEEHC = (CaloG4HitCollection*) allHC->GetHC(EEHCid);
   LogDebug("HcalSim") << "HcalTestAnalysis :: Hit Collection for " << names[2]
 		      << " of ID " << EEHCid << " is obtained at " << theEEHC;
-  if (EEHCid >= 0 && theEEHC > 0) {
+  if (EEHCid >= 0 && theEEHC != nullptr) {
     for (j = 0; j < theEEHC->entries(); j++) {
 
       CaloG4Hit* aHit = (*theEEHC)[j]; 

--- a/SimG4CMS/Forward/src/TotemTestGem.cc
+++ b/SimG4CMS/Forward/src/TotemTestGem.cc
@@ -81,7 +81,7 @@ void TotemTestGem::update(const EndOfEvent * evt) {
     LogDebug("ForwardSim") << "TotemTestGem :: Hit Collection for " <<names[in]
 			   << " of ID " << HCid << " is obtained at " << theHC;
 
-    if (HCid >= 0 && theHC > 0) {
+    if (HCid >= 0 && theHC != nullptr) {
       int nentries = theHC->entries();
       LogDebug("ForwardSim") << "TotemTestGem :: " << names[in] << " with "
 			     << nentries << " entries";

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
@@ -134,7 +134,7 @@ void HcalTB02Analysis::update(const EndOfEvent * evt) {
   // HCAL
   HcalTB02HcalNumberingScheme *org = new HcalTB02HcalNumberingScheme();   
 
-  if (HCHCid >= 0 && theHCHC > 0) {
+  if (HCHCid >= 0 && theHCHC != nullptr) {
     for ( ihit = 0; ihit < nentries; ihit++) {
 
       CaloG4Hit* aHit = (*theHCHC)[ihit]; 
@@ -287,7 +287,7 @@ void HcalTB02Analysis::update(const EndOfEvent * evt) {
 
     // XTALS
 
-    if (XTALSid >= 0 && theXTHC > 0) {
+    if (XTALSid >= 0 && theXTHC != nullptr) {
       for (int xihit = 0; xihit < xentries; xihit++) {
 
 	CaloG4Hit* xaHit = (*theXTHC)[xihit]; 

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
@@ -412,7 +412,7 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent * evt) {
   LogDebug("HcalTBSim") << "HcalTB04Analysis:: Hit Collection for " << sdName
 			<< " of ID " << idHC << " is obtained at " << theHC;
 
-  if (idHC >= 0 && theHC > 0) {
+  if (idHC >= 0 && theHC != nullptr) {
     hhits.reserve(theHC->entries());
     hhitl.reserve(theHC->entries());
     for (j = 0; j < theHC->entries(); j++) {
@@ -536,7 +536,7 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent * evt) {
   etot1 = etot2 = 0;
   LogDebug("HcalTBSim") << "HcalTB04Analysis:: Hit Collection for " << sdName
 			<< " of ID " << idHC << " is obtained at " << theHC;
-  if (idHC >= 0 && theHC > 0) {
+  if (idHC >= 0 && theHC != nullptr) {
     ehits.reserve(theHC->entries());
     for (j = 0; j < theHC->entries(); j++) {
       CaloG4Hit* aHit = (*theHC)[j]; 

--- a/SimG4CMS/ShowerLibraryProducer/src/HcalForwardAnalysis.cc
+++ b/SimG4CMS/ShowerLibraryProducer/src/HcalForwardAnalysis.cc
@@ -141,7 +141,7 @@ void HcalForwardAnalysis::setPhotons(const EndOfEvent * evt) {
 	std::vector<HFShowerPhoton> LongFiberPhotons;
 	LongFiberPhotons.clear();
 	ShortFiberPhotons.clear();
-	if (idHC >= 0 && theHC> 0) {
+	if (idHC >= 0 && theHC != nullptr) {
 		std::cout << "FiberhitSize " << theHC->entries() << std::endl;
 		for (j = 0; j < theHC->entries(); j++) {
 			FiberG4Hit* aHit = (*theHC)[j];
@@ -179,7 +179,7 @@ void HcalForwardAnalysis::setPhotons(const EndOfEvent * evt) {
 	//	the chamber hit is for primary particle, but step size can be small
 	//	(in newer Geant4 versions) and as a result primary particle may have
 	//	multiple hits. We want to take last one which is close the HF absorber
-	if(idHC >= 0 && theChamberHC> 0) {
+	if(idHC >= 0 && theChamberHC != nullptr) {
 		LogDebug("HcalForwardLib") << "HcalForwardAnalysis::setPhotons() Chamber Hits size: " << theChamberHC->entries();
 		for(j = 0; j < theChamberHC->entries();++j) {
 			HFShowerG4Hit* aHit = (*theChamberHC)[j];

--- a/Validation/HcalHits/src/SimG4HcalValidation.cc
+++ b/Validation/HcalHits/src/SimG4HcalValidation.cc
@@ -298,7 +298,7 @@ void SimG4HcalValidation::fill(const EndOfEvent * evt) {
   LogDebug("ValidHcal") << "SimG4HcalValidation :: Hit Collection for " 
 			<< names[0] << " of ID " << HCHCid <<" is obtained at "
 			<< theHCHC;
-  if (HCHCid >= 0 && theHCHC > 0) {
+  if (HCHCid >= 0 && theHCHC != nullptr) {
     for (j = 0; j < theHCHC->entries(); j++) {
 
       CaloG4Hit* aHit = (*theHCHC)[j]; 
@@ -374,7 +374,7 @@ void SimG4HcalValidation::fill(const EndOfEvent * evt) {
       LogDebug("ValidHcal") << "SimG4HcalValidation:: Hit Collection for "
 			    << names[idty] << " of ID " << ECHCid 
 			    << " is obtained at " << theECHC;
-      if (ECHCid >= 0 && theECHC > 0) {
+      if (ECHCid >= 0 && theECHC != nullptr) {
 	for (j = 0; j < theECHC->entries(); j++) {
 
 	  CaloG4Hit* aHit = (*theECHC)[j]; 


### PR DESCRIPTION
The following errors are fixed:

    error: bool literal returned from 'main'
    error: ordered comparison between pointer and zero

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>