### PR TITLE
FWCore/Framework : missing #include <array> found compiling on macOS with clang

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -22,7 +22,7 @@
 #include <map>
 #include <string>
 #include <vector>
-
+#include <array>
 // user include files
 #include "FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"


### PR DESCRIPTION
\<array\> is indirectly included using gcc on linux. Using clang on macOS this must be explicitly included.