### PR TITLE
OnlineDQM: Add Chi2 2D Quality Test

### DIFF
--- a/DQMServices/ClientConfig/interface/QTestConfigure.h
+++ b/DQMServices/ClientConfig/interface/QTestConfigure.h
@@ -65,6 +65,10 @@ class QTestConfigure{
  void EnableComp2RefChi2Test(std::string testName, 
                      const std::map<std::string, std::string>& params,DQMStore * bei); 
 
+///Creates Comp2Ref2DChi2 test
+ void EnableComp2Ref2DChi2Test(std::string testName, 
+                     const std::map<std::string, std::string>& params,DQMStore * bei); 
+
  ///Creates EnableComp2RefKolmogorov test
  void EnableComp2RefKolmogorovTest(std::string testName, 
                      const std::map<std::string, std::string>& params,DQMStore * bei); 

--- a/DQMServices/ClientConfig/src/QTestConfigure.cc
+++ b/DQMServices/ClientConfig/src/QTestConfigure.cc
@@ -50,6 +50,8 @@ bool QTestConfigure::enableTests(
       this->EnableComp2RefEqualHTest(testName, params,bei);
     if(!std::strcmp(testType.c_str(),  Comp2RefChi2::getAlgoName().c_str()))
       this->EnableComp2RefChi2Test(testName, params,bei);
+    if(!std::strcmp(testType.c_str(),  Comp2Ref2DChi2::getAlgoName().c_str()))
+      this->EnableComp2Ref2DChi2Test(testName, params,bei);
     if(!std::strcmp(testType.c_str(),Comp2RefKolmogorov::getAlgoName().c_str()))
       this->EnableComp2RefKolmogorovTest(testName, params,bei);
     if(!std::strcmp(testType.c_str(),ContentsWithinExpected::getAlgoName().c_str()))
@@ -98,6 +100,25 @@ void QTestConfigure::EnableComp2RefChi2Test(std::string testName,
   me_qc1->setErrorProb(error);
 }
 
+void QTestConfigure::EnableComp2Ref2DChi2Test(std::string testName,
+                                              const std::map<std::string, std::string> & params,
+                                              DQMStore *bei) {
+  QCriterion * qc1;
+  if (! bei->getQCriterion(testName)) {
+    testsConfigured.push_back(testName);
+    qc1 = bei->createQTest(Comp2Ref2DChi2::getAlgoName(), testName);
+  } else {
+    qc1 = bei->getQCriterion(testName);
+  }
+  Comp2Ref2DChi2 * me_qc1 = (Comp2Ref2DChi2 *) qc1;
+  double warning = atof(findOrDefault(params, "warning", "0"));
+  double error   = atof(findOrDefault(params, "error", "0"));
+  int minEntries = atoi(findOrDefault(params, "minEntries", "0"));
+  me_qc1->setWarningProb(warning);
+  me_qc1->setErrorProb(error);
+  if ( minEntries != 0 )
+    me_qc1->setMinimumEntries(minEntries);
+}
 
 void QTestConfigure::EnableComp2RefKolmogorovTest(std::string testName,
                                                   const std::map<std::string, std::string> & params,

--- a/DQMServices/ClientConfig/src/QTestParameterNames.cc
+++ b/DQMServices/ClientConfig/src/QTestParameterNames.cc
@@ -21,6 +21,7 @@ QTestParameterNames::QTestParameterNames(){
 	//======================== new quality tests in the parser =====================//
         this->constructMap(Comp2RefEqualHROOT::getAlgoName(), "testparam");
         this->constructMap(Comp2RefChi2ROOT::getAlgoName(), "testparam");
+        this->constructMap(Comp2Ref2DChi2ROOT::getAlgoName(), "testparam");
         this->constructMap(Comp2RefKolmogorovROOT::getAlgoName(), "testparam");
 
 //        this->constructMap(MostProbableLandauROOT::getAlgoName(), "xmin", "xmax","normalization", "mostprobable", "sigma");

--- a/DQMServices/ClientConfig/test/QT_Comp2Ref2DChi2.xml
+++ b/DQMServices/ClientConfig/test/QT_Comp2Ref2DChi2.xml
@@ -1,0 +1,16 @@
+<TESTSCONFIGURATION>
+
+<QTEST name="exampleQTest">
+        <TYPE>Comp2Ref2DChi2</TYPE>	
+        <PARAM name="testparam">0</PARAM>
+        <PARAM name="minEntries">0</PARAM>
+        <PARAM name="error">0.10</PARAM>
+        <PARAM name="warning">0.40</PARAM>
+</QTEST>
+
+<!-- <LINK name="*clientHisto*"> -->
+ <LINK name="*myHisto1*">
+	<TestName activate="true">exampleQTest</TestName>
+</LINK>
+
+</TESTSCONFIGURATION>

--- a/DQMServices/Core/interface/QTest.h
+++ b/DQMServices/Core/interface/QTest.h
@@ -13,6 +13,7 @@
 //#include "DQMServices/Core/interface/DQMStore.h"
 
 class Comp2RefChi2;			typedef Comp2RefChi2 Comp2RefChi2ROOT;
+class Comp2Ref2DChi2;			typedef Comp2Ref2DChi2 Comp2Ref2DChi2ROOT;
 class Comp2RefKolmogorov;		typedef Comp2RefKolmogorov Comp2RefKolmogorovROOT;
 class Comp2RefEqualH;			typedef Comp2RefEqualH Comp2RefEqualHROOT;
 class ContentsXRange;			typedef ContentsXRange ContentsXRangeROOT;
@@ -188,6 +189,34 @@ public:
     setAlgoName(getAlgoName()); 
   }
   static std::string getAlgoName(void) { return "Comp2RefChi2"; }
+  float runTest(const MonitorElement*me);
+  
+protected:
+
+  void setMessage(void) 
+  {
+    std::ostringstream message;
+    message << "chi2/Ndof = " << chi2_ << "/" << Ndof_
+	    << ", minimum needed statistics = " << minEntries_
+	    << " warning threshold = " << this->warningProb_
+	    << " error threshold = " << this->errorProb_;
+    message_ = message.str();
+  }
+
+  // # of degrees of freedom and chi^2 for test
+  int Ndof_; double chi2_;
+};
+
+//===================== Comp2Ref2DChi2 =================//
+// comparison to reference using the 2D chi^2 algorithm
+class Comp2Ref2DChi2 : public SimpleTest
+{
+public:
+  Comp2Ref2DChi2(const std::string &name) :SimpleTest(name)
+  { 
+    setAlgoName(getAlgoName()); 
+  }
+  static std::string getAlgoName(void) { return "Comp2Ref2DChi2"; }
   float runTest(const MonitorElement*me);
   
 protected:

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -609,6 +609,7 @@ DQMStore::initializeFrom(const edm::ParameterSet& pset) {
   }
 
   initQCriterion<Comp2RefChi2>(qalgos_);
+  initQCriterion<Comp2Ref2DChi2>(qalgos_);
   initQCriterion<Comp2RefKolmogorov>(qalgos_);
   initQCriterion<ContentsXRange>(qalgos_);
   initQCriterion<ContentsYRange>(qalgos_);


### PR DESCRIPTION
Description:
Add a new Chi2 Quality Test to compare a 2D test histogram versus a 2D reference histogram for Online DQM. The Chi2 test is based on the test already implemented in the ROOT framework which  is described here https://root.cern.ch/doc/master/classTH1.html#aa2cecbf3c6a20a1ec3d39b5ec139b6f2 and can be applied to 1D/2D/3D histograms.

Purpose:
The new Chi2 2D Quality Test will be used to compare 2D Online DQM histograms in order to build DQM automatic alarms for L1T.

