### PR TITLE
Add missing includes to HcalRecHitFwd.h.

### DIFF
--- a/DataFormats/HcalRecHit/interface/HcalRecHitFwd.h
+++ b/DataFormats/HcalRecHit/interface/HcalRecHitFwd.h
@@ -5,6 +5,12 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/HcalRecHit/interface/CastorRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "DataFormats/HcalRecHit/interface/HcalCalibRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HFRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HORecHit.h"
+#include "DataFormats/HcalRecHit/interface/ZDCRecHit.h"
 
 class HBHERecHit;
 class HORecHit;


### PR DESCRIPTION
We typedef multiple types in this header but we don't include their
headers. This patch adds all those missing headers.