### PR TITLE
Fixed memory leak in MultipleScatteringX0Data

### DIFF
--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.cc
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.cc
@@ -14,12 +14,13 @@ using namespace std;
 
 
 MultipleScatteringX0Data::MultipleScatteringX0Data()
-  : theFile(0), theData(0)
+  : theData(nullptr)
 {
   string filename = fileName(); 
-  theFile = new TFile(filename.c_str(),"READ");
-  if (theFile) {
-    theData = dynamic_cast<TH2F*> (theFile->GetKey("h100")->ReadObj());
+  TFile theFile(filename.c_str(),"READ");
+  if (not theFile.IsZombie()) {
+    theData.reset(dynamic_cast<TH2F*> (theFile.GetKey("h100")->ReadObj()));
+    theData->SetDirectory(nullptr);
   }
   if (!theData)  {
     throw cms::Exception("Data not found")  
@@ -31,10 +32,6 @@ MultipleScatteringX0Data::MultipleScatteringX0Data()
 
 MultipleScatteringX0Data::~MultipleScatteringX0Data()
 {
-  if(theFile) {
-    theFile->Close();
-    delete theFile;
-  }
 }
 
 string MultipleScatteringX0Data::fileName()

--- a/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.h
+++ b/RecoTracker/TkMSParametrization/src/MultipleScatteringX0Data.h
@@ -6,7 +6,7 @@
  */
 
 #include <string>
-class TFile;
+#include <memory>
 class TH2F;
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
@@ -29,8 +29,7 @@ public:
 private:
   std::string fileName();
 
-   TFile * theFile;
-   TH2F  * theData;
+  std::unique_ptr<TH2F> theData;
 };
 
 #endif


### PR DESCRIPTION
The TH2F was being leaked. Since the TH2F is not owned by the TFile
there is no reason to keep the TFile around.