### PR TITLE
Add missing includes to HGCRecHitComparison.h.

### DIFF
--- a/DataFormats/HGCRecHit/interface/HGCRecHitComparison.h
+++ b/DataFormats/HGCRecHit/interface/HGCRecHitComparison.h
@@ -1,6 +1,10 @@
 #ifndef HGCRecHitComparison_H
 #define HGCRecHitComparison_H
 
+#include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
+
+#include <cstdint>
+
 //ordering capability mandatory for lazy getter framework
 // Comparison operators
 inline bool operator<( const HGCRecHit& one, const HGCRecHit& other) {


### PR DESCRIPTION
We need <cstdint> because we use uint32_t and "HGCRecHit.h" because
we use HGCRecHit.