### PR TITLE
Add missing #include to DeDxHitInfo.h

### DIFF
--- a/DataFormats/TrackReco/interface/DeDxHitInfo.h
+++ b/DataFormats/TrackReco/interface/DeDxHitInfo.h
@@ -8,6 +8,7 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
   class DeDxHitInfo


### PR DESCRIPTION
We typedef RefVector at the bottom of this header to another type, so we
have to include it's header here.