### PR TITLE
TrackingTools : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/TrackingTools/GeomPropagators/interface/HelixLineExtrapolation.h
+++ b/TrackingTools/GeomPropagators/interface/HelixLineExtrapolation.h
@@ -25,8 +25,8 @@ public:
   typedef Basic3DVector<float>   DirectionType;
   typedef Basic3DVector<double>  PositionTypeDouble;
   typedef Basic3DVector<double>  DirectionTypeDouble;
-
 public:
+  virtual ~HelixLineExtrapolation() = default;
   //
   // the helix is passed to the constructor and does not appear in the interface
   //

--- a/TrackingTools/MeasurementDet/interface/MeasurementDet.h
+++ b/TrackingTools/MeasurementDet/interface/MeasurementDet.h
@@ -28,6 +28,7 @@ public:
     theMissingHit(std::make_shared<InvalidTrackingRecHit>(fastGeomDet(),TrackingRecHit::missing)),
     theInactiveHit(std::make_shared<InvalidTrackingRecHit>(fastGeomDet(),TrackingRecHit::inactive)){}
 
+  virtual ~MeasurementDet() = default;
   virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent &) const = 0;
 
   // use a MeasurementEstimator to filter the hits (same algo as below..)

--- a/TrackingTools/MeasurementDet/interface/MeasurementDetSystem.h
+++ b/TrackingTools/MeasurementDet/interface/MeasurementDetSystem.h
@@ -7,7 +7,7 @@
 
 class MeasurementDetSystem {
 public:
-
+  virtual ~MeasurementDetSystem() = default;
   /// Return the pointer to the MeasurementDet corresponding to a given DetId
   /// needs the data, as it could do on-demand unpacking or similar things
   virtual MeasurementDetWithData idToDet(const DetId& id, const MeasurementTrackerEvent &data) const = 0;

--- a/TrackingTools/PatternTools/interface/TrajectoryStateClosestToBeamLineBuilder.h
+++ b/TrackingTools/PatternTools/interface/TrajectoryStateClosestToBeamLineBuilder.h
@@ -16,7 +16,7 @@ class TrajectoryStateClosestToBeamLineBuilder
 public: 
 
   typedef FreeTrajectoryState		FTS;
-
+  virtual ~TrajectoryStateClosestToBeamLineBuilder() = default;
   virtual TrajectoryStateClosestToBeamLine operator()
     (const FTS& originalFTS, const reco::BeamSpot & beamSpot) const = 0;
 

--- a/TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h
@@ -8,7 +8,7 @@ public:
 
   typedef TransientTrackingRecHit::RecHitPointer        RecHitPointer;
   typedef TransientTrackingRecHit::RecHitContainer      RecHitContainer;
-
+  virtual ~TransientTrackingRecHitBuilder() = default;
   /// build a tracking rechit from an existing rechit
   virtual RecHitPointer build ( const TrackingRecHit * p)  const = 0 ;
   


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc:16:0:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/interface/TrajectoryStateClosestToBeamLineBuilder.h:14:7: warning: 'class TrajectoryStateClosestToBeamLineBuilder' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TrajectoryStateClosestToBeamLineBuilder
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/plugins/TSCBLBuilderNoMaterialESProducer.cc:17:0:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h:13:7: warning: base class 'class TrajectoryStateClosestToBeamLineBuilder' has accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TSCBLBuilderNoMaterial : public TrajectoryStateClosestToBeamLineBuilder
       ^~~~~~~~~~~~~~~~~~~~~~
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc:16:0:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/interface/TrajectoryStateClosestToBeamLineBuilder.h:14:7: warning: 'class TrajectoryStateClosestToBeamLineBuilder' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TrajectoryStateClosestToBeamLineBuilder
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/plugins/TSCBLBuilderWithPropagatorESProducer.cc:17:0:
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/TrackingTools/PatternTools/interface/TSCBLBuilderWithPropagator.h:16:7: warning: base class 'class TrajectoryStateClosestToBeamLineBuilder' has accessible non-virtual destructor [-Wnon-virtual-dtor]
  class TSCBLBuilderWithPropagator : public TrajectoryStateClosestToBeamLineBuilder
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
