### PR TITLE
MC GTs updated with JP BTag, minor HCAL updates,SiPixelQuality,CSC APEs and Phase2 updates for Geometry

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,23 +38,23 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '91X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '91X_upgrade2017_design_IdealBS_v3',
+    'phase1_2017_design'       :  '91X_upgrade2017_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '91X_upgrade2017_realistic_v3',
+    'phase1_2017_realistic'    : '91X_upgrade2017_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '91X_upgrade2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      : '91X_upgrade2017cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '91X_upgrade2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' : '91X_upgrade2017cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       : '91X_upgrade2018_design_IdealBS_v3',
+    'phase1_2018_design'       : '91X_upgrade2018_design_IdealBS_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '91X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    : '91X_upgrade2018_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '91X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :   '91X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '91X_upgrade2023_realistic_v1'
+    'phase2_realistic'         : '91X_upgrade2023_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
# Summary of changes in Global Tags

## Upgrade

   * **PhaseII realistic scenario** : [91X_upgrade2023_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2023_realistic_v2) as [91X_upgrade2023_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2023_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2023_realistic_v2/91X_upgrade2023_realistic_v1):
      * Jet Probability Btagger update
      * ECAL alpha values updated : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2913.html
      * Geometry updates : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2895.html

   * **PhaseI 2017 cosmics peak scenario** : [91X_upgrade2017cosmics_realistic_peak_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_peak_v4) as [91X_upgrade2017cosmics_realistic_peak_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_peak_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017cosmics_realistic_peak_v4/91X_upgrade2017cosmics_realistic_peak_v3):
      * Jet Probability Btagger corresponds to Phase1 geometry
      * ZDC reco geometry update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2841/1.html
      * HCAL updates : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2912.html
      * CSC alignment and APE update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2919.html
      * SiPixel Quality updated : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2922.html

   * **PhaseI 2017 cosmics scenario** : [91X_upgrade2017cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_deco_v4) as [91X_upgrade2017cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017cosmics_realistic_deco_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017cosmics_realistic_deco_v4/91X_upgrade2017cosmics_realistic_deco_v3):
      * Jet Probability Btagger corresponds to Phase1 geometry
      * ZDC reco geometry update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2841/1.html
      * HCAL updates : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2912.html
      * CSC alignment and APE update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2919.html
      * SiPixel Quality updated : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2922.html

   * **PhaseI 2017 design scenario** : [91X_upgrade2017_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_design_IdealBS_v4) as [91X_upgrade2017_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_design_IdealBS_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017_design_IdealBS_v4/91X_upgrade2017_design_IdealBS_v3):
      * Jet Probability Btagger corresponds to Phase1 geometry
      * ZDC reco geometry update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2841/1.html
      * HCAL updates : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2912.html

   * **PhaseI 2017 realistic scenario** : [91X_upgrade2017_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_realistic_v4) as [91X_upgrade2017_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2017_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2017_realistic_v4/91X_upgrade2017_realistic_v3):
      * Jet Probability Btagger corresponds to Phase1 geometry
      * ZDC reco geometry update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2841/1.html
      * HCAL updates : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2912.html
      * CSC alignment and APE update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2919.html
      * SiPixel Quality updated : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2922.html
   * **PhaseI 2018 cosmics scenario** : [91X_upgrade2018cosmics_realistic_deco_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018cosmics_realistic_deco_v4) as [91X_upgrade2018cosmics_realistic_deco_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018cosmics_realistic_deco_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2018cosmics_realistic_deco_v4/91X_upgrade2018cosmics_realistic_deco_v3):
      * Jet Probability Btagger corresponds to Phase1 geometry
      * SiPixel Quality updated : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2922.html
      * CSC alignment and APE update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2919.html

   * **PhaseI 2018 design scenario** : [91X_upgrade2018_design_IdealBS_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_design_IdealBS_v4) as [91X_upgrade2018_design_IdealBS_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_design_IdealBS_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2018_design_IdealBS_v4/91X_upgrade2018_design_IdealBS_v3):
      * Jet Probability Btagger corresponds to Phase1 geometry

   * **PhaseI 2018 realistic scenario** : [91X_upgrade2018_realistic_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_realistic_v4) as [91X_upgrade2018_realistic_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/91X_upgrade2018_realistic_v3) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/91X_upgrade2018_realistic_v4/91X_upgrade2018_realistic_v3):
      * Jet Probability Btagger corresponds to Phase1 geometry
      * SiPixel Quality updated : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2922.html
      * CSC alignment and APE update : https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2919.html