### PR TITLE
Make FastSim work with QIE10/11

### DIFF
--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -86,7 +86,9 @@ def loadDigiAliases(premix=False):
                cms.VPSet(
                 cms.PSet(type = cms.string("HBHEDataFramesSorted")),
                 cms.PSet(type = cms.string("HFDataFramesSorted")),
-                cms.PSet(type = cms.string("HODataFramesSorted"))
+                cms.PSet(type = cms.string("HODataFramesSorted")),
+                cms.PSet(type = cms.string('QIE10DataFrameHcalDataFrameContainer')),
+                cms.PSet(type = cms.string('QIE11DataFrameHcalDataFrameContainer'))
                 )
            }
           )

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -15,7 +15,7 @@ hbheprereco = cms.EDProducer(
 
     # Label for the input QIE11DigiCollection, and flag indicating
     # whether we should process this collection
-    digiLabelQIE11 = cms.InputTag("hcalDigis"),
+    digiLabelQIE11 = cms.InputTag("hcalDigis","HBHEQIE11DigiCollection"),
     processQIE11 = cms.bool(True),
 
     # Get the "sample of interest" index from DB?

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -15,7 +15,7 @@ hbheprereco = cms.EDProducer(
 
     # Label for the input QIE11DigiCollection, and flag indicating
     # whether we should process this collection
-    digiLabelQIE11 = cms.InputTag("hcalDigis","HBHEQIE11DigiCollection"),
+    digiLabelQIE11 = cms.InputTag("hcalDigis"),
     processQIE11 = cms.bool(True),
 
     # Get the "sample of interest" index from DB?
@@ -90,3 +90,6 @@ hbheprereco = cms.EDProducer(
 
 # Disable the "triangle peak fit" and the corresponding HBHETriangleNoise flag
 hbheprereco.pulseShapeParametersQIE8.TrianglePeakTS = cms.uint32(10000)
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(hbheprereco, digiLabelQIE11 = cms.InputTag("hcalDigis","HBHEQIE11DigiCollection"))

--- a/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 hfprereco = cms.EDProducer("HFPreReconstructor",
-    digiLabel = cms.InputTag("hcalDigis"),
+    digiLabel = cms.InputTag("hcalDigis","HFQIE10DigiCollection"),
     dropZSmarkedPassed = cms.bool(True),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False)

--- a/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hfprereco_cfi.py
@@ -1,8 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 hfprereco = cms.EDProducer("HFPreReconstructor",
-    digiLabel = cms.InputTag("hcalDigis","HFQIE10DigiCollection"),
+    digiLabel = cms.InputTag("hcalDigis"),
     dropZSmarkedPassed = cms.bool(True),
     tsFromDB = cms.bool(False),
     sumAllTimeSlices = cms.bool(False)
 )
+
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
+fastSim.toModify(hfprereco, digiLabel = cms.InputTag("hcalDigis","HFQIE10DigiCollection"))


### PR DESCRIPTION
FastSim has its own set of digi aliases (used to skip the RAW2DIGI step), which need to be extended for the new HCAL data formats.

In addition, the new RECO modules need to have more specific input tags specified for the new digi collections, otherwise the aliases do not get recognized correctly.

This has been tested privately by myself and @angirar.