### PR TITLE
Integration of constituent subtracted jets into heavy ion reconstruction

### DIFF
--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -73,6 +73,7 @@ akCs4PFJets = cms.EDProducer(
     etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
     rho       = cms.InputTag('hiFJRhoProducer','mapToRho'),
     rhom      = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+    csRParam  = cms.double(-1.),
     csAlpha   = cms.double(1.),
     writeJetsWithConst = cms.bool(True),
     jetCollInstanceName = cms.string("pfParticlesCs")

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -41,9 +41,54 @@ akPu4PFJets = akPu5PFJets.clone(rParam       = cms.double(0.4), puPtMin = 20)
 akPu6PFJets = akPu5PFJets.clone(rParam       = cms.double(0.6), puPtMin = 30)
 akPu7PFJets = akPu5PFJets.clone(rParam       = cms.double(0.7), puPtMin = 35)
 
+kt4PFJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiPFJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm = cms.string("Kt"),
+    rParam       = cms.double(0.4)
+)
+kt4PFJets.src = cms.InputTag('particleFlowTmp')
+kt4PFJets.doAreaFastjet = cms.bool(True)
+kt4PFJets.jetPtMin      = cms.double(0.0)
+kt4PFJets.GhostArea     = cms.double(0.005)
+
+hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
+                                 jetSource = cms.InputTag('kt4PFJets'),
+                                 nExcl = cms.int32(2),
+                                 etaMaxExcl = cms.double(2.),
+                                 ptMinExcl = cms.double(20.),
+                                 nExcl2 = cms.int32(1),
+                                 etaMaxExcl2 = cms.double(3.),
+                                 ptMinExcl2 = cms.double(20.),
+                                 etaRanges = cms.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
+)
+
+akCs4PFJets = cms.EDProducer(
+    "CSJetProducer",
+    HiPFJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm  = cms.string("AntiKt"),
+    rParam        = cms.double(0.4),
+    etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+    rho       = cms.InputTag('hiFJRhoProducer','mapToRho'),
+    rhom      = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+    csAlpha   = cms.double(1.),
+    writeJetsWithConst = cms.bool(True),
+    jetCollInstanceName = cms.string("pfParticlesCs")
+)
+akCs4PFJets.src           = cms.InputTag('particleFlowTmp')
+akCs4PFJets.doAreaFastjet = cms.bool(True)
+akCs4PFJets.jetPtMin      = cms.double(0.0)
+akCs4PFJets.useExplicitGhosts = cms.bool(True)
+akCs4PFJets.GhostArea     = cms.double(0.005)
+
+akCs3PFJets = akCs4PFJets.clone(rParam       = cms.double(0.3))
 
 hiRecoPFJets = cms.Sequence(
     PFTowers
     *akPu3PFJets*akPu4PFJets*akPu5PFJets
+    *hiFJRhoProducer
+    *akCs3PFJets*akCs4PFJets
     )
 

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -41,20 +41,20 @@ akPu4PFJets = akPu5PFJets.clone(rParam       = cms.double(0.4), puPtMin = 20)
 akPu6PFJets = akPu5PFJets.clone(rParam       = cms.double(0.6), puPtMin = 30)
 akPu7PFJets = akPu5PFJets.clone(rParam       = cms.double(0.7), puPtMin = 35)
 
-kt4PFJets = cms.EDProducer(
+kt4PFJetsForRho = cms.EDProducer(
     "FastjetJetProducer",
     HiPFJetParameters,
     AnomalousCellParameters,
     jetAlgorithm = cms.string("Kt"),
     rParam       = cms.double(0.4)
 )
-kt4PFJets.src = cms.InputTag('particleFlowTmp')
-kt4PFJets.doAreaFastjet = cms.bool(True)
-kt4PFJets.jetPtMin      = cms.double(0.0)
-kt4PFJets.GhostArea     = cms.double(0.005)
+kt4PFJetsForRho.src = cms.InputTag('particleFlowTmp')
+kt4PFJetsForRho.doAreaFastjet = cms.bool(True)
+kt4PFJetsForRho.jetPtMin      = cms.double(0.0)
+kt4PFJetsForRho.GhostArea     = cms.double(0.005)
 
 hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
-                                 jetSource = cms.InputTag('kt4PFJets'),
+                                 jetSource = cms.InputTag('kt4PFJetsForRho'),
                                  nExcl = cms.int32(2),
                                  etaMaxExcl = cms.double(2.),
                                  ptMinExcl = cms.double(20.),
@@ -88,7 +88,7 @@ akCs3PFJets = akCs4PFJets.clone(rParam       = cms.double(0.3))
 hiRecoPFJets = cms.Sequence(
     PFTowers
     *akPu3PFJets*akPu4PFJets*akPu5PFJets
-    *kt4PFJets*hiFJRhoProducer
+    *kt4PFJetsForRho*hiFJRhoProducer
     *akCs3PFJets*akCs4PFJets
     )
 

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -88,7 +88,7 @@ akCs3PFJets = akCs4PFJets.clone(rParam       = cms.double(0.3))
 hiRecoPFJets = cms.Sequence(
     PFTowers
     *akPu3PFJets*akPu4PFJets*akPu5PFJets
-    *hiFJRhoProducer
+    *kt4PFJets*hiFJRhoProducer
     *akCs3PFJets*akCs4PFJets
     )
 

--- a/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
+++ b/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
@@ -11,7 +11,7 @@ RecoHiJetsRECO = cms.PSet(
                                             'keep *_akPu5PFJets_*_*',
                                             'keep *_akCs3PFJets_*_*',
                                             'keep *_akCs4PFJets_*_*',
-                                            'keep *_kt4PFJets_*_*',
+                                            'keep *_kt4PFJetsForRho_*_*',
                                             'keep *_*HiGenJets_*_*',
                                             'keep *_PFTowers_*_*',
                                             'keep *_hiFJRhoProducer_*_*'

--- a/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
+++ b/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
@@ -14,9 +14,7 @@ RecoHiJetsRECO = cms.PSet(
                                             'keep *_kt4PFJets_*_*',
                                             'keep *_*HiGenJets_*_*',
                                             'keep *_PFTowers_*_*',
-                                            'keep *_mapEtaEdges_*_*',
-                                            'keep *_mapToRho_*_*',
-                                            'keep *_mapToRhoM_*_*',
+                                            'keep *_hiFJRhoProducer_*_*'
 
                                            )
     )
@@ -26,9 +24,7 @@ RecoHiJetsFEVT = cms.PSet(
                                            'keep *_*PFJets_*_*',
                                            'keep *_*HiGenJets_*_*',
                                            'keep *_*PFTowers_*_*',
-                                           'keep *_mapEtaEdges_*_*',
-                                           'keep *_mapToRho_*_*',
-                                           'keep *_mapToRhoM_*_*',
+                                           'keep *_*hiFJRhoProducer_*_*'
                                            )
     )
 
@@ -37,9 +33,7 @@ RecoHiJetsAOD = cms.PSet(
                                            'keep *_*PFJets_*_*',
                                            'keep *_*HiGenJets_*_*',
                                            'keep *_*PFTowers_*_*',
-                                           'keep *_mapEtaEdges_*_*',
-                                           'keep *_mapToRho_*_*',
-                                           'keep *_mapToRhoM_*_*',
+                                           'keep *_*hiFJRhoProducer_*_*',
                                            'keep CaloTowersSorted_towerMaker_*_*',
                                            'drop recoCandidatesOwned_caloTowers_*_*',
                                            'keep recoPFCandidates_particleFlowTmp_*_*'

--- a/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
+++ b/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
@@ -9,8 +9,14 @@ RecoHiJetsRECO = cms.PSet(
                                             'keep *_akPu3PFJets_*_*',
                                             'keep *_akPu4PFJets_*_*',
                                             'keep *_akPu5PFJets_*_*',
+                                            'keep *_akCs3PFJets_*_*',
+                                            'keep *_akCs4PFJets_*_*',
+                                            'keep *_kt4PFJets_*_*',
                                             'keep *_*HiGenJets_*_*',
-                                            'keep *_PFTowers_*_*'
+                                            'keep *_PFTowers_*_*',
+                                            'keep *_mapEtaEdges_*_*',
+                                            'keep *_mapToRho_*_*',
+                                            'keep *_mapToRhoM_*_*',
 
                                            )
     )
@@ -19,7 +25,10 @@ RecoHiJetsFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_*CaloJets_*_*',
                                            'keep *_*PFJets_*_*',
                                            'keep *_*HiGenJets_*_*',
-                                           'keep *_*PFTowers_*_*'
+                                           'keep *_*PFTowers_*_*',
+                                           'keep *_mapEtaEdges_*_*',
+                                           'keep *_mapToRho_*_*',
+                                           'keep *_mapToRhoM_*_*',
                                            )
     )
 
@@ -28,6 +37,9 @@ RecoHiJetsAOD = cms.PSet(
                                            'keep *_*PFJets_*_*',
                                            'keep *_*HiGenJets_*_*',
                                            'keep *_*PFTowers_*_*',
+                                           'keep *_mapEtaEdges_*_*',
+                                           'keep *_mapToRho_*_*',
+                                           'keep *_mapToRhoM_*_*',
                                            'keep CaloTowersSorted_towerMaker_*_*',
                                            'drop recoCandidatesOwned_caloTowers_*_*',
                                            'keep recoPFCandidates_particleFlowTmp_*_*'

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -1,0 +1,188 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "RecoJets/JetProducers/plugins/CSJetProducer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "RecoJets/JetProducers/interface/JetSpecific.h"
+
+using namespace std;
+using namespace reco;
+using namespace edm;
+using namespace cms;
+
+CSJetProducer::CSJetProducer(edm::ParameterSet const& conf):
+  VirtualJetProducer( conf ),
+  csRho_EtaMax_(-1.0),
+  csRParam_(-1.0),
+  csAlpha_(0.)
+{
+  //get eta range, rho and rhom map
+  etaToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "etaMap" ));
+  rhoToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rho" ));
+  rhomToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rhom" ));
+  csAlpha_ = conf.getParameter<double>("csAlpha");
+}
+
+void CSJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup )
+{
+  // use the default production from one collection
+  VirtualJetProducer::produce( iEvent, iSetup );
+  //use runAlgorithm of this class
+
+
+  // fjClusterSeq_ retains quite a lot of memory - about 1 to 7Mb at 200 pileup
+  // depending on the exact configuration; and there are 24 FastjetJetProducers in the
+  // sequence so this adds up to about 60 Mb. It's allocated every time runAlgorithm
+  // is called, so safe to delete here.
+  fjClusterSeq_.reset();
+}
+
+//______________________________________________________________________________
+void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup)
+{
+  // run algorithm
+  if ( !doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+  } else if (voronoiRfact_ <= 0) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+  } else {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+  }
+
+  fjJets_.clear();
+  std::vector<fastjet::PseudoJet> tempJets = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
+
+  //Get local rho and rhomo map
+  edm::Handle<std::vector<double>> etaRanges;
+  edm::Handle<std::vector<double>> rhoRanges;
+  edm::Handle<std::vector<double>> rhomRanges;
+  
+  iEvent.getByToken(etaToken_, etaRanges);
+  iEvent.getByToken(rhoToken_, rhoRanges);
+  iEvent.getByToken(rhomToken_, rhomRanges);
+
+  //Starting from here re-implementation of constituent subtraction
+  //source: http://fastjet.hepforge.org/svn/contrib/contribs/ConstituentSubtractor/tags/1.0.0/ConstituentSubtractor.cc
+  //some minor modifications with respect to original
+  //main change: eta-dependent rho within the jet
+  for ( std::vector<fastjet::PseudoJet>::const_iterator ijet = tempJets.begin(), ijetEnd = tempJets.end(); ijet != ijetEnd; ++ijet ) {
+  
+    //----------------------------------------------------------------------
+    // sift ghosts and particles in the input jet
+    std::vector<fastjet::PseudoJet> particles, ghosts;
+    fastjet::SelectorIsPureGhost().sift(ijet->constituents(), ghosts, particles);
+    unsigned long nGhosts=ghosts.size();
+    unsigned long nParticles=particles.size();
+    if(nParticles==0) continue; //don't subtract ghost jets
+    
+    //assign rho and rhom to ghosts according to local eta-dependent map
+    std::vector<double> rho;
+    std::vector<double> rhom;
+    for (unsigned int j=0;j<nGhosts; j++) {
+
+      if(ghosts[j].eta()<=etaRanges->at(0)) {
+        rho.push_back(rhoRanges->at(0));
+        rhom.push_back(rhomRanges->at(0));
+      } else if(ghosts[j].eta()>=etaRanges->at(etaRanges->size()-1)) {
+        rho.push_back(rhoRanges->at(rhoRanges->size()-1));
+        rhom.push_back(rhomRanges->at(rhomRanges->size()-1));
+      } else {
+        for(int ie = 0; ie<(int)(etaRanges->size()-1); ie++) {
+          if(ghosts[j].eta()>=etaRanges->at(ie) && ghosts[j].eta()<etaRanges->at(ie+1)) {
+            rho.push_back(rhoRanges->at(ie));
+            rhom.push_back(rhomRanges->at(ie));
+            break;
+          }
+        }
+      }
+      
+    }
+
+    //----------------------------------------------------------------------
+    // computing and sorting the distances, deltaR
+    bool useMaxDeltaR = false;
+    if (csRParam_>0) useMaxDeltaR = true;
+    double maxDeltaR_squared=pow(csRParam_,2); 
+    double alpha_times_two= csAlpha_*2.;
+    std::vector<std::pair<double,int> > deltaRs;  // the first element is deltaR, the second element is only the index in the vector used for sorting
+    std::vector<int> particle_indices_unsorted;
+    std::vector<int> ghost_indices_unsorted;
+    for (unsigned int i=0;i<nParticles; i++){
+      double pt_factor=1.;
+      if (fabs(alpha_times_two)>1e-5) pt_factor=pow(particles[i].pt(),alpha_times_two);
+      for (unsigned int j=0;j<nGhosts; j++){
+	double deltaR_squared = ghosts[j].squared_distance(particles[i])*pt_factor;
+	if (!useMaxDeltaR || deltaR_squared<=maxDeltaR_squared){
+	  particle_indices_unsorted.push_back(i);
+	  ghost_indices_unsorted.push_back(j);
+	  int deltaRs_size=deltaRs.size();  // current position
+	  deltaRs.push_back(std::make_pair(deltaR_squared,deltaRs_size));
+	}
+      }
+    }
+    std::sort(deltaRs.begin(),deltaRs.end(),CSJetProducer::function_used_for_sorting);
+    unsigned long nStoredPairs=deltaRs.size();
+
+    //----------------------------------------------------------------------
+    // the iterative process. Here, only finding the fractions of pt or deltaM to be corrected. The actual correction of particles is done later.
+    std::vector<double> ghosts_fraction_of_pt(nGhosts,1.);
+    std::vector<double> particles_fraction_of_pt(nParticles,1.);
+    std::vector<double> ghosts_fraction_of_mtMinusPt(nGhosts,1.);
+    std::vector<double> particles_fraction_of_mtMinusPt(nParticles,1.);
+    for (unsigned long iindices=0;iindices<nStoredPairs;++iindices){
+      int particle_index=particle_indices_unsorted[deltaRs[iindices].second];
+      int ghost_index=ghost_indices_unsorted[deltaRs[iindices].second];
+      if (ghosts_fraction_of_pt[ghost_index]>0 && particles_fraction_of_pt[particle_index]>0){
+	double ratio_pt=particles[particle_index].pt()*particles_fraction_of_pt[particle_index]/rho[ghost_index]/ghosts[ghost_index].area()/ghosts_fraction_of_pt[ghost_index];
+	if (ratio_pt>1){
+	  particles_fraction_of_pt[particle_index]*=1-1./ratio_pt;
+	  ghosts_fraction_of_pt[ghost_index]=-1;
+	}
+	else {
+	  ghosts_fraction_of_pt[ghost_index]*=1-ratio_pt;
+	  particles_fraction_of_pt[particle_index]=-1;
+	}
+      }
+      if (ghosts_fraction_of_mtMinusPt[ghost_index]>0 && particles_fraction_of_mtMinusPt[particle_index]>0){
+	double ratio_mtMinusPt=(particles[particle_index].mt()-particles[particle_index].pt())*particles_fraction_of_mtMinusPt[particle_index]/rhom[ghost_index]/ghosts[ghost_index].area()/ghosts_fraction_of_mtMinusPt[ghost_index];
+	if (ratio_mtMinusPt>1){
+	  particles_fraction_of_mtMinusPt[particle_index]*=1-1./ratio_mtMinusPt;
+	  ghosts_fraction_of_mtMinusPt[ghost_index]=-1;
+	}
+	else{
+	  ghosts_fraction_of_mtMinusPt[ghost_index]*=1-ratio_mtMinusPt;
+	  particles_fraction_of_mtMinusPt[particle_index]=-1;
+	}
+      }
+    }
+
+    //----------------------------------------------------------------------
+    // do the actual correction for particles:
+    std::vector<fastjet::PseudoJet> subtracted_particles;
+    for (unsigned int i=0;i<particles_fraction_of_pt.size(); i++){
+      if (particles_fraction_of_pt[i]<=0) continue;  // particles with zero pt are not used (but particles with zero mtMinusPt are used)
+      double rapidity=particles[i].rap();
+      double azimuth=particles[i].phi();
+      double subtracted_pt=0;
+      if (particles_fraction_of_pt[i]>0) subtracted_pt=particles[i].pt()*particles_fraction_of_pt[i];
+      double subtracted_mtMinusPt=0;
+      if (particles_fraction_of_mtMinusPt[i]>0) subtracted_mtMinusPt=(particles[i].mt()-particles[i].pt())*particles_fraction_of_mtMinusPt[i];
+      fastjet::PseudoJet subtracted_const(subtracted_pt*cos(azimuth),subtracted_pt*sin(azimuth),(subtracted_pt+subtracted_mtMinusPt)*sinh(rapidity),(subtracted_pt+subtracted_mtMinusPt)*cosh(rapidity));
+      subtracted_const.set_user_index(i);
+      subtracted_particles.push_back(subtracted_const);
+    }
+    fastjet::PseudoJet subtracted_jet=join(subtracted_particles);
+    if(subtracted_jet.perp()>0.)
+      fjJets_.push_back( subtracted_jet );
+    
+  }//jet loop
+  fjJets_ = fastjet::sorted_by_pt(fjJets_); 
+}
+
+bool  CSJetProducer::function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j){
+    return (i.first < j.first);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// define as cmssw plugin
+////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_FWK_MODULE(CSJetProducer);

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -72,7 +72,7 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
   //some minor modifications with respect to original
   //main change: eta-dependent rho within the jet
 
-  for(fastjet::PseudoJet ijet : tempJets ) {
+  for(fastjet::PseudoJet& ijet : tempJets ) {
   
     //----------------------------------------------------------------------
     // sift ghosts and particles in the input jet

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -3,6 +3,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
 
+#include "RecoJets/JetProducers/interface/PileUpSubtractor.h"
+
 using namespace std;
 using namespace reco;
 using namespace edm;
@@ -187,6 +189,34 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
 
 bool  CSJetProducer::function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j){
     return (i.first < j.first);
+}
+
+void CSJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription descCSJetProducer;
+  ////// From CSJetProducer
+  fillDescriptionsFromCSJetProducer(descCSJetProducer);
+  ///// From VirtualJetProducer
+  descCSJetProducer.add<string>("jetCollInstanceName", ""    );
+  VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(descCSJetProducer);
+  ///// From PileUpSubtractor
+  PileUpSubtractor::fillDescriptionsFromPileUpSubtractor(descCSJetProducer);
+  descCSJetProducer.add<bool> ("sumRecHits", false);
+  
+  /////////////////////
+  descriptions.add("CSJetProducer",descCSJetProducer);
+  
+}
+
+void CSJetProducer::fillDescriptionsFromCSJetProducer(edm::ParameterSetDescription& desc) {
+
+  desc.add<double>("csRParam",-1.);
+  desc.add<double>("csAlpha",1.);
+
+  desc.add<edm::InputTag>("etaMap",edm::InputTag("hiFJRhoProducer","mapEtaEdges") );
+  desc.add<edm::InputTag>("rho",edm::InputTag("hiFJRhoProducer","mapToRho") );
+  desc.add<edm::InputTag>("rhom",edm::InputTag("hiFJRhoProducer","mapToRhoM") );
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -3,8 +3,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "RecoJets/JetProducers/interface/JetSpecific.h"
 
-#include "RecoJets/JetProducers/interface/PileUpSubtractor.h"
-
 using namespace std;
 using namespace reco;
 using namespace edm;
@@ -199,8 +197,6 @@ void CSJetProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   ///// From VirtualJetProducer
   descCSJetProducer.add<string>("jetCollInstanceName", ""    );
   VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(descCSJetProducer);
-  ///// From PileUpSubtractor
-  PileUpSubtractor::fillDescriptionsFromPileUpSubtractor(descCSJetProducer);
   descCSJetProducer.add<bool> ("sumRecHits", false);
   
   /////////////////////

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -27,11 +27,7 @@ void CSJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup
   VirtualJetProducer::produce( iEvent, iSetup );
   //use runAlgorithm of this class
 
-
-  // fjClusterSeq_ retains quite a lot of memory - about 1 to 7Mb at 200 pileup
-  // depending on the exact configuration; and there are 24 FastjetJetProducers in the
-  // sequence so this adds up to about 60 Mb. It's allocated every time runAlgorithm
-  // is called, so safe to delete here.
+  //Delete allocated memory. It is allocated every time runAlgorithm is called
   fjClusterSeq_.reset();
 }
 

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -41,7 +41,6 @@ namespace cms
      // calls VirtualJetProducer::inputTowers
     //virtual void inputTowers();
 
-    double csRho_EtaMax_;       /// for constituent subtraction : maximum rapidity for ghosts
     double csRParam_;           /// for constituent subtraction : R parameter for KT alg in jet median background estimator
     double csAlpha_;            /// for HI constituent subtraction : alpha (power of pt in metric)
 

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -1,0 +1,54 @@
+#ifndef RecoJets_JetProducers_CSJetProducer_h
+#define RecoJets_JetProducers_CSJetProducer_h
+
+/* *********************************************************
+  \class CSJetProducer
+
+  \brief Jet producer to produce CMS-style constituent subtracted jets
+
+  \author   Marta Verweij
+  \version  
+
+         Notes on implementation:
+
+         Reimplementation of constituent subtraction from fastjet contrib package (1.0.0)
+         to allow the use of eta-dependent rho and rho_m for the constituents 
+         inside a jet
+
+ ************************************************************/
+
+
+#include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
+
+namespace cms
+{
+  class CSJetProducer : public VirtualJetProducer
+  {
+  public:
+
+    CSJetProducer(const edm::ParameterSet& ps);
+
+    virtual ~CSJetProducer() {}
+
+    virtual void produce( edm::Event & iEvent, const edm::EventSetup & iSetup );
+    
+  protected:
+
+    virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup );
+
+    static bool function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j);
+    
+     // calls VirtualJetProducer::inputTowers
+    //virtual void inputTowers();
+
+    double csRho_EtaMax_;       /// for constituent subtraction : maximum rapidity for ghosts
+    double csRParam_;           /// for constituent subtraction : R parameter for KT alg in jet median background estimator
+    double csAlpha_;            /// for HI constituent subtraction : alpha (power of pt in metric)
+
+    //input rho and rho_m + eta map
+    edm::EDGetTokenT<std::vector<double>>                       etaToken_;
+    edm::EDGetTokenT<std::vector<double>>                       rhoToken_;
+    edm::EDGetTokenT<std::vector<double>>                       rhomToken_;
+  };
+}
+#endif

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -29,6 +29,8 @@ namespace cms
     CSJetProducer(const edm::ParameterSet& ps);
 
     virtual ~CSJetProducer() {}
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    static void fillDescriptionsFromCSJetProducer(edm::ParameterSetDescription& desc);
 
     virtual void produce( edm::Event & iEvent, const edm::EventSetup & iSetup );
     
@@ -38,10 +40,7 @@ namespace cms
 
     static bool function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j);
     
-     // calls VirtualJetProducer::inputTowers
-    //virtual void inputTowers();
-
-    double csRParam_;           /// for constituent subtraction : R parameter for KT alg in jet median background estimator
+    double csRParam_;           /// for constituent subtraction : R parameter
     double csAlpha_;            /// for HI constituent subtraction : alpha (power of pt in metric)
 
     //input rho and rho_m + eta map

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -32,7 +32,7 @@ namespace cms
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     static void fillDescriptionsFromCSJetProducer(edm::ParameterSetDescription& desc);
 
-    virtual void produce( edm::Event & iEvent, const edm::EventSetup & iSetup );
+    virtual void produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) override;
     
   protected:
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -151,7 +151,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 	restrictInputs_ 	= iConfig.getParameter<bool>	("restrictInputs"); 	// restrict inputs to first "maxInputs" towers?
 	maxInputs_      	= iConfig.getParameter<unsigned int>("maxInputs");
 	writeCompound_ 		= iConfig.getParameter<bool>	("writeCompound"); 	// Check to see if we are writing compound jets for substructure and jet grooming
-        if ( iConfig.exists("writeJetsWithConst") ) writeJetsWithConst_ = iConfig.getParameter<bool>("writeJetsWithConst"); //write subtracted jet constituents
+        writeJetsWithConst_     = iConfig.getParameter<bool>("writeJetsWithConst"); //write subtracted jet constituents
 	doFastJetNonUniform_ 	= iConfig.getParameter<bool>   	("doFastJetNonUniform");
 	puCenters_ 		= iConfig.getParameter<vector<double> >("puCenters");
 	puWidth_ 		= iConfig.getParameter<double>	("puWidth");

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -94,23 +94,28 @@ void VirtualJetProducer::makeProduces( std::string alias, std::string tag )
     produces<reco::BasicJetCollection>();
   }
 
-  if (makeCaloJet(jetTypeE)) {
-    produces<reco::CaloJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makePFJet(jetTypeE)) {
-    produces<reco::PFJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makeGenJet(jetTypeE)) {
-    produces<reco::GenJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makeTrackJet(jetTypeE)) {
-    produces<reco::TrackJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makePFClusterJet(jetTypeE)) {
-    produces<reco::PFClusterJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makeBasicJet(jetTypeE)) {
-    produces<reco::BasicJetCollection>(tag).setBranchAlias(alias);
+  if ( writeJetsWithConst_ ) {
+    produces<reco::PFCandidateCollection>(tag).setBranchAlias(alias);
+    produces<reco::PFJetCollection>();
+  } else {
+    if (makeCaloJet(jetTypeE)) {
+      produces<reco::CaloJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makePFJet(jetTypeE)) {
+      produces<reco::PFJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makeGenJet(jetTypeE)) {
+      produces<reco::GenJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makeTrackJet(jetTypeE)) {
+      produces<reco::TrackJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makePFClusterJet(jetTypeE)) {
+      produces<reco::PFClusterJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makeBasicJet(jetTypeE)) {
+      produces<reco::BasicJetCollection>(tag).setBranchAlias(alias);
+    }
   }
 }
 
@@ -146,6 +151,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 	restrictInputs_ 	= iConfig.getParameter<bool>	("restrictInputs"); 	// restrict inputs to first "maxInputs" towers?
 	maxInputs_      	= iConfig.getParameter<unsigned int>("maxInputs");
 	writeCompound_ 		= iConfig.getParameter<bool>	("writeCompound"); 	// Check to see if we are writing compound jets for substructure and jet grooming
+        if ( iConfig.exists("writeJetsWithConst") ) writeJetsWithConst_ = iConfig.getParameter<bool>("writeJetsWithConst"); //write subtracted jet constituents
 	doFastJetNonUniform_ 	= iConfig.getParameter<bool>   	("doFastJetNonUniform");
 	puCenters_ 		= iConfig.getParameter<vector<double> >("puCenters");
 	puWidth_ 		= iConfig.getParameter<double>	("puWidth");
@@ -233,9 +239,9 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 
 	if( ( doFastJetNonUniform_ ) && ( puCenters_.size() == 0 ) ) 
 		throw cms::Exception("doFastJetNonUniform") << "Parameter puCenters for doFastJetNonUniform is not defined." << std::endl;
-
-	// make the "produces" statements
-	makeProduces( moduleLabel_, jetCollInstanceName_ );
+  
+        // make the "produces" statements
+        makeProduces( moduleLabel_, jetCollInstanceName_ );
 	produces<vector<double> >("rhos");
 	produces<vector<double> >("sigmas");
 	produces<double>("rho");
@@ -492,7 +498,29 @@ void VirtualJetProducer::output(edm::Event & iEvent, edm::EventSetup const& iSet
   // Write jets and constitutents. Will use fjJets_, inputs_
   // and fjClusterSeq_
 
-  if ( !writeCompound_ ) {
+  if ( writeCompound_ ) {
+    // Write jets and subjets
+    switch( jetTypeE ) {
+    case JetType::CaloJet :
+      writeCompoundJets<reco::CaloJet>( iEvent, iSetup );
+      break;
+    case JetType::PFJet :
+      writeCompoundJets<reco::PFJet>( iEvent, iSetup );
+      break;
+    case JetType::GenJet :
+      writeCompoundJets<reco::GenJet>( iEvent, iSetup );
+      break;
+    case JetType::BasicJet :
+      writeCompoundJets<reco::BasicJet>( iEvent, iSetup );
+      break;
+    default:
+      throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
+      break;
+    };
+  } else if ( writeJetsWithConst_ ) {
+    // Write jets and new constituents.
+    writeJetsWithConstituents<reco::PFJet>( iEvent, iSetup );
+  } else {
     switch( jetTypeE ) {
     case JetType::CaloJet :
       writeJets<reco::CaloJet>( iEvent, iSetup);
@@ -513,29 +541,11 @@ void VirtualJetProducer::output(edm::Event & iEvent, edm::EventSetup const& iSet
       writeJets<reco::BasicJet>( iEvent, iSetup);
       break;
     default:
-      throw cms::Exception("InvalidInput") << "invalid jet type in VirtualJetProducer\n";
-      break;
-    };
-  } else {
-    // Write jets and constitutents.
-    switch( jetTypeE ) {
-    case JetType::CaloJet :
-      writeCompoundJets<reco::CaloJet>( iEvent, iSetup );
-      break;
-    case JetType::PFJet :
-      writeCompoundJets<reco::PFJet>( iEvent, iSetup );
-      break;
-    case JetType::GenJet :
-      writeCompoundJets<reco::GenJet>( iEvent, iSetup );
-      break;
-    case JetType::BasicJet :
-      writeCompoundJets<reco::BasicJet>( iEvent, iSetup );
-      break;
-    default:
-      throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
+           throw cms::Exception("InvalidInput") << "invalid jet type in VirtualJetProducer\n";
       break;
     };
   }
+  
 }
 
 namespace {
@@ -846,6 +856,110 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
 
 }
 
+/// function template to write out the outputs
+template< class T>
+void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::EventSetup const& iSetup)
+{
+  if ( verbosity_ >= 1 ) {
+    std::cout << "<VirtualJetProducer::writeJetsWithConstituents (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
+  }
+
+  // get a list of output jets  MV: make this compatible with template
+  auto jetCollection = std::make_unique<reco::PFJetCollection>();
+  
+  // this is the mapping of jet to constituents
+  std::vector< std::vector<int> > indices;
+  // this is the list of jet 4-momenta
+  std::vector<math::XYZTLorentzVector> p4_Jets;
+  // this is the jet areas
+  std::vector<double> area_Jets;
+
+  // get a list of output constituents
+  auto constituentCollection = std::make_unique<reco::PFCandidateCollection>();
+  
+  // This will store the handle for the constituents after we write them
+  edm::OrphanHandle<reco::PFCandidateCollection> constituentHandleAfterPut;
+    
+  // Loop over the jets and extract constituents
+  std::vector<fastjet::PseudoJet> constituentsSub;
+  std::vector<fastjet::PseudoJet>::const_iterator it = fjJets_.begin(),
+    iEnd = fjJets_.end(),
+    iBegin = fjJets_.begin();
+  indices.resize( fjJets_.size() );
+
+  for ( ; it != iEnd; ++it ) {
+    fastjet::PseudoJet const & localJet = *it;
+    unsigned int jetIndex = it - iBegin;
+    // Get the 4-vector for the hard jet
+    p4_Jets.push_back( math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e() ));
+    double localJetArea = 0.0;
+    if ( doAreaFastjet_ && localJet.has_area() ) {
+      localJetArea = localJet.area();
+    }
+    area_Jets.push_back( localJetArea );
+
+    // create the constituent list
+    std::vector<fastjet::PseudoJet> constituents,ghosts;
+    if ( it->has_pieces() )
+      constituents = it->pieces();
+    else if ( it->has_constituents() )
+      fastjet::SelectorIsPureGhost().sift(it->constituents(), ghosts, constituents); //filter out ghosts
+    //loop over constituents of jet (can be subjets or normal constituents)
+    std::vector<fastjet::PseudoJet>::const_iterator itConstBegin = constituents.begin(),
+      itConst = itConstBegin, itConstEnd = constituents.end();
+    for (; itConst != itConstEnd; ++itConst ) {
+      fastjet::PseudoJet const & constit = *itConst;
+      if ( verbosity_ >= 1 ) {
+        std::cout << "jet #" << jetIndex << " constituent #" << (itConst - itConstBegin) << ": Pt = " << constit.pt() << ", eta = " << constit.eta() << ", phi = " << constit.phi() << ", mass = " << constit.m() << ", uid: " << constit.user_index() << ", pos: " << constituentsSub.size() << ")" << std::endl;
+      }
+      indices[jetIndex].push_back( constituentsSub.size() );
+      constituentsSub.push_back(constit);
+    }
+  }
+
+  //Loop over constituents and store in the event
+  static const reco::PFCandidate dummySinceTranslateIsNotStatic;
+  for (std::vector<fastjet::PseudoJet>::const_iterator itsub = constituentsSub.begin() ; itsub != constituentsSub.end(); ++itsub ) {
+    fastjet::PseudoJet const & constit = *itsub;
+    auto orig = inputs_[constit.user_index()];
+    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(orig->pdgId());
+    reco::PFCandidate pCand( reco::PFCandidate(orig->charge(), orig->p4(), id) );
+    math::XYZTLorentzVector pVec;
+    pVec.SetPxPyPzE(constit.px(),constit.py(),constit.pz(),constit.e());
+    pCand.setP4(pVec);
+    pCand.setSourceCandidatePtr( orig->sourceCandidatePtr(0) );
+    constituentCollection->push_back(pCand);
+  }
+  // put constituents into event record
+  constituentHandleAfterPut = iEvent.put(std::move(constituentCollection), jetCollInstanceName_ );
+
+  // Now create the jets with ptr's to the constituents
+  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_Jets.begin(),
+    ip4Begin = p4_Jets.begin(),
+    ip4End = p4_Jets.end();
+
+  for ( ; ip4 != ip4End; ++ip4 ) {
+    int p4_index = ip4 - ip4Begin;
+    std::vector<int> & ind = indices[p4_index];
+    std::vector<reco::CandidatePtr> i_jetConstituents;
+    // Add the constituents to the jet
+    for( std::vector<int>::const_iterator iconst = ind.begin(); iconst != ind.end(); ++iconst ) {
+      reco::CandidatePtr candPtr( constituentHandleAfterPut, *iconst, false );
+      i_jetConstituents.push_back( candPtr );
+    }
+    if(i_jetConstituents.size()>0) { //only keep jets which have constituents after subtraction
+      reco::Particle::Point point(0,0,0);
+      reco::PFJet jet;
+      reco::writeSpecific(jet,*ip4,point,i_jetConstituents,iSetup);
+      jet.setJetArea( area_Jets[ip4 - ip4Begin] );
+      jetCollection->push_back( jet );
+    }
+  }
+
+  // put jets into event record
+  iEvent.put(std::move(jetCollection));
+}
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void VirtualJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
@@ -883,6 +997,7 @@ void VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(edm::ParameterSe
 	desc.add<bool> 	("restrictInputs", 	false 	);
 	desc.add<unsigned int> 	("maxInputs", 	1 	);
 	desc.add<bool> 	("writeCompound", 	false 	);
+        desc.add<bool> 	("writeJetsWithConst", 	false 	);
 	desc.add<bool> 	("doFastJetNonUniform", false 	);
 	desc.add<bool> 	("useDeterministicSeed",false 	);
 	desc.add<unsigned int> 	("minSeed", 	14327 	);
@@ -898,4 +1013,3 @@ void VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(edm::ParameterSe
 	vector<double>  puCentersDefault;
 	desc.add<vector<double>>("puCenters", 	puCentersDefault);
 }
-

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -904,13 +904,18 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
       constituents = it->pieces();
     else if ( it->has_constituents() )
       fastjet::SelectorIsPureGhost().sift(it->constituents(), ghosts, constituents); //filter out ghosts
+
     //loop over constituents of jet (can be subjets or normal constituents)
-    std::vector<fastjet::PseudoJet>::const_iterator itConstBegin = constituents.begin(),
-      itConst = itConstBegin, itConstEnd = constituents.end();
-    for (; itConst != itConstEnd; ++itConst ) {
-      fastjet::PseudoJet const & constit = *itConst;
+    for (fastjet::PseudoJet const& constit : constituents) {
       if ( verbosity_ >= 1 ) {
-        std::cout << "jet #" << jetIndex << " constituent #" << (itConst - itConstBegin) << ": Pt = " << constit.pt() << ", eta = " << constit.eta() << ", phi = " << constit.phi() << ", mass = " << constit.m() << ", uid: " << constit.user_index() << ", pos: " << constituentsSub.size() << ")" << std::endl;
+        std::cout << "jet #" << jetIndex <<
+          ": Pt = " << constit.pt() <<
+          ", eta = " << constit.eta() <<
+          ", phi = " << constit.phi() <<
+          ", mass = " << constit.m() <<
+          ", uid: " << constit.user_index() <<
+          ", pos: " << constituentsSub.size() <<
+          ")" << std::endl;
       }
       indices[jetIndex].push_back( constituentsSub.size() );
       constituentsSub.push_back(constit);
@@ -919,8 +924,7 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
 
   //Loop over constituents and store in the event
   static const reco::PFCandidate dummySinceTranslateIsNotStatic;
-  for (std::vector<fastjet::PseudoJet>::const_iterator itsub = constituentsSub.begin() ; itsub != constituentsSub.end(); ++itsub ) {
-    fastjet::PseudoJet const & constit = *itsub;
+  for (fastjet::PseudoJet const& constit : constituentsSub) {
     auto orig = inputs_[constit.user_index()];
     auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(orig->pdgId());
     reco::PFCandidate pCand( reco::PFCandidate(orig->charge(), orig->p4(), id) );

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -149,6 +149,8 @@ protected:
   template< typename T>
   void writeCompoundJets(  edm::Event & iEvent, edm::EventSetup const& iSetup);
 
+  template< typename T>
+    void writeJetsWithConstituents(  edm::Event & iEvent, edm::EventSetup const& iSetup);
 
   // This method copies the constituents from the fjConstituents method
   // to an output of CandidatePtr's. 
@@ -210,6 +212,7 @@ protected:
 
   std::string                     jetCollInstanceName_;       // instance name for output jet collection
   bool                            writeCompound_;    // write compound jets (i.e. jets of jets)
+  bool                            writeJetsWithConst_;    // write jets with constituents
   boost::shared_ptr<PileUpSubtractor>  subtractor_;
 
   bool                            useDeterministicSeed_; // If desired, use a deterministic seed to fastjet


### PR DESCRIPTION
This PR is to add the constituent subtracted (Cs) jets to the heavy ion reconstruction. 

1) added possibility to VirtualJetProducer to write the jet and its constituents to the event record. This is relevant since the constituent subtraction is particle-by-particle subtraction and therefore produces a new set of PF candidates.
2) added the production of background estimates (HiFJRhoProducer) to the heavy ion reconstruction.
3) added CSJetProducer which is heavily based on the FastJet contrib package but has the possibility to use eta-dependent --corresponding to CMS detector response-- background estimates. In the future we might also add phi-dependence and therefore we prefer to maintain our own version.
4) The Cs jet production is added to the standard heavy ion workflow.

This PR doesn't need any specific developments for phase 1.

The PR was tested on wf 145

A report on this method in heavy ion collision at the JMAR meeting can be found here:
https://indico.cern.ch/event/502737/contributions/2012693/attachments/1237496/1817780/160302_ConstituentSubtraction.pdf

@rappoccio @mandrenguyen @cfmcginn @kurtejung @ahinzmann 