### PR TITLE
Added missing includes to Instantiate.h.

### DIFF
--- a/CondFormats/Serialization/interface/Instantiate.h
+++ b/CondFormats/Serialization/interface/Instantiate.h
@@ -2,6 +2,8 @@
 
 #include "CondFormats/Serialization/interface/Archive.h"
 
+#include <boost/serialization/export.hpp>
+
 // Instantiate serialization code. It works with template
 // arguments as well (use one for each specialization)
 #define COND_SERIALIZATION_INSTANTIATE(...) \


### PR DESCRIPTION
The used macro BOOST_CLASS_EXPORT_IMPLEMENT needs to be imported
from export.hpp, otherwise this header will not compile when included and the macro is used.