### PR TITLE
Consolidate stream and thread printout

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -115,7 +115,6 @@ namespace {
       iNThreads = tbb::task_scheduler_init::default_num_threads();
     }
     oPtr = std::make_unique<tbb::task_scheduler_init>(static_cast<int>(iNThreads),iStackSize);
-    edm::LogInfo("ThreadSetup") <<"setting # threads "<<iNThreads;
 
     return iNThreads;
   }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -449,9 +449,11 @@ namespace edm {
       if(nStreams==0) {
         nStreams = nThreads;
       }
-    // PG: Log the number of streams
-      edm::LogInfo("StreamSetup") <<"setting # streams "<<nStreams;
     }
+    if(nThreads >1) {
+      edm::LogInfo("ThreadStreamSetup") <<"setting # threads "<<nThreads<<"\nsetting # streams "<<nStreams;
+    }
+
     /*
       bool nRunsSet = false;
     */


### PR DESCRIPTION
Put the logging of the number of streams and threads used into the same log message.