### PR TITLE
Add missing includes to makeGlobal.h

### DIFF
--- a/FWCore/Framework/interface/stream/makeGlobal.h
+++ b/FWCore/Framework/interface/stream/makeGlobal.h
@@ -19,12 +19,13 @@
 //
 
 // system include files
-
+#include <memory>
 // user include files
-
+#include "FWCore/Framework/interface/stream/dummy_helpers.h"
 // forward declarations
 
 namespace edm {
+  class ParameterSet;
   namespace stream {
     namespace impl {
       template<typename T, typename G>


### PR DESCRIPTION
We have to include memory because we use unique_ptr's in this file.
The include to "dummy_helpers.h" is necessary because we use dummy_ptr()
and the forward declaration for ParameterSet is necessary because
we use that as the function parameters.