### PR TITLE
Precise RPCTime in muons

### DIFF
--- a/DataFormats/RPCRecHit/src/RPCRecHit.cc
+++ b/DataFormats/RPCRecHit/src/RPCRecHit.cc
@@ -10,20 +10,20 @@
 
 RPCRecHit::RPCRecHit(const RPCDetId& rpcId, int bx) :  RecHit2DLocalPos(rpcId),
   theRPCId(rpcId), theBx(bx),theFirstStrip(99),theClusterSize(99), theLocalPosition(), theLocalError(),
-  theTime(0), theTimeError(0)
+  theTime(0), theTimeError(-1)
 {
 }
 
 RPCRecHit::RPCRecHit() :  RecHit2DLocalPos(),
   theRPCId(), theBx(99),theFirstStrip(99),theClusterSize(99), theLocalPosition(), theLocalError(),
-  theTime(0), theTimeError(0)
+  theTime(0), theTimeError(-1)
 {
 }
 
 
 RPCRecHit::RPCRecHit(const RPCDetId& rpcId, int bx, const LocalPoint& pos) :  RecHit2DLocalPos(rpcId),
   theRPCId(rpcId), theBx(bx), theFirstStrip(99),theClusterSize(99), theLocalPosition(pos),
-  theTime(0), theTimeError(0)
+  theTime(0), theTimeError(-1)
 {
   float stripResolution = 3.0 ; //cm  this sould be taken from trimmed cluster size times strip size 
                                  //    taken out from geometry service i.e. topology
@@ -39,7 +39,7 @@ RPCRecHit::RPCRecHit(const RPCDetId& rpcId,
 		     const LocalPoint& pos,
 		     const LocalError& err) :  RecHit2DLocalPos(rpcId),
   theRPCId(rpcId), theBx(bx),theFirstStrip(99), theClusterSize(99), theLocalPosition(pos), theLocalError(err),
-  theTime(0), theTimeError(0)
+  theTime(0), theTimeError(-1)
 {
 }
 
@@ -52,7 +52,7 @@ RPCRecHit::RPCRecHit(const RPCDetId& rpcId,
 		     const LocalPoint& pos,
 		     const LocalError& err) :  RecHit2DLocalPos(rpcId),
   theRPCId(rpcId), theBx(bx),theFirstStrip(firstStrip), theClusterSize(clustSize), theLocalPosition(pos), theLocalError(err),
-  theTime(0), theTimeError(0)
+  theTime(0), theTimeError(-1)
 {
 }
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCRecHitBaseAlgo.cc
@@ -40,7 +40,7 @@ edm::OwnVector<RPCRecHit> RPCRecHitBaseAlgo::reconstruct(const RPCRoll& roll,
     const int firstClustStrip = cl.firstStrip();
     const int clusterSize = cl.clusterSize();
     RPCRecHit* recHit = new RPCRecHit(rpcId,cl.bx(),firstClustStrip,clusterSize,point,tmpErr);
-    if ( timeErr >= 0 ) recHit->setTimeAndError(time, timeErr);
+    recHit->setTimeAndError(time, timeErr);
 
     result.push_back(recHit);
   }


### PR DESCRIPTION
The RPCTime information is computed based on the bunch crossing x 25ns, not taking the precise timing information which is available from the phase-II upgrade.

With this PR, the RPCTime in the reco::Muon is computed using the precise time measurement if available.

@ptraczyk 