### PR TITLE
EventFilter : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -74,7 +74,7 @@ namespace l1t {
    class Payload {
       public:
          Payload(const uint32_t * data, const uint32_t * end) : data_(data), end_(end), algo_(0), infra_(0) {};
-
+         virtual ~Payload() {};
          virtual unsigned getAlgorithmFWVersion() const { return algo_; };
          virtual unsigned getInfrastructureFWVersion() const { return infra_; };
          virtual unsigned getHeaderSize() const = 0;

--- a/EventFilter/L1TRawToDigi/interface/PackingSetup.h
+++ b/EventFilter/L1TRawToDigi/interface/PackingSetup.h
@@ -29,6 +29,7 @@ namespace l1t {
    class PackingSetup {
       public:
          PackingSetup() {};
+         virtual ~PackingSetup() {};
          virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet&, edm::ConsumesCollector&) = 0;
          virtual void registerProducts(edm::stream::EDProducerBase&) = 0;
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/CaloSetup.h
@@ -13,6 +13,7 @@ namespace l1t {
    namespace stage1 {
       class CaloSetup : public PackingSetup {
          public:
+            virtual ~CaloSetup() {};
             virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
             virtual void fillDescription(edm::ParameterSetDescription& desc) override;
             virtual PackerMap getPackers(int fed, unsigned int fw) override;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.h
@@ -13,6 +13,7 @@ namespace l1t {
    namespace stage2 {
       class GTSetup : public PackingSetup {
          public:
+            virtual ~GTSetup() {};
             virtual std::unique_ptr<PackerTokens> registerConsumes(const edm::ParameterSet& cfg, edm::ConsumesCollector& cc) override;
             virtual void fillDescription(edm::ParameterSetDescription& desc) override;
             virtual PackerMap getPackers(int fed, unsigned int fw) override;


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/EventFilter/L1TRawToDigi/interface/Block.h:74:10: warning: 'class l1t::Payload' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/EventFilter/L1TRawToDigi/interface/Block.h:94:10: warning: base class 'class l1t::Payload' has accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/EventFilter/L1TRawToDigi/interface/PackingSetup.h:29:10: warning: 'class l1t::PackingSetup' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
