### PR TITLE
Fix Clang errors (undefined references)

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -122,6 +122,9 @@ class CTPPSPixelDQMSource: public DQMEDAnalyzer
 
 };
 
+constexpr int CTPPSPixelDQMSource::NplaneMAX;
+constexpr int CTPPSPixelDQMSource::NROCsMAX;
+
 //----------------------------------------------------------------------------------
 
 using namespace std;

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -18,6 +18,8 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h"
 
+constexpr float TrajSeedMatcher::kElectronMass_;
+
 TrajSeedMatcher::TrajSeedMatcher(const edm::ParameterSet& pset):
   cacheIDMagField_(0),
   minNrHits_(pset.getParameter<std::vector<unsigned int> >("minNrHits")),


### PR DESCRIPTION
The patch resolves issue with Clang compiler.
N3690 (should be C++11 standard) and latest draft N4567, 9.4.2/3

...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
9.4.2/4 talks about how const static data members are being handled.

Also standard says that no diagnostic is required by compiler.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>