### PR TITLE
Pr92x L1T UnpackerCaloLayer1 & DQMCaloLayer1 Adjust for Non-present FED data in MC

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -68,7 +68,7 @@ void L1TdeStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSe
   }
   
   if ( dataTowerSet.size() != emulTowerSet.size() ) {
-    edm::LogError("L1TdeStage2CaloLayer1") << "Data and Emulation have different number of trigger towers! data=" << dataTowerSet.size() << ", emul=" << emulTowerSet.size() << std::endl;
+    LogDebug("L1TdeStage2CaloLayer1") << "Data and Emulation have different number of trigger towers! data=" << dataTowerSet.size() << ", emul=" << emulTowerSet.size() << std::endl;
     towerCountMismatchesPerBx_->Fill(event.bunchCrossing());
     return;
   }

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -68,7 +68,7 @@ void L1TdeStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSe
   }
   
   if ( dataTowerSet.size() != emulTowerSet.size() ) {
-    edm::LogInfo("L1TdeStage2CaloLayer1") << "Data and Emulation have different number of trigger towers! data=" << dataTowerSet.size() << ", emul=" << emulTowerSet.size() << std::endl;
+    edm::LogError("L1TdeStage2CaloLayer1") << "Data and Emulation have different number of trigger towers! data=" << dataTowerSet.size() << ", emul=" << emulTowerSet.size() << std::endl;
     towerCountMismatchesPerBx_->Fill(event.bunchCrossing());
     return;
   }

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer1.cc
@@ -68,7 +68,7 @@ void L1TdeStage2CaloLayer1::analyze(const edm::Event & event, const edm::EventSe
   }
   
   if ( dataTowerSet.size() != emulTowerSet.size() ) {
-    edm::LogError("L1TdeStage2CaloLayer1") << "Data and Emulation have different number of trigger towers! data=" << dataTowerSet.size() << ", emul=" << emulTowerSet.size() << std::endl;
+    edm::LogInfo("L1TdeStage2CaloLayer1") << "Data and Emulation have different number of trigger towers! data=" << dataTowerSet.size() << ", emul=" << emulTowerSet.size() << std::endl;
     towerCountMismatchesPerBx_->Fill(event.bunchCrossing());
     return;
   }

--- a/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
+++ b/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
@@ -168,7 +168,7 @@ L1TCaloLayer1RawToDigi::produce(Event& iEvent, const EventSetup& iSetup)
       const uint64_t *fedRawDataArray = (const uint64_t *) fedRawData.data();
 
       if ( fedRawData.size() == 0 || fedRawDataArray == nullptr ) {
-        LogError("L1TCaloLayer1RawToDigi") << "Could not load FED data for " << fed << ", putting empty collections!";
+        LogDebug("L1TCaloLayer1RawToDigi") << "Could not load FED data for " << fed << ", putting empty collections!";
         continue;
       }
       

--- a/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
+++ b/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
@@ -97,7 +97,6 @@ private:
   std::vector<int> fedIDs;
 
   uint32_t event;
-  uint32_t warnsa;
 
   bool verbose;
 
@@ -127,8 +126,6 @@ L1TCaloLayer1RawToDigi::L1TCaloLayer1RawToDigi(const ParameterSet& iConfig) :
   produces<L1CaloRegionCollection>();
 
   consumes<FEDRawDataCollection>(fedRawDataLabel);
-
-  warnsa = 0;
 
 }
 
@@ -171,10 +168,7 @@ L1TCaloLayer1RawToDigi::produce(Event& iEvent, const EventSetup& iSetup)
       const uint64_t *fedRawDataArray = (const uint64_t *) fedRawData.data();
 
       if ( fedRawData.size() == 0 || fedRawDataArray == nullptr ) {
-        if (warnsa<5) {
-          warnsa++;
-          LogInfo("L1TCaloLayer1RawToDigi") << "Could not load FED data for " << fed << ", putting empty collections!";
-        }
+        LogError("L1TCaloLayer1RawToDigi") << "Could not load FED data for " << fed << ", putting empty collections!";
         continue;
       }
       

--- a/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
+++ b/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
@@ -97,6 +97,7 @@ private:
   std::vector<int> fedIDs;
 
   uint32_t event;
+  uint32_t warnsa;
 
   bool verbose;
 
@@ -126,6 +127,8 @@ L1TCaloLayer1RawToDigi::L1TCaloLayer1RawToDigi(const ParameterSet& iConfig) :
   produces<L1CaloRegionCollection>();
 
   consumes<FEDRawDataCollection>(fedRawDataLabel);
+
+  warnsa = 0;
 
 }
 
@@ -168,7 +171,10 @@ L1TCaloLayer1RawToDigi::produce(Event& iEvent, const EventSetup& iSetup)
       const uint64_t *fedRawDataArray = (const uint64_t *) fedRawData.data();
 
       if ( fedRawData.size() == 0 || fedRawDataArray == nullptr ) {
-        LogError("L1TCaloLayer1RawToDigi") << "Could not load FED data for " << fed << ", putting empty collections!";
+        if (warnsa<5) {
+          warnsa++;
+          LogInfo("L1TCaloLayer1RawToDigi") << "Could not load FED data for " << fed << ", putting empty collections!";
+        }
         continue;
       }
       


### PR DESCRIPTION
92x:  This fixes the error messages reported by @davidlange6 in https://github.com/cms-sw/cmssw/pull/18085#issuecomment-300752174, which arise only in MC, wherewe still don't pack data for CaloLayer1.  

Once the CaloLayer1 packer developed, this will not be an issue. 
With this PR, the unpacker issues a LogInfo if FED data not found, and is silenced after 5 times.
Again, this only happens when running on RAW MC. 

Also the DQM CaloLayer1 issues a LogInfo in case the emulator of CaloLayer1 and unpacked raw data disagree. In case of MC, they do as unpacked data collection is empty.


