### PR TITLE
Add missing Candidate.h/LeafCandidate.h includes to CandidateWithRef.h.

### DIFF
--- a/DataFormats/Candidate/interface/CandidateWithRef.h
+++ b/DataFormats/Candidate/interface/CandidateWithRef.h
@@ -9,6 +9,8 @@
  *
  */
 #include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 
 namespace reco {


### PR DESCRIPTION
We inherit from LeafCandidate in CandidateWithRef and we use Candidate
in the overlap function, so we need those includes here.