### PR TITLE
Switched from boost::regex to std::regex

### DIFF
--- a/HLTrigger/HLTcore/src/HLTConfigProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigProvider.cc
@@ -19,7 +19,8 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <boost/regex.hpp> 
+#include <regex> 
+
 
 // an empty dummy config data used when we fail to initialize 
 static const HLTConfigData* s_dummyHLTConfigData()
@@ -237,18 +238,18 @@ void HLTConfigProvider::clear()
 
 const std::vector<std::string> HLTConfigProvider::matched(const std::vector<std::string>& inputs, const std::string& pattern) {
   std::vector<std::string> matched;
-  const boost::regex regexp(edm::glob2reg(pattern));
+  const std::regex regexp(edm::glob2reg(pattern));
   const unsigned int n(inputs.size());
   for (unsigned int i=0; i<n; ++i) {
     const std::string& input(inputs[i]);
-    if (boost::regex_match(input,regexp)) matched.push_back(input);
+    if (std::regex_match(input,regexp)) matched.push_back(input);
   }
   return matched;
 }
 
 const std::string HLTConfigProvider::removeVersion(const std::string& trigger) {
-  const boost::regex regexp("_v[0-9]+$");
-  return boost::regex_replace(trigger,regexp,"");
+  const std::regex regexp("_v[0-9]+$");
+  return std::regex_replace(trigger,regexp,"");
 }
 
 const std::vector<std::string> HLTConfigProvider::restoreVersion(const std::vector<std::string>& inputs, const std::string& trigger) {

--- a/HLTrigger/HLTcore/src/TriggerExpressionL1uGTReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionL1uGTReader.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <boost/foreach.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/RegexMatch.h"
@@ -67,9 +67,9 @@ void L1uGTReader::init(const Data & data) {
   } else {
     // expand wildcards in the pattern
     bool match = false;
-    boost::regex re(edm::glob2reg(m_pattern));
+    std::regex re(edm::glob2reg(m_pattern));
     for (auto const & entry: triggerMap)
-      if (boost::regex_match(entry.first, re)) {
+      if (std::regex_match(entry.first, re)) {
         match = true;
         m_triggers.push_back( std::make_pair(entry.first, entry.second.getIndex()) );
       }


### PR DESCRIPTION
Doing a helgrind check uncovered a thread unsafe memory handling
by boost::regex. Switching to std::regex solves that and reduces
dependency on boost.