### PR TITLE
RecoLocalCalo : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationXtrpCalo.h
+++ b/RecoJets/JetAssociationAlgorithms/interface/JetTracksAssociationXtrpCalo.h
@@ -33,7 +33,7 @@ class JetTracksAssociationXtrpCalo {
   JetTracksAssociationXtrpCalo();
   
   /// Destructor
-  ~JetTracksAssociationXtrpCalo();
+  virtual ~JetTracksAssociationXtrpCalo();
 
   /// Associates tracks to jets
   void produce( Association*,

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAbsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAbsAlgo.h
@@ -23,7 +23,7 @@ template<class C> class EcalUncalibRecHitRecAbsAlgo
   //EcalUncalibRecHitRecAbsAlgo() { };
 
   /// Destructor
-  //virtual ~EcalUncalibRecHitRecAbsAlgo() { };
+  virtual ~EcalUncalibRecHitRecAbsAlgo() = default;
 
   /// make rechits from dataframes
 


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAbsAlgo.h:17:25: warning: 'class EcalUncalibRecHitRecAbsAlgo<EBDataFrame>' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

