### PR TITLE
Enabling prototype payloads for uGMT, EMTF, and BMTF

### DIFF
--- a/CondTools/L1TriggerExt/python/L1ConfigTSCPayloadsExt_cff.py
+++ b/CondTools/L1TriggerExt/python/L1ConfigTSCPayloadsExt_cff.py
@@ -25,5 +25,10 @@ def setTSCPayloadsDB(process, DBConnect, DBAuth, protoDBConnect, protoDBAuth):
     process.L1TUtmTriggerMenuOnlineProd.onlineAuthentication       = cms.string( DBAuth )
 
     process.l1caloparProtodb.connect                         = cms.string( protoDBConnect )
+    process.l1bmtfparProtodb.connect                         = cms.string( protoDBConnect )
+    process.l1emtfparProtodb.connect                         = cms.string( protoDBConnect )
+    process.l1gmtparProtodb.connect                          = cms.string( protoDBConnect )
     process.l1caloparProtodb.DBParameters.authenticationPath = cms.untracked.string( protoDBAuth )
-
+    process.l1bmtfparProtodb.DBParameters.authenticationPath = cms.untracked.string( protoDBAuth )
+    process.l1emtfparProtodb.DBParameters.authenticationPath = cms.untracked.string( protoDBAuth )
+    process.l1gmtparProtodb.DBParameters.authenticationPath  = cms.untracked.string( protoDBAuth )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonBarrelParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonBarrelParamsOnline_cfi.py
@@ -1,6 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
-from L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff import *
+#from L1Trigger.L1TMuonBarrel.fakeBmtfParams_cff import *
+
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+
+l1bmtfparProtodb = cms.ESSource("PoolDBESSource",
+       CondDB,
+       toGet   = cms.VPSet(
+            cms.PSet(
+                 record = cms.string('L1TMuonBarrelParamsRcd'),
+                 tag = cms.string("L1TMuonBarrelParamsPrototype_Stage2v0_hlt")
+            )
+       )
+)
 
 L1TMuonBarrelParamsOnlineProd = cms.ESProducer("L1TMuonBarrelParamsOnlineProd",
     onlineAuthentication = cms.string('.'),

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonEndcapParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonEndcapParamsOnline_cfi.py
@@ -1,6 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
-from L1Trigger.L1TMuonEndCap.fakeEmtfParams_cff import *
+#from L1Trigger.L1TMuonEndCap.fakeEmtfParams_cff import *
+
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+
+l1emtfparProtodb = cms.ESSource("PoolDBESSource",
+       CondDB,
+       toGet   = cms.VPSet(
+            cms.PSet(
+                record = cms.string('L1TMuonEndcapParamsRcd'),
+                tag = cms.string('L1TMuonEndCapParamsPrototype_Stage2v0_hlt')
+            )
+       )
+)
 
 L1TMuonEndcapParamsOnlineProd = cms.ESProducer("L1TMuonEndcapParamsOnlineProd",
     onlineAuthentication = cms.string('.'),

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonGlobalParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonGlobalParamsOnline_cfi.py
@@ -1,6 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
-from L1Trigger.L1TMuon.fakeGmtParams_cff import *
+#from L1Trigger.L1TMuon.fakeGmtParams_cff import *
+
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+
+l1gmtparProtodb = cms.ESSource("PoolDBESSource",
+       CondDB,
+       toGet   = cms.VPSet(
+            cms.PSet(
+                 record = cms.string('L1TMuonGlobalParamsRcd'),
+                 tag = cms.string('L1TMuonGlobalParamsPrototype_Stage2v0_hlt')
+            )
+       )
+)
 
 L1TMuonGlobalParamsOnlineProd = cms.ESProducer("L1TMuonGlobalParamsOnlineProd",
     onlineAuthentication = cms.string('.'),


### PR DESCRIPTION
Following AlCa workshop recommendations, I've added the remaining prototype payloads so as not to use the static pythons and have any dependency on the release the L1T O2O is running in,