### PR TITLE
Fixes for regression in the persistency of std::string payloads

### DIFF
--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -35,6 +35,14 @@ namespace cond {
     return new T;
   }
 
+  template <> inline std::string* createPayload<std::string>( const std::string& payloadTypeName ){
+    std::string userTypeName = demangledName( typeid(std::string) );
+    if( payloadTypeName != userTypeName && payloadTypeName != "std::string" )
+      throwException(std::string("Type mismatch, user type: \"std::string\", target type: \"")+payloadTypeName+"\"",
+		     "createPayload" );
+    return new std::string;
+  }
+
   class StreamerInfo {
   public:
     static constexpr char const* TECH_LABEL = "technology";

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -198,6 +198,19 @@ namespace cond {
       }
       return ret;
     }
+
+    template <> inline cond::Hash Session::storePayload<std::string>( const std::string& payload, const boost::posix_time::ptime& creationTime ){
+
+      std::string payloadObjectType("std::string");
+      cond::Hash ret;
+      try{
+        ret = storePayloadData( payloadObjectType, serialize( payload ), creationTime );
+      } catch ( const cond::persistency::Exception& e ){
+	std::string em(e.what());
+        throwException( "Payload of type "+payloadObjectType+" could not be stored. "+em,"Session::storePayload");
+      }
+      return ret;
+    }
     
     template <typename T> inline std::shared_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
       cond::Binary payloadData;

--- a/CondCore/CondDB/test/condTestRegression.py
+++ b/CondCore/CondDB/test/condTestRegression.py
@@ -163,9 +163,9 @@ class CondRegressionTester(object):
               print 'Executable %s not found in local release.'
               executable = None
               for rel_base_env in ['CMSSW_BASE', 'CMSSW_RELEASE_BASE', 'CMSSW_FULL_RELEASE_BASE' ]:
-                  #print "Looking for: %s = %s " %(rel_base_env,os.getenv(rel_base_env))
                   if os.getenv(rel_base_env) and os.path.exists(str(os.environ[rel_base_env])+'/%s' %execName):
                       executable = str(os.environ[rel_base_env])+'/%s' %execName
+                      break
 
           if executable is None:
               raise Exception("Can't find the %s executable." %execName )

--- a/CondCore/CondDB/test/condTestRegression.py
+++ b/CondCore/CondDB/test/condTestRegression.py
@@ -106,19 +106,16 @@ class CondRegressionTester(object):
               print 'SELF: %s [%s]\n' %(self.rel,self.arch)
               print fmt %header
               for result in sorted(self.status.keys()):
-                  params = (result,)+tuple([self.status[result][key] for key in self.status[result].keys()])
+                  params = (result,)+tuple([self.status[result][key] for key in sorted(self.status[result].keys())])
                   print fmt %params
 
           if jsonOut:
               print json.dumps( self.status, sort_keys=True, indent=4 )
 
           overall = True
-          for k,v in self.status.items():
-              # do not take results from 7.1.X into the overall status as this release can not 
-	      # read more recent data until the corresponding boost 1.57 version is backported:
-              if 'CMSSW_7_1_' in k: continue
-
-              if not v : overall = False
+          for result in sorted(self.status.keys()):
+              for result_arch in sorted(self.status[result].keys()):
+                  if not self.status[result][result_arch]: overall = False
 
           return overall
 
@@ -160,10 +157,24 @@ class CondRegressionTester(object):
           if readOrWrite == 'write':
               self.dbList['SELF'] = dbName
 
+          execName = 'test/%s/testReadWritePayloads' %self.arch
+          executable = '%s/%s' %(os.environ['LOCALRT'],execName)
+          if not os.path.exists(executable):
+              print 'Executable %s not found in local release.'
+              executable = None
+              for rel_base_env in ['CMSSW_BASE', 'CMSSW_RELEASE_BASE', 'CMSSW_FULL_RELEASE_BASE' ]:
+                  #print "Looking for: %s = %s " %(rel_base_env,os.getenv(rel_base_env))
+                  if os.getenv(rel_base_env) and os.path.exists(str(os.environ[rel_base_env])+'/%s' %execName):
+                      executable = str(os.environ[rel_base_env])+'/%s' %execName
+
+          if executable is None:
+              raise Exception("Can't find the %s executable." %execName )
+
           # we run in the local environment, but need to make sure that we start "top-level" of the devel area
           # and we assume that the test was already built 
           cmd = 'export SCRAM_ARCH=%s; cd %s/src; eval `scram runtime -sh 2>/dev/null` ; ' % (os.environ['SCRAM_ARCH'],os.environ['CMSSW_BASE'], )
-          cmd += '$LOCALRT/test/%s/testReadWritePayloads %s sqlite_file:///%s/%s ' % (self.arch, readOrWrite, self.dbDir, dbName)
+          cmd += "echo 'CMSSW_BASE='$CMSSW_BASE; echo 'RELEASE_BASE='$RELEASE_BASE; echo 'PATH='$PATH; echo 'LD_LIBRARY_PATH='$LD_LIBRARY_PATH; echo 'LOCALRT='$LOCALRT;"
+          cmd += '%s %s sqlite_file:///%s/%s ' % (executable, readOrWrite, self.dbDir, dbName)
           
           try:
              res = check_output(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
@@ -205,9 +216,11 @@ class CondRegressionTester(object):
                          status = False
                          print "rel %s reading %s FAILED." % (rel, writer)
                      if writer not in self.status.keys():
-                         self.status[writer] = { '%s [%s]' %(rel,arch):status }
+                         key = '%s [%s]' %(rel,arch)
+                         self.status[writer] = { key : status }
                      else:
                          self.status[writer]['%s [%s]' %(rel,arch)] = status 
+
           # ... and also with this IB/devArea
           for writer in self.dbList.keys(): # for any given rel/arch we check all written DBs
              dbName = self.dbList[writer]
@@ -219,10 +232,9 @@ class CondRegressionTester(object):
                 status = False
                 print "rel %s reading %s FAILED." % (self.rel, writer)
              if writer not in self.status.keys():
-                 self.status[writer] = { 'SELF':status }
+                 self.status[writer] = { 'SELF': status }
              else:
                  self.status[writer]['SELF'] = status 
-
           print '='*80
 
 crt = CondRegressionTester()


### PR DESCRIPTION
Fix for std::string type matching.  A recent compiler change has changed the output of the 'demangler' for the std::string class.
Regression test adapted for execution in IB environment. This test will now run correctly once the above fix will be in a main release