### PR TITLE
Fix exception at global begin transition

### DIFF
--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -42,7 +42,6 @@ namespace edm {
   class ThinnedAssociationsHelper;
   class ProcessHistoryRegistry;
   class RunPrincipal;
-  class UnscheduledConfigurator;
 
   class EventPrincipal : public Principal {
   public:
@@ -138,8 +137,6 @@ namespace edm {
     RunPrincipal const& runPrincipal() const;
 
     ProductProvenanceRetriever const* productProvenanceRetrieverPtr() const {return provRetrieverPtr_.get();}
-
-    void setupUnscheduled(UnscheduledConfigurator const&);
 
     EventSelectionIDVector const& eventSelectionIDs() const;
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -48,6 +48,7 @@ namespace edm {
   class SharedResourcesAcquirer;
   class InputProductResolver;
   class WaitingTask;
+  class UnscheduledConfigurator;
 
   struct FilledProductPtr {
     bool operator()(propagate_const<std::shared_ptr<ProductResolverBase>> const& iObj) { return bool(iObj);}
@@ -82,7 +83,9 @@ namespace edm {
     void fillPrincipal(ProcessHistoryID const& hist, ProcessHistoryRegistry const& phr, DelayedReader* reader);
 
     void clearPrincipal();
-
+    
+    void setupUnscheduled(UnscheduledConfigurator const&);
+  
     void setAtEndTransition(bool iAtEnd);
     bool atEndTransition() const {return atEndTransition_;}
     

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -63,7 +63,7 @@ namespace edm {
                               U const* context);
 
     
-    void setupOnDemandSystem(EventPrincipal& principal, EventSetup const& es);
+    void setupOnDemandSystem(Principal& principal, EventSetup const& es);
 
     void beginJob(ProductRegistry const& iRegistry);
     void endJob();

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -390,13 +390,6 @@ namespace edm {
     return getProvenance(bid, mcc);
   }
 
-  void
-  EventPrincipal::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
-    applyToResolvers([&iConfigure](ProductResolverBase* iResolver) {
-      iResolver->setupUnscheduled(iConfigure);
-    });
-  }
-
   EventSelectionIDVector const&
   EventPrincipal::eventSelectionIDs() const {
     return eventSelectionIDs_;

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -270,7 +270,10 @@ namespace edm {
     workerManager_.resetAll();
     
     ParentContext parentContext(globalContext.get());
-
+    //make sure the ProductResolvers know about their
+    // workers to allow proper data dependency handling
+    workerManager_.setupOnDemandSystem(ep,es);
+    
     //make sure the task doesn't get run until all workers have beens started
     WaitingTaskHolder holdForLoop(doneTask);
     for(auto& worker: boost::adaptors::reverse((allWorkers()))) {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -318,6 +318,14 @@ namespace edm {
     phb->unsafe_deleteProduct();
   }
   
+  void
+  Principal::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
+    applyToResolvers([&iConfigure](ProductResolverBase* iResolver) {
+      iResolver->setupUnscheduled(iConfigure);
+    });
+  }
+  
+
   // Set the principal for the Event, Lumi, or Run.
   void
   Principal::fillPrincipal(ProcessHistoryID const& hist,

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -146,7 +146,7 @@ namespace edm {
   }
 
   void
-  WorkerManager::setupOnDemandSystem(EventPrincipal& ep, EventSetup const& es) {
+  WorkerManager::setupOnDemandSystem(Principal& ep, EventSetup const& es) {
     this->resetAll();
     unscheduled_.setEventSetup(es);
     if(&ep != lastSetupEventPrincipal_) {

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -93,6 +93,26 @@ namespace edmtest {
   };
   //--------------------------------------------------------------------
   //
+  class IntFromRunConsumingAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    IntFromRunConsumingAnalyzer(edm::ParameterSet const& iPSet)
+    {
+      consumes<IntProduct, edm::InRun>(iPSet.getUntrackedParameter<edm::InputTag>("getFromModule"));
+    }
+    
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override {}
+    
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<edm::InputTag>("getFromModule");
+      descriptions.add("consumeInt", desc);
+      
+    }
+    
+    
+  };
+  //--------------------------------------------------------------------
+  //
   class ConsumingStreamAnalyzer : public edm::stream::EDAnalyzer<> {
   public:
     ConsumingStreamAnalyzer(edm::ParameterSet const& iPSet) :
@@ -253,6 +273,7 @@ using edmtest::DSVAnalyzer;
 DEFINE_FWK_MODULE(NonAnalyzer);
 DEFINE_FWK_MODULE(IntTestAnalyzer);
 DEFINE_FWK_MODULE(IntConsumingAnalyzer);
+DEFINE_FWK_MODULE(edmtest::IntFromRunConsumingAnalyzer);
 DEFINE_FWK_MODULE(ConsumingStreamAnalyzer);
 DEFINE_FWK_MODULE(ConsumingOneSharedResourceAnalyzer);
 DEFINE_FWK_MODULE(SCSimpleAnalyzer);

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -53,6 +53,32 @@ namespace edmtest {
 
   //--------------------------------------------------------------------
   //
+  // throws an exception.
+  // Announces an IntProduct but does not produce one;
+  // every call to FailingProducer::produce throws a cms exception
+  //
+  class FailingInRunProducer : public edm::global::EDProducer<edm::BeginRunProducer> {
+  public:
+    explicit FailingInRunProducer(edm::ParameterSet const& /*p*/) {
+      produces<IntProduct,edm::Transition::BeginRun>();
+    }
+    virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+    
+    void globalBeginRunProduce( edm::Run&, edm::EventSetup const&) const override;
+
+  };
+  
+  void
+  FailingInRunProducer::produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const {
+  }
+  void
+  FailingInRunProducer::globalBeginRunProduce( edm::Run&, edm::EventSetup const&) const {
+    // We throw an edm exception with a configurable action.
+    throw edm::Exception(edm::errors::NotFound) << "Intentional 'NotFound' exception for testing purposes\n";
+  }
+
+  //--------------------------------------------------------------------
+  //
   // Announces an IntProduct but does not produce one;
   // every call to NonProducer::produce does nothing.
   //
@@ -371,6 +397,7 @@ using edmtest::IntProducerFromTransient;
 using edmtest::Int16_tProducer;
 using edmtest::AddIntsProducer;
 DEFINE_FWK_MODULE(FailingProducer);
+DEFINE_FWK_MODULE(edmtest::FailingInRunProducer);
 DEFINE_FWK_MODULE(NonProducer);
 DEFINE_FWK_MODULE(IntProducer);
 DEFINE_FWK_MODULE(IntLegacyProducer);

--- a/FWCore/Framework/test/test_dependentRunDataAndException_cfg.py
+++ b/FWCore/Framework/test/test_dependentRunDataAndException_cfg.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.intMaker = cms.EDProducer("edmtest::FailingInRunProducer")
+
+process.consumer = cms.EDAnalyzer("edmtest::IntFromRunConsumingAnalyzer",
+                                  getFromModule = cms.untracked.InputTag("intMaker"))
+
+process.p = cms.Path(process.consumer,cms.Task(process.intMaker))
+
+process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(2))

--- a/FWCore/Framework/test/test_earlyTerminationSignal.sh
+++ b/FWCore/Framework/test/test_earlyTerminationSignal.sh
@@ -9,3 +9,6 @@ echo "running cmsRun testEarlyTerminationSignal_cfg.py"
 
 echo "runnig cmsRun test_dependentPathsAndExceptions_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/test_dependentPathsAndExceptions_cfg.py 2>&1 | grep -q "Intentional 'NotFound' exception for testing purposes") || die "dependent Paths and Exceptions failed" $?
+
+echo "runnig cmsRun test_dependentRunDataAndException_cfg.py"
+(cmsRun ${LOCAL_TEST_DIR}/test_dependentRunDataAndException_cfg.py 2>&1 | grep -q "Intentional 'NotFound' exception for testing purposes") || die "dependent Run data and Exceptions failed" $?


### PR DESCRIPTION
Properly handle the case where a module consumes a Run or LuminosityBlock data product and the EDProducer that makes data throws an exception during that transition.