### PR TITLE
[9_2_X_patchX] fix name of input collection in pathALCARECOHcalCalMinBias

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasHI_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBiasHI_cff.py
@@ -30,14 +30,14 @@ seqALCARECOHcalCalMinBias = cms.Sequence(hcalminbiasHLT*hcalDigiAlCaMB*gtDigisAl
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoMBNZS = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(True),
     forceSOI = cms.int32(1)
 )
 hfprerecoNoise = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False),

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalMinBias_cff.py
@@ -60,14 +60,14 @@ seqALCARECOHcalCalMinBiasNoHLT = cms.Sequence(hcalDigiAlCaMB*gtDigisAlCaMB*hbher
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoNoise = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False),
     forceSOI = cms.int32(0)
 )
 hfprerecoMBNZS = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(True),

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -80,7 +80,7 @@ seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestalHLT*
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoPedestal = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(
-    digiLabel = cms.InputTag("hcalDigiAlaMB"),
+    digiLabel = cms.InputTag("hcalDigiAlCaMB"),
     dropZSmarkedPassed = cms.bool(False),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False),


### PR DESCRIPTION
replica of : https://github.com/cms-sw/cmssw/pull/18892#issue-230512055
note that master has this other one: https://github.com/cms-sw/cmssw/pull/18890

The alcareco running on HcalNZS, HcalCalMinBias, has a few modules in its path with typo (hcalDigiAlaMB instead of hcalDigiAlcaMB) in the name of the HCAL digis input collection they (try to) consume.
This failure emerges now thanks to the fact that patch2 fixed another problem with the same alcareco.

The issue originated here https://github.com/cms-sw/cmssw/pull/18367/files .
It is understood how such mis-labelling passed the IB tests: the prompt-like relval workflow (1000) processes MinBias PD form 2011 where the rate of events firing HLT_HcalPhiSym* is low; because of the HLT selection at the start of HcalCalMinBias, the misconfigured modules were never executed.