### PR TITLE
First Round of Phase 1 Tracking changes for Heavy Ions

### DIFF
--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -49,6 +49,11 @@ globalRecoPbPb = cms.Sequence(hiTracking_wSplitting
                               * hcalnoise
                               * muonRecoHighLevelPbPb
                               )
+globalRecoPbPb_wPhase1 = globalRecoPbPb.copy()
+globalRecoPbPb_wPhase1.replace(hiTracking_wSplitting, hiTracking_wSplitting_Phase1)
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toReplaceWith(globalRecoPbPb, globalRecoPbPb_wPhase1)
+
 
 globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               * hiParticleFlowLocalReco

--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -51,8 +51,8 @@ globalRecoPbPb = cms.Sequence(hiTracking_wSplitting
                               )
 globalRecoPbPb_wPhase1 = globalRecoPbPb.copy()
 globalRecoPbPb_wPhase1.replace(hiTracking_wSplitting, hiTracking_wSplitting_Phase1)
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
-trackingPhase1QuadProp.toReplaceWith(globalRecoPbPb, globalRecoPbPb_wPhase1)
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toReplaceWith(globalRecoPbPb, globalRecoPbPb_wPhase1)
 
 
 globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -29,12 +29,27 @@ hiRegitMuDetachedTripletStepTrackingRegions = HiTrackingRegionFactoryFromSTAMuon
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import *
 
 # NEW CLUSTERS (remove previously used clusters)
+"""
+#Problem with this setup is because in pp, the iteration before detachedTriplet is detachedQuadruplets. 
 hiRegitMuDetachedTripletStepClusters = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepClusters.clone(
     trajectories          = cms.InputTag("hiRegitMuPixelLessStepTracks"),
     overrideTrkQuals      = cms.InputTag('hiRegitMuPixelLessStepSelector','hiRegitMuPixelLessStep'),
     trackClassifier       = cms.InputTag(''),
     TrackQuality          = cms.string('tight')
 )
+"""
+from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
+hiRegitMuDetachedTripletStepClusters = _trackClusterRemover.clone(
+    maxChi2                                  = 9.0,
+    pixelClusters                            = "siPixelClusters",
+    stripClusters                            = "siStripClusters",
+    trajectories          		     = cms.InputTag("hiRegitMuPixelLessStepTracks"),
+    overrideTrkQuals      		     = cms.InputTag('hiRegitMuPixelLessStepSelector','hiRegitMuPixelLessStep'),
+    TrackQuality                             = 'tight',
+    trackClassifier       		     = cms.InputTag(''),
+    minNumberOfLayersWithMeasBeforeFiltering = 0
+)
+
 
 # SEEDING LAYERS
 hiRegitMuDetachedTripletStepSeedLayers =  RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeedLayers.clone()

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -29,15 +29,6 @@ hiRegitMuDetachedTripletStepTrackingRegions = HiTrackingRegionFactoryFromSTAMuon
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import *
 
 # NEW CLUSTERS (remove previously used clusters)
-"""
-#Problem with this setup is because in pp, the iteration before detachedTriplet is detachedQuadruplets. 
-hiRegitMuDetachedTripletStepClusters = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepClusters.clone(
-    trajectories          = cms.InputTag("hiRegitMuPixelLessStepTracks"),
-    overrideTrkQuals      = cms.InputTag('hiRegitMuPixelLessStepSelector','hiRegitMuPixelLessStep'),
-    trackClassifier       = cms.InputTag(''),
-    TrackQuality          = cms.string('tight')
-)
-"""
 from RecoLocalTracker.SubCollectionProducers.trackClusterRemover_cfi import trackClusterRemover as _trackClusterRemover
 hiRegitMuDetachedTripletStepClusters = _trackClusterRemover.clone(
     maxChi2                                  = 9.0,

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -102,7 +102,7 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuDetachedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -114,14 +114,14 @@ hiRegitMuDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
             name = 'hiRegitMuDetachedTripletStepTight',
             preFilterName = 'hiRegitMuDetachedTripletStepLoose',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuDetachedTripletStep',
             preFilterName = 'hiRegitMuDetachedTripletStepTight',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.09)
             )
         ) #end of vpset

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -93,10 +93,33 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuDetachedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+           name = 'hiRegitMuDetachedTripletStepLoose',
+           min_nhits = cms.uint32(8)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuDetachedTripletStepTight',
+            preFilterName = 'hiRegitMuDetachedTripletStepLoose',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuDetachedTripletStep',
+            preFilterName = 'hiRegitMuDetachedTripletStepTight',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
+            )
+        ) #end of vpset
+    )
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuDetachedTripletStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuDetachedTripletStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuDetachedTripletStepLoose',
            min_nhits = cms.uint32(8)
@@ -115,9 +138,8 @@ hiRegitMuDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
             useMVA = cms.bool(False),
             minMVA = cms.double(-0.09)
             )
-        ) #end of vpset
-    )
-
+        )
+)
 
 hiRegitMuonDetachedTripletStep = cms.Sequence(hiRegitMuDetachedTripletStepClusters*
                                               hiRegitMuDetachedTripletStepSeedLayers*

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -33,7 +33,7 @@ hiRegitMuInitialStepSeedLayers =  RecoTracker.IterativeTracking.InitialStep_cff.
 hiRegitMuInitialStepHitDoublets = RecoTracker.IterativeTracking.InitialStep_cff.initialStepHitDoublets.clone(
     seedingLayers = "hiRegitMuInitialStepSeedLayers",
     trackingRegions = "hiRegitMuInitialStepTrackingRegions",
-    clusterCheck = "hiRegitMuClusterCheck",
+    clusterCheck = "hiRegitMuClusterCheck"
 )
 hiRegitMuInitialStepHitTriplets = RecoTracker.IterativeTracking.InitialStep_cff.initialStepHitTriplets.clone(
     doublets = "hiRegitMuInitialStepHitDoublets"
@@ -80,7 +80,7 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuInitialStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter4'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -92,14 +92,14 @@ hiRegitMuInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMult
             name = 'hiRegitMuInitialStepTight',
             preFilterName = 'hiRegitMuInitialStepLoose',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.38)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuInitialStep',
             preFilterName = 'hiRegitMuInitialStepTight',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.77)
             ),
         ) #end of vpset

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -80,10 +80,33 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuInitialStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter4'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+           name = 'hiRegitMuInitialStepLoose',
+           min_nhits = cms.uint32(8)
+            ), #end of pset
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuInitialStepTight',
+            preFilterName = 'hiRegitMuInitialStepLoose',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.38)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuInitialStep',
+            preFilterName = 'hiRegitMuInitialStepTight',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.77)
+            ),
+        ) #end of vpset
+    )
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuInitialStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuInitialStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuInitialStepLoose',
            min_nhits = cms.uint32(8)
@@ -102,8 +125,8 @@ hiRegitMuInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMult
             useMVA = cms.bool(False),
             minMVA = cms.double(-0.77)
             ),
-        ) #end of vpset
-    )
+        )
+)
 
 hiRegitMuonInitialStep = cms.Sequence(hiRegitMuInitialStepSeedLayers*
                                       hiRegitMuInitialStepTrackingRegions*

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -35,6 +35,9 @@ hiRegitMuInitialStepHitDoublets = RecoTracker.IterativeTracking.InitialStep_cff.
     trackingRegions = "hiRegitMuInitialStepTrackingRegions",
     clusterCheck = "hiRegitMuClusterCheck"
 )
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuInitialStepHitDoublets, layerPairs = [0])
+
 hiRegitMuInitialStepHitTriplets = RecoTracker.IterativeTracking.InitialStep_cff.initialStepHitTriplets.clone(
     doublets = "hiRegitMuInitialStepHitDoublets"
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -125,10 +125,33 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuMixedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 = 'hiRegitMuMixedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+           name = 'hiRegitMuMixedTripletStepLoose',
+           min_nhits = cms.uint32(8)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuMixedTripletStepTight',
+            preFilterName = 'hiRegitMuMixedTripletStepLoose',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuMixedTripletStep',
+            preFilterName = 'hiRegitMuMixedTripletStepTight',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
+            )
+        ) #end of vpset
+    ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuMixedTripletStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuMixedTripletStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuMixedTripletStepLoose',
            min_nhits = cms.uint32(8)
@@ -148,7 +171,7 @@ hiRegitMuMixedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.h
             minMVA = cms.double(-0.09)
             )
         ) #end of vpset
-    ) #end of clone
+)
 
 hiRegitMuonMixedTripletStep = cms.Sequence(hiRegitMuMixedTripletStepClusters*
                                          hiRegitMuMixedTripletStepSeedLayersA*

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -125,7 +125,7 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuMixedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 = 'hiRegitMuMixedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -137,14 +137,14 @@ hiRegitMuMixedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.h
             name = 'hiRegitMuMixedTripletStepTight',
             preFilterName = 'hiRegitMuMixedTripletStepLoose',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuMixedTripletStep',
             preFilterName = 'hiRegitMuMixedTripletStepTight',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.09)
             )
         ) #end of vpset

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -93,10 +93,33 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelLessStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuPixelLessStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors = cms.VPSet(  
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+           name = 'hiRegitMuPixelLessStepLoose',
+           min_nhits = cms.uint32(8)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuPixelLessStepTight',
+            preFilterName = 'hiRegitMuPixelLessStepLoose',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuPixelLessStep',
+            preFilterName = 'hiRegitMuPixelLessStepTight',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
+            ),
+        ) #end of vpset
+)
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuPixelLessStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuPixelLessStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelLessStepLoose',
            min_nhits = cms.uint32(8)

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -93,7 +93,7 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelLessStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuPixelLessStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors = cms.VPSet(  
@@ -105,14 +105,14 @@ hiRegitMuPixelLessStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMu
             name = 'hiRegitMuPixelLessStepTight',
             preFilterName = 'hiRegitMuPixelLessStepLoose',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelLessStep',
             preFilterName = 'hiRegitMuPixelLessStepTight',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.09)
             ),
         ) #end of vpset

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -96,10 +96,33 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuPixelPairStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter6'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+           name = 'hiRegitMuPixelPairStepLoose',
+           min_nhits = cms.uint32(8)
+            ), #end of pset
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuPixelPairStepTight',
+            preFilterName = 'hiRegitMuPixelPairStepLoose',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.58)
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuPixelPairStep',
+            preFilterName = 'hiRegitMuPixelPairStepTight',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(0.77)
+            ),
+        ) #end of vpset
+)
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuPixelPairStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuPixelPairStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelPairStepLoose',
            min_nhits = cms.uint32(8)

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -96,7 +96,7 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuPixelPairStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter6'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -108,14 +108,14 @@ hiRegitMuPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMu
             name = 'hiRegitMuPixelPairStepTight',
             preFilterName = 'hiRegitMuPixelPairStepLoose',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.58)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelPairStep',
             preFilterName = 'hiRegitMuPixelPairStepTight',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(0.77)
             ),
         ) #end of vpset

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -70,10 +70,33 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
       src='hiRegitMuonSeededTracksInOut',
       vertices            = cms.InputTag("hiSelectedVertex"),
-      useAnyMVA = cms.bool(False),
+      useAnyMVA = cms.bool(True),
       GBRForestLabel = cms.string('HIMVASelectorIter7'),
       GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
       trackSelectors= cms.VPSet(
+         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'hiRegitMuonSeededTracksInOutLoose',
+            min_nhits = cms.uint32(8)
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuonSeededTracksInOutTight',
+            preFilterName = 'hiRegitMuonSeededTracksInOutLoose',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuonSeededTracksInOutHighPurity',
+            preFilterName = 'hiRegitMuonSeededTracksInOutTight',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
+            ),
+         ) #end of vpset
+      ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuonSeededTracksInOutSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuonSeededTracksInOutSelector, trackSelectors= cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'hiRegitMuonSeededTracksInOutLoose',
             min_nhits = cms.uint32(8)
@@ -93,15 +116,38 @@ hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
             minMVA = cms.double(-0.09)
             ),
          ) #end of vpset
-      ) #end of clone
+)
 
 hiRegitMuonSeededTracksOutInSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
       src='hiRegitMuonSeededTracksOutIn',
       vertices            = cms.InputTag("hiSelectedVertex"),
-      useAnyMVA = cms.bool(False),
+      useAnyMVA = cms.bool(True),
       GBRForestLabel = cms.string('HIMVASelectorIter7'),
       GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
       trackSelectors= cms.VPSet(
+         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'hiRegitMuonSeededTracksOutInLoose',
+            min_nhits = cms.uint32(8)
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuonSeededTracksOutInTight',
+            preFilterName = 'hiRegitMuonSeededTracksOutInLoose',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuonSeededTracksOutInHighPurity',
+            preFilterName = 'hiRegitMuonSeededTracksOutInTight',
+            min_nhits = cms.uint32(8),
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
+            ),
+         ) #end of vpset
+      ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiRegitMuonSeededTracksOutInSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuonSeededTracksOutInSelector, trackSelectors= cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'hiRegitMuonSeededTracksOutInLoose',
             min_nhits = cms.uint32(8)
@@ -121,7 +167,7 @@ hiRegitMuonSeededTracksOutInSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
             minMVA = cms.double(-0.09)
             ),
          ) #end of vpset
-      ) #end of clone
+)
 
 hiRegitMuonSeededStepCore = cms.Sequence(
       hiRegitMuonSeededSeedsInOut + hiRegitMuonSeededTrackCandidatesInOut + hiRegitMuonSeededTracksInOut +

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -70,7 +70,7 @@ import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
       src='hiRegitMuonSeededTracksInOut',
       vertices            = cms.InputTag("hiSelectedVertex"),
-      useAnyMVA = cms.bool(True),
+      useAnyMVA = cms.bool(False),
       GBRForestLabel = cms.string('HIMVASelectorIter7'),
       GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
       trackSelectors= cms.VPSet(
@@ -82,14 +82,14 @@ hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
             name = 'hiRegitMuonSeededTracksInOutTight',
             preFilterName = 'hiRegitMuonSeededTracksInOutLoose',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.2)
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuonSeededTracksInOutHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksInOutTight',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.09)
             ),
          ) #end of vpset
@@ -98,7 +98,7 @@ hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
 hiRegitMuonSeededTracksOutInSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
       src='hiRegitMuonSeededTracksOutIn',
       vertices            = cms.InputTag("hiSelectedVertex"),
-      useAnyMVA = cms.bool(True),
+      useAnyMVA = cms.bool(False),
       GBRForestLabel = cms.string('HIMVASelectorIter7'),
       GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
       trackSelectors= cms.VPSet(
@@ -110,14 +110,14 @@ hiRegitMuonSeededTracksOutInSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
             name = 'hiRegitMuonSeededTracksOutInTight',
             preFilterName = 'hiRegitMuonSeededTracksOutInLoose',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.2)
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuonSeededTracksOutInHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksOutInTight',
             min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
+            useMVA = cms.bool(False),
             minMVA = cms.double(-0.09)
             ),
          ) #end of vpset

--- a/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
@@ -24,8 +24,8 @@ hiPixel3PrimTracksHitDoublets = _hitPairEDProducer.clone(
     maxElement = 0,
     produceIntermediateHitDoublets = True,
 )
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
-trackingPhase1QuadProp.toModify(hiPixel3PrimTracksHitDoublets,
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiPixel3PrimTracksHitDoublets,
     seedingLayers = "hiPixelLayerQuadruplets"
 )
 
@@ -73,7 +73,7 @@ hiPixel3PrimTracks = cms.EDProducer("PixelTrackProducer",
     # Cleaner
     Cleaner = cms.string("trackCleaner")
 )
-trackingPhase1QuadProp.toModify(hiPixel3PrimTracks,
+trackingPhase1.toModify(hiPixel3PrimTracks,
     SeedingHitSets = cms.InputTag("hiPixel3PrimTracksHitQuadrupletsCA"),
 )
 
@@ -90,4 +90,4 @@ hiPixel3PrimTracksSequence = cms.Sequence(
 hiPixel3PrimTracksSequence_Phase1 = hiPixel3PrimTracksSequence.copy()
 hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitDoublets,hiPixelLayerQuadruplets+hiPixel3PrimTracksHitDoubletsCA)
 hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitTriplets,hiPixel3PrimTracksHitQuadrupletsCA)
-trackingPhase1QuadProp.toReplaceWith(hiPixel3PrimTracksSequence,hiPixel3PrimTracksSequence_Phase1)
+trackingPhase1.toReplaceWith(hiPixel3PrimTracksSequence,hiPixel3PrimTracksSequence_Phase1)

--- a/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
@@ -2,12 +2,19 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
 from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletEDProducer_cfi import pixelQuadrupletEDProducer as _pixelQuadrupletEDProducer
+from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 from RecoPixelVertexing.PixelLowPtUtilities.trackCleaner_cfi import *
 from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjections_cfi import *
 from RecoHI.HiTracking.HIPixelTrackFilter_cff import *
 from RecoHI.HiTracking.HITrackingRegionProducer_cfi import *
 from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
+
+#from RecoTracker.TkSeedingLayers.seedingLayersEDProducer_cfi import *
+
+hiPixelLayerQuadruplets = PixelLayerTriplets.clone()
+hiPixelLayerQuadruplets.layerList = PixelSeedMergerQuadruplets.layerList
 
 # Hit ntuplets
 hiPixel3PrimTracksHitDoublets = _hitPairEDProducer.clone(
@@ -17,12 +24,67 @@ hiPixel3PrimTracksHitDoublets = _hitPairEDProducer.clone(
     maxElement = 0,
     produceIntermediateHitDoublets = True,
 )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(hiPixel3PrimTracksHitDoublets,
+    seedingLayers = "hiPixelLayerQuadruplets"
+)
+
 
 hiPixel3PrimTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
     doublets = "hiPixel3PrimTracksHitDoublets",
     maxElement = 1000000, # increase threshold for triplets in generation step (default: 100000)
     produceSeedingHitSets = True,
+    produceIntermediateHitTriplets = True,
 )
+
+
+# pixelQuadrupletMerger is not in use here. pp use it for trackingPhase1PU70
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
+from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
+_hiPixel3PrimTracksHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
+    triplets = "hiPixel3PrimTracksHitTriplets",
+    layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+)
+####
+
+hiPixel3PrimTracksHitQuadruplets = _pixelQuadrupletEDProducer.clone(
+    triplets = "hiPixel3PrimTracksHitTriplets",
+    extraHitRZtolerance = hiPixel3PrimTracksHitTriplets.extraHitRZtolerance,
+    extraHitRPhitolerance = hiPixel3PrimTracksHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 200, value2 = 100,
+        enabled = True,
+    ),
+    extraPhiTolerance = dict(
+        pt1    = 0.6, pt2    = 1,
+        value1 = 0.15, value2 = 0.1,
+        enabled = True,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    SeedComparitorPSet = hiPixel3PrimTracksHitTriplets.SeedComparitorPSet
+)
+
+from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
+hiPixel3PrimTracksHitDoubletsCA = hiPixel3PrimTracksHitDoublets.clone()
+hiPixel3PrimTracksHitDoubletsCA.layerPairs = [0,1,2]
+
+hiPixel3PrimTracksHitQuadrupletsCA = _caHitQuadrupletEDProducer.clone(
+    doublets = "hiPixel3PrimTracksHitDoubletsCA",
+    extraHitRPhitolerance = hiPixel3PrimTracksHitTriplets.extraHitRPhitolerance,
+    SeedComparitorPSet = hiPixel3PrimTracksHitTriplets.SeedComparitorPSet,
+    maxChi2 = dict(
+        pt1    = 0.7, pt2    = 2,
+        value1 = 200, value2 = 50,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    CAThetaCut = 0.0012,
+    CAPhiCut = 0.2,
+) 
 
 # Pixel tracks
 hiPixel3PrimTracks = cms.EDProducer("PixelTrackProducer",
@@ -31,6 +93,7 @@ hiPixel3PrimTracks = cms.EDProducer("PixelTrackProducer",
 
     # Ordered Hits
     SeedingHitSets = cms.InputTag("hiPixel3PrimTracksHitTriplets"),
+    #SeedingHitSets = cms.InputTag("hiPixel3PrimTracksHitQuadruplets"),
 	
     # Fitter
     Fitter = cms.InputTag("pixelFitterByHelixProjections"),
@@ -41,6 +104,9 @@ hiPixel3PrimTracks = cms.EDProducer("PixelTrackProducer",
     # Cleaner
     Cleaner = cms.string("trackCleaner")
 )
+trackingPhase1QuadProp.toModify(hiPixel3PrimTracks,
+    SeedingHitSets = cms.InputTag("hiPixel3PrimTracksHitQuadrupletsCA"),
+)
 
 hiPixel3PrimTracksSequence = cms.Sequence(
     hiTrackingRegionWithVertex +
@@ -50,3 +116,9 @@ hiPixel3PrimTracksSequence = cms.Sequence(
     hiFilter +
     hiPixel3PrimTracks
 )
+
+#phase 1 changes
+hiPixel3PrimTracksSequence_Phase1 = hiPixel3PrimTracksSequence.copy()
+hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitDoublets,hiPixelLayerQuadruplets+hiPixel3PrimTracksHitDoubletsCA)#can remove 'CA' to get regular seeds
+hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitTriplets,hiPixel3PrimTracksHitTriplets+hiPixel3PrimTracksHitQuadrupletsCA)#can remove 'CA' to get regular seeds
+trackingPhase1QuadProp.toReplaceWith(hiPixel3PrimTracksSequence,hiPixel3PrimTracksSequence_Phase1)

--- a/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixel3PrimTracks_cfi.py
@@ -37,36 +37,6 @@ hiPixel3PrimTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
     produceIntermediateHitTriplets = True,
 )
 
-
-# pixelQuadrupletMerger is not in use here. pp use it for trackingPhase1PU70
-from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
-from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
-_hiPixel3PrimTracksHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
-    triplets = "hiPixel3PrimTracksHitTriplets",
-    layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
-)
-####
-
-hiPixel3PrimTracksHitQuadruplets = _pixelQuadrupletEDProducer.clone(
-    triplets = "hiPixel3PrimTracksHitTriplets",
-    extraHitRZtolerance = hiPixel3PrimTracksHitTriplets.extraHitRZtolerance,
-    extraHitRPhitolerance = hiPixel3PrimTracksHitTriplets.extraHitRPhitolerance,
-    maxChi2 = dict(
-        pt1    = 0.8, pt2    = 2,
-        value1 = 200, value2 = 100,
-        enabled = True,
-    ),
-    extraPhiTolerance = dict(
-        pt1    = 0.6, pt2    = 1,
-        value1 = 0.15, value2 = 0.1,
-        enabled = True,
-    ),
-    useBendingCorrection = True,
-    fitFastCircle = True,
-    fitFastCircleChi2Cut = True,
-    SeedComparitorPSet = hiPixel3PrimTracksHitTriplets.SeedComparitorPSet
-)
-
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
 hiPixel3PrimTracksHitDoubletsCA = hiPixel3PrimTracksHitDoublets.clone()
 hiPixel3PrimTracksHitDoubletsCA.layerPairs = [0,1,2]
@@ -93,7 +63,6 @@ hiPixel3PrimTracks = cms.EDProducer("PixelTrackProducer",
 
     # Ordered Hits
     SeedingHitSets = cms.InputTag("hiPixel3PrimTracksHitTriplets"),
-    #SeedingHitSets = cms.InputTag("hiPixel3PrimTracksHitQuadruplets"),
 	
     # Fitter
     Fitter = cms.InputTag("pixelFitterByHelixProjections"),
@@ -119,6 +88,6 @@ hiPixel3PrimTracksSequence = cms.Sequence(
 
 #phase 1 changes
 hiPixel3PrimTracksSequence_Phase1 = hiPixel3PrimTracksSequence.copy()
-hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitDoublets,hiPixelLayerQuadruplets+hiPixel3PrimTracksHitDoubletsCA)#can remove 'CA' to get regular seeds
-hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitTriplets,hiPixel3PrimTracksHitTriplets+hiPixel3PrimTracksHitQuadrupletsCA)#can remove 'CA' to get regular seeds
+hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitDoublets,hiPixelLayerQuadruplets+hiPixel3PrimTracksHitDoubletsCA)
+hiPixel3PrimTracksSequence_Phase1.replace(hiPixel3PrimTracksHitTriplets,hiPixel3PrimTracksHitQuadrupletsCA)
 trackingPhase1QuadProp.toReplaceWith(hiPixel3PrimTracksSequence,hiPixel3PrimTracksSequence_Phase1)

--- a/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
@@ -6,10 +6,31 @@ import FWCore.ParameterSet.Config as cms
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiGlobalPrimTracks',
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter4'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiInitialStepLoose',
+    useMVA = cms.bool(False)
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiInitialStepTight',
+    preFilterName = 'hiInitialStepLoose',
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.77)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiInitialStep',
+    preFilterName = 'hiInitialStepTight',
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.77)
+    ),
+    ) #end of vpset
+    ) #end of clone  
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiInitialStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiInitialStepSelector, trackSelectors= cms.VPSet(
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
     name = 'hiInitialStepLoose',
     useMVA = cms.bool(False)
@@ -27,7 +48,7 @@ hiInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackS
     minMVA = cms.double(-0.77)
     ),
     ) #end of vpset
-    ) #end of clone  
+)
 
 
 

--- a/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HISelectedTracks_cfi.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiGlobalPrimTracks',
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter4'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -17,13 +17,13 @@ hiInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackS
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
     name = 'hiInitialStepTight',
     preFilterName = 'hiInitialStepLoose',
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.77)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiInitialStep',
     preFilterName = 'hiInitialStepTight',
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.77)
     ),
     ) #end of vpset

--- a/RecoHI/HiTracking/python/HiTracking_cff.py
+++ b/RecoHI/HiTracking/python/HiTracking_cff.py
@@ -7,6 +7,10 @@ from RecoHI.HiTracking.hiPixelPairStep_cff import *
 from RecoHI.HiTracking.hiDetachedTripletStep_cff import *
 from RecoHI.HiTracking.hiJetCoreRegionalStep_cff import *
 from RecoHI.HiTracking.MergeTrackCollectionsHI_cff import *
+from RecoHI.HiTracking.hiLowPtQuadStep_cff import *
+from RecoHI.HiTracking.hiHighPtTripletStep_cff import *
+from RecoHI.HiTracking.hiDetachedQuadStep_cff import *
+
 
 from RecoHI.HiMuonAlgos.hiMuonIterativeTk_cff import *
 
@@ -31,6 +35,17 @@ hiTracking_noRegitMu_wSplitting = cms.Sequence(
     *hiPixelPairStep
     )
 
+hiTracking_noRegitMu_wSplitting_Phase1 = cms.Sequence(
+    hiInitialJetCoreClusterSplitting
+    *hiBasicTracking
+    *hiLowPtQuadStep#New iteration
+    *hiHighPtTripletStep#New iteration
+    *hiDetachedQuadStep#New iteration
+    *hiDetachedTripletStep
+    *hiLowPtTripletStep
+    *hiPixelPairStep #no CA seeding implemented
+    )
+
 hiTracking = cms.Sequence(
     hiTracking_noRegitMu
     *hiRegitMuTrackingAndSta
@@ -39,6 +54,13 @@ hiTracking = cms.Sequence(
 
 hiTracking_wSplitting = cms.Sequence(
     hiTracking_noRegitMu_wSplitting
+    *hiJetCoreRegionalStep 
+    *hiRegitMuTrackingAndSta
+    *hiGeneralTracks
+    )
+
+hiTracking_wSplitting_Phase1 = cms.Sequence(
+    hiTracking_noRegitMu_wSplitting_Phase1
     *hiJetCoreRegionalStep 
     *hiRegitMuTrackingAndSta
     *hiGeneralTracks

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiGeneralTracksNoRegitMu = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
@@ -21,6 +20,29 @@ hiGeneralTracksNoRegitMu = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.t
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(hiGeneralTracksNoRegitMu,
+    TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
+                      cms.InputTag('hiLowPtQuadStepTracks'),
+                      cms.InputTag('hiHighPtTripletStepTracks'),
+                      cms.InputTag('hiDetachedQuadStepTracks'),
+                      cms.InputTag('hiDetachedTripletStepTracks'),
+                      cms.InputTag('hiLowPtTripletStepTracks'),
+                      cms.InputTag('hiPixelPairGlobalPrimTracks'),
+                      cms.InputTag('hiJetCoreRegionalStepTracks')
+                     ),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1),
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6), pQual=cms.bool(True))),
+    selectedTrackQuals = cms.VInputTag(
+    cms.InputTag("hiInitialStepSelector","hiInitialStep"),
+    cms.InputTag("hiLowPtQuadStepSelector","hiLowPtQuadStep"),
+    cms.InputTag("hiHighPtTripletStepSelector","hiHighPtTripletStep"),
+    cms.InputTag("hiDetachedQuadStepSelector","hiDetachedQuadStep"),
+    cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
+    cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
+    cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
+    )                    
+)    
 
 hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
@@ -55,4 +77,41 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
-    )
+)
+trackingPhase1QuadProp.toModify(hiGeneralTracks,
+    TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
+                      cms.InputTag('hiLowPtQuadStepTracks'),
+                      cms.InputTag('hiHighPtTripletStepTracks'),
+                      cms.InputTag('hiDetachedQuadStepTracks'),
+                      cms.InputTag('hiDetachedTripletStepTracks'),
+                      cms.InputTag('hiLowPtTripletStepTracks'),
+                      cms.InputTag('hiPixelPairGlobalPrimTracks'),
+                      cms.InputTag('hiJetCoreRegionalStepTracks'),
+                      cms.InputTag('hiRegitMuInitialStepTracks'),
+                      cms.InputTag('hiRegitMuPixelPairStepTracks'),
+                      cms.InputTag('hiRegitMuMixedTripletStepTracks'),
+                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
+                      cms.InputTag('hiRegitMuDetachedTripletStepTracks'),
+                      cms.InputTag('hiRegitMuonSeededTracksOutIn'),
+                      cms.InputTag('hiRegitMuonSeededTracksInOut')
+                     ),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1),
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14), pQual=cms.bool(True))),  # should this be False?
+    selectedTrackQuals = cms.VInputTag(
+    cms.InputTag("hiInitialStepSelector","hiInitialStep"),
+    cms.InputTag("hiLowPtQuadStepSelector","hiLowPtQuadStep"),
+    cms.InputTag("hiHighPtTripletStepSelector","hiHighPtTripletStep"),
+    cms.InputTag("hiDetachedQuadStepSelector","hiDetachedQuadStep"),
+    cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
+    cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
+    cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
+    cms.InputTag("hiJetCoreRegionalStepSelector","hiJetCoreRegionalStep"),
+    cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
+    cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
+    cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
+    cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
+    cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep"),
+    cms.InputTag("hiRegitMuonSeededTracksOutInSelector","hiRegitMuonSeededTracksOutInHighPurity"),
+    cms.InputTag("hiRegitMuonSeededTracksInOutSelector","hiRegitMuonSeededTracksInOutHighPurity")
+    )                    
+)    

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -20,8 +20,8 @@ hiGeneralTracksNoRegitMu = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.t
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
-trackingPhase1QuadProp.toModify(hiGeneralTracksNoRegitMu,
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiGeneralTracksNoRegitMu,
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
                       cms.InputTag('hiLowPtQuadStepTracks'),
                       cms.InputTag('hiHighPtTripletStepTracks'),
@@ -78,7 +78,7 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
 )
-trackingPhase1QuadProp.toModify(hiGeneralTracks,
+trackingPhase1.toModify(hiGeneralTracks,
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
                       cms.InputTag('hiLowPtQuadStepTracks'),
                       cms.InputTag('hiHighPtTripletStepTracks'),

--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -167,10 +167,34 @@ hiDetachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProd
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiDetachedQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiDetachedQuadStepTracks',
-    useAnyMVA = cms.bool(False), 
+    useAnyMVA = cms.bool(True), 
     GBRForestLabel = cms.string('HIMVASelectorIter10'),#FIXME MVA for new iteration
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiDetachedQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(False),
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiDetachedQuadStepTight',
+    preFilterName = 'hiDetachedQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(True),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.2)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiDetachedQuadStep',
+    preFilterName = 'hiDetachedQuadStepTight',
+    applyAdaptedPVCuts = cms.bool(True),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.09)
+    ),
+    ) #end of vpset
+    ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiDetachedQuadStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiDetachedQuadStepSelector, trackSelectors= cms.VPSet(
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
     name = 'hiDetachedQuadStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
@@ -191,7 +215,7 @@ hiDetachedQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiT
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset
-    ) #end of clone
+)
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiDetachedQuadStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(

--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -1,0 +1,261 @@
+from RecoTracker.IterativeTracking.DetachedQuadStep_cff import *
+from HIPixelTripletSeeds_cff import *
+from HIPixel3PrimTracks_cfi import *
+
+hiDetachedQuadStepClusters = cms.EDProducer("HITrackClusterRemover",
+     clusterLessSolution = cms.bool(True),
+     trajectories = cms.InputTag("hiHighPtTripletStepTracks"),
+     overrideTrkQuals = cms.InputTag("hiHighPtTripletStepSelector","hiHighPtTripletStep"),
+     TrackQuality = cms.string('highPurity'),
+     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+     pixelClusters = cms.InputTag("siPixelClusters"),
+     stripClusters = cms.InputTag("siStripClusters"),
+     Common = cms.PSet(
+         maxChi2 = cms.double(9.0),
+     ),
+     Strip = cms.PSet(
+        #Yen-Jie's mod to preserve merged clusters
+        maxSize = cms.uint32(2),
+        maxChi2 = cms.double(9.0)
+     )
+)
+
+# SEEDING LAYERS
+# Using 4 layers layerlist
+hiDetachedQuadStepSeedLayers = hiPixelLayerQuadruplets.clone()
+hiDetachedQuadStepSeedLayers.BPix.skipClusters = cms.InputTag('hiDetachedQuadStepClusters')
+hiDetachedQuadStepSeedLayers.FPix.skipClusters = cms.InputTag('hiDetachedQuadStepClusters')
+
+# SEEDS
+from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cfi import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
+from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
+from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletEDProducer_cfi import pixelQuadrupletEDProducer as _pixelQuadrupletEDProducer
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+from RecoPixelVertexing.PixelLowPtUtilities.trackCleaner_cfi import *
+from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjections_cfi import *
+from RecoHI.HiTracking.HIPixelTrackFilter_cff import *
+from RecoHI.HiTracking.HITrackingRegionProducer_cfi import *
+
+hiDetachedQuadStepTrackingRegions = _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+    precise = True,
+    useMultipleScattering = False,
+    useFakeVertices       = False,
+    beamSpot = "offlineBeamSpot",
+    useFixedError = True,
+    nSigmaZ = 4.0,
+    sigmaZVertex = 4.0,
+    fixedError = 0.5,
+    VertexCollection = "hiSelectedVertex",
+    ptMin = 0.9,# 0.3 for pp
+    useFoundVertices = True,
+    #originHalfLength = 15.0, # 15 for pp, useTrackingRegionWithVertices, does not have this parameter. Only with BeamSpot
+    originRadius = 1.5 # 1.5 for pp
+
+))
+hiDetachedQuadStepTracksHitDoublets = _hitPairEDProducer.clone(
+    clusterCheck = "",
+    seedingLayers = "hiDetachedQuadStepSeedLayers",
+    trackingRegions = "hiDetachedQuadStepTrackingRegions",
+    maxElement = 0,
+    produceIntermediateHitDoublets = True,
+)
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+hiDetachedQuadStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
+    doublets = "hiDetachedQuadStepTracksHitDoublets",
+    extraHitRPhitolerance = 0.0,
+    extraHitRZtolerance = 0.0,
+    maxElement = 1000000,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
+    produceSeedingHitSets = True,
+    produceIntermediateHitTriplets = True,
+)
+
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
+from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
+_hiDetachedQuadStepTracksHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
+    triplets = "hiDetachedQuadStepTracksHitTriplets",
+    layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+)
+
+hiDetachedQuadStepTracksHitQuadruplets = _pixelQuadrupletEDProducer.clone(
+    triplets = "hiDetachedQuadStepTracksHitTriplets",
+    extraHitRZtolerance = hiDetachedQuadStepTracksHitTriplets.extraHitRZtolerance,
+    extraHitRPhitolerance = hiDetachedQuadStepTracksHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 500, value2 = 100,
+        enabled = True,
+    ),
+    extraPhiTolerance = dict(
+        pt1    = 0.4, pt2    = 1,
+        value1 = 0.2, value2 = 0.05,
+        enabled = True,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    SeedComparitorPSet = hiDetachedQuadStepTracksHitTriplets.SeedComparitorPSet
+)
+
+from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
+hiDetachedQuadStepTracksHitDoubletsCA = hiDetachedQuadStepTracksHitDoublets.clone()
+hiDetachedQuadStepTracksHitDoubletsCA.layerPairs = [0,1,2]
+
+hiDetachedQuadStepTracksHitQuadrupletsCA = _caHitQuadrupletEDProducer.clone(
+    doublets = "hiDetachedQuadStepTracksHitDoubletsCA",
+    extraHitRPhitolerance = hiDetachedQuadStepTracksHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 500, value2 = 100,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    CAThetaCut = 0.0011,
+    CAPhiCut = 0,
+)
+
+hiDetachedQuadStepPixelTracksFilter = hiFilter.clone(
+    nSigmaTipMaxTolerance = 0,
+    lipMax = 1.0,
+    tipMax = 1.0,
+    ptMin = 0.95, #seeding region is 0.3
+)
+hiDetachedQuadStepPixelTracks = cms.EDProducer("PixelTrackProducer",
+
+    passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
+
+    # Ordered Hits
+    #SeedingHitSets = cms.InputTag("hiDetachedQuadStepTracksHitQuadruplets"),
+    SeedingHitSets = cms.InputTag("hiDetachedQuadStepTracksHitQuadrupletsCA"),
+	
+    # Fitter
+    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
+	
+    # Filter
+    Filter = cms.InputTag("hiDetachedQuadStepPixelTracksFilter"),
+	
+    # Cleaner
+    Cleaner = cms.string("trackCleaner")
+)
+
+
+import RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi
+hiDetachedQuadStepSeeds = RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi.pixelTrackSeeds.clone(
+        InputCollection = 'hiDetachedQuadStepPixelTracks'
+  )
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+hiDetachedQuadStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    #maxLostHits = 1,
+    minimumNumberOfHits = 3,#3 for pp
+    minPt = cms.double(0.075),# 0.075 for pp
+    #constantValueForLostHitsFractionFilter = cms.double(0.701)
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
+hiDetachedQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+        ComponentName = cms.string('hiDetachedQuadStepChi2Est'),
+            nSigma = cms.double(3.0),
+            MaxChi2 = cms.double(9.0)
+        )
+
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+hiDetachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('hiDetachedQuadStepTrajectoryFilter')),
+    maxCand = 4,#4 for pp
+    estimator = cms.string('hiDetachedQuadStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),#2.0 for pp
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7),# 0.7 for pp
+    alwaysUseInvalidHits = cms.bool(False)
+    )
+
+# MAKING OF TRACK CANDIDATES
+
+# Trajectory cleaner in default
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+hiDetachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('hiDetachedQuadStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('hiDetachedQuadStepTrajectoryBuilder')),
+    TrajectoryBuilder = cms.string('hiDetachedQuadStepTrajectoryBuilder'),
+    clustersToSkip = cms.InputTag('hiDetachedQuadStepClusters'),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+hiDetachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'hiDetachedQuadStepTrackCandidates',
+    AlgorithmName = cms.string('detachedQuadStep'),
+    Fitter=cms.string('FlexibleKFFittingSmoother')
+    )
+
+# Final selection
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
+hiDetachedQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
+    src='hiDetachedQuadStepTracks',
+    useAnyMVA = cms.bool(True), 
+    GBRForestLabel = cms.string('HIMVASelectorIter10'),#FIXME MVA for new iteration
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
+    trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiDetachedQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(False),
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiDetachedQuadStepTight',
+    preFilterName = 'hiDetachedQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.2)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiDetachedQuadStep',
+    preFilterName = 'hiDetachedQuadStepTight',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.09)
+    ),
+    ) #end of vpset
+    ) #end of clone
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+hiDetachedQuadStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers=cms.VInputTag(cms.InputTag('hiDetachedQuadStepTracks')),
+    hasSelector=cms.vint32(1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hiDetachedQuadStepSelector","hiDetachedQuadStep")),
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False),
+    )
+
+
+hiDetachedQuadStep = cms.Sequence(hiDetachedQuadStepClusters*
+                                     hiDetachedQuadStepSeedLayers*
+                                     hiDetachedQuadStepTrackingRegions*
+                                     hiDetachedQuadStepTracksHitDoubletsCA* # 'CA' can be removed
+                                     hiDetachedQuadStepTracksHitTriplets*
+                                     hiDetachedQuadStepTracksHitQuadrupletsCA* # 'CA' can be removed
+				     pixelFitterByHelixProjections*
+                                     hiDetachedQuadStepPixelTracksFilter*
+                                     hiDetachedQuadStepPixelTracks*
+                                     hiDetachedQuadStepSeeds*
+                                     hiDetachedQuadStepTrackCandidates*
+                                     hiDetachedQuadStepTracks*
+                                     hiDetachedQuadStepSelector*
+                                     hiDetachedQuadStepQual)
+
+

--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -53,58 +53,19 @@ hiDetachedQuadStepTrackingRegions = _globalTrackingRegionWithVertices.clone(Regi
     originRadius = 1.5 # 1.5 for pp
 
 ))
-hiDetachedQuadStepTracksHitDoublets = _hitPairEDProducer.clone(
+hiDetachedQuadStepTracksHitDoubletsCA = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiDetachedQuadStepSeedLayers",
     trackingRegions = "hiDetachedQuadStepTrackingRegions",
     maxElement = 0,
     produceIntermediateHitDoublets = True,
-)
-import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-hiDetachedQuadStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
-    doublets = "hiDetachedQuadStepTracksHitDoublets",
-    extraHitRPhitolerance = 0.0,
-    extraHitRZtolerance = 0.0,
-    maxElement = 1000000,
-    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
-    produceSeedingHitSets = True,
-    produceIntermediateHitTriplets = True,
-)
-
-from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
-from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
-_hiDetachedQuadStepTracksHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
-    triplets = "hiDetachedQuadStepTracksHitTriplets",
-    layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
-)
-
-hiDetachedQuadStepTracksHitQuadruplets = _pixelQuadrupletEDProducer.clone(
-    triplets = "hiDetachedQuadStepTracksHitTriplets",
-    extraHitRZtolerance = hiDetachedQuadStepTracksHitTriplets.extraHitRZtolerance,
-    extraHitRPhitolerance = hiDetachedQuadStepTracksHitTriplets.extraHitRPhitolerance,
-    maxChi2 = dict(
-        pt1    = 0.8, pt2    = 2,
-        value1 = 500, value2 = 100,
-        enabled = True,
-    ),
-    extraPhiTolerance = dict(
-        pt1    = 0.4, pt2    = 1,
-        value1 = 0.2, value2 = 0.05,
-        enabled = True,
-    ),
-    useBendingCorrection = True,
-    fitFastCircle = True,
-    fitFastCircleChi2Cut = True,
-    SeedComparitorPSet = hiDetachedQuadStepTracksHitTriplets.SeedComparitorPSet
+    layerPairs = [0,1,2]
 )
 
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
-hiDetachedQuadStepTracksHitDoubletsCA = hiDetachedQuadStepTracksHitDoublets.clone()
-hiDetachedQuadStepTracksHitDoubletsCA.layerPairs = [0,1,2]
-
 hiDetachedQuadStepTracksHitQuadrupletsCA = _caHitQuadrupletEDProducer.clone(
     doublets = "hiDetachedQuadStepTracksHitDoubletsCA",
-    extraHitRPhitolerance = hiDetachedQuadStepTracksHitTriplets.extraHitRPhitolerance,
+    extraHitRPhitolerance = 0.0,
     maxChi2 = dict(
         pt1    = 0.8, pt2    = 2,
         value1 = 500, value2 = 100,
@@ -127,7 +88,6 @@ hiDetachedQuadStepPixelTracks = cms.EDProducer("PixelTrackProducer",
     passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
 
     # Ordered Hits
-    #SeedingHitSets = cms.InputTag("hiDetachedQuadStepTracksHitQuadruplets"),
     SeedingHitSets = cms.InputTag("hiDetachedQuadStepTracksHitQuadrupletsCA"),
 	
     # Fitter
@@ -246,9 +206,8 @@ hiDetachedQuadStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.tra
 hiDetachedQuadStep = cms.Sequence(hiDetachedQuadStepClusters*
                                      hiDetachedQuadStepSeedLayers*
                                      hiDetachedQuadStepTrackingRegions*
-                                     hiDetachedQuadStepTracksHitDoubletsCA* # 'CA' can be removed
-                                     hiDetachedQuadStepTracksHitTriplets*
-                                     hiDetachedQuadStepTracksHitQuadrupletsCA* # 'CA' can be removed
+                                     hiDetachedQuadStepTracksHitDoubletsCA* 
+                                     hiDetachedQuadStepTracksHitQuadrupletsCA* 
 				     pixelFitterByHelixProjections*
                                      hiDetachedQuadStepPixelTracksFilter*
                                      hiDetachedQuadStepPixelTracks*

--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -207,7 +207,7 @@ hiDetachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProd
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiDetachedQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiDetachedQuadStepTracks',
-    useAnyMVA = cms.bool(True), 
+    useAnyMVA = cms.bool(False), 
     GBRForestLabel = cms.string('HIMVASelectorIter10'),#FIXME MVA for new iteration
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -220,14 +220,14 @@ hiDetachedQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiT
     name = 'hiDetachedQuadStepTight',
     preFilterName = 'hiDetachedQuadStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.2)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiDetachedQuadStep',
     preFilterName = 'hiDetachedQuadStepTight',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -63,6 +63,10 @@ hiDetachedTripletStepTracksHitDoublets = _hitPairEDProducer.clone(
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 hiDetachedTripletStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
     doublets = "hiDetachedTripletStepTracksHitDoublets",
+    extraHitRPhitolerance = 0.0,
+    extraHitRZtolerance = 0.0,
+    maxElement = 1000000,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
     produceSeedingHitSets = True,
 )
 

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -95,7 +95,6 @@ hiDetachedTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
     # Ordered Hits
     SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTriplets"),
-    #SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTripletsCA"),
 	
     # Fitter
     Fitter = cms.InputTag("pixelFitterByHelixProjections"),
@@ -223,7 +222,7 @@ hiDetachedTripletStep = cms.Sequence(hiDetachedTripletStepClusters*
                                      hiDetachedTripletStepSelector*
                                      hiDetachedTripletStepQual)
 hiDetachedTripletStep_Phase1 = hiDetachedTripletStep.copy()
-hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitDoublets, hiDetachedTripletStepTracksHitDoubletsCA)# 'CA' can be removed
-hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitTriplets, hiDetachedTripletStepTracksHitTripletsCA)# 'CA' can be removed
+hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitDoublets, hiDetachedTripletStepTracksHitDoubletsCA)
+hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitTriplets, hiDetachedTripletStepTracksHitTripletsCA)
 trackingPhase1QuadProp.toReplaceWith(hiDetachedTripletStep, hiDetachedTripletStep_Phase1)
 

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -173,7 +173,7 @@ hiDetachedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackP
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiDetachedTripletStepTracks',
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -186,14 +186,14 @@ hiDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMul
     name = 'hiDetachedTripletStepTight',
     preFilterName = 'hiDetachedTripletStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.2)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiDetachedTripletStep',
     preFilterName = 'hiDetachedTripletStepTight',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -172,10 +172,34 @@ hiDetachedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackP
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiDetachedTripletStepTracks',
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter7'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiDetachedTripletStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(False),
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiDetachedTripletStepTight',
+    preFilterName = 'hiDetachedTripletStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.2)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiDetachedTripletStep',
+    preFilterName = 'hiDetachedTripletStepTight',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.09)
+    ),
+    ) #end of vpset
+    ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiDetachedTripletStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiDetachedTripletStepSelector, trackSelectors= cms.VPSet(
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
     name = 'hiDetachedTripletStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
@@ -196,7 +220,7 @@ hiDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMul
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset
-    ) #end of clone
+)
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiDetachedTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -60,14 +60,29 @@ hiDetachedTripletStepTracksHitDoublets = _hitPairEDProducer.clone(
     maxElement = 0,
     produceIntermediateHitDoublets = True,
 )
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 hiDetachedTripletStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
     doublets = "hiDetachedTripletStepTracksHitDoublets",
-    extraHitRPhitolerance = 0.0,
-    extraHitRZtolerance = 0.0,
-    maxElement = 1000000,
-    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
     produceSeedingHitSets = True,
 )
+
+from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
+hiDetachedTripletStepTracksHitDoubletsCA = hiDetachedTripletStepTracksHitDoublets.clone()
+hiDetachedTripletStepTracksHitDoubletsCA.layerPairs = [0,1]
+
+hiDetachedTripletStepTracksHitTripletsCA = _caHitTripletEDProducer.clone(
+    doublets = "hiDetachedTripletStepTracksHitDoubletsCA",
+    extraHitRPhitolerance = hiDetachedTripletStepTracksHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 300 , value2 = 10,
+    ),
+    useBendingCorrection = True,
+    CAThetaCut = 0.001,
+    CAPhiCut = 0,
+    CAHardPtCut = 0.2,
+)
+
 hiDetachedTripletStepPixelTracksFilter = hiFilter.clone(
     nSigmaTipMaxTolerance = 0,
     lipMax = 1.0,
@@ -80,6 +95,7 @@ hiDetachedTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
     # Ordered Hits
     SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTriplets"),
+    #SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTripletsCA"),
 	
     # Fitter
     Fitter = cms.InputTag("pixelFitterByHelixProjections"),
@@ -89,6 +105,10 @@ hiDetachedTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 	
     # Cleaner
     Cleaner = cms.string("trackCleaner")
+)
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(hiDetachedTripletStepPixelTracks,
+    SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTripletsCA")
 )
 
 
@@ -179,7 +199,6 @@ hiDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMul
     ) #end of vpset
     ) #end of clone
 
-from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiDetachedTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers=cms.VInputTag(cms.InputTag('hiDetachedTripletStepTracks')),
@@ -193,8 +212,8 @@ hiDetachedTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.
 hiDetachedTripletStep = cms.Sequence(hiDetachedTripletStepClusters*
                                      hiDetachedTripletStepSeedLayers*
                                      hiDetachedTripletStepTrackingRegions*
-                                     hiDetachedTripletStepTracksHitDoublets*
-                                     hiDetachedTripletStepTracksHitTriplets*
+                                     hiDetachedTripletStepTracksHitDoublets*  
+                                     hiDetachedTripletStepTracksHitTriplets* 
                                      pixelFitterByHelixProjections*
                                      hiDetachedTripletStepPixelTracksFilter*
                                      hiDetachedTripletStepPixelTracks*
@@ -203,5 +222,8 @@ hiDetachedTripletStep = cms.Sequence(hiDetachedTripletStepClusters*
                                      hiDetachedTripletStepTracks*
                                      hiDetachedTripletStepSelector*
                                      hiDetachedTripletStepQual)
-
+hiDetachedTripletStep_Phase1 = hiDetachedTripletStep.copy()
+hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitDoublets, hiDetachedTripletStepTracksHitDoubletsCA)# 'CA' can be removed
+hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitTriplets, hiDetachedTripletStepTracksHitTripletsCA)# 'CA' can be removed
+trackingPhase1QuadProp.toReplaceWith(hiDetachedTripletStep, hiDetachedTripletStep_Phase1)
 

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -105,8 +105,8 @@ hiDetachedTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
     # Cleaner
     Cleaner = cms.string("trackCleaner")
 )
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
-trackingPhase1QuadProp.toModify(hiDetachedTripletStepPixelTracks,
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiDetachedTripletStepPixelTracks,
     SeedingHitSets = cms.InputTag("hiDetachedTripletStepTracksHitTripletsCA")
 )
 
@@ -224,5 +224,5 @@ hiDetachedTripletStep = cms.Sequence(hiDetachedTripletStepClusters*
 hiDetachedTripletStep_Phase1 = hiDetachedTripletStep.copy()
 hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitDoublets, hiDetachedTripletStepTracksHitDoubletsCA)
 hiDetachedTripletStep_Phase1.replace(hiDetachedTripletStepTracksHitTriplets, hiDetachedTripletStepTracksHitTripletsCA)
-trackingPhase1QuadProp.toReplaceWith(hiDetachedTripletStep, hiDetachedTripletStep_Phase1)
+trackingPhase1.toReplaceWith(hiDetachedTripletStep, hiDetachedTripletStep_Phase1)
 

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -50,30 +50,20 @@ hiHighPtTripletStepTrackingRegions = _globalTrackingRegionWithVertices.clone(Reg
     useFoundVertices = True,
     originRadius = 0.02 #0.02 for pp
 ))
-hiHighPtTripletStepTracksHitDoublets = _hitPairEDProducer.clone(
+hiHighPtTripletStepTracksHitDoubletsCA = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiHighPtTripletStepSeedLayers",
     trackingRegions = "hiHighPtTripletStepTrackingRegions",
     maxElement = 0,
     produceIntermediateHitDoublets = True,
-)
-hiHighPtTripletStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
-    doublets = "hiHighPtTripletStepTracksHitDoublets",
-    extraHitRPhitolerance = 0.0,
-    extraHitRZtolerance = 0.0,
-    maxElement = 1000000,
-    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
-    produceSeedingHitSets = True,
+    layerPairs = [0,1]
 )
 
 from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
-hiHighPtTripletStepTracksHitDoubletsCA = hiHighPtTripletStepTracksHitDoublets.clone()
-hiHighPtTripletStepTracksHitDoubletsCA.layerPairs = [0,1]
-
 hiHighPtTripletStepTracksHitTripletsCA = _caHitTripletEDProducer.clone(
     doublets = "hiHighPtTripletStepTracksHitDoubletsCA",
-    extraHitRPhitolerance = hiHighPtTripletStepTracksHitTriplets.extraHitRPhitolerance,
-    SeedComparitorPSet = hiHighPtTripletStepTracksHitTriplets.SeedComparitorPSet,
+    extraHitRPhitolerance = 0.0,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
     maxChi2 = dict(
         pt1    = 0.8, pt2    = 8,
         value1 = 100, value2 = 6,
@@ -95,7 +85,6 @@ hiHighPtTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
     passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
 
     # Ordered Hits
-    #SeedingHitSets = cms.InputTag("hiHighPtTripletStepTracksHitTriplets"),
     SeedingHitSets = cms.InputTag("hiHighPtTripletStepTracksHitTripletsCA"),
 	
     # Fitter
@@ -214,8 +203,8 @@ hiHighPtTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.tr
 hiHighPtTripletStep = cms.Sequence(hiHighPtTripletStepClusters*
                                      hiHighPtTripletStepSeedLayers*
                                      hiHighPtTripletStepTrackingRegions*
-                                     hiHighPtTripletStepTracksHitDoubletsCA* # 'CA' can be removed
-                                     hiHighPtTripletStepTracksHitTripletsCA* # 'CA' can be removed
+                                     hiHighPtTripletStepTracksHitDoubletsCA* 
+                                     hiHighPtTripletStepTracksHitTripletsCA* 
 				     pixelFitterByHelixProjections*
                                      hiHighPtTripletStepPixelTracksFilter*
                                      hiHighPtTripletStepPixelTracks*

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -1,0 +1,228 @@
+from RecoTracker.IterativeTracking.HighPtTripletStep_cff import *
+from HIPixelTripletSeeds_cff import *
+from HIPixel3PrimTracks_cfi import *
+
+hiHighPtTripletStepClusters = cms.EDProducer("HITrackClusterRemover",
+     clusterLessSolution = cms.bool(True),
+     trajectories = cms.InputTag("hiLowPtQuadStepTracks"),
+     overrideTrkQuals = cms.InputTag("hiLowPtQuadStepSelector","hiLowPtQuadStep"),
+     TrackQuality = cms.string('highPurity'),
+     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+     pixelClusters = cms.InputTag("siPixelClusters"),
+     stripClusters = cms.InputTag("siStripClusters"),
+     Common = cms.PSet(
+         maxChi2 = cms.double(9.0),
+     ),
+     Strip = cms.PSet(
+        #Yen-Jie's mod to preserve merged clusters
+        maxSize = cms.uint32(2),
+        maxChi2 = cms.double(9.0)
+     )
+)
+
+# SEEDING LAYERS
+# Using 3 layers layerlist
+hiHighPtTripletStepSeedLayers = highPtTripletStepSeedLayers.clone()
+hiHighPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('hiHighPtTripletStepClusters')
+hiHighPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('hiHighPtTripletStepClusters')
+
+# SEEDS
+from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cfi import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
+from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
+from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+from RecoPixelVertexing.PixelLowPtUtilities.trackCleaner_cfi import *
+from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjections_cfi import *
+from RecoHI.HiTracking.HIPixelTrackFilter_cff import *
+from RecoHI.HiTracking.HITrackingRegionProducer_cfi import *
+
+hiHighPtTripletStepTrackingRegions = _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+    precise = True,
+    useMultipleScattering = False,
+    useFakeVertices       = False,
+    beamSpot = "offlineBeamSpot",
+    useFixedError = True,
+    nSigmaZ = 4.0,
+    sigmaZVertex = 4.0,
+    fixedError = 0.5,
+    VertexCollection = "hiSelectedVertex",
+    ptMin = 0.8,#0.6 for pp
+    useFoundVertices = True,
+    originRadius = 0.02 #0.02 for pp
+))
+hiHighPtTripletStepTracksHitDoublets = _hitPairEDProducer.clone(
+    clusterCheck = "",
+    seedingLayers = "hiHighPtTripletStepSeedLayers",
+    trackingRegions = "hiHighPtTripletStepTrackingRegions",
+    maxElement = 0,
+    produceIntermediateHitDoublets = True,
+)
+hiHighPtTripletStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
+    doublets = "hiHighPtTripletStepTracksHitDoublets",
+    extraHitRPhitolerance = 0.0,
+    extraHitRZtolerance = 0.0,
+    maxElement = 1000000,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
+    produceSeedingHitSets = True,
+)
+
+from RecoPixelVertexing.PixelTriplets.caHitTripletEDProducer_cfi import caHitTripletEDProducer as _caHitTripletEDProducer
+hiHighPtTripletStepTracksHitDoubletsCA = hiHighPtTripletStepTracksHitDoublets.clone()
+hiHighPtTripletStepTracksHitDoubletsCA.layerPairs = [0,1]
+
+hiHighPtTripletStepTracksHitTripletsCA = _caHitTripletEDProducer.clone(
+    doublets = "hiHighPtTripletStepTracksHitDoubletsCA",
+    extraHitRPhitolerance = hiHighPtTripletStepTracksHitTriplets.extraHitRPhitolerance,
+    SeedComparitorPSet = hiHighPtTripletStepTracksHitTriplets.SeedComparitorPSet,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 8,
+        value1 = 100, value2 = 6,
+    ),
+    useBendingCorrection = True,
+    CAThetaCut = 0.004,
+    CAPhiCut = 0.07,
+    CAHardPtCut = 0.3,
+)
+
+hiHighPtTripletStepPixelTracksFilter = hiFilter.clone(
+    nSigmaTipMaxTolerance = 0,
+    lipMax = 1.0,
+    tipMax = 1.0,
+    ptMin = 1.0, #seeding region is 0.6
+)
+hiHighPtTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
+
+    passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
+
+    # Ordered Hits
+    #SeedingHitSets = cms.InputTag("hiHighPtTripletStepTracksHitTriplets"),
+    SeedingHitSets = cms.InputTag("hiHighPtTripletStepTracksHitTripletsCA"),
+	
+    # Fitter
+    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
+	
+    # Filter
+    Filter = cms.InputTag("hiHighPtTripletStepPixelTracksFilter"),
+	
+    # Cleaner
+    Cleaner = cms.string("trackCleaner")
+)
+
+
+import RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi
+hiHighPtTripletStepSeeds = RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi.pixelTrackSeeds.clone(
+        InputCollection = 'hiHighPtTripletStepPixelTracks'
+  )
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+hiHighPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    #maxLostHits = 1,
+    minimumNumberOfHits = 3,#3 for pp
+    minPt = cms.double(0.2),# 0.2 for pp
+    #constantValueForLostHitsFractionFilter = cms.double(0.701)
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
+hiHighPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+        ComponentName = cms.string('hiHighPtTripletStepChi2Est'),
+            nSigma = cms.double(3.0),
+            MaxChi2 = cms.double(9.0)# 30 for pp
+        )
+
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+hiHighPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('hiHighPtTripletStepTrajectoryFilter')),
+    maxCand = 3,#3 for pp
+    estimator = cms.string('hiHighPtTripletStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),#2.0 for pp
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7),# 0.7 for pp
+    alwaysUseInvalidHits = cms.bool(False)
+    )
+
+# MAKING OF TRACK CANDIDATES
+
+# Trajectory cleaner in default
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+hiHighPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('hiHighPtTripletStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('hiHighPtTripletStepTrajectoryBuilder')),
+    TrajectoryBuilder = cms.string('hiHighPtTripletStepTrajectoryBuilder'),
+    clustersToSkip = cms.InputTag('hiHighPtTripletStepClusters'),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+hiHighPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'hiHighPtTripletStepTrackCandidates',
+    AlgorithmName = cms.string('highPtTripletStep'),
+    Fitter=cms.string('FlexibleKFFittingSmoother')
+    )
+
+# Final selection
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
+hiHighPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
+    src='hiHighPtTripletStepTracks',
+    useAnyMVA = cms.bool(True), 
+    GBRForestLabel = cms.string('HIMVASelectorIter9'),#FIXME MVA for new iteration
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
+    trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiHighPtTripletStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(False),
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiHighPtTripletStepTight',
+    preFilterName = 'hiHighPtTripletStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.2)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiHighPtTripletStep',
+    preFilterName = 'hiHighPtTripletStepTight',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.09)
+    ),
+    ) #end of vpset
+    ) #end of clone
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+hiHighPtTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers=cms.VInputTag(cms.InputTag('hiHighPtTripletStepTracks')),
+    hasSelector=cms.vint32(1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hiHighPtTripletStepSelector","hiHighPtTripletStep")),
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False),
+    )
+
+
+hiHighPtTripletStep = cms.Sequence(hiHighPtTripletStepClusters*
+                                     hiHighPtTripletStepSeedLayers*
+                                     hiHighPtTripletStepTrackingRegions*
+                                     hiHighPtTripletStepTracksHitDoubletsCA* # 'CA' can be removed
+                                     hiHighPtTripletStepTracksHitTripletsCA* # 'CA' can be removed
+				     pixelFitterByHelixProjections*
+                                     hiHighPtTripletStepPixelTracksFilter*
+                                     hiHighPtTripletStepPixelTracks*
+                                     hiHighPtTripletStepSeeds*
+                                     hiHighPtTripletStepTrackCandidates*
+                                     hiHighPtTripletStepTracks*
+                                     hiHighPtTripletStepSelector*
+                                     hiHighPtTripletStepQual)
+
+

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -175,7 +175,7 @@ hiHighPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackPro
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiHighPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiHighPtTripletStepTracks',
-    useAnyMVA = cms.bool(True), 
+    useAnyMVA = cms.bool(False), 
     GBRForestLabel = cms.string('HIMVASelectorIter9'),#FIXME MVA for new iteration
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -188,14 +188,14 @@ hiHighPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMulti
     name = 'hiHighPtTripletStepTight',
     preFilterName = 'hiHighPtTripletStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.2)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiHighPtTripletStep',
     preFilterName = 'hiHighPtTripletStepTight',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -164,10 +164,34 @@ hiHighPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackPro
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiHighPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiHighPtTripletStepTracks',
-    useAnyMVA = cms.bool(False), 
+    useAnyMVA = cms.bool(True), 
     GBRForestLabel = cms.string('HIMVASelectorIter9'),#FIXME MVA for new iteration
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiHighPtTripletStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(False),
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiHighPtTripletStepTight',
+    preFilterName = 'hiHighPtTripletStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.2)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiHighPtTripletStep',
+    preFilterName = 'hiHighPtTripletStepTight',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.09)
+    ),
+    ) #end of vpset
+    ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiHighPtTripletStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiHighPtTripletStepSelector, trackSelectors= cms.VPSet(
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
     name = 'hiHighPtTripletStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
@@ -188,7 +212,7 @@ hiHighPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMulti
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset
-    ) #end of clone
+)
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiHighPtTripletStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -51,6 +51,29 @@ hiJetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         HitProducer = cms.string('siPixelRecHits'),
     )
 )
+from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
+trackingPhase1QuadProp.toModify(hiJetCoreRegionalStepSeedLayers, layerList = cms.vstring('BPix1+BPix2+BPix3',
+    'BPix2+BPix3+BPix4',
+    'BPix1+BPix3+BPix4',
+    'BPix1+BPix2+BPix4',
+    'BPix2+BPix3+FPix1_pos',
+    'BPix2+BPix3+FPix1_neg',
+    'BPix1+BPix2+FPix1_pos',
+    'BPix1+BPix2+FPix1_neg',
+    'BPix2+FPix1_pos+FPix2_pos',
+    'BPix2+FPix1_neg+FPix2_neg',
+    'BPix1+FPix1_pos+FPix2_pos',
+    'BPix1+FPix1_neg+FPix2_neg',
+    'FPix1_pos+FPix2_pos+FPix3_pos',
+    'FPix1_neg+FPix2_neg+FPix3_neg',#up to here, same as what is in RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py for phase 1
+    'BPix1+BPix2+TIB1',#use TIB1 to try to recover tracks w/ 2 hits missing in pix barrel
+    'BPix1+BPix3+TIB1',
+    'BPix1+BPix4+TIB1',
+    'BPix2+BPix3+TIB1',
+    'BPix2+BPix4+TIB1',
+    'BPix3+BPix4+TIB1',
+    )
+)
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -51,8 +51,8 @@ hiJetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         HitProducer = cms.string('siPixelRecHits'),
     )
 )
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
-trackingPhase1QuadProp.toModify(hiJetCoreRegionalStepSeedLayers, layerList = cms.vstring('BPix1+BPix2+BPix3',
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiJetCoreRegionalStepSeedLayers, layerList = cms.vstring('BPix1+BPix2+BPix3',
     'BPix2+BPix3+BPix4',
     'BPix1+BPix3+BPix4',
     'BPix1+BPix2+BPix4',

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -51,59 +51,21 @@ hiLowPtQuadStepTrackingRegions = _globalTrackingRegionWithVertices.clone(RegionP
     useFoundVertices = True,
     originRadius = 0.02 #0.02 for pp
 ))
-hiLowPtQuadStepTracksHitDoublets = _hitPairEDProducer.clone(
+hiLowPtQuadStepTracksHitDoubletsCA = _hitPairEDProducer.clone(
     clusterCheck = "",
     seedingLayers = "hiLowPtQuadStepSeedLayers",
     trackingRegions = "hiLowPtQuadStepTrackingRegions",
     maxElement = 0,
     produceIntermediateHitDoublets = True,
+    layerPairs = [0,1,2]
 )
+
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-hiLowPtQuadStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
-    doublets = "hiLowPtQuadStepTracksHitDoublets",
-    extraHitRPhitolerance = 0.0,
-    extraHitRZtolerance = 0.0,
-    maxElement = 1000000,
-    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
-    produceSeedingHitSets = True,
-    produceIntermediateHitTriplets = True,
-)
-
-from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
-from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
-_hiLowPtQuadStepTracksHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
-    triplets = "hiLowPtQuadStepTracksHitTriplets",
-    layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
-)
-
-hiLowPtQuadStepTracksHitQuadruplets = _pixelQuadrupletEDProducer.clone(
-    triplets = "hiLowPtQuadStepTracksHitTriplets",
-    extraHitRZtolerance = hiLowPtQuadStepTracksHitTriplets.extraHitRZtolerance,
-    extraHitRPhitolerance = hiLowPtQuadStepTracksHitTriplets.extraHitRPhitolerance,
-    maxChi2 = dict(
-        pt1    = 0.8, pt2    = 2,
-        value1 = 2000, value2 = 100,
-        enabled = True,
-    ),
-    extraPhiTolerance = dict(
-        pt1    = 0.3, pt2    = 1,
-        value1 = 0.4, value2 = 0.05,
-        enabled = True,
-    ),
-    useBendingCorrection = True,
-    fitFastCircle = True,
-    fitFastCircleChi2Cut = True,
-    SeedComparitorPSet = hiLowPtQuadStepTracksHitTriplets.SeedComparitorPSet
-)
-
 from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
-hiLowPtQuadStepTracksHitDoubletsCA = hiLowPtQuadStepTracksHitDoublets.clone()
-hiLowPtQuadStepTracksHitDoubletsCA.layerPairs = [0,1,2]
-
 hiLowPtQuadStepTracksHitQuadrupletsCA = _caHitQuadrupletEDProducer.clone(
     doublets = "hiLowPtQuadStepTracksHitDoubletsCA",
-    extraHitRPhitolerance = hiLowPtQuadStepTracksHitTriplets.extraHitRPhitolerance,
-    SeedComparitorPSet = hiLowPtQuadStepTracksHitTriplets.SeedComparitorPSet,
+    extraHitRPhitolerance = 0.0,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(,
     maxChi2 = dict(
         pt1    = 0.7, pt2    = 2,
         value1 = 1000, value2 = 150,
@@ -127,7 +89,6 @@ hiLowPtQuadStepPixelTracks = cms.EDProducer("PixelTrackProducer",
     passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
 
     # Ordered Hits
-    #SeedingHitSets = cms.InputTag("hiLowPtQuadStepTracksHitQuadruplets"),
     SeedingHitSets = cms.InputTag("hiLowPtQuadStepTracksHitQuadrupletsCA"),
 	
     # Fitter
@@ -246,9 +207,8 @@ hiLowPtQuadStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackL
 hiLowPtQuadStep = cms.Sequence(hiLowPtQuadStepClusters*
                                      hiLowPtQuadStepSeedLayers*
                                      hiLowPtQuadStepTrackingRegions*
-                                     hiLowPtQuadStepTracksHitDoubletsCA* # 'CA' can be removed
-                                     hiLowPtQuadStepTracksHitTriplets*
-                                     hiLowPtQuadStepTracksHitQuadrupletsCA* # 'CA' can be removed
+                                     hiLowPtQuadStepTracksHitDoubletsCA* 
+                                     hiLowPtQuadStepTracksHitQuadrupletsCA* 
 				     pixelFitterByHelixProjections*
                                      hiLowPtQuadStepPixelTracksFilter*
                                      hiLowPtQuadStepPixelTracks*

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -207,7 +207,7 @@ hiLowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduce
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiLowPtQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiLowPtQuadStepTracks',
-    useAnyMVA = cms.bool(True), 
+    useAnyMVA = cms.bool(False), 
     GBRForestLabel = cms.string('HIMVASelectorIter8'),#FIXME MVA for new iteration
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -220,14 +220,14 @@ hiLowPtQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrac
     name = 'hiLowPtQuadStepTight',
     preFilterName = 'hiLowPtQuadStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.2)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiLowPtQuadStep',
     preFilterName = 'hiLowPtQuadStepTight',
     applyAdaptedPVCuts = cms.bool(False),
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -168,10 +168,34 @@ hiLowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduce
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiLowPtQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiLowPtQuadStepTracks',
-    useAnyMVA = cms.bool(False), 
+    useAnyMVA = cms.bool(True), 
     GBRForestLabel = cms.string('HIMVASelectorIter8'),#FIXME MVA for new iteration
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiLowPtQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(False),
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiLowPtQuadStepTight',
+    preFilterName = 'hiLowPtQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.2)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiLowPtQuadStep',
+    preFilterName = 'hiLowPtQuadStepTight',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.09)
+    ),
+    ) #end of vpset
+    ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiLowPtQuadStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiLowPtQuadStepSelector, trackSelectors= cms.VPSet(
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
     name = 'hiLowPtQuadStepLoose',
     applyAdaptedPVCuts = cms.bool(False),
@@ -192,7 +216,7 @@ hiLowPtQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrac
     minMVA = cms.double(-0.09)
     ),
     ) #end of vpset
-    ) #end of clone
+)
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiLowPtQuadStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -65,7 +65,7 @@ from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHit
 hiLowPtQuadStepTracksHitQuadrupletsCA = _caHitQuadrupletEDProducer.clone(
     doublets = "hiLowPtQuadStepTracksHitDoubletsCA",
     extraHitRPhitolerance = 0.0,
-    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
     maxChi2 = dict(
         pt1    = 0.7, pt2    = 2,
         value1 = 1000, value2 = 150,

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -1,0 +1,261 @@
+from RecoTracker.IterativeTracking.LowPtQuadStep_cff import *
+from HIPixelTripletSeeds_cff import *
+from HIPixel3PrimTracks_cfi import *
+
+hiLowPtQuadStepClusters = cms.EDProducer("HITrackClusterRemover",
+     clusterLessSolution = cms.bool(True),
+     trajectories = cms.InputTag("hiGlobalPrimTracks"),
+     overrideTrkQuals = cms.InputTag('hiInitialStepSelector','hiInitialStep'),
+     TrackQuality = cms.string('highPurity'),
+     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+     pixelClusters = cms.InputTag("siPixelClusters"),
+     stripClusters = cms.InputTag("siStripClusters"),
+     Common = cms.PSet(
+         maxChi2 = cms.double(9.0),
+     ),
+     Strip = cms.PSet(
+        #Yen-Jie's mod to preserve merged clusters
+        maxSize = cms.uint32(2),
+        maxChi2 = cms.double(9.0)
+     )
+)
+
+# SEEDING LAYERS
+# Using 4 layers layerlist
+hiLowPtQuadStepSeedLayers = hiPixelLayerQuadruplets.clone()
+hiLowPtQuadStepSeedLayers.BPix.skipClusters = cms.InputTag('hiLowPtQuadStepClusters')
+hiLowPtQuadStepSeedLayers.FPix.skipClusters = cms.InputTag('hiLowPtQuadStepClusters')
+
+# SEEDS
+from RecoTracker.TkTrackingRegions.globalTrackingRegionWithVertices_cfi import globalTrackingRegionWithVertices as _globalTrackingRegionWithVertices
+from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
+from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletEDProducer_cfi import pixelQuadrupletEDProducer as _pixelQuadrupletEDProducer
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+from RecoPixelVertexing.PixelLowPtUtilities.trackCleaner_cfi import *
+from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjections_cfi import *
+from RecoHI.HiTracking.HIPixelTrackFilter_cff import *
+from RecoHI.HiTracking.HITrackingRegionProducer_cfi import *
+
+hiLowPtQuadStepTrackingRegions = _globalTrackingRegionWithVertices.clone(RegionPSet=dict(
+    precise = True,
+    useMultipleScattering = False,
+    useFakeVertices       = False,
+    beamSpot = "offlineBeamSpot",
+    useFixedError = True,
+    nSigmaZ = 4.0,
+    sigmaZVertex = 4.0,
+    fixedError = 0.5,
+    VertexCollection = "hiSelectedVertex",
+    ptMin = 0.3,#0.2 for pp
+    useFoundVertices = True,
+    originRadius = 0.02 #0.02 for pp
+))
+hiLowPtQuadStepTracksHitDoublets = _hitPairEDProducer.clone(
+    clusterCheck = "",
+    seedingLayers = "hiLowPtQuadStepSeedLayers",
+    trackingRegions = "hiLowPtQuadStepTrackingRegions",
+    maxElement = 0,
+    produceIntermediateHitDoublets = True,
+)
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+hiLowPtQuadStepTracksHitTriplets = _pixelTripletHLTEDProducer.clone(
+    doublets = "hiLowPtQuadStepTracksHitDoublets",
+    extraHitRPhitolerance = 0.0,
+    extraHitRZtolerance = 0.0,
+    maxElement = 1000000,
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone(),
+    produceSeedingHitSets = True,
+    produceIntermediateHitTriplets = True,
+)
+
+from RecoPixelVertexing.PixelTriplets.pixelQuadrupletMergerEDProducer_cfi import pixelQuadrupletMergerEDProducer as _pixelQuadrupletMergerEDProducer
+from RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff import *
+_hiLowPtQuadStepTracksHitQuadrupletsMerging = _pixelQuadrupletMergerEDProducer.clone(
+    triplets = "hiLowPtQuadStepTracksHitTriplets",
+    layerList = dict(refToPSet_ = cms.string("PixelSeedMergerQuadruplets")),
+)
+
+hiLowPtQuadStepTracksHitQuadruplets = _pixelQuadrupletEDProducer.clone(
+    triplets = "hiLowPtQuadStepTracksHitTriplets",
+    extraHitRZtolerance = hiLowPtQuadStepTracksHitTriplets.extraHitRZtolerance,
+    extraHitRPhitolerance = hiLowPtQuadStepTracksHitTriplets.extraHitRPhitolerance,
+    maxChi2 = dict(
+        pt1    = 0.8, pt2    = 2,
+        value1 = 2000, value2 = 100,
+        enabled = True,
+    ),
+    extraPhiTolerance = dict(
+        pt1    = 0.3, pt2    = 1,
+        value1 = 0.4, value2 = 0.05,
+        enabled = True,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    SeedComparitorPSet = hiLowPtQuadStepTracksHitTriplets.SeedComparitorPSet
+)
+
+from RecoPixelVertexing.PixelTriplets.caHitQuadrupletEDProducer_cfi import caHitQuadrupletEDProducer as _caHitQuadrupletEDProducer
+hiLowPtQuadStepTracksHitDoubletsCA = hiLowPtQuadStepTracksHitDoublets.clone()
+hiLowPtQuadStepTracksHitDoubletsCA.layerPairs = [0,1,2]
+
+hiLowPtQuadStepTracksHitQuadrupletsCA = _caHitQuadrupletEDProducer.clone(
+    doublets = "hiLowPtQuadStepTracksHitDoubletsCA",
+    extraHitRPhitolerance = hiLowPtQuadStepTracksHitTriplets.extraHitRPhitolerance,
+    SeedComparitorPSet = hiLowPtQuadStepTracksHitTriplets.SeedComparitorPSet,
+    maxChi2 = dict(
+        pt1    = 0.7, pt2    = 2,
+        value1 = 1000, value2 = 150,
+    ),
+    useBendingCorrection = True,
+    fitFastCircle = True,
+    fitFastCircleChi2Cut = True,
+    CAThetaCut = 0.0017,
+    CAPhiCut = 0.3,
+)
+
+
+hiLowPtQuadStepPixelTracksFilter = hiFilter.clone(
+    nSigmaTipMaxTolerance = 0,
+    lipMax = 1.0,
+    tipMax = 1.0,
+    ptMin = 0.4, #seeding region is 0.3
+)
+hiLowPtQuadStepPixelTracks = cms.EDProducer("PixelTrackProducer",
+
+    passLabel  = cms.string('Pixel detached tracks with vertex constraint'),
+
+    # Ordered Hits
+    #SeedingHitSets = cms.InputTag("hiLowPtQuadStepTracksHitQuadruplets"),
+    SeedingHitSets = cms.InputTag("hiLowPtQuadStepTracksHitQuadrupletsCA"),
+	
+    # Fitter
+    Fitter = cms.InputTag("pixelFitterByHelixProjections"),
+	
+    # Filter
+    Filter = cms.InputTag("hiLowPtQuadStepPixelTracksFilter"),
+	
+    # Cleaner
+    Cleaner = cms.string("trackCleaner")
+)
+
+
+import RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi
+hiLowPtQuadStepSeeds = RecoPixelVertexing.PixelLowPtUtilities.TrackSeeds_cfi.pixelTrackSeeds.clone(
+        InputCollection = 'hiLowPtQuadStepPixelTracks'
+  )
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+hiLowPtQuadStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    #maxLostHits = 1,
+    minimumNumberOfHits = 3,#3 for pp
+    minPt = cms.double(0.075),# 0.075 for pp
+    #constantValueForLostHitsFractionFilter = cms.double(0.701)
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
+hiLowPtQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+        ComponentName = cms.string('hiLowPtQuadStepChi2Est'),
+            nSigma = cms.double(3.0),
+            MaxChi2 = cms.double(9.0)
+        )
+
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+hiLowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('hiLowPtQuadStepTrajectoryFilter')),
+    maxCand = 4,#4 for pp
+    estimator = cms.string('hiLowPtQuadStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),#2.0 for pp
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7),# 0.7 for pp
+    alwaysUseInvalidHits = cms.bool(False)
+    )
+
+# MAKING OF TRACK CANDIDATES
+
+# Trajectory cleaner in default
+
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+hiLowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('hiLowPtQuadStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('hiLowPtQuadStepTrajectoryBuilder')),
+    TrajectoryBuilder = cms.string('hiLowPtQuadStepTrajectoryBuilder'),
+    clustersToSkip = cms.InputTag('hiLowPtQuadStepClusters'),
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+hiLowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'hiLowPtQuadStepTrackCandidates',
+    AlgorithmName = cms.string('lowPtQuadStep'),
+    Fitter=cms.string('FlexibleKFFittingSmoother')
+    )
+
+# Final selection
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
+hiLowPtQuadStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
+    src='hiLowPtQuadStepTracks',
+    useAnyMVA = cms.bool(True), 
+    GBRForestLabel = cms.string('HIMVASelectorIter8'),#FIXME MVA for new iteration
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
+    trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiLowPtQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(False),
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiLowPtQuadStepTight',
+    preFilterName = 'hiLowPtQuadStepLoose',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.2)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiLowPtQuadStep',
+    preFilterName = 'hiLowPtQuadStepTight',
+    applyAdaptedPVCuts = cms.bool(False),
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.09)
+    ),
+    ) #end of vpset
+    ) #end of clone
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+hiLowPtQuadStepQual = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers=cms.VInputTag(cms.InputTag('hiLowPtQuadStepTracks')),
+    hasSelector=cms.vint32(1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hiLowPtQuadStepSelector","hiLowPtQuadStep")),
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False),
+    )
+
+
+hiLowPtQuadStep = cms.Sequence(hiLowPtQuadStepClusters*
+                                     hiLowPtQuadStepSeedLayers*
+                                     hiLowPtQuadStepTrackingRegions*
+                                     hiLowPtQuadStepTracksHitDoubletsCA* # 'CA' can be removed
+                                     hiLowPtQuadStepTracksHitTriplets*
+                                     hiLowPtQuadStepTracksHitQuadrupletsCA* # 'CA' can be removed
+				     pixelFitterByHelixProjections*
+                                     hiLowPtQuadStepPixelTracksFilter*
+                                     hiLowPtQuadStepPixelTracks*
+                                     hiLowPtQuadStepSeeds*
+                                     hiLowPtQuadStepTrackCandidates*
+                                     hiLowPtQuadStepTracks*
+                                     hiLowPtQuadStepSelector*
+                                     hiLowPtQuadStepQual)
+
+

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -97,7 +97,6 @@ hiLowPtTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
 
     # Ordered Hits
     SeedingHitSets = cms.InputTag("hiLowPtTripletStepTracksHitTriplets"),
-    #SeedingHitSets = cms.InputTag("hiLowPtTripletStepTracksHitTripletsCA"),
 	
     # Fitter
     Fitter = cms.InputTag("pixelFitterByHelixProjections"),
@@ -225,6 +224,6 @@ hiLowPtTripletStep = cms.Sequence(hiLowPtTripletStepClusters*
                                         hiLowPtTripletStepQual
                                         )
 hiLowPtTripletStep_Phase1 = hiLowPtTripletStep.copy()
-hiLowPtTripletStep_Phase1.replace(hiLowPtTripletStepTracksHitDoublets, hiLowPtTripletStepTracksHitDoubletsCA)# 'CA' can be removed
-hiLowPtTripletStep_Phase1.replace(hiLowPtTripletStepTracksHitTriplets, hiLowPtTripletStepTracksHitTripletsCA)# 'CA' can be removed
+hiLowPtTripletStep_Phase1.replace(hiLowPtTripletStepTracksHitDoublets, hiLowPtTripletStepTracksHitDoubletsCA)
+hiLowPtTripletStep_Phase1.replace(hiLowPtTripletStepTracksHitTriplets, hiLowPtTripletStepTracksHitTripletsCA)
 trackingPhase1QuadProp.toReplaceWith(hiLowPtTripletStep, hiLowPtTripletStep_Phase1)

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -174,10 +174,31 @@ hiLowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProd
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiLowPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiLowPtTripletStepTracks',
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter5'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'relpterr', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiLowPtTripletStepLoose',
+    useMVA = cms.bool(False)
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiLowPtTripletStepTight',
+    preFilterName = 'hiLowPtTripletStepLoose',
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.58)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiLowPtTripletStep',
+    preFilterName = 'hiLowPtTripletStepTight',
+    useMVA = cms.bool(True),
+    minMVA = cms.double(0.35)
+    ),
+    ) #end of vpset
+    ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiLowPtTripletStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiLowPtTripletStepSelector, trackSelectors= cms.VPSet(
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
     name = 'hiLowPtTripletStepLoose',
     useMVA = cms.bool(False)
@@ -195,7 +216,7 @@ hiLowPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiT
     minMVA = cms.double(0.35)
     ),
     ) #end of vpset
-    ) #end of clone
+)
 
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -175,7 +175,7 @@ hiLowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProd
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiLowPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiLowPtTripletStepTracks',
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter5'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'relpterr', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -186,13 +186,13 @@ hiLowPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiT
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
     name = 'hiLowPtTripletStepTight',
     preFilterName = 'hiLowPtTripletStepLoose',
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.58)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiLowPtTripletStep',
     preFilterName = 'hiLowPtTripletStepTight',
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(0.35)
     ),
     ) #end of vpset

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -107,8 +107,8 @@ hiLowPtTripletStepPixelTracks = cms.EDProducer("PixelTrackProducer",
     # Cleaner
     Cleaner = cms.string("trackCleaner")
 )
-from Configuration.Eras.Modifier_trackingPhase1QuadProp_cff import trackingPhase1QuadProp
-trackingPhase1QuadProp.toModify(hiLowPtTripletStepPixelTracks,
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiLowPtTripletStepPixelTracks,
     SeedingHitSets = cms.InputTag("hiLowPtTripletStepTracksHitTripletsCA")
 )
 
@@ -226,4 +226,4 @@ hiLowPtTripletStep = cms.Sequence(hiLowPtTripletStepClusters*
 hiLowPtTripletStep_Phase1 = hiLowPtTripletStep.copy()
 hiLowPtTripletStep_Phase1.replace(hiLowPtTripletStepTracksHitDoublets, hiLowPtTripletStepTracksHitDoubletsCA)
 hiLowPtTripletStep_Phase1.replace(hiLowPtTripletStepTracksHitTriplets, hiLowPtTripletStepTracksHitTripletsCA)
-trackingPhase1QuadProp.toReplaceWith(hiLowPtTripletStep, hiLowPtTripletStep_Phase1)
+trackingPhase1.toReplaceWith(hiLowPtTripletStep, hiLowPtTripletStep_Phase1)

--- a/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
@@ -121,10 +121,31 @@ hiPixelPairGlobalPrimTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackP
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiPixelPairGlobalPrimTracks',
-    useAnyMVA = cms.bool(False),
+    useAnyMVA = cms.bool(True),
     GBRForestLabel = cms.string('HIMVASelectorIter6'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+    name = 'hiPixelPairStepLoose',
+    useMVA = cms.bool(False)
+    ), #end of pset
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+    name = 'hiPixelPairStepTight',
+    preFilterName = 'hiPixelPairStepLoose',
+    useMVA = cms.bool(True),
+    minMVA = cms.double(-0.58)
+    ),
+    RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+    name = 'hiPixelPairStep',
+    preFilterName = 'hiPixelPairStepTight',
+    useMVA = cms.bool(True),
+    minMVA = cms.double(0.77)
+    ),
+    ) #end of vpset
+    ) #end of clone
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiPixelPairStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiPixelPairStepSelector, trackSelectors= cms.VPSet(
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
     name = 'hiPixelPairStepLoose',
     useMVA = cms.bool(False)
@@ -142,7 +163,7 @@ hiPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrac
     minMVA = cms.double(0.77)
     ),
     ) #end of vpset
-    ) #end of clone
+)
 
 
 

--- a/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
@@ -121,7 +121,7 @@ hiPixelPairGlobalPrimTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackP
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src='hiPixelPairGlobalPrimTracks',
-    useAnyMVA = cms.bool(True),
+    useAnyMVA = cms.bool(False),
     GBRForestLabel = cms.string('HIMVASelectorIter6'),
     GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
@@ -132,13 +132,13 @@ hiPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrac
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
     name = 'hiPixelPairStepTight',
     preFilterName = 'hiPixelPairStepLoose',
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(-0.58)
     ),
     RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
     name = 'hiPixelPairStep',
     preFilterName = 'hiPixelPairStepTight',
-    useMVA = cms.bool(True),
+    useMVA = cms.bool(False),
     minMVA = cms.double(0.77)
     ),
     ) #end of vpset


### PR DESCRIPTION
This PR makes many changes aimed at improving the Heavy Ion Tracking for use with the Phase 1 pixel detector. In particular, it is for HI tracking done under the Run2_2017_trackingPhase1QuadProp era. The following changes are made:

1) Fixed a missing product in the regional muon tracking which was causing a crash.
2) Changed tracking iterations to use all 4 layers of the pixels instead of the first 3
3) Added tracking iterations: LowPtQuadStep, DetachedQuadStep, and highPtTripletStep
4) Changed seeding from triplets to Cellular Automaton quadruplets

Most of these changes are attached to the 'trackingPhase1QuadProp.' modifier. I am not sure if this is more appropriate to use than the 'trackingPhase1' modifer; perhaps someone can comment.

In order to Test this PR, one needs do the following:

1) Merge the PR and do a 'scram build.'
2) Comment out lines 38-50 in RecoHI/Configuration/python/Reconstruction_HI_cff.py in order to prevent issues related to workflows downstream of the tracking (some of these do not work in Run2_2017 era, but are out of the scope of this PR).
3) Copy and run the config file found here: /afs/cern.ch/user/a/abaty/work/public/forPeople/forPhase1PR_May5/
, which runs the Run2_2017 track reconstruction on a sample of MB Hydjet events privately produced with SIM of the new pixel detector.
@mandrenguyen