### PR TITLE
Add parameterSet retrieval function to Event

### DIFF
--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -51,7 +51,7 @@ namespace fwlite {
       ChainEvent(std::vector<std::string> const& iFileNames);
       virtual ~ChainEvent();
 
-      ChainEvent const& operator++();
+      ChainEvent const& operator++() override;
 
       ///Go to the event at index iIndex
       bool to(Long64_t iIndex);
@@ -63,31 +63,31 @@ namespace fwlite {
       bool to(edm::RunNumber_t run, edm::LuminosityBlockNumber_t lumi, edm::EventNumber_t event);
 
       // Go to the very first Event.
-      ChainEvent const& toBegin();
+      ChainEvent const& toBegin() override;
 
       // ---------- const member functions ---------------------
       virtual std::string const getBranchNameFor(std::type_info const&,
                                                  char const*,
                                                  char const*,
-                                                 char const*) const;
+                                                 char const*) const override;
 
       using fwlite::EventBase::getByLabel;
 
       // This function should only be called by fwlite::Handle<>
-      virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const;
+      virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
       //void getByBranchName(std::type_info const&, char const*, void*&) const;
 
       bool isValid() const;
       operator bool() const;
-      virtual bool atEnd() const;
+      virtual bool atEnd() const override;
 
       Long64_t size() const;
 
-      virtual edm::EventAuxiliary const& eventAuxiliary() const;
+      virtual edm::EventAuxiliary const& eventAuxiliary() const override;
 
       std::vector<edm::BranchDescription> const& getBranchDescriptions() const;
       std::vector<std::string> const& getProcessHistory() const;
-      virtual edm::ProcessHistory const& processHistory() const;
+      virtual edm::ProcessHistory const& processHistory() const override;
       TFile* getTFile() const {
         return event_->getTFile();
       }
@@ -99,7 +99,7 @@ namespace fwlite {
       // 0 events. To get the path of the file where the current event resides
       // in, fwlite::ChainEvent::getTFile()->GetPath() is preferred.
       Long64_t eventIndex() const { return eventIndex_; }
-      virtual Long64_t fileIndex() const { return eventIndex_; }
+      virtual Long64_t fileIndex() const override { return eventIndex_; }
 
       void setGetter(std::shared_ptr<edm::EDProductGetter const> getter){
          event_->setGetter(getter);
@@ -107,16 +107,18 @@ namespace fwlite {
 
       Event const* event() const { return &*event_; }
 
-      virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
-      void fillParameterSetRegistry() const;
-      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
+      virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
+      void fillParameterSetRegistry() const ;
+      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
+
+      virtual edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
 
       // ---------- static member functions --------------------
       static void throwProductNotFoundException(std::type_info const&, char const*, char const*, char const*);
 
       // ---------- member functions ---------------------------
 
-      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
       edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
 
       void getThinnedProducts(edm::ProductID const& pid,

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -91,7 +91,7 @@ namespace fwlite {
          virtual ~Event();
 
          ///Advance to next event in the TFile
-         Event const& operator++();
+         Event const& operator++() override;
 
          ///Find index of given event-id
          Long64_t indexFromEventId(edm::RunNumber_t run, edm::LuminosityBlockNumber_t lumi, edm::EventNumber_t event);
@@ -105,18 +105,18 @@ namespace fwlite {
          bool to(edm::RunNumber_t run, edm::LuminosityBlockNumber_t lumi, edm::EventNumber_t event);
 
          /// Go to the very first Event.
-         Event const& toBegin();
+         Event const& toBegin() override;
 
          // ---------- const member functions ---------------------
          ///Return the branch name in the TFile which contains the data
          virtual std::string const getBranchNameFor(std::type_info const&,
                                                     char const* iModuleLabel,
                                                     char const* iProductInstanceLabel,
-                                                    char const* iProcessName) const;
+                                                    char const* iProcessName) const override;
 
          using fwlite::EventBase::getByLabel;
          /// This function should only be called by fwlite::Handle<>
-         virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const;
+         virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
          //void getByBranchName(std::type_info const&, char const*, void*&) const;
 
          ///Properly setup for edm::Ref, etc and then call TTree method
@@ -127,12 +127,12 @@ namespace fwlite {
 
          bool isValid() const;
          operator bool () const;
-         virtual bool atEnd() const;
+         virtual bool atEnd() const override;
 
          ///Returns number of events in the file
          Long64_t size() const;
 
-         virtual edm::EventAuxiliary const& eventAuxiliary() const;
+         virtual edm::EventAuxiliary const& eventAuxiliary() const override;
 
          std::vector<edm::BranchDescription> const& getBranchDescriptions() const {
             return branchMap_.getBranchDescriptions();
@@ -142,17 +142,19 @@ namespace fwlite {
             return branchMap_.getFile();
          }
 
-         virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+         virtual edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
+
+         virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
          edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
          void getThinnedProducts(edm::ProductID const& pid,
                                  std::vector<edm::WrapperBase const*>& foundContainers,
                                  std::vector<unsigned int>& keys) const;
 
-         virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
+         virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
 
-         virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
+         virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
 
-         virtual edm::ProcessHistory const& processHistory() const {return history();}
+         virtual edm::ProcessHistory const& processHistory() const override {return history();}
 
          fwlite::LuminosityBlock const& getLuminosityBlock() const;
          fwlite::Run             const& getRun() const;

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -61,7 +61,7 @@ class MultiChainEvent: public EventBase
 		      bool useSecFileMapSorted = false);
       virtual ~MultiChainEvent();
 
-      const MultiChainEvent& operator++();
+      const MultiChainEvent& operator++() override;
 
       ///Go to the event at index iIndex
       bool to(Long64_t iIndex);
@@ -73,31 +73,31 @@ class MultiChainEvent: public EventBase
       bool to(edm::RunNumber_t run, edm::LuminosityBlockNumber_t lumi, edm::EventNumber_t event);
 
       // Go to the very first Event.
-      const MultiChainEvent& toBegin();
+      const MultiChainEvent& toBegin() override;
 
       // ---------- const member functions ---------------------
       virtual std::string const getBranchNameFor(std::type_info const&,
                                                  char const*,
                                                  char const*,
-                                                 char const*) const;
+                                                 char const*) const override;
 
       using fwlite::EventBase::getByLabel;
 
       /** This function should only be called by fwlite::Handle<>*/
-      virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const;
+      virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const override;
       //void getByBranchName(std::type_info const&, char const*, void*&) const;
 
       bool isValid() const;
       operator bool() const;
-      bool atEnd() const;
+      bool atEnd() const override;
 
       Long64_t size() const;
 
-      virtual edm::EventAuxiliary const& eventAuxiliary() const;
+      virtual edm::EventAuxiliary const& eventAuxiliary() const override;
 
       std::vector<edm::BranchDescription> const& getBranchDescriptions() const;
       std::vector<std::string> const& getProcessHistory() const;
-      edm::ProcessHistory const& processHistory() const;
+      edm::ProcessHistory const& processHistory() const override;
       TFile* getTFile() const {
         return event1_->getTFile();
       }
@@ -117,13 +117,15 @@ class MultiChainEvent: public EventBase
       }
 
 
-      virtual Long64_t fileIndex()          const
+      virtual Long64_t fileIndex()          const override
       { return event1_->eventIndex(); }
-      virtual Long64_t secondaryFileIndex() const
+      virtual Long64_t secondaryFileIndex() const override
       { return event2_->eventIndex(); }
 
-      virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
-      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
+      virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
+      virtual edm::TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
+
+      virtual edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const override;
 
       // ---------- static member functions --------------------
       static void throwProductNotFoundException(std::type_info const&, char const*, char const*, char const*);
@@ -134,7 +136,7 @@ class MultiChainEvent: public EventBase
 
       // ---------- member functions ---------------------------
 
-      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const override;
 
       edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
 

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -319,6 +319,11 @@ ChainEvent::triggerNames(edm::TriggerResults const& triggerResults) const
   return event_->triggerNames(triggerResults);
 }
 
+edm::ParameterSet const*
+ChainEvent::parameterSet(edm::ParameterSetID const& psID) const {
+  return event_->parameterSet(psID);
+}
+  
 void
 ChainEvent::fillParameterSetRegistry() const
 {

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -492,6 +492,15 @@ Event::fillParameterSetRegistry() const {
   }
 }
 
+edm::ParameterSet const*
+Event::parameterSet(edm::ParameterSetID const& psID) const {
+  if(!parameterSetRegistryFilled_) {
+    fillParameterSetRegistry();
+  }
+  return parameterSetForID_(psID);
+}
+
+  
 edm::TriggerResultsByName
 Event::triggerResultsByName(edm::TriggerResults const& triggerResults) const {
 

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -477,6 +477,14 @@ MultiChainEvent::triggerResultsByName(edm::TriggerResults const& triggerResults)
   return edm::TriggerResultsByName(&triggerResults, names);
 }
 
+edm::ParameterSet const*
+MultiChainEvent::parameterSet(edm::ParameterSetID const& psID) const {
+  auto pset = event1_->parameterSet(psID);
+  if(nullptr ==pset) {
+      pset = event2_->parameterSet(psID);
+  }
+  return pset;
+}
 //
 // static member functions
 //

--- a/FWCore/Common/interface/EventBase.h
+++ b/FWCore/Common/interface/EventBase.h
@@ -26,6 +26,7 @@
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Common/interface/ConvertHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Common/interface/TriggerResultsByName.h"
@@ -40,6 +41,7 @@ namespace edm {
    class ProductID;
    class TriggerResults;
    class TriggerNames;
+   class ParameterSet;
 
    class EventBase {
 
@@ -69,9 +71,12 @@ namespace edm {
       virtual TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const = 0;
       virtual ProcessHistory const& processHistory() const = 0;
 
+      virtual edm::ParameterSet const* parameterSet(edm::ParameterSetID const& psID) const = 0;
    protected:
 
       static TriggerNames const* triggerNames_(edm::TriggerResults const& triggerResults);
+
+      static edm::ParameterSet const* parameterSetForID_(edm::ParameterSetID const& psID);
 
    private:
       //EventBase(EventBase const&); // allow default

--- a/FWCore/Common/src/EventBase.cc
+++ b/FWCore/Common/src/EventBase.cc
@@ -44,6 +44,11 @@ namespace edm
    {
    }
 
+   edm::ParameterSet const*
+   EventBase::parameterSetForID_(edm::ParameterSetID const& iPSID) {
+      return edm::pset::Registry::instance()->getMapped(iPSID);
+   }
+
    TriggerNames const*
    EventBase::triggerNames_(edm::TriggerResults const& triggerResults) {
 

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -75,7 +75,7 @@ namespace edm {
     void setSharedResourcesAcquirer( SharedResourcesAcquirer* iResourceAcquirer);
 
     // AUX functions are defined in EventBase
-    EventAuxiliary const& eventAuxiliary() const {return aux_;}
+    EventAuxiliary const& eventAuxiliary() const override {return aux_;}
 
     ///\return The id for the particular Stream processing the Event
     StreamID streamID() const {
@@ -215,12 +215,15 @@ namespace edm {
     getProcessParameterSet(std::string const& processName, ParameterSet& ps) const;
 
     virtual ProcessHistory const&
-    processHistory() const;
+    processHistory() const override;
+
+    virtual edm::ParameterSet const*
+    parameterSet(edm::ParameterSetID const& psID) const override;
 
     size_t size() const;
 
-    virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
-    virtual TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const;
+    virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const override;
+    virtual TriggerResultsByName triggerResultsByName(edm::TriggerResults const& triggerResults) const override;
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
@@ -242,10 +245,10 @@ namespace edm {
     makeProductID(BranchDescription const& desc) const;
 
     //override used by EventBase class
-    virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const;
+    virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const override;
 
     //override used by EventBase class
-    virtual BasicHandle getImpl(std::type_info const& iProductType, ProductID const& pid) const;
+    virtual BasicHandle getImpl(std::type_info const& iProductType, ProductID const& pid) const override;
 
     // commit_() is called to complete the transaction represented by
     // this PrincipalGetAdapter. The friendships required seems gross, but any

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -109,6 +109,11 @@ namespace edm {
     return process_found;
   }
 
+  edm::ParameterSet const*
+  Event::parameterSet(edm::ParameterSetID const& psID) const{
+    return parameterSetForID_(psID);
+  }
+  
   BasicHandle
   Event::getByProductID_(ProductID const& oid) const {
     return eventPrincipal().getByProductID(oid);


### PR DESCRIPTION
Added the method parameterSet to the base class for all Events, edm::EventBase. This function guarantees that the ParameterSetRegistry has already been filled before attempting to do a lookup.