### PR TITLE
Update ALCARECOMuAlGlobalCosmics_cff.py

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECOMuAlGlobalCosmicsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
     andOr = True, ## choose logical OR between Triggerbits
-    eventSetupPathsKey = 'MuAlGlobalCosmics',
+    eventSetupPathsKey = 'MuAlGlobalCosmicsInCollisions',
     throw = False # tolerate triggers not available
 )
 


### PR DESCRIPTION
This one-line PR fixes the crashes in workflows 7.2, 7.3, 7.4, as seen in PR #18753 . We tested and checked that this allows the workflows to run into completion, at the expense of making the AlCaReco and the eventSetupPathsKey having different names.