### PR TITLE
Make PythiaDecays.h a standalone header.

### DIFF
--- a/FastSimulation/ParticleDecay/interface/PythiaDecays.h
+++ b/FastSimulation/ParticleDecay/interface/PythiaDecays.h
@@ -30,7 +30,7 @@ class PythiaDecays
  public:
 
   PythiaDecays();
-  ~PythiaDecays(){};
+  ~PythiaDecays();
   const DaughterParticleList & particleDaughters(ParticlePropagator& particle, CLHEP::HepRandomEngine*);
 
  private:

--- a/FastSimulation/ParticleDecay/src/PythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/src/PythiaDecays.cc
@@ -26,6 +26,10 @@ PythiaDecays::PythiaDecays()
     }
 }
 
+
+PythiaDecays::~PythiaDecays() {
+}
+
 const DaughterParticleList&
 PythiaDecays::particleDaughters(ParticlePropagator& particle, CLHEP::HepRandomEngine* engine)
 {


### PR DESCRIPTION
PythiaDecays.h currently doesn't compile on its own because we create
a std::vector of RawParticle, which is only a forward declared class.
This is already a border-case and *can* compile as long as we don't
touch the vector itself in the rest of the header code.

However, the destructor that is destroying the vector as part of
the header code and is therefore is accessing it, so we get in the
modules case compiler errors for this header.

This patch just moves the constructor to the cpp file so that we
generate the destruction code in the source file where we actually
have the definition of RawParticle available.