### PR TITLE
RecoMuon : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/RecoMuon/MuonIsolation/interface/CutsConeSizeFunction.h
+++ b/RecoMuon/MuonIsolation/interface/CutsConeSizeFunction.h
@@ -8,6 +8,7 @@ namespace muonisolation {
 class CutsConeSizeFunction : public IsolatorByDeposit::ConeSizeFunction {
 public: 
   CutsConeSizeFunction(const Cuts & cuts) : theLastCut(0), theCuts(cuts) {} 
+  virtual ~CutsConeSizeFunction() = default;
   float threshold() const { return theLastCut->threshold; }
   float coneSize( float eta, float pt) const {
     theLastCut = & theCuts(eta); 

--- a/RecoMuon/MuonIsolation/interface/IsolatorByDeposit.h
+++ b/RecoMuon/MuonIsolation/interface/IsolatorByDeposit.h
@@ -19,6 +19,7 @@ public:
   typedef MuIsoBaseIsolator::DepositContainer DepositContainer;
 
   struct ConeSizeFunction {
+   virtual ~ConeSizeFunction() = default;
    virtual float  coneSize( float eta, float pt) const = 0;
   };
 

--- a/RecoMuon/MuonIsolation/interface/IsolatorByDepositCount.h
+++ b/RecoMuon/MuonIsolation/interface/IsolatorByDepositCount.h
@@ -19,6 +19,7 @@ public:
   typedef MuIsoBaseIsolator::DepositContainer DepositContainer;
 
   struct ConeSizeFunction {
+   virtual ~ConeSizeFunction() = default;
    virtual float  coneSize( float eta, float pt) const = 0;
   };
 
@@ -26,7 +27,7 @@ public:
   IsolatorByDepositCount(float conesize, const std::vector<double>& thresh);
   IsolatorByDepositCount(const ConeSizeFunction * conesize, const std::vector<double>& thresh);
 
-  virtual ~IsolatorByDepositCount() {}
+  virtual ~IsolatorByDepositCount() = default;
 
   //! Compute the deposit within the cone and return the isolation result
   virtual Result result(const DepositContainer& deposits, const edm::Event* = 0) const;


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h:12:7: warning: base class 'class TransientTrackingRecHitBuilder' has accessible non-virtual destructor [-Wnon-virtual-dtor]


  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoMuon/MuonIsolation/interface/IsolatorByDepositCount.h:21:10: warning: 'struct muonisolation::IsolatorByDepositCount::ConeSizeFunction' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
