### PR TITLE
DataFormats/TrackerRecHit2D: Fix warning warning: 'class TkCloner' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/TkCloner.h
+++ b/DataFormats/TrackerRecHit2D/interface/TkCloner.h
@@ -18,6 +18,7 @@ public:
     return hit.clone(*this, tsos);
   }
 
+ virtual ~TkCloner() {}
 #ifndef __GCCXML__
   TrackingRecHit::ConstRecHitPointer makeShared(TrackingRecHit::ConstRecHitPointer const & hit, TrajectoryStateOnSurface const& tsos) const {
     return hit->canImproveWithTrack() ?  hit->cloneSH(*this, tsos) : hit;


### PR DESCRIPTION
This gcc 7.0.0 warning appears throughout the build log. 

DataFormats/TrackerRecHit2D/interface/TkCloner.h:15:7: warning: 'class TkCloner' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

Fixed by adding virtual destructor for TkCloner.