### PR TITLE
Add missing includes to GeneratorInterface/Pythia8Interface.

### DIFF
--- a/GeneratorInterface/Pythia8Interface/interface/MultiUserHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/MultiUserHook.h
@@ -1,5 +1,7 @@
 //to allow combining multiple user hooks
 
+#include "Pythia8/UserHooks.h"
+
 class MultiUserHook : public Pythia8::UserHooks {
 
 public:  

--- a/GeneratorInterface/Pythia8Interface/interface/PTFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/PTFilterHook.h
@@ -1,3 +1,6 @@
+
+#include "Pythia8/UserHooks.h"
+
 class PTFilterHook : public Pythia8::UserHooks {
 
 public:  

--- a/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
+++ b/GeneratorInterface/Pythia8Interface/interface/ResonanceDecayFilterHook.h
@@ -1,3 +1,7 @@
+
+#include "Pythia8/UserHooks.h"
+#include "Pythia8/Event.h"
+
 class ResonanceDecayFilterHook : public Pythia8::UserHooks {
 
 public:  


### PR DESCRIPTION
Those headers were missing an include to UserHook which they're
inheriting from. ResonanceDecayFilterHook is also using
the Pythia8::Event class, so we also add the missing include
to the Event.h header.