### PR TITLE
Comment out commentary behind #endif in Constants.h

### DIFF
--- a/CondFormats/Common/interface/Constants.h
+++ b/CondFormats/Common/interface/Constants.h
@@ -15,4 +15,4 @@ namespace cond {
 
 }
 
-#endif CondCommon_Constants_h
+#endif //CondCommon_Constants_h


### PR DESCRIPTION
Tokens behind #endif aren't allowed, so let's turn them into a
comment.