### PR TITLE
Add missing include to LocalErrorBaseExtended.h

### DIFF
--- a/DataFormats/GeometrySurface/interface/LocalErrorBaseExtended.h
+++ b/DataFormats/GeometrySurface/interface/LocalErrorBaseExtended.h
@@ -2,6 +2,7 @@
 #define LocalErrorType_H
 
 #include "DataFormats/GeometryCommonDetAlgo/interface/DeepCopyPointer.h"
+#include "DataFormats/GeometrySurface/interface/TrivialError.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 //
 // Exceptions


### PR DESCRIPTION
We use InvalidError in the constructor, so we also
need to include the TrivialError.h header to get the
definition of this class.