### PR TITLE
CalibCalorimetry + CaloOnlineTools : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h
@@ -47,7 +47,7 @@ class HcalTextCalibrations : public edm::ESProducer,
 {
 public:
   HcalTextCalibrations (const edm::ParameterSet& );
-  ~HcalTextCalibrations ();
+  virtual ~HcalTextCalibrations ();
 
   void produce () {};
 
@@ -60,6 +60,7 @@ public:
         if(!HcalDbASCIIIO::getObject(inStream, &*result)) result.reset(nullptr);
         return result;
       }
+      virtual ~CheckGetObject() = default ;
     protected:
       virtual std::unique_ptr<T> makeResult(){ return std::make_unique<T>(); }
   };
@@ -67,6 +68,7 @@ public:
   class CheckGetObjectTopo : public CheckGetObject<T> {
     public:
       CheckGetObjectTopo(const HcalTopology* topo) : CheckGetObject<T>(topo), topo_(topo) {}
+      virtual ~CheckGetObjectTopo() = default;
     protected:
       std::unique_ptr<T> makeResult() override { return std::make_unique<T>(topo_); }
     private:

--- a/CaloOnlineTools/HcalOnlineDb/interface/PluginManager.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/PluginManager.hh
@@ -16,7 +16,7 @@ namespace hcal {
   class Pluggable {
   public:
     /// A virtual destructor is required to establish the inheritance tree
-    virtual ~Pluggable() {}
+    virtual ~Pluggable() = default;
   };
 
   /** \brief Class which is able to create instances of another class.
@@ -32,6 +32,7 @@ namespace hcal {
   */
   class AbstractPluginFactory {
   public:
+    virtual ~AbstractPluginFactory() = default;
     /** \brief Create a new instance of the class which this factory provides */
     virtual Pluggable* newInstance() = 0;
     /** \brief Get the name of the class which is considered the base for this factory's class.  
@@ -81,6 +82,7 @@ namespace hcal {
   class PluginFactoryTemplate : public AbstractPluginFactory {
   public:
     PluginFactoryTemplate(const char* bc, const char* dc) : m_baseClass(bc), m_derivedClass(dc) { PluginManager::registerFactory(bc,dc,this); }
+    virtual ~PluginFactoryTemplate() = default;
     virtual Pluggable* newInstance() { return new T; }
     virtual const char* getBaseClass() const { return m_baseClass; }
     virtual const char* getDerivedClass() const { return m_derivedClass; }


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/CaloOnlineTools/HcalOnlineDb/interface/PluginManager.hh:33:9: warning: 'class hcal::AbstractPluginFactory' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h:55:9: warning: 'class HcalTextCalibrations::CheckGetObject<HcalPedestals>' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.h:67:9: warning: base class 'class HcalTextCalibrations::CheckGetObject<HcalPedestals>' has accessible non-virtual destructor [-Wnon-virtual-dtor]
