### PR TITLE
Add missing includes to TrajectoryStopReasons.h

### DIFF
--- a/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
+++ b/DataFormats/TrackReco/interface/TrajectoryStopReasons.h
@@ -1,6 +1,8 @@
 #ifndef TRAJECTORYSTOPREASONS_H
 #define TRAJECTORYSTOPREASONS_H
 
+#include <string>
+
 enum class StopReason {
   UNINITIALIZED = 0,
   MAX_HITS = 1,


### PR DESCRIPTION
We declare std::string array in this header, so we also
need to include the string header.