### PR TITLE
adding a PFJets-Tau overlap removal module for HLT

### DIFF
--- a/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
+++ b/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
@@ -1,0 +1,35 @@
+#ifndef PFJetsTauOverlapRemoval_H
+#define PFJetsTauOverlapRemoval_H
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/TauReco/interface/PFTauFwd.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
+#include <map>
+#include <vector>
+class PFJetsTauOverlapRemoval: public edm::global::EDProducer<> {
+ public:
+  explicit PFJetsTauOverlapRemoval(const edm::ParameterSet&);
+  ~PFJetsTauOverlapRemoval();
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+ private:
+    
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc;
+  const edm::EDGetTokenT<reco::PFJetCollection> PFJetSrc;
+
+};
+#endif

--- a/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
+++ b/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
@@ -28,8 +28,8 @@ class PFJetsTauOverlapRemoval: public edm::global::EDProducer<> {
 
  private:
     
-  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc;
-  const edm::EDGetTokenT<reco::PFJetCollection> PFJetSrc;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc_;
+  const edm::EDGetTokenT<reco::PFJetCollection> pfJetSrc_;
 
 };
 #endif

--- a/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
+++ b/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
@@ -22,13 +22,12 @@ class PFJetsTauOverlapRemoval: public edm::global::EDProducer<> {
  private:
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc_;
   const edm::EDGetTokenT<reco::PFJetCollection> pfJetSrc_;
-  const double mindR_;
+  const double matchingR2_;
 
  public:
   explicit PFJetsTauOverlapRemoval(const edm::ParameterSet&);
   ~PFJetsTauOverlapRemoval();
   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  const double matchingR2;
 };
 #endif

--- a/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
+++ b/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
@@ -17,19 +17,18 @@
 #include "DataFormats/HLTReco/interface/TriggerObject.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
 
-#include <map>
-#include <vector>
 class PFJetsTauOverlapRemoval: public edm::global::EDProducer<> {
+
+ private:
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc_;
+  const edm::EDGetTokenT<reco::PFJetCollection> pfJetSrc_;
+  const double mindR_;
+
  public:
   explicit PFJetsTauOverlapRemoval(const edm::ParameterSet&);
   ~PFJetsTauOverlapRemoval();
   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
- private:
-    
-  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc_;
-  const edm::EDGetTokenT<reco::PFJetCollection> pfJetSrc_;
-  const double mindR_;
+  const double matchingR2;
 };
 #endif

--- a/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
+++ b/RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h
@@ -1,5 +1,5 @@
-#ifndef PFJetsTauOverlapRemoval_H
-#define PFJetsTauOverlapRemoval_H
+#ifndef RecoTauTag_HLTProducers_PFJetsTauOverlapRemoval_H
+#define RecoTauTag_HLTProducers_PFJetsTauOverlapRemoval_H
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -30,6 +30,6 @@ class PFJetsTauOverlapRemoval: public edm::global::EDProducer<> {
     
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauSrc_;
   const edm::EDGetTokenT<reco::PFJetCollection> pfJetSrc_;
-
+  const double mindR_;
 };
 #endif

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -13,8 +13,8 @@ using namespace edm    ;
 using namespace trigger;
 
 PFJetsTauOverlapRemoval::PFJetsTauOverlapRemoval(const edm::ParameterSet& iConfig):
-  tauSrc    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("TauSrc"      ) ) ),
-  PFJetSrc( consumes<PFJetCollection>(iConfig.getParameter<InputTag>("PFJetSrc") ) )
+  tauSrc_    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("TauSrc"      ) ) ),
+  pfJetSrc_  ( consumes<PFJetCollection>(iConfig.getParameter<InputTag>("PFJetSrc") ) )
 {  
   produces<PFJetCollection>();
 }
@@ -25,14 +25,14 @@ void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, co
     
   unique_ptr<PFJetCollection> cleanedPFJets(new PFJetCollection);
     
-  double deltaR    = 1.0;
-  double matchingR = 0.5;
+  double deltaR2   = 1.0;
+  double matchingR2 = 0.25;
   
   edm::Handle<trigger::TriggerFilterObjectWithRefs> tauJets;
-  iEvent.getByToken( tauSrc, tauJets );
+  iEvent.getByToken( tauSrc_, tauJets );
   
   edm::Handle<PFJetCollection> PFJets;
-  iEvent.getByToken(PFJetSrc,PFJets);
+  iEvent.getByToken(pfJetSrc_,PFJets);
                 
   trigger::VRpftau taus; 
   tauJets->getObjects(trigger::TriggerTau,taus);
@@ -41,8 +41,8 @@ void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, co
     for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
       for(unsigned int iJet = 0; iJet < PFJets->size(); iJet++){
         const PFJet &  myPFJet = (*PFJets)[iJet];
-        deltaR = ROOT::Math::VectorUtil::DeltaR((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-        if(deltaR > matchingR) cleanedPFJets->push_back(myPFJet);
+        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+        if(deltaR2 > matchingR2) cleanedPFJets->push_back(myPFJet);
         break;
       }
     }
@@ -51,8 +51,8 @@ void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, co
     for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
       for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
         const PFJet &  myPFJet = (*PFJets)[iJet];
-        deltaR = ROOT::Math::VectorUtil::DeltaR((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-        if(deltaR > matchingR) cleanedPFJets->push_back(myPFJet);
+        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+        if(deltaR2 > matchingR2) cleanedPFJets->push_back(myPFJet);
         break;
       }
     }

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -18,7 +18,7 @@ PFJetsTauOverlapRemoval::~PFJetsTauOverlapRemoval(){ }
 void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
 {
     
-  unique_ptr<reco::PFJetCollection> cleanedPFJets(new reco::PFJetCollection);
+    std::unique_ptr<reco::PFJetCollection> cleanedPFJets(new reco::PFJetCollection);
     
   double deltaR2   = 1.0;
   double matchingR2 = 0.25;  

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -7,106 +7,46 @@
 //
 // class declaration
 //
-using namespace reco   ;
-using namespace std    ;
-using namespace edm    ;
-using namespace trigger;
-
 PFJetsTauOverlapRemoval::PFJetsTauOverlapRemoval(const edm::ParameterSet& iConfig):
-  tauSrc_    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("TauSrc"      ) ) ),
-  pfJetSrc_  ( consumes<PFJetCollection>(iConfig.getParameter<InputTag>("PFJetSrc") ) )
+  tauSrc_    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<edm::InputTag>("TauSrc"      ) ) ),
+  pfJetSrc_  ( consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("PFJetSrc") ) )
 {  
-  produces<PFJetCollection>();
+  produces<reco::PFJetCollection>();
 }
 PFJetsTauOverlapRemoval::~PFJetsTauOverlapRemoval(){ }
 
 void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
 {
     
-  unique_ptr<PFJetCollection> cleanedPFJets(new PFJetCollection);
+  unique_ptr<reco::PFJetCollection> cleanedPFJets(new reco::PFJetCollection);
     
   double deltaR2   = 1.0;
-  double matchingR2 = 0.25;
+  double matchingR2 = 0.25;  
   
   edm::Handle<trigger::TriggerFilterObjectWithRefs> tauJets;
-  iEvent.getByToken( tauSrc_, tauJets );
+  iEvent.getByToken(tauSrc_, tauJets);
   
-  edm::Handle<PFJetCollection> PFJets;
+  edm::Handle<reco::PFJetCollection> PFJets;
   iEvent.getByToken(pfJetSrc_,PFJets);
                 
   trigger::VRpftau taus; 
   tauJets->getObjects(trigger::TriggerTau,taus);
 
-//  if(PFJets->size() == 2){
-//    for(unsigned int iJet = 0; iJet < PFJets->size(); iJet++){
-//      bool isMatched = false;  
-//      for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-//        const PFJet &  myPFJet = (*PFJets)[iJet];
-//        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-//        if(deltaR2 < matchingR2){
-//          isMatched = true;
-//          break;
-//        }
-//      if(isMatched == false) cleanedPFJets->push_back(myPFJet);
-//      }
-//    }
-//  }
-  
- 
-  //trying something new - combining both cases in one taking only first two jets for matching
-  //and then keeping third or highest pt jet
-  
-  for(unsigned int iJet = 0; iJet < 3; iJet++){
-    bool isMatched = false;  
-    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-      const PFJet &  myPFJet = (*PFJets)[iJet];
-      deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-      if(deltaR2 < matchingR2){
-        isMatched = true;
-        break;
+  if(PFJets->size() > 1){
+    for(unsigned int iJet = 0; iJet < 2; iJet++){  
+      bool isMatched = false;  
+      const reco::PFJet &  myPFJet = (*PFJets)[iJet];
+      for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+        if(deltaR2 < matchingR2){
+          isMatched = true;
+          break;
+        }
       }
+      if(isMatched == false) cleanedPFJets->push_back(myPFJet);
     }
-    if(isMatched == false) cleanedPFJets->push_back(myPFJet);
+    if(PFJets->size() > 2) cleanedPFJets->push_back((*PFJets)[2]);
   }
-
-  cleanedPFJets->push_back((*PFJets)[2]);
-  
-  
-
-
-
-//  else if(PFJets->size() == 3){
-//    for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
-//      bool isMatched = false;  
-//      for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-//        const PFJet &  myPFJet = (*PFJets)[iJet];
-//        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-//        if(deltaR2 < matchingR2){
-//          isMatched = true;
-//          break;
-//        }
-//      if(isMatched == false) cleanedPFJets->push_back(myPFJet);
-//      }
-//    }
-//    cleanedPFJets->push_back((*PFJets)[2]);
-//  }
-// 
-//  else if(PFJets->size() == 3){
-//    for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
-//      bool isMatched = false;  
-//      for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-//        const PFJet &  myPFJet = (*PFJets)[iJet];
-//        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-//        if(deltaR2 < matchingR2){
-//          isMatched = true;
-//          break;
-//        }
-//      if(isMatched == false) cleanedPFJets->push_back(myPFJet);
-//      }
-//    }
-//    cleanedPFJets->push_back((*PFJets)[2]);
-//  }
-  
   iEvent.put(std::move(cleanedPFJets));
 }
 

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -37,28 +37,75 @@ void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, co
   trigger::VRpftau taus; 
   tauJets->getObjects(trigger::TriggerTau,taus);
 
-  if(PFJets->size() == 2 || PFJets->size() > 3){
-    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-      for(unsigned int iJet = 0; iJet < PFJets->size(); iJet++){
-        const PFJet &  myPFJet = (*PFJets)[iJet];
-        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-        if(deltaR2 > matchingR2) cleanedPFJets->push_back(myPFJet);
-        break;
-      }
-    }
-  }
-  else if(PFJets->size() == 3){
-    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-      for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
-        const PFJet &  myPFJet = (*PFJets)[iJet];
-        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
-        if(deltaR2 > matchingR2) cleanedPFJets->push_back(myPFJet);
-        break;
-      }
-    }
-    if(PFJets->size() > 2) cleanedPFJets->push_back((*PFJets)[2]);
-  }
+//  if(PFJets->size() == 2){
+//    for(unsigned int iJet = 0; iJet < PFJets->size(); iJet++){
+//      bool isMatched = false;  
+//      for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+//        const PFJet &  myPFJet = (*PFJets)[iJet];
+//        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+//        if(deltaR2 < matchingR2){
+//          isMatched = true;
+//          break;
+//        }
+//      if(isMatched == false) cleanedPFJets->push_back(myPFJet);
+//      }
+//    }
+//  }
+  
  
+  //trying something new - combining both cases in one taking only first two jets for matching
+  //and then keeping third or highest pt jet
+  
+  for(unsigned int iJet = 0; iJet < 3; iJet++){
+    bool isMatched = false;  
+    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+      const PFJet &  myPFJet = (*PFJets)[iJet];
+      deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+      if(deltaR2 < matchingR2){
+        isMatched = true;
+        break;
+      }
+    }
+    if(isMatched == false) cleanedPFJets->push_back(myPFJet);
+  }
+
+  cleanedPFJets->push_back((*PFJets)[2]);
+  
+  
+
+
+
+//  else if(PFJets->size() == 3){
+//    for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
+//      bool isMatched = false;  
+//      for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+//        const PFJet &  myPFJet = (*PFJets)[iJet];
+//        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+//        if(deltaR2 < matchingR2){
+//          isMatched = true;
+//          break;
+//        }
+//      if(isMatched == false) cleanedPFJets->push_back(myPFJet);
+//      }
+//    }
+//    cleanedPFJets->push_back((*PFJets)[2]);
+//  }
+// 
+//  else if(PFJets->size() == 3){
+//    for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
+//      bool isMatched = false;  
+//      for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+//        const PFJet &  myPFJet = (*PFJets)[iJet];
+//        deltaR2 = ROOT::Math::VectorUtil::DeltaR2((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+//        if(deltaR2 < matchingR2){
+//          isMatched = true;
+//          break;
+//        }
+//      if(isMatched == false) cleanedPFJets->push_back(myPFJet);
+//      }
+//    }
+//    cleanedPFJets->push_back((*PFJets)[2]);
+//  }
   
   iEvent.put(std::move(cleanedPFJets));
 }

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -1,0 +1,73 @@
+#include "RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h"
+#include "Math/GenVector/VectorUtil.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+
+//
+// class declaration
+//
+using namespace reco   ;
+using namespace std    ;
+using namespace edm    ;
+using namespace trigger;
+
+PFJetsTauOverlapRemoval::PFJetsTauOverlapRemoval(const edm::ParameterSet& iConfig):
+  tauSrc    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("TauSrc"      ) ) ),
+  PFJetSrc( consumes<PFJetCollection>(iConfig.getParameter<InputTag>("PFJetSrc") ) )
+{  
+  produces<PFJetCollection>();
+}
+PFJetsTauOverlapRemoval::~PFJetsTauOverlapRemoval(){ }
+
+void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
+{
+    
+  unique_ptr<PFJetCollection> cleanedPFJets(new PFJetCollection);
+    
+  double deltaR    = 1.0;
+  double matchingR = 0.5;
+  
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> tauJets;
+  iEvent.getByToken( tauSrc, tauJets );
+  
+  edm::Handle<PFJetCollection> PFJets;
+  iEvent.getByToken(PFJetSrc,PFJets);
+                
+  trigger::VRpftau taus; 
+  tauJets->getObjects(trigger::TriggerTau,taus);
+
+  if(PFJets->size() == 2 || PFJets->size() > 3){
+    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+      for(unsigned int iJet = 0; iJet < PFJets->size(); iJet++){
+        const PFJet &  myPFJet = (*PFJets)[iJet];
+        deltaR = ROOT::Math::VectorUtil::DeltaR((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+        if(deltaR > matchingR) cleanedPFJets->push_back(myPFJet);
+        break;
+      }
+    }
+  }
+  else if(PFJets->size() == 3){
+    for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
+      for(unsigned int iJet = 0; iJet < PFJets->size()-1; iJet++){
+        const PFJet &  myPFJet = (*PFJets)[iJet];
+        deltaR = ROOT::Math::VectorUtil::DeltaR((taus[iTau])->p4().Vect(), myPFJet.p4().Vect());
+        if(deltaR > matchingR) cleanedPFJets->push_back(myPFJet);
+        break;
+      }
+    }
+    if(PFJets->size() > 2) cleanedPFJets->push_back((*PFJets)[2]);
+  }
+ 
+  
+  iEvent.put(std::move(cleanedPFJets));
+}
+
+void PFJetsTauOverlapRemoval::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
+{
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("PFJetSrc", edm::InputTag("hltAK4PFJetsCorrected"                     ))->setComment("Input collection of PFJets"    );
+  desc.add<edm::InputTag>("TauSrc"      , edm::InputTag("hltPFTau20TrackLooseIso"))->setComment("Input collection of PFTaus that have passed ID and isolation requirements");
+  descriptions.setComment("This module produces a collection of PFJets that are cross-cleaned with respect to PFTaus passing a HLT filter.");
+  descriptions.add       ("PFJetsTauOverlapRemoval",desc);
+}

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -11,9 +11,7 @@
 PFJetsTauOverlapRemoval::PFJetsTauOverlapRemoval(const edm::ParameterSet& iConfig):
   tauSrc_    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<edm::InputTag>("TauSrc"      ) ) ),
   pfJetSrc_  ( consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("PFJetSrc") ) ),
-  mindR_     ( iConfig.getParameter<double>("Min_dR") ),
-
-  matchingR2 ( mindR_*mindR_ )
+  matchingR2_ ( iConfig.getParameter<double>("Min_dR")*iConfig.getParameter<double>("Min_dR") )
 {  
   produces<reco::PFJetCollection>();
 }
@@ -21,7 +19,6 @@ PFJetsTauOverlapRemoval::~PFJetsTauOverlapRemoval(){ }
 
 void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
 {
-    
   std::unique_ptr<reco::PFJetCollection> cleanedPFJets(new reco::PFJetCollection);
     
   edm::Handle<trigger::TriggerFilterObjectWithRefs> tauJets;
@@ -38,7 +35,7 @@ void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, co
       bool isMatched = false;  
       const reco::PFJet &  myPFJet = (*PFJets)[iJet];
       for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-        if(reco::deltaR2(taus[iTau]->p4(), myPFJet.p4()) < matchingR2){
+        if(reco::deltaR2(taus[iTau]->p4(), myPFJet.p4()) < matchingR2_){
           isMatched = true;
           break;
         }

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 //
 // class declaration
@@ -37,7 +38,7 @@ void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, co
       bool isMatched = false;  
       const reco::PFJet &  myPFJet = (*PFJets)[iJet];
       for(unsigned int iTau = 0; iTau < taus.size(); iTau++){  
-        if(ROOT::Math::VectorUtil::DeltaR2((taus[iTau]->p4()).Vect(), myPFJet.p4().Vect()) < matchingR2){
+        if(reco::deltaR2(taus[iTau]->p4(), myPFJet.p4()) < matchingR2){
           isMatched = true;
           break;
         }

--- a/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
+++ b/RecoTauTag/HLTProducers/src/PFJetsTauOverlapRemoval.cc
@@ -11,7 +11,9 @@
 PFJetsTauOverlapRemoval::PFJetsTauOverlapRemoval(const edm::ParameterSet& iConfig):
   tauSrc_    ( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<edm::InputTag>("TauSrc"      ) ) ),
   pfJetSrc_  ( consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("PFJetSrc") ) ),
-  mindR_     ( iConfig.getParameter<double>("Min_dR") )
+  mindR_     ( iConfig.getParameter<double>("Min_dR") ),
+
+  matchingR2 ( mindR_*mindR_ )
 {  
   produces<reco::PFJetCollection>();
 }
@@ -22,8 +24,6 @@ void PFJetsTauOverlapRemoval::produce(edm::StreamID iSId, edm::Event& iEvent, co
     
   std::unique_ptr<reco::PFJetCollection> cleanedPFJets(new reco::PFJetCollection);
     
-  double matchingR2 = mindR_*mindR_;  
-  
   edm::Handle<trigger::TriggerFilterObjectWithRefs> tauJets;
   iEvent.getByToken(tauSrc_, tauJets);
   
@@ -54,7 +54,7 @@ void PFJetsTauOverlapRemoval::fillDescriptions(edm::ConfigurationDescriptions& d
 {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("PFJetSrc", edm::InputTag("hltAK4PFJetsCorrected"))->setComment("Input collection of PFJets"    );
-  desc.add<edm::InputTag>("TauSrc", edm::InputTag("hltPFTau20TrackLooseIso"))->setComment("Input collection of PFTaus that have passed ID and isolation requirements");
+  desc.add<edm::InputTag>("TauSrc", edm::InputTag("hltSinglePFTau20TrackPt1LooseChargedIsolationReg"))->setComment("Input collection of PFTaus that have passed ID and isolation requirements");
   desc.add<double>       ("Min_dR",0.5)->setComment("Minimum dR outside of which PFJets will be saved");
   descriptions.setComment("This module produces a collection of PFJets that are cross-cleaned with respect to PFTaus passing a HLT filter.");
   descriptions.add       ("PFJetsTauOverlapRemoval",desc);

--- a/RecoTauTag/HLTProducers/src/SealModule.cc
+++ b/RecoTauTag/HLTProducers/src/SealModule.cc
@@ -19,6 +19,7 @@
 //#include "RecoTauTag/HLTProducers/interface/L2TauPixelTrackMatch.h"
 #include "HLTPFTauPairLeadTrackDzMatchFilter.h"
 #include "RecoTauTag/HLTProducers/interface/L2TauPixelIsoTagProducer.h"
+#include "RecoTauTag/HLTProducers/interface/PFJetsTauOverlapRemoval.h"
 
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, TauRegionalPixelSeedGenerator, "TauRegionalPixelSeedGenerator");      
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, TrackingRegionsFromBeamSpotAndL2Tau, "TrackingRegionsFromBeamSpotAndL2Tau");
@@ -45,4 +46,4 @@ DEFINE_FWK_MODULE(VertexFromTrackProducer);
 //DEFINE_FWK_MODULE(L2TauPixelTrackMatch);
 DEFINE_FWK_MODULE(HLTPFTauPairLeadTrackDzMatchFilter);
 DEFINE_FWK_MODULE(L2TauPixelIsoTagProducer);
-
+DEFINE_FWK_MODULE(PFJetsTauOverlapRemoval);


### PR DESCRIPTION
This module is able to remove the overlap between PF jets and taus. The PF jets would be taken from a PFJetCollection and the tau objects come from an HLT filter (so that we can use taus that are ID'ed and isolated). This is necessary for the development of VBF jets + tau HLT paths where we need to cross-clean the PF jets from taus. 