### PR TITLE
Add missing includes to SerializationManual.h

### DIFF
--- a/CondFormats/PhysicsToolsObjects/src/SerializationManual.h
+++ b/CondFormats/PhysicsToolsObjects/src/SerializationManual.h
@@ -1,5 +1,6 @@
 
 #include "boost/serialization/assume_abstract.hpp"
+#include "CondFormats/PhysicsToolsObjects/interface/Histogram3D.h"
 
 // take care of instantiating the concrete templates:
 


### PR DESCRIPTION
We use the different Histogram classes in this header, so we
also need to import the different definitions for each.
For simplicity I just added one include for Histogram3D because that's
also including the other Histogram classes.