### PR TITLE
Alignment : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIO.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIO.h
@@ -20,7 +20,7 @@ class AlignmentIO
 {
 
   public:
-
+  virtual ~AlignmentIO() = default;
   /// write AlignmentParameters 
   virtual void writeAlignmentParameters (const align::Alignables& alivec, 
     const char* filename, int iter, bool validCheck, int& ierr) = 0;

--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORoot.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORoot.h
@@ -17,7 +17,7 @@ class AlignmentIORoot : public AlignmentIO
 {
 
   public:
-
+  virtual ~AlignmentIORoot() = default;
   /// write AlignmentParameters 
   void writeAlignmentParameters (const align::Alignables& alivec, 
 				 const char* filename, int iter, bool validCheck, int& ierr );


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIO.h:19:7: warning: 'class AlignmentIO' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/Alignment/CommonAlignmentAlgorithm/interface/AlignmentIORoot.h:16:7: warning: base class 'class AlignmentIO' has accessible non-virtual destructor [-Wnon-virtual-dtor]
