### PR TITLE
Add fake trajectory to PixelTracks

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
@@ -92,6 +93,14 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
     unsigned int nHits = tracks->at(k).numberOfValidHits();
     theTrackExtra.setHits(hitCollProd, cc, nHits);
     cc +=nHits;
+    reco::TrackExtra::TrajParams trajParams;
+    AlgebraicVector5 v = AlgebraicVector5(0,0,0,0,0);
+    reco::TrackExtra::Chi2sFive chi2s;
+    for (unsigned int i = 0; i < nHits; ++i){
+	chi2s.push_back(255);
+        trajParams.push_back(LocalTrajectoryParameters(v,1.));
+    }
+    theTrackExtra.setTrajParams(std::move(trajParams),std::move(chi2s));
     trackExtras->push_back(theTrackExtra);
   }
 

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -98,7 +98,7 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
     reco::TrackExtra::Chi2sFive chi2s;
     for (unsigned int i = 0; i < nHits; ++i){
 	chi2s.push_back(0);
-        trajParams.push_back(LocalTrajectoryParameters(v,1.));
+	trajParams.push_back(LocalTrajectoryParameters(v,1.));
     }
     theTrackExtra.setTrajParams(std::move(trajParams),std::move(chi2s));
     trackExtras->push_back(theTrackExtra);

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -97,7 +97,7 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
     AlgebraicVector5 v = AlgebraicVector5(0,0,0,0,0);
     reco::TrackExtra::Chi2sFive chi2s;
     for (unsigned int i = 0; i < nHits; ++i){
-	chi2s.push_back(255);
+	chi2s.push_back(0);
         trajParams.push_back(LocalTrajectoryParameters(v,1.));
     }
     theTrackExtra.setTrajParams(std::move(trajParams),std::move(chi2s));

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -93,13 +93,9 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
     unsigned int nHits = tracks->at(k).numberOfValidHits();
     theTrackExtra.setHits(hitCollProd, cc, nHits);
     cc +=nHits;
-    reco::TrackExtra::TrajParams trajParams;
     AlgebraicVector5 v = AlgebraicVector5(0,0,0,0,0);
-    reco::TrackExtra::Chi2sFive chi2s;
-    for (unsigned int i = 0; i < nHits; ++i){
-	chi2s.push_back(0);
-	trajParams.push_back(LocalTrajectoryParameters(v,1.));
-    }
+    reco::TrackExtra::TrajParams trajParams(nHits,LocalTrajectoryParameters(v,1.));
+    reco::TrackExtra::Chi2sFive chi2s(nHits,0);
     theTrackExtra.setTrajParams(std::move(trajParams),std::move(chi2s));
     trackExtras->push_back(theTrackExtra);
   }


### PR DESCRIPTION
Add a fake trajectory and dummy chi2 values to the PixelTracks class so that pixel tracks can be used with classes such as TrackListMerger. Needed for mitigation of the effect of non-functioning modules in the new pixel detector 