### PR TITLE
Switch from boost::regex to std::regex

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
@@ -17,7 +17,7 @@
 #include "DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h"
 #include "DQMOffline/Trigger/interface/HLTTauDQMPathSummaryPlotter.h"
 
-#include <boost/regex.hpp>
+#include <regex>
 
 //
 // class declaration
@@ -41,7 +41,7 @@ private:
     edm::EDGetTokenT<trigger::TriggerEvent> triggerEventToken_;
 
     // For path plotters
-    const boost::regex pathRegex_;
+    const std::regex pathRegex_;
     const int nPtBins_, nEtaBins_, nPhiBins_;
     const double ptMax_, highPtMax_, l1MatchDr_, hltMatchDr_;
     const std::string dqmBaseFolder_;

--- a/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
@@ -64,10 +64,10 @@ void HLTTauDQMOfflineSource::dqmBeginRun(const edm::Run& iRun, const edm::EventS
     if(hltMenuChanged) {
       // Find all paths to monitor
       std::vector<std::string> foundPaths;
-      boost::smatch what;
+      std::smatch what;
       LogDebug("HLTTauDQMOffline") << "Looking for paths with regex " << pathRegex_;
       for(const std::string& pathName: HLTCP_.triggerNames()) {
-        if(boost::regex_search(pathName, what, pathRegex_)) {
+        if(std::regex_search(pathName, what, pathRegex_)) {
           LogDebug("HLTTauDQMOffline") << "Found path " << pathName;
           foundPaths.emplace_back(pathName);
         }


### PR DESCRIPTION
The helgrind tool reported that boost::regex was sharing memory
between threads. To be sure we are thread safe, switched code to
use std;:regex. This has the added benefit of using more of the
standard library which is more future proof than boost.