### PR TITLE
Also store crossing frame in heavy-ion event overlay workflow

### DIFF
--- a/SimGeneral/MixingModule/python/HiMix_cff.py
+++ b/SimGeneral/MixingModule/python/HiMix_cff.py
@@ -35,5 +35,6 @@ mix = cms.EDProducer("MixingModule",
     mixObjects = cms.PSet(theMixObjects)
 )
 
+mix.mixObjects.mixHepMC.makeCrossingFrame = True
 
 


### PR DESCRIPTION
This one liner fixes the problem found by @davidlange6 in #18721 