### PR TITLE
GEM Slice Test Geometry + related Validation Package Changes

### DIFF
--- a/Configuration/Eras/python/Modifier_run2_GEM_2017_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_GEM_2017_cff.py
@@ -1,3 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 run2_GEM_2017 = cms.Modifier()
+run2_GEM_2017_MCTest = cms.Modifier()

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
@@ -1,4 +1,4 @@
-/** Implementation of the GEM Geometry Builder from DDD stored in CondDB
+/** Implementation of the GEM Geometry Builder from GEM record stored in CondDB
  *
  *  \author M. Maggi - INFN Bari
  */
@@ -21,6 +21,8 @@
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
+
 #include <iostream>
 #include <algorithm>
 
@@ -30,7 +32,8 @@ GEMGeometryBuilderFromCondDB::GEMGeometryBuilderFromCondDB()
 GEMGeometryBuilderFromCondDB::~GEMGeometryBuilderFromCondDB() 
 { }
 
-GEMGeometry* GEMGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
+GEMGeometry*
+GEMGeometryBuilderFromCondDB::build( const RecoIdealGeometry& rgeo )
 {
   const std::vector<DetId>& detids(rgeo.detIds());
   GEMGeometry* geometry = new GEMGeometry();
@@ -40,12 +43,12 @@ GEMGeometry* GEMGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
   std::vector<double>::const_iterator shapeStart;
   std::vector<double>::const_iterator rotStart;
   std::vector<std::string>::const_iterator strStart;
-  
+
   for (unsigned int id = 0; id < detids.size(); ++id)
   {  
     GEMDetId gemid(detids[id]);
-    //    GEMDetId chid(gemid.region(),gemid.ring(),gemid.station(),
-    //		  gemid.sector(),gemid.layer(),gemid.subsector(),0);
+    GEMDetId chid(gemid.region(),gemid.ring(),gemid.station(),
+		  gemid.layer(),gemid.chamber(),0);
     
     tranStart = rgeo.tranStart(id);
     shapeStart = rgeo.shapeStart(id);
@@ -78,7 +81,7 @@ GEMGeometry* GEMGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
     
     GEMEtaPartitionSpecs* e_p_specs = new GEMEtaPartitionSpecs(GeomDetEnumerators::GEM, name, pars);
       
-      //Change of axes for the forward
+    //Change of axes for the forward
     Basic3DVector<float> newX(1.,0.,0.);
     Basic3DVector<float> newY(0.,0.,1.);
     //      if (tran[2] > 0. )
@@ -86,24 +89,23 @@ GEMGeometry* GEMGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
     Basic3DVector<float> newZ(0.,1.,0.);
     rot.rotateAxes (newX, newY, newZ);	
   
-    
     BoundPlane* bp = new BoundPlane(pos, rot, bounds);
     ReferenceCountingPointer<BoundPlane> surf(bp);
     GEMEtaPartition* gep=new GEMEtaPartition(gemid, surf, e_p_specs);
+    LogDebug("GEMGeometryBuilder")<<"GEM Eta Partition created with id = "<<gemid<<" and added to the GEMGeometry"<<std::endl;
     geometry->add(gep);
     
-    
     std::list<GEMEtaPartition *> gepls;
-    /*
-    if (chids.find(chid)!=chids.end()){
+    
+    if( chids.find(chid) != chids.end()) {
       gepls = chids[chid];
     }
-    */
-    gepls.push_back(gep);
-    //chids[chid]=gepls;
     
+    gepls.push_back(gep);
+    chids[chid] = gepls;
+
   }
-  /*
+  
   // Create the GEMChambers and store them on the Geometry 
 
   for( std::map<GEMDetId, std::list<GEMEtaPartition *> >::iterator ich=chids.begin();
@@ -121,20 +123,89 @@ GEMGeometry* GEMGeometryBuilderFromCondDB::build(const RecoIdealGeometry& rgeo)
     }
 
     ReferenceCountingPointer<BoundPlane> surf(bp);
+    // Create the superchamber
+    if(chid.layer()==1) {
+      GEMDetId schid(chid.region(),chid.ring(),chid.station(),0,chid.chamber(),0);
+      GEMSuperChamber* sch = new GEMSuperChamber(schid,surf);
+      LogDebug("GEMGeometryBuilder")<<"GEM SuperChamber created with id = "<<schid<<" and added to the GEMGeometry"<<std::endl;
+      geometry->add(sch);
+    }
     // Create the chamber 
     GEMChamber* ch = new GEMChamber (chid, surf); 
+    LogDebug("GEMGeometryBuilder")<<"GEM Chamber created with id = "<<chid<<" = "<<chid.rawId()<<" and added to the GEMGeometry"<<std::endl;
+    LogDebug("GEMGeometryBuilder")<<"GEM Chamber has following eta partitions associated: "<<std::endl;
     // Add the etaps to rhe chamber
     for(std::list<GEMEtaPartition *>::iterator gepl=gepls.begin();
     gepl!=gepls.end(); gepl++){
       ch->add(*gepl);
+      LogDebug("GEMGeometryBuilder")<<"   --> GEM Eta Partition "<<GEMDetId((*gepl)->id())<<std::endl;
     }
     // Add the chamber to the geometry
     geometry->add(ch);
 
   }
-  */
+  
+  // The super chamber is composed of 2 chambers.
+  // It's detId is layer 0, chambers are layer 1 and 2
+
+  auto& superChambers( geometry->superChambers());
+  // construct the regions, stations and rings. 
+  for( int re = -1; re <= 1; re = re+2 ) {
+    GEMRegion* region = new GEMRegion( re );
+    for( int st = 1; st <= GEMDetId::maxStationId; ++st ) {
+      GEMStation* station = new GEMStation(re, st);
+      std::string sign( re==-1 ? "-" : "");
+      std::string name("GE" + sign + std::to_string(st) + "/1");
+      station->setName(name);
+      for( int ri = 1; ri <= 1; ++ri ) {
+	GEMRing* ring = new GEMRing( re, st, ri );
+	for( unsigned sch = 0; sch < superChambers.size(); ++sch ) {
+	  GEMSuperChamber* superChamber = const_cast<GEMSuperChamber*>( superChambers.at(sch));
+	  const GEMDetId detId( superChamber->id());
+	  if (detId.region() != re || detId.station() != st || detId.ring() != ri) continue;
+	  
+	  auto ch1 = geometry->chamber(GEMDetId(detId.region(),detId.ring(),detId.station(),1,detId.chamber(),0));
+	  auto ch2 = geometry->chamber(GEMDetId(detId.region(),detId.ring(),detId.station(),2,detId.chamber(),0));
+	  superChamber->add(const_cast<GEMChamber*>(ch1));
+	  superChamber->add(const_cast<GEMChamber*>(ch2));
+       
+	  ring->add(superChamber);
+	  LogDebug("GEMGeometryBuilderFromDDD") << "Adding super chamber " << detId << " to ring: " 
+						<< "re " << re << " st " << st << " ri " << ri << std::endl;
+	}
+	LogDebug("GEMGeometryBuilderFromDDD") << "Adding ring " <<  ri << " to station " << "re " << re << " st " << st << std::endl;
+	station->add(const_cast<GEMRing*>(ring));
+	geometry->add(const_cast<GEMRing*>(ring));
+      }
+      LogDebug("GEMGeometryBuilderFromDDD") << "Adding station " << st << " to region " << re << std::endl;
+      region->add(const_cast<GEMStation*>(station));
+      geometry->add(const_cast<GEMStation*>(station));
+    }
+    LogDebug("GEMGeometryBuilderFromDDD") << "Adding region " << re << " to the geometry " << std::endl;
+    geometry->add(const_cast<GEMRegion*>(region));
+  }
+
   return geometry;
 }
 
-    
+GEMSuperChamber*
+GEMGeometryBuilderFromCondDB::buildSuperChamber( const GEMDetId id, const RecoIdealGeometry& rig,
+						 size_t idt ) const
+{
+  RCPPlane surf;
+  GEMSuperChamber* chamber = new GEMSuperChamber( id, surf );
+
+  return chamber;
+}
+  
+GEMChamber*
+GEMGeometryBuilderFromCondDB::buildChamber( const GEMDetId id,  const RecoIdealGeometry& rig,
+					    size_t idt ) const
+{
+  RCPPlane surf;
+  GEMChamber* chamber = new GEMChamber( id, surf );
+
+  return chamber;
+}
+
 

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.h
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.h
@@ -2,34 +2,44 @@
 #define Geometry_GEMGeometry_GEMGeometryBuilderFromCondDB_H
 
 /** \class  GEMGeometryBuilderFromCondDB
- *  Build the GEMGeometry from the DDD description stored in Condition DB 
+ *  Build the GEMGeometry from the RecoIdealGeometry description stored in Condition DB 
  *
  *  \author M. Maggi - INFN Bari
  *
  */
 
-#include <CondFormats/GeometryObjects/interface/RecoIdealGeometry.h>
+#include "CondFormats/GeometryObjects/interface/RecoIdealGeometry.h"
+#include "DataFormats/GeometrySurface/interface/Plane.h"
 #include <string>
 #include <map>
 #include <list>
 
-
 class GEMGeometry;
 class GEMDetId;
 class GEMEtaPartition;
+class GEMSuperChamber;
+class GEMChamber;
 
 class GEMGeometryBuilderFromCondDB 
-{ 
+{
  public:
 
   GEMGeometryBuilderFromCondDB();
 
   ~GEMGeometryBuilderFromCondDB();
-
+  
   GEMGeometry* build(const RecoIdealGeometry& rgeo);
-
+  
  private:
-  //  std::map<GEMDetId,std::list<GEMEtaPartition *> > chids;
+  typedef ReferenceCountingPointer<Plane> RCPPlane;
+  
+  GEMSuperChamber* buildSuperChamber( const GEMDetId id, const RecoIdealGeometry& rig,
+				      size_t idt ) const;
+  
+  GEMChamber* buildChamber( const GEMDetId id,  const RecoIdealGeometry& rig,
+			    size_t idt ) const;
+  
+  std::map<GEMDetId, std::list<GEMEtaPartition *> > chids;
 };
 
 #endif

--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -172,6 +172,11 @@ RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
 
 randomEngineStateProducer = cms.EDProducer("RandomEngineStateProducer")
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toModify(RandomNumberGeneratorService, simMuonGEMDigis = cms.PSet(
+        initialSeed = cms.untracked.uint32(1234567),
+        engineName = cms.untracked.string('HepJamesRandom')) )
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify(RandomNumberGeneratorService, simMuonGEMDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -508,6 +508,18 @@ run2_common.toModify( cscTriggerPrimitiveDigis,
                            )
 
 ## GEM-CSC ILT in ME1/1
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toModify( cscTriggerPrimitiveDigis,
+                        GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),
+                        commonParam = dict(
+                            isSLHC = cms.bool(True),
+                            smartME1aME1b = cms.bool(True),
+                            runME11ILT = cms.bool(True)),                        
+                        clctSLHC = dict(clctNplanesHitPattern = 3),
+                        me11tmbSLHCGEM = me11tmbSLHCGEM
+)
+
+## GEM-CSC ILT in ME1/1
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( cscTriggerPrimitiveDigis,
                    GEMPadDigiProducer = cms.InputTag("simMuonGEMPadDigis"),

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -380,6 +380,13 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
   const CSCDetId me1aId(me1bId.endcap(), 1, 4, me1bId.chamber());
   const CSCChamber* cscChamberME1a(csc_g->chamber(me1aId));
 
+  const bool isEven(me1bId.chamber()%2==0);
+  const int region((theEndcap == 1) ? 1: -1);
+  const GEMDetId gem_id(region, 1, theStation, 1, me1bId.chamber(), 0);
+  const GEMChamber* gemChamber(gem_g->chamber(gem_id));
+  // check if the GEM chamber is really there 
+  if (!gemChamber) runME11ILT_ = false;
+
   if (runME11ILT_){
       
     // check for GEM geometry
@@ -394,11 +401,6 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
     const CSCLayerGeometry* keyLayerGeometryME1b(keyLayerME1b->geometry());
     const CSCLayer* keyLayerME1a(cscChamberME1a->layer(3));
     const CSCLayerGeometry* keyLayerGeometryME1a(keyLayerME1a->geometry());
-
-    const bool isEven(me1bId.chamber()%2==0);
-    const int region((theEndcap == 1) ? 1: -1);
-    const GEMDetId gem_id(region, 1, theStation, 1, me1bId.chamber(), 0);
-    const GEMChamber* gemChamber(gem_g->chamber(gem_id));
 
     // initialize depending on whether even or odd     
     maxDeltaBXPad_ = isEven ? maxDeltaBXPadEven_ : maxDeltaBXPadOdd_;

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -32,8 +32,10 @@ def _updateOutput( era, outputPSets, commands):
    for o in outputPSets:
       era.toModify( o, outputCommands = o.outputCommands + commands )
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 _outputs = [RecoLocalMuonFEVT, RecoLocalMuonRECO, RecoLocalMuonAOD]
+_updateOutput( run2_GEM_2017, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
 _updateOutput( run3_GEM, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
 _updateOutput(phase2_muon, _outputs, ['keep *_me0RecHits_*_*', 'keep *_me0Segments_*_*'])

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -32,10 +32,10 @@ def _updateOutput( era, outputPSets, commands):
    for o in outputPSets:
       era.toModify( o, outputCommands = o.outputCommands + commands )
 
-from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 _outputs = [RecoLocalMuonFEVT, RecoLocalMuonRECO, RecoLocalMuonAOD]
-_updateOutput( run2_GEM_2017, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
+_updateOutput( run2_GEM_2017_MCTest, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
 _updateOutput( run3_GEM, _outputs, ['keep *_gemRecHits_*_*', 'keep *_gemSegments_*_*'] )
 _updateOutput(phase2_muon, _outputs, ['keep *_me0RecHits_*_*', 'keep *_me0Segments_*_*'])

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -40,12 +40,17 @@ muonlocalreco = cms.Sequence(dtlocalreco+csclocalreco+rpcRecHits)
 from RecoLocalMuon.GEMRecHit.gemLocalReco_cff import *
 from RecoLocalMuon.GEMRecHit.me0LocalReco_cff import *
 
+_run2_GEM_2017_muonlocalreco = muonlocalreco.copy()
+_run2_GEM_2017_muonlocalreco += gemLocalReco
+
 _run3_muonlocalreco = muonlocalreco.copy()
 _run3_muonlocalreco += gemLocalReco
 
 _phase2_muonlocalreco = _run3_muonlocalreco.copy()
 _phase2_muonlocalreco += me0LocalReco
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+run2_GEM_2017.toReplaceWith( muonlocalreco , _run2_GEM_2017_muonlocalreco )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonlocalreco , _run3_muonlocalreco )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -49,8 +49,8 @@ _run3_muonlocalreco += gemLocalReco
 _phase2_muonlocalreco = _run3_muonlocalreco.copy()
 _phase2_muonlocalreco += me0LocalReco
 
-from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-run2_GEM_2017.toReplaceWith( muonlocalreco , _run2_GEM_2017_muonlocalreco )
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toReplaceWith( muonlocalreco , _run2_GEM_2017_muonlocalreco )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonlocalreco , _run3_muonlocalreco )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -221,6 +221,14 @@ mixPCFHepMCProducts = cms.PSet(
 
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchefrontDigitizer
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toModify( theMixObjects,
+    mixSH = dict(
+        input = theMixObjects.mixSH.input + [ cms.InputTag("g4SimHits","MuonGEMHits") ],
+        subdets = theMixObjects.mixSH.subdets + [ 'MuonGEMHits' ],
+        crossingFrames = theMixObjects.mixSH.crossingFrames + [ 'MuonGEMHits' ]
+    )
+)
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( theMixObjects,
     mixSH = dict(

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -51,6 +51,10 @@ if fastSim.isChosen():
     trackingParticles.simTrackCollection = cms.InputTag('famosSimHits')
     trackingParticles.simVertexCollection = cms.InputTag('famosSimHits')
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toModify(trackingParticles, simHitCollections = dict(
+        muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonGEMHits")]))
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify(trackingParticles, simHitCollections = dict(
         muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonGEMHits")]))

--- a/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/TrackingParticleSelection_cfi.py
@@ -58,6 +58,10 @@ mergedtruth = cms.EDProducer("TrackingTruthProducer",
 
 trackingParticleSelection = cms.Sequence(mergedtruth)
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toModify(trackingParticleSelection, simHitCollections = dict(
+        muon = trackingParticleSelection.simHitCollections.muon+["g4SimHitsMuonGEMHits"]))
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify(trackingParticleSelection, simHitCollections = dict(
         muon = trackingParticleSelection.simHitCollections.muon+["g4SimHitsMuonGEMHits"]))

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -39,12 +39,22 @@ SimMuonAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*',
+                                                                                              'keep *_simMuonGEMPadDigis_*_*',
+                                                                                              'keep *_simMuonGEMPadDigiClusters_*_*'] )
+run2_GEM_2017_MCTest.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+run2_GEM_2017_MCTest.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonGEMDigis_*_*',
                                                                                               'keep *_simMuonGEMPadDigis_*_*',
                                                                                               'keep *_simMuonGEMPadDigiClusters_*_*'] )
 run3_GEM.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
 run3_GEM.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonGEMDigis_*_*'] )
+
+
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0Digis_*_*',
                                                                                             'keep *_simMuonME0ReDigis_*_*'] )

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -23,6 +23,8 @@ _run3_muonDigi += muonGEMDigi
 _phase2_muonDigi = _run3_muonDigi.copy()
 _phase2_muonDigi += muonME0Digi
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toReplaceWith( muonDigi, _run3_muonDigi )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonDigi, _run3_muonDigi )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -173,6 +173,8 @@ _run3_globalValidation += gemSimValid
 _phase2_globalValidation = _run3_globalValidation.copy()
 _phase2_globalValidation += me0SimValid
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toReplaceWith( globalValidation, _run3_globalValidation )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( globalValidation, _run3_globalValidation )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -116,6 +116,8 @@ _phase2_postValidation += hgcalPostProcessor
 _phase2_postValidation += MuonME0DigisPostProcessors
 _phase2_postValidation += MuonME0SegPostProcessors
 
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017_MCTest
+run2_GEM_2017_MCTest.toReplaceWith( postValidation, _run3_postValidation )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( postValidation, _run3_postValidation )
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/Validation/MuonGEMDigis/src/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/src/GEMCoPadDigiValidation.cc
@@ -17,7 +17,7 @@ void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Ru
   int npadsGE21 = 0;
   int nPads = 0;
 
-  if ( nStation() > 1 ) {
+  if ( GEMGeometry_->regions()[0]->stations()[1]->superChambers().size() != 0 ) {
     npadsGE21  = GEMGeometry_->regions()[0]->stations()[1]->superChambers()[0]->chambers()[0]->etaPartitions()[0]->npads();
   }
 

--- a/Validation/MuonGEMDigis/src/GEMPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/src/GEMPadDigiValidation.cc
@@ -13,10 +13,9 @@ void GEMPadDigiValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run 
   int npadsGE21 = 0;
   int nPads = 0;
 
-  if ( nStation() > 1 ) {
+  if ( GEMGeometry_->regions()[0]->stations()[1]->superChambers().size() != 0 ) {
     npadsGE21 = GEMGeometry_->regions()[0]->stations()[1]->superChambers()[0]->chambers()[0]->etaPartitions()[0]->npads();
   }
-
 
   for( auto& region : GEMGeometry_->regions()  ){
     int re = region->region();

--- a/Validation/MuonGEMHits/src/GEMBaseValidation.cc
+++ b/Validation/MuonGEMHits/src/GEMBaseValidation.cc
@@ -30,10 +30,17 @@ const GEMGeometry* GEMBaseValidation::initGeometry(edm::EventSetup const & iSetu
     edm::LogError("MuonGEMBaseValidation") << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return nullptr;
   }
+
+  LogDebug("MuonBaseValidation") << "GEMGeometry_->regions().size() " << GEMGeometry_->regions().size() << "\n";
+  LogDebug("MuonBaseValidation") << "GEMGeometry_->stations().size() " << GEMGeometry_->regions().front()->stations().size() << "\n";
+  LogDebug("MuonBaseValidation") << "GEMGeometry_->superChambers().size() " << GEMGeometry_->superChambers().size() << "\n";
+  LogDebug("MuonBaseValidation") << "GEMGeometry_->chambers().size() " << GEMGeometry_->chambers().size() << "\n";
+  LogDebug("MuonBaseValidation") << "GEMGeometry_->etaPartitions().size() " << GEMGeometry_->etaPartitions().size() << "\n"; 
+
   nregion  = GEMGeometry_->regions().size();
-  nstation = GEMGeometry_->regions()[0]->stations().size() ;
-  nstationForLabel = GEMGeometry_->regions()[0]->stations().size() ;
-  npart    = GEMGeometry_->regions()[0]->stations()[0]->superChambers()[0]->chambers()[0]->etaPartitions().size();
+  nstation = GEMGeometry_->regions().front()->stations().size() ;
+  nstationForLabel = nstation;
+  npart    = GEMGeometry_->chambers().front()->etaPartitions().size();
 
   return GEMGeometry_;
 }
@@ -105,18 +112,17 @@ MonitorElement* GEMBaseValidation::getSimpleZR(DQMStore::IBooker& ibooker, TStri
 }
 
 MonitorElement* GEMBaseValidation::getDCEta(DQMStore::IBooker& ibooker, const GEMStation* station, TString title, TString histname ) {
-  if( station->rings()[0]->superChambers().size() ==0) {
+  if( station->rings().front()->superChambers().size() == 0 ) {
     LogDebug("MuonBaseValidation")<<"+++ Error! can not get superChambers. Skip "<<getSuffixTitle(station->region(), station->station())<<" on "<<histname<<"\n";
     return nullptr;
   }
 
-  int nXbins = station->rings()[0]->nSuperChambers()*2;;
-  int nRoll1 = station->rings()[0]->superChambers()[0]->chambers()[0]->etaPartitions().size();;
-  int nRoll2 = station->rings()[0]->superChambers()[0]->chambers()[1]->etaPartitions().size();;
-  int nYbins = ( nRoll1 > nRoll2 ) ? nRoll1 : nRoll2;;
+  int nXbins = station->rings().front()->nSuperChambers()*2;
+  int nYbins = station->rings().front()->superChambers().front()->chambers().front()->nEtaPartitions();
 
   TH2F* dcEta_temp = new TH2F(title,histname,nXbins, 0, nXbins, nYbins, 1, nYbins+1);
   int idx = 0 ;
+
   for(unsigned int sCh = 1; sCh <= station->superChambers().size(); sCh++){
     for(unsigned int Ch = 1; Ch <= 2; Ch++){
       idx++;

--- a/Validation/MuonGEMHits/src/GEMTrackMatch.cc
+++ b/Validation/MuonGEMHits/src/GEMTrackMatch.cc
@@ -96,8 +96,8 @@ void GEMTrackMatch::FillWithTrigger( MonitorElement* hist[4][3][3], bool array[3
 std::pair<double,double> GEMTrackMatch::getEtaRange( int station, int chamber )
 {
   if( gem_geom_ != nullptr) {
-    auto& ch = gem_geom_->regions()[0]->stations()[station-1]->rings()[0]->superChambers()[chamber-1]->chambers()[0];
-    auto& roll1 = ch->etaPartitions()[0]; //.begin();
+    auto& ch = gem_geom_->chambers().front();
+    auto& roll1 = ch->etaPartitions().front(); //.begin();
     auto& roll2 = ch->etaPartitions()[ch->nEtaPartitions()-1];
     const BoundPlane& bSurface1(roll1->surface());
     const BoundPlane& bSurface2(roll2->surface());
@@ -139,24 +139,28 @@ bool GEMTrackMatch::isSimTrackGood(const SimTrack &t)
 
 void GEMTrackMatch::buildLUT(const int maxChamberId)
 {
-
+  edm::LogInfo("GEMTrackMatch")<<"GEMTrackMatch::buildLUT"<<std::endl;
   edm::LogInfo("GEMTrackMatch")<<"max chamber "<<maxChamberId<<"\n";
 
-  std::vector<int> pos_ids;
-  pos_ids.push_back(GEMDetId(1,1,1,1,maxChamberId,useRoll_).rawId());
-
-  std::vector<int> neg_ids;
-  neg_ids.push_back(GEMDetId(-1,1,1,1,maxChamberId,useRoll_).rawId());
-
-  // VK: I would really suggest getting phis from GEMGeometry
-
+  std::vector<int> pos_ids, neg_ids;
   std::vector<float> phis;
-  phis.push_back(0.);
-  for(int i=1; i<maxChamberId+1; ++i)
-  {
-    pos_ids.push_back(GEMDetId(1,1,1,1,i,useRoll_).rawId());
-    neg_ids.push_back(GEMDetId(-1,1,1,1,i,useRoll_).rawId());
-    phis.push_back(i*10.);
+
+  for(auto it : gem_geom_->chambers()) {
+    if(it->id().region()>0) {
+      pos_ids.push_back(it->id().rawId());
+      edm::LogInfo("GEMTrackMatch")<<"added id = "<<it->id()<<" = "<<it->id().rawId()<<" to pos ids"<<std::endl;
+    }
+    if(it->id().region()<0) {
+      neg_ids.push_back(it->id().rawId());
+      edm::LogInfo("GEMTrackMatch")<<"added id = "<<it->id()<<" = "<<it->id().rawId()<<" to neg ids"<<std::endl;
+      const BoundPlane& bSurface(it->surface());
+      LocalPoint  lCentre( 0., 0., 0. );
+      GlobalPoint gCentre(bSurface.toGlobal(lCentre));
+      int cphi(static_cast<int>(gCentre.phi().degrees()));
+      if (cphi < 0) cphi += 360;
+      phis.push_back(cphi);
+      edm::LogInfo("GEMTrackMatch")<<"added phi = "<<cphi<<" to phi vector"<<std::endl;
+    }
   }
   positiveLUT_ = std::make_pair(phis,pos_ids);
   negativeLUT_ = std::make_pair(phis,neg_ids);
@@ -165,17 +169,13 @@ void GEMTrackMatch::buildLUT(const int maxChamberId)
 
 void GEMTrackMatch::setGeometry(const GEMGeometry& geom)
 {
+  edm::LogInfo("GEMTrackMatch")<<"GEMTrackMatch :: setGeometry"<<std::endl;
   gem_geom_ = &geom;
-  bool isEvenOK = true;
-  bool isOddOK  = true;
-  useRoll_=1;
-  if ( geom.etaPartition( GEMDetId(1,1,1,1,1,1) ) == nullptr) isOddOK = false;
-  if ( geom.etaPartition( GEMDetId(1,1,1,1,2,1) ) == nullptr) isEvenOK = false;
-  if ( !isEvenOK || !isOddOK) useRoll_=2;
-
-  const auto top_chamber = static_cast<const GEMEtaPartition*>(geom.idToDetUnit(GEMDetId(1,1,1,1,1,useRoll_))); 
-  const int nEtaPartitions(geom.chamber(GEMDetId(1,1,1,1,1,useRoll_))->nEtaPartitions());
-  const auto bottom_chamber = static_cast<const GEMEtaPartition*>(geom.idToDetUnit(GEMDetId(1,1,1,1,1,nEtaPartitions)));
+  GEMDetId chId(gem_geom_->chambers().front()->id());
+  useRoll_ = 1;
+  const auto top_chamber = static_cast<const GEMEtaPartition*>(geom.idToDetUnit(GEMDetId(chId.region(),chId.ring(),chId.station(),chId.layer(),chId.chamber(),useRoll_)));
+  const int nEtaPartitions(gem_geom_->chambers().front()->nEtaPartitions());
+  const auto bottom_chamber = static_cast<const GEMEtaPartition*>(geom.idToDetUnit(GEMDetId(chId.region(),chId.ring(),chId.station(),chId.layer(),chId.chamber(),nEtaPartitions)));
   const float top_half_striplength = top_chamber->specs()->specificTopology().stripLength()/2.;
   const float bottom_half_striplength = bottom_chamber->specs()->specificTopology().stripLength()/2.;
   const LocalPoint lp_top(0., top_half_striplength, 0.);
@@ -187,6 +187,7 @@ void GEMTrackMatch::setGeometry(const GEMGeometry& geom)
   chamberHeight_ = gp_top.perp() - gp_bottom.perp();
 
   const int maxChamberId = geom.regions()[0]->stations()[0]->superChambers().size();
+  edm::LogInfo("GEMTrackMatch")<<"GEMTrackMatch :: setGeometry --> Calling buildLUT"<<std::endl;
   buildLUT(maxChamberId);
 }  
 

--- a/Validation/MuonGEMRecHits/src/GEMRecHitTrackMatch.cc
+++ b/Validation/MuonGEMRecHits/src/GEMRecHitTrackMatch.cc
@@ -23,10 +23,14 @@ GEMRecHitTrackMatch::GEMRecHitTrackMatch(const edm::ParameterSet& ps) : GEMTrack
 }
 
 void GEMRecHitTrackMatch::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& run, edm::EventSetup const & iSetup){
+  edm::LogInfo("GEMRecHitTrackMatch")<<"GEM RecHitTrackMatch :: bookHistograms"<<std::endl;
   edm::ESHandle<GEMGeometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const GEMGeometry& geom = *hGeom;
+  edm::LogInfo("GEMRecHitTrackMatch")<<"GEM RecHitTrackMatch :: about to set the geometry"<<std::endl;
   setGeometry(geom);
+  edm::LogInfo("GEMRecHitTrackMatch")<<"GEM RecHitTrackMatch :: successfully set the geometry"<<std::endl;
+  edm::LogInfo("GEMRecHitTrackMatch")<<"GEM RecHitTrackMatch :: geom = "<<&geom<<std::endl;
 
   const float PI=TMath::Pi();
   const char* l_suffix[4] = {"_l1","_l2","_l1or2","_l1and2"};
@@ -76,6 +80,7 @@ GEMRecHitTrackMatch::~GEMRecHitTrackMatch() {  }
 
 void GEMRecHitTrackMatch::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  edm::LogInfo("GEMRecHitTrackMatch")<<"GEM RecHitTrackMatch :: analyze"<<std::endl;
   edm::ESHandle<GEMGeometry> hGeom;
   iSetup.get<MuonGeometryRecord>().get(hGeom);
   const GEMGeometry& geom = *hGeom;
@@ -124,7 +129,7 @@ void GEMRecHitTrackMatch::analyze(const edm::Event& iEvent, const edm::EventSetu
       const GEMDetId id(d);
       if ( id.chamber() %2 ==0 ) track_.hitEven[id.station()-1] = true;
       else if ( id.chamber() %2 ==1 ) track_.hitOdd[id.station()-1] = true;
-      else { std::cout<<"Error to get chamber id"<<std::endl;}
+      else { edm::LogInfo("GEMRecHitTrackMatch")<<"Error to get chamber id"<<std::endl; }
 
       track_.gem_sh[ id.station()-1][ (id.layer()-1)] = true;
 


### PR DESCRIPTION
This PR fixes the GEMGeometryBuilder to be constructed from the CondDB.
This way the GEM Slice Test geometry (5 chambers) in the negative endcap
gets constructed correctly from the database.
Furthermore it adds several fixes to the Validation Package such that it works
with the GEM Slice geometry.

This is a follow up on PR  #18257 with as modification another GEM_2017_MCTest 
identifier for the GEM Simulation that is not included in the standard Run_2 Era.