### PR TITLE
Change m_end to m_size in EZArrayVL.h

### DIFF
--- a/Geometry/CaloGeometry/interface/EZArrayVL.h
+++ b/Geometry/CaloGeometry/interface/EZArrayVL.h
@@ -68,7 +68,7 @@ class EZArrayVL
 
       bool empty()         const { return ( 0 == size() ) ;  }
 
-      size_type size()     const { return ( m_end - m_begin ) ; }
+      size_type size()     const { return ( m_size ) ; }
 
       size_type capacity() const { return size() ; }
 


### PR DESCRIPTION
Seems like m_end was removed and this reference not updated. This causes this header not to compile.