### PR TITLE
Add missing #include to DeDxHit.h.

### DIFF
--- a/DataFormats/TrackReco/interface/DeDxHit.h
+++ b/DataFormats/TrackReco/interface/DeDxHit.h
@@ -1,5 +1,7 @@
 #ifndef TrackDeDxHits_H
 #define TrackDeDxHits_H
+
+#include <cstdint>
 #include <vector>
 
 namespace reco


### PR DESCRIPTION
We use uint32_t in this header, so we also need to include <cstdint>