### PR TITLE
Added missing <vector> include to PattRecoTree.h

### DIFF
--- a/DataFormats/JetReco/interface/PattRecoTree.h
+++ b/DataFormats/JetReco/interface/PattRecoTree.h
@@ -13,6 +13,8 @@
 
 #include "DataFormats/JetReco/interface/PattRecoNode.h"
 
+#include <vector>
+
 namespace reco {
     template<typename ScaleType, class Cluster>
     class PattRecoTree


### PR DESCRIPTION
We have two member variables using std::vector, so we also need
to include the <vector> header if we want to compile this header.