### PR TITLE
ECAL aging condition customizations

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -119,6 +119,29 @@ def ageEcal(process,lumi,instLumi):
         #these lines need to be further activiated by tuning on 'complete' aging for ecal 
         process.g4SimHits.ECalSD.InstLuminosity = cms.double(instLumi)
         process.g4SimHits.ECalSD.DelivLuminosity = cms.double(float(lumi))
+
+   # available conditions
+    ecal_lumis = [300,1000,3000,4500]
+    ecal_conditions = [
+        ['EcalIntercalibConstantsRcd','EcalIntercalibConstants_TL{:d}_upgrade_8deg_mc'],
+        ['EcalIntercalibConstantsMCRcd','EcalIntercalibConstantsMC_TL{:d}_upgrade_8deg_mc'],
+        ['EcalLaserAPDPNRatiosRcd','EcalLaserAPDPNRatios_TL{:d}_upgrade_8deg_mc'],
+        ['EcalPedestalsRcd','EcalPedestals_TL{:d}_upgradeTIA_8deg_mc'],
+        ['EcalTPGLinearizationConstRcd','EcalTPGLinearizationConst_TL{:d}_upgrade_8deg_mc'],
+    ]
+
+    # try to get conditions
+    if int(lumi) in ecal_lumis:
+        if not hasattr(process.GlobalTag,'toGet'):
+            process.GlobalTag.toGet=cms.VPSet()
+        for ecal_condition in ecal_conditions:
+            process.GlobalTag.toGet.append(cms.PSet(
+                record = cms.string(ecal_condition[0]),
+                tag = cms.string(ecal_condition[1].format(int(lumi))),
+                connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+                )
+            )
+        
     return process
 
 def ecal_complete_aging(process):


### PR DESCRIPTION
This PR adds a customization to enable the latest ECAL aging conditions for Phase2 studies. The list of conditions is given here: https://hypernews.cern.ch/HyperNews/CMS/get/ecal-calibration/1053.html. This PR will be backported to 91X.