### PR TITLE
fix fwlite build by removing dependency on TrackingTools/PatternTools/interface/Trajectory.h

### DIFF
--- a/DataFormats/EgammaTrackReco/interface/ConversionTrack.h
+++ b/DataFormats/EgammaTrackReco/interface/ConversionTrack.h
@@ -14,7 +14,7 @@
 #define EgammaReco_ConversionTrack_h
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
+class Trajectory;
 namespace reco
 {
   class ConversionTrack


### PR DESCRIPTION
We keep the BuiuldFile level dependencyso that scram can build TrackingTools/PatternTools before DataFormats/EgammaTrackReco