### PR TITLE
Fix spacing by replacing all tabs with spaces.

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -95,8 +95,8 @@ class JetCorrectorParameters
     JetCorrectorParameters() { valid_ = false;}
     JetCorrectorParameters(const std::string& fFile, const std::string& fSection = "");
     JetCorrectorParameters(const JetCorrectorParameters::Definitions& fDefinitions,
-			 const std::vector<JetCorrectorParameters::Record>& fRecords) 
-      : mDefinitions(fDefinitions),mRecords(fRecords) { valid_ = true;}
+                           const std::vector<JetCorrectorParameters::Record>& fRecords) 
+                           : mDefinitions(fDefinitions),mRecords(fRecords) { valid_ = true;}
     //-------- Member functions ----------
     const Record& record(unsigned fBin)                                                       const {return mRecords[fBin]; }
     const Definitions& definitions()                                                          const {return mDefinitions;   }
@@ -134,44 +134,44 @@ class JetCorrectorParametersCollection {
   //       enum value is in order of appearance when people thought of them.
  public:
   enum Level_t { L1Offset=0,
-		 L1JPTOffset=7,
-                 L1FastJet = 10,
-		 L2Relative=1,
-		 L3Absolute=2,
-		 L2L3Residual=8,
-		 L4EMF=3,
-		 L5Flavor=4,
-		 L6UE=5,
-		 L7Parton=6,
-		 Uncertainty=9,
-		 UncertaintyAbsolute=11, 
-		 UncertaintyHighPtExtra=12, 
-		 UncertaintySinglePionECAL=13, 
-		 UncertaintySinglePionHCAL=27, 
-		 UncertaintyFlavor=14, 
-		 UncertaintyTime=15,
-		 UncertaintyRelativeJEREC1=16, 
-		 UncertaintyRelativeJEREC2=17, 
-		 UncertaintyRelativeJERHF=18,
-		 UncertaintyRelativePtEC1=28,
-		 UncertaintyRelativePtEC2=29,
-		 UncertaintyRelativePtHF=30,
-		 UncertaintyRelativeStatEC2=19, 
-		 UncertaintyRelativeStatHF=20, 
-		 UncertaintyRelativeFSR=21,
-		 UncertaintyRelativeSample=31,
-		 UncertaintyPileUpDataMC=22, 
-		 UncertaintyPileUpOOT=23, 
-		 UncertaintyPileUpPtBB=24,
-		 UncertaintyPileUpPtEC=32, 
-		 UncertaintyPileUpPtHF=33, 
-		 UncertaintyPileUpBias=25, 
-		 UncertaintyPileUpJetRate=26,
-		 L1RC=34,
-		 L1Residual=35,
-		 UncertaintyAux3=36,
-		 UncertaintyAux4=37,
-		 N_LEVELS=38
+     L1JPTOffset=7,
+     L1FastJet = 10,
+     L2Relative=1,
+     L3Absolute=2,
+     L2L3Residual=8,
+     L4EMF=3,
+     L5Flavor=4,
+     L6UE=5,
+     L7Parton=6,
+     Uncertainty=9,
+     UncertaintyAbsolute=11, 
+     UncertaintyHighPtExtra=12, 
+     UncertaintySinglePionECAL=13, 
+     UncertaintySinglePionHCAL=27, 
+     UncertaintyFlavor=14, 
+     UncertaintyTime=15,
+     UncertaintyRelativeJEREC1=16, 
+     UncertaintyRelativeJEREC2=17, 
+     UncertaintyRelativeJERHF=18,
+     UncertaintyRelativePtEC1=28,
+     UncertaintyRelativePtEC2=29,
+     UncertaintyRelativePtHF=30,
+     UncertaintyRelativeStatEC2=19, 
+     UncertaintyRelativeStatHF=20, 
+     UncertaintyRelativeFSR=21,
+     UncertaintyRelativeSample=31,
+     UncertaintyPileUpDataMC=22, 
+     UncertaintyPileUpOOT=23, 
+     UncertaintyPileUpPtBB=24,
+     UncertaintyPileUpPtEC=32, 
+     UncertaintyPileUpPtHF=33, 
+     UncertaintyPileUpBias=25, 
+     UncertaintyPileUpJetRate=26,
+     L1RC=34,
+     L1Residual=35,
+     UncertaintyAux3=36,
+     UncertaintyAux4=37,
+     N_LEVELS=38
   };
 
 
@@ -209,8 +209,8 @@ class JetCorrectorParametersCollection {
 
   // Helper method to find all of the sections in a given 
   // parameters file
-  static void getSections( std::string inputFile,
-			   std::vector<std::string> & outputs );
+  static void getSections(std::string inputFile,
+                          std::vector<std::string> & outputs );
 
   // Find the L5 bin for hashing
   static key_type getL5Bin( std::string const & flav );

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParametersHelper.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParametersHelper.h
@@ -46,7 +46,7 @@ class JetCorrectorParametersHelper
     // Maps a set of lower bounds for the first N-1 dimensions to the range of lower bound indices mBinBoundaries for the N dimension
     std::unordered_map<tuple_type_Nm1, std::pair<size_t,size_t> > mMap;
     // The number of binned dimensions as given by the JetCorrectorParameters::Definitions class
-    unsigned													  SIZE;
+    unsigned                                                      SIZE;
 };
 
 #endif

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -57,9 +57,9 @@ JetCorrectorParameters::Definitions::Definitions(const std::string& fLine)
       else if (ss == "Correction")
         mIsResponse = false;
       else if (ss == "Resolution")
-	mIsResponse = false;
+        mIsResponse = false;
       else if (ss.find("PAR")==0)
-	mIsResponse = false;
+        mIsResponse = false;
       else
         {
           std::stringstream sserr;
@@ -83,7 +83,7 @@ JetCorrectorParameters::Record::Record(const std::string& fLine,unsigned fNvar) 
       if (tokens.size() < 3)
         {
           std::stringstream sserr;
-	  sserr<<"(line "<<fLine<<"): "<<"three tokens expected, "<<tokens.size()<<" provided.";
+          sserr<<"(line "<<fLine<<"): "<<"three tokens expected, "<<tokens.size()<<" provided.";
           handleError("JetCorrectorParameters::Record",sserr.str());
         }
       for(unsigned i=0;i<mNvar;i++)
@@ -95,7 +95,7 @@ JetCorrectorParameters::Record::Record(const std::string& fLine,unsigned fNvar) 
       if (nParam != tokens.size()-(2*mNvar+1))
         {
           std::stringstream sserr;
-	  sserr<<"(line "<<fLine<<"): "<<tokens.size()-(2*mNvar+1)<<" parameters, but nParam="<<nParam<<".";
+          sserr<<"(line "<<fLine<<"): "<<tokens.size()-(2*mNvar+1)<<" parameters, but nParam="<<nParam<<".";
           handleError("JetCorrectorParameters::Record",sserr.str());
         }
       for (unsigned i = (2*mNvar+1); i < tokens.size(); ++i)
@@ -457,8 +457,8 @@ JetCorrectorParametersCollection::findL7Parton( key_type k ){
     return l7Partons_[k / 1000 - 1];
 }
 
-void JetCorrectorParametersCollection::getSections( std::string inputFile,
-						    std::vector<std::string> & outputs )
+void JetCorrectorParametersCollection::getSections(std::string inputFile,
+                                                   std::vector<std::string> & outputs )
 {
   outputs.clear();
   std::ifstream input( inputFile.c_str() );
@@ -469,7 +469,7 @@ void JetCorrectorParametersCollection::getSections( std::string inputFile,
     if ( in[0] == '[' ) {
       std::string tok = getSection(in);
       if ( tok != "" ) {
-	outputs.push_back( tok );
+        outputs.push_back( tok );
       }
     }
   }
@@ -519,7 +519,7 @@ JetCorrectorParameters const & JetCorrectorParametersCollection::operator[]( key
     if ( k == i->first ) return i->second;
   }
   throw cms::Exception("InvalidInput") << " cannot find key " << static_cast<int>(k)
-				       << " in the JEC payload, this usually means you have to change the global tag" << std::endl;
+                                       << " in the JEC payload, this usually means you have to change the global tag" << std::endl;
 }
 
 // Get a list of valid keys. These will contain hashed keys
@@ -527,15 +527,15 @@ JetCorrectorParameters const & JetCorrectorParametersCollection::operator[]( key
 void JetCorrectorParametersCollection::validKeys(std::vector<key_type> & keys ) const {
   keys.clear();
   for ( collection_type::const_iterator ibegin = corrections_.begin(),
-	  iend = corrections_.end(), i = ibegin; i != iend; ++i ) {
+        iend = corrections_.end(), i = ibegin; i != iend; ++i ) {
     keys.push_back( i->first );
   }
   for ( collection_type::const_iterator ibegin = correctionsL5_.begin(),
-	  iend = correctionsL5_.end(), i = ibegin; i != iend; ++i ) {
+        iend = correctionsL5_.end(), i = ibegin; i != iend; ++i ) {
     keys.push_back( i->first );
   }
   for ( collection_type::const_iterator ibegin = correctionsL7_.begin(),
-	  iend = correctionsL7_.end(), i = ibegin; i != iend; ++i ) {
+        iend = correctionsL7_.end(), i = ibegin; i != iend; ++i ) {
     keys.push_back( i->first );
   }
 }

--- a/CondFormats/JetMETObjects/test/BuildFile.xml
+++ b/CondFormats/JetMETObjects/test/BuildFile.xml
@@ -2,7 +2,7 @@
     <use name="CondFormats/JetMETObjects"/>
 </bin>
 <bin name="TestCondFormatsJetMETObjectsJetCorrectorParameters" file="JetCorrectorParameters_t.cpp">
-	 <use name="FWCore/ParameterSet"/>
-	 <use name="CondFormats/JetMETObjects"/>
-	 <use name="cppunit"/>
+     <use name="FWCore/ParameterSet"/>
+     <use name="CondFormats/JetMETObjects"/>
+     <use name="cppunit"/>
 </bin>

--- a/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
+++ b/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
@@ -46,7 +46,7 @@ public:
    void compareBinIndex3D();
 
    inline void loadbar3(unsigned int x, unsigned int n, unsigned int w = 50, unsigned int freq = 100, string prefix = "") {
-	  if ( (x != n) && (x % (n/freq) != 0) ) return;
+      if ( (x != n) && (x % (n/freq) != 0) ) return;
       float ratio  =  x/(float)n;
       int   c      =  ratio * w;
 
@@ -73,35 +73,35 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testJetCorrectorParameters);
 
 void testJetCorrectorParameters::setUp() {
     m_benchmark = new TBenchmark();
-	veta = {-5.191,-4.889,-4.716,-4.538,-4.363,-4.191,-4.013,-3.839,-3.664,-3.489,
-			-3.314, -3.139,-2.964,-2.853,-2.65, -2.5,  -2.322,-2.172,-2.043,-1.93,
-			-1.83,  -1.74, -1.653,-1.566,-1.479,-1.392,-1.305,-1.218,-1.131,-1.044,
-			-0.957, -0.879,-0.783,-0.696,-0.609,-0.522,-0.435,-0.348,-0.261,-0.174,
-			-0.087, 0,     0.087, 0.174, 0.261, 0.348, 0.435 ,0.522, 0.609, 0.696,
-			0.783,  0.879, 0.957, 1.044, 1.131, 1.218, 1.305 ,1.392, 1.479, 1.566,
-			1.653,  1.74,  1.83,  1.93,  2.043, 2.172, 2.322 ,2.5,   2.65,  2.853,
-			2.964,  3.139, 3.314, 3.489, 3.664, 3.839, 4.013 ,4.191, 4.363, 4.538,
-			4.716,4.889,5.191};
-	for(unsigned int irho=1; irho<=50; irho++) {
-		vrho.push_back(irho);
-	}
-	vpt = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17,20,23,27,30,35,40,45,57,72,90,120,
-		   150,200,300,400,550,750,1000,1500,2000,2500,3000,3500,4000,4500,5000,5500,
-		   6000,6500};
+    veta = {-5.191,-4.889,-4.716,-4.538,-4.363,-4.191,-4.013,-3.839,-3.664,-3.489,
+            -3.314, -3.139,-2.964,-2.853,-2.65, -2.5,  -2.322,-2.172,-2.043,-1.93,
+            -1.83,  -1.74, -1.653,-1.566,-1.479,-1.392,-1.305,-1.218,-1.131,-1.044,
+            -0.957, -0.879,-0.783,-0.696,-0.609,-0.522,-0.435,-0.348,-0.261,-0.174,
+            -0.087, 0,     0.087, 0.174, 0.261, 0.348, 0.435 ,0.522, 0.609, 0.696,
+            0.783,  0.879, 0.957, 1.044, 1.131, 1.218, 1.305 ,1.392, 1.479, 1.566,
+            1.653,  1.74,  1.83,  1.93,  2.043, 2.172, 2.322 ,2.5,   2.65,  2.853,
+            2.964,  3.139, 3.314, 3.489, 3.664, 3.839, 4.013 ,4.191, 4.363, 4.538,
+            4.716,4.889,5.191};
+    for(unsigned int irho=1; irho<=50; irho++) {
+        vrho.push_back(irho);
+    }
+    vpt = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17,20,23,27,30,35,40,45,57,72,90,120,
+           150,200,300,400,550,750,1000,1500,2000,2500,3000,3500,4000,4500,5000,5500,
+           6000,6500};
 
     generateFiles();
 }
 
 void testJetCorrectorParameters::tearDown() {
-	if(m_benchmark!=nullptr)
-		delete m_benchmark;
+    if(m_benchmark!=nullptr)
+        delete m_benchmark;
 }
 
 void testJetCorrectorParameters::setupCorrector(bool is3D) {
-	string path = "CondFormats/JetMETObjects/data/";
-	try {
-	   string to_try = path + ((is3D) ? "testJetCorrectorParameters_3D_L1FastJet_AK4PFchs.txt"
-	                      	     	  : "testJetCorrectorParameters_1D_L1FastJet_AK4PFchs.txt");
+    string path = "CondFormats/JetMETObjects/data/";
+    try {
+       string to_try = path + ((is3D) ? "testJetCorrectorParameters_3D_L1FastJet_AK4PFchs.txt"
+                                      : "testJetCorrectorParameters_1D_L1FastJet_AK4PFchs.txt");
        edm::FileInPath strFIP(to_try);
        filename = strFIP.fullPath();
     }
@@ -115,59 +115,59 @@ void testJetCorrectorParameters::setupCorrector(bool is3D) {
 }
 
 void testJetCorrectorParameters::destroyCorrector() {
-	delete L1JetPar;
-	delete jetCorrector;
+    delete L1JetPar;
+    delete jetCorrector;
 }
 
 void testJetCorrectorParameters::generateFiles() {
-	string path = std::getenv("CMSSW_BASE");
-	path+="/src/CondFormats/JetMETObjects/data/";
-	string name1D = "testJetCorrectorParameters_1D_L1FastJet_AK4PFchs.txt";
-	string name3D = "testJetCorrectorParameters_3D_L1FastJet_AK4PFchs.txt";
+    string path = std::getenv("CMSSW_BASE");
+    path+="/src/CondFormats/JetMETObjects/data/";
+    string name1D = "testJetCorrectorParameters_1D_L1FastJet_AK4PFchs.txt";
+    string name3D = "testJetCorrectorParameters_3D_L1FastJet_AK4PFchs.txt";
 
-	ofstream txtFile1D;
-	txtFile1D.open((path+name1D).c_str());
-	CPPUNIT_ASSERT(txtFile1D.is_open());
-	txtFile1D << "{1 JetEta 3 Rho JetPt JetA 1 Correction L1FastJet}" << endl;
-	for(unsigned int ieta=0; ieta<veta.size()-1; ieta++) {
-		txtFile1D << std::setw(15) << veta[ieta] << std::setw(15) << veta[ieta+1] << std::setw(15) << "6" << std::setw(15)
-				  << "0" << std::setw(15) << "200" << std::setw(15) << "1" << std::setw(15) << "6500" << std::setw(15)
-				  << "0" << std::setw(15) << "10" << std::setw(15) << endl;
-	}
-	txtFile1D.close();
+    ofstream txtFile1D;
+    txtFile1D.open((path+name1D).c_str());
+    CPPUNIT_ASSERT(txtFile1D.is_open());
+    txtFile1D << "{1 JetEta 3 Rho JetPt JetA 1 Correction L1FastJet}" << endl;
+    for(unsigned int ieta=0; ieta<veta.size()-1; ieta++) {
+        txtFile1D << std::setw(15) << veta[ieta] << std::setw(15) << veta[ieta+1] << std::setw(15) << "6" << std::setw(15)
+                  << "0" << std::setw(15) << "200" << std::setw(15) << "1" << std::setw(15) << "6500" << std::setw(15)
+                  << "0" << std::setw(15) << "10" << std::setw(15) << endl;
+    }
+    txtFile1D.close();
 
     vector<float> ptbins = {4,8,10,13,16,19,22,25,30,35,40,45,60,75,100,160,230,330,440,600,820,1100,1400};
-	ofstream txtFile3D;
-	txtFile3D.open((path+name3D).c_str());
-	CPPUNIT_ASSERT(txtFile3D.is_open());
-	txtFile3D << "{3 JetEta Rho JetPt 1 JetPt 1 Correction L1FastJet}" << endl;
-	for(unsigned int ieta=0; ieta<veta.size()-1; ieta++) {
-		for(unsigned int irho=0; irho<vrho.size()-1; irho++) {
-			for(unsigned int ipt=0; ipt<ptbins.size()-1; ipt++) {
-				txtFile3D << std::setw(15) << veta[ieta] << std::setw(15) << veta[ieta+1]
-						  << std::setw(15) << vrho[irho] << std::setw(15);
-				if(vrho[irho+1]==50) txtFile3D << "200" << std::setw(15);
-				else 				 txtFile3D << vrho[irho+1] << std::setw(15);
-				txtFile3D << ptbins[ipt] << std::setw(15);
-				if(ipt+1==ptbins.size()-1) txtFile3D << "6500" << std::setw(15);
-				else                       txtFile3D << ptbins[ipt+1] << std::setw(15);
-				txtFile3D << "2" << std::setw(15) << ptbins[ipt] << std::setw(15) << ptbins[ipt+1] << std::setw(15) << endl;
-			}
-		}
-	}
-	txtFile3D.close();
+    ofstream txtFile3D;
+    txtFile3D.open((path+name3D).c_str());
+    CPPUNIT_ASSERT(txtFile3D.is_open());
+    txtFile3D << "{3 JetEta Rho JetPt 1 JetPt 1 Correction L1FastJet}" << endl;
+    for(unsigned int ieta=0; ieta<veta.size()-1; ieta++) {
+        for(unsigned int irho=0; irho<vrho.size()-1; irho++) {
+            for(unsigned int ipt=0; ipt<ptbins.size()-1; ipt++) {
+                txtFile3D << std::setw(15) << veta[ieta] << std::setw(15) << veta[ieta+1]
+                          << std::setw(15) << vrho[irho] << std::setw(15);
+                if(vrho[irho+1]==50) txtFile3D << "200" << std::setw(15);
+                else                 txtFile3D << vrho[irho+1] << std::setw(15);
+                txtFile3D << ptbins[ipt] << std::setw(15);
+                if(ipt+1==ptbins.size()-1) txtFile3D << "6500" << std::setw(15);
+                else                       txtFile3D << ptbins[ipt+1] << std::setw(15);
+                txtFile3D << "2" << std::setw(15) << ptbins[ipt] << std::setw(15) << ptbins[ipt+1] << std::setw(15) << endl;
+            }
+        }
+    }
+    txtFile3D.close();
 }
 
 void testJetCorrectorParameters::benchmarkBinIndex(bool is3D) {
-	float oldCPU = 0, newCPU = 0, oldReal = 0, newReal = 0;
-	unsigned int ntests = (is3D) ? 1000 : 1000000;
-	if(is3D) fX = {5.0,50.0,100.0};
-	else     fX = {5.0};
-	setupCorrector(is3D);
+    float oldCPU = 0, newCPU = 0, oldReal = 0, newReal = 0;
+    unsigned int ntests = (is3D) ? 1000 : 1000000;
+    if(is3D) fX = {5.0,50.0,100.0};
+    else     fX = {5.0};
+    setupCorrector(is3D);
 
-	cout << endl << "testJetCorrectorParameters::benchmarkBinIndex NTests = " << ntests << endl;
-	cout << "testJetCorrectorParameters::benchmarkBinIndex benchmarking binIndex with file " << filename << " ... " << flush;
-	m_benchmark->Reset();
+    cout << endl << "testJetCorrectorParameters::benchmarkBinIndex NTests = " << ntests << endl;
+    cout << "testJetCorrectorParameters::benchmarkBinIndex benchmarking binIndex with file " << filename << " ... " << flush;
+    m_benchmark->Reset();
     m_benchmark->Start("event");
     for(unsigned int i=0; i<ntests; i++) {
        L1JetPar->binIndex(fX);
@@ -203,78 +203,76 @@ void testJetCorrectorParameters::benchmarkBinIndex(bool is3D) {
 }
 
 void testJetCorrectorParameters::compareBinIndex1D() {
-	fX = {0.0};
-	float eta=-9999;
-	int oldBin=-1, newBin=-1;
-	setupCorrector(false);
+    fX = {0.0};
+    float eta=-9999;
+    int oldBin=-1, newBin=-1;
+    setupCorrector(false);
 
-	cout << endl << "testJetCorrectorParameters::compareBinIndex1D" << endl;
+    cout << endl << "testJetCorrectorParameters::compareBinIndex1D" << endl;
     for(unsigned int ieta=0; ieta<veta.size()-1; ieta++) {
-    	loadbar3(ieta+1, veta.size()-1, 50, 10, "\tProgress:");
-		eta = (veta[ieta]+veta[ieta+1])/2.0;
-		fX = {eta};
-		oldBin = L1JetPar->binIndex(fX);
-		newBin = L1JetPar->binIndexN(fX);
-		if((oldBin < 0 && newBin >= 0) || (oldBin >= 0 && newBin < 0)) {
-			cout << "ERROR::testJetCorrectorParameters::compareBinIndex1D Unable to find the right bin for (eta)=(" << eta << ")" << endl
-				 << "\t(oldBin,newBin)=(" << oldBin << "," << newBin << ")" << endl;
-			CPPUNIT_ASSERT(oldBin >= 0 && newBin >= 0);
-		}
-		else if(oldBin!=newBin) {
-			cout << "ERROR::testJetCorrectorParameters::compareBinIndex1D oldBin!=newBin (" << oldBin << "!=" << newBin << ") for (eta)=("
-			     << eta << ")" << endl;
-			CPPUNIT_ASSERT(oldBin==newBin);
-		}
+        loadbar3(ieta+1, veta.size()-1, 50, 10, "\tProgress:");
+        eta = (veta[ieta]+veta[ieta+1])/2.0;
+        fX = {eta};
+        oldBin = L1JetPar->binIndex(fX);
+        newBin = L1JetPar->binIndexN(fX);
+        if((oldBin < 0 && newBin >= 0) || (oldBin >= 0 && newBin < 0)) {
+            cout << "ERROR::testJetCorrectorParameters::compareBinIndex1D Unable to find the right bin for (eta)=(" << eta << ")" << endl
+                 << "\t(oldBin,newBin)=(" << oldBin << "," << newBin << ")" << endl;
+            CPPUNIT_ASSERT(oldBin >= 0 && newBin >= 0);
+        }
+        else if(oldBin!=newBin) {
+            cout << "ERROR::testJetCorrectorParameters::compareBinIndex1D oldBin!=newBin (" << oldBin << "!=" << newBin << ") for (eta)=("
+                 << eta << ")" << endl;
+            CPPUNIT_ASSERT(oldBin==newBin);
+        }
 
-		jetCorrector->setJetEta(eta);
-		jetCorrector->setRho(50.0);
-		jetCorrector->setJetA(0.5);
-		jetCorrector->setJetPt(100.0);
-		CPPUNIT_ASSERT(jetCorrector->getCorrection()>=0);
-	}
-	destroyCorrector();
-	cout << endl << "testJetCorrectorParameters::compareBinIndex1D All bins match between the linear and non-linear search algorithms for 1D files." << endl;
+        jetCorrector->setJetEta(eta);
+        jetCorrector->setRho(50.0);
+        jetCorrector->setJetA(0.5);
+        jetCorrector->setJetPt(100.0);
+        CPPUNIT_ASSERT(jetCorrector->getCorrection()>=0);
+    }
+    destroyCorrector();
+    cout << endl << "testJetCorrectorParameters::compareBinIndex1D All bins match between the linear and non-linear search algorithms for 1D files." << endl;
 }
 
 void testJetCorrectorParameters::compareBinIndex3D() {
-	fX = {0.0,0.0,0.0};
-	float eta=-9999, rho=-9999, pt=-9999;
-	int oldBin=-1, newBin=-1;
-	setupCorrector(true);
+    fX = {0.0,0.0,0.0};
+    float eta=-9999, rho=-9999, pt=-9999;
+    int oldBin=-1, newBin=-1;
+    setupCorrector(true);
 
-	cout << endl << "testJetCorrectorParameters::compareBinIndex3D" << endl;
+    cout << endl << "testJetCorrectorParameters::compareBinIndex3D" << endl;
     for(unsigned int ieta=0; ieta<veta.size()-1; ieta++) {
-		for(unsigned int irho=0; irho<vrho.size()-1; irho++) {
-			for(unsigned int ipt=0; ipt<vpt.size()-1; ipt++) {
-				loadbar3(ieta*((vrho.size()-1)*(vpt.size()-1))+irho*(vpt.size()-1)+ipt+1,
-				         (veta.size()-1)*(vrho.size()-1)*(vpt.size()-1), 50, 100, "\tProgress");
-				eta = (veta[ieta]+veta[ieta+1])/2.0;
-				rho = (vrho[irho]+vrho[irho+1])/2.0;
-				pt = (vpt[ipt]+vpt[ipt+1])/2.0;
-				fX = {eta,rho,pt};
-				oldBin = L1JetPar->binIndex(fX);
-				newBin = L1JetPar->binIndexN(fX);
-				if((oldBin < 0 && newBin >= 0) || (oldBin >= 0 && newBin < 0)) {
-					cout << "ERROR::testJetCorrectorParameters::compareBinIndex3D Unable to find the right bin for (eta,rho,pt)=(" << eta << "," << rho << "," << pt << ")" << endl
-						 << "\t(oldBin,newBin)=(" << oldBin << "," << newBin << ")" << endl;
-					CPPUNIT_ASSERT(oldBin >= 0 && newBin >= 0);
-				}
-				else if(oldBin!=newBin) {
-					cout << "ERROR::testJetCorrectorParameters::compareBinIndex3D oldBin!=newBin (" << oldBin << "!=" << newBin << ") for (eta,rho,pt)=("
-					     << eta << "," << rho << "," << pt << ")" << endl;
-					CPPUNIT_ASSERT(oldBin==newBin);
-				}
+        for(unsigned int irho=0; irho<vrho.size()-1; irho++) {
+            for(unsigned int ipt=0; ipt<vpt.size()-1; ipt++) {
+                loadbar3(ieta*((vrho.size()-1)*(vpt.size()-1))+irho*(vpt.size()-1)+ipt+1,
+                         (veta.size()-1)*(vrho.size()-1)*(vpt.size()-1), 50, 100, "\tProgress");
+                eta = (veta[ieta]+veta[ieta+1])/2.0;
+                rho = (vrho[irho]+vrho[irho+1])/2.0;
+                pt = (vpt[ipt]+vpt[ipt+1])/2.0;
+                fX = {eta,rho,pt};
+                oldBin = L1JetPar->binIndex(fX);
+                newBin = L1JetPar->binIndexN(fX);
+                if((oldBin < 0 && newBin >= 0) || (oldBin >= 0 && newBin < 0)) {
+                    cout << "ERROR::testJetCorrectorParameters::compareBinIndex3D Unable to find the right bin for (eta,rho,pt)=(" << eta << "," << rho << "," << pt << ")" << endl
+                         << "\t(oldBin,newBin)=(" << oldBin << "," << newBin << ")" << endl;
+                    CPPUNIT_ASSERT(oldBin >= 0 && newBin >= 0);
+                }
+                else if(oldBin!=newBin) {
+                    cout << "ERROR::testJetCorrectorParameters::compareBinIndex3D oldBin!=newBin (" << oldBin << "!=" << newBin << ") for (eta,rho,pt)=("
+                         << eta << "," << rho << "," << pt << ")" << endl;
+                    CPPUNIT_ASSERT(oldBin==newBin);
+                }
 
-				jetCorrector->setJetEta(eta);
-				jetCorrector->setRho(rho);
-				jetCorrector->setJetA(0.5);
-				jetCorrector->setJetPt(pt);
-				CPPUNIT_ASSERT(jetCorrector->getCorrection()>=0);
-			}
-		}
-	}
-	destroyCorrector();
-	cout << endl << "testJetCorrectorParameters::compareBinIndex3D All bins match between the linear and non-linear search algorithms for 3D files." << endl;
+                jetCorrector->setJetEta(eta);
+                jetCorrector->setRho(rho);
+                jetCorrector->setJetA(0.5);
+                jetCorrector->setJetPt(pt);
+                CPPUNIT_ASSERT(jetCorrector->getCorrection()>=0);
+            }
+        }
+    }
+    destroyCorrector();
+    cout << endl << "testJetCorrectorParameters::compareBinIndex3D All bins match between the linear and non-linear search algorithms for 3D files." << endl;
 }
-
-


### PR DESCRIPTION
There was a tab vs 3-space issue introduced by PR #18415 that this PR seeks to fix. All of the files touched by the previous PR were checked and if a tab was found it was converted to spaces. Only white space was changed, no actual code.