### PR TITLE
Fixed TotemRPGeometry to be const correct

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/interface/TotemRPGeometry.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/TotemRPGeometry.h
@@ -39,8 +39,8 @@ class DetId;
 class TotemRPGeometry
 {
   public:
-    typedef std::map<unsigned int, DetGeomDesc* > mapType;
-    typedef std::map<int, DetGeomDesc* > RPDeviceMapType;
+    typedef std::map<unsigned int, const DetGeomDesc* > mapType;
+    typedef std::map<int, const DetGeomDesc* > RPDeviceMapType;
     typedef std::map<unsigned int, std::set<unsigned int> > mapSetType;
 
     TotemRPGeometry() {}
@@ -65,7 +65,7 @@ class TotemRPGeometry
     ///\brief returns geometry of a detector
     /// performs necessary checks, returns NULL if fails
     /// input is raw ID
-    DetGeomDesc *GetDetector(unsigned int) const;
+    const DetGeomDesc *GetDetector(unsigned int) const;
 
     const DetGeomDesc* GetDetector( const TotemRPDetId& id ) const
     {
@@ -89,7 +89,7 @@ class TotemRPGeometry
     CLHEP::Hep3Vector GetDetEdgeNormalVector(unsigned int id) const;
 
     /// returns geometry of a RP box
-    DetGeomDesc *GetRPDevice(unsigned int id) const;
+    const DetGeomDesc *GetRPDevice(unsigned int id) const;
 
     /// returns the (outer) position of the thin foil of a RP box
     CLHEP::Hep3Vector GetRPThinFoilPosition(int copy_no) const;
@@ -126,26 +126,26 @@ class TotemRPGeometry
     void BuildSets();
 
     /// after checks returns set of stations corresponding to the given arm ID
-    std::set<unsigned int> StationsInArm(unsigned int) const;
+    std::set<unsigned int> const& StationsInArm(unsigned int) const;
 
     /// after checks returns set of RP corresponding to the given station ID
-    std::set<unsigned int> RPsInStation(unsigned int) const;
+    std::set<unsigned int> const& RPsInStation(unsigned int) const;
     
     /// after checks returns set of detectors corresponding to the given RP ID
     /// containts decimal detetector IDs
-    std::set<unsigned int> DetsInRP(unsigned int) const;
+    std::set<unsigned int> const& DetsInRP(unsigned int) const;
 
     /// coordinate transformations between local<-->global reference frames
     /// dimensions in mm, raw ID expected
-    CLHEP::Hep3Vector LocalToGlobal(DetGeomDesc *gd, const CLHEP::Hep3Vector r) const;
-    CLHEP::Hep3Vector GlobalToLocal(DetGeomDesc *gd, const CLHEP::Hep3Vector r) const;
-    CLHEP::Hep3Vector LocalToGlobal(unsigned int id, const CLHEP::Hep3Vector r) const;
-    CLHEP::Hep3Vector GlobalToLocal(unsigned int id, const CLHEP::Hep3Vector r) const;
+    CLHEP::Hep3Vector LocalToGlobal(const DetGeomDesc *gd, const CLHEP::Hep3Vector& r) const;
+    CLHEP::Hep3Vector GlobalToLocal(const DetGeomDesc *gd, const CLHEP::Hep3Vector& r) const;
+    CLHEP::Hep3Vector LocalToGlobal(unsigned int id, const CLHEP::Hep3Vector& r) const;
+    CLHEP::Hep3Vector GlobalToLocal(unsigned int id, const CLHEP::Hep3Vector& r) const;
 
     /// direction transformations between local<-->global reference frames
     /// (dimensions in mm), raw ID expected
-    CLHEP::Hep3Vector LocalToGlobalDirection(unsigned int id, const CLHEP::Hep3Vector dir) const;
-    CLHEP::Hep3Vector GlobalToLocalDirection(unsigned int id, const CLHEP::Hep3Vector dir) const;
+    CLHEP::Hep3Vector LocalToGlobalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const;
+    CLHEP::Hep3Vector GlobalToLocalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const;
 
     /// returns translation (position) of a detector
     /// raw ID as input

--- a/Geometry/VeryForwardGeometryBuilder/src/TotemRPGeometry.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/TotemRPGeometry.cc
@@ -55,13 +55,13 @@ char TotemRPGeometry::AddDetector(unsigned int id, const DetGeomDesc* &gD)
     return 1;
 
   // add gD
-  theMap[id] = (DetGeomDesc*) gD;
+  theMap[id] = gD;
   return 0;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc* TotemRPGeometry::GetDetector(unsigned int id) const
+const DetGeomDesc* TotemRPGeometry::GetDetector(unsigned int id) const
 {
   // check if id is RP id?
 
@@ -120,7 +120,7 @@ char TotemRPGeometry::AddRPDevice(unsigned int id, const DetGeomDesc* &gD)
 
 //----------------------------------------------------------------------------------------------------
 
-DetGeomDesc* TotemRPGeometry::GetRPDevice(unsigned int id) const
+const DetGeomDesc* TotemRPGeometry::GetRPDevice(unsigned int id) const
 {
   // check if there is a corresponding key
   RPDeviceMapType::const_iterator it = theRomanPotMap.find(id);
@@ -171,7 +171,7 @@ void TotemRPGeometry::BuildSets()
 }
 
 //----------------------------------------------------------------------------------------------------
-std::set<unsigned int> TotemRPGeometry::StationsInArm(unsigned int id) const
+std::set<unsigned int> const& TotemRPGeometry::StationsInArm(unsigned int id) const
 {
   mapSetType::const_iterator it = stationsInArm.find(id);
   if (it == stationsInArm.end())
@@ -181,7 +181,7 @@ std::set<unsigned int> TotemRPGeometry::StationsInArm(unsigned int id) const
 
 //----------------------------------------------------------------------------------------------------
 
-std::set<unsigned int> TotemRPGeometry::RPsInStation(unsigned int id) const
+std::set<unsigned int> const& TotemRPGeometry::RPsInStation(unsigned int id) const
 {
   mapSetType::const_iterator it = rpsInStation.find(id);
   if (it == rpsInStation.end())
@@ -191,7 +191,7 @@ std::set<unsigned int> TotemRPGeometry::RPsInStation(unsigned int id) const
 
 //----------------------------------------------------------------------------------------------------
 
-std::set<unsigned int> TotemRPGeometry::DetsInRP(unsigned int id) const
+std::set<unsigned int> const& TotemRPGeometry::DetsInRP(unsigned int id) const
 {
   mapSetType::const_iterator it = detsInRP.find(id);
   if (it == detsInRP.end())
@@ -201,7 +201,7 @@ std::set<unsigned int> TotemRPGeometry::DetsInRP(unsigned int id) const
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobal(DetGeomDesc *gd, const CLHEP::Hep3Vector r) const
+CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobal(const DetGeomDesc *gd, const CLHEP::Hep3Vector& r) const
 {
   CLHEP::Hep3Vector tmp = gd->rotation() * r;
   tmp.setX(tmp.x() + (gd->translation()).x());
@@ -212,9 +212,9 @@ CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobal(DetGeomDesc *gd, const CLHEP::H
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobal(unsigned int id, const CLHEP::Hep3Vector r) const
+CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobal(unsigned int id, const CLHEP::Hep3Vector& r) const
 {
-  DetGeomDesc *gd = GetDetector(id);
+  auto gd = GetDetector(id);
   CLHEP::Hep3Vector tmp = gd->rotation() * r;
   tmp.setX(tmp.x() + (gd->translation()).x());
   tmp.setY(tmp.y() + (gd->translation()).y());
@@ -224,7 +224,7 @@ CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobal(unsigned int id, const CLHEP::H
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocal(DetGeomDesc *gd, const CLHEP::Hep3Vector r) const
+CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocal(const DetGeomDesc *gd, const CLHEP::Hep3Vector& r) const
 {
   CLHEP::Hep3Vector tmp = r;
   tmp.setX(tmp.x() - (gd->translation()).x());
@@ -235,9 +235,9 @@ CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocal(DetGeomDesc *gd, const CLHEP::H
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocal(unsigned int id, const CLHEP::Hep3Vector r) const
+CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocal(unsigned int id, const CLHEP::Hep3Vector& r) const
 {
-  DetGeomDesc *gd = GetDetector(id);
+  auto gd = GetDetector(id);
   CLHEP::Hep3Vector tmp = r;
   tmp.setX(tmp.x() - (gd->translation()).x());
   tmp.setY(tmp.y() - (gd->translation()).y());
@@ -247,14 +247,14 @@ CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocal(unsigned int id, const CLHEP::H
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobalDirection(unsigned int id, const CLHEP::Hep3Vector dir) const
+CLHEP::Hep3Vector TotemRPGeometry::LocalToGlobalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const
 {
   return GetDetector(id)->rotation() * dir;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocalDirection(unsigned int id, const CLHEP::Hep3Vector dir) const
+CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocalDirection(unsigned int id, const CLHEP::Hep3Vector& dir) const
 {
   return (GetDetector(id)->rotation()).Inverse() * dir;
 }
@@ -263,7 +263,7 @@ CLHEP::Hep3Vector TotemRPGeometry::GlobalToLocalDirection(unsigned int id, const
 
 CLHEP::Hep3Vector TotemRPGeometry::GetDetTranslation(unsigned int id) const
 {
-  DetGeomDesc *gd = GetDetector(id);
+  auto gd = GetDetector(id);
   CLHEP::Hep3Vector tmp;
   tmp.setX((gd->translation()).x());
   tmp.setY((gd->translation()).y());
@@ -285,7 +285,7 @@ void TotemRPGeometry::GetReadoutDirection(unsigned int id, double &dx, double &d
 CLHEP::Hep3Vector TotemRPGeometry::GetRPGlobalTranslation(int copy_no) const
 {
   CLHEP::Hep3Vector tmp;
-  DetGeomDesc * gd = GetRPDevice(copy_no);
+  auto gd = GetRPDevice(copy_no);
   tmp.setX((gd->translation()).x());
   tmp.setY((gd->translation()).y());
   tmp.setZ((gd->translation()).z());


### PR DESCRIPTION
Changed const functions so they returned pointers to const objects.
Changes functions to return const & or to take const & as arguments to avoid unnecessary copying.