### PR TITLE
enabling profiling with intel Amplifier by ignoring signal 38

### DIFF
--- a/FWCore/Utilities/src/UnixSignalHandlers.cc
+++ b/FWCore/Utilities/src/UnixSignalHandlers.cc
@@ -55,6 +55,10 @@ namespace edm {
       tmpact.sa_handler = SIG_IGN;
 
       for(int num = SIGRTMIN; num <= SIGRTMAX; ++num) {
+          // signal 38 is used by Intel Amplifier
+          if( num == 38) continue;
+
+
 	  MUST_BE_ZERO(sigaddset(&myset,num));
 	  MUST_BE_ZERO(sigaction(num,&tmpact,NULL));
       }


### PR DESCRIPTION
Intel Amplifier uses signal 38 to collect profiling data. 
For this reason, this signal should be ignored by the framework.

@fwyzard @rovere @VinInn 