### PR TITLE
HLTrigger : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/HLTrigger/HLTanalyzers/interface/HLTrigReportService.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTrigReportService.h
@@ -11,7 +11,7 @@ class HLTrigReport;
 class HLTrigReportService {
 
  public:
-
+  virtual ~HLTrigReportService() = default;
   virtual void registerModule(const HLTrigReport *)=0;
 
   virtual void setDatasetNames(const std::vector<std::string>&)=0 ;

--- a/HLTrigger/Tools/bin/hltDiff.cc
+++ b/HLTrigger/Tools/bin/hltDiff.cc
@@ -59,6 +59,7 @@ void error(std::ostream & out, const std::string & message) {
 
 class HLTConfigInterface {
 public:
+  virtual ~HLTConfigInterface()  = default;
   virtual std::string const & processName() const = 0;
   virtual unsigned int size() const = 0;
   virtual unsigned int size(unsigned int trigger) const = 0;
@@ -87,7 +88,7 @@ public:
       }
     }
   }
-
+  virtual ~HLTConfigDataEx()  = default;
   std::string const & processName() const override {
     return data_.processName();
   }
@@ -150,7 +151,7 @@ public:
       config_(config),
       index_(index)
     { }
-
+    virtual ~View()  = default;
     std::string const & processName() const override;
     unsigned int size() const override;
     unsigned int size(unsigned int trigger) const override;


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/HLTrigger/Tools/bin/hltDiff.cc:60:7: warning: 'class HLTConfigInterface' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/HLTrigger/Tools/bin/hltDiff.cc:73:7: warning: base class 'class HLTConfigInterface' has accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/HLTrigger/Tools/bin/hltDiff.cc:73:7: warning: 'class HLTConfigDataEx' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

   /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/HLTrigger/Tools/bin/hltDiff.cc:147:9: warning: base class 'class HLTConfigInterface' has accessible non-virtual destructor [-Wnon-virtual-dtor]
