### PR TITLE
Add missing include to XercesStrUtils.h

### DIFF
--- a/Utilities/Xerces/interface/XercesStrUtils.h
+++ b/Utilities/Xerces/interface/XercesStrUtils.h
@@ -4,6 +4,7 @@
 #include <xercesc/util/XercesDefs.hpp>
 #include <xercesc/util/XMLString.hpp>
 #include <memory>
+#include <sstream>
 
 #ifdef XERCES_CPP_NAMESPACE_USE
 XERCES_CPP_NAMESPACE_USE


### PR DESCRIPTION
We use istringstream in this header, so we also need a include
to sstream.