### PR TITLE
BPix cabling map and geometry fix

### DIFF
--- a/CondFormats/SiPixelObjects/interface/FrameConversion.h
+++ b/CondFormats/SiPixelObjects/interface/FrameConversion.h
@@ -19,6 +19,8 @@ public:
     : theRowConversion( LinearConversion(rowOffset,rowSlopeSign) ),
     theCollumnConversion( LinearConversion(colOffset, colSlopeSign) ) {}
   // for phase1
+  FrameConversion(bool bpix, int side, int layer, int rocIdInDetUnit);
+  // Frame conversion compatible with CMSSW_9_0_X Monte Carlo samples
   FrameConversion(bool bpix, int side, int rocIdInDetUnit);
 
   const sipixelobjects::LinearConversion & row() const { return theRowConversion; }

--- a/CondFormats/SiPixelObjects/interface/PixelROC.h
+++ b/CondFormats/SiPixelObjects/interface/PixelROC.h
@@ -78,6 +78,8 @@ public:
   void initFrameConversion();
   void initFrameConversionPhase1();
   //void initFrameConversion(const TrackerTopology *tt, bool phase1=false);
+  // Frame conversion compatible with CMSSW_9_0_X Monte Carlo samples
+  void initFrameConversionPhase1_CMSSW_9_0_X();
 
 private:
   uint32_t theDetUnit;

--- a/CondFormats/SiPixelObjects/src/FrameConversion.cc
+++ b/CondFormats/SiPixelObjects/src/FrameConversion.cc
@@ -8,6 +8,84 @@ using namespace std;
 using namespace edm;
 using namespace sipixelobjects;
 
+FrameConversion::FrameConversion(bool bpix, int side, int layer, int rocIdInDetUnit) {
+  int slopeRow =0;
+  int slopeCol = 0;
+  int  rowOffset = 0;
+  int  colOffset = 0; 
+ 
+  if (bpix ) { // bpix 
+    
+    if (side==-1 && layer!=1) {  // -Z side: 4 non-flipped modules oriented like 'dddd', except Layer 1
+
+      if (rocIdInDetUnit <8) {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;	
+      } else {
+	slopeRow = -1;
+	slopeCol = 1;      
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+      } // if roc
+      
+    } else {  // +Z side: 4 non-flipped modules oriented like 'pppp', but all 8 in Layer 1
+      
+      if (rocIdInDetUnit <8) {
+	slopeRow = -1;
+	slopeCol = 1;
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = rocIdInDetUnit * LocalPixel::numColsInRoc; 
+      } else {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (16-rocIdInDetUnit)*LocalPixel::numColsInRoc-1; 
+      }
+      
+    } // end if +-Z
+
+
+
+  } else { // fpix 
+
+    // for fpix follow Urs's code for pilot blade
+    // no difference between panels
+    if(side==-1) { // pannel 1
+      if (rocIdInDetUnit < 8) {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+      } else {
+	slopeRow = -1;
+	slopeCol = 1;
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+      }
+    } else { // pannel 2 
+      if (rocIdInDetUnit < 8) {
+	slopeRow = 1;
+	slopeCol = -1;
+	rowOffset = 0;
+	colOffset = (8-rocIdInDetUnit)*LocalPixel::numColsInRoc-1;
+      } else {
+	slopeRow = -1;
+	slopeCol = 1;
+	rowOffset = 2*LocalPixel::numRowsInRoc-1;
+	colOffset = (rocIdInDetUnit-8)*LocalPixel::numColsInRoc;
+      }
+      
+    } // side 
+
+  } // bpix/fpix
+
+  theRowConversion      = LinearConversion(rowOffset,slopeRow);
+  theCollumnConversion =  LinearConversion(colOffset, slopeCol);
+  
+}
+
 FrameConversion::FrameConversion(bool bpix, int side, int rocIdInDetUnit) {
   int slopeRow =0;
   int slopeCol = 0;

--- a/CondFormats/SiPixelObjects/src/PixelROC.cc
+++ b/CondFormats/SiPixelObjects/src/PixelROC.cc
@@ -53,7 +53,8 @@ PixelROC::PixelROC(uint32_t du, int idDU, int idLk)
 // }
 
 // works for phase 1, find det side from the local method
-void PixelROC::initFrameConversionPhase1() {
+// Frame conversion compatible with CMSSW_9_0_X Monte Carlo samples
+void PixelROC::initFrameConversionPhase1_CMSSW_9_0_X() {
   int side = 0;
   bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
   if(isBarrel) {
@@ -63,6 +64,22 @@ void PixelROC::initFrameConversionPhase1() {
   }
 
   theFrameConverter = FrameConversion(isBarrel,side, theIdDU);
+
+}
+
+// works for phase 1, find det side from the local method
+void PixelROC::initFrameConversionPhase1() {
+  int side = 0;
+  int layer = 0;
+  bool isBarrel = PixelModuleName::isBarrel(theDetUnit);
+  if(isBarrel) {
+    side = bpixSidePhase1(theDetUnit); // find the side for phase1
+    layer = bpixLayerPhase1(theDetUnit);
+  } else {
+    side = fpixSidePhase1(theDetUnit);
+  }
+
+  theFrameConverter = FrameConversion(isBarrel, side, layer, theIdDU);
 
 }
 

--- a/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelFedCablingMap.cc
@@ -18,6 +18,14 @@ void SiPixelFedCablingMap::initializeRocs() {
   // Decide if it is phase0 or phase1 based on the first fed, 0-phase0, 1200-phase1
   unsigned int fedId = (theMap.begin())->first.fed; // get the first fed
 
+  // Specifically for CMSSW_9_0_X, we need to call a different version of the frame 
+  // conversion steered by the version name in the cabling map
+  if (theVersion.find("CMSSW_9_0_X")!=std::string::npos) {
+    for (auto & v : theMap) v.second.initFrameConversionPhase1_CMSSW_9_0_X(); // works
+    std::cout<<"*** Found CMSSW_9_0_X specific cabling map\n";
+    return;
+  }
+
   if(fedId>=FEDNumbering::MINSiPixeluTCAFEDID) { // phase1 >= 1200
     for (auto & v : theMap) v.second.initFrameConversionPhase1(); // works
   } else { // phase0

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbar.xml
@@ -1015,18 +1015,22 @@
  <PosPart copyNumber="1">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbarlayer0:PixelBarrelLayer0"/>
+  <rRotation name="pixbar:180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbarlayer1:PixelBarrelLayer1"/>
+  <rRotation name="pixbar:180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbarlayer2:PixelBarrelLayer2"/>
+  <rRotation name="pixbar:180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbar:PixelBarrel"/>
    <rChild name="pixbarlayer3:PixelBarrelLayer3"/>
+  <rRotation name="pixbar:180D"/>
  </PosPart>
 </PosPartSection>
 

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladder.xml
@@ -72,6 +72,8 @@
 <RotationSection label="pixbarladder.xml">
   <Rotation name="Z2XY" thetaX="90*deg" phiX="0*deg"     thetaY="180*deg" 
                         phiY="0*deg"    thetaZ="90*deg"  phiZ="90*deg" />
+  <Rotation name="Y180D" thetaX="90*deg" phiX="180*deg"   thetaY="90*deg" 
+                         phiY="90*deg"   thetaZ="180*deg" phiZ="0*deg" />
 </RotationSection>
 
 </DDDefinition>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull0.xml
@@ -262,6 +262,7 @@
    <rParent name="pixbarladderfull0:PixelBarrelModuleFullMinus"/>
    <rChild name="pixbarladderfull0:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelModuleFullMinus"/>
@@ -289,6 +290,7 @@
    <rParent name="pixbarladderfull0:PixelBarrelModuleFullPlus"/>
    <rChild name="pixbarladderfull0:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull0:PixelBarrelModuleFullPlus"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull1.xml
@@ -245,6 +245,7 @@
    <rParent name="pixbarladderfull1:PixelBarrelModuleFullMinus"/>
    <rChild name="pixbarladderfull1:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull1:PixelBarrelModuleFullMinus"/>
@@ -270,6 +271,7 @@
    <rParent name="pixbarladderfull1:PixelBarrelModuleFullPlus"/>
    <rChild name="pixbarladderfull1:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull1:PixelBarrelModuleFullPlus"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull2.xml
@@ -231,6 +231,7 @@
    <rParent name="pixbarladderfull2:PixelBarrelModuleFullMinus"/>
    <rChild name="pixbarladderfull2:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull2:PixelBarrelModuleFullMinus"/>
@@ -256,6 +257,7 @@
    <rParent name="pixbarladderfull2:PixelBarrelModuleFullPlus"/>
    <rChild name="pixbarladderfull2:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull2:PixelBarrelModuleFullPlus"/>

--- a/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml
+++ b/Geometry/TrackerCommonData/data/PhaseI/pixbarladderfull3.xml
@@ -230,6 +230,7 @@
    <rParent name="pixbarladderfull3:PixelBarrelModuleFullMinus"/>
    <rChild name="pixbarladderfull3:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull3:PixelBarrelModuleFullMinus"/>
@@ -255,6 +256,7 @@
    <rParent name="pixbarladderfull3:PixelBarrelModuleFullPlus"/>
    <rChild name="pixbarladderfull3:PixelBarrelSensorFull"/>
   <Translation x="[zero]" y="[SensorY]" z="[zero]" />
+  <rRotation name="pixbarladder:Y180D"/>
  </PosPart>
  <PosPart copyNumber="1">
    <rParent name="pixbarladderfull3:PixelBarrelModuleFullPlus"/>


### PR DESCRIPTION
Three bugs found with BPix reconstruction of CRUZET is treated here:
1) the local frame conversion assumed an incorrect orientation for Layer 1 modules on the -Z half of the ladders 
2) a small mistake in the cabling map related to the ROC grouping in Layer 1 modules. 
3) an inverted pattern of flipped and non-flipped ladders were implemented in the BPix geometry for all layers

The PR corrects all bugs from first principle. The fix is mandatory for data-reconstruction, and recommended for future MC production (when data-MC comparison becomes important.)

A new cabling map in Prep called 'SiPixelFedCablingMap_phase1_v7_May2' corrects for 2). The use of this new object and the fix for 1) will invalidate MC generated in earlier CMSSW versions and saved in RAW format. This PR introduces a mechanism which turns on the use of the old local frame conversion if the string "CMSSW_9_0_X" is found in the version name of the cabling map. A new object in Prep called 'SiPixelFedCablingMap_phase1_v6.3_May2' contains this string and the old mapping. Using it will assure backward compatibility.
The fix of 3) will invalidate all earlier MC in GEN-SIM if propagated to the DB.

The following GT-s should be created after merging this PR
- old ideal geometry + cabling v6.3 + old (mis)alignment scenario for compatibility with old MC
- new ideal geometry from xml + cabling v7 + new alignment for collision data reconstruction (and cosmics rereco)
- new ideal geometry from xml + cabling v7 + new misalignment scenario for new MC

Note: the fix in 3) rotated all ladders around by Pi about the direction of global Z, therefore the support structure, the cables, and the cooling tubes moved from one side of the modules to the other for all modules  concerning their arrangement along the global radial direction. The total amount of material budget did not change. Tracking POG was notified that tracking reco material might need to be cross-checked.