### PR TITLE
do not look for headers under $CMSSW_RELEASE_BASE

### DIFF
--- a/HLTrigger/Timer/test/BuildFile.xml
+++ b/HLTrigger/Timer/test/BuildFile.xml
@@ -9,6 +9,6 @@
 <bin name="testChrono" file="chrono/test/chrono.cc chrono/src/*.cc chrono/src/native/*.cc">
   <use   name="boost"/>
   <use   name="tbb"/>
-  <flags CXXFLAGS="-I${CMSSW_BASE}/src/HLTrigger/Timer/test/chrono -I${CMSSW_RELEASE_BASE}/src/HLTrigger/Timer/test/chrono -fopenmp -DHAVE_TBB -DHAVE_BOOST_CHRONO -lboost_chrono"/>
+  <flags CXXFLAGS="-I${CMSSW_BASE}/src/HLTrigger/Timer/test/chrono -fopenmp -DHAVE_TBB -DHAVE_BOOST_CHRONO -lboost_chrono"/>
   <flags NO_TESTRUN="1"/>
 </bin>


### PR DESCRIPTION
this fixes two issues:
  - do not pick up headers from the release area if they have been removed locally
  - do not add `-I/src/HLTrigger/Timer/test/chrono` when building a release