### PR TITLE
RPCRecHits nan protection

### DIFF
--- a/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
@@ -26,11 +26,11 @@ int RPCCluster::bx() const { return bunchx; }
 
 bool RPCCluster::hasTime() const { return nTime > 0; }
 float RPCCluster::time() const { return hasTime() ? sumTime/nTime : 0; }
-float RPCCluster::timeRMS() const { return hasTime() ? sqrt((sumTime2*nTime - sumTime*sumTime)/nTime) : -1; }
+float RPCCluster::timeRMS() const { return hasTime() ? sqrt(std::max(0.F, sumTime2*nTime - sumTime*sumTime)/nTime) : -1; }
 
 bool RPCCluster::hasY() const { return nY > 0; }
 float RPCCluster::y() const { return hasY() ? sumY/nY : 0; }
-float RPCCluster::yRMS() const { return hasY() ? sqrt((sumY2*nY - sumY*sumY)/nY) : -1; }
+float RPCCluster::yRMS() const { return hasY() ? sqrt(std::max(0.F, sumY2*nY - sumY*sumY)/nY) : -1; }
 
 bool RPCCluster::isAdjacent(const RPCCluster& cl) const
 {

--- a/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCCluster.cc
@@ -26,11 +26,11 @@ int RPCCluster::bx() const { return bunchx; }
 
 bool RPCCluster::hasTime() const { return nTime > 0; }
 float RPCCluster::time() const { return hasTime() ? sumTime/nTime : 0; }
-float RPCCluster::timeRMS() const { return hasTime() ? sqrt(std::max(0.F, sumTime2*nTime - sumTime*sumTime)/nTime) : -1; }
+float RPCCluster::timeRMS() const { return hasTime() ? sqrt(max(0.F, sumTime2*nTime - sumTime*sumTime))/nTime : -1; }
 
 bool RPCCluster::hasY() const { return nY > 0; }
 float RPCCluster::y() const { return hasY() ? sumY/nY : 0; }
-float RPCCluster::yRMS() const { return hasY() ? sqrt(std::max(0.F, sumY2*nY - sumY*sumY)/nY) : -1; }
+float RPCCluster::yRMS() const { return hasY() ? sqrt(max(0.F, sumY2*nY - sumY*sumY))/nY : -1; }
 
 bool RPCCluster::isAdjacent(const RPCCluster& cl) const
 {


### PR DESCRIPTION
(modified) RMS of timing in the RPC local reconstruction had bug in the fomula and gave nan values.

This PR fixes fomula, but also forces the variance to have non-negative value, protect from possible crash or undefined behaviour.
We found unphysical peak at time=0 in the phase-II RPCRecHit validation and this must be linked with this problem.
(https://cmsweb.cern.ch/dqm/relval/plotfairy/archive/1/RelValSingleMuPt100Extended/CMSSW_9_1_1-91X_upgrade2023_realistic_v1_D17-v1/DQMIO/RPC/RPCRecHitV/SimVsReco/HitProperty/RecHitTimeBarrel?session=0vLmrp;v=1495479251889465704;w=924;h=715)

With the limited number of events, the peak is disappeared after the fix (red=before, blue=after).
![image](https://cloud.githubusercontent.com/assets/4388926/26476980/97f8b37e-41c2-11e7-8fd2-49864e61389e.png)

The current data taking is not affected. The timing information is filled only for the phase-II upgrade.

@bapavlov @mileva 
