### PR TITLE
temporarily disable setNoiseFlagsQIE11 for NZS

### DIFF
--- a/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalRecoNZS_cff.py
@@ -58,7 +58,8 @@ run2_HF_2017.toReplaceWith( hfrecoMB, _phase1_hfrecoMB )
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hbherecoMB,
     processQIE11 = cms.bool(True),
-    setNoiseFlagsQIE11 = cms.bool(True),
+# temporarily disabled until RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py:flagParametersQIE11 is filled
+#    setNoiseFlagsQIE11 = cms.bool(True),
 )
 
 _plan1_hcalLocalRecoSequenceNZS = _phase1_hcalLocalRecoSequenceNZS.copy()


### PR DESCRIPTION
Some status bits were requested to be kept for NZS runs, but the reco cfi doesn't have any parameters for this for QIE11:
https://github.com/cms-sw/cmssw/blob/CMSSW_9_1_X/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py#L86
`flagParametersQIE11 = cms.PSet(),`

Therefore, this has to be disabled until the appropriate parameter set is prepared for QIE11.