### PR TITLE
Add missing include to PdfInto.h

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/PdfInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PdfInfo.h
@@ -1,6 +1,8 @@
 #ifndef SimDataFormats_GeneratorProducts_PdfInfo_h
 #define SimDataFormats_GeneratorProducts_PdfInfo_h
 
+#include <utility>
+
 /** \class PdfInfo
  *
  */


### PR DESCRIPTION
We need to include utiliy in this header to get the definition
of std::pair.