### PR TITLE
adjust HF TP emulator and compression LUTs

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -549,6 +549,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
     const int shift = samples.presamples() - numberOfPresamplesHF_;
     assert(shift >= 0);
     assert((shift + numberOfSamplesHF_) <= samples.size());
+    assert(hf_lumi_shift>=2);
 
     // Try to find the HFDetails from the map corresponding to our samples
     const HcalTrigTowerDetId detId(samples.id());
@@ -594,25 +595,20 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
             if (saturated) {
                output[ibin] = QIE10_MAX_LINEARIZATION_ET;
             } else {
-               // For details of the energy handling, see:
-               // https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12306
-               //
-               // If a channel for one fiber is invalid, use the value of the
-               // other channel (by doubling the sum) to calculate the
-               // energy in the fiber
-               if (long_fiber_count == 1)
-                  long_fiber_val *= 2;
-               if (short_fiber_count == 1)
-                  short_fiber_val *= 2;
+		// For details of the energy handling, see:
+		// https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12306
+		// If both readouts are valid, average of the two energies is taken
+		// division by 2 is compensated by adjusting the total scale shift in the end
+		if (long_fiber_count == 2) long_fiber_val >>=1;
+		if (short_fiber_count == 2) short_fiber_val >>=1;
+		
+		auto sum = long_fiber_val + short_fiber_val;
+		// Similar to above, if both channels are valid, 
+		// average of the two energies is calculated
+		// division by 2 here is also compensated by adjusting the total scale shift in the end
+		if (long_fiber_count > 0 and short_fiber_count > 0) sum >>=1;
 
-               auto sum = long_fiber_val + short_fiber_val;
-               // Similar to above, if a fiber is invalid (i.e., both
-               // channels for the fiber invalid), substitute the value of
-               // the other fiber by doubling the sum.
-               if (long_fiber_count == 0 or short_fiber_count == 0)
-                  sum *= 2;
-
-               output[ibin] += sum;
+		output[ibin] += sum;
             }
 
             for (const auto& detail: details) {
@@ -634,7 +630,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHF2017(
     }
 
     for (int bin = 0; bin < numberOfSamplesHF_; ++bin) {
-       output[bin] = min({(unsigned int) QIE10_MAX_LINEARIZATION_ET, output[bin]}) >> hf_lumi_shift;
+       output[bin] = min({(unsigned int) QIE10_MAX_LINEARIZATION_ET, output[bin] >> (hf_lumi_shift-2)});
     }
     std::vector<int> finegrain_converted;
     for (const auto& fg: finegrain)

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -60,4 +60,5 @@ run2_HF_2017.toModify(simHcalTriggerPrimitiveDigis,
                       numberOfSamplesHF = cms.int32(2),
                       numberOfPresamplesHF = cms.int32(1)
 )
+run2_HF_2017.toModify(hfTPScaleShift, NCT=cms.int32(2))
 run3_HB.toModify(simHcalTriggerPrimitiveDigis, upgradeHB=cms.bool(True))


### PR DESCRIPTION
Moving factor of 2 from the HF TP emulation algorithm to the compression LUTs to match what is done online. MC and emulated TP energies will remain unchanged up-to rounding, but emulated TPs will match data exactly after the change. No change in TP scale (no change needed in Layer-1 tables).