### PR TITLE
Update of PointSeededTrackingRegionsProducer to work in CMSSW 9

### DIFF
--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -9,6 +9,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -102,6 +104,47 @@ public:
   }
   
   virtual ~PointSeededTrackingRegionsProducer() {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+
+    edm::ParameterSetDescription descPoint;
+    descPoint.add<double>("eta", 0.0);
+    descPoint.add<double>("phi", 0.0);
+    desc.add<edm::ParameterSetDescription>("point_input", descPoint);
+
+    desc.add<std::string>("mode", "BeamSpotFixed");
+    desc.add<int>("maxNRegions", 10);
+    desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
+    desc.add<edm::InputTag>("vertexCollection", edm::InputTag("hltPixelVertices"));
+    desc.add<int>("maxNVertices", 1);
+
+    desc.add<double>("ptMin", 0.9);
+    desc.add<double>("originRadius", 0.2);
+    desc.add<double>("zErrorBeamSpot", 24.2);
+    desc.add<double>("deltaEta", 0.5);
+    desc.add<double>("deltaPhi", 0.5);
+    desc.add<bool>("precise", true);
+
+    desc.add<double>("nSigmaZVertex", 3.);
+    desc.add<double>("zErrorVetex", 0.2);
+    desc.add<double>("nSigmaZBeamSpot", 4.);
+
+    desc.add<std::string>("whereToUseMeasurementTracker", "ForSiStrips");
+    desc.add<edm::InputTag>("measurementTrackerName", edm::InputTag(""));
+ 
+    desc.add<bool>("searchOpt", false); 
+
+    // Only for backwards-compatibility
+    edm::ParameterSetDescription descRegion;
+    descRegion.add<edm::ParameterSetDescription>("RegionPSet", desc);
+    //edm::ParameterSetDescription descPoint;
+    //descPoint.add<edm::ParameterSetDescription>("point_input", desc);
+
+
+    descriptions.add("pointSeededTrackingRegion", descRegion);
+  }
+
     
 
   virtual std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& e, const edm::EventSetup& es) const override

--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -68,7 +68,8 @@ public:
     edm::ParameterSet points = regPSet.getParameter<edm::ParameterSet>("points");
     etaPoints = points.getParameter<std::vector<double>>("eta");
     phiPoints = points.getParameter<std::vector<double>>("phi");
-    if (!(etaPoints.size() == phiPoints.size()))  edm::LogError ("PointSeededTrackingRegionsProducer")<<"same number of eta and phi coordinates must be specified";
+    //if (!(etaPoints.size() == phiPoints.size()))  edm::Exception ("PointSeededTrackingRegionsProducer")<<"same number of eta and phi coordinates must be specified";
+    if (!(etaPoints.size() == phiPoints.size()))  throw edm::Exception(edm::errors::Configuration) << "The parameters 'eta' and 'phi' must have the same size";;
     m_maxNRegions      = regPSet.getParameter<int>("maxNRegions");
     token_beamSpot     = iC.consumes<reco::BeamSpot>(regPSet.getParameter<edm::InputTag>("beamSpot"));
     m_maxNVertices     = 1;
@@ -109,6 +110,16 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
 
+/*    edm::ParameterSetDescription descPoints;
+    descPoints.add<double>("eta", 0.0);
+    descPoints.add<double>("phi", 0.0);
+    std::vector<edm::ParameterSet> vDefaults;
+    edm::ParameterSet vDefaults1;
+    vDefaults1.addParameter<double>("eta", 0.0);
+    vDefaults1.addParameter<double>("phi", 0.0);
+    vDefaults.push_back(vDefaults1);
+    desc.addVPSet("points", descPoints,vDefaults);
+  */ 
     edm::ParameterSetDescription descPoints;
     descPoints.add<std::vector<double>> ("eta", {0.} ); 
     descPoints.add<std::vector<double>> ("phi", {0.} ); 
@@ -202,10 +213,10 @@ public:
     int n_regions = 0;
     for(size_t i = 0; i < n_points && n_regions < m_maxNRegions; ++i ) {
 
-      double x = TMath::Cos(phiPoints[i]);
-      double y = TMath::Sin(phiPoints[i]);
-      double theta = 2*TMath::ATan(TMath::Exp(-etaPoints[i]));
-      double z = (x*x+y*y)/TMath::Tan(theta);
+      double x = std::cos(phiPoints[i]);
+      double y = std::sin(phiPoints[i]);
+      double theta = 2*std::atan(std::exp(-etaPoints[i]));
+      double z = (x*x+y*y)/std::tan(theta);
 
       GlobalVector direction( x,y,z );
 	
@@ -227,6 +238,7 @@ public:
         ++n_regions;
       }
     }
+    //std::cout<<"n_seeded_regions = "<<n_regions<<std::endl;
     edm::LogInfo ("PointSeededTrackingRegionsProducer") << "produced "<<n_regions<<" regions";
     
     return result;

--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -68,7 +68,6 @@ public:
     edm::ParameterSet points = regPSet.getParameter<edm::ParameterSet>("points");
     etaPoints = points.getParameter<std::vector<double>>("eta");
     phiPoints = points.getParameter<std::vector<double>>("phi");
-    //if (!(etaPoints.size() == phiPoints.size()))  edm::Exception ("PointSeededTrackingRegionsProducer")<<"same number of eta and phi coordinates must be specified";
     if (!(etaPoints.size() == phiPoints.size()))  throw edm::Exception(edm::errors::Configuration) << "The parameters 'eta' and 'phi' must have the same size";;
     m_maxNRegions      = regPSet.getParameter<int>("maxNRegions");
     token_beamSpot     = iC.consumes<reco::BeamSpot>(regPSet.getParameter<edm::InputTag>("beamSpot"));
@@ -110,16 +109,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
 
-/*    edm::ParameterSetDescription descPoints;
-    descPoints.add<double>("eta", 0.0);
-    descPoints.add<double>("phi", 0.0);
-    std::vector<edm::ParameterSet> vDefaults;
-    edm::ParameterSet vDefaults1;
-    vDefaults1.addParameter<double>("eta", 0.0);
-    vDefaults1.addParameter<double>("phi", 0.0);
-    vDefaults.push_back(vDefaults1);
-    desc.addVPSet("points", descPoints,vDefaults);
-  */ 
     edm::ParameterSetDescription descPoints;
     descPoints.add<std::vector<double>> ("eta", {0.} ); 
     descPoints.add<std::vector<double>> ("phi", {0.} ); 
@@ -238,7 +227,6 @@ public:
         ++n_regions;
       }
     }
-    //std::cout<<"n_seeded_regions = "<<n_regions<<std::endl;
     edm::LogInfo ("PointSeededTrackingRegionsProducer") << "produced "<<n_regions<<" regions";
     
     return result;

--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -216,7 +216,7 @@ public:
       double x = std::cos(phiPoints[i]);
       double y = std::sin(phiPoints[i]);
       double theta = 2*std::atan(std::exp(-etaPoints[i]));
-      double z = (x*x+y*y)/std::tan(theta);
+      double z = 1./std::tan(theta);
 
       GlobalVector direction( x,y,z );
 	

--- a/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h
@@ -203,7 +203,7 @@ public:
     for(size_t i = 0; i < n_points && n_regions < m_maxNRegions; ++i ) {
 
       double x = TMath::Cos(phiPoints[i]);
-      double y = TMath::Sin(etaPoints[i]);
+      double y = TMath::Sin(phiPoints[i]);
       double theta = 2*TMath::ATan(TMath::Exp(-etaPoints[i]));
       double z = (x*x+y*y)/TMath::Tan(theta);
 

--- a/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
@@ -25,3 +25,6 @@ DEFINE_FWK_MODULE(GlobalTrackingRegionFromBeamSpotEDProducer);
 
 using GlobalTrackingRegionWithVerticesEDProducer = TrackingRegionEDProducerT<GlobalTrackingRegionWithVerticesProducer>;
 DEFINE_FWK_MODULE(GlobalTrackingRegionWithVerticesEDProducer);
+
+using PointSeededTrackingRegionsEDProducer = TrackingRegionEDProducerT<PointSeededTrackingRegionsProducer>;
+DEFINE_FWK_MODULE(PointSeededTrackingRegionsEDProducer);


### PR DESCRIPTION
The PointSeededTrackingRegionsProducer.h is updated with a correct fillDescription method to work in CMSSW 91X. Also, the possibility of using multiple eta-phi points to seed regions is added. Need for mitigation of the effect of non-functioning modules in the new pixel detector at HLT. 