### PR TITLE
update L1REPACK configuration to use unpacked digis also for HCAL upgrades

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullMC_cff.py
@@ -48,6 +48,10 @@ else:
         cms.InputTag('unpackHcal'),
         cms.InputTag('unpackHcal')
     )
+    simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
+        cms.InputTag('unpackHcal'),     # upgrade HBHE
+        cms.InputTag('unpackHcal')      # upgrade HF
+    )
 
     from L1Trigger.Configuration.SimL1Emulator_cff import *
     # DT TPs

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -60,6 +60,10 @@ else:
         cms.InputTag('unpackHcal'),
         cms.InputTag('unpackHcal')
     )
+    simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
+        cms.InputTag('unpackHcal'),     # upgrade HBHE
+        cms.InputTag('unpackHcal')      # upgrade HF
+    )
 
     from L1Trigger.Configuration.SimL1Emulator_cff import *
     

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -49,12 +49,14 @@ else:
 
     # Second, Re-Emulate the entire L1T
 
-    # Legacy trigger primitive emulations still running in 2016 trigger:
-    # NOTE:  2016 HCAL HF TPs require a new emulation, which is not yet available...    
     from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
     simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag(
         cms.InputTag('unpackHcal'),
         cms.InputTag('unpackHcal')
+    )
+    simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag(
+        cms.InputTag('unpackHcal'),     # upgrade HBHE
+        cms.InputTag('unpackHcal')      # upgrade HF
     )
 
     from L1Trigger.Configuration.SimL1Emulator_cff import *


### PR DESCRIPTION
Update the L1REPACK configuration to use the digis unpacked from the RAW data also for the upgraded HCAL collection: QIE10 for HF and QIE11 for HE.

Tested to give indentical results as using the simHcalUnsuppressedDigis when running over non-zero-suppressed MonteCarlo events.