### PR TITLE
expand 2017 wf list for IB

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -13,9 +13,12 @@ workflows = Matrix()
 
 #just define all of them
 
-#2017 WFs to run in IB (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
-#same for 2018
-numWFIB = [10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
+#WFs to run in IB:
+#   2017 (ele guns 10, 35, 1000; pho guns 10, 35; mu guns 1, 10, 100, 1000, QCD 3TeV, QCD Flat)
+#   2017 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
+#   2018 (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
+numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
+           10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
            10842.0,10824.0,10825.0,10826.0,10823.0,11024.0,11025.0,11224.0]
 for i,key in enumerate(upgradeKeys[2017]):
     numWF=numWFAll[2017][i]


### PR DESCRIPTION
add 2017
(ele guns 10, 35, 1000; pho guns 10, 35; mu guns 1, 10, 100, 1000, QCD 3TeV, QCD Flat)
This will also help to keep the input files in cmsbuild eos space,
since these are actively used in local MC checkout of pull requests.
