### PR TITLE
fixed unit test to work in IB env

### DIFF
--- a/Alignment/Geners/test/test_cdump.csh
+++ b/Alignment/Geners/test/test_cdump.csh
@@ -1,7 +1,14 @@
 #!/bin/tcsh
 
+set cdump_cmd=${CMSSW_BASE}/test/${SCRAM_ARCH}/cdump
+foreach dir (${CMSSW_BASE} ${CMSSW_RELEASE_BASE} ${CMSSW_FULL_RELEASE_BASE})
+  if ( -e ${dir}/test/${SCRAM_ARCH}/cdump ) then
+    set cdump_cmd=${dir}/test/${SCRAM_ARCH}/cdump
+    break
+  endif
+end
 rm -f $LOCAL_TMP_DIR/cdump.out
-$LOCAL_TEST_BIN/cdump -f $LOCAL_TEST_DIR/archive.gsbmf >& $LOCAL_TMP_DIR/cdump.out
+${cdump_cmd} -f $LOCAL_TEST_DIR/archive.gsbmf >& $LOCAL_TMP_DIR/cdump.out
 diff $LOCAL_TMP_DIR/cdump.out $LOCAL_TEST_DIR/cdump.ref >& /dev/null
 if ($status) then
     echo "!!!! Catalog dump regression test FAILED"


### PR DESCRIPTION
In Ib env, test executables are not available in local dev area. This Pr fixes the unit test to pick the cdump for release area.