### PR TITLE
Add missing includes to XMLUtils.h

### DIFF
--- a/GeneratorInterface/LHEInterface/src/XMLUtils.h
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <vector>
 
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/util/XMLUni.hpp>


### PR DESCRIPTION
The buffer_ member variable is a std::vector, but we don't include
vector (either directly or indirectly) here, so this header
won't compile for modules.