### PR TITLE
CTPPS: bug fix #2 in run ranges for FEDs channels mapping

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -285,8 +285,8 @@ edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysis
 {
   assert(currentBlockValid);
 
-  std::shared_ptr<TotemDAQMapping> mapping(new TotemDAQMapping());
-  std::shared_ptr<TotemAnalysisMask> mask(new TotemAnalysisMask());
+  auto mapping = std::make_shared<TotemDAQMapping>();
+  auto mask = std::make_shared<TotemAnalysisMask>();
 
   // initialize Xerces
   try

--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -234,6 +234,12 @@ void TotemDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetu
   {
     const auto &bl = configuration[idx];
 
+    edm::EventRange range = bl.validityRange;
+
+    // event id "1:min" has a special meaning and is translated to a truly minimal event id (1:0:0)
+    if (range.startEventID()==edm::EventID(1, 0, 1))
+      range = edm::EventRange(edm::EventID(1, 0, 0), range.endEventID());
+
     if (edm::contains(bl.validityRange, iosv.eventID()))
     {
       currentBlockValid = true;

--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -6,6 +6,7 @@
 *   Jan Kašpar (jan.kaspar@cern.ch)
 *   Marcin Borratynski (mborratynski@gmail.com)
 *   Seyed Mohsen Etesami (setesami@cern.ch)
+*   Laurent Forthomme
 ****************************************************************************/
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -71,7 +72,7 @@ public:
   TotemDAQMappingESSourceXML(const edm::ParameterSet &);
   ~TotemDAQMappingESSourceXML();
 
-  edm::ESProducts< boost::shared_ptr<TotemDAQMapping>, boost::shared_ptr<TotemAnalysisMask> > produce( const TotemReadoutRcd & );
+  edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysisMask> > produce( const TotemReadoutRcd & );
 
 private:
   unsigned int verbosity;
@@ -110,15 +111,15 @@ private:
   enum ParseType { pMapping, pMask };
 
   /// parses XML file
-  void ParseXML(ParseType, const string &file, const boost::shared_ptr<TotemDAQMapping>&, const boost::shared_ptr<TotemAnalysisMask>&);
+  void ParseXML(ParseType, const string &file, const std::shared_ptr<TotemDAQMapping>&, const std::shared_ptr<TotemAnalysisMask>&);
 
   /// recursive method to extract RP-related information from the DOM tree
   void ParseTreeRP(ParseType, xercesc::DOMNode *, NodeType, unsigned int parentID,
-    const boost::shared_ptr<TotemDAQMapping>&, const boost::shared_ptr<TotemAnalysisMask>&);
+    const std::shared_ptr<TotemDAQMapping>&, const std::shared_ptr<TotemAnalysisMask>&);
 
   /// recursive method to extract RP-related information from the DOM tree
   void ParseTreeDiamond(ParseType, xercesc::DOMNode *, NodeType, unsigned int parentID,
-    const boost::shared_ptr<TotemDAQMapping>&, const boost::shared_ptr<TotemAnalysisMask>&);
+    const std::shared_ptr<TotemDAQMapping>&, const std::shared_ptr<TotemAnalysisMask>&);
 
 private:
   /// adds the path prefix, if needed
@@ -273,13 +274,13 @@ string TotemDAQMappingESSourceXML::CompleteFileName(const string &fn)
 
 //----------------------------------------------------------------------------------------------------
 
-edm::ESProducts< boost::shared_ptr<TotemDAQMapping>, boost::shared_ptr<TotemAnalysisMask> >
+edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysisMask> >
   TotemDAQMappingESSourceXML::produce( const TotemReadoutRcd & )
 {
   assert(currentBlockValid);
 
-  boost::shared_ptr<TotemDAQMapping> mapping(new TotemDAQMapping());
-  boost::shared_ptr<TotemAnalysisMask> mask(new TotemAnalysisMask());
+  std::shared_ptr<TotemDAQMapping> mapping(new TotemDAQMapping());
+  std::shared_ptr<TotemAnalysisMask> mask(new TotemAnalysisMask());
 
   // initialize Xerces
   try
@@ -311,7 +312,7 @@ edm::ESProducts< boost::shared_ptr<TotemDAQMapping>, boost::shared_ptr<TotemAnal
 //----------------------------------------------------------------------------------------------------
 
 void TotemDAQMappingESSourceXML::ParseXML(ParseType pType, const string &file,
-  const boost::shared_ptr<TotemDAQMapping> &mapping, const boost::shared_ptr<TotemAnalysisMask> &mask)
+  const std::shared_ptr<TotemDAQMapping> &mapping, const std::shared_ptr<TotemAnalysisMask> &mask)
 {
   unique_ptr<XercesDOMParser> parser(new XercesDOMParser());
   parser->parse(file.c_str());
@@ -336,8 +337,8 @@ void TotemDAQMappingESSourceXML::ParseXML(ParseType pType, const string &file,
 //-----------------------------------------------------------------------------------------------------------
 
 void TotemDAQMappingESSourceXML::ParseTreeRP(ParseType pType, xercesc::DOMNode * parent, NodeType parentType,
-  unsigned int parentID, const boost::shared_ptr<TotemDAQMapping>& mapping,
-  const boost::shared_ptr<TotemAnalysisMask>& mask)
+  unsigned int parentID, const std::shared_ptr<TotemDAQMapping>& mapping,
+  const std::shared_ptr<TotemAnalysisMask>& mask)
 {
 #ifdef DEBUG
   printf(">> TotemDAQMappingESSourceXML::ParseTreeRP(%s, %u, %u)\n", XMLString::transcode(parent->getNodeName()),
@@ -470,8 +471,8 @@ void TotemDAQMappingESSourceXML::ParseTreeRP(ParseType pType, xercesc::DOMNode *
 //----------------------------------------------------------------------------------------------------
 
 void TotemDAQMappingESSourceXML::ParseTreeDiamond(ParseType pType, xercesc::DOMNode * parent, NodeType parentType,
-  unsigned int parentID, const boost::shared_ptr<TotemDAQMapping>& mapping,
-  const boost::shared_ptr<TotemAnalysisMask>& mask)
+  unsigned int parentID, const std::shared_ptr<TotemDAQMapping>& mapping,
+  const std::shared_ptr<TotemAnalysisMask>& mask)
 {
 
 #ifdef DEBUG

--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -240,18 +240,18 @@ void TotemDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetu
     if (range.startEventID()==edm::EventID(1, 0, 1))
       range = edm::EventRange(edm::EventID(1, 0, 0), range.endEventID());
 
-    if (edm::contains(bl.validityRange, iosv.eventID()))
+    if (edm::contains(range, iosv.eventID()))
     {
       currentBlockValid = true;
       currentBlock = idx;
   
-      const IOVSyncValue begin(bl.validityRange.startEventID());
-      const IOVSyncValue end(bl.validityRange.endEventID());
+      const IOVSyncValue begin(range.startEventID());
+      const IOVSyncValue end(range.endEventID());
       oValidity = edm::ValidityInterval(begin, end);
       
       LogVerbatim("TotemDAQMappingESSourceXML")
         << "    block found: index=" << currentBlock
-        << ", interval=(" << bl.validityRange.startEventID() << " - " << bl.validityRange.endEventID() << ")";
+        << ", interval=(" << range.startEventID() << " - " << range.endEventID() << ")";
 
       return;
     }

--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -233,23 +233,18 @@ void TotemDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetu
   {
     const auto &bl = configuration[idx];
 
-    // event id "1:min" has a special meaning and is translated to a truly minimal event id (1:0:0)
-    EventID startEventID = bl.validityRange.startEventID();
-    if (startEventID.event() == 1)
-      startEventID = EventID(startEventID.run(), startEventID.luminosityBlock(), 0);
-
-    if (startEventID <= iosv.eventID() && iosv.eventID() <= bl.validityRange.endEventID())
+    if (edm::contains(bl.validityRange, iosv.eventID()))
     {
       currentBlockValid = true;
       currentBlock = idx;
   
-      const IOVSyncValue begin(startEventID);
+      const IOVSyncValue begin(bl.validityRange.startEventID());
       const IOVSyncValue end(bl.validityRange.endEventID());
-      oValidity = ValidityInterval(begin, end);
+      oValidity = edm::ValidityInterval(begin, end);
       
       LogVerbatim("TotemDAQMappingESSourceXML")
         << "    block found: index=" << currentBlock
-        << ", interval=(" << startEventID << " - " << bl.validityRange.endEventID() << ")";
+        << ", interval=(" << bl.validityRange.startEventID() << " - " << bl.validityRange.endEventID() << ")";
 
       return;
     }


### PR DESCRIPTION
Follow-up of https://github.com/cms-sw/cmssw/pull/18461#issuecomment-301406407 to ensure a proper handling of the begin/end conditions through the usage of a `edm::contains` (instead of a home-brewed check).
This patch was tested on the conditions defined in [this HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/prep-ops/3940/1/1/1/1/1.html) and successfully passed it.

`runTheMatrix.py -l limited` yielded `8 8 7 5 4 1 1 1 tests passed, 1 0 0 0 0 0 0 0 failed` at 483c88698325daada2d4782c0c70aa6a40b95159 (with the usual DAS error at `step1` of `4.22`)