### PR TITLE
Change DQMEDHarvester from an edm::one::EDAnalyzer to an edm::one::EDProducer

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeDQMModule_cff.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 import  Alignment.MillePedeAlignmentAlgorithm.MillePedeFileReader_cfi as MillePedeFileReader_cfi
 
-SiPixelAliDQMModule = cms.EDAnalyzer("MillePedeDQMModule",
+SiPixelAliDQMModule = cms.EDProducer("MillePedeDQMModule",
                                      MillePedeFileReader = cms.PSet(MillePedeFileReader_cfi.MillePedeFileReader.clone())
                                      )

--- a/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLHarvester_cfi.py
+++ b/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLHarvester_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-SiStripGainsPCLHarvester = cms.EDAnalyzer(
+SiStripGainsPCLHarvester = cms.EDProducer(
     "SiStripGainsPCLHarvester",
     Record              = cms.untracked.string('SiStripApvGainRcd'),
     CalibrationLevel    = cms.untracked.int32(0), # 0==APV, 1==Laser, 2==module

--- a/Calibration/EcalCalibAlgos/python/ecalPedestalPCLHarvester_cfi.py
+++ b/Calibration/EcalCalibAlgos/python/ecalPedestalPCLHarvester_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-ECALpedestalPCLHarvester = cms.EDAnalyzer('ECALpedestalPCLHarvester',
+ECALpedestalPCLHarvester = cms.EDProducer('ECALpedestalPCLHarvester',
                                           MinEntries = cms.int32(100), #skip channel if stat is low
                                           ChannelStatusToExclude = cms.vstring(), # db statuses to exclude
                                           checkAnomalies  = cms.bool(False), # whether or not to avoid creating sqlite file in case of many changed pedestals

--- a/DQM/CSCMonitorModule/python/csc_certification_info_cfi.py
+++ b/DQM/CSCMonitorModule/python/csc_certification_info_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-cscCertificationInfo = cms.EDAnalyzer("CSCCertificationInfo")
+cscCertificationInfo = cms.EDProducer("CSCCertificationInfo")
 

--- a/DQM/CSCMonitorModule/python/csc_daq_info_cfi.py
+++ b/DQM/CSCMonitorModule/python/csc_daq_info_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-cscDaqInfo = cms.EDAnalyzer("CSCDaqInfo")
+cscDaqInfo = cms.EDProducer("CSCDaqInfo")
 

--- a/DQM/CSCMonitorModule/python/csc_dcs_info_cfi.py
+++ b/DQM/CSCMonitorModule/python/csc_dcs_info_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-cscDcsInfo = cms.EDAnalyzer("CSCDcsInfo")
+cscDcsInfo = cms.EDProducer("CSCDcsInfo")
 

--- a/DQM/CSCMonitorModule/python/csc_dqm_offlineclient_cfi.py
+++ b/DQM/CSCMonitorModule/python/csc_dqm_offlineclient_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.CSCMonitorModule.csc_dqm_masked_hw_cfi import *
 
-dqmCSCOfflineClient = cms.EDAnalyzer("CSCOfflineClient",
+dqmCSCOfflineClient = cms.EDProducer("CSCOfflineClient",
 
   MASKEDHW = CSCMaskedHW,
 

--- a/DQM/CTPPS/python/totemRPDQMHarvester_cfi.py
+++ b/DQM/CTPPS/python/totemRPDQMHarvester_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-totemRPDQMHarvester = cms.EDAnalyzer("TotemRPDQMHarvester",
+totemRPDQMHarvester = cms.EDProducer("TotemRPDQMHarvester",
 )

--- a/DQM/DTMonitorClient/python/dtBlockedROChannelsTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtBlockedROChannelsTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-blockedROChannelTest = cms.EDAnalyzer("DTBlockedROChannelsTest",
+blockedROChannelTest = cms.EDProducer("DTBlockedROChannelsTest",
                                       offlineMode = cms.untracked.bool(False),
                                       diagnosticPrescale = cms.untracked.int32(1)
                                       )

--- a/DQM/DTMonitorClient/python/dtCertificationSummary_cfi.py
+++ b/DQM/DTMonitorClient/python/dtCertificationSummary_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-dtCertificationSummary = cms.EDAnalyzer("DTCertificationSummary")
+dtCertificationSummary = cms.EDProducer("DTCertificationSummary")
 
 

--- a/DQM/DTMonitorClient/python/dtChamberEfficiencyClient_cfi.py
+++ b/DQM/DTMonitorClient/python/dtChamberEfficiencyClient_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-dtChamberEfficiencyClient = cms.EDAnalyzer("DTChamberEfficiencyClient",
+dtChamberEfficiencyClient = cms.EDProducer("DTChamberEfficiencyClient",
                                            diagnosticPrescale = cms.untracked.int32(1))

--- a/DQM/DTMonitorClient/python/dtChamberEfficiencyTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtChamberEfficiencyTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-chamberEfficiencyTest = cms.EDAnalyzer("DTChamberEfficiencyTest",
+chamberEfficiencyTest = cms.EDProducer("DTChamberEfficiencyTest",
     runningStandalone = cms.untracked.bool(True),
     #Names of the quality tests: they must match those specified in "qtList"
     XEfficiencyTestName = cms.untracked.string('ChEfficiencyInRangeX'),

--- a/DQM/DTMonitorClient/python/dtDAQInfo_cfi.py
+++ b/DQM/DTMonitorClient/python/dtDAQInfo_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-dtDAQInfo = cms.EDAnalyzer("DTDAQInfo")
+dtDAQInfo = cms.EDProducer("DTDAQInfo")
 
 

--- a/DQM/DTMonitorClient/python/dtDCSByLumiSummary_cfi.py
+++ b/DQM/DTMonitorClient/python/dtDCSByLumiSummary_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-dtDCSByLumiSummary = cms.EDAnalyzer("DTDCSByLumiSummary")
+dtDCSByLumiSummary = cms.EDProducer("DTDCSByLumiSummary")
 
 

--- a/DQM/DTMonitorClient/python/dtDCSSummary_cfi.py
+++ b/DQM/DTMonitorClient/python/dtDCSSummary_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-dtDCSSummary = cms.EDAnalyzer("DTDCSSummary")
+dtDCSSummary = cms.EDProducer("DTDCSSummary")
 
 

--- a/DQM/DTMonitorClient/python/dtDataIntegrityTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtDataIntegrityTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dataIntegrityTest = cms.EDAnalyzer("DTDataIntegrityTest",
+dataIntegrityTest = cms.EDProducer("DTDataIntegrityTest",
                                    diagnosticPrescale = cms.untracked.int32(1)
 )
 

--- a/DQM/DTMonitorClient/python/dtEfficiencyTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtEfficiencyTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-efficiencyTest = cms.EDAnalyzer("DTEfficiencyTest",
+efficiencyTest = cms.EDProducer("DTEfficiencyTest",
     runningStandalone = cms.untracked.bool(True),
     UnassEfficiencyTestName = cms.untracked.string('UnassEfficiencyInRange'),
     #Names of the quality tests: they must match those specified in "qtList"

--- a/DQM/DTMonitorClient/python/dtLocalTriggerEfficiencyTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerEfficiencyTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-triggerEfficiencyTest = cms.EDAnalyzer("DTLocalTriggerEfficiencyTest",
+triggerEfficiencyTest = cms.EDProducer("DTLocalTriggerEfficiencyTest",
     # prescale factor (in luminosity blocks) to perform client analysis
     diagnosticPrescale = cms.untracked.int32(1),
     # run in online environment

--- a/DQM/DTMonitorClient/python/dtLocalTriggerLutTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerLutTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-triggerLutTest = cms.EDAnalyzer("DTLocalTriggerLutTest",
+triggerLutTest = cms.EDProducer("DTLocalTriggerLutTest",
     # prescale factor (in luminosity blocks) to perform client analysis
     diagnosticPrescale = cms.untracked.int32(1),
     # run in online environment

--- a/DQM/DTMonitorClient/python/dtLocalTriggerSynchTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerSynchTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-triggerSynchTest = cms.EDAnalyzer("DTLocalTriggerSynchTest",
+triggerSynchTest = cms.EDProducer("DTLocalTriggerSynchTest",
     # prescale factor (in luminosity blocks) to perform client analysis
     diagnosticPrescale = cms.untracked.int32(1),
     # run in online environment

--- a/DQM/DTMonitorClient/python/dtLocalTriggerTest_TP_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerTest_TP_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtTPTriggerTest = cms.EDAnalyzer("DTLocalTriggerTPTest",
+dtTPTriggerTest = cms.EDProducer("DTLocalTriggerTPTest",
     # prescale factor (in luminosity blocks) to perform client analysis
     diagnosticPrescale = cms.untracked.int32(1),
     # run in online environment

--- a/DQM/DTMonitorClient/python/dtLocalTriggerTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtLocalTriggerTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-triggerTest = cms.EDAnalyzer("DTLocalTriggerTest",
+triggerTest = cms.EDProducer("DTLocalTriggerTest",
     # prescale factor (in luminosity blocks) to perform client analysis
     diagnosticPrescale = cms.untracked.int32(1),
     # run in online environment

--- a/DQM/DTMonitorClient/python/dtNoiseAnalysis_cfi.py
+++ b/DQM/DTMonitorClient/python/dtNoiseAnalysis_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtNoiseAnalysisMonitor = cms.EDAnalyzer("DTNoiseAnalysisTest",
+dtNoiseAnalysisMonitor = cms.EDProducer("DTNoiseAnalysisTest",
                                         noisyCellDef = cms.untracked.int32(1500),
                                         doSynchNoise = cms.untracked.bool(False),
                                         detailedAnalysis = cms.untracked.bool(False),

--- a/DQM/DTMonitorClient/python/dtOccupancyTest_TP_cfi.py
+++ b/DQM/DTMonitorClient/python/dtOccupancyTest_TP_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtTPmonitorTest = cms.EDAnalyzer("DTOccupancyTest",
+dtTPmonitorTest = cms.EDProducer("DTOccupancyTest",
                                  testPulseMode = cms.untracked.bool(True),
                                  runOnAllHitsOccupancies = cms.untracked.bool(False),
                                  runOnNoiseOccupancies = cms.untracked.bool(False),

--- a/DQM/DTMonitorClient/python/dtOccupancyTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtOccupancyTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtOccupancyTest = cms.EDAnalyzer("DTOccupancyTest",
+dtOccupancyTest = cms.EDProducer("DTOccupancyTest",
                                  testPulseMode = cms.untracked.bool(False),
                                  runOnAllHitsOccupancies = cms.untracked.bool(True),
                                  runOnNoiseOccupancies = cms.untracked.bool(False),

--- a/DQM/DTMonitorClient/python/dtOfflineSummaryClients_cfi.py
+++ b/DQM/DTMonitorClient/python/dtOfflineSummaryClients_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-dtOfflineSummaryClients = cms.EDAnalyzer("DTOfflineSummaryClients")
+dtOfflineSummaryClients = cms.EDProducer("DTOfflineSummaryClients")
 
 

--- a/DQM/DTMonitorClient/python/dtResolutionAnalysisTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtResolutionAnalysisTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtResolutionAnalysisTest = cms.EDAnalyzer("DTResolutionAnalysisTest",
+dtResolutionAnalysisTest = cms.EDProducer("DTResolutionAnalysisTest",
                                           diagnosticPrescale = cms.untracked.int32(1),
                                           maxGoodMeanValue = cms.untracked.double(0.005),
                                           minBadMeanValue = cms.untracked.double(0.015),

--- a/DQM/DTMonitorClient/python/dtResolutionAnalysisTest_hlt_cfi.py
+++ b/DQM/DTMonitorClient/python/dtResolutionAnalysisTest_hlt_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtResolutionTestHLT = cms.EDAnalyzer("DTResolutionAnalysisTest",
+dtResolutionTestHLT = cms.EDProducer("DTResolutionAnalysisTest",
                                      diagnosticPrescale = cms.untracked.int32(1),
                                      permittedMeanRange = cms.untracked.double(0.01),
                                      permittedSigmaRange = cms.untracked.double(0.08),

--- a/DQM/DTMonitorClient/python/dtResolutionTestFinalCalib_cfi.py
+++ b/DQM/DTMonitorClient/python/dtResolutionTestFinalCalib_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-resolutionTest = cms.EDAnalyzer("DTResolutionAnalysisTest",
+resolutionTest = cms.EDProducer("DTResolutionAnalysisTest",
                                  diagnosticPrescale = cms.untracked.int32(1),
                                  permittedMeanRange = cms.untracked.double(0.02),
                                  permittedSigmaRange = cms.untracked.double(0.12),

--- a/DQM/DTMonitorClient/python/dtResolutionTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtResolutionTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-resolutionTest = cms.EDAnalyzer("DTResolutionTest",
+resolutionTest = cms.EDProducer("DTResolutionTest",
     runningStandalone = cms.untracked.bool(True),
     diagnosticPrescale = cms.untracked.int32(1),
     calibModule = cms.untracked.bool(True),

--- a/DQM/DTMonitorClient/python/dtRunConditionVarClient_cfi.py
+++ b/DQM/DTMonitorClient/python/dtRunConditionVarClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtRunConditionVarClient = cms.EDAnalyzer("DTRunConditionVarClient",
+dtRunConditionVarClient = cms.EDProducer("DTRunConditionVarClient",
 
    minRangeVDrift  = cms.untracked.double(-1.),
    maxRangeVDrift  = cms.untracked.double(1.), 

--- a/DQM/DTMonitorClient/python/dtSegmentAnalysisTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtSegmentAnalysisTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-segmentTest = cms.EDAnalyzer("DTSegmentAnalysisTest",
+segmentTest = cms.EDProducer("DTSegmentAnalysisTest",
                              detailedAnalysis = cms.untracked.bool(False),
                              #Perform basic diagnostic in endLumi/EndRun
                              runOnline = cms.untracked.bool(True),

--- a/DQM/DTMonitorClient/python/dtSegmentAnalysisTest_hlt_cfi.py
+++ b/DQM/DTMonitorClient/python/dtSegmentAnalysisTest_hlt_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dtSegmentTestkHLT = cms.EDAnalyzer("DTSegmentAnalysisTest",
+dtSegmentTestkHLT = cms.EDProducer("DTSegmentAnalysisTest",
                                    detailedAnalysis = cms.untracked.bool(False),
                                    #Perform basic diagnostic in endLumi/EndRun
                                    runOnline = cms.untracked.bool(True),

--- a/DQM/DTMonitorClient/python/dtSummaryClients_cfi.py
+++ b/DQM/DTMonitorClient/python/dtSummaryClients_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-dtSummaryClients = cms.EDAnalyzer("DTSummaryClients")
+dtSummaryClients = cms.EDProducer("DTSummaryClients")
 
 

--- a/DQM/DTMonitorClient/python/dtTriggerEfficiencyTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtTriggerEfficiencyTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-triggerEffTest = cms.EDAnalyzer("DTTriggerEfficiencyTest",
+triggerEffTest = cms.EDProducer("DTTriggerEfficiencyTest",
     # prescale factor (in luminosity blocks) to perform client analysis
     diagnosticPrescale = cms.untracked.int32(1),
     # run in online environment

--- a/DQM/DTMonitorClient/python/dtTriggerLutTest_cfi.py
+++ b/DQM/DTMonitorClient/python/dtTriggerLutTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-triggerLutTest = cms.EDAnalyzer("DTTriggerLutTest",
+triggerLutTest = cms.EDProducer("DTTriggerLutTest",
     # prescale factor (in luminosity blocks) to perform client analysis
     diagnosticPrescale = cms.untracked.int32(1),
     # run in online environment

--- a/DQM/EcalCommon/python/EcalMEFormatter_cfi.py
+++ b/DQM/EcalCommon/python/EcalMEFormatter_cfi.py
@@ -20,7 +20,7 @@ from DQM.EcalMonitorClient.TimingClient_cfi import ecalTimingClient
 from DQM.EcalMonitorClient.TrigPrimClient_cfi import ecalTrigPrimClient
 from DQM.EcalMonitorClient.SummaryClient_cfi import ecalSummaryClient
 
-ecalMEFormatter = cms.EDAnalyzer("EcalMEFormatter",
+ecalMEFormatter = cms.EDProducer("EcalMEFormatter",
     MEs = cms.untracked.PSet(),
     verbosity = cms.untracked.int32(0)
 )

--- a/DQM/EcalMonitorClient/python/EcalCalibMonitorClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalCalibMonitorClient_cfi.py
@@ -12,7 +12,7 @@ from DQM.EcalMonitorClient.PNIntegrityClient_cfi import ecalPNIntegrityClient
 from DQM.EcalMonitorClient.SummaryClient_cfi import ecalSummaryClient
 from DQM.EcalMonitorClient.CalibrationSummaryClient_cfi import ecalCalibrationSummaryClient
 
-ecalCalibMonitorClient = cms.EDAnalyzer("EcalDQMonitorClient",
+ecalCalibMonitorClient = cms.EDProducer("EcalDQMonitorClient",
     moduleName = cms.untracked.string("EcalCalib Monitor Client"),
     # workers to be turned on
     workers = cms.untracked.vstring(

--- a/DQM/EcalMonitorClient/python/EcalCertification_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalCertification_cfi.py
@@ -4,7 +4,7 @@ from DQM.EcalCommon.CommonParams_cfi import ecalCommonParams
 
 from DQM.EcalMonitorClient.CertificationClient_cfi import ecalCertificationClient
 
-ecalCertification = cms.EDAnalyzer("EcalDQMonitorClient",
+ecalCertification = cms.EDProducer("EcalDQMonitorClient",
     moduleName = cms.untracked.string("Ecal Certification Client"),
     # workers to be turned on
     workers = cms.untracked.vstring(

--- a/DQM/EcalMonitorClient/python/EcalDaqInfoTask_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalDaqInfoTask_cfi.py
@@ -4,7 +4,7 @@ from DQM.EcalCommon.CommonParams_cfi import ecalCommonParams
 
 from DQM.EcalMonitorClient.TowerStatusTask_cfi import ecalTowerStatusTask
 
-ecalDaqInfoTask = cms.EDAnalyzer("EcalDQMonitorClient",
+ecalDaqInfoTask = cms.EDProducer("EcalDQMonitorClient",
     moduleName = cms.untracked.string("Ecal DAQ Monitor"),
     # tasks to be turned on
     workers = cms.untracked.vstring(

--- a/DQM/EcalMonitorClient/python/EcalDcsInfoTask_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalDcsInfoTask_cfi.py
@@ -4,7 +4,7 @@ from DQM.EcalCommon.CommonParams_cfi import ecalCommonParams
 
 from DQM.EcalMonitorClient.TowerStatusTask_cfi import ecalTowerStatusTask
 
-ecalDcsInfoTask = cms.EDAnalyzer("EcalDQMonitorClient",
+ecalDcsInfoTask = cms.EDProducer("EcalDQMonitorClient",
     moduleName = cms.untracked.string("Ecal DCS Monitor"),
     # tasks to be turned on
     workers = cms.untracked.vstring(

--- a/DQM/EcalMonitorClient/python/EcalMonitorClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/EcalMonitorClient_cfi.py
@@ -11,7 +11,7 @@ from DQM.EcalMonitorClient.TimingClient_cfi import ecalTimingClient
 from DQM.EcalMonitorClient.TrigPrimClient_cfi import ecalTrigPrimClient
 from DQM.EcalMonitorClient.SummaryClient_cfi import ecalSummaryClient
 
-ecalMonitorClient = cms.EDAnalyzer("EcalDQMonitorClient",
+ecalMonitorClient = cms.EDProducer("EcalDQMonitorClient",
     moduleName = cms.untracked.string("Ecal Monitor Client"),
     # workers to be turned on
     workers = cms.untracked.vstring(

--- a/DQM/EcalMonitorDbModule/python/EcalCondDBWriter_cfi.py
+++ b/DQM/EcalMonitorDbModule/python/EcalCondDBWriter_cfi.py
@@ -53,7 +53,7 @@ halo = "HALO"
 # run tags are only used if the DAQ failed to write the RunIOV
 # Otherwise existing IOV will be used
 
-ecalCondDBWriter = cms.EDAnalyzer("EcalCondDBWriter",
+ecalCondDBWriter = cms.EDProducer("EcalCondDBWriter",
     DBName = cms.untracked.string(""),
     hostName = cms.untracked.string(""),
     hostPort = cms.untracked.int32(0),

--- a/DQM/EcalPreshowerMonitorClient/python/EcalPreshowerLocalMonitorClient_cfi.py
+++ b/DQM/EcalPreshowerMonitorClient/python/EcalPreshowerLocalMonitorClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalPreshowerLocalMonitorClient = cms.EDAnalyzer('EcalPreshowerMonitorClient',	
+ecalPreshowerLocalMonitorClient = cms.EDProducer('EcalPreshowerMonitorClient',	
                                             LookupTable = cms.untracked.FileInPath('EventFilter/ESDigiToRaw/data/ES_lookup_table.dat'),
                                             enableCleanup = cms.untracked.bool(False),
                                             enabledClients = cms.untracked.vstring('Pedestal'),

--- a/DQM/EcalPreshowerMonitorClient/python/EcalPreshowerMonitorClient_cfi.py
+++ b/DQM/EcalPreshowerMonitorClient/python/EcalPreshowerMonitorClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalPreshowerMonitorClient = cms.EDAnalyzer('EcalPreshowerMonitorClient',	
+ecalPreshowerMonitorClient = cms.EDProducer('EcalPreshowerMonitorClient',	
                                             LookupTable = cms.untracked.FileInPath('EventFilter/ESDigiToRaw/data/ES_lookup_table.dat'),
                                             enabledClients = cms.untracked.vstring('Integrity',
                                                                                    'Summary'

--- a/DQM/HcalTasks/python/HcalOfflineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOfflineHarvesting.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hcalOfflineHarvesting = cms.EDAnalyzer(
+hcalOfflineHarvesting = cms.EDProducer(
 	"HcalOfflineHarvesting",
 
 	name = cms.untracked.string("HcalOfflineHarvesting"),

--- a/DQM/Integration/python/clients/bril_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/bril_dqm_clientPB-live_cfg.py
@@ -29,7 +29,7 @@ if process.dqmRunConfig.type.value() == "production":
 # remove EventInfo
 process.dqmEnv.eventInfoFolder = 'EventInfo/Random'
 
-process.BrilClient = cms.EDAnalyzer("BrilClient")
+process.BrilClient = cms.EDProducer("BrilClient")
 
 process.bril_path = cms.Path(process.BrilClient)
 process.p = cms.EndPath(process.dqmEnv + process.dqmSaver)

--- a/DQM/L1TMonitorClient/python/L1EmulatorErrorFlagClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1EmulatorErrorFlagClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1EmulatorErrorFlagClient = cms.EDAnalyzer("L1EmulatorErrorFlagClient",
+l1EmulatorErrorFlagClient = cms.EDProducer("L1EmulatorErrorFlagClient",
     #
     # for each L1 system, give:
     #     - SystemLabel:  system label

--- a/DQM/L1TMonitorClient/python/L1TCSCTFClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TCSCTFClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tCsctfClient = cms.EDAnalyzer("L1TCSCTFClient",
+l1tCsctfClient = cms.EDProducer("L1TCSCTFClient",
     input_dir = cms.untracked.string('L1T/L1TCSCTF'),
     prescaleLS = cms.untracked.int32(-1),
     verbose = cms.untracked.bool(False),

--- a/DQM/L1TMonitorClient/python/L1TDTTFClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TDTTFClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tDttfClient = cms.EDAnalyzer("L1TDTTFClient",
+l1tDttfClient = cms.EDProducer("L1TDTTFClient",
     l1tSourceFolder = cms.untracked.string('L1T/L1TDTTF'),
     dttfSource = cms.InputTag("l1tDttf"),
     online = cms.untracked.bool(True),

--- a/DQM/L1TMonitorClient/python/L1TDTTPGClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TDTTPGClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tDttpgClient = cms.EDAnalyzer("L1TDTTPGClient",
+l1tDttpgClient = cms.EDProducer("L1TDTTPGClient",
     input_dir = cms.untracked.string('L1T/L1TDTTPG'),
     prescaleLS = cms.untracked.int32(-1),
     output_dir = cms.untracked.string('L1T/L1TDTTPG/Tests'),

--- a/DQM/L1TMonitorClient/python/L1TEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TEventInfoClient_cfi.py
@@ -11,7 +11,7 @@
 
 import FWCore.ParameterSet.Config as cms
 
-l1tEventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
+l1tEventInfoClient = cms.EDProducer("L1TEventInfoClient",
     monitorDir = cms.untracked.string("L1T"),
     
     # decide when to run and update the results of the quality tests

--- a/DQM/L1TMonitorClient/python/L1TGCTClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TGCTClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tGctClient = cms.EDAnalyzer("L1TGCTClient",
+l1tGctClient = cms.EDProducer("L1TGCTClient",
     prescaleLS = cms.untracked.int32(-1),
     monitorDir = cms.untracked.string('L1T/L1TGCT'),
     prescaleEvt = cms.untracked.int32(1),

--- a/DQM/L1TMonitorClient/python/L1TGMTClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TGMTClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tGmtClient = cms.EDAnalyzer("L1TGMTClient",
+l1tGmtClient = cms.EDProducer("L1TGMTClient",
     input_dir = cms.untracked.string('L1T/L1TGMT'),
     monitorName = cms.untracked.string('L1T/L1TGMT'),
     output_dir = cms.untracked.string('L1T/L1TGMT/Client'),

--- a/DQM/L1TMonitorClient/python/L1TOccupancyClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TOccupancyClient_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.L1TMonitorClient.L1TOccupancyTestParameters_cff import *
 
-l1tOccupancyClient = cms.EDAnalyzer("L1TOccupancyClient",
+l1tOccupancyClient = cms.EDProducer("L1TOccupancyClient",
   verbose = cms.bool(False),
   testParams = cms.VPSet(
     #---------------------------------------------

--- a/DQM/L1TMonitorClient/python/L1TRPCTFClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TRPCTFClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tRpctfClient = cms.EDAnalyzer("L1TRPCTFClient",
+l1tRpctfClient = cms.EDProducer("L1TRPCTFClient",
     input_dir = cms.untracked.string('L1T/L1TRPCTF'),
     prescaleEvt = cms.untracked.int32(1),
     verbose = cms.untracked.bool(False),

--- a/DQM/L1TMonitorClient/python/L1TStage1Layer2Client_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage1Layer2Client_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tStage1Layer2Client = cms.EDAnalyzer("L1TGCTClient",
+l1tStage1Layer2Client = cms.EDProducer("L1TGCTClient",
     prescaleLS = cms.untracked.int32(-1),
     monitorDir = cms.untracked.string('L1T/L1TStage1Layer2'),
     prescaleEvt = cms.untracked.int32(1),

--- a/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2CaloLayer2DEClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tStage2CaloLayer2DEClient = cms.EDAnalyzer("L1TStage2CaloLayer2DEClient",
+l1tStage2CaloLayer2DEClient = cms.EDProducer("L1TStage2CaloLayer2DEClient",
                   monitorDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2DERatio'),
                   inputDataDir = cms.untracked.string('L1T/L1TStage2CaloLayer2'),
                   inputEmulDir = cms.untracked.string('L1TEMU/L1TStage2CaloLayer2EMU')

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -11,7 +11,7 @@
 
 import FWCore.ParameterSet.Config as cms
 
-l1tStage2EventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
+l1tStage2EventInfoClient = cms.EDProducer("L1TEventInfoClient",
     monitorDir = cms.untracked.string("L1T"),
 
     # decide when to run and update the results of the quality tests

--- a/DQM/L1TMonitorClient/python/L1TTestsSummary_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TTestsSummary_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tTestsSummary = cms.EDAnalyzer("L1TTestsSummary",
+l1tTestsSummary = cms.EDProducer("L1TTestsSummary",
   verbose = cms.untracked.bool(False),
   MonitorL1TRate      = cms.untracked.bool(True),
   MonitorL1TSync      = cms.untracked.bool(True),

--- a/DQM/RPCMonitorClient/python/RPCChamberQuality_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCChamberQuality_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcChamberQuality = cms.EDAnalyzer("RPCChamberQuality",
+rpcChamberQuality = cms.EDProducer("RPCChamberQuality",
                                    OfflineDQM = cms.untracked.bool(True),
                                    PrescaleFactor  = cms.untracked.int32(5),
                                    NumberOfEndcapDisks  = cms.untracked.int32(4),
@@ -9,7 +9,7 @@ rpcChamberQuality = cms.EDAnalyzer("RPCChamberQuality",
                                    )
 
 
-rpcMuonChamberQuality = cms.EDAnalyzer("RPCChamberQuality",
+rpcMuonChamberQuality = cms.EDProducer("RPCChamberQuality",
                                        OfflineDQM = cms.untracked.bool(True),
                                        PrescaleFactor  = cms.untracked.int32(5),
                                        NumberOfEndcapDisks  = cms.untracked.int32(4),

--- a/DQM/RPCMonitorClient/python/RPCDCSSummary_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCDCSSummary_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcDCSSummary = cms.EDAnalyzer("RPCDCSSummary", 
+rpcDCSSummary = cms.EDProducer("RPCDCSSummary", 
                                NumberOfEndcapDisks  = cms.untracked.int32(4),
                                )

--- a/DQM/RPCMonitorClient/python/RPCDaqInfo_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCDaqInfo_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcDaqInfo = cms.EDAnalyzer("RPCDaqInfo",
+rpcDaqInfo = cms.EDProducer("RPCDaqInfo",
                             NumberOfEndcapDisks  = cms.untracked.int32(4)
                             )
 

--- a/DQM/RPCMonitorClient/python/RPCDataCertification_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCDataCertification_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcDataCertification = cms.EDAnalyzer("RPCDataCertification",
+rpcDataCertification = cms.EDProducer("RPCDataCertification",
                                       NumberOfEndcapDisks  = cms.untracked.int32(4)
                                       )
 

--- a/DQM/RPCMonitorClient/python/RPCDcsInfoClient_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCDcsInfoClient_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcDcsInfoClient = cms.EDAnalyzer("RPCDcsInfoClient",
+rpcDcsInfoClient = cms.EDProducer("RPCDcsInfoClient",
                                   dcsInfoFolder = cms.untracked.string("RPC/DCSInfo")
                                   )

--- a/DQM/RPCMonitorClient/python/RPCDqmClient_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCDqmClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcdqmclient = cms.EDAnalyzer("RPCDqmClient",                               
+rpcdqmclient = cms.EDProducer("RPCDqmClient",                               
                               RPCDqmClientList = cms.untracked.vstring("RPCMultiplicityTest", "RPCDeadChannelTest", "RPCClusterSizeTest", "RPCOccupancyTest","RPCNoisyStripTest"),
                               DiagnosticPrescale = cms.untracked.int32(5),
                               MinimumRPCEvents  = cms.untracked.int32(10000),
@@ -13,7 +13,7 @@ rpcdqmclient = cms.EDAnalyzer("RPCDqmClient",
                               )
 
 
-rpcdqmMuonclient = cms.EDAnalyzer("RPCDqmClient",                               
+rpcdqmMuonclient = cms.EDProducer("RPCDqmClient",                               
                                   RPCDqmClientList = cms.untracked.vstring("RPCMultiplicityTest", "RPCDeadChannelTest", "RPCClusterSizeTest", "RPCOccupancyTest","RPCNoisyStripTest"),
                                   DiagnosticPrescale = cms.untracked.int32(5),
                                   MinimumRPCEvents  = cms.untracked.int32(10000),

--- a/DQM/RPCMonitorClient/python/RPCEfficiencyPerRingLayer_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCEfficiencyPerRingLayer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcEfficiencyPerRingLayer = cms.EDAnalyzer("RPCEfficiencyPerRingLayer",
+rpcEfficiencyPerRingLayer = cms.EDProducer("RPCEfficiencyPerRingLayer",
                                            GlobalFolder = cms.untracked.string('RPC/RPCEfficiency/'),
                                            NumberOfEndcapDisks  = cms.untracked.int32(4),
                                            NumberOfInnermostEndcapRings  = cms.untracked.int32(2)

--- a/DQM/RPCMonitorClient/python/RPCEfficiencySecondStep_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCEfficiencySecondStep_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcEfficiencySecond = cms.EDAnalyzer("RPCEfficiencySecond",
+rpcEfficiencySecond = cms.EDProducer("RPCEfficiencySecond",
     SaveFile = cms.untracked.bool(False),
     NameFile = cms.untracked.string('/tmp/carrillo/RPCEfficiency.root'),
     debug = cms.untracked.bool(False),

--- a/DQM/RPCMonitorClient/python/RPCEfficiencyShiftHisto_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCEfficiencyShiftHisto_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcEfficiencyShiftHisto = cms.EDAnalyzer("RPCEfficiencyShiftHisto",
+rpcEfficiencyShiftHisto = cms.EDProducer("RPCEfficiencyShiftHisto",
    EffCut = cms.untracked.int32(90),
    GlobalFolder = cms.untracked.string('RPC/RPCEfficiency/'),
    NumberOfEndcapDisks = cms.untracked.int32(4)

--- a/DQM/RPCMonitorClient/python/RPCEventSummary_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCEventSummary_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcEventSummary = cms.EDAnalyzer("RPCEventSummary",
+rpcEventSummary = cms.EDProducer("RPCEventSummary",
                                  EventInfoPath = cms.untracked.string('RPC/EventInfo'),
                                  PrescaleFactor = cms.untracked.int32(5),
                                  MinimumRPCEvents = cms.untracked.int32(10000),

--- a/DQM/RPCMonitorClient/python/RPCRecHitProbabilityClient_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCRecHitProbabilityClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcrechitprobabilityclient = cms.EDAnalyzer("RPCRecHitProbabilityClient",
+rpcrechitprobabilityclient = cms.EDProducer("RPCRecHitProbabilityClient",
                                             RPCFolder = cms.untracked.string("RPC"),
                                             GlobalFolder = cms.untracked.string("SummaryHistograms/RecHits"),
                                             MuonFolder = cms.untracked.string("Muon")

--- a/DQM/RPCMonitorClient/python/RPCResidualsHLTClient_cfi.py
+++ b/DQM/RPCMonitorClient/python/RPCResidualsHLTClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-rpcGlobalEfficiencyHLT = cms.EDAnalyzer("RPCEfficiencySecond",
+rpcGlobalEfficiencyHLT = cms.EDProducer("RPCEfficiencySecond",
     SaveFile = cms.untracked.bool(False),
     debug = cms.untracked.bool(False),
     barrel = cms.untracked.bool(True),

--- a/DQM/RPCMonitorClient/python/RPC_Client_on_RootFile.py
+++ b/DQM/RPCMonitorClient/python/RPC_Client_on_RootFile.py
@@ -57,7 +57,7 @@ process.qTesterRPC = cms.EDAnalyzer("QualityTester",
 
 
 ################# Open Root file and provide MEs ############
-process.ReadMeFromFile = cms.EDAnalyzer("ReadMeFromFile",
+process.ReadMeFromFile = cms.EDProducer("ReadMeFromFile",
 #InputFile = cms.untracked.string('/afs/cern.ch/user/d/dlomidze/scratch0/CMSSW_3_0_0_pre3/src/DQM/RPCMonitorClient/python/DQM_V0001_RPC_R000069800.root')
 InputFile = cms.untracked.string('rfio:/castor/cern.ch/user/d/dlomidze/RPC/GlobalRuns/CosmicsCommissioning08-PromptReco-v2RECO/70664/root/Merge_tot.root')
 #InputFile = cms.untracked.string('rfio:/castor/cern.ch/user/d/dlomidze/DQM_150.000_RPCEvents.root')                                       
@@ -67,14 +67,14 @@ InputFile = cms.untracked.string('rfio:/castor/cern.ch/user/d/dlomidze/RPC/Globa
 
 
 ################# RPC Client Modules #######################
-process.RPCDeadChannelTest = cms.EDAnalyzer("RPCDeadChannelTest")
-process.RPCOccupancyTest = cms.EDAnalyzer("RPCOccupancyTest")
-process.RPCClusterSizeTest = cms.EDAnalyzer("RPCClusterSizeTest")
-process.RPCChamberQuality = cms.EDAnalyzer("RPCChamberQuality")
-#process.RPCDCSDataSimulator = cms.EDAnalyzer("RPCDCSDataSimulator")
-process.RPCMultiplicityTest = cms.EDAnalyzer("RPCMultiplicityTest")
-process.RPCOccupancyChipTest = cms.EDAnalyzer("RPCOccupancyChipTest");
-process.RPCNoisyStripTest = cms.EDAnalyzer("RPCNoisyStripTest");
+process.RPCDeadChannelTest = cms.EDProducer("RPCDeadChannelTest")
+process.RPCOccupancyTest = cms.EDProducer("RPCOccupancyTest")
+process.RPCClusterSizeTest = cms.EDProducer("RPCClusterSizeTest")
+process.RPCChamberQuality = cms.EDProducer("RPCChamberQuality")
+#process.RPCDCSDataSimulator = cms.EDProducer("RPCDCSDataSimulator")
+process.RPCMultiplicityTest = cms.EDProducer("RPCMultiplicityTest")
+process.RPCOccupancyChipTest = cms.EDProducer("RPCOccupancyChipTest");
+process.RPCNoisyStripTest = cms.EDProducer("RPCNoisyStripTest");
 
 #process.p = cms.Path(process.ReadMeFromFile*process.qTesterRPC*process.RPCClusterSizeTest*process.RPCDeadChannelTest*process.RPCOccupancyTest*process.RPCDCSDataSimulator*process.RPCMultiplicityTest*process.RPCChamberQuality*process.dqmSaver)
 

--- a/DQM/RPCMonitorClient/test/rpcefficiencySecondHLT_cfg.py
+++ b/DQM/RPCMonitorClient/test/rpcefficiencySecondHLT_cfg.py
@@ -24,7 +24,7 @@ process.source = cms.Source("PoolSource",
 
 process.MessageLogger = cms.Service("MessageLogger")
 
-process.second = cms.EDAnalyzer("RPCEfficiencySecond",
+process.second = cms.EDProducer("RPCEfficiencySecond",
     debug = cms.untracked.bool(False),
     barrel = cms.untracked.bool(True),
     endcap = cms.untracked.bool(True),

--- a/DQM/RPCMonitorClient/test/rpcefficiencySecond_cfg.py
+++ b/DQM/RPCMonitorClient/test/rpcefficiencySecond_cfg.py
@@ -16,7 +16,7 @@ process.source = cms.Source("PoolSource",
 
 process.MessageLogger = cms.Service("MessageLogger")
 
-process.rpcEfficiencySecond = cms.EDAnalyzer("RPCEfficiencySecond",
+process.rpcEfficiencySecond = cms.EDProducer("RPCEfficiencySecond",
     SaveFile = cms.untracked.bool(True),
     NameFile = cms.untracked.string('/tmp/cimmino/RPCEfficiency.root'),
     debug = cms.untracked.bool(False),

--- a/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelOfflineDQM_client_cff.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 #
 
 #Client:
-sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     EventOffsetForInit = cms.untracked.int32(10),
     ActionOnLumiSection = cms.untracked.bool(False),
     ActionOnRunEnd = cms.untracked.bool(True),
@@ -33,9 +33,9 @@ sipixelQTesterHI = sipixelQTester.clone(
 )
 
 #DataCertification:
-sipixelDaqInfo = cms.EDAnalyzer("SiPixelDaqInfo")
-sipixelDcsInfo = cms.EDAnalyzer("SiPixelDcsInfo")
-sipixelCertification = cms.EDAnalyzer("SiPixelCertification")
+sipixelDaqInfo = cms.EDProducer("SiPixelDaqInfo")
+sipixelDcsInfo = cms.EDProducer("SiPixelDcsInfo")
+sipixelCertification = cms.EDProducer("SiPixelCertification")
 
 #Predefined Sequences:
 PixelOfflineDQMClient = cms.Sequence(sipixelEDAClient)

--- a/DQM/SiPixelCommon/python/SiPixelP5DQM_client_cff.py
+++ b/DQM/SiPixelCommon/python/SiPixelP5DQM_client_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #Client:
-sipixelEDAClientP5 = cms.EDAnalyzer("SiPixelEDAClient",
+sipixelEDAClientP5 = cms.EDProducer("SiPixelEDAClient",
     EventOffsetForInit = cms.untracked.int32(10),
     ActionOnLumiSection = cms.untracked.bool(True), ## do not set to False, otherwise Summary histos not filled!
     ActionOnRunEnd = cms.untracked.bool(True),
@@ -14,9 +14,9 @@ sipixelEDAClientP5 = cms.EDAnalyzer("SiPixelEDAClient",
 )
 
 #DataCertification:
-sipixelDaqInfo = cms.EDAnalyzer("SiPixelDaqInfo")
-sipixelDcsInfo = cms.EDAnalyzer("SiPixelDcsInfo")
-sipixelCertification = cms.EDAnalyzer("SiPixelCertification")
+sipixelDaqInfo = cms.EDProducer("SiPixelDaqInfo")
+sipixelDcsInfo = cms.EDProducer("SiPixelDcsInfo")
+sipixelCertification = cms.EDProducer("SiPixelCertification")
 
 #Predefined Sequences:
 PixelP5DQMClient = cms.Sequence(sipixelEDAClientP5)

--- a/DQM/SiPixelCommon/python/reco_calib_source_client_cfg.py
+++ b/DQM/SiPixelCommon/python/reco_calib_source_client_cfg.py
@@ -47,7 +47,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.AdaptorConfig = cms.Service("AdaptorConfig")
 
-process.sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+process.sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     StaticUpdateFrequency = cms.untracked.int32(10),
     OutputFilePath = cms.untracked.string('.'),
 )

--- a/DQM/SiPixelCommon/test/client_template_calib_cfg.py
+++ b/DQM/SiPixelCommon/test/client_template_calib_cfg.py
@@ -118,7 +118,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.AdaptorConfig = cms.Service("AdaptorConfig")
 
-process.sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+process.sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     EventOffsetForInit = cms.untracked.int32(10),
     ActionOnLumiSection = cms.untracked.bool(False),
     ActionOnRunEnd = cms.untracked.bool(True),

--- a/DQM/SiPixelCommon/test/client_template_cfg.py
+++ b/DQM/SiPixelCommon/test/client_template_cfg.py
@@ -81,7 +81,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 process.AdaptorConfig = cms.Service("AdaptorConfig")
 
 # DQM modules:
-process.sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+process.sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     FileSaveFrequency = cms.untracked.int32(50),
     StaticUpdateFrequency = cms.untracked.int32(10)
 )

--- a/DQM/SiPixelCommon/test/client_template_physics_cfg.py
+++ b/DQM/SiPixelCommon/test/client_template_physics_cfg.py
@@ -103,7 +103,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.AdaptorConfig = cms.Service("AdaptorConfig")
 
-process.sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+process.sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     EventOffsetForInit = cms.untracked.int32(10),
     ActionOnLumiSection = cms.untracked.bool(False),
     ActionOnRunEnd = cms.untracked.bool(True),

--- a/DQM/SiPixelCommon/test/pixel_reco_dqm_cfg.py
+++ b/DQM/SiPixelCommon/test/pixel_reco_dqm_cfg.py
@@ -62,7 +62,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.AdaptorConfig = cms.Service("AdaptorConfig")
 
-process.sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+process.sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     FileSaveFrequency = cms.untracked.int32(50),
     StaticUpdateFrequency = cms.untracked.int32(10)
 )

--- a/DQM/SiPixelCommon/test/reco_calib_source_client_cfg.py
+++ b/DQM/SiPixelCommon/test/reco_calib_source_client_cfg.py
@@ -47,7 +47,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.AdaptorConfig = cms.Service("AdaptorConfig")
 
-process.sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+process.sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     StaticUpdateFrequency = cms.untracked.int32(10),
     OutputFilePath = cms.untracked.string('.'),
 )

--- a/DQM/SiPixelMonitorClient/python/pixel_dqm_sourceclient-file_cfg.py
+++ b/DQM/SiPixelMonitorClient/python/pixel_dqm_sourceclient-file_cfg.py
@@ -55,7 +55,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.AdaptorConfig = cms.Service("AdaptorConfig")
 
-process.sipixelEDAClient = cms.EDAnalyzer("SiPixelEDAClient",
+process.sipixelEDAClient = cms.EDProducer("SiPixelEDAClient",
     FileSaveFrequency = cms.untracked.int32(50),
     StaticUpdateFrequency = cms.untracked.int32(10)
 )

--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -264,7 +264,7 @@ SiPixelPhase1ClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1Clusters",
         triggerflag = SiPixelPhase1ClustersTriggers,
 )
 
-SiPixelPhase1ClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1ClustersHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1ClustersConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1Common/README.md
+++ b/DQM/SiPixelPhase1Common/README.md
@@ -128,7 +128,7 @@ The `VPSet` alone will not do anything. Add it to the configuration of your plug
             histograms = SiPixelPhase1DigisConf,
             geometry = SiPixelPhase1Geometry
     )
-    SiPixelPhase1DigisHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+    SiPixelPhase1DigisHarvester = cms.EDProducer("SiPixelPhase1Harvester",
             histograms = SiPixelPhase1DigisConf,
             geometry = SiPixelPhase1Geometry
     )

--- a/DQM/SiPixelPhase1Common/python/SiPixelPhase1GeometryDebug_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/SiPixelPhase1GeometryDebug_cfi.py
@@ -69,7 +69,7 @@ SiPixelPhase1GeometryDebugAnalyzer = cms.EDAnalyzer("SiPixelPhase1GeometryDebug"
     geometry = SiPixelPhase1Geometry
 )
 
-SiPixelPhase1GeometryDebugHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1GeometryDebugHarvester = cms.EDProducer("SiPixelPhase1Harvester",
     histograms = SiPixelPhase1GeometryDebugConf,
     geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -184,7 +184,7 @@ SiPixelPhase1DigisAnalyzer = cms.EDAnalyzer("SiPixelPhase1Digis",
         geometry = SiPixelPhase1Geometry
 )
 
-SiPixelPhase1DigisHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1DigisHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1DigisConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
+++ b/DQM/SiPixelPhase1RawData/python/SiPixelPhase1RawData_cfi.py
@@ -97,7 +97,7 @@ SiPixelPhase1RawDataAnalyzer = cms.EDAnalyzer("SiPixelPhase1RawData",
         geometry = SiPixelPhase1Geometry
 )
 
-SiPixelPhase1RawDataHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1RawDataHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1RawDataConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -97,7 +97,7 @@ SiPixelPhase1RecHitsAnalyzer = cms.EDAnalyzer("SiPixelPhase1RecHits",
 
 )
 
-SiPixelPhase1RecHitsHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1RecHitsHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1RecHitsConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
+++ b/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # This object is used to make changes for different running scenarios
 #
 
-SiPixelPhase1Summary_Online = cms.EDAnalyzer("SiPixelPhase1Summary",
+SiPixelPhase1Summary_Online = cms.EDProducer("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(True),
     RunOnEndJob = cms.bool(True),
@@ -36,7 +36,7 @@ SiPixelPhase1Summary_Online = cms.EDAnalyzer("SiPixelPhase1Summary",
         )
 )
 
-SiPixelPhase1Summary_Offline = cms.EDAnalyzer("SiPixelPhase1Summary",
+SiPixelPhase1Summary_Offline = cms.EDProducer("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(False),
     RunOnEndJob = cms.bool(True),
@@ -68,7 +68,7 @@ SiPixelPhase1Summary_Offline = cms.EDAnalyzer("SiPixelPhase1Summary",
         )
 )
 
-SiPixelPhase1Summary_Cosmics = cms.EDAnalyzer("SiPixelPhase1Summary",
+SiPixelPhase1Summary_Cosmics = cms.EDProducer("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(False),
     RunOnEndJob = cms.bool(True),

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -164,7 +164,7 @@ SiPixelPhase1TrackClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackClusters"
         geometry = SiPixelPhase1Geometry
 )
 
-SiPixelPhase1TrackClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1TrackClustersHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1TrackClustersConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
+++ b/DQM/SiPixelPhase1TrackEfficiency/python/SiPixelPhase1TrackEfficiency_cfi.py
@@ -91,7 +91,7 @@ SiPixelPhase1TrackEfficiencyAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackEfficie
         geometry = SiPixelPhase1Geometry
 )
 
-SiPixelPhase1TrackEfficiencyHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1TrackEfficiencyHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1TrackEfficiencyConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -32,7 +32,7 @@ SiPixelPhase1TrackResidualsAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackResidual
         geometry = SiPixelPhase1Geometry
 )
 
-SiPixelPhase1TrackResidualsHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+SiPixelPhase1TrackResidualsHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = SiPixelPhase1TrackResidualsConf,
         geometry = SiPixelPhase1Geometry
 )

--- a/DQM/TrackingMonitor/python/TrackEfficiencyClient_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackEfficiencyClient_cfi.py
@@ -5,7 +5,7 @@
 
 import FWCore.ParameterSet.Config as cms
 
-TrackEffClient = cms.EDAnalyzer("TrackEfficiencyClient",
+TrackEffClient = cms.EDProducer("TrackEfficiencyClient",
   
     FolderName = cms.string('Track/Efficiencies'),
     AlgoName = cms.string('CTF'),

--- a/DQM/TrackingMonitorClient/python/DQMScaleToClient_cfi.py
+++ b/DQM/TrackingMonitorClient/python/DQMScaleToClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-dqmScaleToClient = cms.EDAnalyzer('DQMScaleToClient',
+dqmScaleToClient = cms.EDProducer('DQMScaleToClient',
   outputme = cms.PSet(
     folder = cms.string(''),
     name = cms.string(''),

--- a/DQM/TrackingMonitorClient/python/TrackingCertification_cfi.py
+++ b/DQM/TrackingMonitorClient/python/TrackingCertification_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-trackingCertificationInfo = cms.EDAnalyzer("TrackingCertificationInfo",
+trackingCertificationInfo = cms.EDProducer("TrackingCertificationInfo",
     TopFolderName = cms.untracked.string("Tracking"),
     checkPixelFEDs = cms.bool(False),
     TrackingGlobalQualityPSets = cms.VPSet(

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfigP5_Cosmic_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfigP5_Cosmic_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #  TrackingMonitorAnalyser ####
-TrackingAnalyserCosmic = cms.EDAnalyzer("TrackingAnalyser",
+TrackingAnalyserCosmic = cms.EDProducer("TrackingAnalyser",
     nFEDinfoDir              = cms.string("SiStrip/FEDIntegrity_SM"),                                   
     nFEDinVsLSname           = cms.string("nFEDinVsLS"),
     nFEDinWdataVsLSname      = cms.string("nFEDinWdataVsLS"),

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfigP5_HeavyIons_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfigP5_HeavyIons_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 #from DQM.TrackingMonitorSummary.OnDemandMonitoring_cfi import *
 #  TrackingMonitorAnalyser ####
-TrackingAnalyserHI = cms.EDAnalyzer("TrackingAnalyser",
+TrackingAnalyserHI = cms.EDProducer("TrackingAnalyser",
     nFEDinfoDir              = cms.string("SiStrip/FEDIntegrity_SM"),                                   
     nFEDinVsLSname           = cms.string("nFEDinVsLS"),
     nFEDinWdataVsLSname      = cms.string("nFEDinWdataVsLS"),

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfigP5_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfigP5_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 #from DQM.TrackingMonitorSummary.OnDemandMonitoring_cfi import *
 #  TrackingMonitorAnalyser ####
-TrackingAnalyser = cms.EDAnalyzer("TrackingAnalyser",
+TrackingAnalyser = cms.EDProducer("TrackingAnalyser",
     nFEDinfoDir              = cms.string("SiStrip/FEDIntegrity_SM"),                                   
     nFEDinVsLSname           = cms.string("nFEDinVsLS"),
     nFEDinWdataVsLSname      = cms.string("nFEDinWdataVsLS"),

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_Cosmic_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #  TrackingOfflineDQM (for Tier0 Harvesting Step) ####
-trackingOfflineAnalyser = cms.EDAnalyzer("TrackingOfflineDQM",
+trackingOfflineAnalyser = cms.EDProducer("TrackingOfflineDQM",
     GlobalStatusFilling        = cms.untracked.int32(2),
     UsedWithEDMtoMEConverter   = cms.untracked.bool(True),
     TopFolderName              = cms.untracked.string("Tracking"),                                     

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_HeavyIons_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_HeavyIons_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #  TrackingOfflineDQM (for Tier0 Harvesting Step) ####
-trackingOfflineAnalyser = cms.EDAnalyzer("TrackingOfflineDQM",
+trackingOfflineAnalyser = cms.EDProducer("TrackingOfflineDQM",
     GlobalStatusFilling      = cms.untracked.int32(2),
     UsedWithEDMtoMEConverter = cms.untracked.bool(True),
     TrackRatePSet            = cms.PSet(

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #  TrackingOfflineDQM (for Tier0 Harvesting Step) ####
-trackingOfflineAnalyser = cms.EDAnalyzer("TrackingOfflineDQM",
+trackingOfflineAnalyser = cms.EDProducer("TrackingOfflineDQM",
     GlobalStatusFilling        = cms.untracked.int32(2),
     UsedWithEDMtoMEConverter   = cms.untracked.bool(True),
     TopFolderName              = cms.untracked.string("Tracking"),                                     

--- a/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
+++ b/DQM/TrackingMonitorClient/python/TrackingDQMClientHeavyIons_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-hiTrackingDqmClientHeavyIons = cms.EDAnalyzer("TrackingDQMClientHeavyIons",
+hiTrackingDqmClientHeavyIons = cms.EDProducer("TrackingDQMClientHeavyIons",
                                               FolderName = cms.string('Tracking/TrackParameters/GeneralProperties')
                                               )

--- a/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfig_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingEffFromHitPatternClientConfig_cff.py
@@ -43,7 +43,7 @@ def _layers(suffix, quant, histoPostfix):
         "effic_vs_{0}_TEC9  'TEC Layer9 Efficiency vs {1}'  Hits{2}_valid_TEC_Subdet9  Hits{2}_total_TEC_Subdet9" .format(suffix, quant, histoPostfix),
     ]
 
-trackingEffFromHitPattern = cms.EDAnalyzer("DQMGenericClient",
+trackingEffFromHitPattern = cms.EDProducer("DQMGenericClient",
                                            subDirs = cms.untracked.vstring(
         "Tracking/TrackParameters/generalTracks/HitEffFromHitPattern*",
         "Tracking/TrackParameters/highPurityTracks/pt_1/HitEffFromHitPattern*",

--- a/DQMOffline/Alignment/python/muonAlignmentSummary_cfi.py
+++ b/DQMOffline/Alignment/python/muonAlignmentSummary_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 # MuonAlignmentAnalyzer
-muonAlignmentSummary = cms.EDAnalyzer("MuonAlignmentSummary",
+muonAlignmentSummary = cms.EDProducer("MuonAlignmentSummary",
     doDT = cms.untracked.bool(True),
     doCSC = cms.untracked.bool(True),
     meanPositionRange = cms.untracked.double(0.5),

--- a/DQMOffline/CalibCalo/python/PostProcessorHcalIsoTrack_cfi.py
+++ b/DQMOffline/CalibCalo/python/PostProcessorHcalIsoTrack_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-PostProcessorHcalIsoTrack = cms.EDAnalyzer("DQMHcalIsoTrackPostProcessor",
+PostProcessorHcalIsoTrack = cms.EDProducer("DQMHcalIsoTrackPostProcessor",
      subDir = cms.untracked.string("AlCaReco/HcalIsoTrack"),
 )

--- a/DQMOffline/EGamma/python/electronOfflineClient_cfi.py
+++ b/DQMOffline/EGamma/python/electronOfflineClient_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.EGamma.photonAnalyzer_cfi import *
 
 
-dqmElectronOfflineClient = cms.EDAnalyzer("ElectronOfflineClient",
+dqmElectronOfflineClient = cms.EDProducer("ElectronOfflineClient",
 
     Verbosity = cms.untracked.int32(0),
     FinalStep = cms.string("AtJobEnd"),

--- a/DQMOffline/EGamma/python/photonDataCertification_cfi.py
+++ b/DQMOffline/EGamma/python/photonDataCertification_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 
 ################# Photon Certification #########################
-photonDataCertification = cms.EDAnalyzer("PhotonDataCertification",
+photonDataCertification = cms.EDProducer("PhotonDataCertification",
                               verbose = cms.bool(False)
                                          )

--- a/DQMOffline/EGamma/python/photonOfflineClient_cfi.py
+++ b/DQMOffline/EGamma/python/photonOfflineClient_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.EGamma.photonAnalyzer_cfi import *
 
 
-photonOfflineClient = cms.EDAnalyzer("PhotonOfflineClient",
+photonOfflineClient = cms.EDProducer("PhotonOfflineClient",
 
     ComponentName = cms.string('photonOfflineClient'),
     analyzerName = cms.string('gedPhotonAnalyzer'),

--- a/DQMOffline/Ecal/python/EcalZmassClient_cfi.py
+++ b/DQMOffline/Ecal/python/EcalZmassClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-ecalzmassclient = cms.EDAnalyzer('EcalZmassClient',
+ecalzmassclient = cms.EDProducer('EcalZmassClient',
       prefixME = cms.untracked.string('EcalCalibration')
 
 )

--- a/DQMOffline/Hcal/python/CaloTowersDQMClient_cfi.py
+++ b/DQMOffline/Hcal/python/CaloTowersDQMClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-calotowersDQMClient = cms.EDAnalyzer("CaloTowersDQMClient",
+calotowersDQMClient = cms.EDProducer("CaloTowersDQMClient",
 #     outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory

--- a/DQMOffline/Hcal/python/HcalNoiseRatesClient_cfi.py
+++ b/DQMOffline/Hcal/python/HcalNoiseRatesClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hcalNoiseRatesClient = cms.EDAnalyzer("HcalNoiseRatesClient", 
+hcalNoiseRatesClient = cms.EDProducer("HcalNoiseRatesClient", 
 #     outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory

--- a/DQMOffline/Hcal/python/HcalRecHitsDQMClient_cfi.py
+++ b/DQMOffline/Hcal/python/HcalRecHitsDQMClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hcalRecHitsDQMClient = cms.EDAnalyzer("HcalRecHitsDQMClient", 
+hcalRecHitsDQMClient = cms.EDProducer("HcalRecHitsDQMClient", 
 #     outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory

--- a/DQMOffline/JetMET/python/SusyPostProcessor_cff.py
+++ b/DQMOffline/JetMET/python/SusyPostProcessor_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 
-SusyPostProcessor = cms.EDAnalyzer("SusyPostProcessor",
+SusyPostProcessor = cms.EDProducer("SusyPostProcessor",
                                    folderName = cms.string("JetMET/SUSYDQM/"),
                                    quantile = cms.double(0.05)
                                    )

--- a/DQMOffline/JetMET/python/dataCertificationJetMET_cfi.py
+++ b/DQMOffline/JetMET/python/dataCertificationJetMET_cfi.py
@@ -17,7 +17,7 @@ qTesterMET = cms.EDAnalyzer("QualityTester",
  )
 
 ################# Data Certification #########################
-dataCertificationJetMET = cms.EDAnalyzer('DataCertificationJetMET',
+dataCertificationJetMET = cms.EDProducer('DataCertificationJetMET',
                               fileName       = cms.untracked.string(""),
                               refFileName    = cms.untracked.string(""),
                               OutputFile     = cms.untracked.bool(False),

--- a/DQMOffline/JetMET/test/cruzet09_CRT.py
+++ b/DQMOffline/JetMET/test/cruzet09_CRT.py
@@ -59,7 +59,7 @@ process.dqmInfoJetMET = cms.EDAnalyzer("DQMEventInfo",
 # JetMET Certification Module 
 #-----------------------------
 process.load("DQMOffline.JetMET.dataCertificationJetMET_cff")
-process.dataCertificationJetMET = cms.EDAnalyzer('DataCertificationJetMET',
+process.dataCertificationJetMET = cms.EDProducer('DataCertificationJetMET',
 #
 #--- Always define reference root file by process.DQMStore.referenceFileName
                               refFileName    = cms.untracked.string(""),

--- a/DQMOffline/JetMET/test/cruzet09_CRT_fromDQMRootFile.py
+++ b/DQMOffline/JetMET/test/cruzet09_CRT_fromDQMRootFile.py
@@ -47,7 +47,7 @@ process.dqmInfoJetMET = cms.EDAnalyzer("DQMEventInfo",
 # JetMET Certification Module 
 #-----------------------------
 process.load("DQMOffline.JetMET.dataCertificationJetMET_cff")
-process.dataCertificationJetMET = cms.EDAnalyzer('DataCertificationJetMET',
+process.dataCertificationJetMET = cms.EDProducer('DataCertificationJetMET',
 #
 #--- Always define reference root file by process.DQMStore.referenceFileName
                               refFileName    = cms.untracked.string(""),

--- a/DQMOffline/JetMET/test/cruzet09_PromptAna_CRT.py
+++ b/DQMOffline/JetMET/test/cruzet09_PromptAna_CRT.py
@@ -57,7 +57,7 @@ process.dqmInfoJetMET = cms.EDAnalyzer("DQMEventInfo",
 # JetMET Certification Module 
 #-----------------------------
 process.load("DQMOffline.JetMET.dataCertificationJetMET_cff")
-process.dataCertificationJetMET = cms.EDAnalyzer('DataCertificationJetMET',
+process.dataCertificationJetMET = cms.EDProducer('DataCertificationJetMET',
 #
 #--- Always define reference root file by process.DQMStore.referenceFileName
                               refFileName    = cms.untracked.string(""),

--- a/DQMOffline/JetMET/test/datacertificationjetmet_cfg.py
+++ b/DQMOffline/JetMET/test/datacertificationjetmet_cfg.py
@@ -21,7 +21,7 @@ process.dqmInfoJetMET = cms.EDAnalyzer("DQMEventInfo",
                                      )
 
 process.load("DQMOffline.JetMET.dataCertificationJetMET_cfi")
-process.dataCertificationJetMET = cms.EDAnalyzer('DataCertificationJetMET',
+process.dataCertificationJetMET = cms.EDProducer('DataCertificationJetMET',
                               fileName       = cms.untracked.string("/uscms_data/d1/hatake/DQM-data/DQM_V0001_R000066594__Cosmics__Commissioning08-PromptReco-v2__RECO.root"),
                               refFileName    = cms.untracked.string("/uscms_data/d1/hatake/DQM-data/DQM_V0001_R000066714__Cosmics__Commissioning08-PromptReco-v2__RECO.root"),
                               OutputFile     = cms.untracked.bool(False),

--- a/DQMOffline/L1Trigger/python/L1TDiffHarvesting_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TDiffHarvesting_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tDiffHarvesting = cms.EDAnalyzer(
+l1tDiffHarvesting = cms.EDProducer(
     "L1TDiffHarvesting",
     verbose=cms.untracked.bool(False),
     plotCfgs=cms.untracked.VPSet(

--- a/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting2_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting2_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tEfficiencyHarvesting = cms.EDAnalyzer(
+l1tEfficiencyHarvesting = cms.EDProducer(
     "L1TEfficiencyHarvesting",
     verbose=cms.untracked.bool(False),
     plotCfgs=cms.untracked.VPSet(

--- a/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-l1tEfficiencyMuons_Harvesting = cms.EDAnalyzer("L1TEfficiency_Harvesting",
+l1tEfficiencyMuons_Harvesting = cms.EDProducer("L1TEfficiency_Harvesting",
     verbose  = cms.untracked.bool(False),
     plotCfgs = cms.untracked.VPSet(
         cms.untracked.PSet( dqmBaseDir = cms.untracked.string("L1T/Efficiency/Muons"),

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-effPlotter_Loose = cms.EDAnalyzer("EfficiencyPlotter",
+effPlotter_Loose = cms.EDProducer("EfficiencyPlotter",
                                   folder = cms.string("Muons/EfficiencyAnalyzer"),
                                   phiMin = cms.double(-3.2),
                                   etaMin = cms.double(-2.5),
@@ -18,7 +18,7 @@ effPlotter_Loose = cms.EDAnalyzer("EfficiencyPlotter",
                                   )
 
 
-effPlotter_Medium = cms.EDAnalyzer("EfficiencyPlotter",
+effPlotter_Medium = cms.EDProducer("EfficiencyPlotter",
                                    folder = cms.string("Muons/EfficiencyAnalyzer"),
                                    phiMin = cms.double(-3.2),
                                    etaMin = cms.double(-2.5),
@@ -36,7 +36,7 @@ effPlotter_Medium = cms.EDAnalyzer("EfficiencyPlotter",
                                    )
 
 
-effPlotter_Tight = cms.EDAnalyzer("EfficiencyPlotter",
+effPlotter_Tight = cms.EDProducer("EfficiencyPlotter",
                                   folder = cms.string("Muons/EfficiencyAnalyzer"),
                                   phiMin = cms.double(-3.2),
                                   etaMin = cms.double(-2.5),
@@ -52,7 +52,7 @@ effPlotter_Tight = cms.EDAnalyzer("EfficiencyPlotter",
                                   vtxMax = cms.double(40.5),
                                   MuonID = cms.string("Tight")
                                   )
-effPlotter_Loose_miniAOD = cms.EDAnalyzer("EfficiencyPlotter",
+effPlotter_Loose_miniAOD = cms.EDProducer("EfficiencyPlotter",
                                           folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer"),
                                           phiMin = cms.double(-3.2),
                                           etaMin = cms.double(-2.5),
@@ -70,7 +70,7 @@ effPlotter_Loose_miniAOD = cms.EDAnalyzer("EfficiencyPlotter",
                                           )
 
 
-effPlotter_Medium_miniAOD = cms.EDAnalyzer("EfficiencyPlotter",
+effPlotter_Medium_miniAOD = cms.EDProducer("EfficiencyPlotter",
                                            folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer"),
                                            phiMin = cms.double(-3.2),
                                            etaMin = cms.double(-2.5),
@@ -88,7 +88,7 @@ effPlotter_Medium_miniAOD = cms.EDAnalyzer("EfficiencyPlotter",
                                            )
 
 
-effPlotter_Tight_miniAOD = cms.EDAnalyzer("EfficiencyPlotter",
+effPlotter_Tight_miniAOD = cms.EDProducer("EfficiencyPlotter",
                                           folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer"),
                                           phiMin = cms.double(-3.2),
                                           etaMin = cms.double(-2.5),

--- a/DQMOffline/Muon/python/muonRecoTest_cfi.py
+++ b/DQMOffline/Muon/python/muonRecoTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-muRecoTest = cms.EDAnalyzer("MuonRecoTest",
+muRecoTest = cms.EDProducer("MuonRecoTest",
                             phiMin = cms.double(-3.2),
                             # number of luminosity block to analyse
                             diagnosticPrescale = cms.untracked.int32(1),

--- a/DQMOffline/Muon/python/muonTestSummary_cfi.py
+++ b/DQMOffline/Muon/python/muonTestSummary_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-muonTestSummary = cms.EDAnalyzer("MuonTestSummary",
+muonTestSummary = cms.EDProducer("MuonTestSummary",
                              # tests parameters
                              etaExpected = cms.double(1.),
                              phiExpected = cms.double(1.),

--- a/DQMOffline/Muon/python/trackResidualsTest_cfi.py
+++ b/DQMOffline/Muon/python/trackResidualsTest_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-muTrackResidualsTest = cms.EDAnalyzer("MuonTrackResidualsTest",
+muTrackResidualsTest = cms.EDProducer("MuonTrackResidualsTest",
     sigmaTestName = cms.untracked.string('ResidualsSigmaInRange'),
     meanTestName = cms.untracked.string('ResidualsMeanInRange'),
     # number of luminosity block to analyse

--- a/DQMOffline/Muon/test/rpcefficiencySecondHLT_cfg.py
+++ b/DQMOffline/Muon/test/rpcefficiencySecondHLT_cfg.py
@@ -24,7 +24,7 @@ process.source = cms.Source("PoolSource",
 
 process.MessageLogger = cms.Service("MessageLogger")
 
-process.second = cms.EDAnalyzer("RPCEfficiencySecond",
+process.second = cms.EDProducer("RPCEfficiencySecond",
     debug = cms.untracked.bool(False),
     barrel = cms.untracked.bool(True),
     endcap = cms.untracked.bool(True),

--- a/DQMOffline/PFTau/python/PFClient_cfi.py
+++ b/DQMOffline/PFTau/python/PFClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-pfClient = cms.EDAnalyzer("PFClient",
+pfClient = cms.EDProducer("PFClient",
                           FolderNames = cms.vstring("PFJet/CompWithGenJet","PFJet/CompWithCaloJet"),
                           HistogramNames = cms.vstring( "delta_et_Over_et_VS_et_"),
                           CreateEfficiencyPlots = cms.bool(False),
@@ -11,7 +11,7 @@ pfClient = cms.EDAnalyzer("PFClient",
                           )
 
 # need a different Client to store the slices  
-pfClient_JetRes = cms.EDAnalyzer("PFClient_JetRes",
+pfClient_JetRes = cms.EDProducer("PFClient_JetRes",
                                   FolderNames = cms.vstring("PFJet/CompWithGenJet","PFJet/CompWithCaloJet"),
                                   HistogramNames = cms.vstring( "delta_et_Over_et_VS_et_"),
                                   CreateEfficiencyPlots = cms.bool(False),

--- a/DQMOffline/RecoB/python/bTagAnalysisData_cfi.py
+++ b/DQMOffline/RecoB/python/bTagAnalysisData_cfi.py
@@ -6,7 +6,7 @@ bTagAnalysis = cms.EDAnalyzer("BTagPerformanceAnalyzerOnData",
                               bTagCommonBlock,
                               )
 
-bTagHarvest = cms.EDAnalyzer("BTagPerformanceHarvester",
+bTagHarvest = cms.EDProducer("BTagPerformanceHarvester",
                              bTagCommonBlock,
                              produceEps = cms.bool(False),
                              producePs = cms.bool(False),

--- a/DQMOffline/Trigger/python/BPHMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/BPHMonitoring_Client_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-bphEfficiency = cms.EDAnalyzer("DQMGenericClient",
+bphEfficiency = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/BPH/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),

--- a/DQMOffline/Trigger/python/EgHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/EgHLTOfflineClient_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.EgHLTOffFiltersToMon_cfi import *
 
-egHLTOffDQMClient = cms.EDAnalyzer("EgHLTOfflineClient",
+egHLTOffDQMClient = cms.EDProducer("EgHLTOfflineClient",
                                  egHLTOffFiltersToMon,
                                  DQMDirName=cms.string("HLT/EgOffline"),
                                  hltTag = cms.string("HLT"),

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-metEfficiency = cms.EDAnalyzer("DQMGenericClient",
+metEfficiency = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/MET/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),

--- a/DQMOffline/Trigger/python/FSQHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineClient_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #print "please remember to switch off gen jet efficiency plots in client"
-fsqClient = cms.EDAnalyzer("DQMGenericClient",
+fsqClient = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/FSQ/HLT_DiPFJetAve*", "HLT/FSQ/HLT_PixelTracks_Multiplicity*",\
                                            "HLT/FSQ/HLT_ZeroBias_SinglePixelTrack*", \
                                            "HLT/FSQ/HLT_PFJet*", "HLT/FSQ/HLT_DiPFJet*" ),

--- a/DQMOffline/Trigger/python/HILowLumiHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/HILowLumiHLTOfflineClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-HiJetClient = cms.EDAnalyzer("DQMGenericClient",
+HiJetClient = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/HI/HLT_AK4Calo*", "HLT/HI/HLT_AK4PF*", "HLT/HI/HLT_HISinglePhoton*", "HLT/HI/HLT_FullTrack*", "HLT/HI/HLT_PAFullTracks*", "HLT/HI/HLT_PAAK4*", "HLT/HI/HLT_PASinglePhoton*", "HLT/HI/HLT_L1MinimumBiasHF*", "HLT/HI/HLT_ZeroBias*", "HLT/HI/HLT_PADoubleEG2*", "HLT/HI/HLT_PASingleEG5*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     outputFileName = cms.untracked.string(''),

--- a/DQMOffline/Trigger/python/HLTTauCertifier_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauCertifier_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltTauOfflineCertification = cms.EDAnalyzer("HLTTauCertifier",
+hltTauOfflineCertification = cms.EDProducer("HLTTauCertifier",
                                    targetDir = cms.string("HLT/EventInfo/reportSummaryContents"),
                                    targetME  = cms.string("HLT_Tau"),
                                    inputMEs = cms.vstring(

--- a/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.HLTTauDQMOffline_cfi import *
 
 def makeInclusiveAnalyzer(monitorModule):
-    m1 = cms.EDAnalyzer("DQMGenericClient",
+    m1 = cms.EDProducer("DQMGenericClient",
         subDirs        = cms.untracked.vstring(monitorModule.DQMBaseFolder.value()+"/"+monitorModule.PathSummaryPlotter.DQMFolder.value()),
         verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
         outputFileName = cms.untracked.string(''),
@@ -14,7 +14,7 @@ def makeInclusiveAnalyzer(monitorModule):
         ),
     )
 
-    m2 = cms.EDAnalyzer("HLTTauPostProcessor",
+    m2 = cms.EDProducer("HLTTauPostProcessor",
         DQMBaseFolder = cms.untracked.string(monitorModule.DQMBaseFolder.value())
     )
 

--- a/DQMOffline/Trigger/python/JetMETHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/JetMETHLTOfflineClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-jetMETHLTOfflineClientAK4 = cms.EDAnalyzer("JetMETHLTOfflineClient",
+jetMETHLTOfflineClientAK4 = cms.EDProducer("JetMETHLTOfflineClient",
 
                                  processname = cms.string("HLT"),
                                  DQMDirName=cms.string("HLT/JetMET"),

--- a/DQMOffline/Trigger/python/MuonHLTValidation_cfi.py
+++ b/DQMOffline/Trigger/python/MuonHLTValidation_cfi.py
@@ -15,7 +15,7 @@ qTesterMuonHLT = cms.EDAnalyzer("QualityTester",
         #reportThreshold = cms.untracked.string("black")
 )
 
-muonHLTCertSummary = cms.EDAnalyzer("HLTMuonCertSummary",
+muonHLTCertSummary = cms.EDProducer("HLTMuonCertSummary",
     verbose = cms.untracked.bool(False),
 )
 

--- a/DQMOffline/Trigger/python/MuonPostProcessor_cff.py
+++ b/DQMOffline/Trigger/python/MuonPostProcessor_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltMuonEfficiencies = cms.EDAnalyzer("DQMGenericClient",
+hltMuonEfficiencies = cms.EDProducer("DQMGenericClient",
 
     subDirs        = cms.untracked.vstring("HLT/Muon/Distributions.*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
@@ -269,7 +269,7 @@ hltSiPixelPhase1ClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1Clusters",
         triggerflag = hltSiPixelPhase1ClustersTriggers,
 )
 
-hltSiPixelPhase1ClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+hltSiPixelPhase1ClustersHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = hltSiPixelPhase1ClustersConf,
         geometry   = hltSiPixelPhase1Geometry
 )

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -142,7 +142,7 @@ hltSiPixelPhase1TrackClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackCluste
         geometry   = hltSiPixelPhase1Geometry
 )
 
-hltSiPixelPhase1TrackClustersHarvester = cms.EDAnalyzer("SiPixelPhase1Harvester",
+hltSiPixelPhase1TrackClustersHarvester = cms.EDProducer("SiPixelPhase1Harvester",
         histograms = hltSiPixelPhase1TrackClustersConf,
         geometry   = hltSiPixelPhase1Geometry
 )

--- a/DQMServices/Components/python/test/harv_file1_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_cfg.py
@@ -21,7 +21,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file1_file2_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_file2_cfg.py
@@ -22,7 +22,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file1_file2_file3_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_file2_file3_cfg.py
@@ -23,7 +23,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file1_file2_file3_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_file2_file3_oldf_cfg.py
@@ -27,7 +27,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file1_file2_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_file2_oldf_cfg.py
@@ -26,7 +26,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file1_file3_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_file3_cfg.py
@@ -22,7 +22,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file1_file3_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_file3_oldf_cfg.py
@@ -26,7 +26,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file1_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_file1_oldf_cfg.py
@@ -30,7 +30,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file2_cfg.py
+++ b/DQMServices/Components/python/test/harv_file2_cfg.py
@@ -21,7 +21,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file2_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_file2_oldf_cfg.py
@@ -30,7 +30,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file4_cfg.py
+++ b/DQMServices/Components/python/test/harv_file4_cfg.py
@@ -21,7 +21,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_file4_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_file4_oldf_cfg.py
@@ -25,7 +25,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_filePB_cfg.py
+++ b/DQMServices/Components/python/test/harv_filePB_cfg.py
@@ -23,7 +23,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_filePB_mon_cfg.py
+++ b/DQMServices/Components/python/test/harv_filePB_mon_cfg.py
@@ -25,7 +25,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_filePB_ref_cfg.py
+++ b/DQMServices/Components/python/test/harv_filePB_ref_cfg.py
@@ -21,7 +21,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_merged_file1_file2_cfg.py
+++ b/DQMServices/Components/python/test/harv_merged_file1_file2_cfg.py
@@ -21,7 +21,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_merged_file1_file2_file3_cfg.py
+++ b/DQMServices/Components/python/test/harv_merged_file1_file2_file3_cfg.py
@@ -21,7 +21,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_merged_file1_file2_file3_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_merged_file1_file2_file3_oldf_cfg.py
@@ -30,7 +30,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_merged_file1_file2_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_merged_file1_file2_oldf_cfg.py
@@ -30,7 +30,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_merged_file1_file3_cfg.py
+++ b/DQMServices/Components/python/test/harv_merged_file1_file3_cfg.py
@@ -21,7 +21,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Components/python/test/harv_merged_file1_file3_oldf_cfg.py
+++ b/DQMServices/Components/python/test/harv_merged_file1_file3_oldf_cfg.py
@@ -30,7 +30,7 @@ process.harvester = cms.EDAnalyzer("DummyHarvestingClient",
                                    cumulateRuns = cms.untracked.bool(False),
                                    cumulateLumis = cms.untracked.bool(True))
 
-process.eff = cms.EDAnalyzer("DQMGenericClient",
+process.eff = cms.EDProducer("DQMGenericClient",
                              efficiency = cms.vstring("eff1 \'Eff1\' Bar0 Bar1"),
                              resolution = cms.vstring(),
                              subDirs = cms.untracked.vstring(folder))

--- a/DQMServices/Core/interface/DQMEDHarvester.h
+++ b/DQMServices/Core/interface/DQMEDHarvester.h
@@ -3,6 +3,7 @@
 
 //<<<<<< INCLUDES                                                       >>>>>>
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 //<<<<<< PUBLIC DEFINES                                                 >>>>>>
@@ -13,7 +14,8 @@
 //<<<<<< CLASS DECLARATIONS                                             >>>>>>
 
 class DQMEDHarvester
-: public edm::one::EDAnalyzer<edm::one::WatchRuns,edm::one::WatchLuminosityBlocks,edm::one::SharedResources>
+: public edm::one::EDProducer<edm::one::WatchRuns,edm::one::WatchLuminosityBlocks,edm::one::SharedResources,
+edm::EndLuminosityBlockProducer>
 {
 public:
   DQMEDHarvester(void);
@@ -24,13 +26,14 @@ public:
   // implicit assignment operator
   // implicit destructor
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) {};
-  virtual void analyze(edm::Event const&, edm::EventSetup const&) final {};
+  virtual void produce(edm::Event&, edm::EventSetup const&) override final {};
   virtual void endRun(edm::Run const&, edm::EventSetup const&) {};
   virtual void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final {};
   virtual void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final;
   virtual void endJob() final;
   virtual void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) {};
   virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) = 0;
+  void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override final;
 
 private:
 

--- a/DQMServices/Core/src/DQMEDHarvester.cc
+++ b/DQMServices/Core/src/DQMEDHarvester.cc
@@ -20,3 +20,6 @@ void DQMEDHarvester::endLuminosityBlock(edm::LuminosityBlock const& iLumi,
       this->dqmEndLuminosityBlock(b, g, iLumi, iSetup);
     });
 }
+
+void DQMEDHarvester::endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) {}
+

--- a/DQMServices/Examples/python/test/DQMExample_GenericClient_cfi.py
+++ b/DQMServices/Examples/python/test/DQMExample_GenericClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-DQMExample_GenericClient = cms.EDAnalyzer("DQMGenericClient",
+DQMExample_GenericClient = cms.EDProducer("DQMGenericClient",
                                           subDirs = cms.untracked.vstring("Physics/TopTest"),
                                           efficiency = cms.vstring(
                                               "myEfficiencyEta 'Efficiency vs Eta' EleEta_leading_HLT_matched EleEta_leading",

--- a/DQMServices/Examples/python/test/DQMExample_Step2_cfi.py
+++ b/DQMServices/Examples/python/test/DQMExample_Step2_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-DQMExample_Step2 = cms.EDAnalyzer("DQMExample_Step2",
+DQMExample_Step2 = cms.EDProducer("DQMExample_Step2",
                                   numMonitorName = cms.string("Physics/TopTest/ElePt_leading_HLT_matched"),
                                   denMonitorName = cms.string("Physics/TopTest/ElePt_leading")
                                   )

--- a/FastSimulation/Calorimetry/test/neutrinogun_fastsim_cfg.py
+++ b/FastSimulation/Calorimetry/test/neutrinogun_fastsim_cfg.py
@@ -95,7 +95,7 @@ process.hcalRecoAnalyzer = cms.EDAnalyzer("HcalRecHitsValidation",
                                           ecalselector              = cms.untracked.string('no'),
                                           )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
                                            outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
                                            DQMDirName = cms.string("/") # root directory
                                            )

--- a/GeneratorInterface/RivetInterface/python/PostProcessor_cff.py
+++ b/GeneratorInterface/RivetInterface/python/PostProcessor_cff.py
@@ -293,7 +293,7 @@ postCMS_2011_S9086218 = cms.EDAnalyzer(
 ###################
 #CMS_2011_S9088458
 ###################
-postCMS_2011_S9088458 = cms.EDAnalyzer(
+postCMS_2011_S9088458 = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Rivet/CMS_2011_S9088458"),
     efficiencyProfile = cms.untracked.vstring("d01-x01-y01 d01-x01-y01 trijet dijet"),

--- a/HLTriggerOffline/B2G/python/b2gHLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/B2G/python/b2gHLTValidationHarvest_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 
-b2gSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+b2gSingleMuonHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/B2GHLTValidation/B2G/SemiMuonic"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -13,7 +13,7 @@ b2gSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-b2gDoubleLeptonEleMuHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+b2gDoubleLeptonEleMuHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/B2GHLTValidation/B2G/EleMu"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -23,7 +23,7 @@ b2gDoubleLeptonEleMuHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-b2gDoubleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+b2gDoubleElectronHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/B2GHLTValidation/B2G/DoubleEle"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -33,7 +33,7 @@ b2gDoubleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-b2gSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+b2gSingleElectronHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/B2GHLTValidation/B2G/SemiElectronic"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -45,7 +45,7 @@ b2gSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-b2gSingleJetHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+b2gSingleJetHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/B2GHLTValidation/B2G/SingleJet"),
         efficiency = cms.vstring(
             "hEffLastJetEta 'Efficiency vs Eta Last Jet' EtaLastJetSel EtaLastJetAll",
@@ -55,7 +55,7 @@ b2gSingleJetHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-b2gDiJetHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+b2gDiJetHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/B2GHLTValidation/B2G/DiJet"),
         efficiency = cms.vstring(
             "hEffLastJetEta 'Efficiency vs Eta Last Jet' EtaLastJetSel EtaLastJetAll",

--- a/HLTriggerOffline/Btag/python/HltBtagPostValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagPostValidation_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 #define HltBTagPostValidation for the b-tag DQM validation (efficiency and mistagrate plot)
-HltBTagPostValidation = cms.EDAnalyzer("HLTBTagHarvestingAnalyzer",
+HltBTagPostValidation = cms.EDProducer("HLTBTagHarvestingAnalyzer",
 	HLTPathNames = cms.vstring(
 	'HLT_PFMET120_',
 	'HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_',

--- a/HLTriggerOffline/Btag/test/test.py
+++ b/HLTriggerOffline/Btag/test/test.py
@@ -83,7 +83,7 @@ process.bTagValidation = cms.EDAnalyzer("HLTBTagPerformanceAnalyzer",
 )
 
 #define bTagPostValidation for the b-tag DQM validation (efficiency and mistagrate plot)
-process.bTagPostValidation = cms.EDAnalyzer("HLTBTagHarvestingAnalyzer",
+process.bTagPostValidation = cms.EDProducer("HLTBTagHarvestingAnalyzer",
 	HLTPathNames = fileini.btag_pathes,
 	histoName	= fileini.btag_modules_string,
 	minTag	= cms.double(0.6),

--- a/HLTriggerOffline/Common/python/PostProcessorExample_cfi.py
+++ b/HLTriggerOffline/Common/python/PostProcessorExample_cfi.py
@@ -10,7 +10,7 @@
 import FWCore.ParameterSet.Config as cms
 
 
-myMuonPostVal = cms.EDAnalyzer("DQMGenericClient",
+myMuonPostVal = cms.EDProducer("DQMGenericClient",
     verbose        = cms.untracked.uint32(0), #set this to zero!
     outputFileName = cms.untracked.string(''),# set this to empty!
     #outputFileName= cms.untracked.string('MuonPostProcessor.root'),
@@ -23,7 +23,7 @@ myMuonPostVal = cms.EDAnalyzer("DQMGenericClient",
 )
 
 
-myEgammaPostVal = cms.EDAnalyzer("DQMGenericClient",
+myEgammaPostVal = cms.EDProducer("DQMGenericClient",
     #outputFileName= cms.untracked.string('EgammaPostProcessor.root'),
     commands       = cms.vstring(),
     resolution     = cms.vstring(),                                    
@@ -33,7 +33,7 @@ myEgammaPostVal = cms.EDAnalyzer("DQMGenericClient",
     )
 )
 
-myTauPostVal = cms.EDAnalyzer("DQMGenericClient",
+myTauPostVal = cms.EDProducer("DQMGenericClient",
     #outputFileName= cms.untracked.string('TauPostProcessor.root'),
     commands       = cms.vstring(),
     resolution     = cms.vstring(),                                    
@@ -44,7 +44,7 @@ myTauPostVal = cms.EDAnalyzer("DQMGenericClient",
 )
 
 
-myTopPostVal = cms.EDAnalyzer("DQMGenericClient",
+myTopPostVal = cms.EDProducer("DQMGenericClient",
     #outputFileName= cms.untracked.string('TopPostProcessor.root'),
     commands       = cms.vstring(),
     resolution     = cms.vstring(),                                    

--- a/HLTriggerOffline/Egamma/python/EgammaPostProcessor_cfi.py
+++ b/HLTriggerOffline/Egamma/python/EgammaPostProcessor_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-EgammaPostVal = cms.EDAnalyzer("EmDQMPostProcessor",
+EgammaPostVal = cms.EDProducer("EmDQMPostProcessor",
    subDir = cms.untracked.string("HLT/HLTEgammaValidation"),
    dataSet = cms.untracked.string("unknown"),                  
    noPhiPlots = cms.untracked.bool(True),                  

--- a/HLTriggerOffline/Egamma/test/testDQMProcessFromHLTMenu_SinglePath.py
+++ b/HLTriggerOffline/Egamma/test/testDQMProcessFromHLTMenu_SinglePath.py
@@ -70,7 +70,7 @@ process.dqmPath = cms.Path(
 # E/gamma HLT specific DQM configuration
 #----------------------------------------
 
-process.post=cms.EDAnalyzer("EmDQMPostProcessor",
+process.post=cms.EDProducer("EmDQMPostProcessor",
                             subDir = cms.untracked.string("HLT/HLTEgammaValidation"),
                             dataSet = cms.untracked.string("unknown"),
     )

--- a/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testEmDQM_cfg.py
@@ -42,7 +42,7 @@ process.p = cms.Path(
                     )
 
 #----------------------------------------
-process.post=cms.EDAnalyzer("EmDQMPostProcessor",
+process.post=cms.EDProducer("EmDQMPostProcessor",
                             subDir = cms.untracked.string("HLT/HLTEgammaValidation"),
                             dataSet = cms.untracked.string("unknown"),
                             noPhiPlots = cms.untracked.bool(False),

--- a/HLTriggerOffline/Egamma/test/testReco_cfg.py
+++ b/HLTriggerOffline/Egamma/test/testReco_cfg.py
@@ -8,7 +8,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.load("HLTriggerOffline.Egamma.EgammaValidationReco_cff")
-process.post=cms.EDAnalyzer("EmDQMPostProcessor",
+process.post=cms.EDProducer("EmDQMPostProcessor",
                             subDir = cms.untracked.string("HLT/HLTEgammaValidation"),
                             dataSet = cms.untracked.string("unknown"),
                             normalizeToReco = cms.untracked.bool(True),

--- a/HLTriggerOffline/Egamma/test/test_cfg.py
+++ b/HLTriggerOffline/Egamma/test/test_cfg.py
@@ -8,7 +8,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.load("HLTriggerOffline.Egamma.EgammaValidation_cff")
-process.post=cms.EDAnalyzer("EmDQMPostProcessor",
+process.post=cms.EDProducer("EmDQMPostProcessor",
                             subDir = cms.untracked.string("HLT/HLTEgammaValidation"),
                             dataSet = cms.untracked.string("unknown"),
     )

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessor_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessor_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltExoticaPostProcessor  = cms.EDAnalyzer("DQMGenericClient",
+hltExoticaPostProcessor  = cms.EDProducer("DQMGenericClient",
     subDirs           = cms.untracked.vstring('HLT/Exotica/*'),
     verbose           = cms.untracked.uint32(2),
     outputFileName    = cms.untracked.string(''),

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvestingSequence_cff.py
@@ -109,7 +109,7 @@ hfvDoubleMu0 = heavyFlavorValidationHarvesting.clone(
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_DoubleMu0')
 )
 
-combiner = cms.EDAnalyzer('PlotCombiner',
+combiner = cms.EDProducer('PlotCombiner',
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT'),
   Plots = cms.untracked.VPSet(
     cms.untracked.PSet(

--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvesting_cfi.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidationHarvesting_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-heavyFlavorValidationHarvesting = cms.EDAnalyzer("HeavyFlavorHarvesting",
+heavyFlavorValidationHarvesting = cms.EDProducer("HeavyFlavorHarvesting",
   MyDQMrootFolder = cms.untracked.string('HLT/HeavyFlavor/HLT/HLT_Mu5'),
   Efficiencies = cms.untracked.VPSet(
     cms.untracked.PSet( NumDenEffMEnames = cms.untracked.vstring("globMuon_genEtaPt","genMuon_genEtaPt","effGlobGen_genEtaPt") ),

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessor_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessor_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltHiggsPostProcessor  = cms.EDAnalyzer("DQMGenericClient",
+hltHiggsPostProcessor  = cms.EDProducer("DQMGenericClient",
     subDirs           = cms.untracked.vstring('HLT/Higgs/*'),
     verbose           = cms.untracked.uint32(2),
     outputFileName    = cms.untracked.string(''),

--- a/HLTriggerOffline/JetMET/python/Validation/JetMETPostProcessor_cff.py
+++ b/HLTriggerOffline/JetMET/python/Validation/JetMETPostProcessor_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-JetMETPostVal = cms.EDAnalyzer("JetMETDQMPostProcessor",
+JetMETPostVal = cms.EDProducer("JetMETDQMPostProcessor",
      subDir = cms.untracked.string("HLT/HLTJETMET"),
      PatternJetTrg = cms.untracked.string("Jet([0-9])+"),
      PatternMetTrg = cms.untracked.string("M([E,H])+T([0-9])+")

--- a/HLTriggerOffline/Muon/python/hltMuonPostProcessor_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonPostProcessor_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltMuonPostProcessor  = cms.EDAnalyzer("DQMGenericClient",
+hltMuonPostProcessor  = cms.EDProducer("DQMGenericClient",
     subDirs           = cms.untracked.vstring('HLT/Muon/Distributions/*'),
     verbose           = cms.untracked.uint32(0),
     outputFileName    = cms.untracked.string(''),

--- a/HLTriggerOffline/SMP/python/hltSMPPostProcessor_cfi.py
+++ b/HLTriggerOffline/SMP/python/hltSMPPostProcessor_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltSMPPostProcessor  = cms.EDAnalyzer("DQMGenericClient",
+hltSMPPostProcessor  = cms.EDProducer("DQMGenericClient",
     subDirs           = cms.untracked.vstring('HLT/SMP/*'),
     verbose           = cms.untracked.uint32(2),
     outputFileName    = cms.untracked.string(''),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_DiJet_MET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_DiJet_MET_cff.py
@@ -19,7 +19,7 @@ SUSY_HLT_DiJet_MET = cms.EDAnalyzer("SUSY_HLT_DiJet_MET",
   OfflineMetCut = cms.untracked.double(250.0),
 )
 
-SUSY_HLT_DiJet_MET_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_DiJet_MET_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DiCentralPFJet55_PFMET110_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
@@ -42,7 +42,7 @@ SUSY_HLT_Ele_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                    csvThreshold = cms.untracked.double(0.898)
                                                    )
 
-SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                   subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_BTagCSV_p067_PFHT400'),
                                                                   efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
@@ -42,7 +42,7 @@ SUSY_HLT_Ele_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                       csvThreshold = cms.untracked.double(-1.0)
                                                       )
 
-SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                      subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT350'),
                                                                      efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
@@ -42,7 +42,7 @@ SUSY_HLT_Ele15_HT350_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton'
                                                   csvThreshold = cms.untracked.double(-1.0)
                                                   )
 
-SUSY_HLT_Ele15_HT350_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele15_HT350_MET50_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT350_PFMET50'),
                                                                  efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -93,7 +93,7 @@ SUSY_HLT_Ele15_HT400_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton'
                                                   csvThreshold = cms.untracked.double(-1.0)
                                                   )
 
-SUSY_HLT_Ele15_HT400_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele15_HT400_MET50_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT400_PFMET50'),
                                                                  efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
@@ -42,7 +42,7 @@ SUSY_HLT_Ele15_HT600_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               csvThreshold = cms.untracked.double(-1.0)
                                               )
 
-SUSY_HLT_Ele15_HT600_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele15_HT600_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                              subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT600'),
                                                              efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -92,7 +92,7 @@ SUSY_HLT_Ele15_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               csvThreshold = cms.untracked.double(-1.0)
                                               )
 
-SUSY_HLT_Ele15_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele15_HT400_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                              subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT400'),
                                                              efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -142,7 +142,7 @@ SUSY_HLT_Ele50_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               csvThreshold = cms.untracked.double(-1.0)
                                               )
 
-SUSY_HLT_Ele50_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Ele50_HT400_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                              subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele50_IsoVVVL_PFHT400'),
                                                              efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_ElecFakes_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_ElecFakes_cff.py
@@ -8,7 +8,7 @@ SUSY_HLT_Ele8_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle8CaloIdLTrackIdLIsoVLTrackIsoFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle8PFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele8_IdL_Iso_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele8_IdL_Iso_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -23,7 +23,7 @@ SUSY_HLT_Ele12_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle12CaloIdLTrackIdLIsoVLTrackIsoFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle12PFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele12_IdL_Iso_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele12_IdL_Iso_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -39,7 +39,7 @@ SUSY_HLT_Ele17_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerJetFilter = cms.InputTag('hltEle17PFJet30EleCleaned', '', 'HLT'), #the last filter in the path
 )
 
-SUSY_HLT_Ele17_IdL_Iso_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele17_IdL_Iso_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele17_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -55,7 +55,7 @@ SUSY_HLT_Ele23_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerJetFilter = cms.InputTag('hltEle23PFJet30EleCleaned', '', 'HLT'), #the last filter in the path
 )
 
-SUSY_HLT_Ele23_IdL_Iso_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele23_IdL_Iso_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -71,7 +71,7 @@ SUSY_HLT_Ele8_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle8CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle8NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele8_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele8_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -86,7 +86,7 @@ SUSY_HLT_Ele12_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle12CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle12NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele12_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele12_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele12_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -101,7 +101,7 @@ SUSY_HLT_Ele17_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle17CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle17NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele17_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele17_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -116,7 +116,7 @@ SUSY_HLT_Ele23_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle23CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle23NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele23_Jet30_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Ele23_Jet30_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Electron_BJet_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Electron_BJet_cff.py
@@ -14,7 +14,7 @@ SUSY_HLT_Electron_BJet = cms.EDAnalyzer("SUSY_HLT_Electron_BJet",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_Electron_BJet_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Electron_BJet_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele10_CaloIdM_TrackIdM_CentralPFJet30_BTagCSV_p13_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleElectron_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleElectron_cff.py
@@ -34,7 +34,7 @@ SUSY_HLT_HT250_DoubleEle = cms.EDAnalyzer("SUSY_HLT_DoubleEle_Hadronic",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT_DoubleEle_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT_DoubleEle_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -44,7 +44,7 @@ SUSY_HLT_HT_DoubleEle_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     )
 )
 
-SUSY_HLT_HT250_DoubleEle_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT250_DoubleEle_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT250_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleMuon_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleMuon_cff.py
@@ -31,7 +31,7 @@ SUSY_HLT_HT250_DoubleMuon = cms.EDAnalyzer("SUSY_HLT_DoubleMuon_Hadronic",
 )
 
 
-SUSY_HLT_HT_DoubleMuon_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT_DoubleMuon_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu8_Mass8_PFHT300_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -41,7 +41,7 @@ SUSY_HLT_HT_DoubleMuon_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     )
 )
 
-SUSY_HLT_HT250_DoubleMuon_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT250_DoubleMuon_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu8_Mass8_PFHT250_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_MuEle_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_MuEle_cff.py
@@ -37,7 +37,7 @@ SUSY_HLT_HT250_MuEle = cms.EDAnalyzer("SUSY_HLT_MuEle_Hadronic",
 )
 
 
-SUSY_HLT_HT_MuEle_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT_MuEle_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -48,7 +48,7 @@ SUSY_HLT_HT_MuEle_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     )
 )
 
-SUSY_HLT_HT250_MuEle_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT250_MuEle_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT250_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Muon_BJet_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Muon_BJet_cff.py
@@ -15,7 +15,7 @@ SUSY_HLT_Muon_BJet = cms.EDAnalyzer("SUSY_HLT_Muon_BJet",
 )
 
 
-SUSY_HLT_Muon_BJet_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Muon_BJet_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu10_CentralPFJet30_BTagCSV_p13_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
@@ -36,7 +36,7 @@ SUSY_HLT_PhotonMET_pt75 = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
    metThrOffline = cms.untracked.double(100),
 )
 
-SUSY_HLT_PhotonMET_pt36_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_PhotonMET_pt36_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon36_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
    resolution     = cms.vstring(""),
@@ -46,7 +46,7 @@ SUSY_HLT_PhotonMET_pt36_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
    )
 )
 
-SUSY_HLT_PhotonMET_pt50_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_PhotonMET_pt50_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon50_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
    resolution     = cms.vstring(""),
@@ -56,7 +56,7 @@ SUSY_HLT_PhotonMET_pt50_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
    )
 )
 
-SUSY_HLT_PhotonMET_pt75_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_PhotonMET_pt75_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon75_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
    resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
@@ -29,7 +29,7 @@ SUSY_HLT_Mu10_VBF = cms.EDAnalyzer("SUSY_HLT_VBF_Mu10",
                                  
                                  )
 
-SUSY_HLT_Mu10_VBF_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Mu10_VBF_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
                                                 subDirs        = cms.untracked.vstring("HLT/SUSYBSM/SUSY_HLT_VBF_Mu10_v"),
                                                 verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
                                                 resolution     = cms.vstring(""),
@@ -70,7 +70,7 @@ SUSY_HLT_Mu8_VBF = cms.EDAnalyzer("SUSY_HLT_VBF_Mu8",
                                  
                                  )
 
-SUSY_HLT_Mu8_VBF_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Mu8_VBF_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
                                                 subDirs        = cms.untracked.vstring("HLT/SUSYBSM/SUSY_HLT_VBF_Mu8_v"),
                                                 verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
                                                 resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HT_MET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HT_MET_cff.py
@@ -13,7 +13,7 @@ SUSY_HLT_HT350_MET100 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT350_MET100_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT350_MET100_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT350_PFMET100_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -35,7 +35,7 @@ SUSY_HLT_HT300_MET100 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT300_MET100_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT300_MET100_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT300_PFMET100_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -57,7 +57,7 @@ SUSY_HLT_HT300_MET110 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT300_MET110_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_HT300_MET110_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT300_PFMET110_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_BTAG_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_BTAG_cff.py
@@ -13,7 +13,7 @@ SUSY_HLT_MET_BTAG = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_MET_BTAG_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET_BTAG_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET120_BTagCSV_p067_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_BTAG_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_BTAG_cff.py
@@ -23,7 +23,7 @@ SUSY_HLT_MET_HT_MUON_BTAG = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_HT_MUON_BTAG_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET_HT_MUON_BTAG_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu6_PFHT200_PFMET80_BTagCSV_p067_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_ER_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_ER_cff.py
@@ -21,7 +21,7 @@ SUSY_HLT_MET_HT_MUON_ER = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_HT_MUON_ER_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET_HT_MUON_ER_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu3er_PFHT140_PFMET125_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_cff.py
@@ -21,7 +21,7 @@ SUSY_HLT_MET_HT_MUON = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_HT_MUON_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET_HT_MUON_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu6_PFHT200_PFMET100_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_ER_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_ER_cff.py
@@ -21,7 +21,7 @@ SUSY_HLT_MET_MUON_ER = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_MUON_ER_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET_MUON_ER_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLTriggerOffline/SUSYBSM/HLT_Mu14er_PFMET100_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
@@ -21,7 +21,7 @@ SUSY_HLT_MET120_MUON5 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET120_MUON5_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET120_MUON5_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET120_Mu5_v"),
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(
@@ -52,7 +52,7 @@ SUSY_HLT_MET50_DIMUON3 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET50_DIMUON3_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_MET50_DIMUON3_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu3_PFMET50_v"),
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
@@ -42,7 +42,7 @@ SUSY_HLT_Mu_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                   csvThreshold = cms.untracked.double(0.898)
                                                   )
 
-SUSY_HLT_Mu_HT_BTag_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu_HT_BTag_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_BTagCSV_p067_PFHT400'),
                                                                  efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
@@ -42,7 +42,7 @@ SUSY_HLT_Mu_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                      csvThreshold = cms.untracked.double(-1.0)
                                                      )
 
-SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                     subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT350_v'),
                                                                     efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Mu15_HT350_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                  )
 
 
-SUSY_HLT_Mu15_HT350_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu15_HT350_MET50_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT350_PFMET50_v'),
                                                                 efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -95,7 +95,7 @@ SUSY_HLT_Mu15_HT400_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                  )
 
 
-SUSY_HLT_Mu15_HT400_MET50_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu15_HT400_MET50_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT400_PFMET50_v'),
                                                                 efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
@@ -42,7 +42,7 @@ SUSY_HLT_Mu15_HT600_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              csvThreshold = cms.untracked.double(-1.0)
                                              )
 
-SUSY_HLT_Mu15_HT600_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu15_HT600_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT600_v'),
                                                             efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -92,7 +92,7 @@ SUSY_HLT_Mu15_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              csvThreshold = cms.untracked.double(-1.0)
                                              )
 
-SUSY_HLT_Mu15_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu15_HT400_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT400_v'),
                                                             efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -142,7 +142,7 @@ SUSY_HLT_Mu50_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              csvThreshold = cms.untracked.double(-1.0)
                                              )
 
-SUSY_HLT_Mu50_HT400_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+SUSY_HLT_Mu50_HT400_SingleLepton_POSTPROCESSING = cms.EDProducer('DQMGenericClient',
                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu50_IsoVVVL_PFHT400_v'),
                                                             efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MuonFakes_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MuonFakes_cff.py
@@ -8,7 +8,7 @@ SUSY_HLT_Mu8_TrkIsoVVL = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f5L3Filtered8TkIsoFiltered0p4', '', 'HLT'), #the last filter in the path                                        
 )
 
-SUSY_HLT_Mu8_TrkIsoVVL_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Mu8_TrkIsoVVL_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_TrkIsoVVL_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -23,7 +23,7 @@ SUSY_HLT_Mu8 = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f5L3Filtered8', '', 'HLT'), #the last filter in the path                                        
 )
 
-SUSY_HLT_Mu8_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Mu8_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -38,7 +38,7 @@ SUSY_HLT_Mu17_TrkIsoVVL = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu1lqL1f0L2f10L3Filtered17TkIsoFiltered0p4', '', 'HLT'), #the last filter in the path                                 
 )
 
-SUSY_HLT_Mu17_TrkIsoVVL_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Mu17_TrkIsoVVL_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu17_TrkIsoVVL_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -53,7 +53,7 @@ SUSY_HLT_Mu17 = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu10lqL1f0L2f10L3Filtered17', '', 'HLT'), #the last filter in the path                                 
 )
 
-SUSY_HLT_Mu17_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Mu17_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu17_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -68,7 +68,7 @@ SUSY_HLT_TkMu17 = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu10lqTkFiltered17Q', '', 'HLT'), #the last filter in the path                                 
 )
 
-SUSY_HLT_TkMu17_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_TkMu17_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_TkMu17_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_PhotonHT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_PhotonHT_cff.py
@@ -14,7 +14,7 @@ SUSY_HLT_PhotonHT = cms.EDAnalyzer("SUSY_HLT_PhotonHT",
   htThrOffline = cms.untracked.double( 600 ),
 )
 
-SUSY_HLT_PhotonHT_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_PhotonHT_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon90_CaloIdL_PFHT500_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Razor_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Razor_cff.py
@@ -221,7 +221,7 @@ SUSY_HLT_Razor_DM_Calo_Rsq0p25 = cms.EDAnalyzer("SUSY_HLT_Razor",
   hemispheres = cms.InputTag('caloHemispheres')
 )
 
-SUSY_HLT_Razor_PostVal_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_Razor_PostVal_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_RsqMR300_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR300_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_Rsq0p36_v", "HLT/SUSYBSM/HLT_RsqMR270_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR270_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_Rsq0p30_v", "HLT/SUSYBSM/HLT_RsqMR260_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR260_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_Rsq0p25_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_Calo_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_4jet_Calo_v", "HLT/SUSYBSM/HLT_Rsq0p25_Calo_v", "HLT/SUSYBSM/HLT_Rsq0p02_MR300_TriPFJet80_60_40_BTagCSV_p063_p20_Mbb60_200_v", "HLT/SUSYBSM/HLT_Rsq0p02_MR300_TriPFJet80_60_40_DoubleBTagCSV_p063_Mbb60_200_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
@@ -202,7 +202,7 @@ SUSY_HLT_HT400_alphaT0p52 = cms.EDAnalyzer("SUSY_HLT_alphaT",
   caloHtThrTurnon = cms.untracked.double(400),
 )
 
-SUSY_HLT_alphaT_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_alphaT_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
     subDirs        = cms.untracked.vstring(
         "HLT/SUSYBSM/HLT_PFHT200_DiPFJetAve90_PFAlphaT0p51_v"
         "HLT/SUSYBSM/HLT_PFHT200_DiPFJetAve90_PFAlphaT0p57_v",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_caloHT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_caloHT_cff.py
@@ -66,7 +66,7 @@ SUSY_HLT_CaloHT400 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
 )
 
 
-SUSY_HLT_CaloHT_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_CaloHT_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring(
   "HLT/SUSYBSM/HLT_HT200_v",
   "HLT/SUSYBSM/HLT_HT250_v",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveHT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveHT_cff.py
@@ -13,7 +13,7 @@ SUSY_HLT_InclusiveHT_800 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_800_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_800_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT800_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -35,7 +35,7 @@ SUSY_HLT_InclusiveHT_900 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_900_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_900_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT900_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -57,7 +57,7 @@ SUSY_HLT_InclusiveHT_aux125 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux125_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux125_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT125_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -79,7 +79,7 @@ SUSY_HLT_InclusiveHT_aux200 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux200_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux200_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT200_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -101,7 +101,7 @@ SUSY_HLT_InclusiveHT_aux250 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux250_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux250_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT250_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -123,7 +123,7 @@ SUSY_HLT_InclusiveHT_aux300 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux300_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux300_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT300_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -145,7 +145,7 @@ SUSY_HLT_InclusiveHT_aux350 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux350_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux350_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT350_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -167,7 +167,7 @@ SUSY_HLT_InclusiveHT_aux400 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux400_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux400_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT400_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -189,7 +189,7 @@ SUSY_HLT_InclusiveHT_aux475 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux475_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux475_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT475_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -211,7 +211,7 @@ SUSY_HLT_InclusiveHT_aux600 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux600_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveHT_aux600_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT600_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveMET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveMET_cff.py
@@ -87,7 +87,7 @@ SUSY_HLT_InclusiveType1PFMET_HBHE_BeamHaloCleaned = cms.EDAnalyzer("SUSY_HLT_Inc
 
 
 
-SUSY_HLT_InclusiveMET_HBHE_BeamHaloCleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveMET_HBHE_BeamHaloCleaned_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_HBHE_BeamHaloCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -96,7 +96,7 @@ SUSY_HLT_InclusiveMET_HBHE_BeamHaloCleaned_POSTPROCESSING = cms.EDAnalyzer("DQMG
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveMET_Default_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveMET_Default_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -105,7 +105,7 @@ SUSY_HLT_InclusiveMET_Default_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient"
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveMET_HBHECleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveMET_HBHECleaned_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_HBHECleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -114,7 +114,7 @@ SUSY_HLT_InclusiveMET_HBHECleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGenericCli
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveMET_BeamHaloCleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveMET_BeamHaloCleaned_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_BeamHaloCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -124,7 +124,7 @@ SUSY_HLT_InclusiveMET_BeamHaloCleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGeneri
 )
 
 
-SUSY_HLT_InclusiveMET_NotCleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveMET_NotCleaned_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_NotCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -133,7 +133,7 @@ SUSY_HLT_InclusiveMET_NotCleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClie
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveType1PFMET_HBHE_BeamHaloCleaned_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
+SUSY_HLT_InclusiveType1PFMET_HBHE_BeamHaloCleaned_POSTPROCESSING = cms.EDProducer("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMETTypeOne190_HBHE_BeamHaloCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",

--- a/HLTriggerOffline/Top/python/topHLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Top/python/topHLTValidationHarvest_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-DiMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+DiMuonHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/DiMuon"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -12,7 +12,7 @@ DiMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-DiElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+DiElectronHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/DiElectron"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -24,7 +24,7 @@ DiElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-ElecMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+ElecMuonHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/ElecMuon"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -36,7 +36,7 @@ ElecMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-topSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+topSingleMuonHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/SemiMuonic"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -48,7 +48,7 @@ topSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-topSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+topSingleElectronHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/TopHLTValidation/Top/SemiElectronic"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -60,7 +60,7 @@ topSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-SingleTopSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+SingleTopSingleMuonHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/TopHLTValidation/SingleTop/SingleMuon"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",
@@ -72,7 +72,7 @@ SingleTopSingleMuonHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
         resolution = cms.vstring(""),
         )
 
-SingleTopSingleElectronHLTValidationHarvest = cms.EDAnalyzer("DQMGenericClient",
+SingleTopSingleElectronHLTValidationHarvest = cms.EDProducer("DQMGenericClient",
         subDirs = cms.untracked.vstring("HLT/TopHLTValidation/SingleTop/SingleElectron"),
         efficiency = cms.vstring(
             "hEffLeptonEta 'Efficiency vs Eta Lepton ' EtaLeptonSel EtaLeptonAll ",

--- a/SLHCUpgradeSimulations/Geometry/test/Harvesting_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/Harvesting_cfg.py
@@ -62,7 +62,7 @@ process.schedule = cms.Schedule(process.edmtome_step,process.dqmHarvesting,proce
 
 # For some reason a seed harvester isn't included in the standard sequences. If this next processor isn't
 # run then things like efficiencies are just added together instead of recalculated.
-process.postProcessorSeed = cms.EDAnalyzer("DQMGenericClient",
+process.postProcessorSeed = cms.EDProducer("DQMGenericClient",
 	resolution = cms.vstring(),
 	efficiency = cms.vstring("effic \'Efficiency vs #eta\' num_assoc(simToReco)_eta num_simul_eta", 
 		"efficPt \'Efficiency vs p_{T}\' num_assoc(simToReco)_pT num_simul_pT", 

--- a/Validation/CaloTowers/python/CaloTowersClient_cfi.py
+++ b/Validation/CaloTowers/python/CaloTowersClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-calotowersClient = cms.EDAnalyzer("CaloTowersClient",
+calotowersClient = cms.EDProducer("CaloTowersClient",
 #     outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory

--- a/Validation/CaloTowers/test/CaloScan/merging_cfg.py
+++ b/Validation/CaloTowers/test/CaloScan/merging_cfg.py
@@ -53,16 +53,16 @@ cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
 process.dqmSaver.workflow = Workflow
 
-process.hcaldigisClient = cms.EDAnalyzer("HcalDigisClient",
+process.hcaldigisClient = cms.EDProducer("HcalDigisClient",
      outputFile	= cms.untracked.string('HcalDigisHarvestingME.root'),
      DQMDirName	= cms.string("/") # root directory
 )
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/CaloTowers/test/client_cfg.py
+++ b/Validation/CaloTowers/test/client_cfg.py
@@ -46,17 +46,17 @@ cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
 process.dqmSaver.workflow = Workflow
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+process.noiseratesClient = cms.EDProducer("NoiseRatesClient", 
      outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/CaloTowers/test/client_data_cfg.py
+++ b/Validation/CaloTowers/test/client_data_cfg.py
@@ -94,33 +94,33 @@ process.dqmSaver.saveByRun = -1
 process.dqmSaver.saveAtJobEnd = True
 process.dqmSaver.forceRunNumber = config.runNumber
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+process.noiseratesClient = cms.EDProducer("NoiseRatesClient", 
      outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
 ##########
-process.calotowersDQMClient = cms.EDAnalyzer("CaloTowersDQMClient",
+process.calotowersDQMClient = cms.EDProducer("CaloTowersDQMClient",
       outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
 #     outputFile = cms.untracked.string(''),
       DQMDirName = cms.string("/") # root directory
 )
-process.hcalNoiseRatesClient = cms.EDAnalyzer("HcalNoiseRatesClient", 
+process.hcalNoiseRatesClient = cms.EDProducer("HcalNoiseRatesClient", 
      outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
 #     outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory
 )
-process.hcalRecHitsDQMClient = cms.EDAnalyzer("HcalRecHitsDQMClient", 
+process.hcalRecHitsDQMClient = cms.EDProducer("HcalRecHitsDQMClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
 #    outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory

--- a/Validation/CaloTowers/test/runNoise_NZS_cfg.py
+++ b/Validation/CaloTowers/test/runNoise_NZS_cfg.py
@@ -72,7 +72,7 @@ process.hcalRecoAnalyzer = cms.EDAnalyzer("HcalRecHitsValidation",
     hcalselector = cms.untracked.string('noise'),
     ecalselector = cms.untracked.string('no'),
 )
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/CaloTowers/test/runNoise_valid_simhits_digis_rechits_calotowers_ZS_cfg.py
+++ b/Validation/CaloTowers/test/runNoise_valid_simhits_digis_rechits_calotowers_ZS_cfg.py
@@ -126,12 +126,12 @@ cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
 process.dqmSaver.workflow = Workflow
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME_ZS.root'),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/CaloTowers/test/run_onRelVal_cfg.py
+++ b/Validation/CaloTowers/test/run_onRelVal_cfg.py
@@ -42,7 +42,7 @@ process.hcalTowerAnalyzer = cms.EDAnalyzer("CaloTowersValidation",
     useAllHistos             = cms.untracked.bool(False)                         
 )
 
-process.hcalNoiseRates = cms.EDAnalyzer('NoiseRates',
+process.hcalNoiseRates = cms.EDProducer('NoiseRates',
     outputFile   = cms.untracked.string('NoiseRatesRelVal.root'),
     rbxCollName  = cms.untracked.InputTag('hcalnoise'),
 
@@ -70,17 +70,17 @@ cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
 process.dqmSaver.workflow = Workflow
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+process.noiseratesClient = cms.EDProducer("NoiseRatesClient", 
      outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
+++ b/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
@@ -49,7 +49,7 @@ process.hcalTowerAnalyzer = cms.EDAnalyzer("CaloTowersValidation",
     useAllHistos             = cms.untracked.bool(False)                         
 )
 
-process.noiseRates = cms.EDAnalyzer('NoiseRates',
+process.noiseRates = cms.EDProducer('NoiseRates',
     outputFile   = cms.untracked.string('NoiseRatesRelVal.root'),
     rbxCollName  = cms.untracked.InputTag('hcalnoise'),
 
@@ -79,17 +79,17 @@ process.dqmSaver.workflow = Workflow
 #process.dqmSaver.saveByRun         = 1
 #process.dqmSaver.saveAtJobEnd = False
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+process.noiseratesClient = cms.EDProducer("NoiseRatesClient", 
      outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
@@ -116,7 +116,7 @@ process.hcalRecHitsAnalyzer = cms.EDAnalyzer("HcalRecHitsAnalyzer",
     useAllHistos              = cms.untracked.bool(False)                                 
 )
 
-process.hcalNoiseRates = cms.EDAnalyzer('HcalNoiseRates',
+process.hcalNoiseRates = cms.EDProducer('HcalNoiseRates',
 #    outputFile   = cms.untracked.string('NoiseRatesRelVal.root'),
     outputFile   = cms.untracked.string(''),
     rbxCollName  = cms.untracked.InputTag('hcalnoise'),

--- a/Validation/CaloTowers/test/run_onRelVal_oneGo_4val_cfg.py
+++ b/Validation/CaloTowers/test/run_onRelVal_oneGo_4val_cfg.py
@@ -68,7 +68,7 @@ process.hcalTowerAnalyzer = cms.EDAnalyzer("CaloTowersValidation",
     useAllHistos             = cms.untracked.bool(False)                         
 )
 
-process.hcalNoiseRates = cms.EDAnalyzer('NoiseRates',
+process.hcalNoiseRates = cms.EDProducer('NoiseRates',
     outputFile   = cms.untracked.string('NoiseRatesRelVal.root'),
     rbxCollName  = cms.untracked.InputTag('hcalnoise'),
 
@@ -97,22 +97,22 @@ cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
 process.dqmSaver.workflow = Workflow
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+process.noiseratesClient = cms.EDProducer("NoiseRatesClient", 
      outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcaldigisClient = cms.EDAnalyzer("HcalDigisClient",
+process.hcaldigisClient = cms.EDProducer("HcalDigisClient",
      outputFile	= cms.untracked.string('HcalDigisHarvestingME.root'),
      DQMDirName	= cms.string("/") # root directory
 )   

--- a/Validation/CaloTowers/test/run_onRelVal_rereco_cfg.py
+++ b/Validation/CaloTowers/test/run_onRelVal_rereco_cfg.py
@@ -59,7 +59,7 @@ process.hcalTowerAnalyzer = cms.EDAnalyzer("CaloTowersValidation",
     useAllHistos             = cms.untracked.bool(False)                         
 )
 
-process.hcalNoiseRates = cms.EDAnalyzer('NoiseRates',
+process.hcalNoiseRates = cms.EDProducer('NoiseRates',
     outputFile   = cms.untracked.string('NoiseRatesRelVal.root'),
 
     rbxCollName  = cms.untracked.InputTag('newhcalnoise'),
@@ -132,17 +132,17 @@ cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
 process.dqmSaver.workflow = Workflow
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+process.noiseratesClient = cms.EDProducer("NoiseRatesClient", 
      outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
 
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/CaloTowers/test/single_pi_merging_cfg.py
+++ b/Validation/CaloTowers/test/single_pi_merging_cfg.py
@@ -56,11 +56,11 @@ cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
 process.dqmSaver.workflow = Workflow
 
-process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+process.calotowersClient = cms.EDProducer("CaloTowersClient", 
      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )
-process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+process.hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
      outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/EventGenerator/python/PostProcessor_cff.py
+++ b/Validation/EventGenerator/python/PostProcessor_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-postProcessorBasicHepMCValidation = cms.EDAnalyzer(
+postProcessorBasicHepMCValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/Particles*"),
     efficiency = cms.vstring(""),
@@ -345,7 +345,7 @@ postProcessorBasicHepMCValidation.normalization.extend(["gluonLifeTime nEvt",
                                                         "unknownPDTNumber nEvt",
                                                         "vrtxRadius nEvt"])
 
-postProcessorBasicGenParticleValidation = cms.EDAnalyzer(
+postProcessorBasicGenParticleValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/GenParticles*"),
     efficiency = cms.vstring(""),
@@ -367,7 +367,7 @@ postProcessorBasicGenParticleValidation = cms.EDAnalyzer(
                                           "genJetTotPt nEvt")        
 )    
 
-postProcessorMBUEandQCDValidation = cms.EDAnalyzer(
+postProcessorMBUEandQCDValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/MBUEandQCD*"),
     efficiency = cms.vstring(""),
@@ -452,7 +452,7 @@ postProcessorMBUEandQCDValidation = cms.EDAnalyzer(
                                           "Tracketa nEvt")
 )        
 
-postProcessorWValidation = cms.EDAnalyzer(
+postProcessorWValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/W*"),
     efficiency = cms.vstring(""),
@@ -476,7 +476,7 @@ postProcessorWValidation = cms.EDAnalyzer(
                                           "leadeta nEvt")
 )    
 
-postProcessorDrellYanValidation = cms.EDAnalyzer(
+postProcessorDrellYanValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/DrellYan*"),
     efficiency = cms.vstring(""),
@@ -500,7 +500,7 @@ postProcessorDrellYanValidation = cms.EDAnalyzer(
                                           "seceta nEvt")
 )
 
-postProcessorTauValidation = cms.EDAnalyzer(
+postProcessorTauValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/Tau*"),
     efficiency = cms.vstring(""),
@@ -581,7 +581,7 @@ postProcessorTauValidation = cms.EDAnalyzer(
                                           )
     )
 
-postProcessorTTbarValidation = cms.EDAnalyzer(
+postProcessorTTbarValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/TTbar*"),
     efficiency = cms.vstring(""),
@@ -634,7 +634,7 @@ postProcessorTTbarValidation = cms.EDAnalyzer(
                                           )
     )
 
-postProcessorTTbarSpinCorr = cms.EDAnalyzer("DQMGenericClient",
+postProcessorTTbarSpinCorr = cms.EDProducer("DQMGenericClient",
                                               subDirs = cms.untracked.vstring("Generator/TTbarSpinCorr*"),
                                               efficiency = cms.vstring(""),
                                               resolution = cms.vstring(""),
@@ -646,7 +646,7 @@ postProcessorTTbarSpinCorr = cms.EDAnalyzer("DQMGenericClient",
                                               )
 
 
-postProcessorHiggsValidation = cms.EDAnalyzer(
+postProcessorHiggsValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/Higgs*"),
     efficiency = cms.vstring(""),
@@ -685,7 +685,7 @@ postProcessorHiggsValidation = cms.EDAnalyzer(
                                          )
     )
 
-postProcessorHplusValidation = cms.EDAnalyzer(
+postProcessorHplusValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/Hplus*"),
     efficiency = cms.vstring(""),
@@ -725,7 +725,7 @@ postProcessorHplusValidation = cms.EDAnalyzer(
     )
 
 
-postProcessorBPhysicsValidation = cms.EDAnalyzer(
+postProcessorBPhysicsValidation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Generator/BPhysics*"),
     efficiency = cms.vstring(""),

--- a/Validation/HGCalValidation/python/HGCalDigiClient_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalDigiClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hgcalDigiClientEE = cms.EDAnalyzer("HGCalDigiClient", 
+hgcalDigiClientEE = cms.EDProducer("HGCalDigiClient", 
                                    DetectorName = cms.string("HGCalEESensitive"),
                                    Verbosity    = cms.untracked.int32(0)
                                    )

--- a/Validation/HGCalValidation/python/HGCalRecHitsClient_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalRecHitsClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hgcalRecHitClientEE = cms.EDAnalyzer("HGCalRecHitsClient", 
+hgcalRecHitClientEE = cms.EDProducer("HGCalRecHitsClient", 
                                      DetectorName = cms.string("HGCalEESensitive"),
                                      Verbosity     = cms.untracked.int32(0)
                                      )

--- a/Validation/HGCalValidation/python/HGCalSimHitsClient_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalSimHitsClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hgcalSimHitClientEE = cms.EDAnalyzer("HGCalSimHitsClient", 
+hgcalSimHitClientEE = cms.EDProducer("HGCalSimHitsClient", 
                                      DetectorName = cms.string("HGCalEESensitive"),
                                      Verbosity     = cms.untracked.int32(0)
                                      )

--- a/Validation/HGCalValidation/python/hgcGeometryClient_cfi.py
+++ b/Validation/HGCalValidation/python/hgcGeometryClient_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-hgcalGeometryClient = cms.EDAnalyzer("HGCalGeometryClient", 
+hgcalGeometryClient = cms.EDProducer("HGCalGeometryClient", 
                                      DirectoryName = cms.string("Geometry"),
                                      )

--- a/Validation/HGCalValidation/python/hgcalHitClient_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalHitClient_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-hgcalHitClient = cms.EDAnalyzer("HGCalHitClient", 
+hgcalHitClient = cms.EDProducer("HGCalHitClient", 
                                 DirectoryName = cms.string("HitValidation"),
                                 )

--- a/Validation/HGCalValidation/python/simhitClient_cfi.py
+++ b/Validation/HGCalValidation/python/simhitClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hgcalSimHitClientEE = cms.EDAnalyzer("HGCalSimHitsClient", 
+hgcalSimHitClientEE = cms.EDProducer("HGCalSimHitsClient", 
                                      DetectorName = cms.string("HGCalEESensitive"),
                                      TimeSlices   = cms.int32(2),
                                      Verbosity    = cms.untracked.int32(0),

--- a/Validation/HcalDigis/python/HcalDigisClient_cfi.py
+++ b/Validation/HcalDigis/python/HcalDigisClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hcaldigisClient = cms.EDAnalyzer("HcalDigisClient",
+hcaldigisClient = cms.EDProducer("HcalDigisClient",
      outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory
 )

--- a/Validation/HcalHits/python/hcalSimHitsClient_cfi.py
+++ b/Validation/HcalHits/python/hcalSimHitsClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hcalsimhitsClient = cms.EDAnalyzer("HcalSimHitsClient", 
+hcalsimhitsClient = cms.EDProducer("HcalSimHitsClient", 
      DQMDirName = cms.string("/"), # root directory
      Verbosity  = cms.untracked.bool(False),
 )

--- a/Validation/HcalRecHits/python/HcalRecHitsClient_cfi.py
+++ b/Validation/HcalRecHits/python/HcalRecHitsClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+hcalrechitsClient = cms.EDProducer("HcalRecHitsClient", 
 #     outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
      outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory

--- a/Validation/HcalRecHits/python/NoiseRatesClient_cfi.py
+++ b/Validation/HcalRecHits/python/NoiseRatesClient_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+noiseratesClient = cms.EDProducer("NoiseRatesClient", 
 #     outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
      outputFile = cms.untracked.string(''),
      DQMDirName = cms.string("/") # root directory

--- a/Validation/L1T/python/postProcessorL1Gen_cff.py
+++ b/Validation/L1T/python/postProcessorL1Gen_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-postProcessorL1Gen = cms.EDAnalyzer("DQMGenericClient",
+postProcessorL1Gen = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("L1T/L1TriggerVsGen/"),
     efficiency = cms.vstring(
        "Muon_Eff_Pt 'L1 efficiency vs p_{T}' Muon_Eff_Pt_Nomin Muon_Eff_Pt_Denom", 

--- a/Validation/MuonGEMDigis/python/PostProcessor_cff.py
+++ b/Validation/MuonGEMDigis/python/PostProcessor_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-gemDigiHarvesting = cms.EDAnalyzer("MuonGEMDigisHarvestor",
+gemDigiHarvesting = cms.EDProducer("MuonGEMDigisHarvestor",
   dbePath = cms.string("MuonGEMDigisV/GEMDigisTask/"),
   compareDBEPath = cms.string("MuonGEMHitsV/GEMHitsTask/"),
   dbeHistPrefix = cms.string("copad_dcEta"),

--- a/Validation/MuonGEMHits/python/PostProcessor_cff.py
+++ b/Validation/MuonGEMHits/python/PostProcessor_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-gemSimHarvesting = cms.EDAnalyzer("MuonGEMHitsHarvestor")
+gemSimHarvesting = cms.EDProducer("MuonGEMHitsHarvestor")
 MuonGEMHitsPostProcessors = cms.Sequence( gemSimHarvesting ) 

--- a/Validation/MuonGEMRecHits/python/PostProcessor_cff.py
+++ b/Validation/MuonGEMRecHits/python/PostProcessor_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-gemRecHitHarvesting = cms.EDAnalyzer("MuonGEMRecHitsHarvestor")
+gemRecHitHarvesting = cms.EDProducer("MuonGEMRecHitsHarvestor")
 MuonGEMRecHitsPostProcessors = cms.Sequence( gemRecHitHarvesting ) 

--- a/Validation/MuonIsolation/python/PostProcessor_cff.py
+++ b/Validation/MuonIsolation/python/PostProcessor_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-postProcessorMuonIsolation = cms.EDAnalyzer(
+postProcessorMuonIsolation = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/MuonIsolationV*"),
     efficiency = cms.vstring(""),

--- a/Validation/MuonME0Validation/python/PostProcessor_cff.py
+++ b/Validation/MuonME0Validation/python/PostProcessor_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-me0DigiHarvesting = cms.EDAnalyzer("MuonME0DigisHarvestor")
+me0DigiHarvesting = cms.EDProducer("MuonME0DigisHarvestor")
 MuonME0DigisPostProcessors = cms.Sequence( me0DigiHarvesting )
 
-me0SegHarvesting = cms.EDAnalyzer("MuonME0SegHarvestor")
+me0SegHarvesting = cms.EDProducer("MuonME0SegHarvestor")
 MuonME0SegPostProcessors = cms.Sequence( me0SegHarvesting )

--- a/Validation/RPCRecHits/python/postValidation_cfi.py
+++ b/Validation/RPCRecHits/python/postValidation_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.ClientConfig.genericClientPSetHelper_cff import *
 
-rpcRecHitSimRecoClient = cms.EDAnalyzer("RPCRecHitValidClient",
+rpcRecHitSimRecoClient = cms.EDProducer("RPCRecHitValidClient",
     subDir = cms.string("RPC/RPCRecHitV/SimVsReco"),
 )
 
-rpcRecHitPostValidation = cms.EDAnalyzer("DQMGenericClient",
+rpcRecHitPostValidation = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("RPC/RPCRecHitV/SimVsReco",),
     #subDirs = cms.untracked.vstring("RPC/RPCRecHitV/SimVsReco",
     #                                "RPC/RPCRecHitV/SimVsDTExt",
@@ -56,7 +56,7 @@ rpcRecHitPostValidation = cms.EDAnalyzer("DQMGenericClient",
     outputFileName = cms.untracked.string("")
 )
 
-rpcPointVsRecHitPostValidation = cms.EDAnalyzer("DQMGenericClient",
+rpcPointVsRecHitPostValidation = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("RPC/RPCRecHitV/DTVsReco",
                                     "RPC/RPCRecHitV/CSCVsReco"),
 #                                    "RPC/RPCRecHitV/TrackVsReco"),

--- a/Validation/RecoB/python/BDHadronTrackMonitoring_cfi.py
+++ b/Validation/RecoB/python/BDHadronTrackMonitoring_cfi.py
@@ -16,5 +16,5 @@ BDHadronTrackMonitoringAnalyze = cms.EDAnalyzer("BDHadronTrackMonitoringAnalyzer
                                 )
 
 
-BDHadronTrackMonitoringHarvest = cms.EDAnalyzer("BDHadronTrackMonitoringHarvester"
+BDHadronTrackMonitoringHarvest = cms.EDProducer("BDHadronTrackMonitoringHarvester"
 								)

--- a/Validation/RecoB/python/bTagAnalysis_cfi.py
+++ b/Validation/RecoB/python/bTagAnalysis_cfi.py
@@ -20,7 +20,7 @@ bTagValidation = cms.EDAnalyzer("BTagPerformanceAnalyzerMC",
                                 )
 
 
-bTagHarvestMC = cms.EDAnalyzer("BTagPerformanceHarvester",
+bTagHarvestMC = cms.EDProducer("BTagPerformanceHarvester",
                                bTagCommonBlock,
                                produceEps = cms.bool(False),
                                producePs = cms.bool(False),

--- a/Validation/RecoEgamma/python/ElectronMcFakePostValidator_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcFakePostValidator_cfi.py
@@ -5,7 +5,7 @@ electronMcFakeHistosCfg = cms.PSet(
   EfficiencyFlag = cms.bool(True),StatOverflowFlag = cms.bool(False)
 )
 
-electronMcFakePostValidator = cms.EDAnalyzer("ElectronMcFakePostValidator",
+electronMcFakePostValidator = cms.EDProducer("ElectronMcFakePostValidator",
 
   Verbosity = cms.untracked.int32(0),
   FinalStep = cms.string("AtJobEnd"),

--- a/Validation/RecoEgamma/python/ElectronMcSignalPostValidatorMiniAOD_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalPostValidatorMiniAOD_cfi.py
@@ -5,7 +5,7 @@ electronMcSignalHistosCfg = cms.PSet(
   EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False)
 )
 
-electronMcSignalPostValidatorMiniAOD = cms.EDAnalyzer("ElectronMcSignalPostValidatorMiniAOD",
+electronMcSignalPostValidatorMiniAOD = cms.EDProducer("ElectronMcSignalPostValidatorMiniAOD",
 
   Verbosity = cms.untracked.int32(0),
   FinalStep = cms.string("AtJobEnd"),

--- a/Validation/RecoEgamma/python/ElectronMcSignalPostValidatorPt1000_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalPostValidatorPt1000_cfi.py
@@ -5,7 +5,7 @@ electronMcSignalHistosCfg = cms.PSet(
   EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False)
 )
 
-electronMcSignalPostValidatorPt1000 = cms.EDAnalyzer("ElectronMcSignalPostValidator",
+electronMcSignalPostValidatorPt1000 = cms.EDProducer("ElectronMcSignalPostValidator",
 
   Verbosity = cms.untracked.int32(0),
   FinalStep = cms.string("AtJobEnd"),

--- a/Validation/RecoEgamma/python/ElectronMcSignalPostValidator_cfi.py
+++ b/Validation/RecoEgamma/python/ElectronMcSignalPostValidator_cfi.py
@@ -5,7 +5,7 @@ electronMcSignalHistosCfg = cms.PSet(
   EfficiencyFlag = cms.bool(True), StatOverflowFlag = cms.bool(False)
 )
 
-electronMcSignalPostValidator = cms.EDAnalyzer("ElectronMcSignalPostValidator",
+electronMcSignalPostValidator = cms.EDProducer("ElectronMcSignalPostValidator",
 
   Verbosity = cms.untracked.int32(0),
   FinalStep = cms.string("AtJobEnd"),

--- a/Validation/RecoJets/python/JetPostProcessor_cfi.py
+++ b/Validation/RecoJets/python/JetPostProcessor_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 ################# Postprocessing #########################
-JetPostprocessing = cms.EDAnalyzer('JetTesterPostProcessor',
+JetPostprocessing = cms.EDProducer('JetTesterPostProcessor',
                     JetTypeRECO = cms.InputTag("ak4PFJetsCHS"),
                     JetTypeMiniAOD = cms.InputTag("slimmedJets")
                    )  

--- a/Validation/RecoMET/python/METPostProcessor_cfi.py
+++ b/Validation/RecoMET/python/METPostProcessor_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 ################# Postprocessing #########################
-METPostprocessing = cms.EDAnalyzer('METTesterPostProcessor')  
+METPostprocessing = cms.EDProducer('METTesterPostProcessor')  
 
 ################ Postprocessing Harvesting #########################
-METPostprocessingHarvesting = cms.EDAnalyzer('METTesterPostProcessorHarvesting',
+METPostprocessingHarvesting = cms.EDProducer('METTesterPostProcessorHarvesting',
                     METTypeRECO = cms.InputTag("PfMetT1"),
                     METTypeMiniAOD = cms.InputTag("slimmedMETs")
                    )  

--- a/Validation/RecoMuon/python/NewPostProcessorHLT_cff.py
+++ b/Validation/RecoMuon/python/NewPostProcessorHLT_cff.py
@@ -6,7 +6,7 @@ from Validation.RecoMuon.NewPostProcessor_cff import NEWpostProcessorMuonTrack
 NEWpostProcessorMuonTrackHLT = NEWpostProcessorMuonTrack.clone()
 NEWpostProcessorMuonTrackHLT.subDirs = cms.untracked.vstring("HLT/Muon/MuonTrack/*")
 
-NEWpostProcessorMuonTrackHLTComp = cms.EDAnalyzer(
+NEWpostProcessorMuonTrackHLTComp = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("HLT/Muon/MuonTrack/"), 
     efficiency = cms.vstring(

--- a/Validation/RecoMuon/python/NewPostProcessor_RecoMuonValidator_cff.py
+++ b/Validation/RecoMuon/python/NewPostProcessor_RecoMuonValidator_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-NEWpostProcessorRecoMuon = cms.EDAnalyzer("DQMGenericClient",
+NEWpostProcessorRecoMuon = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc"),
     #efficiencies and fractions
     efficiency = cms.vstring("EffP   'Efficiency vs p'     P   SimP  ",
@@ -55,7 +55,7 @@ NEWpostProcessorRecoMuon_StaPF = NEWpostProcessorRecoMuon.clone()
 NEWpostProcessorRecoMuon_StaPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_StaPF")
 
 #not sure about this one, which types are monitored
-NEWpostProcessorRecoMuonComp = cms.EDAnalyzer(
+NEWpostProcessorRecoMuonComp = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/"),
     efficiency = cms.vstring(
@@ -72,7 +72,7 @@ NEWpostProcessorRecoMuonComp = cms.EDAnalyzer(
     outputFileName = cms.untracked.string("")
 )
 
-NEWpostProcessorRecoMuonCompPF = cms.EDAnalyzer(
+NEWpostProcessorRecoMuonCompPF = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/"),
     efficiency = cms.vstring(

--- a/Validation/RecoMuon/python/NewPostProcessor_cff.py
+++ b/Validation/RecoMuon/python/NewPostProcessor_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Validation.RecoMuon.NewPostProcessor_RecoMuonValidator_cff import *
 
-NEWpostProcessorMuonTrack = cms.EDAnalyzer("DQMGenericClient",
+NEWpostProcessorMuonTrack = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/MuonTrack/*"),
     efficiency = cms.vstring(
         "effic_vs_eta 'Efficiency vs #eta' num_assoSimToReco_eta num_simul_eta",
@@ -76,7 +76,7 @@ NEWpostProcessorMuonTrack = cms.EDAnalyzer("DQMGenericClient",
 )
 
 
-NEWpostProcessorMuonTrackComp = cms.EDAnalyzer("DQMGenericClient",
+NEWpostProcessorMuonTrackComp = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/MuonTrack/"),
     efficiency = cms.vstring(
     "Eff_GlbTk_Eta_mabh 'Eff_{GLB,TK} vs #eta' globalMuons/effic_vs_eta probeTrks/effic_vs_eta",

--- a/Validation/RecoMuon/python/PostProcessorHLT_cff.py
+++ b/Validation/RecoMuon/python/PostProcessorHLT_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-postProcessorMuonMultiTrackHLT = cms.EDAnalyzer("DQMGenericClient",
+postProcessorMuonMultiTrackHLT = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("HLT/Muon/MultiTrack/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
@@ -48,7 +48,7 @@ postProcessorMuonMultiTrackHLT = cms.EDAnalyzer("DQMGenericClient",
     outputFileName = cms.untracked.string("")
 )
 
-postProcessorMuonMultiTrackHLTComp = cms.EDAnalyzer(
+postProcessorMuonMultiTrackHLTComp = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("HLT/Muon/MultiTrack/"), 
     efficiency = cms.vstring(
@@ -63,7 +63,7 @@ postProcessorMuonMultiTrackHLTComp = cms.EDAnalyzer(
     outputFileName = cms.untracked.string("")
     )
 
-postProcessorMuonMultiTrackHLTCompFS = cms.EDAnalyzer(
+postProcessorMuonMultiTrackHLTCompFS = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("HLT/Muon/MultiTrack/"), 
     efficiency = cms.vstring(

--- a/Validation/RecoMuon/python/PostProcessor_cff.py
+++ b/Validation/RecoMuon/python/PostProcessor_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-postProcessorMuonMultiTrack = cms.EDAnalyzer("DQMGenericClient",
+postProcessorMuonMultiTrack = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/MultiTrack/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
@@ -49,7 +49,7 @@ postProcessorMuonMultiTrack = cms.EDAnalyzer("DQMGenericClient",
 )
 
 
-postProcessorMuonMultiTrackComp = cms.EDAnalyzer("DQMGenericClient",
+postProcessorMuonMultiTrackComp = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/MultiTrack/"),
     efficiency = cms.vstring(
     "Eff_GlbTk_Eta_mabh 'Eff_{GLB,TK} vs #eta' extractedGlobalMuons/effic probeTrks/effic",
@@ -63,7 +63,7 @@ postProcessorMuonMultiTrackComp = cms.EDAnalyzer("DQMGenericClient",
     outputFileName = cms.untracked.string("")
 )
 
-postProcessorMuonMultiTrackCompFS = cms.EDAnalyzer("DQMGenericClient",
+postProcessorMuonMultiTrackCompFS = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/MultiTrack/"),
     efficiency = cms.vstring(
     "Eff_GlbTk_Eta_mabh 'Eff_{GLB,TK} vs #eta' extractedGlobalMuons/effic probeTrks/effic",
@@ -78,7 +78,7 @@ postProcessorMuonMultiTrackCompFS = cms.EDAnalyzer("DQMGenericClient",
 )
 
 
-postProcessorRecoMuon = cms.EDAnalyzer("DQMGenericClient",
+postProcessorRecoMuon = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc"),
     #efficiencies and fractions
     efficiency = cms.vstring("EffP   'Efficiency vs p'     P   SimP  ",
@@ -133,7 +133,7 @@ postProcessorRecoMuon_StaPF = postProcessorRecoMuon.clone()
 postProcessorRecoMuon_StaPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_StaPF")
 
 #not sure about this one, which types are monitored
-postProcessorRecoMuonComp = cms.EDAnalyzer(
+postProcessorRecoMuonComp = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/"),
     efficiency = cms.vstring(
@@ -150,7 +150,7 @@ postProcessorRecoMuonComp = cms.EDAnalyzer(
     outputFileName = cms.untracked.string("")
 )
 
-postProcessorRecoMuonCompPF = cms.EDAnalyzer(
+postProcessorRecoMuonCompPF = cms.EDProducer(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Muons/RecoMuonV/"),
     efficiency = cms.vstring(

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
+postProcessorTrack = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
@@ -220,7 +220,7 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
 # nrec/nsim makes sense only for
 # - all tracks vs. all in-time TrackingParticles
 # - PV tracks vs. signal TrackingParticles
-postProcessorTrackNrecVsNsim = cms.EDAnalyzer("DQMGenericClient",
+postProcessorTrackNrecVsNsim = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Tracking/TrackFromPV/*", "Tracking/TrackAllTPEffic/*"),
     efficiency = cms.vstring(
         "nrecPerNsim 'Tracks/TrackingParticles vs #eta' num_reco2_eta num_simul_eta simpleratio",
@@ -230,7 +230,7 @@ postProcessorTrackNrecVsNsim = cms.EDAnalyzer("DQMGenericClient",
     resolution = cms.vstring()
 )
 
-postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
+postProcessorTrackSummary = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackConversion", "Tracking/TrackGsf", "Tracking/TrackBHadron"),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",

--- a/Validation/RecoVertex/python/PostProcessorV0_cfi.py
+++ b/Validation/RecoVertex/python/PostProcessorV0_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-postProcessorV0 = cms.EDAnalyzer("DQMGenericClient",
+postProcessorV0 = cms.EDProducer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Vertexing/V0V/*"),
     efficiency = cms.vstring(
        "K0sEffVsR 'K^{0}_{S} efficiency vs R (radial)' K0sEffVsR_num K0sEffVsR_denom", 

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
@@ -36,7 +36,7 @@ def _resolPull(prefix):
     ]
 
 
-postProcessorVertex = cms.EDAnalyzer("DQMGenericClient",
+postProcessorVertex = cms.EDProducer("DQMGenericClient",
                                      subDirs = cms.untracked.vstring("Vertexing/PrimaryVertexV/*"),
                                      efficiency = cms.vstring(
                                          "effic_vs_NumVertices 'Efficiency vs NumVertices' GenAllAssoc2RecoMatched_NumVertices GenAllAssoc2Reco_NumVertices",


### PR DESCRIPTION
Resubmit of #18701

This also changes all config files for classes that directly or indirectly
inherit from DQMEDHarvester. The config for these classes was changed
from cms.EDAnalyzer to cms.EDProducer.