### PR TITLE
HLTL1MuonNoL2Selector fix to avoid the need of duplicating the class

### DIFF
--- a/HLTrigger/Muon/interface/HLTL1MuonNoL2Selector.h
+++ b/HLTrigger/Muon/interface/HLTL1MuonNoL2Selector.h
@@ -11,7 +11,7 @@
  *   based on RecoMuon/L2MuonSeedGenerator
  *
  *
- *   \author  D. Olivito
+ *   \author  S. Folgueras
  */
 //
 //--------------------------------------------------
@@ -53,12 +53,11 @@ class HLTL1MuonNoL2Selector : public edm::global::EDProducer<> {
   const double theL1MinPt_;
   const double theL1MaxEta_;
   const unsigned theL1MinQuality_;
+  bool centralBxOnly_;
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muCollToken_;
   edm::InputTag                                          theL2CandTag_;   
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> theL2CandToken_;
-  edm::InputTag                                          theL1CandTag_; 
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> theL1CandToken_; 
   edm::InputTag             seedMapTag_;
   edm::EDGetTokenT<SeedMap> seedMapToken_;
   

--- a/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
+++ b/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
@@ -34,10 +34,9 @@ HLTL1MuonNoL2Selector::HLTL1MuonNoL2Selector(const edm::ParameterSet& iConfig) :
   theL1MinPt_(iConfig.getParameter<double>("L1MinPt")),
   theL1MaxEta_(iConfig.getParameter<double>("L1MaxEta")),
   theL1MinQuality_(iConfig.getParameter<unsigned int>("L1MinQuality")),
+  centralBxOnly_( iConfig.getParameter<bool>("CentralBxOnly") ),
   theL2CandTag_     (iConfig.getParameter< edm::InputTag > ("L2CandTag")),
   theL2CandToken_   (consumes<reco::RecoChargedCandidateCollection>(theL2CandTag_)),
-  theL1CandTag_   (iConfig.getParameter<InputTag > ("L1CandTag")),
-  theL1CandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(theL1CandTag_)),
   seedMapTag_( iConfig.getParameter<InputTag >("SeedMapTag") ),
   seedMapToken_(consumes<SeedMap>(seedMapTag_))
 {
@@ -59,6 +58,7 @@ HLTL1MuonNoL2Selector::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<double>("L1MinPt",-1.);
   desc.add<double>("L1MaxEta",5.0);
   desc.add<unsigned int>("L1MinQuality",0);
+  desc.add<bool>("CentralBxOnly", true);
   descriptions.add("hltL1MuonNoL2Selector",desc);
 }
 
@@ -76,9 +76,6 @@ void HLTL1MuonNoL2Selector::produce(edm::StreamID, edm::Event& iEvent, const edm
   edm::Handle<RecoChargedCandidateCollection> L2cands;
   iEvent.getByToken(theL2CandToken_,L2cands);
   
-  // get the L2 to L1 map object for this event
-  //  HLTMuonL2ToL1TMap mapL2ToL1(theL1CandToken_, seedMapToken_, iEvent);
-
   // Muon particles 
   edm::Handle<MuonBxCollection> muColl;
   iEvent.getByToken(muCollToken_, muColl);
@@ -87,19 +84,17 @@ void HLTL1MuonNoL2Selector::produce(edm::StreamID, edm::Event& iEvent, const edm
   edm::Handle<SeedMap> seedMapHandle;
   iEvent.getByToken(seedMapToken_, seedMapHandle);
   
-  std::vector<l1t::MuonRef> firedL1Muons_;
-  edm::Handle<trigger::TriggerFilterObjectWithRefs> L1Cands;
-  iEvent.getByToken(theL1CandToken_, L1Cands);
-  L1Cands->getObjects(trigger::TriggerL1Mu, firedL1Muons_);
-      
   for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX(); ++ibx) {
-    if (ibx != 0) continue;
+    if (centralBxOnly_ && (ibx != 0)) continue;
     for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++){
       l1t::MuonRef l1muon(muColl, distance(muColl->begin(muColl->getFirstBX()),it) );
       
-      // only select L1's that fired: 
-      if(find(firedL1Muons_.begin(), firedL1Muons_.end(), l1muon) == firedL1Muons_.end()) continue;
-      
+      unsigned int quality = it->hwQual();
+      float pt    =  it->pt();
+      float eta   =  it->eta();
+
+      if ( pt < theL1MinPt_ || fabs(eta) > theL1MaxEta_  || quality <= theL1MinQuality_) continue;
+
       // Loop over L2's to find whether the L1 fired this L2. 
       bool isTriggeredByL1=false;
       for (auto const & cand : *L2cands) {
@@ -107,7 +102,7 @@ void HLTL1MuonNoL2Selector::produce(edm::StreamID, edm::Event& iEvent, const edm
 	const edm::RefVector<L2MuonTrajectorySeedCollection>& seeds = (*seedMapHandle)[l2muon->seedRef().castTo<edm::Ref<L2MuonTrajectorySeedCollection> >()];
 	for(auto const & seed : seeds){
 	  // Check if the L2 was seeded by a triggered L1, in such case skip the loop. 
-	  if(find(firedL1Muons_.begin(), firedL1Muons_.end(), seed->l1tParticle()) != firedL1Muons_.end()){
+	  if(seed->l1tParticle()==l1muon) {
 	    isTriggeredByL1 = true;
 	    break;
 	  }
@@ -115,10 +110,9 @@ void HLTL1MuonNoL2Selector::produce(edm::StreamID, edm::Event& iEvent, const edm
 	if (!isTriggeredByL1) {
 	  output->push_back( ibx, *it);
 	}
-      }	
+      }
     }
   } // loop over L1
   
   iEvent.put(std::move(output));
 }
-

--- a/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
+++ b/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
@@ -93,7 +93,7 @@ void HLTL1MuonNoL2Selector::produce(edm::StreamID, edm::Event& iEvent, const edm
       float pt    =  it->pt();
       float eta   =  it->eta();
 
-      if ( pt < theL1MinPt_ || fabs(eta) > theL1MaxEta_  || quality <= theL1MinQuality_) continue;
+      if ( pt < theL1MinPt_ || std::abs(eta) > theL1MaxEta_  || quality <= theL1MinQuality_) continue;
 
       // Loop over L2's to find whether the L1 fired this L2. 
       bool isTriggeredByL1=false;


### PR DESCRIPTION
This is needed to avoid using filter-objects and hence duplicating this module for every different L1 seed.  
