### PR TITLE
make const correct muon seeding in tracking

### DIFF
--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -1,7 +1,3 @@
-
-//
-//
-
 /**
   \class    pat::OutsideInMuonSeeder MuonReSeeder.h "MuonAnalysis/MuonAssociators/interface/MuonReSeeder.h"
   \brief    Matcher of reconstructed objects to other reconstructed objects using the tracks inside them
@@ -41,7 +37,7 @@
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 
-class OutsideInMuonSeeder : public edm::stream::EDProducer<> {
+class OutsideInMuonSeeder final : public edm::stream::EDProducer<> {
     public:
       explicit OutsideInMuonSeeder(const edm::ParameterSet & iConfig);
       virtual ~OutsideInMuonSeeder() { }
@@ -56,25 +52,26 @@ class OutsideInMuonSeeder : public edm::stream::EDProducer<> {
       StringCutObjectSelector<reco::Muon> selector_;
 
       /// How many layers to try
-      int layersToTry_;
+      const int layersToTry_;
 
       /// How many hits to try on same layer
-      int hitsToTry_;
+      const int hitsToTry_;
 
       /// Do inside-out
-      bool fromVertex_;
+      const bool fromVertex_;
 
       /// How much to rescale errors from STA
-      double errorRescaling_;
+      const double errorRescaling_;
 
-      std::string trackerPropagatorName_;
-      std::string muonPropagatorName_;
+      const std::string trackerPropagatorName_;
+      const std::string muonPropagatorName_;
       edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
-      std::string measurementTrackerName_;
-      std::string estimatorName_;
-      std::string updatorName_;
+      const std::string measurementTrackerName_;
+      const std::string estimatorName_;
+      const std::string updatorName_;
 
-      double minEtaForTEC_, maxEtaForTOB_;
+      float const minEtaForTEC_;
+      float const maxEtaForTOB_;
 
       edm::ESHandle<MagneticField>          magfield_;
       edm::ESHandle<Propagator>             muonPropagator_;
@@ -84,7 +81,7 @@ class OutsideInMuonSeeder : public edm::stream::EDProducer<> {
       edm::ESHandle<TrajectoryStateUpdator>         updator_;
 
       /// Dump deug information
-      bool debug_;
+      const bool debug_;
 
       /// Surface used to make a TSOS at the PCA to the beamline
       Plane::PlanePointer dummyPlane_;
@@ -110,13 +107,12 @@ OutsideInMuonSeeder::OutsideInMuonSeeder(const edm::ParameterSet & iConfig) :
     muonPropagatorName_(iConfig.getParameter<std::string>("muonPropagator")),
     measurementTrackerTag_(consumes<MeasurementTrackerEvent>(edm::InputTag("MeasurementTrackerEvent"))),
     estimatorName_(iConfig.getParameter<std::string>("hitCollector")),
+    updatorName_("KFUpdator"),
     minEtaForTEC_(iConfig.getParameter<double>("minEtaForTEC")),
     maxEtaForTOB_(iConfig.getParameter<double>("maxEtaForTOB")),
-    debug_(iConfig.getUntrackedParameter<bool>("debug",false)),
-    dummyPlane_(Plane::build(Plane::PositionType(), Plane::RotationType()))
+    debug_(iConfig.getUntrackedParameter<bool>("debug",false))
 {
     produces<std::vector<TrajectorySeed> >();
-    updatorName_ = "KFUpdator";
 }
 
 void
@@ -140,8 +136,7 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 
     auto out = std::make_unique<std::vector<TrajectorySeed>>();
 
-    for (View<reco::Muon>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
-        const reco::Muon &mu = *it;
+    for (auto const & mu : *src) {
         if (mu.outerTrack().isNull() || !selector_(mu)) continue;
         if (debug_ && mu.innerTrack().isNonnull()) doDebug(*mu.innerTrack());
 
@@ -156,14 +151,10 @@ OutsideInMuonSeeder::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
         if (debug_) std::cout << "\n\n\nSeeding for muon of pt " << mu.pt() << ", eta " << mu.eta() << ", phi " << mu.phi() << std::endl;
         const reco::Track &tk = *mu.outerTrack();
 
-        TrajectoryStateOnSurface state;
-        if (fromVertex_) {
-            FreeTrajectoryState fstate = trajectoryStateTransform::initialFreeState(tk, magfield_.product());
-            dummyPlane_->move(fstate.position() - dummyPlane_->position());
-            state = TrajectoryStateOnSurface(fstate, *dummyPlane_);
-        } else {
-            state = trajectoryStateTransform::innerStateOnSurface(tk, *geometry_, magfield_.product());
-        }
+        TrajectoryStateOnSurface state = fromVertex_ ?
+           TrajectoryStateOnSurface(trajectoryStateTransform::initialFreeState(tk, magfield_.product())) :
+           trajectoryStateTransform::innerStateOnSurface(tk, *geometry_, magfield_.product());
+
         if (std::abs(tk.eta()) < maxEtaForTOB_) {
             std::vector< BarrelDetLayer const* > const & tob = measurementTracker->geometricSearchTracker()->tobLayers();
             int iLayer = 6, found = 0;

--- a/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc
@@ -83,9 +83,6 @@ class OutsideInMuonSeeder final : public edm::stream::EDProducer<> {
       /// Dump deug information
       const bool debug_;
 
-      /// Surface used to make a TSOS at the PCA to the beamline
-      Plane::PlanePointer dummyPlane_;
-
       int doLayer(const GeometricSearchDet &layer,
                   const TrajectoryStateOnSurface &state,
                   std::vector<TrajectorySeed> &out,

--- a/TrackingTools/TrackRefitter/interface/RefitDirection.h
+++ b/TrackingTools/TrackRefitter/interface/RefitDirection.h
@@ -22,7 +22,7 @@ public:
     theGeoDirection = undetermined;
   }
 
-  RefitDirection(std::string& type){ 
+  explicit RefitDirection(std::string const& type){ 
 
     thePropagationDirection = anyDirection;
     theGeoDirection = undetermined;
@@ -40,9 +40,6 @@ public:
 	<< "RefitDirection = [alongMomentum, oppositeToMomentum, insideOut, outsideIn]";
   }
   
-  /// Destructor
-  virtual ~RefitDirection(){};
-
   // Operations
   inline GeometricalDirection geometricalDirection() const {
     if(theGeoDirection == undetermined) LogTrace("Reco|TrackingTools|TrackTransformer") << "Try to use undetermined geometrical direction";

--- a/TrackingTools/TrackRefitter/interface/TrackTransformer.h
+++ b/TrackingTools/TrackRefitter/interface/TrackTransformer.h
@@ -35,27 +35,27 @@ class Propagator;
 class TransientTrackingRecHitBuilder;
 class Trajectory;
 
-class TrackTransformer: public TrackTransformerBase{
+class TrackTransformer final : public TrackTransformerBase{
 
 public:
 
   /// Constructor
-  TrackTransformer(const edm::ParameterSet&);
+  explicit TrackTransformer(const edm::ParameterSet&);
 
   /// Destructor
-  virtual ~TrackTransformer();
+  ~TrackTransformer();
   
   // Operations
 
   /// Convert a reco::Track into Trajectory
-  virtual std::vector<Trajectory> transform(const reco::Track&) const;
+  std::vector<Trajectory> transform(const reco::Track&) const override;
 
   /// Convert a reco::TrackRef into Trajectory
   std::vector<Trajectory> transform(const reco::TrackRef&) const;
 
   /// Convert a reco::TrackRef into Trajectory, refit with a new set of hits
   std::vector<Trajectory> transform(const reco::TransientTrack&,
-                                    const TransientTrackingRecHit::ConstRecHitContainer&) const;
+                                    TransientTrackingRecHit::ConstRecHitContainer&) const;
 
   /// the magnetic field
   const MagneticField* magneticField() const {return &*theMGField;}
@@ -64,7 +64,7 @@ public:
   edm::ESHandle<GlobalTrackingGeometry> trackingGeometry() const {return theTrackingGeometry;}
 
   /// set the services needed by the TrackTransformer
-  virtual void setServices(const edm::EventSetup&);
+  void setServices(const edm::EventSetup&) override;
 
   /// the refitter used to refit the reco::Track
   std::unique_ptr<TrajectoryFitter> const & refitter() const {return theFitter;}
@@ -75,43 +75,40 @@ public:
   TransientTrackingRecHit::ConstRecHitContainer
     getTransientRecHits(const reco::TransientTrack& track) const;
   
- protected:
-  
  private:
 
-  std::string thePropagatorName;
-  edm::ESHandle<Propagator> propagator() const {return thePropagator;}
-  edm::ESHandle<Propagator> thePropagator;
-  
-  unsigned long long theCacheId_TC;
-  unsigned long long theCacheId_GTG;
-  unsigned long long theCacheId_MG;
-  unsigned long long theCacheId_TRH;
-  
-  bool theRPCInTheFit;
+ RefitDirection::GeometricalDirection
+    checkRecHitsOrdering(TransientTrackingRecHit::ConstRecHitContainer const&) const;
 
-  bool theDoPredictionsOnly;
-  RefitDirection theRefitDirection;
+  
+  unsigned long long theCacheId_TC=0;
+  unsigned long long theCacheId_GTG=0;
+  unsigned long long theCacheId_MG=0;
+  unsigned long long theCacheId_TRH=0;
+  
+  const bool theRPCInTheFit;
+
+  const bool theDoPredictionsOnly;
+  const RefitDirection theRefitDirection;
 
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   edm::ESHandle<MagneticField> theMGField;
   
-  std::string theFitterName;
+  const std::string theFitterName;
   std::unique_ptr<TrajectoryFitter> theFitter;
   
-  std::string theSmootherName;
+  const std::string theSmootherName;
   std::unique_ptr<TrajectorySmoother> theSmoother;
  
-  RefitDirection::GeometricalDirection
-    checkRecHitsOrdering(TransientTrackingRecHit::ConstRecHitContainer&) const;
+  const std::string thePropagatorName;
+  edm::ESHandle<Propagator> const & propagator() const {return thePropagator;}
+  edm::ESHandle<Propagator> thePropagator;
 
-  //  void reorder(TransientTrackingRecHit::ConstRecHitContainer& recHits) const;
-
-  std::string theTrackerRecHitBuilderName;
+  const std::string theTrackerRecHitBuilderName;
   edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
   TkClonerImpl hitCloner;
   
-  std::string theMuonRecHitBuilderName;
+  const std::string theMuonRecHitBuilderName;
   edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 };
 #endif

--- a/TrackingTools/TrackRefitter/interface/TrackTransformerBase.h
+++ b/TrackingTools/TrackRefitter/interface/TrackTransformerBase.h
@@ -15,10 +15,10 @@ namespace edm {class EventSetup;}
 class TrackTransformerBase {
 public:
   /// Constructor
-  TrackTransformerBase(){};
+  TrackTransformerBase(){}
 
   /// Destructor
-  virtual ~TrackTransformerBase(){};
+  virtual ~TrackTransformerBase(){}
 
   // Operations
 
@@ -27,10 +27,6 @@ public:
 
   /// set the services needed by the TrackTransformers
   virtual void setServices(const edm::EventSetup&) = 0;
-
-protected:
-
-private:
 
 };
 #endif

--- a/TrackingTools/TrackRefitter/plugins/TracksToTrajectories.cc
+++ b/TrackingTools/TrackRefitter/plugins/TracksToTrajectories.cc
@@ -121,7 +121,7 @@ void TracksToTrajectories::produce(Event& event, const EventSetup& setup){
   theTrackTransformer->setServices(setup);
   
   // Collection of Trajectory
-  unique_ptr<vector<Trajectory> > trajectoryCollection(new vector<Trajectory>);
+  auto trajectoryCollection = std::make_unique<vector<Trajectory>>();
   
   // Get the reference
   RefProd<vector<Trajectory> > trajectoryCollectionRefProd 
@@ -132,18 +132,17 @@ void TracksToTrajectories::produce(Event& event, const EventSetup& setup){
   event.getByToken(theTracksToken, tracks);
   
   // Association map between Trajectory and Track
-  unique_ptr<TrajTrackAssociationCollection> trajTrackMap(new TrajTrackAssociationCollection(trajectoryCollectionRefProd, tracks));
+  auto trajTrackMap = std::make_unique<TrajTrackAssociationCollection>(trajectoryCollectionRefProd, tracks);
   
   Ref<vector<Trajectory> >::key_type trajectoryIndex = 0;
   reco::TrackRef::key_type trackIndex = 0;
 
   // Loop over the Rec tracks
-  for (reco::TrackCollection::const_iterator newTrack = tracks->begin(); 
-       newTrack != tracks->end(); ++newTrack) {
+  for (auto const & newTrack : *tracks ) {
     
     ++(globalCache()->theNTracks);
 
-    vector<Trajectory> trajectoriesSM = theTrackTransformer->transform(*newTrack);
+    auto const & trajectoriesSM = theTrackTransformer->transform(newTrack);
     
     if(!trajectoriesSM.empty()){
       // Load the trajectory in the Trajectory Container

--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -97,6 +97,19 @@ public:
 			const SurfaceSide side = SurfaceSideDefinition::atCenterOfSurface);
 
 
+  /** Constructor from FTS: just a wrapper
+   */
+  explicit BasicTrajectoryState( const FreeTrajectoryState& fts):
+    theFreeState(fts),
+    theLocalError(InvalidError()),
+    theLocalParameters(),
+    theLocalParametersValid(false),
+    theValid(true),
+    theWeight(1.)
+    {}
+
+
+
 
   /** Constructor from local parameters, errors and surface. For surfaces 
    *  with material the side of the surface should be specified explicitely. 


### PR DESCRIPTION
Technical modifications to ensure const-correctness in code affecting muon seeding and guarantee full independence of reco seed by seed.

No regression expected.