### PR TITLE
CondCore : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -48,7 +48,7 @@ namespace cond {
   // Basic element of the IOV sequence.
   struct Iov_t {
     Iov_t(): since(time::MAX_VAL),till(time::MIN_VAL),payloadId(""){}
-    virtual ~Iov_t(){}
+    virtual ~Iov_t() = default;
     virtual void clear();
     bool isValid() const;
     bool isValidFor( Time_t target ) const;
@@ -58,6 +58,7 @@ namespace cond {
   };
 
   struct Tag_t {
+    virtual ~Tag_t() = default;
     virtual void clear();
     std::string tag;
     std::string payloadType;

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -121,7 +121,7 @@ namespace cond {
     class PlotBase {
     public:
       PlotBase();
-
+      virtual ~PlotBase() = default;
       // required in the browser to find corresponding tags
       std::string payloadType() const;
 
@@ -185,7 +185,7 @@ namespace cond {
 	m_plotAnnotations.m[PlotAnnotations::YAXIS_K] = yLabel;
         m_plotAnnotations.m[PlotAnnotations::PAYLOAD_TYPE_K] = cond::demangledName( typeid(PayloadType) );
       }
-
+      virtual ~Plot2D() = default;
       std::string serializeData(){
 	return serialize( m_plotAnnotations, m_plotData);
       }
@@ -215,7 +215,7 @@ namespace cond {
         m_plotAnnotations.m[PlotAnnotations::ZAXIS_K] = zLabel;
         m_plotAnnotations.m[PlotAnnotations::PAYLOAD_TYPE_K] = cond::demangledName( typeid(PayloadType) );
       }
-
+      virtual ~Plot3D() = default;
       std::string serializeData(){
 	return serialize( m_plotAnnotations, m_plotData);
       }
@@ -241,7 +241,7 @@ namespace cond {
       HistoryPlot( const std::string& title, const std::string& yLabel ) : 
 	Base( "History", title, "iov_since" , yLabel ){
       }
-
+      virtual ~HistoryPlot() = default;
       bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override {
 	for( auto iov : iovs ) {
 	  std::shared_ptr<PayloadType> payload = Base::fetchPayload( std::get<1>(iov) );
@@ -264,7 +264,7 @@ namespace cond {
       RunHistoryPlot( const std::string& title, const std::string& yLabel ) :
         Base( "RunHistory", title, "iov_since" , yLabel ){
       }
-
+      virtual ~RunHistoryPlot() = default;
       bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override {
         // for the lumi iovs we need to count the number of lumisections in every runs
 	std::map<cond::Time_t,unsigned int> runs;
@@ -333,7 +333,7 @@ namespace cond {
       TimeHistoryPlot( const std::string& title, const std::string& yLabel ) : 
 	Base( "TimeHistory", title, "iov_since" , yLabel ){
       }
-
+      virtual ~TimeHistoryPlot() = default;
       bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override {
 	cond::persistency::RunInfoProxy runInfo;
 	if(  Base::tagTimeType()==cond::lumiid ||  Base::tagTimeType()==cond::runnumber){
@@ -388,7 +388,7 @@ namespace cond {
       ScatterPlot( const std::string& title, const std::string& xLabel, const std::string& yLabel ) :
 	Base( "Scatter", title, xLabel , yLabel ){
       }
-
+      virtual ~ScatterPlot() = default;
       bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override {
 	for( auto iov : iovs ) {
 	  std::shared_ptr<PayloadType> payload = Base::fetchPayload( std::get<1>(iov) );
@@ -412,7 +412,7 @@ namespace cond {
       Histogram1D( const std::string& title, const std::string& xLabel, size_t nbins, float min, float max ):
 	Base( "Histo1D", title, xLabel , "entries" ),m_nbins(nbins),m_min(min),m_max(max){
       }
-
+      virtual ~Histogram1D() = default;
       // 
       void init(){
 	Base::m_plotData.clear();
@@ -469,6 +469,7 @@ namespace cond {
 	Base( "Histo2D", title, xLabel , yLabel, "entries" ),m_nxbins( nxbins), m_xmin(xmin),m_xmax(xmax),m_nybins(nybins),m_ymin(ymin),m_ymax(ymax){
       }
 
+      virtual ~Histogram2D() = default;
       //
       void init(){
 	Base::m_plotData.clear();

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -12,7 +12,7 @@ namespace {
   public:
     BasicPayload_data0() : cond::payloadInspector::HistoryPlot<cond::BasicPayload,float>( "Example Trend", "data0"){
     }
-
+    virtual ~BasicPayload_data0() = default;
     float getFromPayload( cond::BasicPayload& payload ){
       return payload.m_data0;
     }
@@ -22,7 +22,7 @@ namespace {
   public:
     BasicPayload_data1() : cond::payloadInspector::RunHistoryPlot<cond::BasicPayload,float>( "Example Run-based Trend", "data0"){
     }
-
+    virtual ~BasicPayload_data1() = default;
     float getFromPayload( cond::BasicPayload& payload ){
       return payload.m_data0;
     }
@@ -32,6 +32,7 @@ namespace {
   public:
     BasicPayload_data2() : cond::payloadInspector::TimeHistoryPlot<cond::BasicPayload,float>( "Example Time-based Trend", "data0"){
     }
+    virtual ~BasicPayload_data2() = default;
 
     float getFromPayload( cond::BasicPayload& payload ){
       return payload.m_data0;
@@ -42,6 +43,7 @@ namespace {
   public:
     BasicPayload_data3() : cond::payloadInspector::ScatterPlot<cond::BasicPayload,float,float>( "Example Scatter", "data0","data1"){
     }
+    virtual ~BasicPayload_data3() = default;
 
     std::tuple<float,float> getFromPayload( cond::BasicPayload& payload ){
       return std::make_tuple(payload.m_data0,payload.m_data1);
@@ -53,6 +55,7 @@ namespace {
     BasicPayload_data4() : cond::payloadInspector::Histogram1D<cond::BasicPayload>( "Example Histo1d", "x",10,0,10){
       Base::setSingleIov( true );
     }
+    virtual ~BasicPayload_data4() = default;
 
     bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ){
       for( auto iov : iovs ) {
@@ -72,6 +75,7 @@ namespace {
     BasicPayload_data5() : cond::payloadInspector::Histogram2D<cond::BasicPayload>( "Example Histo2d", "x",10,0,10,"y",10,0,10){
       Base::setSingleIov( true );
     }
+    virtual ~BasicPayload_data5() = default;
 
     bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ){
       for( auto iov : iovs ) {


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/CondCore/CondDB/interface/Types.h:60:10: warning: 'struct cond::Tag_t' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/CondCore/Utilities/interface/PayloadInspector.h:121:11: warning: 'class cond::payloadInspector::PlotBase' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/CondCore/Utilities/interface/PayloadInspector.h:178:67: warning: base class 'class cond::payloadInspector::PlotBase' has accessible non-virtual destructor [-Wnon-virtual-dtor]

