### PR TITLE
Adding new instances of HLTCaloObjInRegionsProducer for HLT filtering: 91X

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalDigiCollections.h
+++ b/DataFormats/EcalDigi/interface/EcalDigiCollections.h
@@ -26,6 +26,7 @@ public:
   explicit EcalDigiCollection(size_type istride=MAXSAMPLES, int isubdet=0)  : 
     edm::DataFrameContainer(istride, isubdet){}
   void swap(DataFrameContainer& other) {this->DataFrameContainer::swap(other);}
+  
 };
 
 // make edm (and ecal client) happy
@@ -38,6 +39,10 @@ public:
   EBDigiCollection(size_type istride=MAXSAMPLES) : 
     EcalDigiCollection(istride, EcalBarrel){}
   void swap(EBDigiCollection& other) {this->EcalDigiCollection::swap(other);}
+  void push_back(const Digi& digi){ DataFrameContainer::push_back(digi.id(), digi.frame().begin()); }
+  void push_back(id_type iid){DataFrameContainer::push_back(iid);}
+  void push_back(id_type iid,data_type const* idata){DataFrameContainer::push_back(iid,idata);}
+  
 };
 
 class EEDigiCollection : public  EcalDigiCollection {
@@ -49,6 +54,10 @@ public:
   EEDigiCollection(size_type istride=MAXSAMPLES) : 
     EcalDigiCollection(istride, EcalEndcap){}
   void swap(EEDigiCollection& other) {this->EcalDigiCollection::swap(other);}
+  void push_back(const Digi& digi){ edm::DataFrameContainer::push_back(digi.id(), digi.frame().begin()); }
+  void push_back(id_type iid){DataFrameContainer::push_back(iid);}
+  void push_back(id_type iid,data_type const* idata){DataFrameContainer::push_back(iid,idata);}
+  
 };
 
 class ESDigiCollection : public EcalDigiCollection 

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h
@@ -7,13 +7,13 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// Reco candidates (might not need)
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
@@ -22,7 +22,6 @@
 #include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
 
 
-// Geometry and topology
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
@@ -34,12 +33,7 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 
-#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
-#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
-#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
-
 #include "L1Trigger/L1TCalorimeter/interface/CaloTools.h"
-
 #include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
 
 /**************************************************************
@@ -145,6 +139,9 @@ HLTCaloObjInRegionsProducer<CaloObjType,CaloObjCollType>::HLTCaloObjInRegionsPro
 
   outputProductNames_=para.getParameter<std::vector<std::string>>("outputProductNames");
   inputCollTags_=para.getParameter<std::vector<edm::InputTag>>("inputCollTags");
+  if(outputProductNames_.size()!=inputCollTags_.size()){
+    throw cms::Exception("InvalidConfiguration") <<" error outputProductNames and inputCollTags must be the same size, they are "<<outputProductNames_.size()<<" vs "<<inputCollTags_.size();
+  }
   for (unsigned int collNr=0; collNr<inputCollTags_.size(); collNr++) { 
     inputTokens_.push_back(consumes<CaloObjCollType>(inputCollTags_[collNr]));
     produces<CaloObjCollType> (outputProductNames_[collNr]);
@@ -224,7 +221,7 @@ makeFilteredColl(const edm::Handle<CaloObjCollType>& inputColl,
   
   auto outputColl = std::make_unique<CaloObjCollType>();
   if(!inputColl->empty()){
-    const CaloSubdetectorGeometry* subDetGeom=caloGeomHandle->getSubdetectorGeometry(inputColl->front().id());
+    const CaloSubdetectorGeometry* subDetGeom=caloGeomHandle->getSubdetectorGeometry(inputColl->begin()->id());
     if(!regions.empty()){
       for(const CaloObjType& obj : *inputColl){
 	const CaloCellGeometry* objGeom = subDetGeom->getGeometry(obj.id());
@@ -232,7 +229,7 @@ makeFilteredColl(const edm::Handle<CaloObjCollType>& inputColl,
 	  //wondering what to do here
 	  //something is very very wrong
 	  //given HLT should never crash or throw, decided to log an error and 
-	  edm::LogError("HLTCaloObjInRegionsProducer") << "for an object of type "<<typeid(CaloObjType).name()<<" the geometry returned null for id "<<obj.id()<<" in HLTCaloObjsInRegion, this shouldnt be possible and something has gone wrong, auto accepting hit";
+	  edm::LogError("HLTCaloObjInRegionsProducer") << "for an object of type "<<typeid(CaloObjType).name()<<" the geometry returned null for id "<<DetId(obj.id()).rawId()<<" in HLTCaloObjsInRegion, this shouldnt be possible and something has gone wrong, auto accepting hit";
 	  outputColl->push_back(obj);
 	}
 	float eta = objGeom->getPosition().eta();
@@ -298,8 +295,6 @@ void EtaPhiRegionData<CandCollType>::getEtaPhiRegions(const edm::Event& event,st
 }
 
 
-typedef HLTCaloObjInRegionsProducer<HBHEDataFrame> HLTHcalDigisInRegionsProducer;
-DEFINE_FWK_MODULE(HLTHcalDigisInRegionsProducer);
 
 #endif
 

--- a/RecoEgamma/EgammaHLTProducers/src/HLTCaloObjInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTCaloObjInRegionsProducer.cc
@@ -1,1 +1,35 @@
 #include "RecoEgamma/EgammaHLTProducers/interface/HLTCaloObjInRegionsProducer.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
+using HLTHcalDigisInRegionsProducer = HLTCaloObjInRegionsProducer<HBHEDataFrame>;
+DEFINE_FWK_MODULE(HLTHcalDigisInRegionsProducer);
+
+
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+using HLTHcalQIE11DigisInRegionsProducer = HLTCaloObjInRegionsProducer<QIE11DataFrame,QIE11DigiCollection>;
+DEFINE_FWK_MODULE(HLTHcalQIE11DigisInRegionsProducer);
+
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+using HLTHcalQIE10DigisInRegionsProducer = HLTCaloObjInRegionsProducer<QIE10DataFrame,QIE10DigiCollection>;
+DEFINE_FWK_MODULE(HLTHcalQIE10DigisInRegionsProducer);
+
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+using HLTEcalEBDigisInRegionsProducer = HLTCaloObjInRegionsProducer<EBDataFrame,EBDigiCollection>;
+DEFINE_FWK_MODULE(HLTEcalEBDigisInRegionsProducer);
+using HLTEcalEEDigisInRegionsProducer = HLTCaloObjInRegionsProducer<EEDataFrame,EEDigiCollection>;
+DEFINE_FWK_MODULE(HLTEcalEEDigisInRegionsProducer);
+using HLTEcalESDigisInRegionsProducer = HLTCaloObjInRegionsProducer<ESDataFrame,ESDigiCollection>;
+DEFINE_FWK_MODULE(HLTEcalESDigisInRegionsProducer);
+
+//these two classes are intended to ultimately replace the EcalRecHit and EcalUncalibratedRecHit
+//instances of HLTRecHitInAllL1RegionsProducer, particulary as we're free of legacy / stage-1 L1 now
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+using HLTEcalRecHitsInRegionsProducer = HLTCaloObjInRegionsProducer<EcalRecHit>;
+DEFINE_FWK_MODULE(HLTEcalRecHitsInRegionsProducer);
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
+using HLTEcalUnCalibRecHitsInRegionsProducer = HLTCaloObjInRegionsProducer<EcalUncalibratedRecHit>;
+DEFINE_FWK_MODULE(HLTEcalUnCalibRecHitsInRegionsProducer);


### PR DESCRIPTION
This is the 91X flavour of https://github.com/cms-sw/cmssw/pull/18544.

It is necessary to be able to prefilter HCAL PhaseI digis so that method2 can be run on rec-hits of interest to E/gamma in the HLT. 