### PR TITLE
CSC TP bugfixes for high PU running

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -921,7 +921,7 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
   
   bool first = true;
   unsigned int n1b=0, n1a=0;
-  for (auto p : readoutLCTs1b())
+  for (const auto& p : readoutLCTs1b())
     {
       if (debug_gem_matching and first){
         std::cout << "========================================================================" << std::endl;
@@ -936,7 +936,7 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
         std::cout << "1b LCT "<<n1b<<"  " << p <<std::endl;
     }
   
-  for (auto p : readoutLCTs1a())
+  for (const auto& p : readoutLCTs1a())
     {
       if (debug_gem_matching and first){
         std::cout << "========================================================================" << std::endl;
@@ -1424,7 +1424,7 @@ void CSCMotherboardME11GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
     deltas.clear();
 
     if (hasCoPads){
-      for (auto p : copads) {
+      for (const auto& p : copads) {
         const GEMDetId detId(p.first);
         const int rollN(detId.roll());
         const int padN((p.second).pad());
@@ -1465,7 +1465,7 @@ void CSCMotherboardME11GEM::correlateLCTsGEM(CSCALCTDigi bestALCT,
 
     // if no copads were found, do the same with pads...
     if (hasPads){
-      for (auto p : pads) {
+      for (const auto& p : pads) {
         const GEMDetId detId(p.first);
         const int rollN(detId.roll());
         const int padN((p.second).pad());
@@ -1852,7 +1852,7 @@ void CSCMotherboardME11GEM::printGEMTriggerPads(int bx_start, int bx_stop, bool 
     if (!iscopad) std::cout << "N(pads) BX " << bx << " : " << in_pads.size() << std::endl;
     else          std::cout << "N(copads) BX " << bx << " : " << in_pads.size() << std::endl;
     if (hasPads){
-      for (auto pad : in_pads){
+      for (const auto& pad : in_pads){
         auto roll_id(GEMDetId(pad.first));
         std::cout << "\tdetId " << pad.first << " " << roll_id << ", pad = " << pad.second.pad() << ", BX = " << pad.second.bx() + 6;
         if (isPadInOverlap(roll_id.roll())) std::cout << " (in overlap)" << std::endl;
@@ -1867,8 +1867,8 @@ void CSCMotherboardME11GEM::printGEMTriggerPads(int bx_start, int bx_stop, bool 
 void CSCMotherboardME11GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads, unsigned id)
 {
   auto superChamber(gem_g->superChamber(id));
-  for (auto ch : superChamber->chambers()) {
-    for (auto roll : ch->etaPartitions()) {
+  for (const auto& ch : superChamber->chambers()) {
+    for (const auto& roll : ch->etaPartitions()) {
       GEMDetId roll_id(roll->id());
       auto pads_in_det = gemPads->get(roll_id);
       for (auto pad = pads_in_det.first; pad != pads_in_det.second; ++pad) {
@@ -1883,7 +1883,7 @@ void CSCMotherboardME11GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads,
 
 void CSCMotherboardME11GEM::retrieveGEMCoPads()
 {
-  for (auto copad: gemCoPadV){
+  for (const auto& copad: gemCoPadV){
     if (copad.first().bx() != lct_central_bx) continue;
     coPads_[copad.bx(1)].push_back(std::make_pair(copad.roll(), copad.first()));  
     coPads_[copad.bx(1)].push_back(std::make_pair(copad.roll(), copad.second()));  
@@ -1892,7 +1892,7 @@ void CSCMotherboardME11GEM::retrieveGEMCoPads()
 
 bool CSCMotherboardME11GEM::isPadInOverlap(int roll)
 {
-  for (auto& p : cscWgToGemRoll_) {
+  for (const auto& p : cscWgToGemRoll_) {
     // overlap region are WGs 10-15
     if ((p.first < 10) or (p.first > 15)) continue;
     if (((p.second).first <= roll) and (roll <= (p.second).second)) return true;
@@ -1951,7 +1951,7 @@ CSCMotherboardME11GEM::matchingGEMPads(const CSCALCTDigi& alct, const GEMPadsBX&
   auto alctRoll(cscWgToGemRoll_[alct.getKeyWG()]);
   const bool debug(false);
   if (debug) std::cout << "ALCT keyWG " << alct.getKeyWG() << ", rolls " << alctRoll.first << " " << alctRoll.second << std::endl;
-  for (auto p: pads){
+  for (const auto& p: pads){
     if (DetId(p.first).subdetId() != MuonSubdetId::GEM or DetId(p.first).det() != DetId::Muon) {
       continue;
     }
@@ -1985,9 +1985,9 @@ CSCMotherboardME11GEM::matchingGEMPads(const CSCCLCTDigi& clct, const CSCALCTDig
   const bool debug(false);
   if (debug) std::cout << "-----------------------------------------------------------------------"<<std::endl;
   // Check if the pads overlap
-  for (auto p : padsAlct){
+  for (const auto& p : padsAlct){
     if (debug) std::cout<< "Candidate ALCT: " << p.first << " " << p.second << std::endl;
-    for (auto q: padsClct){
+    for (const auto& q: padsClct){
       if (debug) std::cout<< "++Candidate CLCT: " << q.first << " " << q.second << std::endl;
       // look for exactly the same pads
       if ((p.first != q.first) or GEMPadDigi(p.second) != q.second) continue;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -397,8 +397,8 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
 
     const bool isEven(me1bId.chamber()%2==0);
     const int region((theEndcap == 1) ? 1: -1);
-    const GEMDetId gem_id(region, 1, theStation, 1, me1bId.chamber(), 0);
-    const GEMChamber* gemChamber(gem_g->chamber(gem_id));
+    const GEMDetId gem_id(region, 1, theStation, 0, me1bId.chamber(), 0);
+    const GEMSuperChamber* gemChamber(gem_g->superChamber(gem_id));
 
     // initialize depending on whether even or odd     
     maxDeltaBXPad_ = isEven ? maxDeltaBXPadEven_ : maxDeltaBXPadOdd_;
@@ -430,7 +430,7 @@ void CSCMotherboardME11GEM::run(const CSCWireDigiCollection* wiredc,
     }
 
     // pick any roll
-    auto randRoll(gemChamber->etaPartition(2));
+    auto randRoll(gemChamber->chamber(1)->etaPartition(2));
 
     // ME1a
     auto nStripsME1a(keyLayerGeometryME1a->numberOfStrips());
@@ -1927,7 +1927,10 @@ CSCMotherboardME11GEM::matchingGEMPads(const CSCCLCTDigi& clct, const GEMPadsBX&
   const int highPad(mymap[clct.getKeyStrip()].second);
   const bool debug(false);
   if (debug) std::cout << "lowpad " << lowPad << " highpad " << highPad << " delta pad " << deltaPad <<std::endl;
-  for (auto p: pads){
+  for (const auto& p: pads){
+    if (DetId(p.first).subdetId() != MuonSubdetId::GEM or DetId(p.first).det() != DetId::Muon) {
+      continue;
+    }
     auto padRoll((p.second).pad());
     if (debug) std::cout << "padRoll " << padRoll << std::endl;
     if (std::abs(lowPad - padRoll) <= deltaPad or std::abs(padRoll - highPad) <= deltaPad){
@@ -1949,6 +1952,9 @@ CSCMotherboardME11GEM::matchingGEMPads(const CSCALCTDigi& alct, const GEMPadsBX&
   const bool debug(false);
   if (debug) std::cout << "ALCT keyWG " << alct.getKeyWG() << ", rolls " << alctRoll.first << " " << alctRoll.second << std::endl;
   for (auto p: pads){
+    if (DetId(p.first).subdetId() != MuonSubdetId::GEM or DetId(p.first).det() != DetId::Muon) {
+      continue;
+    }
     auto padRoll(GEMDetId(p.first).roll());
     if (debug) std::cout << "Candidate ALCT: " << padRoll << std::endl;
     // only pads in overlap are good for ME1A

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
@@ -530,7 +530,7 @@ CSCMotherboardME21GEM::run(const CSCWireDigiCollection* wiredc,
   
   bool first = true;
   unsigned int n=0;
-  for (auto p : readoutLCTs()) {
+  for (const auto& p : readoutLCTs()) {
     if (debug_gem_matching and first){
       std::cout << "========================================================================" << std::endl;
       std::cout << "Counting the final LCTs" << std::endl;
@@ -977,8 +977,8 @@ CSCMotherboardME21GEM::createGEMRollEtaLUT()
 void CSCMotherboardME21GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads, unsigned id)
 {
   auto superChamber(gem_g->superChamber(id));
-  for (auto ch : superChamber->chambers()) {
-    for (auto roll : ch->etaPartitions()) {
+  for (const auto& ch : superChamber->chambers()) {
+    for (const auto& roll : ch->etaPartitions()) {
       GEMDetId roll_id(roll->id());
       auto pads_in_det = gemPads->get(roll_id);
       for (auto pad = pads_in_det.first; pad != pads_in_det.second; ++pad) {
@@ -994,7 +994,7 @@ void CSCMotherboardME21GEM::retrieveGEMPads(const GEMPadDigiCollection* gemPads,
 
 void CSCMotherboardME21GEM::retrieveGEMCoPads()
 {
-  for (auto copad: gemCoPadV){
+  for (const auto& copad: gemCoPadV){
     if (copad.first().bx() != lct_central_bx) continue;
     coPads_[copad.bx(1)].push_back(std::make_pair(copad.roll(), copad.first()));  
     coPads_[copad.bx(1)].push_back(std::make_pair(copad.roll(), copad.second()));  
@@ -1021,7 +1021,7 @@ void CSCMotherboardME21GEM::printGEMTriggerPads(int bx_start, int bx_stop, bool 
     if (!iscopad) std::cout << "N(pads) BX " << bx << " : " << in_pads.size() << std::endl;
     else          std::cout << "N(copads) BX " << bx << " : " << in_pads.size() << std::endl;
     if (hasPads){
-      for (auto pad : in_pads){
+      for (const auto& pad : in_pads){
 	if (DetId(pad.first).subdetId() != MuonSubdetId::GEM or DetId(pad.first).det() != DetId::Muon) {
 	  continue;
 	}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
@@ -204,8 +204,8 @@ CSCMotherboardME21GEM::run(const CSCWireDigiCollection* wiredc,
     //    const bool isEven(csc_id%2==0);
     const int region((theEndcap == 1) ? 1: -1);
     const bool isEven(csc_id.chamber()%2==0);
-    const GEMDetId gem_id_long(region, 1, 2, 1, csc_id.chamber(), 0);
-    const GEMChamber* gemChamberLong(gem_g->chamber(gem_id_long));
+    const GEMDetId gem_id_long(region, 1, 2, 0, csc_id.chamber(), 0);
+    const GEMSuperChamber* gemChamberLong(gem_g->superChamber(gem_id_long));
     
     // LUT<roll,<etaMin,etaMax> >    
     gemRollToEtaLimits_ = createGEMRollEtaLUT();
@@ -230,7 +230,7 @@ CSCMotherboardME21GEM::run(const CSCWireDigiCollection* wiredc,
       }
     }
 
-    auto randRoll(gemChamberLong->etaPartition(2));
+    auto randRoll(gemChamberLong->chamber(1)->etaPartition(2));
     auto nStrips(keyLayerGeometry->numberOfStrips());
     for (float i = 0; i< nStrips; i = i+0.5){
       const LocalPoint lpCSC(keyLayerGeometry->topology()->localPosition(i));
@@ -1022,6 +1022,9 @@ void CSCMotherboardME21GEM::printGEMTriggerPads(int bx_start, int bx_stop, bool 
     else          std::cout << "N(copads) BX " << bx << " : " << in_pads.size() << std::endl;
     if (hasPads){
       for (auto pad : in_pads){
+	if (DetId(pad.first).subdetId() != MuonSubdetId::GEM or DetId(pad.first).det() != DetId::Muon) {
+	  continue;
+	}
         auto roll_id(GEMDetId(pad.first));
         std::cout << "\tdetId " << pad.first << " " << roll_id << ", pad = " << pad.second.pad() << ", BX = " << pad.second.bx() + 6 << std::endl;
       }
@@ -1045,8 +1048,10 @@ CSCMotherboardME21GEM::matchingGEMPads(const CSCCLCTDigi& clct, const GEMPadsBX&
   const int highPad(cscHsToGemPad_[clct.getKeyStrip()].second);
   const bool debug(false);
   if (debug) std::cout << "lowpad " << lowPad << " highpad " << highPad << " delta pad " << deltaPad <<std::endl;
-  for (auto p: pads){
-    if (debug) std::cout<<"DetId"<<GEMDetId(p.first)<<"   "<< p.second<<std::endl;
+  for (const auto& p: pads){
+    if (DetId(p.first).subdetId() != MuonSubdetId::GEM or DetId(p.first).det() != DetId::Muon) {
+      continue;
+    }
     auto padRoll((p.second).pad());
     int pad_bx = (p.second).bx()+lct_central_bx;
     if (debug) std::cout << "padRoll " << padRoll << std::endl;
@@ -1077,10 +1082,13 @@ CSCMotherboardME21GEM::matchingGEMPads(const CSCALCTDigi& alct, const GEMPadsBX&
 
   const bool debug(false);
   if (debug) std::cout << "ALCT keyWG " << alct.getKeyWG() << std::endl;
-  for (auto alctRoll : Rolls)
+  for (const auto& alctRoll : Rolls)
   {
   if (debug) std::cout <<"roll " << alctRoll << std::endl;
-  for (auto p: pads){
+  for (const auto& p: pads){
+    if (DetId(p.first).subdetId() != MuonSubdetId::GEM or DetId(p.first).det() != DetId::Muon) {
+      continue;
+    }
     auto padRoll(GEMDetId(p.first).roll());
     int pad_bx = (p.second).bx()+lct_central_bx;
     if (debug) std::cout<<"Detid "<< GEMDetId(p.first) <<"  "<< p.second<<std::endl;
@@ -1109,9 +1117,9 @@ CSCMotherboardME21GEM::matchingGEMPads(const CSCCLCTDigi& clct, const CSCALCTDig
   const bool debug(false);
   if (debug) std::cout << "-----------------------------------------------------------------------"<<std::endl;
   // Check if the pads overlap
-  for (auto p : padsAlct){
+  for (const auto& p : padsAlct){
     if (debug) std::cout<< "Candidate ALCT: " << p.first << " " << p.second << std::endl;
-    for (auto q: padsClct){
+    for (const auto& q: padsClct){
       if (debug) std::cout<< "++Candidate CLCT: " << q.first << " " << q.second << std::endl;
       // look for exactly the same pads
       if ((p.first != q.first) or p.second != q.second) continue;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -387,7 +387,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 		oc_pretrig.put(std::make_pair(preTriggerBXs.begin(),preTriggerBXs.end()), detid);
 	      }            
 	      // 0th layer means whole chamber.
-	      GEMDetId gemId(detid.zendcap(), 1, 1, 1, chid, 0);
+	      GEMDetId gemId(detid.zendcap(), 1, 1, 0, chid, 0);
               
 	      // GEM coincidence pads
 	      if (!copads.empty()) {
@@ -492,7 +492,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 	      }
 	      
 	      // 0th layer means whole chamber.
-	      GEMDetId gemId(detid.zendcap(), 1, 2, 1, chid, 0);
+	      GEMDetId gemId(detid.zendcap(), 1, 2, 0, chid, 0);
 	      
 	      // GEM coincidence pads
 	      if (!copads.empty()) {

--- a/Validation/MuonGEMDigis/src/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/src/GEMCoPadDigiValidation.cc
@@ -114,18 +114,19 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& e,
     //loop over digis of given roll
     for (digiItr = (*cItr ).second.first; digiItr != (*cItr ).second.second; ++digiItr)
     {
-      GEMDetId roId = GEMDetId(re, id.ring(), st, la, chamber, digiItr->roll());
-      Short_t nroll = roId.roll();  
-      LogDebug("GEMCoPadDigiValidation")<<"roId : "<<roId;
-      const GeomDet* gdet = GEMGeometry_->idToDet(roId);
+      // GEM copads are stored per super chamber!
+      GEMDetId schId = GEMDetId(re, id.ring(), st, 0, chamber, 0);
+      Short_t nroll = (*digiItr).roll();
+      LogDebug("GEMCoPadDigiValidation")<<"schId : "<<schId;
+      const GeomDet* gdet = GEMGeometry_->idToDet(schId);
       if ( gdet == nullptr) {
-        edm::LogError("GEMCoPadDigiValidation")<<roId<<" : This part can not load from GEMGeometry // Original"<<id<<" station : "<<st;
-        edm::LogError("GEMCoPadDigiValidation")<<"Getting DetId failed. Discard this gem copad hit.Maybe it comes from unmatched geometry between GEN and DIGI.";
+        edm::LogError("GEMCoPadDigiValidation")<<schId<<" : This detId cannot be loaded from GEMGeometry // Original"<<id<<" station : "<<st;
+        edm::LogError("GEMCoPadDigiValidation")<<"Getting DetId failed. Discard this gem copad hit. ";
         continue; 
       }
       const BoundPlane & surface = gdet->surface();
-      const GEMEtaPartition * roll = GEMGeometry_->etaPartition(roId);
-      LogDebug("GEMCoPadDigiValidation")<<" roll's n pad : "<<roll->npads();
+      const GEMSuperChamber * superChamber = GEMGeometry_->superChamber(schId);
+      LogDebug("GEMCoPadDigiValidation")<<" #pads in this partition : "<< superChamber->chamber(1)->etaPartition(1)->npads();
 
       Short_t pad1 = (Short_t) digiItr->pad(1);
       Short_t pad2 = (Short_t) digiItr->pad(2);
@@ -138,8 +139,8 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& e,
       if ( bx1 < (Short_t)minBXGEM_ || bx1 > (Short_t)maxBXGEM_) continue;
       if ( bx2 < (Short_t)minBXGEM_ || bx2 > (Short_t)maxBXGEM_) continue;
 
-      LocalPoint lp1 = roll->centreOfPad(pad1);
-      LocalPoint lp2 = roll->centreOfPad(pad2);
+      LocalPoint lp1 = superChamber->chamber(1)->etaPartition(1)->centreOfPad(pad1);
+      LocalPoint lp2 = superChamber->chamber(1)->etaPartition(1)->centreOfPad(pad2);
 
       GlobalPoint gp1 = surface.toGlobal(lp1);
       GlobalPoint gp2 = surface.toGlobal(lp2);
@@ -156,7 +157,7 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& e,
       if ( re == -1 ) region_num = 0 ; 
       else if (re == 1 ) region_num = 1; 
       else {
-        edm::LogError("GEMCoPadDIGIValidation")<<"region : "<<re<<std::endl;
+        edm::LogError("GEMCoPadDigiValidation")<<"region : "<<re<<std::endl;
       }
       int binX = (chamber-1)*2+(la-1);
       int binY = nroll;


### PR DESCRIPTION
Last week Stefan Piperov reported that the PU-samples with the D12 geometry crash with an error rate of 85% in the DIGI step with error
<PRE>
cmsRun1
Fatal Exception (Exit Code: 8001)
An exception of category 'InvalidDetId' occurred while
   [0] Processing  Event run: 1 lumi: 181 event: 9005 stream: 0
   [1] Running path 'L1simulation_step'
   [2] Calling method for module 
CSCTriggerPrimitivesProducer/'simCscTriggerPrimitiveDigis'
Exception Message:
GEMDetId ctor: det: 0 subdet: 0 is not a valid GEM id
</PRE>

After investigation it was found that the pad DetIds sometimes get corrupted. I put in place a few checks to ensure that the constructor is not called when the DetId is not a GEMDetId. 

This update needs to be included in 91X and 92X.

@calabria