### PR TITLE
CTPPS: DQM configuration fix (9_1_X)

### DIFF
--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -157,10 +157,12 @@ using namespace edm;
 
 void TotemRPDQMSource::GlobalPlots::Init(DQMStore::IBooker &ibooker)
 {
-  ibooker.setCurrentFolder("CTPPS/TrackingStrip");
+  ibooker.setCurrentFolder("CTPPS");
 
   events_per_bx = ibooker.book1D("events per BX", "rp;Event.BX", 4002, -1.5, 4000. + 0.5);
   events_per_bx_short = ibooker.book1D("events per BX (short)", "rp;Event.BX", 102, -1.5, 100. + 0.5);
+
+  ibooker.setCurrentFolder("CTPPS/TrackingStrip");
 
   h_trackCorr_hor = ibooker.book2D("track correlation RP-210-hor", "rp, 210, hor", 4, -0.5, 3.5, 4, -0.5, 3.5);
   TH2F *hist = h_trackCorr_hor->getTH2F();

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -5,10 +5,15 @@ from DQM.CTPPS.totemDAQTriggerDQMSource_cfi import *
 from DQM.CTPPS.totemRPDQMHarvester_cfi import *
 from DQM.CTPPS.totemRPDQMSource_cfi import *
 
+from DQM.CTPPS.ctppsDiamondDQMSource_cfi import *
+
 from DQM.CTPPS.ctppsPixelDQMSource_cfi import *
 
 ctppsDQM = cms.Sequence(
-  totemDAQTriggerDQMSource
- *(totemRPDQMSource + ctppsPixelDQMSource)
- *totemRPDQMHarvester
+    totemDAQTriggerDQMSource *
+    totemRPDQMSource *
+    ctppsDiamondDQMSource *
+    ctppsPixelDQMSource *
+
+    totemRPDQMHarvester
 )

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -10,10 +10,8 @@ from DQM.CTPPS.ctppsDiamondDQMSource_cfi import *
 from DQM.CTPPS.ctppsPixelDQMSource_cfi import *
 
 ctppsDQM = cms.Sequence(
-    totemDAQTriggerDQMSource *
-    totemRPDQMSource *
-    ctppsDiamondDQMSource *
-    ctppsPixelDQMSource *
-
-    totemRPDQMHarvester
+    totemDAQTriggerDQMSource
+    + (totemRPDQMSource * totemRPDQMHarvester)
+    + ctppsDiamondDQMSource
+    + ctppsPixelDQMSource
 )

--- a/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ctpps_dqm_sourceclient-live_cfg.py
@@ -12,14 +12,13 @@ else:
   # for testing in lxplus
   process.load("DQM.Integration.config.fileinputsource_cfi")
   process.source.fileNames = cms.untracked.vstring(
-    'file:/afs/cern.ch/user/j/jkaspar/public/run273062_ls0001-2_stream.root',
+    #'root://eostotem.cern.ch//eos/totem/user/j/jkaspar/04C8034A-9626-E611-9B6E-02163E011F93.root'
     '/store/express/Run2016H/ExpressPhysics/FEVT/Express-v2/000/283/877/00000/4EE44B0E-2499-E611-A155-02163E011938.root'
   )
   process.source.inputCommands = cms.untracked.vstring(
     'drop *',
     'keep FEDRawDataCollection_*_*_*'
   )
-
 
 # DQM environment
 process.load("DQM.Integration.config.environment_cfi")
@@ -47,7 +46,7 @@ process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
 process.load("RecoCTPPS.Configuration.recoCTPPS_cff")
 
 # DQM Modules
-process.load("DQM.CTPPS.totemDQM_cff")
+process.load("DQM.CTPPS.ctppsDQM_cff")
 
 # processing path
 process.recoStep = cms.Sequence(
@@ -56,7 +55,7 @@ process.recoStep = cms.Sequence(
 )
 
 process.dqmModules = cms.Sequence(
-  process.totemDQM +
+  process.ctppsDQM +
   process.dqmEnv +
   process.dqmSaver
 )


### PR DESCRIPTION
Backport of #18718 to `9_1_X`

Several fixes for CTPPS DQM configuration. Important for commissioning/calibration at the LHC restart.