### PR TITLE
Adding plots for the hltbtag HEP17 validation

### DIFF
--- a/HLTriggerOffline/Btag/interface/HLTBTagHarvestingAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagHarvestingAnalyzer.h
@@ -33,6 +33,7 @@ class HLTBTagHarvestingAnalyzer : public DQMEDHarvester {
 			TH1F  calculateEfficiency1D( DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, TH1 & num, TH1 & den, std::string name );
 			bool GetNumDenumerators(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, std::string num, std::string den,TH1 * & ptrnum,TH1* & ptrden,int type);
 			void mistagrate( DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, TH1F* num, TH1F* den, std::string effName );
+			void modulesrate( DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, TH1F* num, TH1F* den, std::string effName );
 
 		private:
 			// ----------member data ---------------------------
@@ -47,6 +48,8 @@ class HLTBTagHarvestingAnalyzer : public DQMEDHarvester {
 
 			// Histogram handler
 			std::map<std::string, MonitorElement *> H1_;
+
+			std::vector<std::string> modules_;
 
 	};
 

--- a/HLTriggerOffline/Btag/interface/HLTBTagHarvestingAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagHarvestingAnalyzer.h
@@ -49,7 +49,8 @@ class HLTBTagHarvestingAnalyzer : public DQMEDHarvester {
 			// Histogram handler
 			std::map<std::string, MonitorElement *> H1_;
 
-			std::vector<std::string> modules_;
+			enum HCALSpecials {HEP17, HEP18, HEM17};
+			std::map<HLTBTagHarvestingAnalyzer::HCALSpecials,std::string> HCALSpecialsNames;
 
 	};
 

--- a/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
@@ -84,7 +84,9 @@ class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 
 		// Histogram handler
 		std::vector< std::map<std::string, MonitorElement *> > H1_;
+		std::vector< std::map<std::string, std::map<std::string, MonitorElement *> > > H1mod_;
 		std::vector< std::map<std::string, MonitorElement *> > H2_;
+		std::vector< std::map<std::string, std::map<std::string, MonitorElement *> > > H2mod_;
 		std::vector< std::map<std::string, MonitorElement *> > H2Eta_;
 		std::vector< std::map<std::string, MonitorElement *> > H2Phi_;
 
@@ -94,6 +96,7 @@ class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 		std::vector<std::string> JetTagCollection_Label;
 		std::string hlTriggerResults_Label;
 		std::string hltConfigProvider_Label;
+		std::vector<std::string> modules_;
 
 };
 

--- a/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
@@ -58,6 +58,8 @@ class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 
 		typedef std::map<edm::RefToBase<reco::Jet>, float, JetRefCompare> JetTagMap;
 
+		enum HCALSpecials {HEP17, HEP18, HEM17};
+
 		// variables from python configuration
 		edm::EDGetTokenT<edm::TriggerResults> hlTriggerResults_;
 		std::vector<std::string> hltPathNames_;
@@ -84,9 +86,9 @@ class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 
 		// Histogram handler
 		std::vector< std::map<std::string, MonitorElement *> > H1_;
-		std::vector< std::map<std::string, std::map<std::string, MonitorElement *> > > H1mod_;
+		std::vector< std::map<std::string, std::map<HCALSpecials, MonitorElement *> > > H1mod_;
 		std::vector< std::map<std::string, MonitorElement *> > H2_;
-		std::vector< std::map<std::string, std::map<std::string, MonitorElement *> > > H2mod_;
+		std::vector< std::map<std::string, std::map<HCALSpecials, MonitorElement *> > > H2mod_;
 		std::vector< std::map<std::string, MonitorElement *> > H2Eta_;
 		std::vector< std::map<std::string, MonitorElement *> > H2Phi_;
 
@@ -96,7 +98,7 @@ class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 		std::vector<std::string> JetTagCollection_Label;
 		std::string hlTriggerResults_Label;
 		std::string hltConfigProvider_Label;
-		std::vector<std::string> modules_;
+		std::map<HLTBTagPerformanceAnalyzer::HCALSpecials,std::string> HCALSpecialsNames;
 
 };
 

--- a/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
@@ -8,6 +8,8 @@ HLTBTagHarvestingAnalyzer::HLTBTagHarvestingAnalyzer(const edm::ParameterSet& iC
 	m_mcLabels				= mc.getParameterNamesForType<std::vector<unsigned int> >();
 	m_histoName				= iConfig.getParameter<std::vector<std::string> >("histoName");
 	m_minTag				= iConfig.getParameter<double>("minTag");
+
+	modules_ = {"HEP17", "HEP18", "HEM17"};
 }
 
 HLTBTagHarvestingAnalyzer::~HLTBTagHarvestingAnalyzer()
@@ -27,11 +29,14 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 	{
 		dqmFolder_hist = Form("HLT/BTag/Discriminator/%s",hltPathNames_[ind].c_str());
 		std::string effDir = Form("HLT/BTag/Discriminator/%s/efficiency",hltPathNames_[ind].c_str());
+		std::string relationsDir = Form("HLT/BTag/Discriminator/%s/HEP17_HEM17",hltPathNames_[ind].c_str());
 		ibooker.setCurrentFolder(effDir);
 		TH1 *den =NULL;
 		TH1 *num =NULL; 
 		std::map<TString,TH1F> effics;
 		std::map<TString,bool> efficsOK;
+		std::map<TString,std::map<std::string,TH1F> > efficsmod;
+		std::map<TString,std::map<std::string,bool> > efficsmodOK;
 		for (unsigned int i = 0; i < m_mcLabels.size(); ++i)
 		{
 			bool isOK=false;
@@ -45,6 +50,18 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 				effics[flavour]=calculateEfficiency1D(ibooker,igetter,*num,*den,(label+"_efficiency_vs_disc").Data());
 				efficsOK[flavour]=isOK;
 			}
+			//for modules (HEP17 etc.)
+			for (unsigned int j=0; j<modules_.size();j++){
+				ibooker.setCurrentFolder(dqmFolder_hist+"/"+modules_[j]+"/efficiency");
+				isOK=GetNumDenumerators(ibooker,igetter,(TString(dqmFolder_hist)+"/"+modules_[j]+"/"+label).Data(),(TString(dqmFolder_hist)+"/"+modules_[j]+"/"+label).Data(),num,den,0);
+				if (isOK){
+			
+					//do the 'b-tag efficiency vs discr' plot
+					efficsmod[flavour][modules_[j]]=calculateEfficiency1D(ibooker,igetter,*num,*den,(label+"_efficiency_vs_disc").Data());
+					efficsmodOK[flavour][modules_[j]]=isOK;
+				}
+			}
+			ibooker.setCurrentFolder(effDir);
 			label= m_histoName.at(ind)+std::string("___");
 			std::string labelEta = label.Data();
 			std::string labelPhi = label.Data();
@@ -69,12 +86,37 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 				//do the 'b-tag efficiency vs Phi' plot
 				TH1F eff=calculateEfficiency1D(ibooker,igetter,*num,*den,labelPhi+"_efficiency_vs_phi");
 			}
+
+			///save efficiency_vs_disc_HEP17 / efficiency_vs_disc_HEM17 plots
+			ibooker.setCurrentFolder(relationsDir);
+			if (efficsmodOK[flavour]["HEP17"] && efficsmodOK[flavour]["HEM17"]) 
+				modulesrate(ibooker,igetter,&efficsmod[flavour]["HEP17"], &efficsmod[flavour]["HEM17"], m_histoName.at(ind)+"_"+flavour.Data()+"_HEP17_HEM17_effs_vs_disc_rate" );
+			ibooker.setCurrentFolder(effDir);
+
 		} /// for mc labels
 		
 		///save mistagrate vs b-eff plots
 		if (efficsOK["b"] && efficsOK["c"])      mistagrate(ibooker,igetter,&effics["b"], &effics["c"], m_histoName.at(ind)+"_b_c_mistagrate" );
 		if (efficsOK["b"] && efficsOK["light"])  mistagrate(ibooker,igetter,&effics["b"], &effics["light"], m_histoName.at(ind)+"_b_light_mistagrate" );
 		if (efficsOK["b"] && efficsOK["g"])      mistagrate(ibooker,igetter,&effics["b"], &effics["g"], m_histoName.at(ind)+"_b_g_mistagrate" );
+
+		///save mistagrate vs b-eff plots for modules (HEP17 etc.)
+		for (unsigned int j=0; j<modules_.size();j++){
+			ibooker.setCurrentFolder(dqmFolder_hist+"/"+modules_[j]+"/efficiency");
+			if (efficsmodOK["b"][modules_[j]] && efficsmodOK["c"][modules_[j]])      mistagrate(ibooker,igetter,&efficsmod["b"][modules_[j]], &efficsmod["c"][modules_[j]], m_histoName.at(ind)+"_b_c_mistagrate" );
+			if (efficsmodOK["b"][modules_[j]] && efficsmodOK["light"][modules_[j]])  mistagrate(ibooker,igetter,&efficsmod["b"][modules_[j]], &efficsmod["light"][modules_[j]], m_histoName.at(ind)+"_b_light_mistagrate" );
+			if (efficsmodOK["b"][modules_[j]] && efficsmodOK["g"][modules_[j]])      mistagrate(ibooker,igetter,&efficsmod["b"][modules_[j]], &efficsmod["g"][modules_[j]], m_histoName.at(ind)+"_b_g_mistagrate" );
+		}
+		
+		///save mistagrate_HEP17 / mistagrate_HEM17 plots
+		ibooker.setCurrentFolder(relationsDir);
+		bool isOK=false;
+		isOK=GetNumDenumerators(ibooker,igetter,dqmFolder_hist+"/HEP17/efficiency/"+m_histoName.at(ind)+"_b_c_mistagrate",dqmFolder_hist+"/HEM17/efficiency/"+m_histoName.at(ind)+"_b_c_mistagrate",num,den,3);
+		if (isOK) modulesrate(ibooker,igetter,(TH1F*)num, (TH1F*)den, m_histoName.at(ind)+"_HEP17_HEM17_b_c_mistagrate" );
+		isOK=GetNumDenumerators(ibooker,igetter,dqmFolder_hist+"/HEP17/efficiency/"+m_histoName.at(ind)+"_b_light_mistagrate",dqmFolder_hist+"/HEM17/efficiency/"+m_histoName.at(ind)+"_b_light_mistagrate",num,den,3);
+		if (isOK) modulesrate(ibooker,igetter,(TH1F*)num, (TH1F*)den, m_histoName.at(ind)+"_HEP17_HEM17_b_light_mistagrate" );
+		isOK=GetNumDenumerators(ibooker,igetter,dqmFolder_hist+"/HEP17/efficiency/"+m_histoName.at(ind)+"_b_g_mistagrate",dqmFolder_hist+"/HEM17/efficiency/"+m_histoName.at(ind)+"_b_g_mistagrate",num,den,3);
+		if (isOK) modulesrate(ibooker,igetter,(TH1F*)num, (TH1F*)den, m_histoName.at(ind)+"_HEP17_HEM17_b_g_mistagrate" );
 	} /// for triggers
 }
 
@@ -86,6 +128,7 @@ bool HLTBTagHarvestingAnalyzer::GetNumDenumerators(DQMStore::IBooker& ibooker, D
    type =0 for eff_vs_discriminator
    type =1 for eff_vs_pT
    type =2 for eff_vs_eta or eff_vs_phi
+   type =3 for HEP17 / HEM17 mistagrate relation
  */
 	MonitorElement *denME = NULL;
 	MonitorElement *numME = NULL;
@@ -163,6 +206,14 @@ bool HLTBTagHarvestingAnalyzer::GetNumDenumerators(DQMStore::IBooker& ibooker, D
 		delete cutg_num;
 		delete cutg_den;
 	}
+
+	if (type==3) //mistagrate HEP17 / HEM17 relation: fill "ptrnum" with HEP17 mistagrate and "ptrden" with HEM17 mistagrate
+	{
+		TH1* numH1 = numME->getTH1();
+		TH1* denH1 = denME->getTH1();
+		ptrden=(TH1*)denH1->Clone("denominator");
+		ptrnum=(TH1*)numH1->Clone("numerator");
+	}
 	return true;
 }
 
@@ -193,6 +244,31 @@ void HLTBTagHarvestingAnalyzer::mistagrate(DQMStore::IBooker& ibooker, DQMStore:
 		eff->SetBinContent(binX,miseff);
 		eff->SetBinError(binX,miseffErr);
 	}
+	MonitorElement *me;
+	me = ibooker.book1D(effName.c_str(),eff);
+	me->setEfficiencyFlag();
+
+	delete eff;
+	return;
+}
+
+void HLTBTagHarvestingAnalyzer::modulesrate(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter, TH1F* num, TH1F* den, std::string effName ){
+	//do the eff_vs_disc_HEP17 / eff_vs_disc_HEM17 plot
+	TH1F* eff=new TH1F(*num);
+	//eff = new TH1F(effName.c_str(),effName.c_str(),100,0,1);
+	eff->Divide(den);
+	eff->SetTitle(effName.c_str());
+	eff->SetXTitle(num->GetXaxis()->GetTitle());
+	eff->SetYTitle("");
+	eff->SetOption("E");
+	eff->SetLineColor(2);
+	eff->SetLineWidth(2);
+	eff->SetMarkerStyle(20);
+	eff->SetMarkerSize(0.8);
+	eff->GetYaxis()->SetRangeUser(0.001,2.001);
+	//eff->GetXaxis()->SetRangeUser(-0.001,1.001);
+	eff->SetStats(kFALSE);
+	
 	MonitorElement *me;
 	me = ibooker.book1D(effName.c_str(),eff);
 	me->setEfficiencyFlag();

--- a/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
@@ -35,8 +35,8 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 		TH1 *num =NULL; 
 		std::map<TString,TH1F> effics;
 		std::map<TString,bool> efficsOK;
-		std::map<TString,std::map<std::string,TH1F> > efficsmod;
-		std::map<TString,std::map<std::string,bool> > efficsmodOK;
+		std::map<std::string,std::map<std::string,TH1F> > efficsmod;
+		std::map<std::string,std::map<std::string,bool> > efficsmodOK;
 		for (unsigned int i = 0; i < m_mcLabels.size(); ++i)
 		{
 			bool isOK=false;
@@ -57,8 +57,8 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 				if (isOK){
 			
 					//do the 'b-tag efficiency vs discr' plot
-					efficsmod[flavour][modules_[j]]=calculateEfficiency1D(ibooker,igetter,*num,*den,(label+"_efficiency_vs_disc").Data());
-					efficsmodOK[flavour][modules_[j]]=isOK;
+					efficsmod[flavour.Data()][modules_[j]]=calculateEfficiency1D(ibooker,igetter,*num,*den,(label+"_efficiency_vs_disc").Data());
+					efficsmodOK[flavour.Data()][modules_[j]]=isOK;
 				}
 			}
 			ibooker.setCurrentFolder(effDir);
@@ -89,8 +89,8 @@ HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGet
 
 			///save efficiency_vs_disc_HEP17 / efficiency_vs_disc_HEM17 plots
 			ibooker.setCurrentFolder(relationsDir);
-			if (efficsmodOK[flavour]["HEP17"] && efficsmodOK[flavour]["HEM17"]) 
-				modulesrate(ibooker,igetter,&efficsmod[flavour]["HEP17"], &efficsmod[flavour]["HEM17"], m_histoName.at(ind)+"_"+flavour.Data()+"_HEP17_HEM17_effs_vs_disc_rate" );
+			if (efficsmodOK[flavour.Data()]["HEP17"] && efficsmodOK[flavour.Data()]["HEM17"]) 
+				modulesrate(ibooker,igetter,&efficsmod[flavour.Data()]["HEP17"], &efficsmod[flavour.Data()]["HEM17"], m_histoName.at(ind)+"_"+flavour.Data()+"_HEP17_HEM17_effs_vs_disc_rate" );
 			ibooker.setCurrentFolder(effDir);
 
 		} /// for mc labels

--- a/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
@@ -209,10 +209,8 @@ bool HLTBTagHarvestingAnalyzer::GetNumDenumerators(DQMStore::IBooker& ibooker, D
 
 	if (type==3) //mistagrate HEP17 / HEM17 relation: fill "ptrnum" with HEP17 mistagrate and "ptrden" with HEM17 mistagrate
 	{
-		TH1* numH1 = numME->getTH1();
-		TH1* denH1 = denME->getTH1();
-		ptrden=(TH1*)denH1->Clone("denominator");
-		ptrnum=(TH1*)numH1->Clone("numerator");
+		ptrden=denME->getTH1();
+		ptrnum=numME->getTH1();
 	}
 	return true;
 }

--- a/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
@@ -44,6 +44,8 @@ HLTBTagPerformanceAnalyzer::HLTBTagPerformanceAnalyzer(const edm::ParameterSet& 
 	m_mcMatching = m_mcPartons_Label != "none" ;
 
 	m_mcRadius=0.3;
+
+	modules_ = {"HEP17", "HEP18", "HEM17"};
 }
 
 
@@ -139,8 +141,17 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
 		}
 
 		for (auto & BtagJT: JetTag) {
+			std::map<std::string, bool> inmodule;
+			inmodule["HEP17"]=(BtagJT.first->phi() >= -0.87) && (BtagJT.first->phi() < -0.52) && (BtagJT.first->eta() > 1.3);
+			inmodule["HEP18"]=(BtagJT.first->phi() >= -0.52) && (BtagJT.first->phi() < -0.17) && (BtagJT.first->eta() > 1.3);
+			inmodule["HEM17"]=(BtagJT.first->phi() >= -0.87) && (BtagJT.first->phi() < -0.52) && (BtagJT.first->eta() < -1.3);
+			
 			//fill 1D btag plot for 'all'
 			H1_.at(ind)[JetTagCollection_Label[ind]] -> Fill(std::fmax(0.0,BtagJT.second));
+			for (unsigned int i=0; i<modules_.size();i++){
+				if (inmodule[modules_[i]])
+				H1mod_.at(ind)[JetTagCollection_Label[ind]][modules_[i]] -> Fill(std::fmax(0.0,BtagJT.second));
+			}
 			if (MCOK) {
 				int m = closestJet(BtagJT.first, *h_mcPartons, m_mcRadius);
 				unsigned int flavour = (m != -1) ? abs((*h_mcPartons)[m].second.getFlavour()) : 0;
@@ -152,12 +163,20 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
 					TString label=JetTagCollection_Label[ind] + "__";
 					label+=flavour_str;
 					H1_.at(ind)[label.Data()]->Fill(std::fmax(0.0,BtagJT.second));	//fill 1D btag plot for 'b,c,uds'
+					for (unsigned int i=0; i<modules_.size();i++){
+						if (inmodule[modules_[i]])
+						H1mod_.at(ind)[label.Data()][modules_[i]]->Fill(std::fmax(0.0,BtagJT.second));	//fill 1D btag plot for 'b,c,uds' in modules (HEP17 etc.)
+					}
 					label=JetTagCollection_Label[ind] + "___";
 					label+=flavour_str;
 					std::string labelEta = label.Data();
 					std::string labelPhi = label.Data();
 					label+=TString("_disc_pT");
 					H2_.at(ind)[label.Data()]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->pt());	//fill 2D btag, jetPt plot for 'b,c,uds'
+					for (unsigned int i=0; i<modules_.size();i++){
+						if (inmodule[modules_[i]])
+						H2mod_.at(ind)[label.Data()][modules_[i]]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->pt());
+					}
 					labelEta+="_disc_eta";
 					H2Eta_.at(ind)[labelEta]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->eta());	//fill 2D btag, jetEta plot for 'b,c,uds'
 					labelPhi+="_disc_phi";
@@ -185,6 +204,8 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 		dqmFolder = Form("HLT/BTag/Discriminator/%s",hltPathNames_[ind].c_str());
 		H1_.push_back(std::map<std::string, MonitorElement *>());
 		H2_.push_back(std::map<std::string, MonitorElement *>());
+		H1mod_.push_back(std::map<std::string, std::map<std::string, MonitorElement *> > ());
+		H2mod_.push_back(std::map<std::string, std::map<std::string, MonitorElement *> > ());
 		H2Eta_.push_back(std::map<std::string, MonitorElement *>());
 		H2Phi_.push_back(std::map<std::string, MonitorElement *>());
 		ibooker.setCurrentFolder(dqmFolder);
@@ -193,6 +214,12 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 		if ( JetTagCollection_Label[ind] != "" && JetTagCollection_Label[ind] != "NULL" ) { 
 			H1_.back()[JetTagCollection_Label[ind]]       = ibooker.book1D(JetTagCollection_Label[ind] + "_all",      (JetTagCollection_Label[ind]+ "_all").c_str(),  btagBins, btagL, btagU );
 			H1_.back()[JetTagCollection_Label[ind]]      -> setAxisTitle(JetTagCollection_Label[ind] +"discriminant",1);
+			for (unsigned int i=0; i<modules_.size();i++){
+				ibooker.setCurrentFolder(dqmFolder+"/"+modules_[i]);
+				H1mod_.back()[JetTagCollection_Label[ind]][modules_[i]]       = ibooker.book1D(JetTagCollection_Label[ind] + "_all",      (JetTagCollection_Label[ind]+ "_all").c_str(),  btagBins, btagL, btagU );
+				H1mod_.back()[JetTagCollection_Label[ind]][modules_[i]]      -> setAxisTitle(JetTagCollection_Label[ind] +"discriminant",1);
+			}
+			ibooker.setCurrentFolder(dqmFolder);
 		} 
 		int nBinsPt=60;
 		double pTmin=30;
@@ -217,6 +244,12 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 				//book 1D btag plot for 'b,c,light,g'
 				H1_.back()[label.Data()] = 		 ibooker.book1D(label.Data(),   Form("%s %s",JetTagCollection_Label[ind].c_str(),flavour.Data()), btagBins, btagL, btagU );
 				H1_.back()[label.Data()]->setAxisTitle("disc",1);
+				for (unsigned int i=0; i<modules_.size();i++){
+					ibooker.setCurrentFolder(dqmFolder+"/"+modules_[i]);
+					H1mod_.back()[label.Data()][modules_[i]] = 		 ibooker.book1D(label.Data(),   Form("%s %s",JetTagCollection_Label[ind].c_str(),flavour.Data()), btagBins, btagL, btagU );
+					H1mod_.back()[label.Data()][modules_[i]]->setAxisTitle("disc",1);
+				}
+				ibooker.setCurrentFolder(dqmFolder);
 				label=JetTagCollection_Label[ind]+"___";
 				labelEta=label;
 				labelPhi=label;
@@ -228,6 +261,13 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 				H2_.back()[label.Data()] =  ibooker.book2D( label.Data(), label.Data(), btagBins, btagL, btagU, nBinsPt, pTmin, pTMax );
 				H2_.back()[label.Data()]->setAxisTitle("pT",2);
 				H2_.back()[label.Data()]->setAxisTitle("disc",1);
+				for (unsigned int i=0; i<modules_.size();i++){
+					ibooker.setCurrentFolder(dqmFolder+"/"+modules_[i]);
+					H2mod_.back()[label.Data()][modules_[i]] =  ibooker.book2D( label.Data(), label.Data(), btagBins, btagL, btagU, nBinsPt, pTmin, pTMax );
+					H2mod_.back()[label.Data()][modules_[i]]->setAxisTitle("pT",2);
+					H2mod_.back()[label.Data()][modules_[i]]->setAxisTitle("disc",1);
+				}
+				ibooker.setCurrentFolder(dqmFolder);
 				H2Eta_.back()[labelEta] =  ibooker.book2D( labelEta, labelEta, btagBins, btagL, btagU, nBinsEta, etamin, etaMax );
 				H2Eta_.back()[labelEta]->setAxisTitle("eta",2);
 				H2Eta_.back()[labelEta]->setAxisTitle("disc",1);

--- a/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
@@ -163,9 +163,9 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
 					TString label=JetTagCollection_Label[ind] + "__";
 					label+=flavour_str;
 					H1_.at(ind)[label.Data()]->Fill(std::fmax(0.0,BtagJT.second));	//fill 1D btag plot for 'b,c,uds'
-					for (unsigned int i=0; i<modules_.size();i++){
-						if (inmodule[modules_[i]])
-						H1mod_.at(ind)[label.Data()][modules_[i]]->Fill(std::fmax(0.0,BtagJT.second));	//fill 1D btag plot for 'b,c,uds' in modules (HEP17 etc.)
+					for (unsigned int j=0; j<modules_.size();j++){
+						if (inmodule[modules_[j]])
+						H1mod_.at(ind)[label.Data()][modules_[j]]->Fill(std::fmax(0.0,BtagJT.second));	//fill 1D btag plot for 'b,c,uds' in modules (HEP17 etc.)
 					}
 					label=JetTagCollection_Label[ind] + "___";
 					label+=flavour_str;
@@ -173,9 +173,9 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
 					std::string labelPhi = label.Data();
 					label+=TString("_disc_pT");
 					H2_.at(ind)[label.Data()]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->pt());	//fill 2D btag, jetPt plot for 'b,c,uds'
-					for (unsigned int i=0; i<modules_.size();i++){
-						if (inmodule[modules_[i]])
-						H2mod_.at(ind)[label.Data()][modules_[i]]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->pt());
+					for (unsigned int j=0; j<modules_.size();j++){
+						if (inmodule[modules_[j]])
+						H2mod_.at(ind)[label.Data()][modules_[j]]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->pt());
 					}
 					labelEta+="_disc_eta";
 					H2Eta_.at(ind)[labelEta]->Fill(std::fmax(0.0,BtagJT.second),BtagJT.first->eta());	//fill 2D btag, jetEta plot for 'b,c,uds'
@@ -244,10 +244,10 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 				//book 1D btag plot for 'b,c,light,g'
 				H1_.back()[label.Data()] = 		 ibooker.book1D(label.Data(),   Form("%s %s",JetTagCollection_Label[ind].c_str(),flavour.Data()), btagBins, btagL, btagU );
 				H1_.back()[label.Data()]->setAxisTitle("disc",1);
-				for (unsigned int i=0; i<modules_.size();i++){
-					ibooker.setCurrentFolder(dqmFolder+"/"+modules_[i]);
-					H1mod_.back()[label.Data()][modules_[i]] = 		 ibooker.book1D(label.Data(),   Form("%s %s",JetTagCollection_Label[ind].c_str(),flavour.Data()), btagBins, btagL, btagU );
-					H1mod_.back()[label.Data()][modules_[i]]->setAxisTitle("disc",1);
+				for (unsigned int j=0; j<modules_.size();j++){
+					ibooker.setCurrentFolder(dqmFolder+"/"+modules_[j]);
+					H1mod_.back()[label.Data()][modules_[j]] = 		 ibooker.book1D(label.Data(),   Form("%s %s",JetTagCollection_Label[ind].c_str(),flavour.Data()), btagBins, btagL, btagU );
+					H1mod_.back()[label.Data()][modules_[j]]->setAxisTitle("disc",1);
 				}
 				ibooker.setCurrentFolder(dqmFolder);
 				label=JetTagCollection_Label[ind]+"___";
@@ -261,11 +261,11 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, edm
 				H2_.back()[label.Data()] =  ibooker.book2D( label.Data(), label.Data(), btagBins, btagL, btagU, nBinsPt, pTmin, pTMax );
 				H2_.back()[label.Data()]->setAxisTitle("pT",2);
 				H2_.back()[label.Data()]->setAxisTitle("disc",1);
-				for (unsigned int i=0; i<modules_.size();i++){
-					ibooker.setCurrentFolder(dqmFolder+"/"+modules_[i]);
-					H2mod_.back()[label.Data()][modules_[i]] =  ibooker.book2D( label.Data(), label.Data(), btagBins, btagL, btagU, nBinsPt, pTmin, pTMax );
-					H2mod_.back()[label.Data()][modules_[i]]->setAxisTitle("pT",2);
-					H2mod_.back()[label.Data()][modules_[i]]->setAxisTitle("disc",1);
+				for (unsigned int j=0; j<modules_.size();j++){
+					ibooker.setCurrentFolder(dqmFolder+"/"+modules_[j]);
+					H2mod_.back()[label.Data()][modules_[j]] =  ibooker.book2D( label.Data(), label.Data(), btagBins, btagL, btagU, nBinsPt, pTmin, pTMax );
+					H2mod_.back()[label.Data()][modules_[j]]->setAxisTitle("pT",2);
+					H2mod_.back()[label.Data()][modules_[j]]->setAxisTitle("disc",1);
 				}
 				ibooker.setCurrentFolder(dqmFolder);
 				H2Eta_.back()[labelEta] =  ibooker.book2D( labelEta, labelEta, btagBins, btagL, btagU, nBinsEta, etamin, etaMax );


### PR DESCRIPTION
Adding the usual validation plots for specific modules (HEP17, HEM17, HEP18).
Adding the HEP17/HEM17 relation plots.
An example of relation plots are here:
https://twiki.cern.ch/twiki/bin/view/Sandbox/NataliaTsirovaSandbox#Relations_HEP17_HEM17