### PR TITLE
Drop-box metadata management: updates and introduce AAG, BSHP, EcalPed

### DIFF
--- a/CondFormats/Common/test/BeamSpotObjectsRcdByLumi_prep.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdByLumi_prep.json
@@ -2,7 +2,7 @@
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
         "BeamSpotObjects_PCL_byLumi_v1_prompt": {}
-    },
+    }, 
     "inputTag": "BeamSpotObject_ByLumi", 
     "since": null, 
     "userText": "Tier0 PCL Upload for BS byLumi"

--- a/CondFormats/Common/test/BeamSpotObjectsRcdByLumi_prod.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdByLumi_prod.json
@@ -2,7 +2,7 @@
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "BeamSpotObjects_PCL_byLumi_v0_prompt": {}
-    },
+    }, 
     "inputTag": "BeamSpotObject_ByLumi", 
     "since": null, 
     "userText": "Tier0 PCL Upload for BS byLumi"

--- a/CondFormats/Common/test/BeamSpotObjectsRcdByRun_prep.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdByRun_prep.json
@@ -1,12 +1,11 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "BeamSpotObjects_PCL_byRun_v1_prompt": {},
-	"BeamSpotObjects_PCL_byRun_v1_express": {},
-        "BeamSpotObjects_PCL_byRun_v1_hlt": {}
-    },
+        "BeamSpotObjects_PCL_byRun_v1_express": {}, 
+        "BeamSpotObjects_PCL_byRun_v1_hlt": {}, 
+        "BeamSpotObjects_PCL_byRun_v1_prompt": {}
+    }, 
     "inputTag": "BeamSpotObject_ByRun", 
     "since": null, 
     "userText": "Tier0 PCL Upload for BS byRun"
 }
-

--- a/CondFormats/Common/test/BeamSpotObjectsRcdByRun_prod.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdByRun_prod.json
@@ -1,12 +1,11 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "BeamSpotObjects_PCL_byRun_v0_prompt": {},
-        "BeamSpotObjects_2009_v1_express": {},
-        "BeamSpotObjects_PCL_byRun_v0_hlt": {}
-    },
+        "BeamSpotObjects_2009_v1_express": {}, 
+        "BeamSpotObjects_PCL_byRun_v0_hlt": {}, 
+        "BeamSpotObjects_PCL_byRun_v0_prompt": {}
+    }, 
     "inputTag": "BeamSpotObject_ByRun", 
     "since": null, 
     "userText": "Tier0 PCL Upload for BS byRun"
 }
-

--- a/CondFormats/Common/test/BeamSpotObjectsRcdHPbyLumi_prep.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdHPbyLumi_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "BeamSpotObjectsHP_PCL_byLumi_v0_prompt": {}
+    }, 
+    "inputTag": "BeamSpotObjectHP_ByLumi", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for high performance BS byLumi"
+}

--- a/CondFormats/Common/test/BeamSpotObjectsRcdHPbyLumi_prod.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdHPbyLumi_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "BeamSpotObjectsHP_PCL_byLumi_v0_prompt": {}
+    }, 
+    "inputTag": "BeamSpotObjectHP_ByLumi", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for high performance BS byLumi"
+}

--- a/CondFormats/Common/test/EcalPedestal_prep.json
+++ b/CondFormats/Common/test/EcalPedestal_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "EcalPedestals_PCL_byRun_v0_express": {}
+    }, 
+    "inputTag": "EcalPedestals_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for ECAL pedestals by run (prod)"
+}

--- a/CondFormats/Common/test/EcalPedestal_prod.json
+++ b/CondFormats/Common/test/EcalPedestal_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "EcalPedestals_PCL_byRun_v0_express": {}
+    }, 
+    "inputTag": "EcalPedestals_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for ECAL pedestals by run (prod)"
+}

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.cc
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.cc
@@ -31,11 +31,11 @@ using namespace edm;
 ProduceDropBoxMetadata::ProduceDropBoxMetadata(const edm::ParameterSet& pSet) {
   
 
-  read = pSet.getUntrackedParameter<bool>("read");
-  write = pSet.getUntrackedParameter<bool>("write");
+  read     = pSet.getUntrackedParameter<bool>("read");
+  write    = pSet.getUntrackedParameter<bool>("write");
 
   fToWrite =  pSet.getParameter<vector<ParameterSet> >("toWrite");
-  fToRead =  pSet.getUntrackedParameter<vector<string> >("toRead");
+  fToRead  =  pSet.getUntrackedParameter<vector<string> >("toRead");
 
 }
 
@@ -58,7 +58,7 @@ void ProduceDropBoxMetadata::beginRun(const edm::Run& run, const edm::EventSetup
  
 
   if(write) {
-    
+    cout << "\n\n[ProduceDropBoxMetadata] entering write, to loop over toWrite\n" << endl;
     DropBoxMetadata *metadata = new DropBoxMetadata;
 
     // loop over all the pSets for the TF1 that we want to write to DB
@@ -67,7 +67,7 @@ void ProduceDropBoxMetadata::beginRun(const edm::Run& run, const edm::EventSetup
 	++fSetup) {
       
       string record = (*fSetup).getUntrackedParameter<string>("record");
-      cout << "--- record: " << record << endl;
+      cout << "\n--- record: " << record << endl;
       DropBoxMetadata::Parameters params;
       vector<string> paramKeys = (*fSetup).getParameterNames();
       for(vector<string>::const_iterator key = paramKeys.begin();
@@ -93,6 +93,7 @@ void ProduceDropBoxMetadata::beginRun(const edm::Run& run, const edm::EventSetup
 
   if(read) {
     // Read the objects
+    cout << "\n\n[ProduceDropBoxMetadata] entering read, to loop over toRead\n" << endl;
     edm::ESHandle<DropBoxMetadata> mdPayload;
     eSetup.get<DropBoxMetadataRcd>().get(mdPayload);
 
@@ -101,7 +102,7 @@ void ProduceDropBoxMetadata::beginRun(const edm::Run& run, const edm::EventSetup
     // loop 
     for(vector<string>::const_iterator name = fToRead.begin();
 	name != fToRead.end(); ++name) {
-      cout << "--- record: " << *name << endl;
+      cout << "\n--- record: " << *name << endl;
       if(metadata->knowsRecord(*name)) {
 	const map<string, string>  & params = metadata->getRecordParameters(*name).getParameterMap();
 	for(map<string, string>::const_iterator par = params.begin();

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.h
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.h
@@ -23,7 +23,7 @@ public:
   virtual ~ProduceDropBoxMetadata();
 
   // Operations
-//   virtual void beginJob();
+  // virtual void beginJob();
   virtual void beginRun(const edm::Run& run, const edm::EventSetup& eSetup);
   
   virtual void analyze(const edm::Event&, const edm::EventSetup&) {}

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -57,7 +57,7 @@ EcalPedestalsRcd_prep_str = encodeJsonInString("EcalPedestal_prep.json")
 # given a set of .json files in the current dir, ProduceDropBoxMetadata produces a sqlite containign the payload with the prod/and/prep metadata
 process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                   # set to True if you want to write out a sqlite.db translating the json's into a payload
-                                  write = cms.untracked.bool(True),
+                                  write = cms.untracked.bool(False),
 
                                   # toWrite holds a list of Pset's, one for each workflow you want to produce DropBoxMetadata for; you need to have 2 .json files for each PSet
                                   toWrite = cms.VPSet(cms.PSet(record              = cms.untracked.string("BeamSpotObjectsRcdByRun"), 
@@ -106,7 +106,7 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                ),
                                                       ),
                                   # this boolean will read the content of whichever payload is available and print its content to stoutput
-                                  read = cms.untracked.bool(False),
+                                  read = cms.untracked.bool(True),
 
                                   # toRead lists of record naemes to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
                                   toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','EcalPedestalsRcd','SiStripApvGainRcdAfterAbortGap') # same strings as fType
@@ -139,11 +139,11 @@ process.GlobalTag.globaltag = '91X_dataRun2_Express_Queue'
 
 # Set to True if you want to read a DropBoxMetadata payload from a local sqlite
 # specify the name of the sqlitefile.db and the tag name; the payload loaded will be for run 300000
-readsqlite = False
+readsqlite = True
 if readsqlite:
     process.GlobalTag.toGet = cms.VPSet(
         cms.PSet(record = cms.string("DropBoxMetadataRcd"),
                  tag = cms.string("DropBoxMetadata"),
-                 connect = cms.string("sqlite_file:DropBoxMetadata_Wed.db")
+                 connect = cms.string("sqlite_file:DropBoxMetadata_wECAL.db")
                 )
         )

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -50,10 +50,14 @@ SiStripApvGainRcdAfterAbortGap_prep_str = encodeJsonInString("SiStripApvGainRcdA
 SiPixelAliRcd_prod_str = encodeJsonInString("SiPixelAliRcd_prod.json")
 SiPixelAliRcd_prep_str = encodeJsonInString("SiPixelAliRcd_prep.json")
 
+#EcalPedestalsRcd
+EcalPedestalsRcd_prod_str = encodeJsonInString("EcalPedestal_prod.json")
+EcalPedestalsRcd_prep_str = encodeJsonInString("EcalPedestal_prep.json")
+
 # given a set of .json files in the current dir, ProduceDropBoxMetadata produces a sqlite containign the payload with the prod/and/prep metadata
 process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                   # set to True if you want to write out a sqlite.db translating the json's into a payload
-                                  write = cms.untracked.bool(False),
+                                  write = cms.untracked.bool(True),
 
                                   # toWrite holds a list of Pset's, one for each workflow you want to produce DropBoxMetadata for; you need to have 2 .json files for each PSet
                                   toWrite = cms.VPSet(cms.PSet(record              = cms.untracked.string("BeamSpotObjectsRcdByRun"), 
@@ -94,12 +98,18 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                prodMetaData        = cms.untracked.string(SiStripApvGainRcdAfterAbortGap_prod_str),
                                                                prepMetaData        = cms.untracked.string(SiStripApvGainRcdAfterAbortGap_prep_str),
                                                                ),
+                                                      cms.PSet(record              = cms.untracked.string('EcalPedestalsRcd'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(EcalPedestalsRcd_prod_str),
+                                                               prepMetaData        = cms.untracked.string(EcalPedestalsRcd_prep_str),
+                                                               ),
                                                       ),
                                   # this boolean will read the content of whichever payload is available and print its content to stoutput
-                                  read = cms.untracked.bool(True),
+                                  read = cms.untracked.bool(False),
 
                                   # toRead lists of record naemes to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
-                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap') # same strings as fType
+                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','EcalPedestalsRcd','SiStripApvGainRcdAfterAbortGap') # same strings as fType
                                   )
 
 process.p = cms.Path(process.mywriter)
@@ -107,7 +117,7 @@ process.p = cms.Path(process.mywriter)
 if process.mywriter.write:
 
     from CondCore.CondDB.CondDB_cfi import CondDB
-    CondDB.connect = "sqlite_file:DropBoxMetadata.db"
+    CondDB.connect = "sqlite_file:DropBoxMetadata_Wed.db"
 
     process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                               CondDB,
@@ -122,18 +132,18 @@ if process.mywriter.write:
                                               )
     
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = '80X_dataRun2_Express_Queue'
+process.GlobalTag.globaltag = '91X_dataRun2_Express_Queue'
 
 #process.GlobalTag.connect   = 'frontier://PromptProd/CMS_CONDITIONS'
 #process.GlobalTag.connect   = 'sqlite_file:/data/franzoni/92x/CMSSW_9_2_X_2017-05-16-1100_metadata/src/CondFormats/Common/test/last-iov-DropBoxMetadata_v5.1_express.db'
 
 # Set to True if you want to read a DropBoxMetadata payload from a local sqlite
 # specify the name of the sqlitefile.db and the tag name; the payload loaded will be for run 300000
-readsqlite = True
+readsqlite = False
 if readsqlite:
     process.GlobalTag.toGet = cms.VPSet(
         cms.PSet(record = cms.string("DropBoxMetadataRcd"),
-                 tag = cms.string("DropBoxMetadata_v5.1_express"),
-                 connect = cms.string("sqlite_file:last-iov-DropBoxMetadata_v5.1_express.db")
+                 tag = cms.string("DropBoxMetadata"),
+                 connect = cms.string("sqlite_file:DropBoxMetadata_Wed.db")
                 )
         )

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -33,6 +33,10 @@ BeamSpotObjectsRcdByRun_prep_str = encodeJsonInString("BeamSpotObjectsRcdByRun_p
 BeamSpotObjectsRcdByLumi_prod_str = encodeJsonInString("BeamSpotObjectsRcdByLumi_prod.json")
 BeamSpotObjectsRcdByLumi_prep_str = encodeJsonInString("BeamSpotObjectsRcdByLumi_prep.json")
 
+# beamspot High Perf by lumi
+BeamSpotObjectsRcdHPByLumi_prod_str = encodeJsonInString("BeamSpotObjectsRcdHPbyLumi_prod.json")
+BeamSpotObjectsRcdHPByLumi_prep_str = encodeJsonInString("BeamSpotObjectsRcdHPbyLumi_prep.json")
+
 #SiStripBadStripRcd
 SiStripBadStripRcd_prod_str = encodeJsonInString("SiStripBadStripRcd_prod.json")
 SiStripBadStripRcd_prep_str = encodeJsonInString("SiStripBadStripRcd_prep.json")
@@ -72,6 +76,12 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                prodMetaData        = cms.untracked.string(BeamSpotObjectsRcdByLumi_prod_str),
                                                                prepMetaData        = cms.untracked.string(BeamSpotObjectsRcdByLumi_prep_str),
                                                                ),
+                                                      cms.PSet(record              = cms.untracked.string('BeamSpotObjectsRcdHPByLumi'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(BeamSpotObjectsRcdHPByLumi_prod_str),
+                                                               prepMetaData        = cms.untracked.string(BeamSpotObjectsRcdHPByLumi_prep_str),
+                                                               ),
                                                       cms.PSet(record              = cms.untracked.string('SiStripBadStripRcd'),
                                                                Source              = cms.untracked.string("AlcaHarvesting"),
                                                                FileClass           = cms.untracked.string("ALCA"),
@@ -109,7 +119,7 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                   read = cms.untracked.bool(True),
 
                                   # toRead lists of record naemes to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
-                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','EcalPedestalsRcd','SiStripApvGainRcdAfterAbortGap') # same strings as fType
+                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','EcalPedestalsRcd') # same strings as fType
                                   )
 
 process.p = cms.Path(process.mywriter)
@@ -144,6 +154,6 @@ if readsqlite:
     process.GlobalTag.toGet = cms.VPSet(
         cms.PSet(record = cms.string("DropBoxMetadataRcd"),
                  tag = cms.string("DropBoxMetadata"),
-                 connect = cms.string("sqlite_file:DropBoxMetadata_wECAL.db")
+                 connect = cms.string("sqlite_file:DropBoxMetadata_adBSHP.db")
                 )
         )

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -44,11 +44,13 @@ SiStripBadStripRcd_prep_str = encodeJsonInString("SiStripBadStripRcd_prep.json")
 #SiStripApvGainRcd
 SiStripApvGainRcd_prod_str = encodeJsonInString("SiStripApvGainRcd_prod.json")
 SiStripApvGainRcd_multirun_prod_str = encodeJsonInString("SiStripApvGainRcd_multirun_prod.json") 
-SiStripApvGainRcdAfterAbortGap_prod_str = encodeJsonInString("SiStripApvGainRcdAfterAbortGap_prod.json")
+SiStripApvGainRcdAfterAbortGap_prod_str = encodeJsonInString("SiStripApvGainRcdAfterAbortGap_prod.json") # can be removed, once 92x deployed
+SiStripApvGainRcdAAG_prod_str = encodeJsonInString("SiStripApvGainRcdAAG_prod.json") # will take over
 
 SiStripApvGainRcd_prep_str = encodeJsonInString("SiStripApvGainRcd_prep.json")
 SiStripApvGainRcd_multirun_prep_str = encodeJsonInString("SiStripApvGainRcd_multirun_prep.json")
-SiStripApvGainRcdAfterAbortGap_prep_str = encodeJsonInString("SiStripApvGainRcdAfterAbortGap_prep.json")
+SiStripApvGainRcdAfterAbortGap_prep_str = encodeJsonInString("SiStripApvGainRcdAfterAbortGap_prep.json") # can be removed, once 92x deployed
+SiStripApvGainRcdAAG_prep_str = encodeJsonInString("SiStripApvGainRcdAAG_prep.json") # will take over
 
 #SiPixelAli
 SiPixelAliRcd_prod_str = encodeJsonInString("SiPixelAliRcd_prod.json")
@@ -102,11 +104,17 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                prodMetaData        = cms.untracked.string(SiPixelAliRcd_prod_str),
                                                                prepMetaData        = cms.untracked.string(SiPixelAliRcd_prep_str),
                                                                ),
-                                                      cms.PSet(record              = cms.untracked.string('SiStripApvGainRcdAfterAbortGap'),
+                                                      cms.PSet(record              = cms.untracked.string('SiStripApvGainRcdAfterAbortGap'), # can be removed, once 92x deployed...
                                                                Source              = cms.untracked.string("AlcaHarvesting"),
                                                                FileClass           = cms.untracked.string("ALCA"),
                                                                prodMetaData        = cms.untracked.string(SiStripApvGainRcdAfterAbortGap_prod_str),
                                                                prepMetaData        = cms.untracked.string(SiStripApvGainRcdAfterAbortGap_prep_str),
+                                                               ),
+                                                      cms.PSet(record              = cms.untracked.string('SiStripApvGainRcdAAG'), # ... will take over
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(SiStripApvGainRcdAAG_prod_str),
+                                                               prepMetaData        = cms.untracked.string(SiStripApvGainRcdAAG_prep_str),
                                                                ),
                                                       cms.PSet(record              = cms.untracked.string('EcalPedestalsRcd'),
                                                                Source              = cms.untracked.string("AlcaHarvesting"),
@@ -119,7 +127,7 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                   read = cms.untracked.bool(True),
 
                                   # toRead lists of record naemes to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
-                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','EcalPedestalsRcd') # same strings as fType
+                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','SiStripApvGainRcdAAG','EcalPedestalsRcd') # same strings as fType
                                   )
 
 process.p = cms.Path(process.mywriter)
@@ -127,7 +135,7 @@ process.p = cms.Path(process.mywriter)
 if process.mywriter.write:
 
     from CondCore.CondDB.CondDB_cfi import CondDB
-    CondDB.connect = "sqlite_file:DropBoxMetadata_Wed.db"
+    CondDB.connect = "sqlite_file:DropBoxMetadata_addAAG.db"
 
     process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                               CondDB,
@@ -154,6 +162,6 @@ if readsqlite:
     process.GlobalTag.toGet = cms.VPSet(
         cms.PSet(record = cms.string("DropBoxMetadataRcd"),
                  tag = cms.string("DropBoxMetadata"),
-                 connect = cms.string("sqlite_file:DropBoxMetadata_adBSHP.db")
+                 connect = cms.string("sqlite_file:DropBoxMetadata_addAAG.db")
                 )
         )

--- a/CondFormats/Common/test/SiPixelAliRcd_prep.json
+++ b/CondFormats/Common/test/SiPixelAliRcd_prep.json
@@ -1,11 +1,10 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAli_PCL_v0_prompt": {},
-        "SiPixelAli_PCL_v0_hlt": {}
+        "SiPixelAli_PCL_v0_hlt": {}, 
+        "SiPixelAli_PCL_v0_prompt": {}
     }, 
     "inputTag": "SiPixelAli_pcl", 
     "since": null, 
     "userText": "T0 PCL Upload for SiPixel Ali. (prep)"
 }
-

--- a/CondFormats/Common/test/SiPixelAliRcd_prod.json
+++ b/CondFormats/Common/test/SiPixelAliRcd_prod.json
@@ -2,9 +2,9 @@
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiPixelAli_PCL_v0_hlt": {}, 
-        "TrackerAlignment_PCL_byRun_v0_express": {}
+        "TrackerAlignment_PCL_byRun_v1_express": {}
     }, 
     "inputTag": "SiPixelAli_pcl", 
     "since": null, 
-    "userText": "T0 PCL Upload for SiPixel Ali. (prod)"
+    "userText": "T0 PCL Upload for SiPixel Ali - temp. not the tag consumed by prompt. (prod)"
 }

--- a/CondFormats/Common/test/SiPixelAliRcd_prod.json
+++ b/CondFormats/Common/test/SiPixelAliRcd_prod.json
@@ -1,11 +1,10 @@
 {
-    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAli_PCL_v0_prompt": {},
-	"SiPixelAli_PCL_v0_hlt": {}
+        "SiPixelAli_PCL_v0_hlt": {}, 
+        "TrackerAlignment_PCL_byRun_v0_express": {}
     }, 
     "inputTag": "SiPixelAli_pcl", 
     "since": null, 
-    "userText": "T0 PCL Upload for SiPixel Ali. (prep)"
+    "userText": "T0 PCL Upload for SiPixel Ali. (prod)"
 }
-

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_prep.json
@@ -4,7 +4,7 @@
         "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
         "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
     }, 
-    "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
+    "inputTag": "SiStripApvGainAAG_pcl",
     "since": null, 
     "userText": "T0 PCL Upload for SiStrip Gains AfterAbortGap calib. (prep)"
 }

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_prep.json
@@ -1,0 +1,10 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
+        "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
+    "since": null, 
+    "userText": "T0 PCL Upload for SiStrip Gains AfterAbortGap calib. (prep)"
+}

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_prod.json
@@ -1,0 +1,10 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
+        "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
+    "since": null, 
+    "userText": "T0 PCL Upload for SiStrip Gains AfterAbortGap calib. (prod)"
+}

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_prod.json
@@ -4,7 +4,7 @@
         "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
         "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
     }, 
-    "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
+    "inputTag": "SiStripApvGainAAG_pcl",
     "since": null, 
     "userText": "T0 PCL Upload for SiStrip Gains AfterAbortGap calib. (prod)"
 }

--- a/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prep.json
@@ -4,7 +4,7 @@
         "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
         "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
     }, 
-    "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
+    "inputTag": "SiStripApvGainAAG_pcl",
     "since": null, 
     "userText": "T0 PCL Upload for SiStrip Gains AfterAbortGap calib. (prep)"
 }

--- a/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prep.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {},
-        "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}
+        "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
+        "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
     "since": null, 

--- a/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prod.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {},
-        "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}
+        "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
+        "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
     "since": null, 

--- a/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAfterAbortGap_prod.json
@@ -4,7 +4,7 @@
         "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
         "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}
     }, 
-    "inputTag": "SiStripApvGainAfterAbortGap_pcl", 
+    "inputTag": "SiStripApvGainAAG_pcl",
     "since": null, 
     "userText": "T0 PCL Upload for SiStrip Gains AfterAbortGap calib. (prod)"
 }

--- a/CondFormats/Common/test/SiStripApvGainRcd_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcd_prep.json
@@ -1,11 +1,10 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGain_PCL_v0_prompt": {},
-        "SiStripApvGain_PCL_v0_hlt": {}
+        "SiStripApvGain_PCL_multirun_v0_hlt": {}, 
+        "SiStripApvGain_PCL_multirun_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGain_pcl", 
     "since": null, 
-    "userText": "T0 PCL Upload for SiStrip Gains calib. (prod)"
+    "userText": "PCL MultiRun Upload for SiStrip Gains calib. (prep)"
 }
-

--- a/CondFormats/Common/test/SiStripApvGainRcd_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcd_prod.json
@@ -1,11 +1,10 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGain_PCL_v0_prompt": {},
-        "SiStripApvGain_PCL_v0_hlt": {}
+        "SiStripApvGain_PCL_multirun_v0_hlt": {}, 
+        "SiStripApvGain_PCL_multirun_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGain_pcl", 
     "since": null, 
-    "userText": "T0 PCL Upload for SiStrip Gains calib. (prod)"
+    "userText": "PCL MultiRun Upload for SiStrip Gains calib. (prod)"
 }
-

--- a/CondFormats/Common/test/SiStripBadStripRcd_prep.json
+++ b/CondFormats/Common/test/SiStripBadStripRcd_prep.json
@@ -1,11 +1,10 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripBadChannel_PCL_v1_prompt": {},
-	"SiStripBadChannel_PCL_v1_hlt": {}    
+        "SiStripBadChannel_PCL_v1_hlt": {}, 
+        "SiStripBadChannel_PCL_v1_prompt": {}
     }, 
     "inputTag": "SiStripBadStrip_pcl", 
     "since": null, 
     "userText": "T0 PCL Upload for SiStrip bad-channels"
 }
-

--- a/CondFormats/Common/test/SiStripBadStripRcd_prod.json
+++ b/CondFormats/Common/test/SiStripBadStripRcd_prod.json
@@ -2,8 +2,8 @@
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiStripBadChannel_FromOfflineCalibration_GR10_v1_prompt": {}
-    },
-    "inputTag": "SiStripBadStrip_pcl",
-    "since": null,
+    }, 
+    "inputTag": "SiStripBadStrip_pcl", 
+    "since": null, 
     "userText": "T0 PCL Upload for SiStrip bad-channels"
 }

--- a/CondFormats/Common/test/parse_output.py
+++ b/CondFormats/Common/test/parse_output.py
@@ -7,11 +7,11 @@ import json
 if __name__ == "__main__":
     # the input file is in text format, formatted as the outout of cmsRun ProduceDropBoxMetadata.py
     # the inoput file holds metadata for a list of workflows, prod/prep for each
-    filenameinput = "1.log"
+    filenameinput = "last-iov-DropBoxMetadata_v5.1_express.db-f422b9d9589e65175b255acc01700f9103842a6e.log"
 
     # the .json files will be produced inside the specified directory
     # each .json file is the complete metadata for either prod or prep
-    dirnameoutput = 'out_sqlite_v3'
+    dirnameoutput = 'last-iov-DropBoxMetadata_v5.1_express'
     
     filehandler = open(filenameinput, 'r')
     lines = filehandler.readlines()

--- a/CondFormats/Common/test/parse_output.py
+++ b/CondFormats/Common/test/parse_output.py
@@ -3,19 +3,24 @@ import os
 import json
 
 
+# documentation: https://twiki.cern.ch/twiki/bin/view/CMS/AlCaDBPCL#Drop_box_metadata_management
 if __name__ == "__main__":
-    filename = "out_sqlite_v2.txt"
-    dirname = 'out_sqlite_v3'
+    # the input file is in text format, formatted as the outout of cmsRun ProduceDropBoxMetadata.py
+    # the inoput file holds metadata for a list of workflows, prod/prep for each
+    filenameinput = "1.log"
+
+    # the .json files will be produced inside the specified directory
+    # each .json file is the complete metadata for either prod or prep
+    dirnameoutput = 'out_sqlite_v3'
     
-    filehandler = open(filename, 'r')
+    filehandler = open(filenameinput, 'r')
     lines = filehandler.readlines()
 
     
-
     try:
-        os.stat(dirname)
+        os.stat(dirnameoutput)
     except:
-        os.mkdir(dirname)
+        os.mkdir(dirnameoutput)
                 
     recordname = None
     
@@ -34,7 +39,7 @@ if __name__ == "__main__":
             prep_metadata_dump = json.dumps(prep_metadata, sort_keys = True, indent = 4)
             print '----- prepMetaData:'
             print prep_metadata_dump
-            outFilePrep = open('%s/%s_prep.json'%(dirname,recordname), 'w')
+            outFilePrep = open('%s/%s_prep.json'%(dirnameoutput,recordname), 'w')
             outFilePrep.write(prep_metadata_dump+'\n')
             outFilePrep.close()
             
@@ -44,12 +49,10 @@ if __name__ == "__main__":
             prod_metadata_dump = json.dumps(prod_metadata, sort_keys = True, indent = 4)
             print '----- prodMetaData:'
             print prod_metadata_dump
-            outFileProd = open('%s/%s_prod.json'%(dirname,recordname), 'w')
+            outFileProd = open('%s/%s_prod.json'%(dirnameoutput,recordname), 'w')
             outFileProd.write(prod_metadata_dump+'\n')
             outFileProd.close()
         
 
     filehandler.close()
         #print line
-        
-        


### PR DESCRIPTION
Updating the tools used to construct DropBoxMetadata payloads,
as explained here: https://twiki.cern.ch/twiki/bin/view/CMS/AlCaDBPCL#Drop_box_metadata_management

Specifically:
. introduce comments in the tools
. update existing workflows to the content of https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/f422b9d9589e65175b255acc01700f9103842a6e
. add the AAG workflow with the same content as AfterAbortGap
. modify the destination of the geometry objects produced by the pixelAli PCL workflow, as agreed with the tracker DPG
. introduce metadata for BeamstpoHP and EcalPEdestals (soon to be included in the PCL)