### PR TITLE
CalibFormats : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/CalibFormats/CaloTPG/interface/EcalTPGScale.h
+++ b/CalibFormats/CaloTPG/interface/EcalTPGScale.h
@@ -16,6 +16,7 @@ namespace edm {
  */
 class EcalTPGScale {
 public:
+  virtual ~EcalTPGScale() = default;
   /** \brief nominal ET value of this sample/code as to be used in
       RCT LUT creation */
   virtual double et_RCT(const EcalTrigTowerDetId& id, const

--- a/CalibFormats/CaloTPG/interface/HcalTPGScale.h
+++ b/CalibFormats/CaloTPG/interface/HcalTPGScale.h
@@ -16,6 +16,7 @@ namespace edm {
  */
 class HcalTPGScale {
 public:
+  virtual ~HcalTPGScale() = default;
   /** \brief nominal ET value of this sample/code as to be used in
       RCT LUT creation */
   virtual double et_RCT(const HcalTrigTowerDetId& id, const

--- a/CalibFormats/CastorObjects/interface/CastorTPGCoder.h
+++ b/CalibFormats/CastorObjects/interface/CastorTPGCoder.h
@@ -22,7 +22,7 @@ namespace edm {
   */
 class CastorTPGCoder {
 public:
-
+  virtual ~CastorTPGCoder() = default;
   //  virtual void adc2Linear(const CastorDataFrame& df, IntegerCaloSamples& ics) const = 0;
 
   virtual unsigned short adc2Linear(HcalQIESample sample,HcalDetId id) const = 0;

--- a/CalibFormats/HcalObjects/interface/HcalTPGCoder.h
+++ b/CalibFormats/HcalObjects/interface/HcalTPGCoder.h
@@ -25,6 +25,7 @@ namespace edm {
   */
 class HcalTPGCoder {
 public:
+  virtual ~HcalTPGCoder() = default;
   virtual void adc2Linear(const HBHEDataFrame& df, IntegerCaloSamples& ics) const = 0;
   virtual void adc2Linear(const HFDataFrame& df, IntegerCaloSamples& ics) const = 0;
   virtual void adc2Linear(const QIE10DataFrame& df, IntegerCaloSamples& ics) const = 0;

--- a/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
@@ -34,6 +34,8 @@ namespace pos{
      std::cout << "[PixelTimeFormatter::PixelTimeFormatter()]\t\t    Time counter started for " << origin_ << std::endl ;
      startTime_ = getImSecTime() ;
     }
+
+    virtual ~PixelTimeFormatter() = default;
     
     void stopTimer(void) 
     {


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/d36af6c2d5d322e52932978c6b2c4857/opt/cmssw/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_9_2_X_2017-05-23-2300/src/CalibFormats/HcalObjects/interface/HcalTPGCoder.h:26:7: warning: 'class HcalTPGCoder' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

