### PR TITLE
Release the Python GIL when running PythonEventProcessor.

### DIFF
--- a/FWCore/PythonFramework/src/PythonEventProcessor.cc
+++ b/FWCore/PythonFramework/src/PythonEventProcessor.cc
@@ -66,15 +66,23 @@ PythonEventProcessor::PythonEventProcessor(PythonProcessDesc const& iDesc)
 
 PythonEventProcessor::~PythonEventProcessor()
 {
+   auto gil = PyEval_SaveThread();
    try {
       processor_.endJob();
    }catch(...) {
-      
+
    }
+   PyEval_RestoreThread(gil);
 }
 
 void
 PythonEventProcessor::run()
 {
-   (void) processor_.runToCompletion();
+   auto gil = PyEval_SaveThread();
+   try {
+      (void) processor_.runToCompletion();
+   }catch(...) {
+
+   }
+   PyEval_RestoreThread(gil);
 }


### PR DESCRIPTION
The `.run()` method is blocking, so one might want to put it into a Python `threading.Thread`. However, the Python interpreter would still block because of the GIL. This correction releases the GIL so that CMSSW can run while Python is running.

Tested on a simple example: observed concurrent execution and no segmentation faults.
