### PR TITLE
Optimise ECAL multifit (for cmssw 92x)

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
@@ -8,13 +8,9 @@
 <use   name="CondFormats/EcalObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="vdt_headers"/>
-
 <use   name="root"/>
 <use   name="rootminuit"/>
-
 <use   name="eigen"/>
-
-<Flags CXXFLAGS="-Ofast"/>
 
 <export>
   <lib   name="1"/>

--- a/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
@@ -328,9 +328,8 @@ bool PulseChiSqSNNLS::NNLS() {
   constexpr unsigned int nsamples = SampleVector::RowsAtCompileTime;
 
   invcovp = _covdecomp.matrixL().solve(_pulsemat);
-  aTamat = invcovp.transpose()*invcovp; //.triangularView<Eigen::Lower>()
-  //aTamat = aTamat.selfadjointView<Eigen::Lower>();  
-  aTbvec = invcovp.transpose()*_covdecomp.matrixL().solve(_sampvec);  
+  aTamat.noalias() = invcovp.transpose().lazyProduct(invcovp);
+  aTbvec.noalias() = invcovp.transpose().lazyProduct(_covdecomp.matrixL().solve(_sampvec));
   
   int iter = 0;
   Index idxwmax = 0;

--- a/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
@@ -376,9 +376,11 @@ bool PulseChiSqSNNLS::NNLS() {
       eigen_solve_submatrix(aTamat,aTbvec,ampvecpermtest,_nP);
       
       //check solution
-      auto ampvecpermhead = ampvecpermtest.head(_nP);
-      if ( ampvecpermhead.minCoeff()>0. ) {
-        _ampvec.head(_nP) = ampvecpermhead.head(_nP);
+      bool positive = true;
+      for (unsigned int i = 0; i < _nP; ++i)
+        positive &= (ampvecpermtest(i) > 0);
+      if (positive) {
+        _ampvec.head(_nP) = ampvecpermtest.head(_nP);
         break;
       }      
 
@@ -398,7 +400,7 @@ bool PulseChiSqSNNLS::NNLS() {
         }
       }
 
-      _ampvec.head(_nP) += minratio*(ampvecpermhead - _ampvec.head(_nP));
+      _ampvec.head(_nP) += minratio*(ampvecpermtest.head(_nP)- _ampvec.head(_nP));
       
       //avoid numerical problems with later ==0. check
       _ampvec.coeffRef(minratioidx) = 0.;

--- a/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
@@ -412,8 +412,8 @@ bool PulseChiSqSNNLS::NNLS() {
     
     //adaptive convergence threshold to avoid infinite loops but still
     //ensure best value is used
-    if (iter%50==0) {
-      threshold *= 10.;
+    if (iter % 16 == 0) {
+      threshold *= 2;
     }
   }
   

--- a/RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerBaseClass.h
+++ b/RecoLocalCalo/EcalRecProducers/interface/EcalUncalibRecHitWorkerBaseClass.h
@@ -23,6 +23,14 @@ class EcalUncalibRecHitWorkerBaseClass {
   virtual void set(const edm::EventSetup& es) = 0;
   virtual void set(const edm::Event& evt) {}
   virtual bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result) = 0;
+
+  virtual void run(const edm::Event& evt, const EcalDigiCollection & digis, EcalUncalibratedRecHitCollection & result)
+  {
+    result.reserve(result.size() + digis.size());
+    for (auto it = digis.begin(); it != digis.end(); ++it)
+      run(evt, it, result);
+  }
+
   virtual edm::ParameterSetDescription getAlgoDescription() = 0;
 };
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
@@ -116,21 +116,11 @@ EcalUncalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
 
         // loop over EB digis
         if (ebDigis)
-        {
-                ebUncalibRechits->reserve(ebDigis->size());
-                for(EBDigiCollection::const_iterator itdg = ebDigis->begin(); itdg != ebDigis->end(); ++itdg) {
-                        worker_->run(evt, itdg, *ebUncalibRechits);
-                }
-        }
+            worker_->run(evt, *ebDigis, *ebUncalibRechits);
 
         // loop over EB digis
         if (eeDigis)
-        {
-                eeUncalibRechits->reserve(eeDigis->size());
-                for(EEDigiCollection::const_iterator itdg = eeDigis->begin(); itdg != eeDigis->end(); ++itdg) {
-                        worker_->run(evt, itdg, *eeUncalibRechits);
-                }
-        }
+            worker_->run(evt, *eeDigis, *eeUncalibRechits);
 
         // put the collection of recunstructed hits in the event
         evt.put(std::move(ebUncalibRechits), ebHitCollection_);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -250,7 +250,6 @@ double EcalUncalibRecHitWorkerMultiFit::timeCorrection(
 }
 
 
-
 bool
 EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 const EcalDigiCollection::const_iterator & itdg,
@@ -512,6 +511,256 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
         }
 
         return true;
+}
+
+void
+EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
+                const EcalDigiCollection & digis,
+                EcalUncalibratedRecHitCollection & result )
+{
+    if (digis.empty())
+      return;
+
+    // assume all digis come from the same subdetector (either barrel or endcap)
+    DetId detid(digis.begin()->id());
+    bool barrel = (detid.subdetId()==EcalBarrel);
+
+    multiFitMethod_.setSimplifiedNoiseModelForGainSwitch(simplifiedNoiseModelForGainSwitch_);
+    if (barrel) {
+        multiFitMethod_.setDoPrefit(doPrefitEB_);
+        multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB_);
+        multiFitMethod_.setDynamicPedestals(dynamicPedestalsEB_);
+        multiFitMethod_.setMitigateBadSamples(mitigateBadSamplesEB_);
+        multiFitMethod_.setGainSwitchUseMaxSample(gainSwitchUseMaxSampleEB_);
+        multiFitMethod_.setSelectiveBadSampleCriteria(selectiveBadSampleCriteriaEB_);
+        multiFitMethod_.setAddPedestalUncertainty(addPedestalUncertaintyEB_);        
+    } else {
+        multiFitMethod_.setDoPrefit(doPrefitEE_);
+        multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEE_);
+        multiFitMethod_.setDynamicPedestals(dynamicPedestalsEE_);
+        multiFitMethod_.setMitigateBadSamples(mitigateBadSamplesEE_);
+        multiFitMethod_.setGainSwitchUseMaxSample(gainSwitchUseMaxSampleEE_);
+        multiFitMethod_.setSelectiveBadSampleCriteria(selectiveBadSampleCriteriaEE_);
+        multiFitMethod_.setAddPedestalUncertainty(addPedestalUncertaintyEE_);
+    }
+        
+    FullSampleVector fullpulse(FullSampleVector::Zero());
+    FullSampleMatrix fullpulsecov(FullSampleMatrix::Zero());
+
+    result.reserve(result.size() + digis.size());
+    for (auto itdg = digis.begin(); itdg != digis.end(); ++itdg)
+    {
+        DetId detid(itdg->id());
+
+        const EcalSampleMask *sampleMask_ = sampleMaskHand_.product();                
+        
+        // intelligence for recHit computation
+        //EcalUncalibratedRecHit uncalibRecHit;
+        float offsetTime = 0;
+        
+        const EcalPedestals::Item * aped = 0;
+        const EcalMGPAGainRatio * aGain = 0;
+        const EcalXtalGroupId * gid = 0;
+        const EcalPulseShapes::Item * aPulse = 0;
+        const EcalPulseCovariances::Item * aPulseCov = 0;
+
+        if (barrel) {
+            unsigned int hashedIndex = EBDetId(detid).hashedIndex();
+            aped       = &peds->barrel(hashedIndex);
+            aGain      = &gains->barrel(hashedIndex);
+            gid        = &grps->barrel(hashedIndex);
+            aPulse     = &pulseshapes->barrel(hashedIndex);
+            aPulseCov  = &pulsecovariances->barrel(hashedIndex);
+            offsetTime = offtime->getEBValue();
+        } else {
+            unsigned int hashedIndex = EEDetId(detid).hashedIndex();
+            aped       = &peds->endcap(hashedIndex);
+            aGain      = &gains->endcap(hashedIndex);
+            gid        = &grps->endcap(hashedIndex);
+            aPulse     = &pulseshapes->endcap(hashedIndex);
+            aPulseCov  = &pulsecovariances->endcap(hashedIndex);
+            offsetTime = offtime->getEEValue();
+        }
+
+        double pedVec[3]     = { aped->mean_x12, aped->mean_x6, aped->mean_x1 };
+        double pedRMSVec[3]  = { aped->rms_x12,  aped->rms_x6,  aped->rms_x1 };
+        double gainRatios[3] = { 1., aGain->gain12Over6(), aGain->gain6Over1()*aGain->gain12Over6()};
+
+        for (int i=0; i<EcalPulseShape::TEMPLATESAMPLES; ++i)
+            fullpulse(i+7) = aPulse->pdfval[i];
+    
+        for(int i=0; i<EcalPulseShape::TEMPLATESAMPLES;i++)
+        for(int j=0; j<EcalPulseShape::TEMPLATESAMPLES;j++)
+            fullpulsecov(i+7,j+7) = aPulseCov->covval[i][j];
+        
+	// compute the right bin of the pulse shape using time calibration constants
+	EcalTimeCalibConstantMap::const_iterator it = itime->find( detid );
+	EcalTimeCalibConstant itimeconst = 0;
+	if( it != itime->end() ) {
+            itimeconst = (*it);
+	} else {
+            edm::LogError("EcalRecHitError") << "No time intercalib const found for xtal "
+            << detid.rawId()
+            << "! something wrong with EcalTimeCalibConstants in your DB? ";
+	}
+
+        // === amplitude computation ===
+        int leadingSample = ((EcalDataFrame)(*itdg)).lastUnsaturatedSample();
+
+        if ( leadingSample == 4 ) { // saturation on the expected max sample
+            result.emplace_back((*itdg).id(), 4095*12, 0, 0, 0);
+            auto & uncalibRecHit = result.back();
+            uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
+	    // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
+            uncalibRecHit.setChi2(0);
+        } else if ( leadingSample >= 0 ) { // saturation on other samples: cannot extrapolate from the fourth one
+            int gainId = ((EcalDataFrame)(*itdg)).sample(5).gainId();
+            if (gainId==0) gainId=3;
+            auto pedestal = pedVec[gainId-1];
+            auto gainratio = gainRatios[gainId-1];
+            double amplitude = ((double)(((EcalDataFrame)(*itdg)).sample(5).adc()) - pedestal) * gainratio;
+            result.emplace_back((*itdg).id(), amplitude, 0, 0, 0);
+            auto & uncalibRecHit = result.back();
+            uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
+            // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
+            uncalibRecHit.setChi2(0);
+        } else {
+            // multifit
+            const SampleMatrixGainArray &noisecors = noisecor(barrel);
+            
+            result.push_back(multiFitMethod_.makeRecHit(*itdg, aped, aGain, noisecors, fullpulse, fullpulsecov, activeBX));
+            auto & uncalibRecHit = result.back();
+            
+            // === time computation ===
+            if (timealgo_ == ratioMethod) {
+                // ratio method
+                constexpr float clockToNsConstant = 25.;
+                constexpr float invClockToNs = 1./clockToNsConstant;
+                if (not barrel) {
+                    ratioMethod_endcap_.init( *itdg, *sampleMask_, pedVec, pedRMSVec, gainRatios );
+                    ratioMethod_endcap_.computeTime( EEtimeFitParameters_, EEtimeFitLimits_, EEamplitudeFitParameters_ );
+                    ratioMethod_endcap_.computeAmplitude( EEamplitudeFitParameters_);
+                    EcalUncalibRecHitRatioMethodAlgo<EEDataFrame>::CalculatedRecHit crh = ratioMethod_endcap_.getCalculatedRecHit();
+                    double theTimeCorrectionEE = timeCorrection(uncalibRecHit.amplitude(),
+                                                                timeCorrBias_->EETimeCorrAmplitudeBins, timeCorrBias_->EETimeCorrShiftBins);
+                    
+                    uncalibRecHit.setJitter( crh.timeMax - 5 + theTimeCorrectionEE);
+                    uncalibRecHit.setJitterError( std::sqrt(std::pow(crh.timeError,2) + std::pow(EEtimeConstantTerm_*invClockToNs,2)) );
+                    
+                    // consider flagging as kOutOfTime only if above noise
+                    if (uncalibRecHit.amplitude() > pedRMSVec[0] * amplitudeThreshEE_){
+                      float outOfTimeThreshP = outOfTimeThreshG12pEE_;
+                      float outOfTimeThreshM = outOfTimeThreshG12mEE_;
+                      // determine if gain has switched away from gainId==1 (x12 gain)
+                      // and determine cuts (number of 'sigmas') to ose for kOutOfTime
+                      // >3k ADC is necessasry condition for gain switch to occur
+                      if (uncalibRecHit.amplitude() > 3000.){
+                        for (int iSample = 0; iSample < EEDataFrame::MAXSAMPLES; iSample++) {
+                          int GainId = ((EcalDataFrame)(*itdg)).sample(iSample).gainId();
+                          if (GainId!=1) {
+                            outOfTimeThreshP = outOfTimeThreshG61pEE_;
+                            outOfTimeThreshM = outOfTimeThreshG61mEE_;
+                            break;
+                          }
+                        }}
+                      float correctedTime = (crh.timeMax-5) * clockToNsConstant + itimeconst + offsetTime;
+                      float cterm         = EEtimeConstantTerm_;
+                      float sigmaped      = pedRMSVec[0];  // approx for lower gains
+                      float nterm         = EEtimeNconst_*sigmaped/uncalibRecHit.amplitude();
+                      float sigmat        = std::sqrt( nterm*nterm  + cterm*cterm   );
+                      if ( ( correctedTime > sigmat*outOfTimeThreshP )   ||
+                           ( correctedTime < -sigmat*outOfTimeThreshM) ) 
+                        {  uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kOutOfTime ); }
+                    }
+
+                } else {
+                    ratioMethod_barrel_.init( *itdg, *sampleMask_, pedVec, pedRMSVec, gainRatios );
+                    ratioMethod_barrel_.fixMGPAslew(*itdg);
+                    ratioMethod_barrel_.computeTime( EBtimeFitParameters_, EBtimeFitLimits_, EBamplitudeFitParameters_ );
+                    ratioMethod_barrel_.computeAmplitude( EBamplitudeFitParameters_);
+                    EcalUncalibRecHitRatioMethodAlgo<EBDataFrame>::CalculatedRecHit crh = ratioMethod_barrel_.getCalculatedRecHit();
+                    
+                    double theTimeCorrectionEB = timeCorrection(uncalibRecHit.amplitude(),
+                                                                timeCorrBias_->EBTimeCorrAmplitudeBins, timeCorrBias_->EBTimeCorrShiftBins);
+                    
+                    uncalibRecHit.setJitter( crh.timeMax - 5 + theTimeCorrectionEB);
+                    //uncalibRecHit.setJitterError( std::sqrt(std::pow(crh.timeError,2) + std::pow(EBtimeConstantTerm_,2)/std::pow(clockToNsConstant,2)) );
+                    uncalibRecHit.setJitterError( std::hypot(crh.timeError, EBtimeConstantTerm_ / clockToNsConstant) );
+
+                    // consider flagging as kOutOfTime only if above noise
+                    if (uncalibRecHit.amplitude() > pedRMSVec[0] * amplitudeThreshEB_){
+                      float outOfTimeThreshP = outOfTimeThreshG12pEB_;
+                      float outOfTimeThreshM = outOfTimeThreshG12mEB_;
+                      // determine if gain has switched away from gainId==1 (x12 gain)
+                      // and determine cuts (number of 'sigmas') to ose for kOutOfTime
+                      // >3k ADC is necessasry condition for gain switch to occur
+                      if (uncalibRecHit.amplitude() > 3000.){
+                        for (int iSample = 0; iSample < EBDataFrame::MAXSAMPLES; iSample++) {
+                          int GainId = ((EcalDataFrame)(*itdg)).sample(iSample).gainId();
+                          if (GainId!=1) {
+                            outOfTimeThreshP = outOfTimeThreshG61pEB_;
+                            outOfTimeThreshM = outOfTimeThreshG61mEB_;
+                            break;}
+                        } }
+                      float correctedTime = (crh.timeMax-5) * clockToNsConstant + itimeconst + offsetTime;
+                      float cterm         = EBtimeConstantTerm_;
+                      float sigmaped      = pedRMSVec[0];  // approx for lower gains
+                      float nterm         = EBtimeNconst_*sigmaped/uncalibRecHit.amplitude();
+                      float sigmat        = std::sqrt( nterm*nterm  + cterm*cterm   );
+                      if ( ( correctedTime > sigmat*outOfTimeThreshP )   ||
+                           ( correctedTime < -sigmat*outOfTimeThreshM )) 
+                        {
+                            uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kOutOfTime );
+                        }
+                    }
+
+                }
+            } else if (timealgo_ == weightsMethod) {
+                //  weights method on the PU subtracted pulse shape
+                std::vector<double> amplitudes;
+                for(unsigned int ibx=0; ibx<activeBX.size(); ++ibx) amplitudes.push_back(uncalibRecHit.outOfTimeAmplitude(ibx));
+                
+                EcalTBWeights::EcalTDCId tdcid(1);
+                EcalTBWeights::EcalTBWeightMap const & wgtsMap = wgts->getMap();
+                EcalTBWeights::EcalTBWeightMap::const_iterator wit;
+                wit = wgtsMap.find( std::make_pair(*gid,tdcid) );
+                if( wit == wgtsMap.end() ) {
+                    edm::LogError("EcalUncalibRecHitError") << "No weights found for EcalGroupId: " 
+                                                            << gid->id() << " and  EcalTDCId: " << tdcid
+                                                            << "\n  skipping digi with id: " << detid.rawId();
+                    result.pop_back();
+                    continue;
+                }
+                const EcalWeightSet& wset = wit->second; // this is the EcalWeightSet
+                
+                const EcalWeightSet::EcalWeightMatrix& mat1 = wset.getWeightsBeforeGainSwitch();
+                const EcalWeightSet::EcalWeightMatrix& mat2 = wset.getWeightsAfterGainSwitch();
+                
+                weights[0] = &mat1;
+                weights[1] = &mat2;
+                
+                double timerh;
+                if (detid.subdetId()==EcalEndcap) { 
+                    timerh = weightsMethod_endcap_.time( *itdg, amplitudes, aped, aGain, fullpulse, weights);
+                } else {
+                    timerh = weightsMethod_barrel_.time( *itdg, amplitudes, aped, aGain, fullpulse, weights);
+                }
+                uncalibRecHit.setJitter( timerh );
+                uncalibRecHit.setJitterError( 0. ); // not computed with weights
+            }  else { // no time method;
+                uncalibRecHit.setJitter( 0. );
+                uncalibRecHit.setJitterError( 0. );                  
+            }
+        }
+
+	// set flags if gain switch has occurred
+        auto & uncalibRecHit = result.back();
+	if( ((EcalDataFrame)(*itdg)).hasSwitchToGain6()  ) uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kHasSwitchToGain6 );
+	if( ((EcalDataFrame)(*itdg)).hasSwitchToGain1()  ) uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kHasSwitchToGain1 );
+
+        // put the recHit in the collection
+        //result.push_back( uncalibRecHit );
+    }
 }
 
 /*

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -47,6 +47,7 @@ class EcalUncalibRecHitWorkerMultiFit final : public EcalUncalibRecHitWorkerBase
                 void set(const edm::EventSetup& es) override;
                 void set(const edm::Event& evt) override;
                 bool run(const edm::Event& evt, const EcalDigiCollection::const_iterator & digi, EcalUncalibratedRecHitCollection & result) override;
+                void run(const edm::Event& evt, const EcalDigiCollection & digis, EcalUncalibratedRecHitCollection & result) override;
 	public:	
 		edm::ParameterSetDescription getAlgoDescription() override;
         private:


### PR DESCRIPTION
loop over DIGIs inside EcalUncalibRecHitWorker*::run()
compile EcalRecProducers and EcalRecAlgos with `-O3`

from @felicepantaleo :
  - faster check for a positive vector
  - increase threshold with a smoother granularity

from @VinInn :
  - use lazyProduct() and noalias() in NNLS
