### PR TITLE
There is a missing dependency that is causing a build error

### DIFF
--- a/DataFormats/CastorReco/BuildFile.xml
+++ b/DataFormats/CastorReco/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Candidate"/>
+<use   name="DataFormats/HcalRecHit"/>
 
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
This fix is an instance of an issue discussed here:
https://github.com/cms-sw/cmssw/issues/14473#issuecomment-301770149
Actual error log in this specific case: 
Checking EDM Class Version for src/DataFormats/CastorReco/src/classes_def.xml in libDataFormatsCastorReco.so
Error in <TInterpreter::TCling::AutoLoad>: failure loading library libDataFormatsHcalRecHit.so ...
