### PR TITLE
miniAODIsolation_91X_V2

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -351,9 +351,9 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
 
                         okGsfFound = true;
                         
-/*                // DEBUG LINES - KEEP IT !
-                        std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
-                // DEBUG LINES - KEEP IT !  */ 
+                // DEBUG LINES - KEEP IT !
+                        //std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
+                // DEBUG LINES - KEEP IT !  /**/ 
                     }
                 }
             }

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -15,13 +15,16 @@ typedef edm::Ptr<pat::Electron> PatElectronPtr;
 ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::ParameterSet& iConfig) : ElectronDqmAnalyzerBase(iConfig)
 {
     mcTruthCollection_ = consumes<edm::View<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("mcTruthCollection")); // prunedGenParticles
-    electronToken_ = consumes<pat::ElectronCollection>(iConfig.getParameter<edm::InputTag>("electrons")); // slimmedElectrons
+    electronToken_     = consumes<pat::ElectronCollection>      (iConfig.getParameter<edm::InputTag>("electrons"));         // slimmedElectrons
+
+   edm::ParameterSet histosSet = iConfig.getParameter<edm::ParameterSet>("histosCfg") ;
+   edm::ParameterSet isolationSet = iConfig.getParameter<edm::ParameterSet>("isolationCfg") ;
 
     //recomp
-    ValueMaps_ChargedHadrons_ = consumes<edm::ValueMap<float> > (iConfig.getParameter<edm::InputTag>( "ValueMaps_ChargedHadrons_src" ) ) ;
-    ValueMaps_NeutralHadrons_ = consumes<edm::ValueMap<float> > (iConfig.getParameter<edm::InputTag>( "ValueMaps_NeutralHadrons_src" ) );
-    ValueMaps_Photons_ = consumes<edm::ValueMap<float> > (iConfig.getParameter<edm::InputTag>( "ValueMaps_Photons_src" ) );
-
+    pfSumChargedHadronPtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumChargedHadronPtTmp" ) ) ; // iConfig 
+    pfSumNeutralHadronEtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumNeutralHadronEtTmp" ) ) ; // iConfig 
+    pfSumPhotonEtTmp_         = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumPhotonEtTmp" ) ) ;        // iConfig 
+    
   maxPt_ = iConfig.getParameter<double>("MaxPt");
   maxAbsEta_ = iConfig.getParameter<double>("MaxAbsEta");
   deltaR_ = iConfig.getParameter<double>("DeltaR");
@@ -31,8 +34,6 @@ ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::Pa
   outputInternalPath_ = iConfig.getParameter<std::string>("OutputFolderName") ;
 
   // histos bining and limits
-
-   edm::ParameterSet histosSet = iConfig.getParameter<edm::ParameterSet>("histosCfg") ;
 
    xyz_nbin=histosSet.getParameter<int>("Nbinxyz");
 
@@ -215,18 +216,16 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
     iEvent.getByToken(mcTruthCollection_, genParticles) ;  
 
     //recomp
-    edm::Handle <edm::ValueMap <float> > ValueMaps_ChargedHadrons;
-    edm::Handle <edm::ValueMap <float> > ValueMaps_NeutralHadrons;
-    edm::Handle <edm::ValueMap <float> > ValueMaps_Photons;
+    edm::Handle <edm::ValueMap <float> > pfSumChargedHadronPtTmp;
+    edm::Handle <edm::ValueMap <float> > pfSumNeutralHadronEtTmp;
+    edm::Handle <edm::ValueMap <float> > pfSumPhotonEtTmp;/**/
   
   //recomp
-    iEvent.getByToken( ValueMaps_ChargedHadrons_ , ValueMaps_ChargedHadrons);
-    iEvent.getByToken( ValueMaps_NeutralHadrons_ , ValueMaps_NeutralHadrons);
-    iEvent.getByToken( ValueMaps_Photons_ , ValueMaps_Photons);
+    iEvent.getByToken( pfSumChargedHadronPtTmp_ , pfSumChargedHadronPtTmp);
+    iEvent.getByToken( pfSumNeutralHadronEtTmp_ , pfSumNeutralHadronEtTmp);
+    iEvent.getByToken( pfSumPhotonEtTmp_ , pfSumPhotonEtTmp);/**/
 
-    edm::LogInfo("ElectronMcSignalValidatorMiniAOD::analyze")
-      <<"Treating event "<<iEvent.id()
-      <<" with "<<electrons.product()->size()<<" electrons" ;
+    edm::LogInfo("ElectronMcSignalValidatorMiniAOD::analyze") << "Treating event " << iEvent.id() << " with " << electrons.product()->size() << " electrons" ;
     h1_recEleNum->Fill((*electrons).size()) ;
 
     //===============================================
@@ -332,7 +331,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
             if ( deltaR2 < deltaR2_ )
             {
                 if ( ( ((*genParticles)[i].pdgId() == 11) && (el.charge() < 0.) ) ||
-                ( ((*genParticles)[i].pdgId() == -11) && (el.charge() > 0.) ) )
+                     ( ((*genParticles)[i].pdgId() == -11) && (el.charge() > 0.) ) )
                 {
                     double tmpGsfRatio = el.p()/(*genParticles)[i].p() ;
                     if ( std::abs(tmpGsfRatio-1) < std::abs(gsfOkRatio-1) )
@@ -341,17 +340,20 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
                         bestGsfElectron=el;
                         PatElectronPtr elePtr(electrons, &el-&(*electrons)[0]) ;
                         pt_ = elePtr->pt();
-                        sumChargedHadronPt_recomp =  (*ValueMaps_ChargedHadrons)[elePtr];
-                        sumNeutralHadronPt_recomp =  (*ValueMaps_NeutralHadrons)[elePtr];
-                        sumPhotonPt_recomp        =  (*ValueMaps_Photons)[elePtr];
+                        sumChargedHadronPt_recomp    =  (*pfSumChargedHadronPtTmp)[elePtr];
                         relisoChargedHadronPt_recomp = sumChargedHadronPt_recomp/pt_;
+
+                        sumNeutralHadronPt_recomp    = (*pfSumNeutralHadronEtTmp)[elePtr];
                         relisoNeutralHadronPt_recomp = sumNeutralHadronPt_recomp/pt_;
-                        relisoPhotonPt_recomp = sumPhotonPt_recomp/pt_; /**/
+
+                        sumPhotonPt_recomp    =  (*pfSumPhotonEtTmp)[elePtr];
+                        relisoPhotonPt_recomp = sumPhotonPt_recomp/pt_;
+
                         okGsfFound = true;
                         
-                // DEBUG LINES - KEEP IT !
+/*                // DEBUG LINES - KEEP IT !
                         std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
-                // DEBUG LINES - KEEP IT !  /**/ 
+                // DEBUG LINES - KEEP IT !  */ 
                     }
                 }
             }
@@ -436,12 +438,11 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
         // -- recomputed pflow over pT
             h1_ele_chargedHadronRelativeIso_mAOD_recomp->Fill( relisoChargedHadronPt_recomp );
             h1_ele_neutralHadronRelativeIso_mAOD_recomp->Fill( relisoNeutralHadronPt_recomp );
-            h1_ele_photonRelativeIso_mAOD_recomp->Fill( relisoPhotonPt_recomp );
-            
+            h1_ele_photonRelativeIso_mAOD_recomp->Fill( relisoPhotonPt_recomp );/**/
+                        
         }
 
     } // fin boucle size_t i
 
-    //std::cout << ("fin analyze\n"); //
 }
 

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -352,7 +352,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
                         okGsfFound = true;
                         
                 // DEBUG LINES - KEEP IT !
-                        //std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
+                //        std::cout << "evt ID : " << iEvent.id() << " - Pt : " << bestGsfElectron.pt() << " - eta : " << bestGsfElectron.eta() << " - phi : " << bestGsfElectron.phi() << std::endl;
                 // DEBUG LINES - KEEP IT !  /**/ 
                     }
                 }

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -220,7 +220,7 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
     edm::Handle <edm::ValueMap <float> > pfSumNeutralHadronEtTmp;
     edm::Handle <edm::ValueMap <float> > pfSumPhotonEtTmp;/**/
   
-  //recomp
+    //recomp
     iEvent.getByToken( pfSumChargedHadronPtTmp_ , pfSumChargedHadronPtTmp);
     iEvent.getByToken( pfSumNeutralHadronEtTmp_ , pfSumNeutralHadronEtTmp);
     iEvent.getByToken( pfSumPhotonEtTmp_ , pfSumPhotonEtTmp);/**/

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -23,7 +23,7 @@ ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::Pa
     //recomp
     pfSumChargedHadronPtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumChargedHadronPtTmp" ) ) ; // iConfig 
     pfSumNeutralHadronEtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumNeutralHadronEtTmp" ) ) ; // iConfig 
-    pfSumPhotonEtTmp_         = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumPhotonEtTmp" ) ) ;        // iConfig 
+    pfSumPhotonEtTmp_ = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumPhotonEtTmp" ) ) ; // iConfig 
     
   maxPt_ = iConfig.getParameter<double>("MaxPt");
   maxAbsEta_ = iConfig.getParameter<double>("MaxAbsEta");

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -14,26 +14,26 @@ typedef edm::Ptr<pat::Electron> PatElectronPtr;
 
 ElectronMcSignalValidatorMiniAOD::ElectronMcSignalValidatorMiniAOD(const edm::ParameterSet& iConfig) : ElectronDqmAnalyzerBase(iConfig)
 {
-    mcTruthCollection_ = consumes<edm::View<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("mcTruthCollection")); // prunedGenParticles
-    electronToken_     = consumes<pat::ElectronCollection>      (iConfig.getParameter<edm::InputTag>("electrons"));         // slimmedElectrons
+   mcTruthCollection_ = consumes<edm::View<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("mcTruthCollection")); // prunedGenParticles
+   electronToken_     = consumes<pat::ElectronCollection>      (iConfig.getParameter<edm::InputTag>("electrons"));         // slimmedElectrons
 
    edm::ParameterSet histosSet = iConfig.getParameter<edm::ParameterSet>("histosCfg") ;
    edm::ParameterSet isolationSet = iConfig.getParameter<edm::ParameterSet>("isolationCfg") ;
 
-    //recomp
-    pfSumChargedHadronPtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumChargedHadronPtTmp" ) ) ; // iConfig 
-    pfSumNeutralHadronEtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumNeutralHadronEtTmp" ) ) ; // iConfig 
-    pfSumPhotonEtTmp_ = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumPhotonEtTmp" ) ) ; // iConfig 
+   //recomp
+   pfSumChargedHadronPtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumChargedHadronPtTmp" ) ) ; // iConfig 
+   pfSumNeutralHadronEtTmp_  = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumNeutralHadronEtTmp" ) ) ; // iConfig 
+   pfSumPhotonEtTmp_ = consumes<edm::ValueMap<float> > (isolationSet.getParameter<edm::InputTag>( "pfSumPhotonEtTmp" ) ) ; // iConfig 
     
-  maxPt_ = iConfig.getParameter<double>("MaxPt");
-  maxAbsEta_ = iConfig.getParameter<double>("MaxAbsEta");
-  deltaR_ = iConfig.getParameter<double>("DeltaR");
-  deltaR2_ = deltaR_ * deltaR_;
-  matchingIDs_ = iConfig.getParameter<std::vector<int> >("MatchingID");
-  matchingMotherIDs_ = iConfig.getParameter<std::vector<int> >("MatchingMotherID");
-  outputInternalPath_ = iConfig.getParameter<std::string>("OutputFolderName") ;
+   maxPt_ = iConfig.getParameter<double>("MaxPt");
+   maxAbsEta_ = iConfig.getParameter<double>("MaxAbsEta");
+   deltaR_ = iConfig.getParameter<double>("DeltaR");
+   deltaR2_ = deltaR_ * deltaR_;
+   matchingIDs_ = iConfig.getParameter<std::vector<int> >("MatchingID");
+   matchingMotherIDs_ = iConfig.getParameter<std::vector<int> >("MatchingMotherID");
+   outputInternalPath_ = iConfig.getParameter<std::string>("OutputFolderName") ;
 
-  // histos bining and limits
+   // histos bining and limits
 
    xyz_nbin=histosSet.getParameter<int>("Nbinxyz");
 

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -30,9 +30,9 @@ class ElectronMcSignalValidatorMiniAOD : public ElectronDqmAnalyzerBase {
       edm::EDGetTokenT<edm::View<reco::GenParticle> > mcTruthCollection_; // prunedGenParticles
       edm::EDGetTokenT<pat::ElectronCollection> electronToken_; // slimmedElectrons
 
-      edm::EDGetTokenT<edm::ValueMap<float> > ValueMaps_ChargedHadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > ValueMaps_NeutralHadrons_;
-      edm::EDGetTokenT<edm::ValueMap<float> > ValueMaps_Photons_;
+      edm::EDGetTokenT<edm::ValueMap<float> > pfSumChargedHadronPtTmp_;
+      edm::EDGetTokenT<edm::ValueMap<float> > pfSumNeutralHadronEtTmp_;
+      edm::EDGetTokenT<edm::ValueMap<float> > pfSumPhotonEtTmp_;/**/
       float pt_;
  
       double maxPt_;
@@ -113,7 +113,7 @@ class ElectronMcSignalValidatorMiniAOD : public ElectronDqmAnalyzerBase {
 
 	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_recomp;
 	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_recomp;
-    MonitorElement *h1_ele_photonRelativeIso_mAOD_recomp;    
+    MonitorElement *h1_ele_photonRelativeIso_mAOD_recomp; 
 };
 
 #endif

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
@@ -101,18 +101,18 @@ class ElectronMcSignalValidatorMiniAOD : public ElectronDqmAnalyzerBase {
     MonitorElement *h1_ele_fbrem_mAOD_endcaps;
 
 	// -- pflow over pT
-	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD;
-	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD;
+    MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_barrel;
     MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_endcaps;
-	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD;
-	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD;
+    MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_barrel;
     MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_endcaps;
-	MonitorElement *h1_ele_photonRelativeIso_mAOD;
-	MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
+    MonitorElement *h1_ele_photonRelativeIso_mAOD;
+    MonitorElement *h1_ele_photonRelativeIso_mAOD_barrel;
     MonitorElement *h1_ele_photonRelativeIso_mAOD_endcaps;
 
-	MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_recomp;
-	MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_recomp;
+    MonitorElement *h1_ele_chargedHadronRelativeIso_mAOD_recomp;
+    MonitorElement *h1_ele_neutralHadronRelativeIso_mAOD_recomp;
     MonitorElement *h1_ele_photonRelativeIso_mAOD_recomp; 
 };
 

--- a/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoEgamma.EgammaElectronProducers.gedGsfElectronFinalizer_cfi import gedGsfElectrons as _gedGsfElectrons
+
 electronMcSignalHistosCfg = cms.PSet(
   Nbinxyz = cms.int32(50),
   Nbinpt = cms.int32(50), Nbinpt2D = cms.int32(50), Nbinpteff = cms.int32(19),Ptmax = cms.double(100.0),
@@ -16,6 +18,12 @@ electronMcSignalHistosCfg = cms.PSet(
   EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False)
 )
 
+electronPFIsolationCfg = cms.PSet(    
+    pfSumChargedHadronPtTmp = cms.InputTag("miniAODElectronIsolation", _gedGsfElectrons.pfIsolationValues.pfSumChargedHadronPt.getProductInstanceLabel()),
+    pfSumNeutralHadronEtTmp = cms.InputTag("miniAODElectronIsolation", _gedGsfElectrons.pfIsolationValues.pfSumNeutralHadronEt.getProductInstanceLabel()), # 
+    pfSumPhotonEtTmp = cms.InputTag("miniAODElectronIsolation", _gedGsfElectrons.pfIsolationValues.pfSumPhotonEt.getProductInstanceLabel()), #  
+)
+
 electronMcSignalValidatorMiniAOD = cms.EDAnalyzer("ElectronMcSignalValidatorMiniAOD",
 
     Verbosity = cms.untracked.int32(0),
@@ -27,15 +35,12 @@ electronMcSignalValidatorMiniAOD = cms.EDAnalyzer("ElectronMcSignalValidatorMini
 
     mcTruthCollection = cms.InputTag("prunedGenParticles"),
     electrons = cms.InputTag("slimmedElectrons"),
-
-    ValueMaps_ChargedHadrons_src = cms.InputTag("ElectronIsolation", "h+-DR030-BarVeto000-EndVeto001"),
-    ValueMaps_NeutralHadrons_src = cms.InputTag("ElectronIsolation", "h0-DR030-BarVeto000-EndVeto000"),
-    ValueMaps_Photons_src = cms.InputTag("ElectronIsolation", "gamma-DR030-BarVeto000-EndVeto008"),
-
+    
     MaxPt = cms.double(100.0),
     DeltaR = cms.double(0.05),
     MaxAbsEta = cms.double(2.5),
     MatchingID = cms.vint32(11,-11),
     MatchingMotherID = cms.vint32(23,24,-24,32),
-    histosCfg = cms.PSet(electronMcSignalHistosCfg)
+    histosCfg = cms.PSet(electronMcSignalHistosCfg),
+    isolationCfg = cms.PSet(electronPFIsolationCfg),
 )

--- a/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
+++ b/Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
@@ -1,7 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
+from FWCore.Modules.printContent_cfi import * 
+
 from Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi import * 
 from Validation.RecoEgamma.ElectronIsolation_cfi import *
+ 
+from RecoParticleFlow.PFProducer.particleFlowEGamma_cff import egmElectronIsolationCITK as _egmElectronIsolationCITK
+from RecoParticleFlow.PFProducer.particleFlowEGamma_cff import *
 
-electronValidationSequenceMiniAOD = cms.Sequence(ElectronIsolation + electronMcSignalValidatorMiniAOD)
+miniAODElectronIsolation = _egmElectronIsolationCITK.clone() 
+miniAODElectronIsolation.srcToIsolate = cms.InputTag("slimmedElectrons")
+miniAODElectronIsolation.srcForIsolationCone = cms.InputTag("packedPFCandidates")
+
+electronValidationSequenceMiniAOD = cms.Sequence( egmElectronIsolationCITK + miniAODElectronIsolation + ElectronIsolation + electronMcSignalValidatorMiniAOD )
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
@@ -11,6 +11,8 @@ process.options = cms.untracked.PSet(
 #    Rethrow = cms.untracked.vstring('ProductNotFound')
 )
 
+#from FWCore.Modules.printContent_cfi import * 
+
 process.DQMStore = cms.Service("DQMStore")
 process.load("DQMServices.Components.DQMStoreStats_cfi")
 from DQMServices.Components.DQMStoreStats_cfi import *
@@ -24,15 +26,18 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(max_number))
 process.source = cms.Source ("PoolSource",
 #eventsToProcess = cms.untracked.VEventRange('1:2682-1:2682'), 
 #eventsToProcess = cms.untracked.VEventRange('1:8259-1:8259'), 
+#eventsToProcess = cms.untracked.VEventRange('1:10-1:10'), 
 fileNames = cms.untracked.vstring([
 #        'file:PAT_249120E2-D1EC-E611-83C2-0CC47A7C347A.root',
 #        'file:PAT_76F9AD07-D3EC-E611-AA87-0CC47A745250.root',
 #        'file:PAT_FA0E1D02-D5EC-E611-B8CA-0025905A6080.root',
 #        'file:PAT_EE728E01-D5EC-E611-9DC5-0025905A6126.root',
+#        '/store/relval/CMSSW_9_1_0_pre2/RelValSingleElectronPt10/MINIAODSIM/90X_upgrade2017_realistic_v20-v1/00000/66B5E60E-5619-E711-8E17-0CC47A4D7632.root',
+#        '/store/relval/CMSSW_9_1_0_pre2/RelValSingleElectronPt10/MINIAODSIM/90X_upgrade2017_realistic_v20-v1/00000/BC08FC0E-5619-E711-98E5-0CC47A4D760C.root',
     ]),
 secondaryFileNames = cms.untracked.vstring() )
 process.source.fileNames.extend(dd.search())
-print "done"
+print "reading files done"
 
 #process.printTree = cms.EDAnalyzer("ParticleListDrawer",
 #  maxEventsToPrint = cms.untracked.int32(1),
@@ -69,6 +74,7 @@ process.load("Configuration.StandardSequences.EDMtoMEAtJobEnd_cff") # new
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
+#process.GlobalTag.globaltag = '90X_upgrade2017_realistic_v20'
 process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 #process.GlobalTag.globaltag = '75X_mcRun2_asymptotic_Queue'
 #process.GlobalTag.globaltag = '75X_mcRun2_startup_Queue'
@@ -76,27 +82,32 @@ process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
 # FOR DATA REDONE FROM RAW, ONE MUST HIDE IsoFromDeps
 # CONFIGURATION
 process.load("Validation.RecoEgamma.electronIsoFromDeps_cff")
-process.load("Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi")
 process.load("Validation.RecoEgamma.ElectronIsolation_cfi")
-#process.load("PhysicsTools.PatAlgos.slimming.prunedGenParticles_cfi")
+process.load("Validation.RecoEgamma.ElectronMcSignalValidatorMiniAOD_cfi")
+
+print "miniAODElectronIsolation call"
+from Validation.RecoEgamma.electronValidationSequenceMiniAOD_cff import miniAODElectronIsolation # as _ElectronIsolationCITK
+process.miniAODElectronIsolation = miniAODElectronIsolation
+print "miniAODElectronIsolation clone done"
 
 # load DQM
 process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
+#process.printContent = printContent
+
 process.EDM = cms.OutputModule("PoolOutputModule",
 outputCommands = cms.untracked.vstring('drop *',"keep *_MEtoEDMConverter_*_*"),
+#fileName = cms.untracked.string(TEST_HISTOS_FILE)
 fileName = cms.untracked.string(os.environ['TEST_HISTOS_FILE'].replace(".root", "_a.root"))
 )
 
 process.electronMcSignalValidatorMiniAOD.InputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
 process.electronMcSignalValidatorMiniAOD.OutputFolderName = cms.string("EgammaV/ElectronMcSignalValidatorMiniAOD")
 
-#process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
-#process.p = cms.Path(process.prunedGenParticles * process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.printTree)
-process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) # * process.printTree
+#process.p = cms.Path(process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) # * process.dqmStoreStats 
 #process.p = cms.Path(process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter * process.dqmStoreStats)
-
+process.p = cms.Path( process.miniAODElectronIsolation * process.ElectronIsolation * process.electronMcSignalValidatorMiniAOD * process.MEtoEDMConverter ) #  process.printContent * 
 process.outpath = cms.EndPath(
 process.EDM,
 )


### PR DESCRIPTION
The electron MC miniAOD validation implements a PF isolation recomputation to ensure that no information is lost when producing the miniAODs.

The PF isolation as computed in RECO has been modified/updated (see
https://github.com/cms-sw/cmssw/commit/455a974a1f21d08cadc9bcc029cbfefab33d841c)
and the miniAOD computation was no longer in sync with the RECO.
The disagreement can be seen here:
http://cms-egamma.web.cern.ch/cms-egamma/validation/Electrons/Releases/9_1_0_pre2_miniAOD_DQM_std/GedvsGed_9_1_0_pre2_miniAOD_DQM_std/Fullgedvsged_RelValSingleElectronPt10_gedGsfE_Startup/#h_ele_chargedHadronRelativeIso_mAOD_recomp
and it was spotted in the validation, see for example:
https://hypernews.cern.ch/HyperNews/CMS/get/relval/7317/11.html

This PR implements a fix in the miniaod electron validation as well as an improvement: in principle any future change in RECO will be automatically picked up in the miniAOD validation.

Changes have been made in :
Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.h
for the producer,

Validation/RecoEgamma/python/ElectronMcSignalValidatorMiniAOD_cfi.py
Validation/RecoEgamma/python/electronValidationSequenceMiniAOD_cff.py
for the isolation module used,

Validation/RecoEgamma/test/ElectronMcSignalValidationMiniAOD_cfg.py
for config file.

The effect can be observed here:
http://cmsdoc.cern.ch/cms/Physics/egamma/www/validation/Electrons/Dev/9_1_0_pre2_miniAOD_9_DQM_dev/GedvsGed_9_1_0_pre2_DQM_dev/Fullgedvsged_RelValSingleElectronPt10_gedGsfE_Startup/#h_ele_chargedHadronRelativeIso_mAOD_recomp

@beaudett @fcouderc 