### PR TITLE
Puppi candidates for b tagging of Puppi jets in all eras (91X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -268,15 +268,9 @@ def miniAOD_customizeCommon(process):
     )
     task.add(process.patJetPuppiCharge)
 
-    ## Using Puppi candidates as input for b tagging in Phase 2
-    _pfCandidates = 'particleFlow'
-    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-    if process.isUsingModifier( phase2_common ):
-        _pfCandidates = 'puppi'
-
     addJetCollection(process, postfix   = "", labelName = 'Puppi', jetSource = cms.InputTag('ak4PFJetsPuppi'),
                     jetCorrections = ('AK4PFPuppi', ['L2Relative', 'L3Absolute'], ''),
-                    pfCandidates = cms.InputTag(_pfCandidates),
+                    pfCandidates = cms.InputTag('puppi'), # using Puppi candidates as input for b tagging of Puppi jets
                     algo= 'AK', rParam = 0.4, btagDiscriminators = map(lambda x: x.value() ,process.patJets.discriminatorSources)
                     )
     


### PR DESCRIPTION
This is a 91X backport of https://github.com/cms-sw/cmssw/pull/18666