### PR TITLE
update EXO NoBPTX trigger paths validation for 2017 pp collisions

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 JetNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_JetE50_NoBPTX3BX_v", # 2016 proposal
-        "HLT_JetE30_NoBPTX_v",
-        "HLT_JetE30_NoBPTX3BX_v",
-        "HLT_JetE70_NoBPTX3BX_v"
+        "HLT_UncorrectedJetE30_NoBPTX_v", # 2017 proposal
+        "HLT_UncorrectedJetE30_NoBPTX3BX_v",
+        "HLT_UncorrectedJetE60_NoBPTX3BX_v",
+        "HLT_UncorrectedJetE70_NoBPTX3BX_v",
         ),
     recCaloJetLabel    = cms.InputTag("ak4CaloJets"),
 

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
@@ -2,14 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 MuonNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v", # 2016 proposal
+        "HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v", # 2017 proposal
         "HLT_L2Mu10_NoVertex_NoBPTX_v",
         "HLT_L2Mu10_NoVertex_NoBPTX3BX_v",
         "HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_v"
-        #"HLT_L2Mu20_NoVertex_2Cha_NoBPTX3BX_NoHalo_v"  # Run1 frozenHLT
         ),
     #recMuonLabel  = cms.InputTag("muons"),
-    recMuonTrkLabel  = cms.InputTag("refittedStandAloneMuons"),
+    recMuonTrkLabel  = cms.InputTag("displacedStandAloneMuons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings


### PR DESCRIPTION
This PR updates the trigger path names in the exotica offline validation, for the NoBPTX triggers, for the 2017 pp collision menu.