### PR TITLE
DataFormats/PatCandidates : missing #include <array> found compiling on macos with clang

### DIFF
--- a/DataFormats/PatCandidates/interface/CovarianceParameterization.h
+++ b/DataFormats/PatCandidates/interface/CovarianceParameterization.h
@@ -4,6 +4,7 @@
 #include <TH3D.h>
 #include <iostream>
 #include <unordered_map>
+#include <array>
 #include <TKey.h>
 class CompressionElement {
     public:


### PR DESCRIPTION

\<array\> is indirectly included using gcc on linux. Using clang on macOS this must be explicitly included.