### PR TITLE
Avoid ambiguous errors with C++17

### DIFF
--- a/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
@@ -49,8 +49,8 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 			std::string labelEta = label.Data();
 			std::string labelPhi = label.Data();
 			label+=flavour+TString("_disc_pT");
-			labelEta+=flavour+"_disc_eta";
-			labelPhi+=flavour+"_disc_phi";
+			labelEta+=std::string(static_cast<const char *>(flavour))+"_disc_eta";
+			labelPhi+=std::string(static_cast<const char *>(flavour))+"_disc_phi";
 			isOK=GetNumDenumerators (ibooker,igetter,(TString(dqmFolder_hist)+"/"+label).Data(),(TString(dqmFolder_hist)+"/"+label).Data(),num,den,1);
 			if (isOK) {
 			

--- a/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
@@ -221,8 +221,8 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 				labelEta=label;
 				labelPhi=label;
 				label+=flavour+TString("_disc_pT");
-				labelEta+=flavour+"_disc_eta";
-				labelPhi+=flavour+"_disc_phi";
+				labelEta+=std::string(static_cast<const char *>(flavour))+"_disc_eta";
+				labelPhi+=std::string(static_cast<const char *>(flavour))+"_disc_phi";
 
 				//book 2D btag plot for 'b,c,light,g'
 				H2_.back()[label.Data()] =  ibooker.book2D( label.Data(), label.Data(), btagBins, btagL, btagU, nBinsPt, pTmin, pTMax );


### PR DESCRIPTION
TString has conversion operators for const char * and std::string_view,
and both are accepted by std::string ctor and some operators. This
causes ambiguous overload errors in C++17.

https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc700/CMSSW_9_2_X_2017-05-04-2300/HLTriggerOffline/Btag

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>