### PR TITLE
fix Utilities/XrdAdapter : gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -55,7 +55,7 @@ class RequestManager : boost::noncopyable {
 public:
     static const unsigned int XRD_DEFAULT_TIMEOUT = 3*60;
 
-    ~RequestManager() = default;
+    virtual ~RequestManager() = default;
 
     /**
      * Interface for handling a client request.


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.
