### PR TITLE
Replace fwd-decl for BranchID with #include.

### DIFF
--- a/FWCore/Framework/src/EarlyDeleteHelper.h
+++ b/FWCore/Framework/src/EarlyDeleteHelper.h
@@ -23,10 +23,9 @@
 #include <atomic>
 
 // user include files
-
+#include "DataFormats/Provenance/interface/BranchID.h"
 // forward declarations
 namespace edm {
-  class BranchID;
   class EventPrincipal;
   
   struct BranchToCount {


### PR DESCRIPTION
We have a member variable 'branch' of type BranchID, so we actually
need the forward declaration in this header.