### PR TITLE
supercluster eta -> seed eta for e/g pixel matching: 91X

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
@@ -7,7 +7,7 @@
 //
 //
 // The module produces the ElectronSeeds, similarly to ElectronSeedProducer
-// although 
+// although with a varible number of required hits
 // 
 //
 // Author : Sam Harper (RAL), 2017
@@ -146,8 +146,16 @@ void ElectronNHitSeedProducer::produce(edm::Event& iEvent, const edm::EventSetup
   for(const auto& superClustersToken : superClustersTokens_){
     auto superClustersHandle = getHandle(iEvent,superClustersToken);
     for(auto& superClusRef : *superClustersHandle){
+
+      //the eta of the supercluster when mustache clustered is slightly biased due to bending in magnetic field
+      //the eta of its seed cluster is a better estimate of the orginal position
+      GlobalPoint caloPosition(GlobalPoint::Polar(superClusRef->seed()->position().theta(), //seed theta
+						  superClusRef->position().phi(), //supercluster phi
+						  superClusRef->position().r())); //supercluster r
+
+
       const std::vector<TrajSeedMatcher::SeedWithInfo> matchedSeeds = 
-	matcher_.compatibleSeeds(*initialSeedsHandle,convertToGP(superClusRef->position()),
+	matcher_.compatibleSeeds(*initialSeedsHandle,caloPosition,
 				 primVtxPos,superClusRef->energy());
       
       for(auto& matchedSeed : matchedSeeds){


### PR DESCRIPTION
91X flavour of: https://github.com/cms-sw/cmssw/pull/18679

This PR changes the eta used for the calo position from the supercluster eta to the seed eta. This is because the supercluster eta is slightly biased w.r.t to the original particles position and so distorts the matching when the electron brems.

This improves our pixel matching performance and is sadly necessary for the HLT. The good news is that it only effects a module used by the HLT so can not effect RECO.

For more information please see Junho Kim's presentation in E/gamma last friday (05/05/17):
https://indico.cern.ch/event/613829/contributions/2581351/attachments/1454808/2244939/5.5.2017_HLTEGv4.pdf

I think with this, the E/gamma HLT pixel matching finally has a good baseline and is sufficient for initial running. Thank you for your patience on this!