### PR TITLE
Configuration files  updated to read correctly the Geometry from xml files

### DIFF
--- a/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
@@ -30,6 +30,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.a = cms.ESSource("PoolDBESSource",
    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),

--- a/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
@@ -32,6 +32,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),

--- a/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_generic_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_generic_cfg.py
@@ -180,6 +180,7 @@ process.source = cms.Source("EmptyIOVSource",
 #process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),

--- a/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_singlemodule_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_singlemodule_cfg.py
@@ -103,6 +103,8 @@ process.source = cms.Source("EmptyIOVSource",
 if options.globalTag == "DONOTEXIST":
     process.load('Configuration.Geometry.GeometryExtended_cff')
     process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+    process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+
     process.poolDBESSource = cms.ESSource("PoolDBESSource",
                                           BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
                                           DBParameters = cms.PSet(

--- a/DQM/SiStripMonitorSummary/test/DBReader_specifc_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_specifc_cfg.py
@@ -32,6 +32,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.poolDBESSource = cms.ESSource("PoolDBESSource",
     BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),

--- a/DQM/SiStripMonitorSummary/test/RunInfo_conddbmonitoring_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/RunInfo_conddbmonitoring_cfg.py
@@ -93,6 +93,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.poolDBESSourceRunInfo = cms.ESSource("PoolDBESSource",
    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateBadStripAndNoise_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateBadStripAndNoise_cfg.py
@@ -17,6 +17,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_cfg.py
@@ -16,6 +16,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_conddbmonitoring_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_conddbmonitoring_cfg.py
@@ -51,6 +51,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 

--- a/DQM/SiStripMonitorSummary/test/SiStripPlotGain_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripPlotGain_cfg.py
@@ -16,6 +16,7 @@ process.source = cms.Source("EmptyIOVSource",
 # the DB Geometry is NOT used because in this cfg only one tag is taken from the DB and no GT is used. To be fixed if this is a problem
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 


### PR DESCRIPTION
The configuration files used  monitor the payloads in CondDB. In the use case is such that the geometry is read from the xml files. This was broken since some time. Following the suggestion from @ianna those
are updated.

@mmusich @boudoul @fioriNTU 