### PR TITLE
Adding anode DB suppression status to the rechits

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HFSimpleTimeCheck.cc
@@ -107,12 +107,12 @@ HFRecHit HFSimpleTimeCheck::reconstruct(const HFPreRecHit& prehit,
     bool isTimingReliable[2] = {true, true};
     for (unsigned ianode=0; ianode<2; ++ianode)
     {
-        const HFQIE10Info* anodeInfo = prehit.getHFQIE10Info(ianode);
-        if (anodeInfo)
+        if (flaggedBadInDB[ianode])
+            states[ianode] = HFAnodeStatus::FLAGGED_BAD;
+        else
         {
-            if (flaggedBadInDB[ianode])
-                states[ianode] = HFAnodeStatus::FLAGGED_BAD;
-            else
+            const HFQIE10Info* anodeInfo = prehit.getHFQIE10Info(ianode);
+            if (anodeInfo)
                 states[ianode] = determineAnodeStatus(ianode, *anodeInfo,
                                                       &isTimingReliable[ianode]);
         }


### PR DESCRIPTION
This change ensures that the status of "anode" in the HF reco will be reflected in the combined PMT rechit whenever that anode is flagged bad in the relevant DB calibration table. In the previous version of the code, this was done only if the anode was actually present in the digis. With this update, the status will be propagated to the rechit even if that anode is not in the data stream (but its neighbor anode is). This will make a difference for "dead" channels flagged in DB.

Since, at the moment, there are no bad channels flagged in the DB for HF, this PR will not change any relval results.
