### PR TITLE
PhysicsTools : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/PhysicsTools/JetMCAlgos/interface/BasePartonSelector.h
+++ b/PhysicsTools/JetMCAlgos/interface/BasePartonSelector.h
@@ -14,7 +14,7 @@ class BasePartonSelector
 {
   public:
     BasePartonSelector();
-    ~BasePartonSelector();
+    virtual ~BasePartonSelector();
 
     virtual void run(const edm::Handle<reco::GenParticleCollection> & particles,
                      std::unique_ptr<reco::GenParticleRefVector> & partons);

--- a/PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h
+++ b/PhysicsTools/PatAlgos/interface/KinematicResolutionProvider.h
@@ -22,6 +22,7 @@ namespace edm  { class ParameterSet; class EventSetup; }
 class KinematicResolutionProvider {
 
  public:
+  virtual ~KinematicResolutionProvider() = default;
   /// everything that needs to be done before the event loop
   virtual void setup(const edm::EventSetup &iSetup) const { }
   /// get a CandKinResolution object from the service; this

--- a/PhysicsTools/RecoAlgos/plugins/MassKinFitterCandCustomProducer.cc
+++ b/PhysicsTools/RecoAlgos/plugins/MassKinFitterCandCustomProducer.cc
@@ -9,6 +9,7 @@
 class CustomKinFitter : public CandMassKinFitter {
 public:
   CustomKinFitter(double mass) : CandMassKinFitter(mass) { }
+  virtual ~CustomKinFitter() = default;
 private:
   virtual double errEt(double et, double eta) const { return 0.2; }
   virtual double errEta(double et, double eta) const { return 0.2; }

--- a/PhysicsTools/RooStatsCms/interface/BinomialInterval.h
+++ b/PhysicsTools/RooStatsCms/interface/BinomialInterval.h
@@ -30,6 +30,7 @@ public:
   // quantile).
   void init(const double alpha, const tail_type t=equal_tailed);
 
+  virtual ~BinomialInterval() = default;
   // Methods which derived classes must implement.
 
   // Calculate the interval given a number of successes and a number

--- a/PhysicsTools/RooStatsCms/interface/ClopperPearsonBinomialInterval.h
+++ b/PhysicsTools/RooStatsCms/interface/ClopperPearsonBinomialInterval.h
@@ -22,7 +22,6 @@ class ClopperPearsonBinomialInterval : public BinomialInterval {
  public:
   void calculate(const double successes, const double trials);
   const char* name() const { return "Clopper-Pearson"; }
-
 #if (defined (STANDALONE) or defined (__CINT__) )
 ClassDef(ClopperPearsonBinomialInterval,1)
 #endif


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/PhysicsTools/RooStatsCms/interface/BinomialInterval.h:18:7: warning: 'class BinomialInterval' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/PhysicsTools/RooStatsCms/interface/BinomialNoncentralInterval.h:31:7: warning: base class 'class BinomialInterval' has accessible non-virtual destructor [-Wnon-virtual-dtor]

