### PR TITLE
L1 muon online DQM uprades

### DIFF
--- a/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
+++ b/DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h
@@ -40,6 +40,7 @@ class L1TMP7ZeroSupp : public DQMEDAnalyzer {
 
   // Add additional bins only before NBINLABELS
   enum binlabels {EVTS=0, EVTSGOOD, EVTSBAD, BLOCKS, ZSBLKSGOOD, ZSBLKSBAD, ZSBLKSBADFALSEPOS, ZSBLKSBADFALSENEG, NBINLABELS};
+  enum ratioBinlabels {REVTS=0, RBLKS, RBLKSFALSEPOS, RBLKSFALSENEG, RNBINLABELS};
 
   edm::EDGetTokenT<FEDRawDataCollection> fedDataToken_;
   bool zsEnabled_;
@@ -65,6 +66,8 @@ class L1TMP7ZeroSupp : public DQMEDAnalyzer {
   std::vector<unsigned int> definedMaskCapIds_;
 
   std::map<unsigned int, MonitorElement*> zeroSuppValMap_;
+  std::map<unsigned int, MonitorElement*> errorSummaryNumMap_;
+  std::map<unsigned int, MonitorElement*> errorSummaryDenMap_;
   std::map<unsigned int, MonitorElement*> readoutSizeNoZSMap_;
   std::map<unsigned int, MonitorElement*> readoutSizeZSMap_;
   std::map<unsigned int, MonitorElement*> readoutSizeZSExpectedMap_;

--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -32,6 +32,7 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
  private:  
 
   enum variables {BXRANGEGOOD=1, BXRANGEBAD, NMUONGOOD, NMUONBAD, MUONALL, MUONGOOD, PTBAD, ETABAD, PHIBAD, ETAATVTXBAD, PHIATVTXBAD, CHARGEBAD, CHARGEVALBAD, QUALBAD, ISOBAD, IDXBAD};
+  enum ratioVariables {RBXRANGE=1, RNMUON, RMUON, RPT, RETA, RPHI, RETAATVTX, RPHIATVTX, RCHARGE, RCHARGEVAL, RQUAL, RISO, RIDX};
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken1;
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken2;
@@ -42,6 +43,8 @@ class L1TStage2MuonComp : public DQMEDAnalyzer {
   bool verbose;
 
   MonitorElement* summary;
+  MonitorElement* errorSummaryNum;
+  MonitorElement* errorSummaryDen;
 
   MonitorElement* muColl1BxRange;
   MonitorElement* muColl1nMu;

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h
@@ -32,6 +32,7 @@ class L1TStage2RegionalMuonCandComp : public DQMEDAnalyzer {
  private:  
 
   enum variables {BXRANGEGOOD=1, BXRANGEBAD, NMUONGOOD, NMUONBAD, MUONALL, MUONGOOD, PTBAD, ETABAD, LOCALPHIBAD, SIGNBAD, SIGNVALBAD, QUALBAD, HFBAD, LINKBAD, PROCBAD, TFBAD, TRACKADDRBAD};
+  enum ratioVariables {RBXRANGE=1, RNMUON, RMUON, RPT, RETA, RLOCALPHI, RSIGN, RSIGNVAL, RQUAL, RHF, RLINK, RPROC, RTF, RTRACKADDR};
   enum tfs {BMTFBIN=1, OMTFNEGBIN, OMTFPOSBIN, EMTFNEGBIN, EMTFPOSBIN};
 
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> muonToken1;
@@ -44,6 +45,8 @@ class L1TStage2RegionalMuonCandComp : public DQMEDAnalyzer {
   bool verbose;
 
   MonitorElement* summary;
+  MonitorElement* errorSummaryNum;
+  MonitorElement* errorSummaryDen;
 
   MonitorElement* muColl1BxRange;
   MonitorElement* muColl1nMu;

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -1,50 +1,58 @@
 import FWCore.ParameterSet.Config as cms
 
+# input modules
+unpackerModule = "gmtStage2Digis"
+emulatorModule = "valGmtStage2Digis"
+
+# directories
+ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
+ugmtEmuImdMuDqmDir = ugmtEmuDqmDir+"/intermediate_muons"
+
 # fills histograms with all uGMT emulated muons
 # uGMT input muon histograms from track finders are not filled since they are identical to the data DQM plots
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import *
 l1tStage2uGMTEmul = l1tStage2uGMT.clone()
-l1tStage2uGMTEmul.muonProducer = cms.InputTag("valGmtStage2Digis")
-l1tStage2uGMTEmul.monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT")
+l1tStage2uGMTEmul.muonProducer = cms.InputTag(emulatorModule)
+l1tStage2uGMTEmul.monitorDir = cms.untracked.string(ugmtEmuDqmDir)
 l1tStage2uGMTEmul.emulator = cms.untracked.bool(True)
 
 # the uGMT intermediate muon DQM modules
 l1tStage2uGMTIntermediateBMTFEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
-    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsBMTF"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/BMTF"),
+    muonProducer = cms.InputTag(emulatorModule, "imdMuonsBMTF"),
+    monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/BMTF"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
     verbose = cms.untracked.bool(False),
 )
 
 l1tStage2uGMTIntermediateOMTFNegEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
-    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFNeg"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg"),
+    muonProducer = cms.InputTag(emulatorModule, "imdMuonsOMTFNeg"),
+    monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
 
 l1tStage2uGMTIntermediateOMTFPosEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
-    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsOMTFPos"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos"),
+    muonProducer = cms.InputTag(emulatorModule, "imdMuonsOMTFPos"),
+    monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
 
 l1tStage2uGMTIntermediateEMTFNegEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
-    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFNeg"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg"),
+    muonProducer = cms.InputTag(emulatorModule, "imdMuonsEMTFNeg"),
+    monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
     verbose = cms.untracked.bool(False),
 )
 
 l1tStage2uGMTIntermediateEMTFPosEmul = cms.EDAnalyzer(
     "L1TStage2uGMTMuon",
-    muonProducer = cms.InputTag("valGmtStage2Digis", "imdMuonsEMTFPos"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos"),
+    muonProducer = cms.InputTag(emulatorModule, "imdMuonsEMTFPos"),
+    monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
     verbose = cms.untracked.bool(False),
 )
@@ -53,14 +61,46 @@ l1tStage2uGMTIntermediateEMTFPosEmul = cms.EDAnalyzer(
 # only muons that do not match are filled in the histograms
 l1tdeStage2uGMT = cms.EDAnalyzer(
     "L1TStage2MuonComp",
-    muonCollection1 = cms.InputTag("gmtStage2Digis", "Muon"),
-    muonCollection2 = cms.InputTag("valGmtStage2Digis"),
-    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison"),
+    muonCollection1 = cms.InputTag(unpackerModule, "Muon"),
+    muonCollection2 = cms.InputTag(emulatorModule),
+    monitorDir = cms.untracked.string(ugmtEmuDqmDir+"/data_vs_emulator_comparison"),
     muonCollection1Title = cms.untracked.string("uGMT data"),
     muonCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT emulator muons"),
     verbose = cms.untracked.bool(False),
 )
+
+# compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
+# only muons that do not match are filled in the histograms
+l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone()
+l1tdeStage2uGMTIntermediateBMTF.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsBMTF")
+l1tdeStage2uGMTIntermediateBMTF.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsBMTF")
+l1tdeStage2uGMTIntermediateBMTF.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison")
+l1tdeStage2uGMTIntermediateBMTF.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated")
+
+l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFNeg")
+l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFNeg")
+l1tdeStage2uGMTIntermediateOMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
+l1tdeStage2uGMTIntermediateOMTFNeg.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated")
+
+l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateOMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFPos")
+l1tdeStage2uGMTIntermediateOMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFPos")
+l1tdeStage2uGMTIntermediateOMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
+l1tdeStage2uGMTIntermediateOMTFPos.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated")
+
+l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFNeg")
+l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFNeg")
+l1tdeStage2uGMTIntermediateEMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
+l1tdeStage2uGMTIntermediateEMTFNeg.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated")
+
+l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateEMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFPos")
+l1tdeStage2uGMTIntermediateEMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFPos")
+l1tdeStage2uGMTIntermediateEMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")
+l1tdeStage2uGMTIntermediateEMTFPos.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated")
 
 # sequences
 l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(
@@ -70,5 +110,10 @@ l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMTIntermediateOMTFPosEmul +
     l1tStage2uGMTIntermediateEMTFNegEmul +
     l1tStage2uGMTIntermediateEMTFPosEmul +
-    l1tdeStage2uGMT
+    l1tdeStage2uGMT +
+    l1tdeStage2uGMTIntermediateBMTF +
+    l1tdeStage2uGMTIntermediateOMTFNeg +
+    l1tdeStage2uGMTIntermediateOMTFPos +
+    l1tdeStage2uGMTIntermediateEMTFNeg +
+    l1tdeStage2uGMTIntermediateEMTFPos
 )

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -53,6 +53,36 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   summary->setBinLabel(ISOBAD, "iso mismatch", 1);
   summary->setBinLabel(IDXBAD, "index mismatch", 1);
 
+  errorSummaryNum = ibooker.book1D("errorSummaryNum", summaryTitle.c_str(), 13, 1, 14); // range to match bin numbering
+  errorSummaryNum->setBinLabel(RBXRANGE, "BX range mismatch", 1);
+  errorSummaryNum->setBinLabel(RNMUON, "muon collection size mismatch", 1);
+  errorSummaryNum->setBinLabel(RMUON, "mismatching muons", 1);
+  errorSummaryNum->setBinLabel(RPT, "p_{T} mismatch", 1);
+  errorSummaryNum->setBinLabel(RETA, "#eta mismatch", 1);
+  errorSummaryNum->setBinLabel(RPHI, "#phi mismatch", 1);
+  errorSummaryNum->setBinLabel(RETAATVTX, "#eta at vertex mismatch", 1);
+  errorSummaryNum->setBinLabel(RPHIATVTX, "#phi at vertex mismatch", 1);
+  errorSummaryNum->setBinLabel(RCHARGE, "charge mismatch", 1);
+  errorSummaryNum->setBinLabel(RCHARGEVAL, "charge valid mismatch", 1);
+  errorSummaryNum->setBinLabel(RQUAL, "quality mismatch", 1);
+  errorSummaryNum->setBinLabel(RISO, "iso mismatch", 1);
+  errorSummaryNum->setBinLabel(RIDX, "index mismatch", 1);
+
+  errorSummaryDen = ibooker.book1D("errorSummaryDen", "denominators", 13, 1, 14); // range to match bin numbering
+  errorSummaryDen->setBinLabel(RBXRANGE, "# events", 1);
+  errorSummaryDen->setBinLabel(RNMUON, "# muon collections", 1);
+  errorSummaryDen->setBinLabel(RMUON, "# muons", 1);
+  errorSummaryDen->setBinLabel(RPT, "# muons", 1);
+  errorSummaryDen->setBinLabel(RETA, "# muons", 1);
+  errorSummaryDen->setBinLabel(RPHI, "# muons", 1);
+  errorSummaryDen->setBinLabel(RETAATVTX, "# muons", 1);
+  errorSummaryDen->setBinLabel(RPHIATVTX, "# muons", 1);
+  errorSummaryDen->setBinLabel(RCHARGE, "# muons", 1);
+  errorSummaryDen->setBinLabel(RCHARGEVAL, "# muons", 1);
+  errorSummaryDen->setBinLabel(RQUAL, "# muons", 1);
+  errorSummaryDen->setBinLabel(RISO, "# muons", 1);
+  errorSummaryDen->setBinLabel(RIDX, "# muons", 1);
+
   muColl1BxRange = ibooker.book1D("muColl1BxRange", (muonColl1Title+" mismatching BX range").c_str(), 5, -2.5, 2.5);
   muColl1BxRange->setAxisTitle("BX range", 1);
   muColl1nMu = ibooker.book1D("muColl1nMu", (muonColl1Title+" mismatching muon multiplicity").c_str(), 9, -0.5, 8.5);
@@ -113,10 +143,12 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
   e.getByToken(muonToken1, muonBxColl1);
   e.getByToken(muonToken2, muonBxColl2);
 
+  errorSummaryDen->Fill(RBXRANGE);
   int bxRange1 = muonBxColl1->getLastBX() - muonBxColl1->getFirstBX() + 1;
   int bxRange2 = muonBxColl2->getLastBX() - muonBxColl2->getFirstBX() + 1;
   if (bxRange1 != bxRange2) {
     summary->Fill(BXRANGEBAD);
+    errorSummaryNum->Fill(RBXRANGE);
     int bx;
     for (bx = muonBxColl1->getFirstBX(); bx <= muonBxColl1->getLastBX(); ++bx) {
         muColl1BxRange->Fill(bx);
@@ -135,9 +167,11 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
     l1t::MuonBxCollection::const_iterator muonIt1;
     l1t::MuonBxCollection::const_iterator muonIt2;
 
+    errorSummaryDen->Fill(RNMUON);
     // check number of muons
     if (muonBxColl1->size(iBx) != muonBxColl2->size(iBx)) {
       summary->Fill(NMUONBAD);
+      errorSummaryNum->Fill(RNMUON);
       muColl1nMu->Fill(muonBxColl1->size(iBx));
       muColl2nMu->Fill(muonBxColl2->size(iBx));
 
@@ -178,50 +212,65 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
     muonIt2 = muonBxColl2->begin(iBx);
     while(muonIt1 != muonBxColl1->end(iBx) && muonIt2 != muonBxColl2->end(iBx)) {
       summary->Fill(MUONALL);
+      for (int i = RMUON; i <= RIDX; ++i) {
+        errorSummaryDen->Fill(i);
+      }
 
       bool muonMismatch = false;
       if (muonIt1->hwPt() != muonIt2->hwPt()) {
         muonMismatch = true;
         summary->Fill(PTBAD);
+        errorSummaryNum->Fill(RPT);
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
         muonMismatch = true;
         summary->Fill(ETABAD);
+        errorSummaryNum->Fill(RETA);
       }
       if (muonIt1->hwPhi() != muonIt2->hwPhi()) {
         muonMismatch = true;
         summary->Fill(PHIBAD);
+        errorSummaryNum->Fill(RPHI);
       }
       if (muonIt1->hwEtaAtVtx() != muonIt2->hwEtaAtVtx()) {
         muonMismatch = true;
         summary->Fill(ETAATVTXBAD);
+        errorSummaryNum->Fill(RETAATVTX);
       }
       if (muonIt1->hwPhiAtVtx() != muonIt2->hwPhiAtVtx()) {
         muonMismatch = true;
         summary->Fill(PHIATVTXBAD);
+        errorSummaryNum->Fill(RPHIATVTX);
       }
       if (muonIt1->hwCharge() != muonIt2->hwCharge()) {
         muonMismatch = true;
         summary->Fill(CHARGEBAD);
+        errorSummaryNum->Fill(RCHARGE);
       }
       if (muonIt1->hwChargeValid() != muonIt2->hwChargeValid()) {
         muonMismatch = true;
         summary->Fill(CHARGEVALBAD);
+        errorSummaryNum->Fill(RCHARGEVAL);
       }
       if (muonIt1->hwQual() != muonIt2->hwQual()) {
         muonMismatch = true;
         summary->Fill(QUALBAD);
+        errorSummaryNum->Fill(RQUAL);
       }
       if (muonIt1->hwIso() != muonIt2->hwIso()) {
         muonMismatch = true;
         summary->Fill(ISOBAD);
+        errorSummaryNum->Fill(RISO);
       }
       if (muonIt1->tfMuonIndex() != muonIt2->tfMuonIndex()) {
         muonMismatch = true;
         summary->Fill(IDXBAD);
+        errorSummaryNum->Fill(RIDX);
       }
 
       if (muonMismatch) {
+        errorSummaryNum->Fill(RMUON);
+
         muColl1hwPt->Fill(muonIt1->hwPt());
         muColl1hwEta->Fill(muonIt1->hwEta());
         muColl1hwPhi->Fill(muonIt1->hwPhi());

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonCandComp.cc
@@ -61,6 +61,38 @@ void L1TStage2RegionalMuonCandComp::bookHistograms(DQMStore::IBooker& ibooker, c
   summary->setBinLabel(TFBAD, "track finder type mismatch", 1);
   summary->setBinLabel(TRACKADDRBAD, "track address mismatch", 1);
 
+  errorSummaryNum = ibooker.book1D("errorSummaryNum", (summaryTitle+trkAddrIgnoreText).c_str(), 14, 1, 15); // range to match bin numbering
+  errorSummaryNum->setBinLabel(RBXRANGE, "BX range mismatch", 1);
+  errorSummaryNum->setBinLabel(RNMUON, "muon collection size mismatch", 1);
+  errorSummaryNum->setBinLabel(RMUON, "mismatching muons", 1);
+  errorSummaryNum->setBinLabel(RPT, "p_{T} mismatch", 1);
+  errorSummaryNum->setBinLabel(RETA, "#eta mismatch", 1);
+  errorSummaryNum->setBinLabel(RLOCALPHI, "local #phi mismatch", 1);
+  errorSummaryNum->setBinLabel(RSIGN, "sign mismatch", 1);
+  errorSummaryNum->setBinLabel(RSIGNVAL, "sign valid mismatch", 1);
+  errorSummaryNum->setBinLabel(RQUAL, "quality mismatch", 1);
+  errorSummaryNum->setBinLabel(RHF, "HF bit mismatch", 1);
+  errorSummaryNum->setBinLabel(RLINK, "link mismatch", 1);
+  errorSummaryNum->setBinLabel(RPROC, "processor mismatch", 1);
+  errorSummaryNum->setBinLabel(RTF, "track finder type mismatch", 1);
+  errorSummaryNum->setBinLabel(RTRACKADDR, "track address mismatch", 1);
+
+  errorSummaryDen = ibooker.book1D("errorSummaryDen", "denominators", 14, 1, 15); // range to match bin numbering
+  errorSummaryDen->setBinLabel(RBXRANGE, "# events", 1);
+  errorSummaryDen->setBinLabel(RNMUON, "# muon collections", 1);
+  errorSummaryDen->setBinLabel(RMUON, "# muons", 1);
+  errorSummaryDen->setBinLabel(RPT, "# muons", 1);
+  errorSummaryDen->setBinLabel(RETA, "# muons", 1);
+  errorSummaryDen->setBinLabel(RLOCALPHI, "# muons", 1);
+  errorSummaryDen->setBinLabel(RSIGN, "# muons", 1);
+  errorSummaryDen->setBinLabel(RSIGNVAL, "# muons", 1);
+  errorSummaryDen->setBinLabel(RQUAL, "# muons", 1);
+  errorSummaryDen->setBinLabel(RHF, "# muons", 1);
+  errorSummaryDen->setBinLabel(RLINK, "# muons", 1);
+  errorSummaryDen->setBinLabel(RPROC, "# muons", 1);
+  errorSummaryDen->setBinLabel(RTF, "# muons", 1);
+  errorSummaryDen->setBinLabel(RTRACKADDR, "# muons", 1);
+
   muColl1BxRange = ibooker.book1D("muColl1BxRange", (muonColl1Title+" mismatching BX range").c_str(), 11, -5.5, 5.5);
   muColl1BxRange->setAxisTitle("BX range", 1);
   muColl1nMu = ibooker.book1D("muColl1nMu", (muonColl1Title+" mismatching muon multiplicity").c_str(), 37, -0.5, 36.5);
@@ -141,10 +173,12 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
   e.getByToken(muonToken1, muonBxColl1);
   e.getByToken(muonToken2, muonBxColl2);
 
+  errorSummaryDen->Fill(RBXRANGE);
   int bxRange1 = muonBxColl1->getLastBX() - muonBxColl1->getFirstBX() + 1;
   int bxRange2 = muonBxColl2->getLastBX() - muonBxColl2->getFirstBX() + 1;
   if (bxRange1 != bxRange2) {
     summary->Fill(BXRANGEBAD);
+    errorSummaryNum->Fill(RBXRANGE);
     int bx;
     for (bx = muonBxColl1->getFirstBX(); bx <= muonBxColl1->getLastBX(); ++bx) {
         muColl1BxRange->Fill(bx);
@@ -163,9 +197,11 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
     l1t::RegionalMuonCandBxCollection::const_iterator muonIt1;
     l1t::RegionalMuonCandBxCollection::const_iterator muonIt2;
 
+    errorSummaryDen->Fill(RNMUON);
     // check number of muons
     if (muonBxColl1->size(iBx) != muonBxColl2->size(iBx)) {
       summary->Fill(NMUONBAD);
+      errorSummaryNum->Fill(RNMUON);
       muColl1nMu->Fill(muonBxColl1->size(iBx));
       muColl2nMu->Fill(muonBxColl2->size(iBx));
 
@@ -225,43 +261,55 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
       //          << ", hwQual=" << muonIt2->hwQual() << ", link=" << muonIt2->link() << ", processor=" << muonIt2->processor()
       //          << ", trackFinderType=" << muonIt2->trackFinderType() << std::endl;
       summary->Fill(MUONALL);
+      for (int i = RMUON; i <= RTRACKADDR; ++i) {
+        errorSummaryDen->Fill(i);
+      }
 
       bool muonMismatch = false;
       if (muonIt1->hwPt() != muonIt2->hwPt()) {
         muonMismatch = true;
         summary->Fill(PTBAD);
+        errorSummaryNum->Fill(RPT);
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
         muonMismatch = true;
         summary->Fill(ETABAD);
+        errorSummaryNum->Fill(RETA);
       }
       if (muonIt1->hwPhi() != muonIt2->hwPhi()) {
         muonMismatch = true;
         summary->Fill(LOCALPHIBAD);
+        errorSummaryNum->Fill(RLOCALPHI);
       }
       if (muonIt1->hwSign() != muonIt2->hwSign()) {
         muonMismatch = true;
         summary->Fill(SIGNBAD);
+        errorSummaryNum->Fill(RSIGN);
       }
       if (muonIt1->hwSignValid() != muonIt2->hwSignValid()) {
         muonMismatch = true;
         summary->Fill(SIGNVALBAD);
+        errorSummaryNum->Fill(RSIGNVAL);
       }
       if (muonIt1->hwQual() != muonIt2->hwQual()) {
         muonMismatch = true;
         summary->Fill(QUALBAD);
+        errorSummaryNum->Fill(RQUAL);
       }
       if (muonIt1->link() != muonIt2->link()) {
         muonMismatch = true;
         summary->Fill(LINKBAD);
+        errorSummaryNum->Fill(RLINK);
       }
       if (muonIt1->processor() != muonIt2->processor()) {
         muonMismatch = true;
         summary->Fill(PROCBAD);
+        errorSummaryNum->Fill(RPROC);
       }
       if (muonIt1->trackFinderType() != muonIt2->trackFinderType()) {
         muonMismatch = true;
         summary->Fill(TFBAD);
+        errorSummaryNum->Fill(RTF);
       }
       // check track address
       const std::map<int, int> muon1TrackAddr = muonIt1->trackAddress();
@@ -285,9 +333,12 @@ void L1TStage2RegionalMuonCandComp::analyze(const edm::Event& e, const edm::Even
           muonMismatch = true;
         }
         summary->Fill(TRACKADDRBAD);
+        errorSummaryNum->Fill(RTRACKADDR);
       }
 
       if (muonMismatch) {
+        errorSummaryNum->Fill(RMUON);
+
         muColl1hwPt->Fill(muonIt1->hwPt());
         muColl1hwEta->Fill(muonIt1->hwEta());
         muColl1hwPhi->Fill(muonIt1->hwPhi());

--- a/DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h
@@ -1,0 +1,40 @@
+#ifndef DQM_L1TMonitorClient_L1TStage2RatioClient_H
+#define DQM_L1TMonitorClient_L1TStage2RatioClient_H
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+class L1TStage2RatioClient: public DQMEDHarvester
+{
+  public:
+
+    L1TStage2RatioClient(const edm::ParameterSet&);
+    virtual ~L1TStage2RatioClient();
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  protected:
+
+    virtual void dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter)override;
+    virtual void dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,DQMStore::IGetter& igetter,const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
+
+  private:
+
+    void book(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter);
+    void processHistograms(DQMStore::IGetter& igetter);
+
+    std::string monitorDir_;
+    std::string inputNum_;
+    std::string inputDen_;
+    std::string ratioName_;
+    std::string ratioTitle_;
+    std::string yAxisTitle_;
+    bool binomialErr_;
+
+    MonitorElement* ratioME_;
+};
+
+#endif
+

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+# RegionalMuonCands
+l1tStage2BMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2BMTF'),
+    inputNum = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF muons and BMTF emulator muons'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+# sequences
+l1tStage2BMTFEmulatorClient = cms.Sequence(
+    l1tStage2BMTFEmulatorCompRatioClient
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+# RegionalMuonCands
+l1tStage2EMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2EMTF'),
+    inputNum = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between EMTF muons and EMTF emulator muons'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+# sequences
+l1tStage2EMTFEmulatorClient = cms.Sequence(
+    l1tStage2EMTFEmulatorCompRatioClient
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -20,6 +20,18 @@ import FWCore.ParameterSet.Config as cms
 # Calo trigger layer2 client
 from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClient_cfi import *
 
+# uGMT emulator client
+from DQM.L1TMonitorClient.L1TStage2uGMTEmulatorClient_cff import *
+
+# BMTF emulator client
+from DQM.L1TMonitorClient.L1TStage2BMTFEmulatorClient_cff import *
+
+# OMTF emulator client
+from DQM.L1TMonitorClient.L1TStage2OMTFEmulatorClient_cff import *
+
+# EMTF emulator client
+from DQM.L1TMonitorClient.L1TStage2EMTFEmulatorClient_cff import *
+
 # L1 emulator event info DQM client 
 # TODO: emulator summaryMap
 #from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
@@ -32,6 +44,10 @@ from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClient_cfi import *
 # L1T monitor client sequence (system clients and quality tests)
 l1TStage2EmulatorClients = cms.Sequence(
                         l1tStage2CaloLayer2DEClient
+                      + l1tStage2uGMTEmulatorClient
+                      + l1tStage2BMTFEmulatorClient
+                      + l1tStage2OMTFEmulatorClient
+                      + l1tStage2EMTFEmulatorClient
                         # l1tStage2EmulatorEventInfoClient 
                         )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2MonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2MonitorClient_cff.py
@@ -19,6 +19,8 @@ from DQM.L1TMonitorClient.L1TStage2QualityTests_cff import *
 # L1 event info DQM client 
 from DQM.L1TMonitorClient.L1TStage2EventInfoClient_cfi import *
 
+# uGMT client
+from DQM.L1TMonitorClient.L1TStage2uGMTClient_cff import *
 
 #
 # define sequences 
@@ -26,7 +28,8 @@ from DQM.L1TMonitorClient.L1TStage2EventInfoClient_cfi import *
 
 # L1T monitor client sequence (system clients and quality tests)
 l1TStage2Clients = cms.Sequence(
-                        l1tStage2EventInfoClient 
+                        l1tStage2EventInfoClient
+                      + l1tStage2uGMTClient
                         )
 
 l1tStage2MonitorClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+# RegionalMuonCands
+l1tStage2OMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2OMTF'),
+    inputNum = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between OMTF muons and OMTF emulator muons'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+# sequences
+l1tStage2OMTFEmulatorClient = cms.Sequence(
+    l1tStage2OMTFEmulatorCompRatioClient
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -1,0 +1,131 @@
+import FWCore.ParameterSet.Config as cms
+
+# Muons
+l1tStage2uGMTOutVsuGTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT output muons and uGT input muons'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 1'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 2'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 3'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 4'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 5'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+# RegionalMuonCands
+l1tStage2BmtfOutVsuGMTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2EmtfOutVsuGMTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from EMTF'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+# zero suppression
+l1tStage2uGMTZeroSuppRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of bad zero suppression rates'),
+    yAxisTitle = cms.untracked.string('# fail / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+l1tStage2uGMTZeroSuppFatEvtsRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts'),
+    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of bad zero suppression rates'),
+    yAxisTitle = cms.untracked.string('# fail / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+# sequences
+l1tStage2uGMTMuonCompClient = cms.Sequence(
+    l1tStage2uGMTOutVsuGTInRatioClient
+  + l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient
+  + l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient
+  + l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient
+  + l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient
+  + l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient
+)
+
+l1tStage2uGMTRegionalMuonCandCompClient = cms.Sequence(
+    l1tStage2BmtfOutVsuGMTInRatioClient
+  + l1tStage2EmtfOutVsuGMTInRatioClient
+)
+
+l1tStage2uGMTZeroSuppCompClient = cms.Sequence(
+    l1tStage2uGMTZeroSuppRatioClient
+  + l1tStage2uGMTZeroSuppFatEvtsRatioClient
+)
+
+l1tStage2uGMTClient = cms.Sequence(
+    l1tStage2uGMTMuonCompClient
+  + l1tStage2uGMTRegionalMuonCandCompClient
+  + l1tStage2uGMTZeroSuppCompClient
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -1,10 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
+# directory path shortening
+ugmtDqmDir = 'L1T/L1TStage2uGMT'
+ugmtMuCpyDqmDir = ugmtDqmDir+'/uGMTMuonCopies'
+ugmtZSDqmDir = ugmtDqmDir+'/zeroSuppression'
+# input histograms
+errHistNumStr = 'errorSummaryNum'
+errHistDenStr = 'errorSummaryDen'
+
 # Muons
 l1tStage2uGMTOutVsuGTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/errorSummaryDen'),
+    monitorDir = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput'),
+    inputNum = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistDenStr),
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT output muons and uGT input muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
@@ -12,60 +20,60 @@ l1tStage2uGMTOutVsuGTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
 )
 
 l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1')
-l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryNum')
-l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1')
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1/'+errHistNumStr)
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1/'+errHistDenStr)
 l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 1')
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2')
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryNum')
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy2')
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistNumStr)
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistDenStr)
 l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 2')
 
 l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3')
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryNum')
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy3')
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistNumStr)
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistDenStr)
 l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 3')
 
 l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4')
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryNum')
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy4')
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistNumStr)
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistDenStr)
 l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 4')
 
 l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5')
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryNum')
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy5')
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistNumStr)
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistDenStr)
 l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 5')
 
 # RegionalMuonCands
 l1tStage2BmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput')
-l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryNum')
-l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryDen')
+l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput')
+l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr)
+l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF')
 
 l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput')
-l1tStage2EmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryNum')
-l1tStage2EmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryDen')
+l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput')
+l1tStage2EmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistNumStr)
+l1tStage2EmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistDenStr)
 l1tStage2EmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from EMTF')
 
 # zero suppression
 l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
-l1tStage2uGMTZeroSuppRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts')
-l1tStage2uGMTZeroSuppRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryNum')
-l1tStage2uGMTZeroSuppRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryDen')
+l1tStage2uGMTZeroSuppRatioClient.monitorDir = cms.untracked.string(ugmtZSDqmDir+'/AllEvts')
+l1tStage2uGMTZeroSuppRatioClient.inputNum = cms.untracked.string(ugmtZSDqmDir+'/AllEvts/'+errHistNumStr)
+l1tStage2uGMTZeroSuppRatioClient.inputDen = cms.untracked.string(ugmtZSDqmDir+'/AllEvts/'+errHistDenStr)
 l1tStage2uGMTZeroSuppRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
 l1tStage2uGMTZeroSuppRatioClient.yAxisTitle = cms.untracked.string('# fail / # total')
 
 l1tStage2uGMTZeroSuppFatEvtsRatioClient = l1tStage2uGMTZeroSuppRatioClient.clone()
-l1tStage2uGMTZeroSuppFatEvtsRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts')
-l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryNum')
-l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryDen')
+l1tStage2uGMTZeroSuppFatEvtsRatioClient.monitorDir = cms.untracked.string(ugmtZSDqmDir+'/FatEvts')
+l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputNum = cms.untracked.string(ugmtZSDqmDir+'/FatEvts/'+errHistNumStr)
+l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputDen = cms.untracked.string(ugmtZSDqmDir+'/FatEvts/'+errHistDenStr)
 l1tStage2uGMTZeroSuppFatEvtsRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
 
 # sequences

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -11,97 +11,62 @@ l1tStage2uGMTOutVsuGTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
     binomialErr = cms.untracked.bool(True)
 )
 
-l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 1'),
-    yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1')
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryNum')
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy1/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 1')
 
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 2'),
-    yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2')
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryNum')
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 2')
 
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 3'),
-    yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3')
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryNum')
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 3')
 
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 4'),
-    yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4')
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryNum')
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 4')
 
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 5'),
-    yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5')
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryNum')
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/errorSummaryDen')
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 5')
 
 # RegionalMuonCands
-l1tStage2BmtfOutVsuGMTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF'),
-    yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2BmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput')
+l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryNum')
+l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/errorSummaryDen')
+l1tStage2BmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF')
 
-l1tStage2EmtfOutVsuGMTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from EMTF'),
-    yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput')
+l1tStage2EmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryNum')
+l1tStage2EmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/errorSummaryDen')
+l1tStage2EmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from EMTF')
 
 # zero suppression
-l1tStage2uGMTZeroSuppRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of bad zero suppression rates'),
-    yAxisTitle = cms.untracked.string('# fail / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
+l1tStage2uGMTZeroSuppRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts')
+l1tStage2uGMTZeroSuppRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryNum')
+l1tStage2uGMTZeroSuppRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/AllEvts/errorSummaryDen')
+l1tStage2uGMTZeroSuppRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
+l1tStage2uGMTZeroSuppRatioClient.yAxisTitle = cms.untracked.string('# fail / # total')
 
-l1tStage2uGMTZeroSuppFatEvtsRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts'),
-    inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryDen'),
-    ratioName = cms.untracked.string('mismatchRatio'),
-    ratioTitle = cms.untracked.string('Summary of bad zero suppression rates'),
-    yAxisTitle = cms.untracked.string('# fail / # total'),
-    binomialErr = cms.untracked.bool(True)
-)
+l1tStage2uGMTZeroSuppFatEvtsRatioClient = l1tStage2uGMTZeroSuppRatioClient.clone()
+l1tStage2uGMTZeroSuppFatEvtsRatioClient.monitorDir = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts')
+l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputNum = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryNum')
+l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputDen = cms.untracked.string('L1T/L1TStage2uGMT/zeroSuppression/FatEvts/errorSummaryDen')
+l1tStage2uGMTZeroSuppFatEvtsRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
 
 # sequences
 l1tStage2uGMTMuonCompClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+# Muons
+l1tStage2uGMTEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison'),
+    inputNum = cms.untracked.string('L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/errorSummaryNum'),
+    inputDen = cms.untracked.string('L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/errorSummaryDen'),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT emulator muons'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True)
+)
+
+# sequences
+l1tStage2uGMTEmulatorClient = cms.Sequence(
+    l1tStage2uGMTEmulatorCompRatioClient
+)
+

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -1,18 +1,63 @@
 import FWCore.ParameterSet.Config as cms
 
+# directories
+ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
+ugmtEmuDEDqmDir = ugmtEmuDqmDir+"/data_vs_emulator_comparison"
+ugmtEmuImdMuDqmDir = ugmtEmuDqmDir+"/intermediate_muons"
+# input histograms
+errHistNumStr = 'errorSummaryNum'
+errHistDenStr = 'errorSummaryDen'
+
 # Muons
 l1tStage2uGMTEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
-    monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison'),
-    inputNum = cms.untracked.string('L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/errorSummaryNum'),
-    inputDen = cms.untracked.string('L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/errorSummaryDen'),
+    monitorDir = cms.untracked.string(ugmtEmuDEDqmDir),
+    inputNum = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistDenStr),
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT emulator muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
     binomialErr = cms.untracked.bool(True)
 )
 
+# intermediate muons
+titleStr = 'Summary of mismatch rates between uGMT intermediate muons and uGMT emulator intermediate muons from '
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison')
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistNumStr)
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistDenStr)
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'BMTF')
+
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison')
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF-')
+
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison')
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF+')
+
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison')
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF-')
+
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison')
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF+')
+
 # sequences
 l1tStage2uGMTEmulatorClient = cms.Sequence(
     l1tStage2uGMTEmulatorCompRatioClient
+  + l1tStage2uGMTEmulImdMuBMTFCompRatioClient
+  + l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient
+  + l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient
+  + l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient
+  + l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient
 )
 

--- a/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
@@ -1,0 +1,81 @@
+#include "DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h"
+
+L1TStage2RatioClient::L1TStage2RatioClient(const edm::ParameterSet& ps):
+  monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")),
+  inputNum_(ps.getUntrackedParameter<std::string>("inputNum")),
+  inputDen_(ps.getUntrackedParameter<std::string>("inputDen")),
+  ratioName_(ps.getUntrackedParameter<std::string>("ratioName")),
+  ratioTitle_(ps.getUntrackedParameter<std::string>("ratioTitle")),
+  yAxisTitle_(ps.getUntrackedParameter<std::string>("yAxisTitle")),
+  binomialErr_(ps.getUntrackedParameter<bool>("binomialErr"))
+{
+}
+
+L1TStage2RatioClient::~L1TStage2RatioClient(){}
+
+void L1TStage2RatioClient::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("monitorDir", "")->setComment("Target directory in the DQM file. Will be created if not existing.");
+  desc.addUntracked<std::string>("inputNum", "")->setComment("Path to numerator histogram.");
+  desc.addUntracked<std::string>("inputDen", "")->setComment("Path to denominator histogram.");
+  desc.addUntracked<std::string>("ratioName", "ratio")->setComment("Ratio plot name.");
+  desc.addUntracked<std::string>("ratioTitle", "ratio")->setComment("Ratio plot title.");
+  desc.addUntracked<std::string>("yAxisTitle", "")->setComment("Title of y axis.");
+  desc.addUntracked<bool>("binomialErr", "true")->setComment("Compute binomial errors.");
+  descriptions.add("l1TStage2RatioClient", desc);
+}
+
+void L1TStage2RatioClient::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c)
+{
+  book(ibooker, igetter);
+  processHistograms(igetter);
+}
+
+void L1TStage2RatioClient::book(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter)
+{
+  ibooker.setCurrentFolder(monitorDir_);
+
+  // get the axis range from the numerator histogram
+  const MonitorElement* numME_ = igetter.get(inputNum_);
+  if (numME_) {
+    TH1F *hNum = numME_->getTH1F();
+
+    ratioME_ = ibooker.book1D(ratioName_, ratioTitle_, hNum->GetNbinsX(), hNum->GetXaxis()->GetXmin(), hNum->GetXaxis()->GetXmax());
+    ratioME_->setAxisTitle(yAxisTitle_, 2);
+  }
+}
+
+void L1TStage2RatioClient::processHistograms(DQMStore::IGetter& igetter)
+{
+  const MonitorElement* numME_ = igetter.get(inputNum_);
+  const MonitorElement* denME_ = igetter.get(inputDen_);
+
+  if (numME_ && denME_) {
+    TH1F *hNum = numME_->getTH1F();
+    TH1F *hDen = dynamic_cast<TH1F *>(denME_->getTH1F()->Clone("den"));
+
+    TH1F *hRatio = ratioME_->getTH1F();
+
+    // Set the axis labels the same as the numerator histogram to be able to divide
+    if (hNum->GetXaxis()->IsAlphanumeric()) {
+      for (int i = 1; i <= hNum->GetNbinsX(); ++i) {
+        hDen->GetXaxis()->SetBinLabel(i, hNum->GetXaxis()->GetBinLabel(i));
+        hRatio->GetXaxis()->SetBinLabel(i, hNum->GetXaxis()->GetBinLabel(i));
+      }
+    }
+
+    std::string errOption;
+    if (binomialErr_) {
+      errOption = "B";
+    }
+     
+    hRatio->Divide(hNum, hDen, 1, 1, errOption.c_str());
+  }
+}
+
+void L1TStage2RatioClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
+  book(ibooker, igetter);
+  processHistograms(igetter);
+}
+

--- a/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
@@ -71,6 +71,8 @@ void L1TStage2RatioClient::processHistograms(DQMStore::IGetter& igetter)
     }
      
     hRatio->Divide(hNum, hDen, 1, 1, errOption.c_str());
+
+    delete hDen;
   }
 }
 

--- a/DQM/L1TMonitorClient/src/SealModule.cc
+++ b/DQM/L1TMonitorClient/src/SealModule.cc
@@ -26,3 +26,6 @@ DEFINE_FWK_MODULE(L1EmulatorErrorFlagClient);
 
 #include <DQM/L1TMonitorClient/interface/L1TStage2CaloLayer2DEClient.h>
 DEFINE_FWK_MODULE(L1TStage2CaloLayer2DEClient);
+
+#include <DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h>
+DEFINE_FWK_MODULE(L1TStage2RatioClient);


### PR DESCRIPTION
Upgrade to the L1 muon online DQM.

Adding plots with ratio of muon and zero suppression mismatches. These are going to be used for quality tests.
Adding data to emulator comparisons for the uGMT intermediate muons.