### PR TITLE
HLTL1MuonNoL2Selector fix to avoid the need of duplicating the class for 91X

### DIFF
--- a/HLTrigger/Muon/interface/HLTL1MuonNoL2Selector.h
+++ b/HLTrigger/Muon/interface/HLTL1MuonNoL2Selector.h
@@ -58,8 +58,6 @@ class HLTL1MuonNoL2Selector : public edm::global::EDProducer<> {
   edm::EDGetTokenT<l1t::MuonBxCollection> muCollToken_;
   edm::InputTag                                          theL2CandTag_;   
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> theL2CandToken_;
-  //  edm::InputTag                                          theL1CandTag_; 
-  //  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> theL1CandToken_; 
   edm::InputTag             seedMapTag_;
   edm::EDGetTokenT<SeedMap> seedMapToken_;
   

--- a/HLTrigger/Muon/interface/HLTL1MuonNoL2Selector.h
+++ b/HLTrigger/Muon/interface/HLTL1MuonNoL2Selector.h
@@ -11,7 +11,7 @@
  *   based on RecoMuon/L2MuonSeedGenerator
  *
  *
- *   \author  D. Olivito
+ *   \author  S. Folgueras
  */
 //
 //--------------------------------------------------
@@ -53,12 +53,13 @@ class HLTL1MuonNoL2Selector : public edm::global::EDProducer<> {
   const double theL1MinPt_;
   const double theL1MaxEta_;
   const unsigned theL1MinQuality_;
+  bool centralBxOnly_;
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muCollToken_;
   edm::InputTag                                          theL2CandTag_;   
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> theL2CandToken_;
-  edm::InputTag                                          theL1CandTag_; 
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> theL1CandToken_; 
+  //  edm::InputTag                                          theL1CandTag_; 
+  //  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> theL1CandToken_; 
   edm::InputTag             seedMapTag_;
   edm::EDGetTokenT<SeedMap> seedMapToken_;
   

--- a/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
+++ b/HLTrigger/Muon/src/HLTL1MuonNoL2Selector.cc
@@ -93,7 +93,7 @@ void HLTL1MuonNoL2Selector::produce(edm::StreamID, edm::Event& iEvent, const edm
       float pt    =  it->pt();
       float eta   =  it->eta();
 
-      if ( pt < theL1MinPt_ || fabs(eta) > theL1MaxEta_  || quality <= theL1MinQuality_) continue;
+      if ( pt < theL1MinPt_ || std::abs(eta) > theL1MaxEta_  || quality <= theL1MinQuality_) continue;
 
       // Loop over L2's to find whether the L1 fired this L2. 
       bool isTriggeredByL1=false;


### PR DESCRIPTION
This is needed to avoid using filter-objects and hence duplicating this module for every different L1 seed.  Backport of #18830

