### PR TITLE
GeneratorInterface : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/GeneratorInterface/Core/interface/BaseHadronizer.h
+++ b/GeneratorInterface/Core/interface/BaseHadronizer.h
@@ -47,7 +47,7 @@ namespace gen {
   class BaseHadronizer {
   public:
     BaseHadronizer( edm::ParameterSet const& ps );
-    ~BaseHadronizer() {}
+    virtual ~BaseHadronizer() noexcept (false) {}
 
     // GenRunInfo and GenEvent passing
     GenRunInfoProduct &getGenRunInfo() { return genRunInfo_; }

--- a/GeneratorInterface/Hydjet2Interface/interface/InitialState.h
+++ b/GeneratorInterface/Hydjet2Interface/interface/InitialState.h
@@ -21,7 +21,7 @@ class InitialState {
     fDatabase->SetMassRange(0.0, 200.);
     fDatabase->SetWidthRange(0., 10.);
   };
-  virtual ~InitialState() {
+  virtual ~InitialState() noexcept(false) {
     delete fDatabase;
   };
   

--- a/GeneratorInterface/PomwigInterface/interface/PomwigHadronizer.h
+++ b/GeneratorInterface/PomwigInterface/interface/PomwigHadronizer.h
@@ -22,7 +22,7 @@ namespace gen
   {
     public:
         PomwigHadronizer(const edm::ParameterSet &params);
-        ~PomwigHadronizer();
+        virtual ~PomwigHadronizer();
 
         bool readSettings( int );
 	bool initializeForInternalPartons();

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.h
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.h
@@ -44,7 +44,7 @@ class JetMatching;
   
   public:
      Pythia6Hadronizer(edm::ParameterSet const& ps);
-     ~Pythia6Hadronizer();
+     virtual ~Pythia6Hadronizer();
 
      // bool generatePartons();
      bool generatePartonsAndHadronize();

--- a/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h
@@ -42,7 +42,7 @@ namespace gen {
   class Py8GunBase : public Py8InterfaceBase {
   public:
     Py8GunBase( edm::ParameterSet const& ps );
-    ~Py8GunBase() {}
+    virtual ~Py8GunBase() {}
     
     virtual bool residualDecay(); // common func
     bool initializeForInternalPartons();

--- a/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
@@ -26,7 +26,7 @@ namespace gen {
       public:
          
 	 Py8InterfaceBase( edm::ParameterSet const& ps );
-	 ~Py8InterfaceBase() {}
+	 virtual ~Py8InterfaceBase() {}
 	 
          virtual bool generatePartonsAndHadronize() = 0;
          bool decay() { return true; } // NOT used - let's call it "design imperfection"

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8toJetInput.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8toJetInput.h
@@ -17,7 +17,7 @@ class Py8toJetInput
       typedef Pythia8::Particle Particle;
    
       Py8toJetInput(): fJetEtaMax(10.) {}
-      ~Py8toJetInput() {}
+      virtual ~Py8toJetInput() {}
       
       virtual const std::vector<fastjet::PseudoJet> fillJetAlgoInput( const Event&, const Event&, 
                                                                       const lhef::LHEEvent* lhee=0,
@@ -41,7 +41,7 @@ class Py8toJetInputHEPEVT : public Py8toJetInput
    public:
    
       Py8toJetInputHEPEVT() {}
-      ~Py8toJetInputHEPEVT() {}
+      virtual ~Py8toJetInputHEPEVT() {}
       
       const std::vector<fastjet::PseudoJet> fillJetAlgoInput( const Event&, const Event&, 
                                                               const lhef::LHEEvent*,


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/GeneratorInterface/Core/interface/BaseHadronizer.h:47:9: warning: 'class gen::BaseHadronizer' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h:24:10: warning: base class 'class gen::BaseHadronizer' has accessible non-virtual destructor [-Wnon-virtual-dtor]
