### PR TITLE
RecoParticleFlow : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h
@@ -17,7 +17,7 @@ class PFClusterEnergyCorrectorBase {
  public:
   PFClusterEnergyCorrectorBase(const edm::ParameterSet& conf) :
     _algoName(conf.getParameter<std::string>("algoName")) { }
-  ~PFClusterEnergyCorrectorBase() { }
+  virtual ~PFClusterEnergyCorrectorBase() = default;
   //get rid of things we should never use
   PFClusterEnergyCorrectorBase(const Corrector&) = delete;
   Corrector& operator=(const Corrector&) = delete;


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h:15:7: warning: 'class PFClusterEnergyCorrectorBase' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
