### PR TITLE
Avoid undefined behavior in PtrVectorBase.h

### DIFF
--- a/DataFormats/Common/interface/PtrVectorBase.h
+++ b/DataFormats/Common/interface/PtrVectorBase.h
@@ -152,7 +152,7 @@ namespace edm {
     //virtual std::type_info const& typeInfo() const = 0;
     virtual std::type_info const& typeInfo() const {
       assert(false);
-      return *reinterpret_cast<const std::type_info*>(0);
+      return typeid(void);
     }
     
     //returns false if the cache is not yet set


### PR DESCRIPTION
Solves the following:

    PtrVectorBase.h:155:14: warning: binding dereferenced null pointer
    to reference has undefined behavior [-Wnull-dereference]

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>