### PR TITLE
add NumberOfEventsPerLS EDFilter

### DIFF
--- a/PhysicsTools/Utilities/plugins/NumberPerLSFilter.cc
+++ b/PhysicsTools/Utilities/plugins/NumberPerLSFilter.cc
@@ -1,0 +1,104 @@
+// system include files
+#include <memory>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+ 
+//
+// class declaration
+//
+
+class NumberPerLSFilter : public edm::one::EDFilter<edm::one::WatchLuminosityBlocks>
+{
+   public:
+      explicit NumberPerLSFilter(const edm::ParameterSet&);
+      ~NumberPerLSFilter() = default;
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+      virtual void endLuminosityBlock(edm::LuminosityBlock const& iEvent, edm::EventSetup const&) override ;
+
+      // ----------member data ---------------------------
+   private:
+  int counter_;
+  int maxN_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+NumberPerLSFilter::NumberPerLSFilter(const edm::ParameterSet& iConfig)
+  : maxN_ ( iConfig.getParameter<int>("maxN") )
+{
+  std::cout << "[NumberPerLSFilter::NumberPerLSFilter] maxN_: " << maxN_ << std::endl;
+   //now do what ever initialization is needed
+  counter_ = 0;
+}
+
+//
+// member functions
+//
+
+// ------------ method called on each new LumiBlock ------------
+void
+NumberPerLSFilter::beginLuminosityBlock(const edm::LuminosityBlock &lumiBlock,
+					const edm::EventSetup &setup)
+{
+  std::cout << "[NumberPerLSFilter::beginLuminosityBlock] counter_: " << counter_ << std::endl;
+  counter_ = 0;
+  std::cout << "[NumberPerLSFilter::beginLuminosityBlock] --> counter_: " << counter_ << std::endl;
+}
+
+void
+NumberPerLSFilter::endLuminosityBlock(edm::LuminosityBlock const& iEvent, edm::EventSetup const&) 
+{
+}
+
+// ------------ method called on each new Event  ------------
+bool
+NumberPerLSFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  
+  bool pass = true;
+  std::cout << "[NumberPerLSFilter::filter] counter_: " << counter_ << std::endl;
+  counter_++;
+  std::cout << "[NumberPerLSFilter::filter] --> counter_: " << counter_ << std::endl;
+
+  if ( maxN_ < 0 ) return pass;
+  if (counter_ > maxN_ ) pass = false;
+
+  std::cout << "[NumberPerLSFilter::filter] pass ? " << ( pass ? "YEAP" : "NOPE" ) << std::endl;
+
+  return pass;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+NumberPerLSFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.add<int>("maxN", 100 );
+
+  descriptions.add("numberPerLSFilter", desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(NumberPerLSFilter);

--- a/PhysicsTools/Utilities/plugins/NumberPerLSFilter.cc
+++ b/PhysicsTools/Utilities/plugins/NumberPerLSFilter.cc
@@ -1,6 +1,5 @@
 // system include files
 #include <memory>
-#include <iostream>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -48,7 +47,6 @@ class NumberPerLSFilter : public edm::one::EDFilter<edm::one::WatchLuminosityBlo
 NumberPerLSFilter::NumberPerLSFilter(const edm::ParameterSet& iConfig)
   : maxN_ ( iConfig.getParameter<int>("maxN") )
 {
-  std::cout << "[NumberPerLSFilter::NumberPerLSFilter] maxN_: " << maxN_ << std::endl;
    //now do what ever initialization is needed
   counter_ = 0;
 }
@@ -62,9 +60,7 @@ void
 NumberPerLSFilter::beginLuminosityBlock(const edm::LuminosityBlock &lumiBlock,
 					const edm::EventSetup &setup)
 {
-  std::cout << "[NumberPerLSFilter::beginLuminosityBlock] counter_: " << counter_ << std::endl;
   counter_ = 0;
-  std::cout << "[NumberPerLSFilter::beginLuminosityBlock] --> counter_: " << counter_ << std::endl;
 }
 
 void
@@ -78,14 +74,10 @@ NumberPerLSFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   
   bool pass = true;
-  std::cout << "[NumberPerLSFilter::filter] counter_: " << counter_ << std::endl;
   counter_++;
-  std::cout << "[NumberPerLSFilter::filter] --> counter_: " << counter_ << std::endl;
 
   if ( maxN_ < 0 ) return pass;
   if (counter_ > maxN_ ) pass = false;
-
-  std::cout << "[NumberPerLSFilter::filter] pass ? " << ( pass ? "YEAP" : "NOPE" ) << std::endl;
 
   return pass;
 }

--- a/PhysicsTools/Utilities/plugins/PileUpFilter.cc
+++ b/PhysicsTools/Utilities/plugins/PileUpFilter.cc
@@ -73,7 +73,7 @@ PileUpFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& i
       // only use the in-time pileup
       if (pileup.getBunchCrossing() == 0) {
 	// use the per-event in-time pileup
-	double pu = pileup.getPU_NumInteractions();
+	double pu = pileup.getTrueNumInteractions();
 	if ( pu >= minPU_ and pu < maxPU_ ) pass = true;
       }
     }

--- a/PhysicsTools/Utilities/python/numberPerLSFilter_cff.py
+++ b/PhysicsTools/Utilities/python/numberPerLSFilter_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.Utilities.numberPerLSFilter_cfi import *
+
+numberPerLSFilter.maxN = 500 # running on all LSs
+#numberPerLSFilter.maxN = 10000 # running every 20-40 LSs

--- a/PhysicsTools/Utilities/python/pileupFilter_cff.py
+++ b/PhysicsTools/Utilities/python/pileupFilter_cff.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+from PhysicsTools.Utilities.pileupFilter_cfi import *
+
+pileupFilter.pileupInfoSummaryInputTag = cms.InputTag("addPileupInfo")
+
 pu20to25 = pileupFilter.clone()
 pu20to25.minPU = cms.double(20)
 pu20to25.maxPU = cms.double(25)


### PR DESCRIPTION
EDFilter for selecting only maxN events per LS
it will be used for skimming data for HLT timing studies, for instance

in addition, I fixed the config file of the PileUpFilter