### PR TITLE
Make FastSim work with QIE10/11

### DIFF
--- a/FastSimulation/Configuration/python/DigiAliases_cff.py
+++ b/FastSimulation/Configuration/python/DigiAliases_cff.py
@@ -83,11 +83,21 @@ def loadDigiAliases(premix=False):
 
     hcalDigis = cms.EDAlias(
         **{"simHcalDigis" if nopremix else "DMHcalDigis" :
-               cms.VPSet(
+            cms.VPSet(
                 cms.PSet(type = cms.string("HBHEDataFramesSorted")),
                 cms.PSet(type = cms.string("HFDataFramesSorted")),
-                cms.PSet(type = cms.string("HODataFramesSorted"))
+                cms.PSet(type = cms.string("HODataFramesSorted")),
+                cms.PSet(
+                    type = cms.string('QIE10DataFrameHcalDataFrameContainer'),
+                    fromProductInstance = cms.string('HFQIE10DigiCollection'),
+                    toProductInstance = cms.string('')
+                ),
+                cms.PSet(
+                    type = cms.string('QIE11DataFrameHcalDataFrameContainer'),
+                    fromProductInstance = cms.string('HBHEQIE11DigiCollection'),
+                    toProductInstance = cms.string('')
                 )
+            )
            }
           )
 


### PR DESCRIPTION
FastSim has its own set of digi aliases (used to skip the RAW2DIGI step), which need to be extended for the new HCAL data formats.

This has been tested privately by myself and @angirar. (Resubmission of #18961 due to merge conflict)