### PR TITLE
Disabling a plot making the GUI unstable 

### DIFF
--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -82,6 +82,7 @@ SiPixelPhase1DigisNdigisPerFEDtrend = DefaultHisto.clone(
   range_max = 1000,
   range_nbins = 200,
   dimensions = 0,
+  enabled = False,
   specs = VPSet(
   Specification().groupBy("FED/Event") #produce the mean number of digis per event and FED per lumisection
                    .reduce("COUNT")

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -10,7 +10,19 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").saveAll(),
     Specification().groupBy("PXForward/PXDisk").saveAll(),
-    StandardSpecification2DProfile
+    StandardSpecification2DProfile,#what is below is only for the timing client
+    Specification(OverlayCurvesForTiming).groupBy("PXBarrel/OnlineBlock")
+         .groupBy("PXBarrel", "EXTEND_Y")
+         .save(),
+    Specification(OverlayCurvesForTiming).groupBy("PXForward/OnlineBlock")
+          .groupBy("PXForward", "EXTEND_Y")
+          .save(),
+    Specification(OverlayCurvesForTiming).groupBy("PXForward/PXDisk/OnlineBlock") # per-layer with history for online
+          .groupBy("PXForward/PXDisk", "EXTEND_Y")
+          .save(),
+    Specification(OverlayCurvesForTiming).groupBy("PXBarrel/PXLayer/OnlineBlock") # per-layer with history for online
+                                 .groupBy("PXBarrel/PXLayer", "EXTEND_Y")
+                                 .save()
   )
 )
 
@@ -68,6 +80,18 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
                    .reduce("COUNT")
                    .groupBy("PXAll")
                    .save(nbins=200, xmin=0, xmax=10000),
+
+    #below is for timing client
+    Specification(OverlayCurvesForTiming).groupBy("DetId/Event")
+                    .reduce("COUNT")
+                    .groupBy("PXForward/OnlineBlock")
+                    .groupBy("PXForward", "EXTEND_Y")
+                    .save(),
+    Specification(OverlayCurvesForTiming).groupBy("DetId/Event")
+                    .reduce("COUNT")
+                    .groupBy("PXBarrel/OnlineBlock")
+                    .groupBy("PXBarrel", "EXTEND_Y")
+                    .save()
   )
 )
 


### PR DESCRIPTION
This PR disables a plot that (for unknown reson) make the GUI unstable (only the Online flavour)

Additionally it adds number of on track clusters and charge in the Timing Client (i.e only for Online)