### PR TITLE
Fix includes/forward declarations in FWCore/Framework

### DIFF
--- a/FWCore/Framework/interface/WillGetIfMatch.h
+++ b/FWCore/Framework/interface/WillGetIfMatch.h
@@ -11,13 +11,12 @@ See comments in the file GetterOfProducts.h.
 */
 
 #include <functional>
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm {
-
-  class BranchDescription;
-  class EDConsumerBase;
 
   template<typename T>
   class WillGetIfMatch {

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -31,6 +31,7 @@
 // forward declarations
 
 namespace edm {
+  class ConfigurationDescriptions;
   namespace stream {
     
     template<typename T, typename M, typename B>

--- a/FWCore/Framework/src/MessageForSource.h
+++ b/FWCore/Framework/src/MessageForSource.h
@@ -25,7 +25,7 @@
 //
 
 // system include files
-
+#include <cstddef>
 // user include files
 
 // forward declarations

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -40,7 +40,7 @@ namespace edm {
   class ProcessContext;
   struct TriggerTimingReport;
   namespace service {
-    class TriggersNameService;
+    class TriggerNamesService;
   }
   
   class SystemTimeKeeper


### PR DESCRIPTION
Multiple headers in FWCore/Framework currently don't compile. This PR fixes this by correcting typos, including the relevant headers and adding the relevant forward declarations.