### PR TITLE
Remove compability header normalizedPhi.h

### DIFF
--- a/CommonTools/Utils/interface/normalizedPhi.h
+++ b/CommonTools/Utils/interface/normalizedPhi.h
@@ -1,7 +1,0 @@
-#ifndef CommonTools_Utils_notmalizedPhi_h
-#define CommonTools_Utils_notmalizedPhi_h
-/* return a value of phi into interval [-pi,+pi]
- *
- */
-#include "DataFormats/Math/include/normalizedPhi.h"
-#endif


### PR DESCRIPTION
The header is no longer used and the contained code is also referencing invalid paths.
