### PR TITLE
recover multi-thread reproducibility in CTPPS diamond local track y position

### DIFF
--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
@@ -63,6 +63,8 @@ class CTPPSDiamondTrackRecognition
 
     float yPosition_;
     float yWidth_;
+    float yPositionInitial_;
+    float yWidthInitial_;
 
     /// Function for pad efficiency
     TF1 hit_f_;

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -24,8 +24,8 @@ CTPPSDiamondTrackRecognition::CTPPSDiamondTrackRecognition( const edm::Parameter
   sigma_               ( iConfig.getParameter<double>( "sigma" ) ),
   startFromX_          ( iConfig.getParameter<double>( "startFromX" ) ),
   stopAtX_             ( iConfig.getParameter<double>( "stopAtX" ) ),
-  yPosition_           ( iConfig.getParameter<double>( "yPosition" ) ),
-  yWidth_              ( iConfig.getParameter<double>( "yWidth" ) ),
+  yPositionInitial_    ( iConfig.getParameter<double>( "yPosition" ) ),
+  yWidthInitial_       ( iConfig.getParameter<double>( "yWidth" ) ),
   hit_f_( "hit_TF1_CTPPS", iConfig.getParameter<std::string>( "pixelEfficiencyFunction" ).c_str(), startFromX_, stopAtX_ )
 {
   if (sigma_==0.0) {
@@ -45,6 +45,8 @@ CTPPSDiamondTrackRecognition::clear()
 {
   hitParametersVectorMap_.clear();
   mhMap_.clear();
+  yPosition_ = yPositionInitial_;
+  yWidth_ = yWidthInitial_;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -56,7 +58,7 @@ CTPPSDiamondTrackRecognition::addHit( const CTPPSDiamondRecHit& recHit )
   hitParametersVectorMap_[recHit.getOOTIndex()].emplace_back( recHit.getX(), recHit.getXWidth() );
 
   // Check vertical coordinates
-  if ( yPosition_ == 0.0 and yWidth_ == 0.0 ) {
+  if ( yPosition_ == yPositionInitial_ and yWidth_ == yWidthInitial_ ) {
     yPosition_ = recHit.getY();
     yWidth_ = recHit.getYWidth();
   }


### PR DESCRIPTION
clear yPosition and width after the fit; test for first hit using yPositionInitial and yWidthInitial instead of hardcoded 0,0

The issue was discovered in 80X.

I'm actually not fully capturing the logic of ```yPosition_``` assignment based on the first hit y position. It looks partially as a way to cache the detector alignment.

In my test job in 80X (running on run 283877) I used 8 threads. The original CTPPSDiamondTrackRecognition.cc can possibly make 2 (arms) * 8 (threads) different values of track y depending which event and which hit ends up on the thread first. The fixed version corresponds to position setting in each event.
On 200 events:  the original getY0 values (with repeat counts)
```
valueIndex   count value
     1        2 3.670e-15
     2       10 5.456e-15
     3        5 5.573e-15
     4        8 5.849e-15
     5        9 7.961e-15
     6        3 8.508e-15
     7        8 9.089e-15
     8        3 9.142e-15
     9        4 9.959e-15
    10        6 1.010e-14
    11        2 1.023e-14
    12        5 1.349e-14
    13        7 1.424e-14
    14       14 1.468e-14
    15        7 1.568e-14
```

The fixed:
```
     1        3 -9.37e-12
     2        4 7.961e-15
     3        2 8.508e-15
     4        3 8.705e-15
     5        1 8.795e-15
     6        1 9.089e-15
     7        2 9.744e-15
     8       10 9.959e-15
     9        2 1.010e-14
    10        9 1.023e-14
    11        4 1.035e-14
    12        3 1.050e-14
    13        1 1.062e-14
    14        1 1.073e-14
    15       10 1.092e-14
    16        5 1.305e-14
    17        3 1.349e-14
    18        8 1.388e-14
    19        3 1.424e-14
    20        4 1.468e-14
    21        1 1.505e-14
    22        7 1.539e-14
    23        1 1.568e-14
    24        5 1.594e-14
```

If these positions are in cm, they look like random roundoffs of zeros.
Still, the assignment should be made without dependence on event order or the number of threads.

@forthommel please check and either confirm that this fix has a meaning or provide a replacement PR.
Thank you.


