### PR TITLE
DQMServices : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/DQMServices/Components/src/DQMStoreStats.h
+++ b/DQMServices/Components/src/DQMStoreStats.h
@@ -72,6 +72,7 @@ class DQMStoreStatsTopLevel : public std::vector<DQMStoreStatsSubsystem> {
 template <class Item>
 class Iterator {
   public:
+    virtual ~Iterator() = default;
     virtual void First() = 0;
     virtual void Next() = 0;
     virtual bool IsDone() const = 0;
@@ -85,7 +86,7 @@ class VIterator : public Iterator<Item>
 {
   public:
     VIterator(const std::vector<Item>* aVector):vector_(aVector),index(0) {;} 
-                     
+    virtual ~VIterator() = default; 
     virtual void First()     {index=0;}
     virtual void Next()      { ++index;}
     virtual int  size()      { return vector_->size();}

--- a/DQMServices/Components/test/DummyBookFillDQMStore.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStore.cc
@@ -20,6 +20,7 @@
 namespace {
 class FillerBase {
  public:
+  virtual ~FillerBase()  = default;
   virtual void fill() = 0;
   virtual void reset() = 0;
 };

--- a/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
@@ -21,6 +21,7 @@
 namespace {
 class FillerBase {
  public:
+  virtual ~FillerBase() = default;
   virtual void fill() = 0;
   virtual void reset() = 0;
 };

--- a/DQMServices/Components/test/DummyHarvestingClient.cc
+++ b/DQMServices/Components/test/DummyHarvestingClient.cc
@@ -58,6 +58,7 @@
 namespace {
 class CumulatorBase {
  public:
+  virtual ~CumulatorBase()  = default;
   virtual void cumulate(int lumi_section) = 0;
   virtual void finalizeCumulate() = 0;
 };

--- a/DQMServices/Components/test/DummyTestReadDQMStore.cc
+++ b/DQMServices/Components/test/DummyTestReadDQMStore.cc
@@ -21,6 +21,7 @@
 namespace {
 class ReaderBase {
  public:
+  virtual ~ReaderBase()  = default;
   virtual void read() = 0;
   virtual void reset() = 0;
 };

--- a/DQMServices/FwkIO/test/DummyFillDQMStore.cc
+++ b/DQMServices/FwkIO/test/DummyFillDQMStore.cc
@@ -39,6 +39,7 @@
 namespace {
   class FillerBase {
   public:
+    virtual ~FillerBase()  = default;
     virtual void fill() = 0;
     virtual void reset() = 0;
   };

--- a/DQMServices/FwkIO/test/DummyReadDQMStore.cc
+++ b/DQMServices/FwkIO/test/DummyReadDQMStore.cc
@@ -39,6 +39,7 @@
 namespace {
   class ReaderBase {
   public:
+    virtual ~ReaderBase()  = default;
     virtual void read() = 0;
   };
   


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/DQMServices/Components/src/DQMStoreStats.h:73:7: warning: 'class Iterator<Folder*>' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/DQMServices/Components/src/DQMStoreStats.h:84:7: warning: base class 'class Iterator<Folder*>' has accessible non-virtual destructor [-Wnon-virtual-dtor]
