### PR TITLE
Convert DD MultiUnion to G4MultiUnion

### DIFF
--- a/SimG4Core/Geometry/interface/DDG4SolidConverter.h
+++ b/SimG4Core/Geometry/interface/DDG4SolidConverter.h
@@ -31,6 +31,7 @@ private:
     static G4VSolid * unionsolid(const DDSolid &);
     static G4VSolid * subtraction(const DDSolid &);
     static G4VSolid * intersection(const DDSolid &);
+    static G4VSolid * multiunion(const DDSolid &);    
     static G4VSolid * shapeless(const DDSolid &);
     static G4VSolid * polycone_rz(const DDSolid &);
     static G4VSolid * polycone_rrz(const DDSolid &);
@@ -52,7 +53,6 @@ private:
 
     friend class testTruncTubs;
     friend class testPseudoTrap;
-
 };
 
 #endif


### PR DESCRIPTION
* Implemented, but not used since G4 rebuild is required with G4GEOM_USE_USOLIDS flag to allow use of USolids

