### PR TITLE
Keep gen-level nuclear info 

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1404,7 +1404,7 @@ class ConfigBuilder(object):
         if self._options.gflash==True:
                 self.loadAndRemember("Configuration/StandardSequences/GFlashDIGI_cff")
 
-        if sequence == 'pdigi_valid':
+        if sequence == 'pdigi_valid' or sequence == 'pdigi_hi':
             self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersValid)")
 
 	if sequence != 'pdigi_nogen' and sequence != 'pdigi_valid_nogen' and not self.process.source.type_()=='EmptySource':

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1008,9 +1008,9 @@ steps['RESIM']=merge([{'-s':'reGEN,reSIM','-n':10},steps['DIGI']])
 #steps['RESIMDIGI']=merge([{'-s':'reGEN,reSIM,DIGI,L1,DIGI2RAW,HLT:@fake,RAW2DIGI,L1Reco','-n':10,'--restoreRNDSeeds':'','--process':'HLT'},steps['DIGI']])
 
     
-steps['DIGIHI']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:HIon'}, hiDefaults, step2Upg2015Defaults])
-steps['DIGIHI2011']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake'}, hiDefaults2011, step2Defaults])
-steps['DIGIHIMIX']=merge([{'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:HIon', '-n':2}, hiDefaults, {'--pileup':'HiMix'}, PUHI, step2Upg2015Defaults])
+steps['DIGIHI']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:HIon'}, hiDefaults, {'--pileup':'HiMixNoPU'}, step2Upg2015Defaults])
+steps['DIGIHI2011']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:@fake'}, hiDefaults2011, {'--pileup':'HiMixNoPU'}, step2Defaults])
+steps['DIGIHIMIX']=merge([{'-s':'DIGI:pdigi_hi,L1,DIGI2RAW,HLT:HIon', '-n':2}, hiDefaults, {'--pileup':'HiMix'}, PUHI, step2Upg2015Defaults])
 
 
 # PRE-MIXING : https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideSimulation#Pre_Mixing_Instructions

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -35,6 +35,10 @@ pdigi_valid = cms.Sequence(pdigi)
 pdigi_nogen=cms.Sequence(generatorSmeared*cms.SequencePlaceholder("randomEngineStateProducer")*cms.SequencePlaceholder("mix")*doAllDigi*addPileupInfo)
 pdigi_valid_nogen=cms.Sequence(pdigi_nogen)
 
+from GeneratorInterface.HiGenCommon.HeavyIon_cff import *
+pdigi_hi=cms.Sequence(pdigi+heavyIon)
+pdigi_hi_nogen=cms.Sequence(pdigi_nogen+heavyIon)
+
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 if fastSim.isChosen():
     # pretend these digis have been through digi2raw and raw2digi, by using the approprate aliases

--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -52,6 +52,7 @@ addMixingScenario("E8TeV_AVE_10_BX_50ns_300ns_spread",{'file':'SimGeneral.Mixing
 addMixingScenario("E8TeV_AVE_10_BX_25ns_300ns_spread",{'file':'SimGeneral.MixingModule.mix_E8TeV_AVE_10_BX_25ns_300ns_spread_cfi'})
 addMixingScenario("HiMix",{'file': 'SimGeneral.MixingModule.HiMix_cff'})
 addMixingScenario("HiMixGEN",{'file': 'SimGeneral.MixingModule.HiMixGEN_cff'})
+addMixingScenario("HiMixNoPU",{'file': 'SimGeneral.MixingModule.HiMixNoPU_cff'})
 addMixingScenario("HighLumiPileUp",{'file': 'SimGeneral.MixingModule.mixHighLumPU_cfi'})
 addMixingScenario("InitialLumiPileUp",{'file': 'SimGeneral.MixingModule.mixInitialLumPU_cfi'})
 addMixingScenario("LowLumiPileUp",{'file': 'SimGeneral.MixingModule.mixLowLumPU_cfi'})

--- a/GeneratorInterface/HiGenCommon/python/HeavyIon_cff.py
+++ b/GeneratorInterface/HiGenCommon/python/HeavyIon_cff.py
@@ -2,10 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from SimGeneral.HepPDTESSource.pythiapdt_cfi import *
 heavyIon = cms.EDProducer("GenHIEventProducer",
-                            doReco     = cms.bool(True),
-                            doMC       = cms.bool(True),
-                            generators = cms.vstring("generatorSmeared"),
-                            ptCut      = cms.double(0),
+                          src = cms.InputTag("mix","generatorSmeared"),
                           )
 
 

--- a/SimGeneral/Configuration/python/SimGeneral_HiMixing_EventContent_cff.py
+++ b/SimGeneral/Configuration/python/SimGeneral_HiMixing_EventContent_cff.py
@@ -2,22 +2,22 @@ import FWCore.ParameterSet.Config as cms
 
 HiMixRAW = cms.PSet(
     outputCommands = cms.untracked.vstring(
-#        'keep *_mix_MergedTrackTruth_*',
-#        'drop CrossingFramePlaybackInfoExtended_mix_*_*',
-#        'keep *_mix_*_SIM',
-    )
+        'keep CrossingFramePlaybackInfoNew_mix_*_*',
+        'keep *_heavyIon_*_*',
+        )
 )
 
 HiMixRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
-#        'keep *_mix_MergedTrackTruth_*',
-#        'drop CrossingFramePlaybackInfoExtended_mix_*_*',
-#        'keep *_mix_*_SIM',
+        'keep CrossingFramePlaybackInfoNew_mix_*_*',
+        'keep *_heavyIon_*_*',
     )
 )
 
 HiMixAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
-    )
+        'keep CrossingFramePlaybackInfoNew_mix_*_*',
+        'keep *_heavyIon_*_*',
+        )
 )
 

--- a/SimGeneral/MixingModule/python/HiMixNoPU_cff.py
+++ b/SimGeneral/MixingModule/python/HiMixNoPU_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# this is a minimum configuration of the Mixing module,
+# to run it in the zero-pileup mode
+#
+from SimGeneral.MixingModule.mixNoPU_cfi import *
+
+mix.mixObjects.mixHepMC.makeCrossingFrame = True


### PR DESCRIPTION
This is a forward port of the 75X PR #12344, which somehow got lost in the shuffle. 
https://github.com/cms-sw/cmssw/pull/12344

This keeps all nuclear information (npart, ncoll, reaction plane) which is necessary when the HepMCProduct is dropped.
This info takes up very little extra space and is contained in:
edm::GenHIEvent                       "heavyIon"                  ""                "HLT" 

This is produced and stored when the following flags are set, e.g., in wf 145:
DIGI:pdigi_hi
--pileup HiMixNoPU


