### PR TITLE
[92X] Apply surface parameters only if selected for alignment.

### DIFF
--- a/Alignment/CommonAlignmentParametrization/src/BowedSurfaceAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/BowedSurfaceAlignmentParameters.cc
@@ -154,13 +154,16 @@ void BowedSurfaceAlignmentParameters::apply()
   align::rectify(rot);
   alignable->rotateInGlobalFrame(rot);
 
-  const AlgebraicVector &params = theData->parameters();
-  const BowedSurfaceDeformation deform(params[dsagittaX], params[dsagittaXY], params[dsagittaY]);
+  // only update the surface deformations if they were selected for alignment
+  if (selector()[dsagittaX] || selector()[dsagittaXY] || selector()[dsagittaY]) {
+    const auto& params = theData->parameters();
+    const BowedSurfaceDeformation deform{params[dsagittaX], params[dsagittaXY], params[dsagittaY]};
 
-  // FIXME: true to propagate down?
-  //        Needed for hierarchy with common deformation parameter,
-  //        but that is not possible now anyway.
-  alignable->addSurfaceDeformation(&deform, false);
+    // FIXME: true to propagate down?
+    //        Needed for hierarchy with common deformation parameter,
+    //        but that is not possible now anyway.
+    alignable->addSurfaceDeformation(&deform, false);
+  }
 }
 
 //_________________________________________________________________________________________________


### PR DESCRIPTION
Mainly a cosmetic fix to ensure that flat modules stay flat when the surfaces are not included in the alignment fit.
Only cosmetic because the created payload is normally not used, but in case someone accidentally loads both alignment and surfaces from the output file, the correct behaviour is ensured now also for ideal surfaces.