### PR TITLE
RecoTracker: fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/RecoTracker/SiTrackerMRHTools/interface/MultiRecHitCollector.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/MultiRecHitCollector.h
@@ -11,7 +11,7 @@ class MultiRecHitCollector {
 
 	public:
 	MultiRecHitCollector(const MeasurementTracker* meas): theMeasurementTracker(meas){}
-	
+        virtual ~MultiRecHitCollector() = default;	
 	virtual std::vector<TrajectoryMeasurement> recHits(const Trajectory&, const MeasurementTrackerEvent *theMTE) const = 0;
 
 	const MeasurementTracker* getMeasurementTracker() const {return theMeasurementTracker;}

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.h
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.h
@@ -13,6 +13,7 @@ class TH2F;
 
 class dso_hidden SumX0AtEtaDataProvider{ 
 public: virtual float sumX0atEta(float eta, float r) const = 0; 
+        virtual ~SumX0AtEtaDataProvider() {}
 }; 
 
 class dso_hidden MultipleScatteringX0Data : public SumX0AtEtaDataProvider {


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoTracker/SiTrackerMRHTools/interface/MultiRecHitCollector.h:10:7: warning: 'class MultiRecHitCollector' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/8fa3f79dab694f86b12f10b4e4cceb97/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-21-2300/src/RecoTracker/SiTrackerMRHTools/interface/MultiRecHitCollector.h:10:7: warning: 'class MultiRecHitCollector' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
