### PR TITLE
Remove Overlap Between EREG and ETCA

### DIFF
--- a/Geometry/EcalCommonData/data/PhaseII/escon.xml
+++ b/Geometry/EcalCommonData/data/PhaseII/escon.xml
@@ -3,7 +3,7 @@
 <ConstantsSection label="escon.xml" eval="true">
   <Constant name="ESFrontZ"            value="2990*mm"/>
   <Constant name="ESRearZ"             value="3170*mm"/>
-  <Constant name="ESMidZ"              value="3045*mm"/>
+  <Constant name="ESMidZ"              value="[ectkcable:z3CabEC]"/>
   <Constant name="R_MIN"               value="317*mm"/>
   <Constant name="R_MAX"               value="1510*mm"/>
   <Constant name="P1"                  value="0.0*cm"/>


### PR DESCRIPTION
* Remove 6.1 cm overlap between EREG and ETCA in Phase 2 scenarios

@kpedro88 - FYI

Before and after snapshots:
![screenshot 2017-05-15 12 20 50](https://cloud.githubusercontent.com/assets/1390682/26054117/c67e17fc-396b-11e7-846b-a2e1c03a6c96.png)
![screenshot 2017-05-15 12 36 38](https://cloud.githubusercontent.com/assets/1390682/26054125/cb014c0e-396b-11e7-967e-4e145931eed6.png)
