### PR TITLE
Add missing include to MakeModuleHelper.h

### DIFF
--- a/FWCore/Framework/src/MakeModuleHelper.h
+++ b/FWCore/Framework/src/MakeModuleHelper.h
@@ -19,11 +19,13 @@
 //
 
 // system include files
-
+#include <memory>
 // user include files
 
 // forward declarations
 namespace edm {
+  class ParameterSet;
+
   template<typename Base>
   class MakeModuleHelper
   {


### PR DESCRIPTION
We need the include to memory because of unique_ptr. The forward
declaration for ParameterSet is needed because we have a function
that has ParameterSet& argument.