### PR TITLE
Fireworks 92X: Visualization of HGCal rec hits in Lego view.

### DIFF
--- a/Fireworks/Calo/BuildFile.xml
+++ b/Fireworks/Calo/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/CaloTowers"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/EcalDetId"/>
+<use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/EgammaReco"/>
 <use name="DataFormats/FWLite"/>

--- a/Fireworks/Calo/plugins/FWHGTowerProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGTowerProxyBuilder.cc
@@ -1,0 +1,245 @@
+// -*- C++ -*-
+//
+// Package:     Calo
+// Class  :     FWHGTowerProxyBuilder
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  
+//         Created:  Mon May 31 16:41:27 CEST 2010
+//
+
+// system include files
+
+// user include files
+#include "TEveCaloData.h"
+#include "TEveCalo.h"
+#include "TH2F.h"
+
+#include "Fireworks/Calo/plugins/FWHGTowerProxyBuilder.h"
+#include "Fireworks/Calo/plugins/FWHGTowerSliceSelector.h"
+#include "Fireworks/Core/interface/Context.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/FWModelChangeManager.h"
+#include "Fireworks/Core/interface/fwLog.h"
+
+FWHGTowerProxyBuilderBase::FWHGTowerProxyBuilderBase():
+   m_hits(0),
+   // m_depth(depth),
+   m_vecData(0)
+{}
+
+FWHGTowerProxyBuilderBase::~FWHGTowerProxyBuilderBase()
+{}
+
+//
+// member functions
+void
+FWHGTowerProxyBuilderBase::setCaloData(const fireworks::Context& ctx)
+{
+   m_vecData  = ctx.getCaloDataHF();// cached to avoid casting
+   m_caloData = m_vecData;
+}
+
+bool
+FWHGTowerProxyBuilderBase::assertCaloDataSlice()
+{
+   if (m_sliceIndex == -1)
+   {
+      m_sliceIndex = m_vecData->AddSlice();
+      // printf("add slice %d \n",m_sliceIndex  );
+      m_caloData->RefSliceInfo(m_sliceIndex).Setup(item()->name().c_str() , 0.,
+                                                   item()->defaultDisplayProperties().color(),
+                                                   item()->defaultDisplayProperties().transparency());
+    
+      // add new selector
+      FWFromTEveCaloDataSelector* sel = 0;
+      if (m_caloData->GetUserData())
+      {
+         FWFromEveSelectorBase* base = reinterpret_cast<FWFromEveSelectorBase*>(m_caloData->GetUserData());
+         assert(0!=base);
+         sel = dynamic_cast<FWFromTEveCaloDataSelector*> (base);
+         assert(0!=sel);
+      }
+      else
+      {
+         sel = new FWFromTEveCaloDataSelector(m_caloData);
+         //make sure it is accessible via the base class
+         m_caloData->SetUserData(static_cast<FWFromEveSelectorBase*>(sel));
+      }
+    
+      sel->addSliceSelector(m_sliceIndex, new FWHGTowerSliceSelector(item(), m_vecData));
+    
+      return true;
+   }
+   return false;
+}
+
+void
+FWHGTowerProxyBuilderBase::build(const FWEventItem* iItem,
+                                 TEveElementList* el, const FWViewContext* ctx)
+{
+   m_hits=0;
+   if (iItem)
+   {
+      iItem->get(m_hits);
+      FWCaloDataProxyBuilderBase::build(iItem, el, ctx);
+   }
+}
+
+void
+FWHGTowerProxyBuilderBase::itemBeingDestroyed(const FWEventItem* iItem)
+{
+  
+   if(0!=m_hits) {
+
+      //reset values for this slice
+      std::vector<float>& sliceVals = m_vecData->GetSliceVals(m_sliceIndex);
+      for (std::vector<float>::iterator i = sliceVals.begin(); i!= sliceVals.end(); ++i)
+      {
+         *i = 0;
+      }
+
+
+   }
+   FWCaloDataProxyBuilderBase::itemBeingDestroyed(iItem);
+}
+
+void
+FWHGTowerProxyBuilderBase::fillCaloData()
+{
+   //reset values for this slice
+   std::vector<float>& sliceVals = m_vecData->GetSliceVals(m_sliceIndex);
+   for (std::vector<float>::iterator i = sliceVals.begin(); i!= sliceVals.end(); ++i)
+   {
+      *i = 0;
+   }
+
+   if (m_hits)
+   {
+      TEveCaloData::vCellId_t& selected = m_vecData->GetCellsSelected();
+
+      if(item()->defaultDisplayProperties().isVisible()) {
+         assert(item()->size() >= m_hits->size());
+
+         unsigned int index=0;
+         TEveCaloData::vCellId_t cellId;
+         for(HGCRecHitCollection::const_iterator it = m_hits->begin(); it != m_hits->end(); ++it,++index) 
+         {
+            const FWEventItem::ModelInfo& info = item()->modelInfo(index);
+            if(info.displayProperties().isVisible())
+            {
+               unsigned int rawid = (*it).detid().rawId();
+               int tower = fillTowerForDetId(rawid, (*it).energy());
+                
+               if(info.isSelected())
+               {
+                  selected.push_back(TEveCaloData::CellId_t(tower, m_sliceIndex));
+               } 
+            }
+         }
+      }
+   }
+}
+
+int
+FWHGTowerProxyBuilderBase::fillTowerForDetId( unsigned int rawid, float val )
+{
+   using namespace TMath;
+   const static float upPhiLimit = Pi() -10*DegToRad() -1e-5;
+
+   TEveCaloData::vCellId_t cellIds;
+   const FWGeometry *geom = item()->getGeom();
+   if( ! geom->contains( rawid ))
+   {
+      fwLog( fwlog::kInfo ) << "FWHGTowerProxyBuilderBase cannot get geometry for DetId: "<< rawid << ". Ignored.\n";
+      return -1;
+   }
+     
+   const float* corners = geom->getCorners( rawid );
+   if( ! corners )
+   {
+      fwLog( fwlog::kInfo ) << "FWHGTowerProxyBuilderBase cannot get corners for DetId: "<< rawid << ". Ignored.\n";
+      return -1;
+   }
+   
+   std::vector<TEveVector> front( 4 );
+   float eta[4], phi[4];
+   bool plusSignPhi  = false;
+   bool minusSignPhi = false;
+   int j = 0;
+   for( int i = 0; i < 4; ++i )
+   {	 
+     front[i] = TEveVector( corners[j], corners[j + 1], corners[j + 2] );
+     j += 3;
+ 
+     eta[i] = front[i].Eta();
+     phi[i] = front[i].Phi();
+
+     // make sure sign around Pi is same as sign of fY
+     phi[i] = Sign( phi[i], front[i].fY );
+
+     ( phi[i] >= 0 ) ? plusSignPhi = true :  minusSignPhi = true;
+   }
+
+   // check for cell around phi and move up edge to negative side
+   if( plusSignPhi && minusSignPhi ) 
+   {
+      for( int i = 0; i < 4; ++i )
+      {
+         if( phi[i] >= upPhiLimit ) 
+         {
+            //  printf("over phi max limit %f \n", phi[i]);
+            phi[i] -= TwoPi();
+         }
+      }
+   }
+  
+   float etaM = -10;
+   float etam =  10;
+   float phiM = -4;
+   float phim =  4;
+   for( int i = 0; i < 4; ++i )
+   { 
+      etam = Min( etam, eta[i] );
+      etaM = Max( etaM, eta[i] );
+      phim = Min( phim, phi[i] );
+      phiM = Max( phiM, phi[i] );
+   }
+
+   /*
+     if (phiM - phim > 1) 
+     printf("!!! [%.2f %.2f] input(%.3f, %.3f, %.3f, %.3f) \n", phim, phiM, phiRef[0] , phiRef[1] , phiRef[2],  phiRef[3]);
+   */
+
+   // check if tower is there
+   Float_t ceta = (etam+etaM)*0.5;
+   Float_t cphi = (phim+phiM)*0.5;
+   int tower = -1;
+   int idx = 0;
+   for ( TEveCaloData::vCellGeom_i i = m_vecData->GetCellGeom().begin(); i!= m_vecData->GetCellGeom().end(); ++i, ++idx)
+   {
+      const TEveCaloData::CellGeom_t &cg = *i;
+      if ((ceta > cg.fEtaMin && ceta < cg.fEtaMax) && (cphi > cg.fPhiMin && cphi < cg.fPhiMax))
+      {
+         tower = idx;
+         break;
+      }
+   }
+
+   // add it if not there 
+   if (tower == -1 )
+   {
+      tower = m_vecData->AddTower(etam, etaM, phim, phiM);
+   }
+
+
+   m_vecData->FillSlice(m_sliceIndex, tower, val);
+   return tower; 
+}
+
+REGISTER_FWPROXYBUILDER(FWHGTowerProxyBuilderBase, HGCRecHitCollection, "HGCalLego", FWViewType::kLegoHFBit |FWViewType::kAllRPZBits | FWViewType::k3DBit );
+
+

--- a/Fireworks/Calo/plugins/FWHGTowerProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWHGTowerProxyBuilder.h
@@ -1,0 +1,72 @@
+#ifndef Fireworks_Calo_FWHGTowerProxyBuilder_h
+#define Fireworks_Calo_FWHGTowerProxyBuilder_h
+// -*- C++ -*-
+//
+// Package:     Calo
+// Class  :     FWHGTowerProxyBuilder
+// 
+/**\class FWHGTowerProxyBuilder FWHGTowerProxyBuilder.h Fireworks/Calo/interface/FWHGTowerProxyBuilder.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  
+//         Created:  Mon May 31 16:41:23 CEST 2010
+//
+
+// system include files
+
+// user include files
+#include "Fireworks/Calo/interface/FWCaloDataProxyBuilderBase.h"
+#include "Fireworks/Calo/src/FWFromTEveCaloDataSelector.h"
+// #include "DataFormats/HGCRecHit/interface/HGRecHit.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
+
+
+class TEveCaloDataVec;
+//
+// base
+//
+class FWHGTowerProxyBuilderBase : public FWCaloDataProxyBuilderBase
+{
+public:
+   FWHGTowerProxyBuilderBase();
+   virtual ~FWHGTowerProxyBuilderBase();
+  
+   // ---------- const member functions ---------------------
+  
+   // ---------- static member functions --------------------
+  
+   // ---------- member functions ---------------------------
+   REGISTER_PROXYBUILDER_METHODS();
+
+protected:
+   virtual void setCaloData(const fireworks::Context&);
+   virtual void fillCaloData();
+   virtual bool assertCaloDataSlice();
+  
+   virtual void itemBeingDestroyed(const FWEventItem*);
+
+private:
+  
+   FWHGTowerProxyBuilderBase(const FWHGTowerProxyBuilderBase&); // stop default
+  
+   const FWHGTowerProxyBuilderBase& operator=(const FWHGTowerProxyBuilderBase&); // stop default
+  
+   virtual void build(const FWEventItem* iItem,
+                      TEveElementList* product, const FWViewContext*);
+  
+   int fillTowerForDetId(unsigned int rawid, float);
+   // ---------- member data --------------------------------
+  
+   const HGCRecHitCollection* m_hits;
+   //   int   m_depth;
+   TEveCaloDataVec* m_vecData;  
+};
+
+
+#endif

--- a/Fireworks/Calo/plugins/FWHGTowerSliceSelector.cc
+++ b/Fireworks/Calo/plugins/FWHGTowerSliceSelector.cc
@@ -1,0 +1,110 @@
+// -*- C++ -*-
+//
+// Package:     Calo
+// Class  :     FWHGTowerSliceSelector
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Alja Mrak-Tadel
+//         Created:  Wed Jun  2 17:39:44 CEST 2010
+//
+
+// system include files
+
+// user include files
+#include "TEveVector.h"
+#include "TEveCaloData.h"
+#include "TH2F.h"
+
+#include "Fireworks/Calo/plugins/FWHGTowerSliceSelector.h"
+#include "Fireworks/Core/interface/FWModelChangeManager.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/fwLog.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
+
+
+//
+// member functions
+//
+
+void
+FWHGTowerSliceSelector::doSelect(const TEveCaloData::CellId_t& iCell)
+{
+   if (!m_item) return;
+
+   const HGCRecHitCollection* hits=0;
+   m_item->get(hits);
+   assert(0!=hits);
+
+   int index = 0;
+   FWChangeSentry sentry(*(m_item->changeManager()));
+   for(HGCRecHitCollection::const_iterator it = hits->begin(); it != hits->end(); ++it,++index)
+   {
+      HGCalDetId id ((*it).detid().rawId());
+      if (findBinFromId(id, iCell.fTower) && 
+          m_item->modelInfo(index).m_displayProperties.isVisible() &&
+          !m_item->modelInfo(index).isSelected()) {
+         // std::cout <<"  doSelect "<<index<<std::endl;
+         m_item->select(index);
+      }
+   }
+}
+
+void
+FWHGTowerSliceSelector::doUnselect(const TEveCaloData::CellId_t& iCell)
+{
+   if (!m_item) return;
+
+   const HGCRecHitCollection* hits=0;
+   m_item->get(hits);
+   assert(0!=hits);
+
+   int index = 0;
+   FWChangeSentry sentry(*(m_item->changeManager()));
+   for(HGCRecHitCollection::const_iterator it = hits->begin(); it != hits->end(); ++it,++index)
+   {
+      HGCalDetId id ((*it).detid().rawId());
+      if (findBinFromId(id, iCell.fTower) && 
+          m_item->modelInfo(index).m_displayProperties.isVisible() &&
+          m_item->modelInfo(index).isSelected()) {
+         // std::cout <<"  doUnselect "<<index<<std::endl;
+         m_item->unselect(index);
+      }
+   }
+}
+
+bool
+FWHGTowerSliceSelector::findBinFromId( HGCalDetId& detId, int tower) const
+{    
+   TEveCaloData::vCellId_t cellIds;
+   const float* corners = m_item->getGeom()->getCorners( detId.rawId());
+   if( corners == 0 )
+   {
+     fwLog( fwlog::kInfo ) << "FWHGTowerSliceSelector cannot get geometry for DetId: "<< detId.rawId() << ". Ignored.\n";
+     return false;
+   }
+   std::vector<TEveVector> front( 4 );
+   float eta = 0, phi = 0;
+   int j = 0;
+   for( int i = 0; i < 4; ++i )
+   {
+     front[i] = TEveVector( corners[j], corners[j + 1], corners[j + 2] );
+     j +=3;
+
+     eta += front[i].Eta();
+     phi += front[i].Phi();
+   }
+   eta /= 4;
+   phi /= 4;
+
+   const TEveCaloData::CellGeom_t &cg = m_vecData->GetCellGeom()[tower] ;
+   if(( eta >= cg.fEtaMin && eta <= cg.fEtaMax) && (phi >= cg.fPhiMin && phi <= cg.fPhiMax))
+   {
+      return true;
+   }
+
+   return false;
+}

--- a/Fireworks/Calo/plugins/FWHGTowerSliceSelector.h
+++ b/Fireworks/Calo/plugins/FWHGTowerSliceSelector.h
@@ -1,0 +1,48 @@
+#ifndef Fireworks_Calo_FWHGTowerSliceSelector_h
+#define Fireworks_Calo_FWHGTowerSliceSelector_h
+// -*- C++ -*-
+//
+// Package:     Calo
+// Class  :     FWHGTowerSliceSelector
+// 
+/**\class FWHGTowerSliceSelector FWHGTowerSliceSelector.h Fireworks/Calo/interface/FWHGTowerSliceSelector.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Alja Mrak-Tadel
+//         Created:  Wed Jun  2 19:21:13 CEST 2010
+//
+
+// system include files
+
+// user include files
+class HGCalDetId;
+class TEveCaloDataVec;
+
+#include "Fireworks/Calo/src/FWFromSliceSelector.h"
+
+// forward declarations
+
+class FWHGTowerSliceSelector : public FWFromSliceSelector
+{
+public:
+   FWHGTowerSliceSelector(const FWEventItem* i, TEveCaloDataVec* data) : 
+      FWFromSliceSelector(i), m_vecData(data) {}
+
+   virtual ~FWHGTowerSliceSelector() {}
+
+   virtual void doSelect(const TEveCaloData::CellId_t&);
+   virtual void doUnselect(const TEveCaloData::CellId_t&);
+   
+private:
+   bool findBinFromId(HGCalDetId& id, int tower) const;
+   TEveCaloDataVec* m_vecData;
+};
+
+
+#endif

--- a/Fireworks/Core/src/FWLegoViewBase.cc
+++ b/Fireworks/Core/src/FWLegoViewBase.cc
@@ -57,7 +57,7 @@ FWLegoViewBase::FWLegoViewBase(TEveWindowSlot* iParent, FWViewType::EType typeId
    m_pixelsPerBin(this, "Pixels per bin", 10., 1., 20.),
    m_projectionMode(this, "Projection", 0l, 0l, 2l),
    m_cell2DMode(this, "Cell2DMode", 1l, 1l, 2l),
-   m_drawValuesIn2D(this,"Draw Cell2D threshold (pixels)",40l,16l,200l),
+   m_drawValuesIn2D(this,"Draw Cell2D threshold (pixels)",40l,16l,1200l),
    m_showOverlay(this,"Draw scales", true)
 {
    viewerGL()->SetCurrentCamera(TGLViewer::kCameraOrthoXOY);


### PR DESCRIPTION
Add Visualiation of HGCal rec hits. 
Note cells are not in regular eta,phi bins. and the view. TEveCaloData is added in HF Lego view.
![zoom](https://cloud.githubusercontent.com/assets/2516492/26130527/1297e3be-3a4a-11e7-9824-8a955784e74a.png)
![all](https://cloud.githubusercontent.com/assets/2516492/26130526/1294bd9c-3a4a-11e7-8ec5-d3387c97a809.png)

