### PR TITLE
Make L1MuDTTFConfig thread safe

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTF.h
@@ -39,17 +39,15 @@
 #include "TTree.h"
 #include "TFile.h"
 
-class L1TdeCSCTF : public thread_unsafe::DQMEDAnalyzer {
+class L1TdeCSCTF : public DQMEDAnalyzer {
 private:
   edm::EDGetTokenT<L1CSCTrackCollection> dataTrackProducer;
   edm::EDGetTokenT<L1CSCTrackCollection> emulTrackProducer;
   edm::EDGetTokenT<CSCTriggerContainer<csctf::TrackStub> > dataStubProducer;
   edm::EDGetTokenT<L1MuDTChambPhContainer> emulStubProducer;
 
-  const L1MuTriggerScales *ts;
-  CSCTFPtLUT* ptLUT_;
   edm::ParameterSet ptLUTset;
-  CSCTFDTReceiver* my_dtrc;
+  std::unique_ptr<CSCTFDTReceiver> my_dtrc;
 	
   // Define Monitor Element Histograms
   ////////////////////////////////////

--- a/DQM/L1TMonitor/src/L1TdeCSCTF.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTF.cc
@@ -44,9 +44,6 @@ L1TdeCSCTF::L1TdeCSCTF(ParameterSet const& pset) {
 	
   m_dirName         = pset.getUntrackedParameter("DQMFolder", string("L1TEMU/CSCTFexpert"));
 
-  ts=0;
-  ptLUT_ = 0;
-	
   ptLUTset = pset.getParameter<ParameterSet>("PTLUT");
 	
   outFile = pset.getUntrackedParameter<string>("outFile", "");
@@ -89,7 +86,7 @@ L1TdeCSCTF::L1TdeCSCTF(ParameterSet const& pset) {
    		} // sectorItr loop
   	} // endcapItr loop
 	*/
-  my_dtrc = new CSCTFDTReceiver();
+  my_dtrc =std::make_unique<CSCTFDTReceiver>();
 }
 void L1TdeCSCTF::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c){
 }
@@ -639,5 +636,4 @@ void L1TdeCSCTF::analyze(Event const& e, EventSetup const& es){
       }
     }
   }
-  if(ptLUT_) delete ptLUT_;
 }		

--- a/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
@@ -14,8 +14,10 @@ CSCTriggerContainer<csctf::TrackStub> CSCTFDTReceiver::process(const L1MuDTChamb
   dtstubs.clear();
   if( !dttrig ) return dtstubs;
 
-  const int dt_minBX = L1MuDTTFConfig::getBxMin();
-  const int dt_maxBX = L1MuDTTFConfig::getBxMax();
+  //Need a better way to get these values since this
+  // violates CMSSW coding policy
+  const int dt_minBX = L1MuDTTFConfig::getBxMinGlobally();
+  const int dt_maxBX = L1MuDTTFConfig::getBxMaxGlobally();
 
   const int dt_toffs = 0;// changed since DT tpg now centers around zero //abs(dt_maxBX - dt_minBX);
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTAssignmentUnit.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTAssignmentUnit.cc
@@ -42,6 +42,7 @@
 #include "CondFormats/L1TObjects/interface/L1MuDTPtaLut.h"
 #include "CondFormats/DataRecord/interface/L1MuDTPtaLutRcd.h"
 #include "L1Trigger/DTTrackFinder/interface/L1MuDTTrack.h"
+#include "L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h"
 
 using namespace std;
 
@@ -55,7 +56,9 @@ using namespace std;
 
 L1MuDTAssignmentUnit::L1MuDTAssignmentUnit(L1MuDTSectorProcessor& sp, int id) : 
                 m_sp(sp), m_id(id), 
-                m_addArray(), m_TSphi(), m_ptAssMethod(NODEF) {
+                m_addArray(), m_TSphi(), m_ptAssMethod(NODEF),
+                nbit_phi(12),nbit_phib(10)
+ {
 
   m_TSphi.reserve(4);  // a track candidate can consist of max 4 TS 
   reset();
@@ -146,8 +149,8 @@ void L1MuDTAssignmentUnit::PhiAU(const edm::EventSetup& c) {
 
   c.get< L1MuDTPhiLutRcd >().get( thePhiLUTs );
 
-  int sh_phi  = 12 - L1MuDTTFConfig::getNbitsPhiPhi();
-  int sh_phib = 10 - L1MuDTTFConfig::getNbitsPhiPhib();
+  int sh_phi  = 12 - m_sp.tf().config()->getNbitsPhiPhi();
+  int sh_phib = 10 - m_sp.tf().config()->getNbitsPhiPhib();
 
   const L1MuDTTrackSegPhi* second = getTSphi(2);  // track segment at station 2
   const L1MuDTTrackSegPhi* first  = getTSphi(1);  // track segment at station 1
@@ -531,13 +534,11 @@ int L1MuDTAssignmentUnit::phiDiff(int stat1, int stat2) const {
 //
 void L1MuDTAssignmentUnit::setPrecision() {
 
-  nbit_phi  = L1MuDTTFConfig::getNbitsPtaPhi();
-  nbit_phib = L1MuDTTFConfig::getNbitsPtaPhib();
+  nbit_phi  = m_sp.tf().config()->getNbitsPtaPhi();
+  nbit_phib = m_sp.tf().config()->getNbitsPtaPhib();
 
 }
 
 
 // static data members
 
-unsigned short int L1MuDTAssignmentUnit::nbit_phi  = 12;
-unsigned short int L1MuDTAssignmentUnit::nbit_phib = 10;

--- a/L1Trigger/DTTrackFinder/src/L1MuDTAssignmentUnit.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTAssignmentUnit.h
@@ -73,7 +73,7 @@ class L1MuDTAssignmentUnit : public L1AbstractProcessor {
     void QuaAU();
 
     /// set precision of phi and phib 
-    static void setPrecision();
+    void setPrecision();
 
   private:
 
@@ -84,10 +84,10 @@ class L1MuDTAssignmentUnit : public L1AbstractProcessor {
     const L1MuDTTrackSegPhi* getTSphi(int station) const;
     
     /// convert sector Id to 8 bit code (= sector center)
-    static int convertSector(int);
+    int convertSector(int);
     
     /// determine charge
-    static int getCharge(PtAssMethod);
+    int getCharge(PtAssMethod);
     
     /// determine pt assignment method
     PtAssMethod getPtMethod() const;
@@ -109,8 +109,8 @@ class L1MuDTAssignmentUnit : public L1AbstractProcessor {
 
     edm::ESHandle< L1MuDTPhiLut > thePhiLUTs;  ///< phi-assignment look-up tables
     edm::ESHandle< L1MuDTPtaLut > thePtaLUTs;  ///< pt-assignment look-up tables
-    static unsigned short      nbit_phi;       ///< # of bits used for pt-assignment
-    static unsigned short      nbit_phib;      ///< # of bits used for pt-assignment
+    unsigned short      nbit_phi;       ///< # of bits used for pt-assignment
+    unsigned short      nbit_phib;      ///< # of bits used for pt-assignment
 
 };
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEUX.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEUX.cc
@@ -28,6 +28,7 @@
 //-------------------------------
 
 #include "L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.h"
+#include "L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h"
 #include "CondFormats/L1TObjects/interface/L1MuDTExtParam.h"
 #include "L1Trigger/DTTrackFinder/src/L1MuDTSectorProcessor.h"
 #include "L1Trigger/DTTrackFinder/src/L1MuDTSEU.h"
@@ -51,9 +52,9 @@ L1MuDTEUX::L1MuDTEUX(const L1MuDTSectorProcessor& sp, const L1MuDTSEU& seu, int 
     m_sp(sp), m_seu(seu), m_id(id), 
     m_result(false), m_quality(0), m_address(15),
     m_start(0), m_target(0), 
-    theExtFilter(L1MuDTTFConfig::getExtTSFilter()),
-    nbit_phi(L1MuDTTFConfig::getNbitsExtPhi()),
-    nbit_phib(L1MuDTTFConfig::getNbitsExtPhib())
+    theExtFilter(sp.tf().config()->getExtTSFilter()),
+    nbit_phi(sp.tf().config()->getNbitsExtPhi()),
+    nbit_phib(sp.tf().config()->getNbitsExtPhib())
 {
 }
 
@@ -91,12 +92,13 @@ void L1MuDTEUX::run(const edm::EventSetup& c) {
   c.get< L1MuDTExtLutRcd >().get( theExtLUTs );
   c.get< L1MuDTTFParametersRcd >().get( pars );
 
-  if ( L1MuDTTFConfig::Debug(4) ) cout << "Run EUX "  << m_id << endl;
-  if ( L1MuDTTFConfig::Debug(4) ) cout << "start :  " << *m_start  << endl;
-  if ( L1MuDTTFConfig::Debug(4) ) cout << "target : " << *m_target << endl;
+  const bool debug4 = m_sp.tf().config()->Debug(4);
+  if ( debug4 ) cout << "Run EUX "  << m_id << endl;
+  if ( debug4 ) cout << "start :  " << *m_start  << endl;
+  if ( debug4 ) cout << "target : " << *m_target << endl;
 
   if ( m_start == 0 || m_target == 0 ) { 
-    if ( L1MuDTTFConfig::Debug(4) ) cout << "Error: EUX has no data loaded" << endl;
+    if ( debug4 ) cout << "Error: EUX has no data loaded" << endl;
     return;
   }
 
@@ -118,7 +120,7 @@ void L1MuDTEUX::run(const edm::EventSetup& c) {
 
   }
 
-  if ( L1MuDTTFConfig::Debug(5) ) cout << "EUX : using look-up table : "
+  if ( m_sp.tf().config()->Debug(5) ) cout << "EUX : using look-up table : "
                                        << static_cast<Extrapolation>(lut_idx)
                                        << endl;
 
@@ -165,7 +167,7 @@ void L1MuDTEUX::run(const edm::EventSetup& c) {
 
   // is phi-difference within the extrapolation window?
   bool openlut = pars->get_soc_openlut_extr(m_sp.id().wheel(), m_sp.id().sector());
-  if (( diff >= low && diff <= high ) || L1MuDTTFConfig::getopenLUTs() || openlut ) {
+  if (( diff >= low && diff <= high ) || m_sp.tf().config()->getopenLUTs() || openlut ) {
     m_result = true;
     int qual_st = m_start->quality();
     int qual_ta = m_target->quality();
@@ -178,7 +180,7 @@ void L1MuDTEUX::run(const edm::EventSetup& c) {
     m_address = m_id;
   }
 
-  if ( L1MuDTTFConfig::Debug(5) ) cout << "diff : "   << low  << " "
+  if ( m_sp.tf().config()->Debug(5) ) cout << "diff : "   << low  << " "
                                        << diff << " " << high << " : "
                                        << m_result << " " << endl;
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
@@ -62,7 +62,7 @@ using namespace std;
 
 L1MuDTEtaProcessor::L1MuDTEtaProcessor(const L1MuDTTrackFinder& tf, int id, edm::ConsumesCollector&& iC) :
       m_tf(tf), m_epid(id), m_foundPattern(0), m_tseta(15),
-      m_DTDigiToken(iC.consumes<L1MuDTChambThContainer>(L1MuDTTFConfig::getDTDigiInputTag())) {
+      m_DTDigiToken(iC.consumes<L1MuDTChambThContainer>(m_tf.config()->getDTDigiInputTag())) {
 
   m_tseta.reserve(15);
   
@@ -85,7 +85,7 @@ L1MuDTEtaProcessor::~L1MuDTEtaProcessor() {}
 //
 void L1MuDTEtaProcessor::run(int bx, const edm::Event& e, const edm::EventSetup& c) {
 
-  if ( L1MuDTTFConfig::getEtaTF() ) {
+  if ( m_tf.config()->getEtaTF() ) {
     receiveData(bx,e,c);
     runEtaTrackFinder(c);
   }

--- a/L1Trigger/DTTrackFinder/src/L1MuDTExtrapolationUnit.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTExtrapolationUnit.cc
@@ -30,6 +30,7 @@
 //-------------------------------
 
 #include "L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.h"
+#include "L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h"
 #include "CondFormats/L1TObjects/interface/L1MuDTExtParam.h"
 #include "L1Trigger/DTTrackFinder/src/L1MuDTSEU.h"
 #include "L1Trigger/DTTrackFinder/src/L1MuDTEUX.h"
@@ -124,7 +125,7 @@ void L1MuDTExtrapolationUnit::run(const edm::EventSetup& c) {
   // use EX21 to cross-check EX12
   //
   bool run_21 = pars->get_soc_run_21(m_sp.id().wheel(), m_sp.id().sector());
-  if ( L1MuDTTFConfig::getUseEX21() || run_21 ) {
+  if ( m_sp.tf().config()->getUseEX21() || run_21 ) {
 
     // search for EX12 + EX21 single extrapolation units
     for ( unsigned int startAdr = 0; startAdr < 2; startAdr++ ) {

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorProcessor.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorProcessor.cc
@@ -110,7 +110,7 @@ void L1MuDTSectorProcessor::run(int bx, const edm::Event& e, const edm::EventSet
 
   // check content of data buffer
   if ( m_DataBuffer ) {
-    if ( L1MuDTTFConfig::Debug(4) && m_DataBuffer->numberTSphi() > 0 ) {
+    if ( m_tf.config()->Debug(4) && m_DataBuffer->numberTSphi() > 0 ) {
       cout << "Phi track segments received by " << m_spid << " : " << endl;
       m_DataBuffer->printTSphi();
     }
@@ -121,7 +121,7 @@ void L1MuDTSectorProcessor::run(int bx, const edm::Event& e, const edm::EventSet
   if ( m_EU && m_DataBuffer && m_DataBuffer->numberTSphi() > 1 ) {
     m_EU->run(c);
     n_ext = m_EU->numberOfExt();
-    if ( L1MuDTTFConfig::Debug(3) && n_ext > 0  ) {
+    if ( m_tf.config()->Debug(3) && n_ext > 0  ) {
       cout << "Number of successful extrapolations : " << n_ext << endl;
       m_EU->print();
     }
@@ -133,7 +133,7 @@ void L1MuDTSectorProcessor::run(int bx, const edm::Event& e, const edm::EventSet
   // perform track assembling
   if ( m_TA &&  n_ext > 0 ) {
     m_TA->run();
-    if ( L1MuDTTFConfig::Debug(3) ) m_TA->print();
+    if ( m_tf.config()->Debug(3) ) m_TA->print();
   }
 
   // assign pt, eta, phi and quality

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.cc
@@ -70,6 +70,8 @@ void L1MuDTTFConfig::setDefaults() {
   // set min and max bunch crossing
   m_BxMin = m_ps->getUntrackedParameter<int>("BX_min",-9);
   m_BxMax = m_ps->getUntrackedParameter<int>("BX_max", 7);
+  s_BxMin = m_BxMin;
+  s_BxMax = m_BxMax;
 
   // set Filter for Extrapolator
   m_extTSFilter = m_ps->getUntrackedParameter<int>("Extrapolation_Filter",1);
@@ -171,27 +173,7 @@ void L1MuDTTFConfig::setDefaults() {
 
 }
 
-
-// static data members
-
-edm::InputTag L1MuDTTFConfig::m_DTDigiInputTag = edm::InputTag();
-edm::InputTag L1MuDTTFConfig::m_CSCTrSInputTag = edm::InputTag();
-
-bool L1MuDTTFConfig::m_debug = false;
-int  L1MuDTTFConfig::m_dbgLevel = -1;
-bool L1MuDTTFConfig::m_overlap = true;
-int  L1MuDTTFConfig::m_BxMin = -9;
-int  L1MuDTTFConfig::m_BxMax =  7;
-int  L1MuDTTFConfig::m_extTSFilter  = 1;
-bool L1MuDTTFConfig::m_openLUTs  = false;
-bool L1MuDTTFConfig::m_useEX21 = false;
-bool L1MuDTTFConfig::m_etaTF = true;
-bool L1MuDTTFConfig::m_etacanc = false;
-bool L1MuDTTFConfig::m_TSOutOfTimeFilter = false;
-int  L1MuDTTFConfig::m_TSOutOfTimeWindow = 1;
-int  L1MuDTTFConfig::m_NbitsExtPhi  = 8; 
-int  L1MuDTTFConfig::m_NbitsExtPhib = 8;
-int  L1MuDTTFConfig::m_NbitsPtaPhi  = 12; 
-int  L1MuDTTFConfig::m_NbitsPtaPhib = 10;
-int  L1MuDTTFConfig::m_NbitsPhiPhi  = 10; 
-int  L1MuDTTFConfig::m_NbitsPhiPhib = 10;
+std::atomic<bool> L1MuDTTFConfig::m_debug{false};
+std::atomic<int> L1MuDTTFConfig::m_dbgLevel{-1};
+std::atomic<int> L1MuDTTFConfig::s_BxMin{-9};
+std::atomic<int> L1MuDTTFConfig::s_BxMax{-7};

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.h
@@ -18,6 +18,7 @@
 //---------------
 
 #include <string>
+#include <atomic>
 
 //----------------------
 // Base Class Headers --
@@ -44,31 +45,33 @@ class L1MuDTTFConfig {
     /// destructor 
     virtual ~L1MuDTTFConfig();
 
-    static edm::InputTag getDTDigiInputTag() { return m_DTDigiInputTag; }
-    static edm::InputTag getCSCTrSInputTag() { return m_CSCTrSInputTag; }
+     edm::InputTag getDTDigiInputTag() const { return m_DTDigiInputTag; }
+     edm::InputTag getCSCTrSInputTag() const { return m_CSCTrSInputTag; }
  
-    static bool Debug() { return m_debug; }
-    static bool Debug(int level) { return (m_debug && m_dbgLevel >= level); }
+     static bool Debug() { return m_debug; }
+     static bool Debug(int level) { return (m_debug && m_dbgLevel >= level); }
  
-    static void setDebugLevel(int level) { m_dbgLevel = level; }
-    static int  getDebugLevel() { return m_dbgLevel; }
+     static void setDebugLevel(int level) { m_dbgLevel = level; }
+     static int  getDebugLevel() { return m_dbgLevel; }
+     static int  getBxMinGlobally()  { return s_BxMin; }
+     static int  getBxMaxGlobally() { return s_BxMax; }
     
-    static int  getBxMin() { return m_BxMin; }
-    static int  getBxMax() { return m_BxMax; }
-    static bool overlap() { return m_overlap; }
-    static int getExtTSFilter() { return m_extTSFilter; } 
-    static bool getopenLUTs() { return m_openLUTs; } 
-    static bool getUseEX21() { return m_useEX21; }
-    static bool getEtaTF() { return m_etaTF; }
-    static bool getEtaCanc() { return m_etacanc; }
-    static bool getTSOutOfTimeFilter() { return m_TSOutOfTimeFilter; }
-    static int  getTSOutOfTimeWindow() { return m_TSOutOfTimeWindow; }
-    static int getNbitsExtPhi() { return m_NbitsExtPhi; }
-    static int getNbitsExtPhib() { return m_NbitsExtPhib; }
-    static int getNbitsPtaPhi() { return m_NbitsPtaPhi; }
-    static int getNbitsPtaPhib() { return m_NbitsPtaPhib; }
-    static int getNbitsPhiPhi() { return m_NbitsPhiPhi; }
-    static int getNbitsPhiPhib() { return m_NbitsPhiPhib; }        
+     int  getBxMin() const { return m_BxMin; }
+     int  getBxMax() const { return m_BxMax; }
+     bool overlap() const { return m_overlap; }
+     int getExtTSFilter() const { return m_extTSFilter; } 
+     bool getopenLUTs() const { return m_openLUTs; } 
+     bool getUseEX21() const { return m_useEX21; }
+     bool getEtaTF() const { return m_etaTF; }
+     bool getEtaCanc() const { return m_etacanc; }
+     bool getTSOutOfTimeFilter() const { return m_TSOutOfTimeFilter; }
+     int  getTSOutOfTimeWindow() const { return m_TSOutOfTimeWindow; }
+     int getNbitsExtPhi() const { return m_NbitsExtPhi; }
+     int getNbitsExtPhib() const { return m_NbitsExtPhib; }
+     int getNbitsPtaPhi() const { return m_NbitsPtaPhi; }
+     int getNbitsPtaPhib() const { return m_NbitsPtaPhib; }
+     int getNbitsPhiPhi() const { return m_NbitsPhiPhi; }
+     int getNbitsPhiPhib() const { return m_NbitsPhiPhib; }        
 
   private:
   
@@ -78,36 +81,38 @@ class L1MuDTTFConfig {
 
     const edm::ParameterSet* m_ps;
 
-    static edm::InputTag m_DTDigiInputTag;
-    static edm::InputTag m_CSCTrSInputTag;
+     edm::InputTag m_DTDigiInputTag;
+     edm::InputTag m_CSCTrSInputTag;
 
-    static bool   m_debug;             // debug flag 
-    static int    m_dbgLevel;          // debug level
-
-    static bool   m_overlap;           // barrel-endcap overlap region
+     static std::atomic<bool>   m_debug;             // debug flag 
+     static std::atomic<int>    m_dbgLevel;          // debug level
+     static std::atomic<int>    s_BxMin;
+     static std::atomic<int>    s_BxMax;
+     
+     bool   m_overlap;           // barrel-endcap overlap region
        
-    static int    m_BxMin;
-    static int    m_BxMax;
+     int    m_BxMin;
+     int    m_BxMax;
 
-    static int    m_extTSFilter;       // Extrapolation TS-Quality Filter
+     int    m_extTSFilter;       // Extrapolation TS-Quality Filter
  
-    static bool   m_openLUTs;          // use open LUTs
+     bool   m_openLUTs;          // use open LUTs
 
-    static bool   m_useEX21;           // perform EX21 extrapolation (cross-check EX12)
+     bool   m_useEX21;           // perform EX21 extrapolation (cross-check EX12)
 
-    static bool   m_etaTF;             // use eta track finder
+     bool   m_etaTF;             // use eta track finder
 
-    static bool   m_etacanc;           // use etaFlag for CSC segment cancellation
+     bool   m_etacanc;           // use etaFlag for CSC segment cancellation
 
-    static bool   m_TSOutOfTimeFilter; // perform out-of-time TS cancellation
-    static int    m_TSOutOfTimeWindow; // phi window size to be checked
+     bool   m_TSOutOfTimeFilter; // perform out-of-time TS cancellation
+     int    m_TSOutOfTimeWindow; // phi window size to be checked
     
-    static int    m_NbitsExtPhi;       // precision for extrapolation
-    static int    m_NbitsExtPhib;    
-    static int    m_NbitsPtaPhi;       // precision for pt-assignment
-    static int    m_NbitsPtaPhib;    
-    static int    m_NbitsPhiPhi;       // precision for phi-assignment
-    static int    m_NbitsPhiPhib;
+     int    m_NbitsExtPhi;       // precision for extrapolation
+     int    m_NbitsExtPhib;    
+     int    m_NbitsPtaPhi;       // precision for pt-assignment
+     int    m_NbitsPtaPhib;    
+     int    m_NbitsPhiPhi;       // precision for phi-assignment
+     int    m_NbitsPhiPhib;
   
 };
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -57,9 +57,9 @@ L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet & ps,edm::ConsumesC
   // set configuration parameters
   if ( m_config == 0 ) m_config = new L1MuDTTFConfig(ps);
 
-  if ( L1MuDTTFConfig::Debug(1) ) cout << endl;
-  if ( L1MuDTTFConfig::Debug(1) ) cout << "**** entering L1MuDTTrackFinder ****" << endl;
-  if ( L1MuDTTFConfig::Debug(1) ) cout << endl;
+  if ( m_config->Debug(1) ) cout << endl;
+  if ( m_config->Debug(1) ) cout << "**** entering L1MuDTTrackFinder ****" << endl;
+  if ( m_config->Debug(1) ) cout << endl;
 
   m_spmap = new L1MuDTSecProcMap();
   m_epvec.reserve(12);
@@ -69,7 +69,7 @@ L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet & ps,edm::ConsumesC
   _cache.reserve(4*17);
   _cache0.reserve(144*17);
 
-  m_DTDigiToken = iC.consumes<L1MuDTChambPhContainer>(L1MuDTTFConfig::getDTDigiInputTag());
+  m_DTDigiToken = iC.consumes<L1MuDTChambPhContainer>(m_config->getDTDigiInputTag());
 }
 
 
@@ -114,9 +114,9 @@ void L1MuDTTrackFinder::setup( edm::ConsumesCollector&& iC) {
 
   // build the barrel Muon Trigger Track Finder
 
-  if ( L1MuDTTFConfig::Debug(1) ) cout << endl;
-  if ( L1MuDTTFConfig::Debug(1) ) cout << "**** L1MuDTTrackFinder building ****" << endl;
-  if ( L1MuDTTFConfig::Debug(1) ) cout << endl;
+  if ( m_config->Debug(1) ) cout << endl;
+  if ( m_config->Debug(1) ) cout << "**** L1MuDTTrackFinder building ****" << endl;
+  if ( m_config->Debug(1) ) cout << endl;
 
   // create new sector processors
   for ( int wh = -3; wh <= 3; wh++ ) {
@@ -124,7 +124,7 @@ void L1MuDTTrackFinder::setup( edm::ConsumesCollector&& iC) {
     for ( int sc = 0; sc < 12; sc++ ) {
       L1MuDTSecProcId tmpspid(wh,sc);
       L1MuDTSectorProcessor* sp = new L1MuDTSectorProcessor(*this,tmpspid,std::move(iC));
-      if ( L1MuDTTFConfig::Debug(2) ) cout << "creating " << tmpspid << endl;
+      if ( m_config->Debug(2) ) cout << "creating " << tmpspid << endl;
       m_spmap->insert(tmpspid,sp);
     }
   }
@@ -132,15 +132,15 @@ void L1MuDTTrackFinder::setup( edm::ConsumesCollector&& iC) {
   // create new eta processors and wedge sorters
   for ( int sc = 0; sc < 12; sc++ ) {
     L1MuDTEtaProcessor* ep = new L1MuDTEtaProcessor(*this,sc,std::move(iC));
-    if ( L1MuDTTFConfig::Debug(2) ) cout << "creating Eta Processor " << sc << endl;
+    if ( m_config->Debug(2) ) cout << "creating Eta Processor " << sc << endl;
     m_epvec.push_back(ep);
     L1MuDTWedgeSorter* ws = new L1MuDTWedgeSorter(*this,sc);
-    if ( L1MuDTTFConfig::Debug(2) ) cout << "creating Wedge Sorter " << sc << endl;
+    if ( m_config->Debug(2) ) cout << "creating Wedge Sorter " << sc << endl;
     m_wsvec.push_back(ws);
   }
 
   // create new muon sorter
-  if ( L1MuDTTFConfig::Debug(2) ) cout << "creating DT Muon Sorter " << endl;
+  if ( m_config->Debug(2) ) cout << "creating DT Muon Sorter " << endl;
   m_ms = new L1MuDTMuonSorter(*this);
 
 }
@@ -157,18 +157,18 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
   e.getByToken(m_DTDigiToken,dttrig);
   if ( dttrig->getContainer()->size() == 0 ) return;
 
-  if ( L1MuDTTFConfig::Debug(2) ) cout << endl;
-  if ( L1MuDTTFConfig::Debug(2) ) cout << "**** L1MuDTTrackFinder processing ****" << endl;
-  if ( L1MuDTTFConfig::Debug(2) ) cout << endl;
+  if ( m_config->Debug(2) ) cout << endl;
+  if ( m_config->Debug(2) ) cout << "**** L1MuDTTrackFinder processing ****" << endl;
+  if ( m_config->Debug(2) ) cout << endl;
 
-  int bx_min = L1MuDTTFConfig::getBxMin();
-  int bx_max = L1MuDTTFConfig::getBxMax();
+  int bx_min = m_config->getBxMin();
+  int bx_max = m_config->getBxMax();
 
   for ( int bx = bx_min; bx <= bx_max; bx++ ) {
 
   if ( dttrig->bxEmpty(bx) ) continue;
 
-  if ( L1MuDTTFConfig::Debug(2) ) cout << "L1MuDTTrackFinder processing bunch-crossing : " << bx << endl;
+  if ( m_config->Debug(2) ) cout << "L1MuDTTrackFinder processing bunch-crossing : " << bx << endl;
 
     // reset MTTF
     reset();
@@ -176,27 +176,27 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
     // run sector processors
     L1MuDTSecProcMap::SPmap_iter it_sp = m_spmap->begin();
     while ( it_sp != m_spmap->end() ) {
-      if ( L1MuDTTFConfig::Debug(2) ) cout << "running " 
+      if ( m_config->Debug(2) ) cout << "running " 
                                            << (*it_sp).second->id() << endl;
       if ( (*it_sp).second ) (*it_sp).second->run(bx,e,c);
-      if ( L1MuDTTFConfig::Debug(2) && (*it_sp).second ) (*it_sp).second->print();
+      if ( m_config->Debug(2) && (*it_sp).second ) (*it_sp).second->print();
       it_sp++;
     } 
 
     // run eta processors
     vector<L1MuDTEtaProcessor*>::iterator it_ep = m_epvec.begin();
     while ( it_ep != m_epvec.end() ) {
-      if ( L1MuDTTFConfig::Debug(2) ) cout << "running Eta Processor "
+      if ( m_config->Debug(2) ) cout << "running Eta Processor "
                                        << (*it_ep)->id() << endl;
       if ( *it_ep ) (*it_ep)->run(bx,e,c);
-      if ( L1MuDTTFConfig::Debug(2) && *it_ep ) (*it_ep)->print();
+      if ( m_config->Debug(2) && *it_ep ) (*it_ep)->print();
       it_ep++;
     }
 
     // read sector processors
     it_sp = m_spmap->begin();
     while ( it_sp != m_spmap->end() ) {
-      if ( L1MuDTTFConfig::Debug(2) ) cout << "reading " 
+      if ( m_config->Debug(2) ) cout << "reading " 
                                            << (*it_sp).second->id() << endl;
       for ( int number = 0; number < 2; number++ ) {
         const L1MuDTTrack* cand = (*it_sp).second->tracK(number);
@@ -210,17 +210,17 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
     // run wedge sorters
     vector<L1MuDTWedgeSorter*>::iterator it_ws = m_wsvec.begin();
     while ( it_ws != m_wsvec.end() ) {
-      if ( L1MuDTTFConfig::Debug(2) ) cout << "running Wedge Sorter " 
+      if ( m_config->Debug(2) ) cout << "running Wedge Sorter " 
                                            << (*it_ws)->id() << endl;
       if ( *it_ws ) (*it_ws)->run();
-      if ( L1MuDTTFConfig::Debug(2) && *it_ws ) (*it_ws)->print();
+      if ( m_config->Debug(2) && *it_ws ) (*it_ws)->print();
       it_ws++;
     }
 
     // run muon sorter
-    if ( L1MuDTTFConfig::Debug(2) ) cout << "running DT Muon Sorter" << endl;
+    if ( m_config->Debug(2) ) cout << "running DT Muon Sorter" << endl;
     if ( m_ms ) m_ms->run();
-    if ( L1MuDTTFConfig::Debug(2) && m_ms ) m_ms->print();
+    if ( m_config->Debug(2) && m_ms ) m_ms->print();
 
     // store found track candidates in container (cache)
     if ( m_ms->numberOfTracks() > 0 ) {


### PR DESCRIPTION
Minimized the number of statics which could be obtained from L1MuDTTFConfig
and made the remaining ones atomic.
This allows the last thread_unsafe::DQMEDAnalyzer, L1TdeCSCTF,
to be converted to a DQMEDAnalyzer.