### PR TITLE
SimCalorimetry : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h
@@ -13,7 +13,7 @@ public:
   // doesn't take ownership of the pointer
   CaloShapes(const CaloVShape * shape) : theShape(shape) {}
   virtual const CaloVShape * shape(const DetId & detId) const {return theShape;}
-
+  virtual ~CaloShapes() = default;
 private:
   const CaloVShape * theShape;
 };

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVHitCorrection.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVHitCorrection.h
@@ -9,6 +9,7 @@ namespace CLHEP {
 
 class CaloVHitCorrection {
 public:
+  virtual ~CaloVHitCorrection() = default;
   virtual double delay(const PCaloHit & hit, CLHEP::HepRandomEngine*) const = 0;
 };
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVHitFilter.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVHitFilter.h
@@ -6,6 +6,7 @@
 
 class CaloVHitFilter {
 public:
+  virtual ~CaloVHitFilter() = default;
   virtual bool accepts(const PCaloHit & hit) const = 0;
 };
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloVSimParameterMap.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloVSimParameterMap.h
@@ -7,6 +7,7 @@ class CaloSimParameters;
 class CaloVSimParameterMap
 {
 public:
+  virtual ~CaloVSimParameterMap() = default;
   virtual const CaloSimParameters & simParameters(const DetId & id) const = 0;
 };
 

--- a/SimCalorimetry/CastorSim/src/CastorHitFilter.h
+++ b/SimCalorimetry/CastorSim/src/CastorHitFilter.h
@@ -6,6 +6,7 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 
 class CastorHitFilter : public CaloVHitFilter {
+  virtual ~CastorHitFilter() = default;
   virtual bool accepts(const PCaloHit & hit) const {
     DetId detId(hit.id());
     return (detId.det()==DetId::Calo && detId.subdetId()==HcalCastorDetId::SubdetectorId);

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -33,7 +33,7 @@ class HGCDigitizerBase {
      @short CTOR
   */
   HGCDigitizerBase(const edm::ParameterSet &ps); 
-      
+  virtual ~HGCDigitizerBase() = default; 
  /**
     @short steer digitization mode
  */

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h
@@ -11,7 +11,7 @@ public:
   void runDigitizer(std::unique_ptr<HGCEEDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,
 		    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
 		    uint32_t digitizationType, CLHEP::HepRandomEngine* engine) override; 
-  ~HGCEEDigitizer();
+  virtual ~HGCEEDigitizer() = default;
 private:
 
 };

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h
@@ -12,7 +12,7 @@ class HGCHEbackDigitizer : public HGCDigitizerBase<HGCBHDataFrame>
   void runDigitizer(std::unique_ptr<HGCBHDigiCollection> &digiColl,hgc::HGCSimHitDataAccumulator &simData,
 		    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
 		    uint32_t digitizationType, CLHEP::HepRandomEngine* engine) override;
-  ~HGCHEbackDigitizer();
+  virtual ~HGCHEbackDigitizer() = default;
 
  private:
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCHEfrontDigitizer.h
@@ -11,7 +11,7 @@ public:
   void runDigitizer(std::unique_ptr<HGCHEDigiCollection> &digiColl, hgc::HGCSimHitDataAccumulator &simData,
 		    const CaloSubdetectorGeometry* theGeom, const std::unordered_set<DetId>& validIds,
 		    uint32_t digitizationType, CLHEP::HepRandomEngine* engine) override;
-  ~HGCHEfrontDigitizer();
+  virtual ~HGCHEfrontDigitizer() = default;
 private:
 
 };

--- a/SimCalorimetry/HcalSimAlgos/interface/ZDCHitFilter.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/ZDCHitFilter.h
@@ -6,6 +6,7 @@
 #include "DataFormats/HcalDetId/interface/HcalZDCDetId.h"
 
 class ZDCHitFilter : public CaloVHitFilter {
+  virtual ~ZDCHitFilter() = default;
   virtual bool accepts(const PCaloHit & hit) const {
     DetId detId(hit.id());
     return (detId.det()==DetId::Calo && detId.subdetId()==HcalZDCDetId::SubdetectorId);

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoEnergy.h
@@ -16,6 +16,7 @@
 class HcalZSAlgoEnergy : public HcalZeroSuppressionAlgo {
 public:
   HcalZSAlgoEnergy(bool markAndPass, int level, int start, int samples, bool twosided);
+  virtual ~HcalZSAlgoEnergy() = default;
   void prepare(const HcalDbService* db);
   void done();
 protected:

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZSAlgoRealistic.h
@@ -15,7 +15,7 @@ class HcalZSAlgoRealistic : public HcalZeroSuppressionAlgo {
 public:
   HcalZSAlgoRealistic(bool markAndPass, std::pair<int,int> HBsearchTS, std::pair<int,int> HEsearchTS, std::pair<int,int> HOsearchTS, std::pair<int,int> HFsearchTS);
   HcalZSAlgoRealistic(bool markAndPass, int levelHB, int levelHE, int levelHO, int levelHF, std::pair<int,int> HBsearchTS, std::pair<int,int> HEsearchTS, std::pair<int,int> HOsearchTS, std::pair<int,int> HFsearchTS);
-  
+  virtual ~HcalZSAlgoRealistic() = default; 
 protected:
   //these need to be overloads instead of templates to avoid linking issues when calling private member function templates
   virtual bool shouldKeep(const HBHEDataFrame& digi) const;

--- a/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.h
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/src/HcalZeroSuppressionAlgo.h
@@ -14,6 +14,7 @@ class HcalDbService;
 
 class HcalZeroSuppressionAlgo {
 public:
+  virtual ~HcalZeroSuppressionAlgo() = default;
   void suppress(const HBHEDigiCollection& input, HBHEDigiCollection& output);
   void suppress(const HODigiCollection& input, HODigiCollection& output);
   void suppress(const HFDigiCollection& input, HFDigiCollection& output);


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h:25:7: warning: 'class HGCDigitizerBase<HGCDataFrame<HGCalDetId, HGCSample> >' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]


  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h:7:7: warning: base class 'class HGCDigitizerBase<HGCDataFrame<HGCalDetId, HGCSample> >' has accessible non-virtual destructor [-Wnon-virtual-dtor]


  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimCalorimetry/HGCalSimProducers/interface/HGCEEDigitizer.h:7:7: warning: base class 'class HGCDigitizerBase<HGCDataFrame<HGCalDetId, HGCSample> >' has accessible non-virtual destructor [-Wnon-virtual-dtor]


  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/SimCalorimetry/HGCalSimProducers/interface/HGCHEbackDigitizer.h:7:7: warning: base class 'class HGCDigitizerBase<HGCDataFrame<HcalDetId, HGCSample> >' has accessible non-virtual destructor [-Wnon-virtual-dtor]
