### PR TITLE
fillDescriptions fix for E/gamma Pixel Matching Modules

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -54,7 +54,13 @@ edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription()
   cutsDesc.add<double>("dRZMaxLowEtThres",20.);
   cutsDesc.add<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5});
   cutsDesc.add<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.15,0.09});
-  desc.addVPSet("matchingCuts",cutsDesc);
+  edm::ParameterSet defaults;
+  defaults.addParameter<double>("dPhiMax",0.04);
+  defaults.addParameter<double>("dRZMax",0.09);
+  defaults.addParameter<double>("dRZMaxLowEtThres",0.09);
+  defaults.addParameter<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5});
+  defaults.addParameter<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.09,0.09});
+  desc.addVPSet("matchingCuts",cutsDesc,std::vector<edm::ParameterSet>{defaults,defaults,defaults});
   return desc;
 }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronNHitSeedProducer.cc
@@ -118,11 +118,11 @@ ElectronNHitSeedProducer::ElectronNHitSeedProducer( const edm::ParameterSet& pse
 void ElectronNHitSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("initialSeeds",edm::InputTag());
+  desc.add<edm::InputTag>("initialSeeds",edm::InputTag("hltElePixelSeedsCombined"));
   desc.add<edm::InputTag>("vertices",edm::InputTag());
-  desc.add<edm::InputTag>("beamSpot",edm::InputTag()); 
-  desc.add<edm::InputTag>("measTkEvt",edm::InputTag());
-  desc.add<std::vector<edm::InputTag> >("superClusters");
+  desc.add<edm::InputTag>("beamSpot",edm::InputTag("hltOnlineBeamSpot")); 
+  desc.add<edm::InputTag>("measTkEvt",edm::InputTag("hltSiStripClusters"));
+  desc.add<std::vector<edm::InputTag> >("superClusters",std::vector<edm::InputTag>{edm::InputTag{"hltEgammaSuperClustersToPixelMatch"}});
   desc.add<edm::ParameterSetDescription>("matcherConfig",TrajSeedMatcher::makePSetDescription());
   
   descriptions.add("electronNHitSeedProducer",desc);

--- a/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/TrackingRegionsFromSuperClustersProducer.h
@@ -183,9 +183,9 @@ fillDescriptions(edm::ConfigurationDescriptions& descriptions)
   desc.add<bool>("useZInVertex", false);
   desc.add<bool>("precise", true);
   desc.add<std::string>("whereToUseMeasTracker","kNever");
-  desc.add<edm::InputTag>("beamSpot", edm::InputTag());
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
   desc.add<edm::InputTag>("vertices", edm::InputTag());
-  desc.add<std::vector<edm::InputTag> >("superClusters", std::vector<edm::InputTag>());
+  desc.add<std::vector<edm::InputTag> >("superClusters", std::vector<edm::InputTag>{edm::InputTag{"hltEgammaSuperClustersToPixelMatch"}});
   desc.add<edm::InputTag>("measurementTrackerEvent",edm::InputTag()); 
   
   edm::ParameterSetDescription descRegion;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTFilteredSuperClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTFilteredSuperClusterProducer.cc
@@ -114,7 +114,7 @@ void EgammaHLTFilteredSuperClusterProducer::
 fillDescriptions(edm::ConfigurationDescriptions & descriptions)
 {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("cands",edm::InputTag());
+  desc.add<edm::InputTag>("cands",edm::InputTag("hltEgammaCandidates"));
   
   edm::ParameterSetDescription cutsDesc;
   edm::ParameterSetDescription regionCutsDesc;
@@ -122,10 +122,19 @@ fillDescriptions(edm::ConfigurationDescriptions & descriptions)
   regionCutsDesc.add<double>("cutOverE",-1);
   regionCutsDesc.add<double>("cutOverE2",-1);
   regionCutsDesc.add<bool>("useEt",false);
+  edm::ParameterSet cutDefaults;
+  cutDefaults.addParameter<double>("cutOverE",0.2);
+  cutDefaults.addParameter<double>("useEt",false);
+  
   cutsDesc.add<edm::ParameterSetDescription>("barrelCut",regionCutsDesc);
   cutsDesc.add<edm::ParameterSetDescription>("endcapCut",regionCutsDesc);
-  cutsDesc.add<edm::InputTag>("var");
-  desc.addVPSet("cuts",cutsDesc);
+  cutsDesc.add<edm::InputTag>("var",edm::InputTag("hltEgammaHoverE"));
+  
+  edm::ParameterSet defaults;
+  defaults.addParameter<edm::InputTag>("var",edm::InputTag("hltEgammaHoverE"));
+  defaults.addParameter<edm::ParameterSet>("barrelCut",cutDefaults);
+  defaults.addParameter<edm::ParameterSet>("endcapCut",cutDefaults);
+  desc.addVPSet("cuts",cutsDesc,std::vector<edm::ParameterSet>{defaults});
  
   descriptions.add("egammaHLTFilteredSuperClusterProducer",desc);
 


### PR DESCRIPTION
Dear All,

With 9_1_0 now parsed in confdb, I have discovered that I set my fillDescriptions incorrectly for two modules. I regret and appologise for this unnecessary work I have caused you all during this busy time.

Specifically I was missing:
EgammaHLTFilteredSuperClusterProducer.cuts
ElectronNHitSeedProducer.superClusters

I have updated my module configs so confdb can properly parse them. At the same time I set them to proper sensible defaults.

Again my deepest appologises for this oversight.