### PR TITLE
E/gamma T&P Offline DQM : 92X 

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTagAndProbeEff.h
+++ b/DQMOffline/Trigger/interface/HLTTagAndProbeEff.h
@@ -1,0 +1,522 @@
+#ifndef DQMOffline_Trigger_HLTTagAndProbeEff_h
+#define DQMOffline_Trigger_HLTTagAndProbeEff_h
+
+
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/RegexMatch.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include <vector>
+#include <string>
+
+//functions we wish to add that are not direct member functions
+namespace{
+  template<typename ObjType> float scEtaFunc(const ObjType& obj){return obj.superCluster()->eta();}
+ 
+  template<typename ObjType>
+  std::function<float(const ObjType&)> getFunc(const std::string& varName){  
+    std::function<float(const ObjType&)> varFunc;
+    if(varName=="et") varFunc = &ObjType::et;
+    else if(varName=="pt") varFunc = &ObjType::pt;
+    else if(varName=="eta") varFunc = &ObjType::eta;
+    else if(varName=="phi") varFunc = &ObjType::phi;
+    else if(varName=="scEta") varFunc = scEtaFunc<ObjType>;
+    else if(!varName.empty()){
+      throw cms::Exception("ConfigError") <<"var "<<varName<<" not recognised"<<std::endl;
+    }
+    return varFunc;
+  }
+}
+
+namespace{
+  bool passTrig(const float objEta,float objPhi, const trigger::TriggerEvent& trigEvt,
+		const std::string & filterName,const std::string& processName){
+    constexpr float kMaxDR2 = 0.1*0.1;
+    
+    edm::InputTag filterTag(filterName,"",processName); 
+    trigger::size_type filterIndex = trigEvt.filterIndex(filterTag); 
+    if(filterIndex<trigEvt.sizeFilters()){ //check that filter is in triggerEvent
+      const trigger::Keys& trigKeys = trigEvt.filterKeys(filterIndex); 
+      const trigger::TriggerObjectCollection & trigObjColl(trigEvt.getObjects());
+      for(trigger::Keys::const_iterator keyIt=trigKeys.begin();keyIt!=trigKeys.end();++keyIt){ 
+	const trigger::TriggerObject& trigObj = trigObjColl[*keyIt];
+	if(reco::deltaR2(trigObj.eta(),trigObj.phi(),objEta,objPhi)<kMaxDR2) return true;
+      }
+    }
+    return false;
+  }
+  bool passTrig(const float objEta,float objPhi, const trigger::TriggerEvent& trigEvt,
+		const std::vector<std::string>& filterNames,const std::string& processName){
+    for(auto& filterName : filterNames){
+      if(passTrig(objEta,objPhi,trigEvt,filterName,processName)==false) return false;
+    }
+    return true;
+  }
+   //inspired by https://github.com/cms-sw/cmssw/blob/fc4f8bbe1258790e46e2d554aacea15c3e5d9afa/HLTrigger/HLTfilters/src/HLTHighLevel.cc#L124-L165
+   //triggers are ORed together
+   //empty pattern is auto pass
+  bool passTrig(const std::string& trigPattern,const edm::TriggerNames& trigNames,const edm::TriggerResults& trigResults){
+    
+    if(trigPattern.empty()) return true;
+    
+    std::vector<std::string> trigNamesToPass;
+    if(edm::is_glob(trigPattern)){
+     
+      //matches is vector of string iterators
+      const auto& matches = edm::regexMatch(trigNames.triggerNames(),trigPattern);
+      for(auto& name : matches) trigNamesToPass.push_back(*name);
+    }else{
+      trigNamesToPass.push_back(trigPattern); //not a pattern, much be a path
+    }
+    for(auto& trigName : trigNamesToPass){
+      size_t pathIndex = trigNames.triggerIndex(trigName);
+      if(pathIndex<trigResults.size() && 
+	 trigResults.accept(pathIndex)) return true; 
+    }
+    
+    return false;
+  }
+  
+  template<typename T> edm::Handle<T> getHandle(const edm::Event& event,const edm::EDGetTokenT<T>& token){
+    edm::Handle<T> handle;
+    event.getByToken(token,handle);
+    return handle;
+  }
+}
+
+
+template<typename ObjType>
+class RangeCuts {
+public:
+  RangeCuts(const edm::ParameterSet& config){
+    varName_ = config.getParameter<std::string>("rangeVar");
+    varFunc_ = getFunc<ObjType>(varName_);
+    auto ranges = config.getParameter<std::vector<std::string> >("allowedRanges");
+    for(auto range: ranges){
+      std::vector<std::string> splitRange;
+      boost::split(splitRange,range,boost::is_any_of(":"));
+      if(splitRange.size()!=2) throw cms::Exception("ConfigError") <<"range "<<range<<" is not of format X:Y"<<std::endl;
+      allowedRanges_.push_back({std::stof(splitRange[0]),std::stof(splitRange[1])});
+    }
+  }
+  bool operator()(const ObjType& obj)const{
+    if(!varFunc_) return true; //auto pass if we dont specify a variable function
+    else{ 
+      float varVal = varFunc_(obj);
+      for(auto& range : allowedRanges_){
+	if(varVal>=range.first && varVal<range.second) return true;
+      }
+      return false;
+    }
+  }
+  const std::string& varName()const{return varName_;}
+  private:
+  std::string varName_;
+  std::function<float(const ObjType&)> varFunc_;
+  std::vector<std::pair<float,float> > allowedRanges_;
+};
+
+template<typename ObjType>
+class RangeCutsColl {
+public:
+  explicit RangeCutsColl(const std::vector<edm::ParameterSet>& configs){
+    for(const auto & cutConfig : configs) rangeCuts_.emplace_back(RangeCuts<ObjType>(cutConfig));
+  }
+  //if no cuts are defined, it returns true
+  bool operator()(const ObjType& obj)const{
+    for(auto& cut : rangeCuts_){
+      if(!cut(obj)) return false;
+    }
+    return true;
+  }
+  //if no cuts are defined, it returns true
+  //this version allows us to skip a range check for a specificed variable
+  //okay this feature requirement was missed in the initial (very rushed) design phase
+  //and thats why its now hacked in 
+  //basically if you're applying an Et cut, you want to automatically turn it of
+  //when you're making a turn on curve...
+  bool operator()(const ObjType& obj,const std::string& varToSkip)const{
+    for(auto& cut : rangeCuts_){
+      if(cut.varName()==varToSkip) continue;
+      if(!cut(obj)) return false;
+    }
+    return true;
+  }
+  bool operator()(const ObjType& obj,const std::vector<std::string>& varsToSkip)const{
+    for(auto& cut : rangeCuts_){
+      if(std::find(varsToSkip.begin(),varsToSkip.end(),cut.varName())!=varsToSkip.end()) continue;
+      if(!cut(obj)) return false;
+    }
+    return true;
+  }
+private:
+  std::vector<RangeCuts<ObjType> > rangeCuts_;
+};
+
+//our base class for our histograms
+//takes an object, edm::Event,edm::EventSetup and fills the histogram
+//with the predetermined variable (or varaibles) 
+template <typename ObjType> 
+class HLTDQMHist {
+public:
+  HLTDQMHist()=default;
+  virtual ~HLTDQMHist()=default;
+  virtual void fill(const ObjType& objType,const edm::Event& event,
+		    const edm::EventSetup& setup,const RangeCutsColl<ObjType>& rangeCuts)=0;
+};
+
+
+//this class is a specific implimentation of a HLTDQMHist
+//it has the value with which to fill the histogram 
+//and the histogram itself
+//we do not own the histogram
+template <typename ObjType,typename ValType> 
+class HLTDQM1DHist : public HLTDQMHist<ObjType> {
+public:
+  HLTDQM1DHist(TH1* hist,const std::string& varName,
+	       std::function<ValType(const ObjType&)> func,
+	       const RangeCutsColl<ObjType>& rangeCuts):
+    var_(func),varName_(varName),localRangeCuts_(rangeCuts),hist_(hist){}
+  void fill(const ObjType& obj,const edm::Event& event,
+	    const edm::EventSetup& setup,const RangeCutsColl<ObjType>& globalRangeCuts)override{
+    if(globalRangeCuts(obj,varName_) && localRangeCuts_(obj)){  //local range cuts are specific to a histogram so dont ignore variables like global ones (all local cuts should be approprate)
+      hist_->Fill(var_(obj));
+    }
+  }
+private:
+  std::function<ValType(const ObjType&)> var_;
+  std::string varName_;
+  RangeCutsColl<ObjType> localRangeCuts_;
+  TH1* hist_; //we do not own this
+};
+
+template <typename ObjType,typename XValType,typename YValType=XValType> 
+class HLTDQM2DHist : public HLTDQMHist<ObjType> {
+public:
+  HLTDQM2DHist(TH2* hist,const std::string& xVarName,const std::string& yVarName,
+	       std::function<XValType(const ObjType&)> xFunc,
+	       std::function<YValType(const ObjType&)> yFunc,
+	       const RangeCutsColl<ObjType>& rangeCuts):
+    xVar_(xFunc),yVar_(yFunc),
+    xVarName_(xVarName),yVarName_(yVarName),
+    localRangeCuts_(rangeCuts),hist_(hist){}
+
+  void fill(const ObjType& obj,const edm::Event& event,
+	    const edm::EventSetup& setup,const RangeCutsColl<ObjType>& globalRangeCuts)override{
+    if(globalRangeCuts(obj,std::vector<std::string>{xVarName_,yVarName_}) &&
+       localRangeCuts_(obj)){  //local range cuts are specific to a histogram so dont ignore variables like global ones (all local cuts should be approprate)
+      hist_->Fill(xVar_(obj),yVar_(obj));
+    }
+  }
+private:
+  std::function<XValType(const ObjType&)> xVar_;
+  std::function<YValType(const ObjType&)> yVar_;
+  std::string xVarName_;
+  std::string yVarName_;
+  RangeCutsColl<ObjType> localRangeCuts_;
+  TH2* hist_; //we do not own this
+};
+
+template <typename ObjType> 
+class HLTDQMHistColl {
+public:
+  
+  explicit HLTDQMHistColl(const edm::ParameterSet& config,
+			  const std::string& baseHistName,
+			  const std::string& hltProcess);
+  void bookHists(DQMStore::IBooker& iBooker,const std::vector<edm::ParameterSet>& histConfigs);
+  void fillHists(const ObjType& tag,const ObjType& probe,const edm::Event& event,
+		 const edm::EventSetup& setup,const trigger::TriggerEvent& trigEvt);
+private:
+  void book1D(DQMStore::IBooker& iBooker,const edm::ParameterSet& histConfig);
+  void book2D(DQMStore::IBooker& iBooker,const edm::ParameterSet& histConfig);
+private:
+  std::vector<std::unique_ptr<HLTDQMHist<ObjType> > > histsPass_;
+  std::vector<std::unique_ptr<HLTDQMHist<ObjType> > > histsTot_;
+  RangeCutsColl<ObjType> rangeCuts_;
+  std::string filterName_;
+  std::string tagExtraFilter_;
+  std::string baseHistName_;
+  std::string histTitle_;
+  std::string folderName_;
+  std::string hltProcess_;
+
+};
+
+template <typename ObjType> 
+HLTDQMHistColl<ObjType>::HLTDQMHistColl(const edm::ParameterSet& config,
+					const std::string& baseHistName,
+					const std::string& hltProcess):
+  rangeCuts_(config.getParameter<std::vector<edm::ParameterSet> >("rangeCuts")),
+  filterName_(config.getParameter<std::string>("filterName")), 
+  tagExtraFilter_(config.getParameter<std::string>("tagExtraFilter")), 
+  baseHistName_(baseHistName),
+  histTitle_(config.getParameter<std::string>("histTitle")),
+  folderName_(config.getParameter<std::string>("folderName")),
+  hltProcess_(hltProcess)
+{
+  
+}
+
+template <typename ObjType>
+void HLTDQMHistColl<ObjType>::bookHists(DQMStore::IBooker& iBooker,const std::vector<edm::ParameterSet>& histConfigs)
+{
+  iBooker.setCurrentFolder(folderName_);
+  for(auto& histConfig : histConfigs){
+    std::string histType = histConfig.getParameter<std::string>("histType");
+    if(histType=="1D"){
+      book1D(iBooker,histConfig);
+    }else if(histType=="2D"){
+      book2D(iBooker,histConfig);
+    }else{
+      throw cms::Exception("ConfigError")<<" histType "<<histType<<" not recognised"<<std::endl;
+    }
+  }
+}
+
+template <typename ObjType>
+void HLTDQMHistColl<ObjType>::book1D(DQMStore::IBooker& iBooker,const edm::ParameterSet& histConfig)
+{
+  auto binLowEdgesDouble = histConfig.getParameter<std::vector<double> >("binLowEdges");
+  std::vector<float> binLowEdges;
+  for(double lowEdge : binLowEdgesDouble) binLowEdges.push_back(lowEdge);
+  auto nameSuffex = histConfig.getParameter<std::string>("nameSuffex");
+  auto mePass = iBooker.book1D((baseHistName_+filterName_+nameSuffex+"_pass").c_str(),
+			       (histTitle_+nameSuffex+" Pass").c_str(),
+			       binLowEdges.size()-1,&binLowEdges[0]);
+  std::unique_ptr<HLTDQMHist<ObjType> > hist;
+  auto vsVar = histConfig.getParameter<std::string>("vsVar");
+  auto vsVarFunc = getFunc<ObjType>(vsVar);
+  if(!vsVarFunc) {
+    throw cms::Exception("ConfigError")<<" vsVar "<<vsVar<<" is giving null ptr (likely empty)"<<std::endl;
+  }
+  RangeCutsColl<ObjType> rangeCuts(histConfig.getParameter<std::vector<edm::ParameterSet> >("rangeCuts"));
+  hist = std::make_unique<HLTDQM1DHist<ObjType,float> >(mePass->getTH1(),vsVar,vsVarFunc,rangeCuts); 
+  histsPass_.emplace_back(std::move(hist));
+  auto meTot = iBooker.book1D((baseHistName_+filterName_+nameSuffex+"_tot").c_str(),
+			      (histTitle_+nameSuffex+" Total").c_str(),
+			      binLowEdges.size()-1,&binLowEdges[0]);
+  hist = std::make_unique<HLTDQM1DHist<ObjType,float> >(meTot->getTH1(),vsVar,vsVarFunc,rangeCuts); 
+  histsTot_.emplace_back(std::move(hist));
+  
+}
+
+template <typename ObjType>
+void HLTDQMHistColl<ObjType>::book2D(DQMStore::IBooker& iBooker,const edm::ParameterSet& histConfig)
+{
+  auto xBinLowEdgesDouble = histConfig.getParameter<std::vector<double> >("xBinLowEdges");
+  auto yBinLowEdgesDouble = histConfig.getParameter<std::vector<double> >("yBinLowEdges");
+  std::vector<float> xBinLowEdges;
+  std::vector<float> yBinLowEdges;
+  for(double lowEdge : xBinLowEdgesDouble) xBinLowEdges.push_back(lowEdge);
+  for(double lowEdge : yBinLowEdgesDouble) yBinLowEdges.push_back(lowEdge);
+  auto nameSuffex = histConfig.getParameter<std::string>("nameSuffex");
+  auto mePass = iBooker.book2D((baseHistName_+filterName_+nameSuffex+"_pass").c_str(),
+			       (histTitle_+nameSuffex+" Pass").c_str(),
+ 			       xBinLowEdges.size()-1,&xBinLowEdges[0],
+			       yBinLowEdges.size()-1,&yBinLowEdges[0]);
+  std::unique_ptr<HLTDQMHist<ObjType> > hist;
+  auto xVar = histConfig.getParameter<std::string>("xVar");
+  auto yVar = histConfig.getParameter<std::string>("yVar");
+  auto xVarFunc = getFunc<ObjType>(xVar);
+  auto yVarFunc = getFunc<ObjType>(yVar);
+  if(!xVarFunc || !yVarFunc) {
+    throw cms::Exception("ConfigError")<<" xVar "<<xVar<<" or yVar "<<yVar<<" is giving null ptr (likely empty)"<<std::endl;
+  }
+  RangeCutsColl<ObjType> rangeCuts(histConfig.getParameter<std::vector<edm::ParameterSet> >("rangeCuts"));
+  
+
+  //really? really no MonitorElement::getTH2...sigh
+  hist = std::make_unique<HLTDQM2DHist<ObjType,float> >(static_cast<TH2*>(mePass->getTH1()),xVar,yVar,xVarFunc,yVarFunc,rangeCuts); 
+  histsPass_.emplace_back(std::move(hist));
+  
+  auto meTot = iBooker.book2D((baseHistName_+filterName_+nameSuffex+"_tot").c_str(),
+			      (histTitle_+nameSuffex+" Total").c_str(),
+			      xBinLowEdges.size()-1,&xBinLowEdges[0],
+			      yBinLowEdges.size()-1,&yBinLowEdges[0]);
+
+  hist = std::make_unique<HLTDQM2DHist<ObjType,float> >(static_cast<TH2*>(meTot->getTH1()),xVar,yVar,xVarFunc,yVarFunc,rangeCuts); 
+  
+  histsTot_.emplace_back(std::move(hist));
+}
+
+template <typename ObjType>
+void HLTDQMHistColl<ObjType>::fillHists(const ObjType& tag,
+					const ObjType& probe,
+					const edm::Event& event,
+					const edm::EventSetup& setup,
+					const trigger::TriggerEvent& trigEvt)
+{
+  if(tagExtraFilter_.empty() || passTrig(tag.eta(),tag.phi(),trigEvt,tagExtraFilter_,hltProcess_)){
+    for(auto& hist : histsTot_){
+      hist->fill(probe,event,setup,rangeCuts_); 
+    }
+    
+    if(passTrig(probe.eta(),probe.phi(),trigEvt,filterName_,hltProcess_)){
+      for(auto& hist : histsPass_){
+	hist->fill(probe,event,setup,rangeCuts_); 
+      }
+      
+    }
+  }
+}
+
+
+template <typename ObjType,typename ObjCollType> 
+class HLTTagAndProbeEff {
+public:
+    
+  explicit HLTTagAndProbeEff(const edm::ParameterSet& pset,edm::ConsumesCollector && cc);
+ 
+  void bookHists(DQMStore::IBooker& iBooker);
+  void fill(const edm::Event& event,const edm::EventSetup& setup);
+  
+private:
+  std::vector<edm::Ref<ObjCollType> >
+  getPassingRefs(const edm::Handle<ObjCollType>& objCollHandle,
+		 const trigger::TriggerEvent& trigEvt,
+		 const std::vector<std::string>& filterNames,
+		 const edm::Handle<edm::ValueMap<bool> >& vidHandle,
+		 const RangeCutsColl<ObjType>& rangeCuts);
+private:
+  edm::EDGetTokenT<ObjCollType> objToken_;
+  edm::EDGetTokenT<trigger::TriggerEvent> trigEvtToken_;
+  edm::EDGetTokenT<edm::TriggerResults> trigResultsToken_;
+  edm::EDGetTokenT<edm::ValueMap<bool> >tagVIDToken_;
+  edm::EDGetTokenT<edm::ValueMap<bool> >probeVIDToken_;
+  
+  std::string hltProcess_;
+
+  std::string tagTrigger_;
+	    
+  std::vector<std::string> tagFilters_;
+  RangeCutsColl<ObjType> tagRangeCuts_;
+
+  std::vector<std::string> probeFilters_;
+  RangeCutsColl<ObjType> probeRangeCuts_;
+
+  float minMass_;
+  float maxMass_;
+  bool requireOpSign_;
+
+  std::vector<edm::ParameterSet> histConfigs_;
+  std::vector<HLTDQMHistColl<ObjType> > histColls_;
+    
+};
+
+template <typename ObjType,typename ObjCollType> 
+HLTTagAndProbeEff<ObjType,ObjCollType>::HLTTagAndProbeEff(const edm::ParameterSet& pset,edm::ConsumesCollector && cc):
+  tagRangeCuts_(pset.getParameter<std::vector<edm::ParameterSet> >("tagRangeCuts")),
+  probeRangeCuts_(pset.getParameter<std::vector<edm::ParameterSet> >("probeRangeCuts"))
+{
+  edm::InputTag trigEvtTag = pset.getParameter<edm::InputTag>("trigEvent");
+
+  objToken_ = cc.consumes<ObjCollType>(pset.getParameter<edm::InputTag>("objColl"));
+  trigEvtToken_ = cc.consumes<trigger::TriggerEvent>(trigEvtTag);
+  trigResultsToken_ = cc.consumes<edm::TriggerResults>(pset.getParameter<edm::InputTag>("trigResults"));
+  tagVIDToken_ = cc.consumes<edm::ValueMap<bool> >(pset.getParameter<edm::InputTag>("tagVIDCuts"));
+  probeVIDToken_ = cc.consumes<edm::ValueMap<bool> >(pset.getParameter<edm::InputTag>("probeVIDCuts"));
+
+  hltProcess_ = trigEvtTag.process();
+
+  tagTrigger_ = pset.getParameter<std::string>("tagTrigger");
+
+  tagFilters_ = pset.getParameter<std::vector<std::string> >("tagFilters");
+  probeFilters_ = pset.getParameter<std::vector<std::string> >("probeFilters");
+  
+  minMass_ = pset.getParameter<double>("minMass");
+  maxMass_ = pset.getParameter<double>("maxMass");
+  requireOpSign_ = pset.getParameter<bool>("requireOpSign");
+
+  histConfigs_ = pset.getParameter<std::vector<edm::ParameterSet> >("histConfigs");
+  const auto& histCollConfigs = pset.getParameter<std::vector<edm::ParameterSet> >("histCollConfigs");
+  
+  std::string baseHistName = pset.getParameter<std::string>("baseHistName");
+
+  for(auto& config: histCollConfigs){
+    histColls_.emplace_back(HLTDQMHistColl<ObjType>(config,baseHistName,hltProcess_));
+  }
+
+}
+
+template <typename ObjType,typename ObjCollType> 
+std::vector<edm::Ref<ObjCollType> > HLTTagAndProbeEff<ObjType,ObjCollType>::
+getPassingRefs(const edm::Handle<ObjCollType>& objCollHandle,
+	       const trigger::TriggerEvent& trigEvt,
+	       const std::vector<std::string>& filterNames,
+	       const edm::Handle<edm::ValueMap<bool> >& vidHandle,
+	       const RangeCutsColl<ObjType>& rangeCuts)
+{
+  std::vector<edm::Ref<ObjCollType> > passingRefs;
+  for(size_t objNr=0;objNr<objCollHandle->size();objNr++){
+    edm::Ref<ObjCollType> ref(objCollHandle,objNr);
+    if(rangeCuts(*ref) && 
+       passTrig(ref->eta(),ref->phi(),trigEvt,filterNames,hltProcess_) && 
+       (vidHandle.isValid()==false || (*vidHandle)[ref]==true)){
+      passingRefs.push_back(ref);
+    }
+  }
+  return passingRefs;
+}
+
+
+template <typename ObjType,typename ObjCollType> 
+void HLTTagAndProbeEff<ObjType,ObjCollType>::fill(const edm::Event& event,const edm::EventSetup& setup)
+{
+  auto objCollHandle = getHandle(event,objToken_); 
+  auto trigEvtHandle = getHandle(event,trigEvtToken_);
+  auto trigResultsHandle = getHandle(event,trigResultsToken_);
+  auto tagVIDHandle = getHandle(event,tagVIDToken_);
+  auto probeVIDHandle = getHandle(event,probeVIDToken_);
+
+  //we need the object collection and trigger info at the minimum
+  if(!objCollHandle.isValid() || !trigEvtHandle.isValid() || !trigResultsHandle.isValid()) return;
+
+  //now check if the tag trigger fired, return if not
+  //if no trigger specified it passes
+  const edm::TriggerNames& trigNames = event.triggerNames(*trigResultsHandle);
+  if(passTrig(tagTrigger_,trigNames,*trigResultsHandle)==false) return;
+  
+  std::vector<edm::Ref<ObjCollType> > tagRefs = getPassingRefs(objCollHandle,*trigEvtHandle,
+							       tagFilters_,
+							       tagVIDHandle,tagRangeCuts_);
+
+  std::vector<edm::Ref<ObjCollType> > probeRefs = getPassingRefs(objCollHandle,*trigEvtHandle,
+								 probeFilters_,
+								 probeVIDHandle,probeRangeCuts_);
+
+  for(auto& tagRef : tagRefs){
+    for(auto& probeRef : probeRefs){
+      if(tagRef==probeRef) continue; //otherwise its the same object...
+      float mass = (tagRef->p4()+probeRef->p4()).mag();
+      if( ( mass>minMass_ || minMass_<0 ) && 
+	  ( mass<maxMass_ || maxMass_<0 ) && 
+	  ( !requireOpSign_ || tagRef->charge()!=probeRef->charge()) ){
+	for(auto& histColl : histColls_){
+	  histColl.fillHists(*tagRef,*probeRef,event,setup,*trigEvtHandle);
+	}	      
+      }//end of t&p pair cuts
+    }//end of probe loop
+  }//end of tag loop
+}
+
+template <typename ObjType,typename ObjCollType> 
+void HLTTagAndProbeEff<ObjType,ObjCollType>::bookHists(DQMStore::IBooker& iBooker)
+{
+  for(auto& histColl:  histColls_) histColl.bookHists(iBooker,histConfigs_);
+}
+
+#endif

--- a/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
@@ -18,6 +18,7 @@ from DQMOffline.Trigger.TrackingMonitoring_Client_cff import *
 from DQMOffline.Trigger.TrackingMonitoringPA_Client_cff import *
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_Client_cff import *
 
+from DQMOffline.Trigger.EgammaMonitoring_Client_cff import *
 from DQMOffline.Trigger.ExoticaMonitoring_Client_cff import *
 from DQMOffline.Trigger.SusyMonitoring_Client_cff import *
 from DQMOffline.Trigger.B2GMonitoring_Client_cff import *
@@ -39,6 +40,7 @@ hltOfflineDQMClient = cms.Sequence(
     HLTTauPostSeq *
     dqmOfflineHLTCert *
     hltInclusiveVBFClient *
+    egammaClient *
     exoticaClient *
     susyClient *
     b2gClient *

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -54,6 +54,8 @@ from DQMOffline.Trigger.heavyionUCCDQM_cfi import *
 import DQMServices.Components.DQMEnvironment_cfi
 dqmEnvHLT= DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
 dqmEnvHLT.subSystemFolder = 'HLT'
+# EGM
+from DQMOffline.Trigger.EgammaMonitoring_cff import *
 # EXO
 from DQMOffline.Trigger.ExoticaMonitoring_cff import *
 
@@ -89,6 +91,7 @@ offlineHLTSource = cms.Sequence(
     eventshapeDQMSequence *
     HeavyIonUCCDQMSequence *
     hotlineDQMSequence *
+    egammaMonitorHLT * 
     exoticaMonitorHLT *
     susyMonitorHLT *
     b2gMonitorHLT *

--- a/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+#urrgh, horrible hack coming in
+def makeEGEffHistDef(baseName,filterName):   
+   
+    return ["{0}_{1}_vsEt_eff '{1} Efficiency vs E_{{T}};E_{{T}} [GeV];Efficiency' {0}_{1}_vsEt_pass {0}_{1}_vsEt_tot".format(baseName,filterName),
+            "{0}_{1}_EBvsEt_eff '{1} Barrel Efficiency vs E_{{T}};E_{{T}} [GeV];Efficiency' {0}_{1}_EBvsEt_pass {0}_{1}_EBvsEt_tot".format(baseName,filterName),
+            "{0}_{1}_EEvsEt_eff '{1} Endcap Efficiency vs E_{{T}};E_{{T}} [GeV];Efficiency' {0}_{1}_EEvsEt_pass {0}_{1}_EEvsEt_tot".format(baseName,filterName),
+            "{0}_{1}_vsSCEta_eff '{1} Efficiency vs SC #eta;#eta_{{SC}};Efficiency' {0}_{1}_vsSCEta_pass {0}_{1}_vsSCEta_tot".format(baseName,filterName),
+            "{0}_{1}_EBvsPhi_eff '{1} Barrel Efficiency vs #phi [rad];#phi [rad];Efficiency' {0}_{1}_EBvsPhi_pass {0}_{1}_EBvsPhi_tot".format(baseName,filterName),
+            "{0}_{1}_EEvsPhi_eff '{1} Endcap Efficiency vs #phi;#phi [rad];Efficiency' {0}_{1}_EEvsPhi_pass {0}_{1}_EEvsPhi_tot".format(baseName,filterName),            
+            "{0}_{1}_vsSCEtaPhi_eff '{1} Efficiency vs SC #eta/#phi;#eta_{{SC}};#phi [rad];' {0}_{1}_vsSCEtaPhi_pass {0}_{1}_vsSCEtaPhi_tot".format(baseName,filterName)]
+            
+def makeAllEGEffHistDefs():
+    baseNames=["ele27Tag","ele27Tag_HEM17","ele27Tag_HEP17"]
+    filterNames=["hltEle33CaloIdLMWPMS2Filter","hltDiEle33CaloIdLMWPMS2UnseededFilter","hltEG300erFilter","hltEG70HEFilter","hltDiEG70HEUnseededFilter","hltEG85HEFilter","hltDiEG85HEUnseededFilter","hltEG30EIso15HE30EcalIsoLastFilter","hltEG18EIso15HE30EcalIsoUnseededFilter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter","hltEle27WPTightGsfTrackIsoFilter","hltEle32noerWPTightGsfTrackIsoFilter","hltEle38noerWPTightGsfTrackIsoFilter","hltEle40noerWPTightGsfTrackIsoFilter","hltEG33L1EG26HEFilter","hltEG50HEFilter","hltEG75HEFilter","hltEG90HEFilter","hltEG120HEFilter","hltEG150HEFilter","hltEG175HEFilter","hltEG200HEFilter","hltSingleCaloJet500","hltSingleCaloJet550"]
+
+    histDefs=[]
+    for baseName in baseNames:
+        for filterName in filterNames:
+            histDefs.extend(makeEGEffHistDef(baseName,filterName))
+    return histDefs
+
+
+egTPEffClient = cms.EDAnalyzer("DQMGenericClient",
+                                subDirs        = cms.untracked.vstring("HLT/EGTagAndProbeEffs/*"),
+                                verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
+                                resolution     = cms.vstring(),
+                                efficiency     = cms.vstring(),
+                                efficiencyProfile = cms.untracked.vstring()
+                                
+                                )
+egTPEffClient.efficiency.extend(makeAllEGEffHistDefs())
+
+egammaClient = cms.Sequence(
+    egTPEffClient
+)

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egHLTDQMSelection,egHLTDQMOfflineTnPSource
+
+egammaMonitorHLT = cms.Sequence(
+    egHLTDQMSelection*
+    egHLTDQMOfflineTnPSource
+)

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -1,0 +1,339 @@
+import FWCore.ParameterSet.Config as cms
+
+#this is the config to define t&p based DQM offline monitoring for e/gamma
+
+etBinsStd=cms.vdouble(5,10,15,20,25,30,35,40,45,50,60,80,100,150,200,250,300,350,400)
+scEtaBinsStd = cms.vdouble(-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.1,1.2,1.3,1.4442,1.566,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5)
+phiBinsStd = cms.vdouble(-3.32,-2.97,-2.62,-2.27,-1.92,-1.57,-1.22,-0.87,-0.52,-0.18,0.18,0.52,0.87,1.22,1.57,1.92,2.27,2.62,2.97,3.32)
+
+etRangeCut= cms.PSet(
+    rangeVar=cms.string("et"),
+    allowedRanges=cms.vstring("0:10000"),
+    )
+ecalBarrelEtaCut=cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("-1.4442:1.4442")
+    )
+ecalEndcapEtaCut=cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("-2.5:-1.556","1.556:2.5")
+    )
+ecalBarrelAndEndcapEtaCut = cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("-1.4442:1.4442","-2.5:-1.556","1.556:2.5"),
+    )
+        
+
+hcalPosEtaCut= cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("1.3:1.4442","1.556:2.5"),
+    )
+hcalNegEtaCut= cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("-2.5:-1.556","-1.4442:-1.3"),
+    )
+hcalPhi17Cut = cms.PSet(
+    rangeVar=cms.string("phi"),
+    allowedRanges=cms.vstring("-0.87:-0.52"),
+    )
+
+
+
+tagAndProbeConfigEle27WPTight = cms.PSet(
+    trigEvent = cms.InputTag("hltTriggerSummaryAOD","","HLTX"),
+    objColl = cms.InputTag("gedGsfElectrons"),
+    trigResults = cms.InputTag("TriggerResults","","HLTX"),
+    tagVIDCuts = cms.InputTag("egHLTDQMSelection"),
+    probeVIDCuts = cms.InputTag("egHLTDQMSelection"),
+    tagTrigger = cms.string("HLT_Ele27_WPTight_Gsf_v*"),
+    tagFilters = cms.vstring("hltEle27WPTightGsfTrackIsoFilter"),
+    tagRangeCuts = cms.VPSet(ecalBarrelEtaCut),
+    probeFilters = cms.vstring(),
+    probeRangeCuts = cms.VPSet(ecalBarrelAndEndcapEtaCut),
+    minMass = cms.double(70.0),
+    maxMass = cms.double(110.0),
+    requireOpSign = cms.bool(False),
+    ) 
+
+
+tagAndProbeConfigEle27WPTightHEP17 = tagAndProbeConfigEle27WPTight.clone( 
+    probeRangeCuts = cms.VPSet(
+        hcalPosEtaCut,
+        hcalPhi17Cut,
+))
+tagAndProbeConfigEle27WPTightHEM17 = tagAndProbeConfigEle27WPTight.clone( 
+    probeRangeCuts = cms.VPSet(
+        hcalNegEtaCut,
+        hcalPhi17Cut,
+))
+    
+
+egammaStdHistConfigs = cms.VPSet(
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("et"),
+        nameSuffex=cms.string("_EBvsEt"),
+        rangeCuts=cms.VPSet(ecalBarrelEtaCut),
+        binLowEdges=etBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("et"),
+        nameSuffex=cms.string("_EEvsEt"),
+        rangeCuts=cms.VPSet(ecalEndcapEtaCut),
+        binLowEdges=etBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("scEta"),
+        nameSuffex=cms.string("_vsSCEta"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=scEtaBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("phi"),
+        nameSuffex=cms.string("_EBvsPhi"),
+        rangeCuts=cms.VPSet(ecalBarrelEtaCut),
+        binLowEdges=phiBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("phi"),
+        nameSuffex=cms.string("_EEvsPhi"),
+        rangeCuts=cms.VPSet(ecalEndcapEtaCut),
+        binLowEdges=phiBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("2D"),
+        xVar=cms.string("scEta"),
+        yVar=cms.string("phi"),
+        nameSuffex=cms.string("_vsSCEtaPhi"), 
+        rangeCuts=cms.VPSet(),
+        xBinLowEdges=scEtaBinsStd,
+        yBinLowEdges=phiBinsStd,
+        ),
+    
+    )
+
+egammaTestFiltersToMonitor = cms.VPSet(
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele5_WPLoose_Gsf"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("5:99999")),),
+        filterName = cms.string("hltEle5CaloIdLGsfTrkIdVLDPhiFilter"),
+        histTitle = cms.string("hltEle5CaloIdLGsfTrkIdVLDPhiFilter"),
+        tagExtraFilter = cms.string(""),
+        ),
+    )
+egammaStdFiltersToMonitor= cms.VPSet(
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoubleEle33_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("40:99999")),),
+        filterName = cms.string("hltEle33CaloIdLMWPMS2Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoubleEle33_CaloIdL_MW"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("40:99999")),),
+        filterName = cms.string("hltDiEle33CaloIdLMWPMS2UnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEle33CaloIdLMWPMS2Filter"),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon300_NoHE"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("320:99999")),),
+        filterName = cms.string("hltEG300erFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoublePhoton70"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("80:99999")),),
+        filterName = cms.string("hltEG70HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoublePhoton70"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("80:99999")),),
+        filterName = cms.string("hltDiEG70HEUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG70HEFilter"),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoublePhoton85"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("90:99999")),),
+        filterName = cms.string("hltEG85HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DoublePhoton85"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("80:99999")),),
+        filterName = cms.string("hltDiEG85HEUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG85HEFilter"),
+        ),
+    
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DiSC30_18_EIso_AND_HE_Mass70"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEG30EIso15HE30EcalIsoLastFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_DiSC30_18_EIso_AND_HE_Mass70"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEG18EIso15HE30EcalIsoUnseededFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEG30EIso15HE30EcalIsoLastFilter"),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("26:99999")),),
+        filterName = cms.string("hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("15:99999")),),
+        filterName = cms.string("hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele27_WPTight_Gsf"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("30:99999")),),
+        filterName = cms.string("hltEle27WPTightGsfTrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele32_WPTight_Gsf"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEle32noerWPTightGsfTrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele38_WPTight_Gsf"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("42:99999")),),
+        filterName = cms.string("hltEle38noerWPTightGsfTrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele40_WPTight_Gsf"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("45:99999")),),
+        filterName = cms.string("hltEle40noerWPTightGsfTrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon33"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("35:99999")),),
+        filterName = cms.string("hltEG33L1EG26HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon50"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("55:99999")),),
+        filterName = cms.string("hltEG50HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),  
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon75"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("80:99999")),),
+        filterName = cms.string("hltEG75HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon90"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("95:99999")),),
+        filterName = cms.string("hltEG90HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon120"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("95:99999")),),
+         filterName = cms.string("hltEG120HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon150"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("160:99999")),),
+        filterName = cms.string("hltEG150HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon175"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("180:99999")),),
+        filterName = cms.string("hltEG175HEFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Photon200"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("220:99999")),),
+        filterName = cms.string("hltEG200HEFilter"),
+        histTitle = cms.string(""),
+         tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_CaloJet500"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("500:99999")),),
+        filterName = cms.string("hltSingleCaloJet500"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_CaloJet550"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("550:99999")),),
+        filterName = cms.string("hltSingleCaloJet550"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+   
+     )
+  
+ 
+
+egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTTagAndProbeOfflineSource",
+                                          histCollections = cms.VPSet(
+        cms.PSet( 
+            tagAndProbeConfigEle27WPTight,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("ele27Tag_"),
+            histCollConfigs = egammaStdFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeConfigEle27WPTightHEM17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("ele27Tag_HEM17_"),
+            histCollConfigs = egammaStdFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeConfigEle27WPTightHEP17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("ele27Tag_HEP17_"),
+            histCollConfigs = egammaStdFiltersToMonitor,
+        ),
+           
+        )
+                                         )
+
+#will be replaced by  VID asap
+egHLTDQMSelection = cms.EDProducer("HLTDQMGsfEleSelector",
+                                   objs=cms.InputTag("gedGsfElectrons"),
+                                   selection=cms.string("et>5 && hcalOverEcal<0.298 && full5x5_sigmaIetaIeta<0.011 && abs(deltaEtaSeedClusterTrackAtVtx)<0.00477 && abs(deltaPhiSuperClusterTrackAtVtx)<0.222")
+                                   )
+

--- a/DQMOffline/Trigger/src/HLTDQMObjSelector.cc
+++ b/DQMOffline/Trigger/src/HLTDQMObjSelector.cc
@@ -1,0 +1,64 @@
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+template<typename ObjType,typename ObjCollType>
+class HLTDQMObjSelector : public edm::stream::EDProducer<> {
+public:
+  explicit HLTDQMObjSelector(const edm::ParameterSet& config);
+  void produce(edm::Event&, edm::EventSetup const&)override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  edm::EDGetTokenT<ObjCollType> token_;
+  StringCutObjectSelector<ObjType,true> selection_;
+
+};
+
+template<typename ObjType,typename ObjCollType>
+HLTDQMObjSelector<ObjType,ObjCollType>::HLTDQMObjSelector(const edm::ParameterSet& config):
+  token_(consumes<ObjCollType>(config.getParameter<edm::InputTag>("objs"))),
+  selection_(config.getParameter<std::string>("selection"))
+{ 
+  produces<edm::ValueMap<bool> >(); 
+}
+
+template<typename ObjType,typename ObjCollType>
+void HLTDQMObjSelector<ObjType,ObjCollType>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("objs", edm::InputTag("gedGsfElectrons"));
+  desc.add<std::string>("selection","et > 5");
+  descriptions.add("hltDQMObjSelector", desc);
+}
+
+template<typename ObjType,typename ObjCollType>
+void HLTDQMObjSelector<ObjType,ObjCollType>::produce(edm::Event& event,const edm::EventSetup& setup)
+{
+  edm::Handle<ObjCollType> handle;
+  event.getByToken(token_,handle);
+  
+  if(!handle.isValid()) return;
+  
+  std::vector<bool> selResults;
+  for(auto& obj : *handle){
+    selResults.push_back(selection_(obj));
+  }
+  auto valMap = std::make_unique<edm::ValueMap<bool> >();
+  edm::ValueMap<bool>::Filler filler(*valMap);
+  filler.insert(handle, selResults.begin(), selResults.end());
+  filler.fill();
+  event.put(std::move(valMap));
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+using HLTDQMGsfEleSelector = HLTDQMObjSelector<reco::GsfElectron,reco::GsfElectronCollection>;
+DEFINE_FWK_MODULE(HLTDQMGsfEleSelector);

--- a/DQMOffline/Trigger/src/HLTTagAndProbeOfflineSource.cc
+++ b/DQMOffline/Trigger/src/HLTTagAndProbeOfflineSource.cc
@@ -1,0 +1,65 @@
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+
+#include "DQMOffline/Trigger/interface/HLTTagAndProbeEff.h"
+
+
+
+#include <vector>
+#include <string>
+
+
+class HLTTagAndProbeOfflineSource : public DQMEDAnalyzer {
+ public:
+  explicit HLTTagAndProbeOfflineSource(const edm::ParameterSet&);
+  ~HLTTagAndProbeOfflineSource()=default;
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void bookHistograms(DQMStore::IBooker &, edm::Run const & run, edm::EventSetup const & c) override;
+  virtual void dqmBeginRun(edm::Run const& run, edm::EventSetup const& c) override{}
+
+private:
+  std::vector<HLTTagAndProbeEff<reco::GsfElectron,reco::GsfElectronCollection> > tagAndProbeEffs_;
+
+};
+
+HLTTagAndProbeOfflineSource::HLTTagAndProbeOfflineSource(const edm::ParameterSet& config)
+{
+  auto histCollConfigs =  config.getParameter<std::vector<edm::ParameterSet> >("histCollections");
+  for(auto& histCollConfig : histCollConfigs){
+    tagAndProbeEffs_.emplace_back(HLTTagAndProbeEff<reco::GsfElectron,reco::GsfElectronCollection>(histCollConfig,consumesCollector()));
+  }
+
+}
+void HLTTagAndProbeOfflineSource::bookHistograms(DQMStore::IBooker& iBooker,const edm::Run& run,const edm::EventSetup& setup)
+{
+  for(auto& tpEff : tagAndProbeEffs_) tpEff.bookHists(iBooker);
+}
+
+void HLTTagAndProbeOfflineSource::analyze(const edm::Event& event, const edm::EventSetup& setup)
+{
+  for(auto& tpEff : tagAndProbeEffs_) tpEff.fill(event,setup);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HLTTagAndProbeOfflineSource);


### PR DESCRIPTION
Dear All,

This is an initial version of the E/gamma T&P offline DQM. This code is near feature complete and produces correct output (as far as I can tell) . However there are some layout and naming issues which I would like to solicit suggestions for before this PR is considered for integration.

The goal of this class is to be object agnostic, hence the templating.

The idea is very simple.

Select the event with a trigger. Require the tag to pass an HLT requirement & selection requirement. Require the probes to pass other selection requirements to entire the sample. Mass and opposite sign requirements are then applied.
There are then a series of histograms associated with each filter we wish to measure, one for all probe passing sample cuts and probes then passing the filter.
There are various levels of tag, probe kinematic and trigger selection: all t&p pairs (ie tag in barrel, passing tag trigger), all histograms of a filter (ie requiring Et to be > threshold, tag to pass an additional trigger, ie the single leg of a double legged trigger), and a specific histogram (ie requiring the probe to be in the endcap to measure the turn on in the endcap region only).

All the magic is in https://github.com/Sam-Harper/cmssw/blob/32a8b63ed2afd1a80771776d7c441b40cd3367bb/DQMOffline/Trigger/interface/HLTTagAndProbeEff.h

There are 3 main classes

HLTTagAndProbeEff : creates tag and probe pairs and then passes the pairs to the histograms.

HLTDQMHistColl : corresponds to a single filter for which we wish to measure the efficiency. Can apply additional selection to the tag & probe (ie restricting them to certain Et, eta ranges, requiring the tag to pass additional HLT requirements). Contains all the individual histograms which are of type HLTDQM1DHist and HLTDQM2DHist and automically fill themselves with the specified vs variable

RangeCutColl: ID selection is handled by edm::ValueMap this class is intended to cut on kinematic variables such as et, eta, phi. It allows us to restrict to a certain eta region (tags in the barrel, probes in HEP17, probes > Et threshold etc)

For the ID selection of tag & probe it was intended to use VID but I didnt get it working so made a temporary ID module to do that for the time being.

Suggestions on names and how to split them up are welcome. RangeCutColl and HLTDQMHist share the same mechanism to store the variable in question which is the sticking point.

Also suggestion on alternative ways to achieve the this are also welcome although performance/clarity gains would have to balanced against work required to make them.