### PR TITLE
run condTestRegression test only on slc/amd64 archs.

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -33,5 +33,6 @@
 </bin>
 <bin   file="testRunInfo.cpp" name="testRunInfo">
 </bin>
-
-<test name="condTestRegression" command="condTestRegression.py"/>
+<architecture name="slc.*_amd64_.*">
+  <test name="condTestRegression" command="condTestRegression.py"/>
+</architecture>


### PR DESCRIPTION
This tests try setup runtime env from older releases for slc6_amd64 ( https://github.com/cms-sw/cmssw/blob/master/CondCore/CondDB/test/condTestRegression.py#L11 ) architectures which does not work on aarch64 and powerpc. This change instruct scram to only run this test on slc*_amd64 releases