### PR TITLE
Module for removing overlap (cross-cleaning) PF Jets from taus

### DIFF
--- a/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
+++ b/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
@@ -1,0 +1,35 @@
+#ifndef PFJetsTauOverlapRemoval_H
+#define PFJetsTauOverlapRemoval_H
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/TauReco/interface/PFTauFwd.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
+#include <map>
+#include <vector>
+class PFJetsTauOverlapRemoval: public edm::global::EDProducer<> {
+ public:
+  explicit PFJetsTauOverlapRemoval(const edm::ParameterSet&);
+  ~PFJetsTauOverlapRemoval();
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+ private:
+    
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc;
+  const edm::EDGetTokenT<reco::PFJetCollection> PFJetSrc;
+
+};
+#endif

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -1,0 +1,75 @@
+#include "RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h"
+#include "Math/GenVector/VectorUtil.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+
+//
+// class declaration
+//
+using namespace reco   ;
+using namespace std    ;
+using namespace edm    ;
+using namespace trigger;
+
+PFJetsTauOverlapRemoval::PFJetsTauOverlapRemoval(const edm::ParameterSet& iConfig):
+  tauSrc    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("TauSrc"      ) ) ),
+  PFJetSrc( consumes<PFJetCollection>(iConfig.getParameter<InputTag>("PFJetSrc") ) )
+{  
+  produces<PFJetCollection>();
+}
+PFJetsTauOverlapRemoval::~PFJetsTauOverlapRemoval(){ }
+
+void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
+{
+    
+  unique_ptr<PFJetCollection> cleanedPFJets(new PFJetCollection);
+    
+  double deltaR    = 1.0;
+  double matchingR = 0.5;
+  
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> tauJets;
+  iEvent.getByToken( tauSrc, tauJets );
+  
+  edm::Handle<PFJetCollection> PFJets;
+  iEvent.getByToken(PFJetSrc,PFJets);
+                
+  trigger::VRpftau taus; 
+  tauJets->getObjects(trigger::TriggerTau,taus);
+  
+  if(edm::InputTag("PFJetSrc") == edm::InputTag("L1PFJetsMatching","TwoJets")){
+    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+      for(unsigned int iJet = 0; iJet < PFJets->size(); iJet++){
+        const PFJet &  myPFJet = (*PFJets)[iJet];
+        deltaR = ROOT::Math::VectorUtil::DeltaR((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+        if(deltaR > matchingR ) cleanedPFJets->push_back(myPFJet);
+         
+        break;
+      }
+    }
+  }
+  if(edm::InputTag("PFJetSrc") == edm::InputTag("L1PFJetsMatching","ThreeJets")){
+    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+      for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
+        const PFJet &  myPFJet = (*PFJets)[iJet];
+        deltaR = ROOT::Math::VectorUtil::DeltaR((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+        if(deltaR > matchingR ) cleanedPFJets->push_back(myPFJet);
+        
+        break;
+      }
+    }
+    if(PFJets->size() > 2) cleanedPFJets->push_back((*PFJets)[2]);
+  }
+ 
+  
+  iEvent.put(std::move(cleanedPFJets));
+}
+
+void PFJetsTauOverlapRemoval::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("PFJetSrc", edm::InputTag("hltAK4PFJetsCorrectedIDPassed"                     ))->setComment("Input collection of PFJets"    );
+  desc.add<edm::InputTag>("TauSrc"      , edm::InputTag("hltPFTau20TrackLooseIso"))->setComment("Input collection of PFTaus that have passed ID and isolation requirements");
+  descriptions.setComment("This module produces a collection of PFJets that are cross-cleaned with respect to PFTaus passing a HLT filter.");
+  descriptions.add       ("PFJetsTauOverlapRemoval",desc);
+}

--- a/RecoTauTag/HLTProducers/src/SealModule.cc
+++ b/RecoTauTag/HLTProducers/src/SealModule.cc
@@ -25,6 +25,14 @@ DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, TauRegionalPixelSeedGenerator, 
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, TrackingRegionsFromBeamSpotAndL2Tau, "TrackingRegionsFromBeamSpotAndL2Tau");
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, CandidateSeededTrackingRegionsProducer, "CandidateSeededTrackingRegionsProducer");
 
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
+using TauRegionalPixelSeedTrackingRegionEDProducer = TrackingRegionEDProducerT<TauRegionalPixelSeedGenerator>;
+DEFINE_FWK_MODULE(TauRegionalPixelSeedTrackingRegionEDProducer);
+using CandidateSeededTrackingRegionsEDProducer = TrackingRegionEDProducerT<CandidateSeededTrackingRegionsProducer>;
+DEFINE_FWK_MODULE(CandidateSeededTrackingRegionsEDProducer);
+using TrackingRegionsFromBeamSpotAndL2TauEDProducer = TrackingRegionEDProducerT<TrackingRegionsFromBeamSpotAndL2Tau>;
+DEFINE_FWK_MODULE(TrackingRegionsFromBeamSpotAndL2TauEDProducer);
+
 DEFINE_FWK_MODULE(L2TauJetsMerger);
 DEFINE_FWK_MODULE(L1HLTJetsMatching);
 DEFINE_FWK_MODULE(L1HLTTauMatching);

--- a/RecoTauTag/HLTProducers/src/SealModule.cc
+++ b/RecoTauTag/HLTProducers/src/SealModule.cc
@@ -19,18 +19,11 @@
 //#include "RecoTauTag/HLTProducers/interface/L2TauPixelTrackMatch.h"
 #include "HLTPFTauPairLeadTrackDzMatchFilter.h"
 #include "RecoTauTag/HLTProducers/interface/L2TauPixelIsoTagProducer.h"
+#include "RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h"
 
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, TauRegionalPixelSeedGenerator, "TauRegionalPixelSeedGenerator");      
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, TrackingRegionsFromBeamSpotAndL2Tau, "TrackingRegionsFromBeamSpotAndL2Tau");
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, CandidateSeededTrackingRegionsProducer, "CandidateSeededTrackingRegionsProducer");
-
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
-using TauRegionalPixelSeedTrackingRegionEDProducer = TrackingRegionEDProducerT<TauRegionalPixelSeedGenerator>;
-DEFINE_FWK_MODULE(TauRegionalPixelSeedTrackingRegionEDProducer);
-using CandidateSeededTrackingRegionsEDProducer = TrackingRegionEDProducerT<CandidateSeededTrackingRegionsProducer>;
-DEFINE_FWK_MODULE(CandidateSeededTrackingRegionsEDProducer);
-using TrackingRegionsFromBeamSpotAndL2TauEDProducer = TrackingRegionEDProducerT<TrackingRegionsFromBeamSpotAndL2Tau>;
-DEFINE_FWK_MODULE(TrackingRegionsFromBeamSpotAndL2TauEDProducer);
 
 DEFINE_FWK_MODULE(L2TauJetsMerger);
 DEFINE_FWK_MODULE(L1HLTJetsMatching);
@@ -45,4 +38,4 @@ DEFINE_FWK_MODULE(VertexFromTrackProducer);
 //DEFINE_FWK_MODULE(L2TauPixelTrackMatch);
 DEFINE_FWK_MODULE(HLTPFTauPairLeadTrackDzMatchFilter);
 DEFINE_FWK_MODULE(L2TauPixelIsoTagProducer);
-
+DEFINE_FWK_MODULE(PFJetsTauOverlapRemoval);


### PR DESCRIPTION
This module is able to cross-clean PFJets from Taus that are ID and isolated. This is helpful for a HLT VBF + Tau path where we need to remove overlap such that we have two clean and well-defined collections at the end of the path.