### PR TITLE
SimG4 : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/SimG4CMS/Tracker/interface/FakeFrameRotation.h
+++ b/SimG4CMS/Tracker/interface/FakeFrameRotation.h
@@ -13,6 +13,7 @@
 class FakeFrameRotation : public FrameRotation 
 {
 public:
+    virtual ~FakeFrameRotation() = default;
     virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const;
 };
 

--- a/SimG4CMS/Tracker/interface/StandardFrameRotation.h
+++ b/SimG4CMS/Tracker/interface/StandardFrameRotation.h
@@ -13,6 +13,7 @@
 class StandardFrameRotation : public FrameRotation 
 {
 public:
+    virtual ~StandardFrameRotation() = default;
     virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const;
 };
 

--- a/SimG4CMS/Tracker/interface/TrackerFrameRotation.h
+++ b/SimG4CMS/Tracker/interface/TrackerFrameRotation.h
@@ -13,6 +13,7 @@
 class TrackerFrameRotation : public FrameRotation 
 {
 public:
+    virtual ~TrackerFrameRotation() = default;
     virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const;
 };
 

--- a/SimG4Core/SensitiveDetector/interface/FrameRotation.h
+++ b/SimG4Core/SensitiveDetector/interface/FrameRotation.h
@@ -9,6 +9,7 @@
 class FrameRotation 
 {
 public:
+    virtual ~FrameRotation() = default;
     virtual Local3DPoint transformPoint(Local3DPoint &,G4VPhysicalVolume *) const = 0;
 };
 


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/SimG4Core/SensitiveDetector/interface/FrameRotation.h:9:7: warning: 'class FrameRotation' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimG4CMS/Tracker/interface/StandardFrameRotation.h:13:7: warning: base class 'class FrameRotation' has accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimG4CMS/Tracker/interface/TrackerFrameRotation.h:13:7: warning: base class 'class FrameRotation' has accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimG4CMS/Tracker/interface/FakeFrameRotation.h:13:7: warning: base class 'class FrameRotation' has accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimG4CMS/Tracker/interface/StandardFrameRotation.h:13:7: warning: base class 'class FrameRotation' has accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimG4CMS/Tracker/interface/StandardFrameRotation.h:13:7: warning: base class 'class FrameRotation' has accessible non-virtual destructor [-Wnon-virtual-dtor]
