### PR TITLE
Add missing includes to BoundaryInformation.h

### DIFF
--- a/DataFormats/METReco/interface/BoundaryInformation.h
+++ b/DataFormats/METReco/interface/BoundaryInformation.h
@@ -2,7 +2,9 @@
 #define BOUNDARYINFORMATION_H_
 
 // system include files
+#include <vector>
 
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
 //using namespace edm;


### PR DESCRIPTION
We need to include vector because we have multiple member variables
of the type std::vector in this header.
The include to EcalRecHit.h is necessary because of the recHits
member variable.