### PR TITLE
Extruded Polygone Visualization

### DIFF
--- a/DetectorDescription/Core/interface/DDSolid.h
+++ b/DetectorDescription/Core/interface/DDSolid.h
@@ -1,5 +1,5 @@
-#ifndef DDSolid_h
-#define DDSolid_h
+#ifndef DETECTOR_DESCRIPTION_CORE_DD_SOLID_H
+#define DETECTOR_DESCRIPTION_CORE_DD_SOLID_H
 
 #include <stddef.h>
 #include <iosfwd>
@@ -13,11 +13,12 @@
 
 class DDSolid;
 class DDStreamer;
+
 namespace DDI {
-class BooleanSolid;
-class Reflection;
-class Solid;
-}  // namespace DDI
+  class BooleanSolid;
+  class Reflection;
+  class Solid;
+}
 struct DDSolidFactory;
 
 std::ostream & operator<<( std::ostream &, const DDSolid & );
@@ -36,7 +37,7 @@ std::ostream & operator<<( std::ostream &, const DDSolid & );
 */
 class DDSolid : public DDBase<DDName, DDI::Solid*>
 {
-  friend std::ostream & operator<<( std::ostream &, const DDSolid & );
+  friend std::ostream & operator <<( std::ostream &, const DDSolid & );
   friend struct DDSolidFactory;
   friend class DDDToPersFactory;
   friend class DDPersToDDDFactory;

--- a/DetectorDescription/Core/interface/DDSolid.h
+++ b/DetectorDescription/Core/interface/DDSolid.h
@@ -265,6 +265,8 @@ public:
 
 private:
   DDExtrudedPolygon( void );
+  auto xyPointsSize( void ) const -> std::size_t;
+  auto zSectionsSize( void ) const -> std::size_t;
 };
 
 class DDTubs : public DDSolid

--- a/DetectorDescription/Core/src/DDSolid.cc
+++ b/DetectorDescription/Core/src/DDSolid.cc
@@ -498,21 +498,21 @@ DDExtrudedPolygon::zVec( void ) const
 std::vector<double>
 DDExtrudedPolygon::zxVec( void ) const
 {
-  return std::vector<double>( rep().parameters().end() - 3 * zSectionsSize()),
+  return std::vector<double>( rep().parameters().end() - 3 * zSectionsSize(),
 			      rep().parameters().end() - 2 * zSectionsSize());
 }
 
 std::vector<double>
 DDExtrudedPolygon::zyVec( void ) const
 {
-  return std::vector<double>( rep().parameters().end() - 2 * zSectionsSize()),
+  return std::vector<double>( rep().parameters().end() - 2 * zSectionsSize(),
 			      rep().parameters().end() - zSectionsSize());
 }
 
 std::vector<double>
 DDExtrudedPolygon::zscaleVec( void ) const
 {
-  return std::vector<double>( rep().parameters().end() - zSectionsSize()),
+  return std::vector<double>( rep().parameters().end() - zSectionsSize(),
 			      rep().parameters().end());
 }
 

--- a/DetectorDescription/Core/src/DDSolid.cc
+++ b/DetectorDescription/Core/src/DDSolid.cc
@@ -448,6 +448,66 @@ DDPolyhedra::rMaxVec() const {
   return tvec;
 }
 
+DDExtrudedPolygon::DDExtrudedPolygon(const DDSolid & s)
+  : DDPolySolid(s)
+{
+  if( s.shape() != ddextrudedpolygon ) {
+    std::string ex  = "Solid [" + s.name().ns() + ":" + s.name().name() + "] is not a DDExtrudedPolygon.\n";
+    ex = ex + "Use a different solid interface!";
+    throw cms::Exception("DDException") << ex;
+  }
+}
+
+std::vector<double>
+DDExtrudedPolygon::xVec( void ) const
+{
+  auto xysize = ( unsigned int )(( rep().parameters().size() - 4*rep().parameters()[0]) * 0.5 );
+  auto it = rep().parameters().begin() + 1;
+  auto itEnd = rep().parameters().begin() + 1 + xysize;
+  return std::vector<double>( it, itEnd );
+}
+
+std::vector<double>
+DDExtrudedPolygon::yVec( void ) const
+{
+  auto xysize = ( unsigned int )(( rep().parameters().size() - 4*rep().parameters()[0]) * 0.5 );
+  auto it = rep().parameters().begin() + 1 + xysize;
+  auto itEnd = rep().parameters().begin() + 1 + 2*xysize;
+  return std::vector<double>( it, itEnd );
+}
+
+std::vector<double>
+DDExtrudedPolygon::zVec( void ) const
+{
+  auto it = rep().parameters().end() - 4*rep().parameters()[0];
+  auto itEnd = rep().parameters().end() - 3*rep().parameters()[0];
+  return std::vector<double>( it, itEnd );
+}
+
+std::vector<double>
+DDExtrudedPolygon::zxVec( void ) const
+{
+  auto it = rep().parameters().end() - 3*rep().parameters()[0];
+  auto itEnd = rep().parameters().end() - 2*rep().parameters()[0];
+  return std::vector<double>( it, itEnd );
+}
+
+std::vector<double>
+DDExtrudedPolygon::zyVec( void ) const
+{
+  auto it = rep().parameters().end() - 2*rep().parameters()[0];
+  auto itEnd = rep().parameters().end() - rep().parameters()[0];
+  return std::vector<double>( it, itEnd );
+}
+
+std::vector<double>
+DDExtrudedPolygon::zscaleVec( void ) const
+{
+  auto it = rep().parameters().end() - rep().parameters()[0];
+  auto itEnd = rep().parameters().end();
+  return std::vector<double>( it, itEnd );
+}
+
 DDCons::DDCons(const DDSolid& s) 
   : DDSolid(s) {
   if (s.shape() != ddcons) {

--- a/DetectorDescription/Core/src/DDSolid.cc
+++ b/DetectorDescription/Core/src/DDSolid.cc
@@ -458,54 +458,62 @@ DDExtrudedPolygon::DDExtrudedPolygon(const DDSolid & s)
   }
 }
 
+auto
+DDExtrudedPolygon::xyPointsSize( void ) const -> std::size_t
+{
+  // Here we compute the size of X and Y polygone vectors
+
+  return ( rep().parameters().size() - 4 * zSectionsSize()) * 0.5;
+}
+
+auto
+DDExtrudedPolygon::zSectionsSize( void ) const -> std::size_t
+{
+  // First parameters element stores a size of four Z section vectors
+
+  return rep().parameters()[0];
+}
+
 std::vector<double>
 DDExtrudedPolygon::xVec( void ) const
 {
-  auto xysize = ( unsigned int )(( rep().parameters().size() - 4*rep().parameters()[0]) * 0.5 );
-  auto it = rep().parameters().begin() + 1;
-  auto itEnd = rep().parameters().begin() + 1 + xysize;
-  return std::vector<double>( it, itEnd );
+  return std::vector<double>( rep().parameters().begin() + 1,
+			      rep().parameters().begin() + 1 + xyPointsSize());
 }
 
 std::vector<double>
 DDExtrudedPolygon::yVec( void ) const
 {
-  auto xysize = ( unsigned int )(( rep().parameters().size() - 4*rep().parameters()[0]) * 0.5 );
-  auto it = rep().parameters().begin() + 1 + xysize;
-  auto itEnd = rep().parameters().begin() + 1 + 2*xysize;
-  return std::vector<double>( it, itEnd );
+  return std::vector<double>( rep().parameters().begin() + 1 + xyPointsSize(),
+			      rep().parameters().begin() + 1 + 2 * xyPointsSize());
 }
 
 std::vector<double>
 DDExtrudedPolygon::zVec( void ) const
 {
-  auto it = rep().parameters().end() - 4*rep().parameters()[0];
-  auto itEnd = rep().parameters().end() - 3*rep().parameters()[0];
-  return std::vector<double>( it, itEnd );
+  return std::vector<double>( rep().parameters().end() - 4 * zSectionsSize(),
+			      rep().parameters().end() - 3 * zSectionsSize());
 }
 
 std::vector<double>
 DDExtrudedPolygon::zxVec( void ) const
 {
-  auto it = rep().parameters().end() - 3*rep().parameters()[0];
-  auto itEnd = rep().parameters().end() - 2*rep().parameters()[0];
-  return std::vector<double>( it, itEnd );
+  return std::vector<double>( rep().parameters().end() - 3 * zSectionsSize()),
+			      rep().parameters().end() - 2 * zSectionsSize());
 }
 
 std::vector<double>
 DDExtrudedPolygon::zyVec( void ) const
 {
-  auto it = rep().parameters().end() - 2*rep().parameters()[0];
-  auto itEnd = rep().parameters().end() - rep().parameters()[0];
-  return std::vector<double>( it, itEnd );
+  return std::vector<double>( rep().parameters().end() - 2 * zSectionsSize()),
+			      rep().parameters().end() - zSectionsSize());
 }
 
 std::vector<double>
 DDExtrudedPolygon::zscaleVec( void ) const
 {
-  auto it = rep().parameters().end() - rep().parameters()[0];
-  auto itEnd = rep().parameters().end();
-  return std::vector<double>( it, itEnd );
+  return std::vector<double>( rep().parameters().end() - zSectionsSize()),
+			      rep().parameters().end());
 }
 
 DDCons::DDCons(const DDSolid& s) 

--- a/DetectorDescription/Core/src/DDSolid.cc
+++ b/DetectorDescription/Core/src/DDSolid.cc
@@ -333,20 +333,19 @@ DDPolySolid::DDPolySolid(const DDSolid & s)
 std::vector<double>
 DDPolySolid::getVec (const size_t& which, 
 		     const size_t& offset,
-		     const size_t& numVecs) const {
-
+		     const size_t& numVecs) const
+{
   // which:  first second or third std::vector 
   // offset: number of non-std::vector components before std::vectors start
-  std::string locErr;
-  std::vector<double> tvec;
   if(( rep().parameters().size() - offset) % numVecs != 0 ) {
-    locErr = std::string("Could not find equal sized components of std::vectors in a PolySolid description.");
-    edm::LogError ("DDSolid") << "rep().parameters().size()=" << rep().parameters().size() << "  numVecs=" << numVecs
-	 << "  offset=" << offset << std::endl;
+    edm::LogError ("DDSolid") << "Could not find equal sized components of std::vectors in a PolySolid description."
+			      << "rep().parameters().size()=" << rep().parameters().size() << "  numVecs=" << numVecs
+			      << "  offset=" << offset << std::endl;
   }
+  std::vector<double> tvec;
   for( size_t i = offset + which; i < rep().parameters().size(); i = i + numVecs ) {
     tvec.emplace_back( rep().parameters()[i]);
-  }		   
+  }               
   return tvec;
 }
 
@@ -461,7 +460,9 @@ DDExtrudedPolygon::DDExtrudedPolygon(const DDSolid & s)
 auto
 DDExtrudedPolygon::xyPointsSize( void ) const -> std::size_t
 {
-  // Here we compute the size of X and Y polygone vectors
+  // Compute the size of the X and Y coordinate vectors
+  // which define the vertices of the outlined polygon
+  // defined in clock-wise order
 
   return ( rep().parameters().size() - 4 * zSectionsSize()) * 0.5;
 }
@@ -469,7 +470,14 @@ DDExtrudedPolygon::xyPointsSize( void ) const -> std::size_t
 auto
 DDExtrudedPolygon::zSectionsSize( void ) const -> std::size_t
 {
-  // First parameters element stores a size of four Z section vectors
+  // The first parameters element stores a size of the four equal size vectors
+  // which form the ExtrudedPolygon shape Z sections:
+  // 
+  //    * first: Z coordinate of the XY polygone plane,
+  //    * second and third: x and y offset of the polygone in the XY plane,
+  //    * fourth: the polygone scale in each XY plane
+  //
+  // The Z sections defined by the z position in an increasing order.
 
   return rep().parameters()[0];
 }

--- a/DetectorDescription/Core/src/DDStreamer.cc
+++ b/DetectorDescription/Core/src/DDStreamer.cc
@@ -457,6 +457,7 @@ void DDStreamer::solids_read()
               (shape==ddpolycone_rrz) ||
               (shape==ddpolyhedra_rz) ||	      	          
               (shape==ddpolyhedra_rrz) ||
+	      (shape==ddextrudedpolygon) ||
               (shape==ddpseudotrap) ||
               (shape==ddshapeless) )
     {

--- a/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
+++ b/DetectorDescription/OfflineDBLoader/src/DDCoreToDDXMLOutput.cc
@@ -303,6 +303,24 @@ DDCoreToDDXMLOutput::solid( const DDSolid& solid, std::ostream& xos )
 	     << std::endl;
          break;
       }
+      case ddextrudedpolygon:
+      {
+	 DDExtrudedPolygon rs(solid);
+	 std::vector<double> x = rs.xVec();
+	 std::vector<double> y = rs.yVec();
+	 std::vector<double> z = rs.zVec();
+	 std::vector<double> zx = rs.zxVec();
+	 std::vector<double> zy = rs.zyVec();
+	 std::vector<double> zs = rs.zscaleVec();
+	 
+         xos << "<ExtrudedPolygon name=\""  << rs.toString() << "\"";
+	 for( unsigned int i : x )
+	   xos << " <XYPoint x=\"" << x[i] << "*mm\" y=\"" << y[i] << "*mm\"/>\n";
+	 for( unsigned int k : z )
+	   xos << " <ZXYSection z=\"" << z[k] << "*mm\" x=\"" << zx[k] << "*mm\" y=\"" << zy[k] << "*mm scale=" <<  zs[k] << "*mm\"/>\n";
+	 xos << "</ExtrudedPolygon>\n";
+         break;
+      }
          //       return new PSolid( pstrs(solid.toString()), solid.parameters()
          // 			 , solid.shape(), pstrs(""), pstrs(""), pstrs("") );
       case dd_not_init:

--- a/DetectorDescription/Parser/test/testDoc.cpp
+++ b/DetectorDescription/Parser/test/testDoc.cpp
@@ -318,6 +318,32 @@ testSolids( void )
   std::cout << "extrudedpgon is an Extruded Polygone solid:" << std::endl;
   std::cout << DDSolid(DDName("extrudedpgon", "testSolids")) << std::endl;
   std::cout << std::endl;
+  std::cout << "verify parameters interface\nx: ";
+  DDExtrudedPolygon extrPgon(DDSolid(DDName("extrudedpgon", "testSolids")));
+  std::vector<double> x = extrPgon.xVec();
+  std::vector<double> y = extrPgon.yVec();
+  std::vector<double> z = extrPgon.zVec();
+  std::vector<double> zx = extrPgon.zxVec();
+  std::vector<double> zy = extrPgon.zyVec();
+  std::vector<double> zs = extrPgon.zscaleVec();
+  for( auto i : x )
+    std::cout << i << ", ";
+  std::cout << "\ny: ";
+  for( auto i : y )
+    std::cout << i << ", ";
+  std::cout << "\nz: ";
+  for( auto i : z )
+    std::cout << i << ", ";
+  std::cout << "\nzx: ";
+  for( auto i : zx )
+    std::cout << i << ", ";
+  std::cout << "\nzy: ";
+  for( auto i : zy )
+    std::cout << i << ", ";
+  std::cout << "\nz scale: ";
+  for( auto i : zs )
+    std::cout << i << ", ";
+  std::cout << std::endl;
 }
 
 void

--- a/DetectorDescription/RegressionTest/src/DDCompareTools.cc
+++ b/DetectorDescription/RegressionTest/src/DDCompareTools.cc
@@ -235,6 +235,7 @@ bool DDCompareSolid::operator()(const DDSolid& lhs, const DDSolid& rhs) const {
     case ddpolyhedra_rz:
     case ddpolycone_rrz:
     case ddpolyhedra_rrz:
+    case ddextrudedpolygon:
     case ddtorus:
     case ddpseudotrap:
     case ddtrunctubs:

--- a/Fireworks/Geometry/src/TGeoFromDddService.cc
+++ b/Fireworks/Geometry/src/TGeoFromDddService.cc
@@ -37,6 +37,7 @@
 #include "TGeoTube.h"
 #include "TGeoArb8.h"
 #include "TGeoTrd2.h"
+#include "TGeoXtru.h"
 
 #include "Math/GenVector/RotationX.h"
 
@@ -386,6 +387,28 @@ TGeoFromDddService::createShape(const std::string& iName,
 		  *it /=cm;
 	       }
 	       rSolid->SetDimensions(&(*(temp.begin())));
+	    }
+	    break;
+         case ddextrudedpolygon:
+	    {
+	      DDExtrudedPolygon extrPgon(iSolid);
+	      std::vector<double> x = extrPgon.xVec();
+	      std::transform(x.begin(), x.end(), x.begin(),[](double d) { return d/cm; });
+	      std::vector<double> y = extrPgon.yVec();
+	      std::transform(y.begin(), y.end(), y.begin(),[](double d) { return d/cm; });
+	      std::vector<double> z = extrPgon.zVec();
+	      std::vector<double> zx = extrPgon.zxVec();
+	      std::vector<double> zy = extrPgon.zyVec();
+	      std::vector<double> zscale = extrPgon.zscaleVec();
+	      
+	      TGeoXtru* mySolid = new TGeoXtru(z.size());
+	      mySolid->DefinePolygon(x.size(), &(*x.begin()), &(*y.begin()));
+	      for( size_t i = 0; i < params[0]; ++i )
+	      {
+		mySolid->DefineSection( i, z[i]/cm, zx[i]/cm, zy[i]/cm, zscale[i]/cm);
+	      }
+	      
+	      rSolid = mySolid;
 	    }
 	    break;
 	 case ddpseudotrap:

--- a/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/src/TGeoMgrFromDdd.cc
@@ -38,6 +38,7 @@
 #include "TGeoTrd2.h"
 #include "TGeoTorus.h"
 #include "TGeoEltu.h"
+#include "TGeoXtru.h"
 
 #include "Math/GenVector/RotationX.h"
 #include "Math/GenVector/RotationZ.h"
@@ -331,6 +332,28 @@ TGeoMgrFromDdd::createShape(const std::string& iName,
 		  *it /=cm;
 	       }
 	       rSolid->SetDimensions(&(*(temp.begin())));
+	    }
+	    break;
+         case ddextrudedpolygon:
+	    {
+	      DDExtrudedPolygon extrPgon(iSolid);
+	      std::vector<double> x = extrPgon.xVec();
+	      std::transform(x.begin(), x.end(), x.begin(),[](double d) { return d/cm; });
+	      std::vector<double> y = extrPgon.yVec();
+	      std::transform(y.begin(), y.end(), y.begin(),[](double d) { return d/cm; });
+	      std::vector<double> z = extrPgon.zVec();
+	      std::vector<double> zx = extrPgon.zxVec();
+	      std::vector<double> zy = extrPgon.zyVec();
+	      std::vector<double> zscale = extrPgon.zscaleVec();
+	      
+	      TGeoXtru* mySolid = new TGeoXtru(z.size());
+	      mySolid->DefinePolygon(x.size(), &(*x.begin()), &(*y.begin()));
+	      for( size_t i = 0; i < params[0]; ++i )
+	      {
+		mySolid->DefineSection( i, z[i]/cm, zx[i]/cm, zy[i]/cm, zscale[i]/cm);
+	      }
+	      
+	      rSolid = mySolid;
 	    }
 	    break;
 	 case ddpseudotrap:

--- a/SimG4Core/Geometry/interface/DDG4SolidConverter.h
+++ b/SimG4Core/Geometry/interface/DDG4SolidConverter.h
@@ -36,6 +36,7 @@ private:
     static G4VSolid * polycone_rrz(const DDSolid &);
     static G4VSolid * polyhedra_rz(const DDSolid &);
     static G4VSolid * polyhedra_rrz(const DDSolid &);
+    static G4VSolid * extrudedpolygon(const DDSolid &);
     static G4VSolid * pseudotrap(const DDSolid & s);
     static G4VSolid * torus(const DDSolid &);
     static G4VSolid * trunctubs(const DDSolid &);

--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -21,7 +21,8 @@ DDG4SolidConverter::DDG4SolidConverter() {
   convDispatch_[ddpolycone_rrz]   = DDG4SolidConverter::polycone_rrz;
   convDispatch_[ddpolycone_rz]    = DDG4SolidConverter::polycone_rz;
   convDispatch_[ddpolyhedra_rrz]  = DDG4SolidConverter::polyhedra_rrz;
-  convDispatch_[ddpolyhedra_rz]   = DDG4SolidConverter::polyhedra_rz;   
+  convDispatch_[ddpolyhedra_rz]   = DDG4SolidConverter::polyhedra_rz;
+  convDispatch_[ddextrudedpolygon]= DDG4SolidConverter::extrudedpolygon;
   convDispatch_[ddtorus]          = DDG4SolidConverter::torus;   
   convDispatch_[ddreflected]      = DDG4SolidConverter::reflected;
   convDispatch_[ddunion]          = DDG4SolidConverter::unionsolid;
@@ -228,6 +229,25 @@ G4VSolid * DDG4SolidConverter::polyhedra_rrz(const DDSolid & solid) {
 			 &(z_p[0]),
 			 &(rmin_p[0]),
 			 &(rmax_p[0]));  
+}
+
+#include "G4ExtrudedSolid.hh"
+G4VSolid * DDG4SolidConverter::extrudedpolygon(const DDSolid & solid) {
+  LogDebug("SimG4CoreGeometry") << "DDG4SolidConverter: extr_pgon = " << solid;
+  std::vector<double> x = static_cast<DDExtrudedPolygon>(solid).xVec();
+  std::vector<double> y = static_cast<DDExtrudedPolygon>(solid).yVec();
+  std::vector<double> z = static_cast<DDExtrudedPolygon>(solid).zVec();
+  std::vector<double> zx = static_cast<DDExtrudedPolygon>(solid).zxVec();
+  std::vector<double> zy = static_cast<DDExtrudedPolygon>(solid).zyVec();
+  std::vector<double> zs = static_cast<DDExtrudedPolygon>(solid).zscaleVec();
+
+  std::vector<G4TwoVector> polygon;
+  std::vector<G4ExtrudedSolid::ZSection> zsections;
+  for( unsigned int it = 0; it < x.size(); ++it )
+    polygon.emplace_back( x[it], y[it] );
+  for( unsigned int it = 0; it < z.size(); ++it )
+    zsections.emplace_back( z[it], G4TwoVector(zx[it], zy[it]), zs[it] );
+  return new G4ExtrudedSolid( solid.name().name(), polygon, zsections );
 }
 
 #include "G4Torus.hh"

--- a/SimG4Core/Geometry/test/BuildFile.xml
+++ b/SimG4Core/Geometry/test/BuildFile.xml
@@ -29,6 +29,10 @@
  <use   name="cppunit"/>
 </bin>
 
+<bin  file="ExtrudedPolygon_.cpp">
+ <use   name="cppunit"/>
+</bin>
+
 <bin  file="Para_.cpp">
  <use   name="cppunit"/>
 </bin>

--- a/SimG4Core/Geometry/test/ExtrudedPolygon_.cpp
+++ b/SimG4Core/Geometry/test/ExtrudedPolygon_.cpp
@@ -1,0 +1,55 @@
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
+
+#include <DetectorDescription/Core/interface/DDSolid.h>
+#include <DetectorDescription/Core/interface/DDSolidShapes.h>
+
+#include <DetectorDescription/Core/src/ExtrudedPolygon.h>
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include <G4ExtrudedSolid.hh>
+#include <string>
+
+class testExtrudedPgon : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE( testExtrudedPgon );
+  CPPUNIT_TEST( matched_g4_and_dd );
+  
+  CPPUNIT_TEST_SUITE_END();
+  
+public:
+  
+  void matched_g4_and_dd( void );
+};
+
+void
+testExtrudedPgon::matched_g4_and_dd( void )
+{
+  std::vector<double> x = { -300, -300, 300, 300, 150, 150, -150, -150 };
+  std::vector<double> y = { -300, 300, 300, -300, -300, 150, 150, -300 };
+  std::vector<double> z = { -600, -150, 100, 600 };
+  std::vector<double> zx = { 0, 0, 0, 0 };
+  std::vector<double> zy = { 300, -300, 0, 300 }; 
+  std::vector<double> zscale = { 8, 10, 6, 12 };
+  std::string name( "fred1" );
+
+  std::vector<G4TwoVector> polygon;
+  std::vector<G4ExtrudedSolid::ZSection> zsections;
+  for( unsigned int it = 0; it < x.size(); ++it )
+    polygon.emplace_back( x[it], y[it] );
+  for( unsigned int it = 0; it < z.size(); ++it )
+    zsections.emplace_back( z[it], G4TwoVector(zx[it], zy[it]), zscale[it] );
+  G4ExtrudedSolid g4( name, polygon, zsections );
+  DDI::ExtrudedPolygon dd( x, y, z, zx, zy, zscale );
+  DDExtrudedPolygon dds = DDSolidFactory::extrudedpolygon( name,  x, y, z, zx, zy, zscale );
+
+  dd.stream(std::cout);
+  std::cout << std::endl;
+  std::cout << "\tg4 volume = " << g4.GetCubicVolume()/cm3 <<" cm3" << std::endl;
+  std::cout << "\tdd volume = " << dd.volume()/cm3 << " cm3"<<  std::endl;
+  std::cout << "\tDD Information: " << dds << " vol= " << dds.volume() << std::endl;
+  
+  // FIXME: dd voulme is not implemented yet!
+  // CPPUNIT_ASSERT( g4.GetCubicVolume()/cm3 == dd.volume()/cm3 );
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION( testExtrudedPgon );

--- a/SimG4Core/Geometry/test/testVolumes.cpp
+++ b/SimG4Core/Geometry/test/testVolumes.cpp
@@ -5,6 +5,7 @@
 #include <DetectorDescription/Core/src/Cons.h>
 #include <DetectorDescription/Core/src/Ellipsoid.h>
 #include <DetectorDescription/Core/src/EllipticalTube.h>
+#include <DetectorDescription/Core/src/ExtrudedPolygon.h>
 #include <DetectorDescription/Core/src/Orb.h>
 #include <DetectorDescription/Core/src/Parallelepiped.h>
 #include <DetectorDescription/Core/src/Polycone.h>
@@ -31,6 +32,7 @@
 #include <G4Trd.hh>
 #include <G4Tubs.hh>
 #include <G4CutTubs.hh>
+#include <G4ExtrudedSolid.hh>
 #include <string>
 
 //
@@ -563,6 +565,40 @@ doCutTubs( const std::string& name, double rIn, double rOut,
   std::cout << "\tDD Information: " << dds << " vol= " << dds.volume() << std::endl;
 }
 
+//
+// 25. Extruded Polygon:
+//
+// The extrusion of an arbitrary polygon (extruded solid)
+// with fixed outline in the defined Z sections can be defined as follows
+// (in a general way, or as special construct with two Z sections):
+//
+//    G4ExtrudedSolid(const G4String& pName,
+//                    std::vector<G4TwoVector> polygon,
+//                    std::vector<ZSection> zsections)
+//
+void
+doExtrudedPgon( const std::string& name, const std::vector<double> x,
+		const std::vector<double> y, const std::vector<double> z,
+		const std::vector<double> zx, const std::vector<double> zy,
+		const std::vector<double> zscale )
+{
+  std::vector<G4TwoVector> polygon;
+  std::vector<G4ExtrudedSolid::ZSection> zsections;
+  for( unsigned int it = 0; it < x.size(); ++it )
+    polygon.emplace_back( x[it], y[it] );
+  for( unsigned int it = 0; it < z.size(); ++it )
+    zsections.emplace_back( z[it], G4TwoVector(zx[it], zy[it]), zscale[it] );
+  G4ExtrudedSolid g4( name, polygon, zsections );
+  DDI::ExtrudedPolygon dd( x, y, z, zx, zy, zscale );
+  DDExtrudedPolygon dds = DDSolidFactory::extrudedpolygon( name,  x, y, z, zx, zy, zscale );
+
+  dd.stream(std::cout);
+  std::cout << std::endl;
+  std::cout << "\tg4 volume = " << g4.GetCubicVolume()/cm3 <<" cm3" << std::endl;
+  std::cout << "\tdd volume = " << dd.volume()/cm3 << " cm3"<<  std::endl;
+  std::cout << "\tDD Information: " << dds << " vol= " << dds.volume() << std::endl;
+}
+
 int
 main( int argc, char *argv[] )
 {
@@ -788,6 +824,28 @@ main( int argc, char *argv[] )
   std::array<double, 3> highNorm = {{ 0.7, 0, 0.71 }};
   
   doCutTubs( name, rIn, rOut, zhalf, startPhi, deltaPhi, lowNorm, highNorm );
+  std::cout << std::endl;
+
+//
+// 25. Extruded Polygon:
+//
+// The extrusion of an arbitrary polygon (extruded solid)
+// with fixed outline in the defined Z sections can be defined as follows
+// (in a general way, or as special construct with two Z sections):
+//
+//    G4ExtrudedSolid(const G4String& pName,
+//                    std::vector<G4TwoVector> polygon,
+//                    std::vector<ZSection> zsections)
+//
+  std::cout << "\n\nExtruded Polygon tests\n" << std::endl;
+  std::vector<double> x = { -300, -300, 300, 300, 150, 150, -150, -150 };
+  std::vector<double> y = { -300, 300, 300, -300, -300, 150, 150, -300 };
+  std::vector<double> epz = { -600, -150, 100, 600 };
+  std::vector<double> zx = { 0, 0, 0, 0 };
+  std::vector<double> zy = { 300, -300, 0, 300 }; 
+  std::vector<double> zscale = { 8, 10, 6, 12 };
+  
+  doExtrudedPgon( name, x, y, epz, zx, zy, zscale );
   std::cout << std::endl;
   
   return EXIT_SUCCESS;

--- a/SimG4Core/PrintGeomInfo/src/PrintGeomSummary.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintGeomSummary.cc
@@ -59,6 +59,7 @@ PrintGeomSummary::PrintGeomSummary(const edm::ParameterSet &p) : theTopPV_(0) {
   solidShape_[ddellipsoid]      = "Ellipsoid";
   solidShape_[ddparallelepiped] = "Parallelepiped";
   solidShape_[ddcuttubs]        = "CutTubs";
+  solidShape_[ddextrudedpolygon]= "ExtrudedPolygon";
   solidShape_[dd_not_init]      = "Unknown";
 }
  


### PR DESCRIPTION
* Interface between DDExtrudedPolygone and TGeo shape

@bsunanda - FYI.

The shape definition in DDL XML and its view in cmsShow:
```
		<ExtrudedPolygon name="extrudedpgon">
		  <XYPoint x="-30*cm" y="-30*cm"/>
		  <XYPoint x="-30*cm" y=" 30*cm"/>
		  <XYPoint x=" 30*cm" y=" 30*cm"/>
		  <XYPoint x=" 30*cm" y="-30*cm"/>
		  <XYPoint x=" 15*cm" y="-30*cm"/>
		  <XYPoint x=" 15*cm" y=" 15*cm"/>
		  <XYPoint x="-15*cm" y=" 15*cm"/>
		  <XYPoint x="-15*cm" y="-30*cm"/>
		  <ZXYSection z="-60*cm" x="0*cm" y="30*cm" scale="0.8*cm"/>
		  <ZXYSection z="-15*cm" x="0*cm" y="-30*cm" scale="1.*cm"/>
		  <ZXYSection z="10*cm" x="0*cm" y="0*cm" scale="0.6*cm"/>
		  <ZXYSection z="60*cm" x="0*cm" y="30*cm" scale="1.2*cm"/>
		</ExtrudedPolygon>

```
![screenshot 2017-05-04 17 07 15](https://cloud.githubusercontent.com/assets/1390682/25710691/449432c0-30ed-11e7-8572-8aedaddd6be6.png)

@davidlange6 and @civanch - this PR is based on https://github.com/cms-sw/cmssw/pull/18552