### PR TITLE
Fixed unit test to use TAxis

### DIFF
--- a/DataFormats/Histograms/test/metoedmformat_t.cc
+++ b/DataFormats/Histograms/test/metoedmformat_t.cc
@@ -16,6 +16,7 @@
 
 // user include files
 #include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+#include "TAxis.h"
 
 class TestMEtoEDMFormat : public CppUnit::TestFixture
 {
@@ -283,15 +284,7 @@ TestMEtoEDMFormat::testMergeTString()
 }
 
 namespace {
-  struct Axis {
-    Axis() {}
-    float GetXmin() const { return 0;}
-    float GetXmax() const {return 1;}
-    
-    static const Axis dummy;
-  };
-
-  const Axis Axis::dummy;
+  const TAxis dummy(1.0, 0.0, 1.0);
 
   struct Dummy {
     Dummy(int i) : m_i(i) {}
@@ -308,9 +301,9 @@ namespace {
     int GetNbinsY() const {return 1;}
     int GetNbinsZ() const {return 1;}
 
-    const Axis* GetXaxis() const {return &Axis::dummy;}
-    const Axis* GetYaxis() const {return &Axis::dummy;}
-    const Axis* GetZaxis() const {return &Axis::dummy;}
+    const TAxis* GetXaxis() const {return &dummy;}
+    const TAxis* GetYaxis() const {return &dummy;}
+    const TAxis* GetZaxis() const {return &dummy;}
 
     bool CanExtendAllAxes() const{return false;}
     long long Merge(void *) {return -1;}


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/blob/master/DataFormats/Histograms/interface/MEtoEDMFormat.h#L146 was converting existing Axis to TAxis which was causing this unit test to fail.