### PR TITLE
RecoBTag : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
@@ -42,7 +42,7 @@
 class CombinedSVComputer {
     public:
 	explicit CombinedSVComputer(const edm::ParameterSet &params);
-
+        virtual ~CombinedSVComputer() = default;
 	virtual reco::TaggingVariableList
 	operator () (const reco::TrackIPTagInfo &ipInfo,
 	             const reco::SecondaryVertexTagInfo &svInfo) const;

--- a/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
@@ -14,7 +14,7 @@
 class CombinedSVSoftLeptonComputer : public CombinedSVComputer {
     public:
 	explicit CombinedSVSoftLeptonComputer(const edm::ParameterSet &params);
-	
+        virtual ~CombinedSVSoftLeptonComputer() = default;	
 	double flipSoftLeptonValue(double value) const;
 	
 	template <class IPTI,class SVTI>

--- a/RecoBTag/SecondaryVertex/interface/GhostTrackComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/GhostTrackComputer.h
@@ -16,7 +16,7 @@
 class GhostTrackComputer {
     public:
 	GhostTrackComputer(const edm::ParameterSet &params);
-
+        virtual ~GhostTrackComputer() = default;
 	virtual reco::TaggingVariableList
 	operator () (const reco::TrackIPTagInfo &ipInfo,
 	             const reco::SecondaryVertexTagInfo &svInfo) const;

--- a/RecoBTag/XMLCalibration/interface/CalibratedObject.h
+++ b/RecoBTag/XMLCalibration/interface/CalibratedObject.h
@@ -14,6 +14,7 @@
 class CalibratedObject 
 {
   public:
+    virtual ~CalibratedObject() = default;
     /** This function has to be implemented in derived class.
     * It should read all the information the calibrated objects need to
     * load to be initialized from the xml file.


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoBTag/XMLCalibration/interface/CalibratedObject.h:14:7: warning: 'class CalibratedObject' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoBTag/SecondaryVertex/interface/GhostTrackComputer.h:16:7: warning: 'class GhostTrackComputer' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

