### PR TITLE
Fix clashes between translator function in PythonModule.h/.cc

### DIFF
--- a/FWCore/PythonParameterSet/src/PythonModule.h
+++ b/FWCore/PythonParameterSet/src/PythonModule.h
@@ -26,14 +26,14 @@
 // to add module type and label context to the messages being caught
 // here. At this point we did not think it worth the time to implement.
 namespace {
-  void translator(cms::Exception const& ex) {
+  void translatorlibFWCorePythonParameterSet(cms::Exception const& ex) {
     PyErr_SetString(PyExc_RuntimeError, ex.message().c_str());
   }
 }
 
 BOOST_PYTHON_MODULE(libFWCorePythonParameterSet)
 {
-  boost::python::register_exception_translator<cms::Exception>(translator);
+  boost::python::register_exception_translator<cms::Exception>(translatorlibFWCorePythonParameterSet);
 
   boost::python::class_<edm::InputTag>("InputTag", boost::python::init<std::string>())
       .def(boost::python::init<std::string, std::string, std::string>())


### PR DESCRIPTION
We have two global TU-local 'translator' functions in CMSSW:
One is in PythonModule.cc and one is in PythonModule.h.

While having TU-local functions in a header is already not recommended,
having them defined twice with the same name like this is causing
undefined behavior that breaks the linker (and also the rest
of clang in the future once someone includes the wrong file).

This patch is making the name of the header function unique to prevent
future compiler errors.