### PR TITLE
L1Trigger : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/L1Trigger/L1TMuonBarrel/src/Twinmux_v1/DTCollector.h
+++ b/L1Trigger/L1TMuonBarrel/src/Twinmux_v1/DTCollector.h
@@ -31,7 +31,7 @@ namespace L1TwinMux {
   class DTCollector {
   public:
     DTCollector();
-    ~DTCollector() {}
+    virtual ~DTCollector() = default;
 
     //virtual void extractPrimitives(const edm::Event&, const edm::EventSetup&,
 	//			   std::vector<L1TMuon::TriggerPrimitive>&) const;

--- a/L1Trigger/L1TMuonBarrel/src/Twinmux_v1/L1ITMuonBarrelPrimitiveProducer.cc
+++ b/L1Trigger/L1TMuonBarrel/src/Twinmux_v1/L1ITMuonBarrelPrimitiveProducer.cc
@@ -37,7 +37,7 @@ class L1ITMuonBarrelPrimitiveProducer  {
 
 public:
   inline L1ITMuonBarrelPrimitiveProducer(std::unique_ptr<MBLTContainer> _mbltContainer);
-  inline ~L1ITMuonBarrelPrimitiveProducer();
+  inline virtual ~L1ITMuonBarrelPrimitiveProducer();
   inline virtual std::unique_ptr<L1MuDTChambPhContainer> produce( const edm::EventSetup&);
 
 private:

--- a/L1Trigger/L1TMuonBarrel/src/Twinmux_v1/RPCCollector.h
+++ b/L1Trigger/L1TMuonBarrel/src/Twinmux_v1/RPCCollector.h
@@ -27,7 +27,7 @@ namespace L1TwinMux {
   class RPCCollector {
   public:
     RPCCollector();
-    ~RPCCollector() {}
+    virtual ~RPCCollector() = default;
 
     virtual void extractPrimitives(edm::Handle<RPCDigiCollection> rpcDigis,
 				   std::vector<L1TMuon::TriggerPrimitive>&) const;

--- a/L1Trigger/L1TMuonEndCap/interface/LossFunctions.h
+++ b/L1Trigger/L1TMuonEndCap/interface/LossFunctions.h
@@ -17,7 +17,7 @@
 class L1TLossFunction
 {
  public:
-  
+  virtual ~L1TLossFunction() =default; 
   // The gradient of the loss function.
   // Each tree is a step in the direction of the gradient
   // towards the minimum of the Loss Function.

--- a/L1Trigger/RPCTrigger/interface/RPCTriggerConfiguration.h
+++ b/L1Trigger/RPCTrigger/interface/RPCTriggerConfiguration.h
@@ -12,6 +12,7 @@
 //f.e. which pac, or TB or TC should run given LogCone
 class RPCTriggerConfiguration {
 public:
+  virtual ~RPCTriggerConfiguration() = default;
   ///returns count of Trigger Crates in system.
   virtual int getTCsCnt() = 0;
 


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/L1Trigger/RPCTrigger/interface/RPCTriggerConfiguration.h:13:7: warning: 'class RPCTriggerConfiguration' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/L1Trigger/RPCTrigger/interface/RPCBasicTrigConfig.h:14:7: warning: base class 'class RPCTriggerConfiguration' has accessible non-virtual destructor [-Wnon-virtual-dtor]

