### PR TITLE
Fixes for the neutron background simulation with GEANT

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/customise_mixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_mixing.py
@@ -59,5 +59,5 @@ def customise_NoCrossing_PU(process):
 
 
 def customise_Mix_LongLived_Neutrons(process):
-    process.mix.WrapLongTimes = cms.untracked.bool(True)
+    process.mix.WrapLongTimes = cms.bool(True)
     return (process)

--- a/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
+++ b/SimMuon/RPCDigitizer/python/muonRPCDigis_cfi.py
@@ -56,7 +56,7 @@ _simMuonRPCDigisPhaseII = cms.EDProducer("RPCandIRPCDigiProducer",
         timeJitter = cms.double(1.0),
         sigmaY = cms.double(2.), # resolution of 2 cm
         do_Y_coordinate = cms.bool(False),
-        digitizeElectrons = cms.bool(False),
+        digitizeElectrons = cms.bool(True),
         IRPC_time_resolution = cms.double(1.0),# resolution of 1 ns, after LB upgrade. Here the RPC resolution is set
         IRPC_electronics_jitter = cms.double(0.1)# resolution of 100 ps
     ),
@@ -85,7 +85,7 @@ _simMuonRPCDigisPhaseII = cms.EDProducer("RPCandIRPCDigiProducer",
         IRPC_electronics_jitter = cms.double(0.1),# resolution of 100 ps
         sigmaY = cms.double(2.), # resolution of 2 cm
         do_Y_coordinate = cms.bool(True),
-        digitizeElectrons = cms.bool(False),
+        digitizeElectrons = cms.bool(True),
     ),
     digiIRPCModel = cms.string('RPCSimModelTiming')
 )


### PR DESCRIPTION
Same as https://github.com/cms-sw/cmssw/pull/18596, it is needed for the Muon TDR production.
@kpedro88 @pietverwilligen @jshlee @bapavlov 