### PR TITLE
Add missing LuminosityBlock fwd declaration to callAbilities.h

### DIFF
--- a/FWCore/Framework/interface/stream/callAbilities.h
+++ b/FWCore/Framework/interface/stream/callAbilities.h
@@ -27,6 +27,7 @@
 namespace edm {
   class Run;
   class EventSetup;
+  class LuminosityBlock;
   namespace stream {
     //********************************
     // CallGlobal


### PR DESCRIPTION
We use this class in the signature of the beginLuminosityBlock function, so we need
a forward declaration to make this header compile.