### PR TITLE
No hack conditions

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -73,10 +73,10 @@ process.l1tEmulatorMonitorPath = cms.Path(
     )
 
 # To get L1 conditions that are not in GlobalTag / O2O yet
-process.load("L1Trigger.L1TCalorimeter.hackConditions_cff")
-process.load("L1Trigger.L1TMuon.hackConditions_cff")
-process.gmtParams.caloInputsMasked = cms.bool(True) # Disable uGMT calo inputs like in the online configuration
-process.load("L1Trigger.L1TGlobal.hackConditions_cff")
+#process.load("L1Trigger.L1TCalorimeter.hackConditions_cff")
+#process.load("L1Trigger.L1TMuon.hackConditions_cff")
+#process.gmtParams.caloInputsMasked = cms.bool(True) # Disable uGMT calo inputs like in the online configuration
+#process.load("L1Trigger.L1TGlobal.hackConditions_cff")
 
 # To get CaloTPGTranscoder
 process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -49,9 +49,9 @@ SimL1Emulator = cms.Sequence( SimL1EmulatorCore )
 # Next we load ES producers for any conditions that are not yet in GT,
 # using the Era configuration.
 #
-from L1Trigger.L1TCalorimeter.hackConditions_cff import *
-from L1Trigger.L1TMuon.hackConditions_cff import *
-from L1Trigger.L1TGlobal.hackConditions_cff import *
+#from L1Trigger.L1TCalorimeter.hackConditions_cff import *
+#from L1Trigger.L1TMuon.hackConditions_cff import *
+#from L1Trigger.L1TGlobal.hackConditions_cff import *
 
 
 # Customisation for the phase2_hgcal era. Includes the HGCAL L1 trigger

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -51,8 +51,8 @@ SimL1Emulator = cms.Sequence( SimL1EmulatorCore )
 #
 #from L1Trigger.L1TCalorimeter.hackConditions_cff import *
 #from L1Trigger.L1TMuon.hackConditions_cff import *
-#from L1Trigger.L1TGlobal.hackConditions_cff import *
-
+# from L1Trigger.L1TGlobal.hackConditions_cff import *
+from L1Trigger.L1TGlobal.GlobalParameters_cff import *
 
 # Customisation for the phase2_hgcal era. Includes the HGCAL L1 trigger
 #from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *

--- a/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
+++ b/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
@@ -10,7 +10,7 @@
 
 #include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
 #include "CondFormats/L1TObjects/interface/CaloParams.h"
-#include "CondFormats/DataRecord/interface/L1TCaloStage2ParamsRcd.h"
+#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
 
 #include "CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h"
 #include "CalibFormats/CaloTPG/interface/CaloTPGRecord.h"
@@ -44,7 +44,7 @@ bool L1TCaloLayer1FetchLUTs(const edm::EventSetup& iSetup,
 
   // CaloParams contains all persisted parameters for Layer 1
   edm::ESHandle<l1t::CaloParams> paramsHandle;
-  iSetup.get<L1TCaloStage2ParamsRcd>().get(paramsHandle);
+  iSetup.get<L1TCaloParamsRcd>().get(paramsHandle);
   if ( paramsHandle.product() == nullptr ) {
     edm::LogError("L1TCaloLayer1FetchLUTs") << "Missing CaloParams object! Check Global Tag, etc.";
     return false;

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -31,7 +31,7 @@
 
 #include "CondFormats/L1TObjects/interface/CaloParams.h"
 #include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
-#include "CondFormats/DataRecord/interface/L1TCaloStage2ParamsRcd.h"
+#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
 
 using namespace std;
 
@@ -48,7 +48,7 @@ public:
 
   typedef std::shared_ptr<CaloParams> ReturnType;
 
-  ReturnType produce(const L1TCaloStage2ParamsRcd&);
+  ReturnType produce(const L1TCaloParamsRcd&);
 
 private:
   CaloParams  m_params ;
@@ -318,7 +318,7 @@ L1TCaloStage2ParamsESProducer::~L1TCaloStage2ParamsESProducer()
 
 // ------------ method called to produce the data  ------------
 L1TCaloStage2ParamsESProducer::ReturnType
-L1TCaloStage2ParamsESProducer::produce(const L1TCaloStage2ParamsRcd& iRecord)
+L1TCaloStage2ParamsESProducer::produce(const L1TCaloParamsRcd& iRecord)
 {
    using namespace edm::es;
    std::shared_ptr<CaloParams> pCaloParams ;

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer1Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer1Producer.cc
@@ -37,7 +37,7 @@
 #include "L1Trigger/L1TCalorimeter/interface/Stage2PreProcessor.h"
 
 #include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
-#include "CondFormats/DataRecord/interface/L1TCaloStage2ParamsRcd.h"
+#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
 
 #include "CondFormats/L1TObjects/interface/L1CaloEcalScale.h"
 #include "CondFormats/DataRecord/interface/L1CaloEcalScaleRcd.h"
@@ -348,14 +348,14 @@ L1TStage2Layer1Producer::beginRun(edm::Run const& iRun, edm::EventSetup const& i
 
   // parameters
 
-  unsigned long long id = iSetup.get<L1TCaloStage2ParamsRcd>().cacheIdentifier();
+  unsigned long long id = iSetup.get<L1TCaloParamsRcd>().cacheIdentifier();
 
   if (id != paramsCacheId_) {
 
     paramsCacheId_ = id;
 
     edm::ESHandle<CaloParams> paramsHandle;
-    iSetup.get<L1TCaloStage2ParamsRcd>().get(paramsHandle);
+    iSetup.get<L1TCaloParamsRcd>().get(paramsHandle);
 
     // replace our local copy of the parameters with a new one using placement new
     params_->~CaloParamsHelper();

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer2Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer2Producer.cc
@@ -38,7 +38,7 @@
 #include "L1Trigger/L1TCalorimeter/interface/CaloTools.h"
 
 #include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
-#include "CondFormats/DataRecord/interface/L1TCaloStage2ParamsRcd.h"
+#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
 
 #include "DataFormats/L1TCalorimeter/interface/CaloTower.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
@@ -262,14 +262,14 @@ L1TStage2Layer2Producer::beginRun(edm::Run const& iRun, edm::EventSetup const& i
 
   // parameters
 
-  unsigned long long id = iSetup.get<L1TCaloStage2ParamsRcd>().cacheIdentifier();
+  unsigned long long id = iSetup.get<L1TCaloParamsRcd>().cacheIdentifier();
 
   if (id != m_paramsCacheId) {
 
     m_paramsCacheId = id;
 
     edm::ESHandle<CaloParams> paramsHandle;
-    iSetup.get<L1TCaloStage2ParamsRcd>().get(paramsHandle);
+    iSetup.get<L1TCaloParamsRcd>().get(paramsHandle);
 
     // replace our local copy of the parameters with a new one using placement new
     m_params->~CaloParamsHelper();

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 caloParamsSource = cms.ESSource(
     "EmptyESSource",
-    recordName = cms.string('L1TCaloStage2ParamsRcd'),
+    recordName = cms.string('L1TCaloParamsRcd'),
     iovIsRunNotTime = cms.bool(True),
     firstValid = cms.vuint32(1)
 )


### PR DESCRIPTION
The changes add the global configuration to the locations where the hack condition statements were commented out in the L1T configuration and L1T DQM python client. "Import" and "process" statements were chosen so as to mirror the style used for referencing the hack conditions.