### PR TITLE
fix name of input collection in pathALCARECOHcalCalMinBias

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasHI_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasHI_cff.py
@@ -79,7 +79,8 @@ hbheplan1Noise = RecoLocalCalo.HcalRecProducers.hbheplan1_cfi.hbheplan1.clone(
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hbherecoNoise,
     processQIE11 = cms.bool(True),
-    setNoiseFlagsQIE11 = cms.bool(True),
+# temporarily disabled until RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py:flagParametersQIE11 is filled
+#    setNoiseFlagsQIE11 = cms.bool(True),
 )
 
 _plan1_seqALCARECOHcalCalMinBias = _phase1_seqALCARECOHcalCalMinBias.copy()

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasHI_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasHI_cff.py
@@ -30,14 +30,14 @@ seqALCARECOHcalCalMinBias = cms.Sequence(hcalminbiasHLT*hcalDigiAlCaMB*gtDigisAl
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoMBNZS = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(True),
     forceSOI = cms.int32(1)
 )
 hfprerecoNoise = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False),

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
@@ -112,11 +112,13 @@ hbheplan1Noise = RecoLocalCalo.HcalRecProducers.hbheplan1_cfi.hbheplan1.clone(
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hbherecoMBNZS,
     processQIE11 = cms.bool(True),
-    setNoiseFlagsQIE11 = cms.bool(True),
+# temporarily disabled until RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py:flagParametersQIE11 is filled
+#    setNoiseFlagsQIE11 = cms.bool(True),
 )
 run2_HCAL_2017.toModify( hbherecoNoise,
     processQIE11 = cms.bool(True),
-    setNoiseFlagsQIE11 = cms.bool(True),
+# temporarily disabled until RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py:flagParametersQIE11 is filled
+#    setNoiseFlagsQIE11 = cms.bool(True),
 )
 
 _plan1_seqALCARECOHcalCalMinBias = _phase1_seqALCARECOHcalCalMinBias.copy()

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
@@ -60,14 +60,14 @@ seqALCARECOHcalCalMinBiasNoHLT = cms.Sequence(hcalDigiAlCaMB*gtDigisAlCaMB*hbher
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoNoise = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False),
     forceSOI = cms.int32(0)
 )
 hfprerecoMBNZS = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(True),

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -105,7 +105,8 @@ hbheplan1Pedestal = RecoLocalCalo.HcalRecProducers.hbheplan1_cfi.hbheplan1.clone
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( hbherecoPedestal,
     processQIE11 = cms.bool(True),
-    setNoiseFlagsQIE11 = cms.bool(True),
+# temporarily disabled until RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py:flagParametersQIE11 is filled
+#    setNoiseFlagsQIE11 = cms.bool(True),
 )
 
 _plan1_seqALCARECOHcalCalPedestal = _phase1_seqALCARECOHcalCalPedestal.copy()

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -80,7 +80,7 @@ seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestalHLT*
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoPedestal = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False),


### PR DESCRIPTION
The alcareco running on HcalNZS, HcalCalMinBias, has a few modules in its path with typo (hcalDigiAlaMB instead of hcalDigiAlcaMB) in the name of the HCAL digis input collection they (try to) consume.
This failure emerges now thanks to the fact that patch2 fixed another problem with the same alcareco.

The issue originated here https://github.com/cms-sw/cmssw/pull/18367/files .
It is understood how such mis-labelling passed the IB tests: the prompt-like relval workflow (1000) processes MinBias PD form 2011 where the rate of events firing HLT_HcalPhiSym* is low; because of the HLT selection at the start of HcalCalMinBias, the misconfigured modules were never executed.

@bsunanda @kpedro88 : may you please Xheck and comment ?
@deguio @hatakeyamak 

