### PR TITLE
Switching to full pulse nonlinearity for SiPMs

### DIFF
--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -28,7 +28,9 @@ def hbheCosmic(module):
             firstSampleShift = cms.int32(-1000),
             samplesToAdd = cms.int32(10),
             correctForPhaseContainment = cms.bool(False),
-        )
+        ),
+        sipmQTSShift = cms.int32(-100),
+        sipmQNTStoSum = cms.int32(200),
     )
 
 hbhereco = hbheCosmic(_hcalLocalReco_cff.hbheprereco)

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -44,6 +44,12 @@ hbheprereco = cms.EDProducer(
     # collection will not include such channels even if this flag is set.
     saveDroppedInfos = cms.bool(False),
 
+    # Parameters which define how we calculate the charge for the basic SiPM
+    # nonlinearity correction. To sum up the charge in all time slices
+    # (e.g., for cosmics), set sipmQTSShift to -100 and sipmQNTStoSum to 200.
+    sipmQTSShift = cms.int32(0),
+    sipmQNTStoSum = cms.int32(3),
+
     # Configure the reconstruction algorithm
     algorithm = cms.PSet(
         # Parameters for "Method 3" (non-keyword arguments have to go first)

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -74,8 +74,15 @@ namespace {
     class RawChargeFromSample
     {
     public:
-        inline RawChargeFromSample(const HcalDbService& cond,
-                                   const HcalDetId id) {}
+        inline RawChargeFromSample(const int sipmQTSShift,
+                                   const int sipmQNTStoSum,
+                                   const bool saveEffectivePedestal,
+                                   const HcalDbService& cond,
+                                   const HcalDetId id,
+                                   const CaloSamples& cs,
+                                   const int soi,
+                                   const DFrame& frame,
+                                   const int maxTS) {}
 
         inline double getRawCharge(const double decodedCharge,
                                    const double pedestal) const
@@ -86,8 +93,15 @@ namespace {
     class RawChargeFromSample<QIE11DataFrame>
     {
     public:
-        inline RawChargeFromSample(const HcalDbService& cond,
-                                   const HcalDetId id)
+        inline RawChargeFromSample(const int sipmQTSShift,
+                                   const int sipmQNTStoSum,
+                                   const bool saveEffectivePedestal,
+                                   const HcalDbService& cond,
+                                   const HcalDetId id,
+                                   const CaloSamples& cs,
+                                   const int soi,
+                                   const QIE11DataFrame& frame,
+                                   const int maxTS)
             : siPMParameter_(*cond.getHcalSiPMParameter(id)),
               fcByPE_(siPMParameter_.getFCByPE()),
               corr_(cond.getHcalSiPMCharacteristics()->getNonLinearities(siPMParameter_.getType()))
@@ -96,20 +110,41 @@ namespace {
                 throw cms::Exception("HBHEPhase1BadDB")
                     << "Invalid fC/PE conversion factor for SiPM " << id
                     << std::endl;
+
+            const HcalCalibrations& calib = cond.getHcalCalibrations(id);
+            const double darkCurrent = siPMParameter_.getDarkCurrent();
+            const double lambda = cond.getHcalSiPMCharacteristics()->getCrossTalk(siPMParameter_.getType());
+            const int firstTS = std::max(soi + sipmQTSShift, 0);
+            const int lastTS = std::min(firstTS + sipmQNTStoSum, maxTS);
+            double sipmQ = 0.0;
+
+            for (int ts = firstTS; ts < lastTS; ++ts)
+            {
+                const double pedestal = calib.pedestal(frame[ts].capid()) +
+                    (saveEffectivePedestal ? darkCurrent * 25. / (1. - lambda) : 0.);
+                sipmQ += (cs[ts] - pedestal);
+            }
+
+            const double effectivePixelsFired = sipmQ/fcByPE_;
+            factor_ = corr_.getRecoCorrectionFactor(effectivePixelsFired);
         }
 
         inline double getRawCharge(const double decodedCharge,
                                    const double pedestal) const
         {
-            const double sipmQ = decodedCharge - pedestal;
-            const double nPixelsFired = sipmQ/fcByPE_;
-            return sipmQ*corr_.getRecoCorrectionFactor(nPixelsFired) + pedestal;
-        }
+            return (decodedCharge - pedestal)*factor_ + pedestal;
+
+            // Old version of TS-by-TS corrections looked as follows:
+            // const double sipmQ = decodedCharge - pedestal;
+            // const double nPixelsFired = sipmQ/fcByPE_;
+            // return sipmQ*corr_.getRecoCorrectionFactor(nPixelsFired) + pedestal;
+       }
 
     private:
         const HcalSiPMParameter& siPMParameter_;
         double fcByPE_;
         HcalSiPMnonlinearity corr_;
+        double factor_;
     };
 
     float getTDCTimeFromSample(const QIE11DataFrame::Sample& s)
@@ -285,6 +320,8 @@ private:
     bool tsFromDB_;
     bool recoParamsFromDB_;
     bool saveEffectivePedestal_;
+    int sipmQTSShift_;
+    int sipmQNTStoSum_;
 
     // Parameters for turning status bit setters on/off
     bool setNegativeFlagsQIE8_;
@@ -347,6 +384,8 @@ HBHEPhase1Reconstructor::HBHEPhase1Reconstructor(const edm::ParameterSet& conf)
       tsFromDB_(conf.getParameter<bool>("tsFromDB")),
       recoParamsFromDB_(conf.getParameter<bool>("recoParamsFromDB")),
       saveEffectivePedestal_(conf.getParameter<bool>("saveEffectivePedestal")),
+      sipmQTSShift_(conf.getParameter<int>("sipmQTSShift")),
+      sipmQNTStoSum_(conf.getParameter<int>("sipmQNTStoSum")),
       setNegativeFlagsQIE8_(conf.getParameter<bool>("setNegativeFlagsQIE8")),
       setNegativeFlagsQIE11_(conf.getParameter<bool>("setNegativeFlagsQIE11")),
       setNoiseFlagsQIE8_(conf.getParameter<bool>("setNoiseFlagsQIE8")),
@@ -461,7 +500,6 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
         const HcalQIECoder* channelCoder = cond.getHcalCoder(cell);
         const HcalQIEShape* shape = cond.getHcalShape(channelCoder);
         const HcalCoderDb coder(*channelCoder, *shape);
-        const RawChargeFromSample<DFrame> rcfs(cond, cell);
 
         // needed for the dark current in the M2
         const HcalSiPMParameter& siPMParameter(*cond.getHcalSiPMParameter(cell));
@@ -477,6 +515,8 @@ void HBHEPhase1Reconstructor::processData(const Collection& coll,
         const int nRead = cs.size();
         const int maxTS = std::min(nRead, static_cast<int>(HBHEChannelInfo::MAXSAMPLES));
         const int soi = tsFromDB_ ? param_ts->firstSample() : frame.presamples();
+        const RawChargeFromSample<DFrame> rcfs(sipmQTSShift_, sipmQNTStoSum_, saveEffectivePedestal_,
+                                               cond, cell, cs, soi, frame, maxTS);
         int soiCapid = 4;
 
         // Go over time slices and fill the samples
@@ -741,7 +781,9 @@ HBHEPhase1Reconstructor::fillDescriptions(edm::ConfigurationDescriptions& descri
     desc.add<bool>("dropZSmarkedPassed");
     desc.add<bool>("tsFromDB");
     desc.add<bool>("recoParamsFromDB");
-    desc.add<bool>("saveEffectivePedestal",false);
+    desc.add<bool>("saveEffectivePedestal", false);
+    desc.add<int>("sipmQTSShift", 0);
+    desc.add<int>("sipmQNTStoSum", 3);
     desc.add<bool>("setNegativeFlagsQIE8");
     desc.add<bool>("setNegativeFlagsQIE11");
     desc.add<bool>("setNoiseFlagsQIE8");


### PR DESCRIPTION
Changing TS-by-TS SiPM nonlinearity calculation to estimating the nonlinearity from the charge collected in the 3 time slices (almost full pulse). This treatment is consistent with what was done for calibrating the SiPM non-linearity so far in the lab. While eventually we will need to go back to correcting nonlinearity for individual time slices, we can not do so with the existing measurements and models.

For a detailed description of the problem, see the talks by Jim Hirschauer, Federico De Guio, and Pawel De Barbaro at https://indico.cern.ch/event/640431/

Please test and integrate asap, this fix is needed for the data taking.
