### PR TITLE
Add missing includes to Migration.h

### DIFF
--- a/DataFormats/CLHEP/interface/Migration.h
+++ b/DataFormats/CLHEP/interface/Migration.h
@@ -2,6 +2,11 @@
 #define _CLEHP_2_SMATRIX_MIGRATION_H_
 
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
+
+#include "CLHEP/Matrix/Matrix.h"
+#include "CLHEP/Matrix/Vector.h"
+#include "CLHEP/Matrix/SymMatrix.h"
+
 #include <cstring>
 
 /*


### PR DESCRIPTION
We reference the CLHEP classes HepVector, HepMatrix and HepSymMtrix
in this header, so we also should include the CLHEP headers here
that contain these classes.