### PR TITLE
Consolidate nuclear interactions files for fastsim 

### DIFF
--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
@@ -78,7 +78,7 @@ class NuclearInteractionSimulator : public MaterialEffectsSimulator
   std::vector<double> theLengthRatio;
   std::vector< std::vector<double> > theRatios;
 
-  std::vector< std::vector<TFile*> > theFiles;
+  TFile* theFile;
   std::vector< std::vector<TTree*> > theTrees;
   std::vector< std::vector<TBranch*> > theBranches;
   std::vector< std::vector<NUEvent*> > theNUEvents;

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
@@ -100,7 +100,7 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
 
   // Open the root files
   //  for ( unsigned file=0; file<theFileNames.size(); ++file ) {
-  edm::FileInPath myDataFile("FastSimulation/MaterialEffects/data/david.root");
+  edm::FileInPath myDataFile("FastSimulation/MaterialEffects/data/NuclearInteractions.root");
 
   fullPath = myDataFile.fullPath();
   theFile = TFile::Open(fullPath.c_str());

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
@@ -53,7 +53,7 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
 
   // Prepare the map of files
   // Loop over the particle names
-  std::vector<TFile*> aVFile(thePionEN.size(),static_cast<TFile*>(0));
+  TFile* aVFile=0;
   std::vector<TTree*> aVTree(thePionEN.size(),static_cast<TTree*>(0));
   std::vector<TBranch*> aVBranch(thePionEN.size(),static_cast<TBranch*>(0));
   std::vector<NUEvent*> aVNUEvents(thePionEN.size(),static_cast<NUEvent*>(0));
@@ -63,7 +63,7 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
   std::vector<unsigned> aVNumberOfInteractions(thePionEN.size(),static_cast<unsigned>(0));
   std::vector<std::string> aVFileName(thePionEN.size(),static_cast<std::string>(""));
   std::vector<double> aVPionCM(thePionEN.size(),static_cast<double>(0));
-  theFiles.resize(thePionNA.size());
+
   theTrees.resize(thePionNA.size());
   theBranches.resize(thePionNA.size());
   theNUEvents.resize(thePionNA.size());
@@ -73,8 +73,8 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
   theNumberOfInteractions.resize(thePionNA.size());
   theFileNames.resize(thePionNA.size());
   thePionCM.resize(thePionNA.size());
+  theFile = aVFile;
   for ( unsigned iname=0; iname<thePionNA.size(); ++iname ) { 
-    theFiles[iname] = aVFile;
     theTrees[iname] = aVTree;
     theBranches[iname] = aVBranch;
     theNUEvents[iname] = aVNUEvents;
@@ -100,6 +100,11 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
 
   // Open the root files
   //  for ( unsigned file=0; file<theFileNames.size(); ++file ) {
+  edm::FileInPath myDataFile("FastSimulation/MaterialEffects/data/david.root");
+
+  fullPath = myDataFile.fullPath();
+  theFile = TFile::Open(fullPath.c_str());
+
   unsigned fileNb = 0;
   for ( unsigned iname=0; iname<thePionNA.size(); ++iname ) {
     for ( unsigned iene=0; iene<thePionEN.size(); ++iene ) {
@@ -110,17 +115,12 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
       theFileNames[iname][iene] = filename.str();
       //std::cout << "thePid/theEne " << thePionID[iname] << " " << theEne << std::endl; 
 
-      edm::FileInPath myDataFile("FastSimulation/MaterialEffects/data/"+theFileNames[iname][iene]);
-      fullPath = myDataFile.fullPath();
-      //    theFiles[file] = TFile::Open(theFileNames[file].c_str());
-      theFiles[iname][iene] = TFile::Open(fullPath.c_str());
-      if ( !theFiles[iname][iene] ) throw cms::Exception("FastSimulation/MaterialEffects") 
-	<< "File " << theFileNames[iname][iene] << " " << fullPath <<  " not found ";
       ++fileNb;
+      std::string treeName="NuclearInteractions_"+thePionNA[iname]+"_E"+std::to_string(int(theEne));
       //
-      theTrees[iname][iene] = (TTree*) theFiles[iname][iene]->Get("NuclearInteractions"); 
+      theTrees[iname][iene] = (TTree*) theFile->Get(treeName.c_str()); 
       if ( !theTrees[iname][iene] ) throw cms::Exception("FastSimulation/MaterialEffects") 
-	<< "Tree with name NuclearInteractions not found in " << theFileNames[iname][iene];
+				      << "Tree with name " << treeName << " not found ";
       //
       theBranches[iname][iene] = theTrees[iname][iene]->GetBranch("nuEvent");
       //std::cout << "The branch = " << theBranches[iname][iene] << std::endl;
@@ -181,16 +181,8 @@ NuclearInteractionSimulator::~NuclearInteractionSimulator() {
   // Close all local files
   // Among other things, this allows the TROOT destructor to end up 
   // without crashing, while trying to close these files from outside
-  for ( unsigned ifile=0; ifile<theFiles.size(); ++ifile ) { 
-    for ( unsigned iene=0; iene<theFiles[ifile].size(); ++iene ) {
-      auto file = theFiles[ifile][iene];
-      if(file) {
-      // std::cout << "Closing file " << iene << " with name " << theFileNames[ifile][iene] << std::endl;
-        file->Close();
-        delete file;
-      }
-    }
-  }
+  theFile->Close();
+  delete theFile;
 
   for(auto& vEvents: theNUEvents) {
     for(auto evtPtr: vEvents) {


### PR DESCRIPTION
Goal - to reduce open files in cmsRun

@smuzaffar - this needs all the data files currently in data-FastSimulation-MaterialEffects to be replaced by this file:
 cmsdev02:/build/dlange/CMSSW_9_2_X_2017-05-11-1100/src/FastSimulation/MaterialEffects/data/NuclearInteractions.root