### PR TITLE
CTPPS: Small memory footprint reduction for the channels mapping handler

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -285,8 +285,8 @@ edm::ESProducts< std::shared_ptr<TotemDAQMapping>, std::shared_ptr<TotemAnalysis
 {
   assert(currentBlockValid);
 
-  std::shared_ptr<TotemDAQMapping> mapping(new TotemDAQMapping());
-  std::shared_ptr<TotemAnalysisMask> mask(new TotemAnalysisMask());
+  auto mapping = std::make_shared<TotemDAQMapping>();
+  auto mask = std::make_shared<TotemAnalysisMask>();
 
   // initialize Xerces
   try


### PR DESCRIPTION
Forward-port of a single commit to keep in sync with the review of the `8_0_X` branch of #18734 (#18732).

Save twice an allocation of shared pointers using the make_shared statement

`runTheMatrix.py` yielded `17 17 16 14 7 1 1 1 tests passed, 1 0 0 0 0 0 0 0 failed` (usual DAS failure of `4.22`)