### PR TITLE
Avoid making three copies of a large PSet in TrackingMonitor

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -82,6 +82,8 @@ class TrackAnalyzer
 	
         edm::ParameterSet const* conf_;
 
+        std::string stateName_;
+
         bool doTrackerSpecific_;
         bool doAllPlots_;
         bool doBSPlots_;

--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -32,15 +32,16 @@ Monitoring source for general quantities related to tracks.
 class DQMStore;
 
 class BeamSpot;
+namespace dqm {
 class TrackAnalyzer 
 {
     public:
         TrackAnalyzer(const edm::ParameterSet&);
-	TrackAnalyzer(const edm::ParameterSet&, edm::ConsumesCollector& iC);
-        virtual ~TrackAnalyzer();
-        virtual void initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup &);
+        TrackAnalyzer(const edm::ParameterSet&, edm::ConsumesCollector& iC);
+        ~TrackAnalyzer();
+        void initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup &, const edm::ParameterSet&);
 
-        virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Track& track);
+        void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Track& track);
 
         void doSoftReset  (DQMStore * dqmStore_);
         void doReset      ();
@@ -79,7 +80,7 @@ class TrackAnalyzer
 	edm::EDGetTokenT<LumiScalersCollection> lumiscalersToken_;
 	float lumi_factor_per_bx_;
 	
-        edm::ParameterSet conf_;
+        edm::ParameterSet const* conf_;
 
         bool doTrackerSpecific_;
         bool doAllPlots_;
@@ -461,4 +462,5 @@ class TrackAnalyzer
 
         std::string histname;  //for naming the histograms according to algorithm used
 };
+}
 #endif

--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -35,9 +35,9 @@ class TrackBuildingAnalyzer
 {
     public:
         TrackBuildingAnalyzer(const edm::ParameterSet&);
-        virtual ~TrackBuildingAnalyzer();
-        virtual void initHisto(DQMStore::IBooker & ibooker);
-        virtual void analyze
+        ~TrackBuildingAnalyzer();
+        void initHisto(DQMStore::IBooker & ibooker, const edm::ParameterSet&);
+        void analyze
         (
             const edm::Event& iEvent, 
             const edm::EventSetup& iSetup, 
@@ -46,7 +46,7 @@ class TrackBuildingAnalyzer
             const edm::ESHandle<MagneticField>& theMF,
             const edm::ESHandle<TransientTrackingRecHitBuilder>& theTTRHBuilder
         );
-        virtual void analyze
+        void analyze
         (
             const edm::Event& iEvent, 
             const edm::EventSetup& iSetup, 
@@ -62,8 +62,6 @@ class TrackBuildingAnalyzer
         void bookHistos(std::string sname, DQMStore::IBooker & ibooker);
 
         // ----------member data ---------------------------
-
-        edm::ParameterSet conf_;
 
         // Track Seeds
         MonitorElement* SeedPt;

--- a/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
@@ -34,7 +34,6 @@
 
 
 class DQMStore;
-class TrackAnalyzer;
 class TProfile;
 
 #include "DataFormats/MuonReco/interface/Muon.h"

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -39,7 +39,9 @@ Monitoring source for general quantities related to tracks.
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-class TrackAnalyzer;
+namespace dqm {
+  class TrackAnalyzer;
+}
 class TrackBuildingAnalyzer;
 class VertexMonitor;
 class GetLumi;
@@ -73,7 +75,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 
 	//        DQMStore * dqmStore_;
 
-        edm::ParameterSet conf_;
+        edm::ParameterSetID confID_;
 
         // the track analyzer
         edm::InputTag bsSrc_;
@@ -97,7 +99,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	std::string AlgoName_;
 
 
-        TrackAnalyzer * theTrackAnalyzer;
+        dqm::TrackAnalyzer * theTrackAnalyzer;
         TrackBuildingAnalyzer  * theTrackBuildingAnalyzer;
 	std::vector<VertexMonitor*> theVertexMonitor;
 	GetLumi*                    theLumiDetails_;

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -25,6 +25,7 @@ using namespace dqm;
 
 TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig) 
     : conf_( nullptr )
+    , stateName_                       (iConfig.getParameter<std::string>("MeasurementState") )
     , doTrackerSpecific_               ( iConfig.getParameter<bool>("doTrackerSpecific") )
     , doAllPlots_                      ( iConfig.getParameter<bool>("doAllPlots") )
     , doBSPlots_                       ( iConfig.getParameter<bool>("doBeamSpotPlots") )
@@ -181,22 +182,21 @@ void TrackAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup
   // ---------------------------------------------------------------------------------//
   if (doMeasurementStatePlots_ || doAllPlots_) {
 
-    std::string StateName = iConfig.getParameter<std::string>("MeasurementState");
     
-    if (StateName == "All") {
+    if (stateName_ == "All") {
       bookHistosForState("OuterSurface", ibooker);
       bookHistosForState("InnerSurface", ibooker);
       bookHistosForState("ImpactPoint" , ibooker);
     } else if (
-	       StateName != "OuterSurface" && 
-	       StateName != "InnerSurface" && 
-	       StateName != "ImpactPoint" &&
-	       StateName != "default" 
+	       stateName_ != "OuterSurface" && 
+	       stateName_ != "InnerSurface" && 
+	       stateName_ != "ImpactPoint" &&
+	       stateName_ != "default" 
 	       ) {
       bookHistosForState("default", ibooker);
 
     } else {
-      bookHistosForState(StateName, ibooker);
+      bookHistosForState(stateName_, ibooker);
     }
     conf_ = nullptr;
   }
@@ -1235,21 +1235,20 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   }
 
   if (doMeasurementStatePlots_ || doAllPlots_){
-    std::string StateName = conf_->getParameter<std::string>("MeasurementState");
 
-    if (StateName == "All") {
+    if (stateName_ == "All") {
       fillHistosForState(iSetup, track, std::string("OuterSurface"));
       fillHistosForState(iSetup, track, std::string("InnerSurface"));
       fillHistosForState(iSetup, track, std::string("ImpactPoint"));
     } else if ( 
-	       StateName != "OuterSurface" && 
-	       StateName != "InnerSurface" && 
-	       StateName != "ImpactPoint" &&
-	       StateName != "default" 
+	       stateName_ != "OuterSurface" && 
+	       stateName_ != "InnerSurface" && 
+	       stateName_ != "ImpactPoint" &&
+	       stateName_ != "default" 
 	       ) {
       fillHistosForState(iSetup, track, std::string("default"));
     } else {
-      fillHistosForState(iSetup, track, StateName);
+      fillHistosForState(iSetup, track, stateName_);
     }
   }
   

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -21,52 +21,54 @@
 #include "TMath.h"
 #include "DQM/TrackingMonitor/interface/GetLumi.h"
 
+using namespace dqm;
+
 TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig) 
-    : conf_( iConfig )
-    , doTrackerSpecific_               ( conf_.getParameter<bool>("doTrackerSpecific") )
-    , doAllPlots_                      ( conf_.getParameter<bool>("doAllPlots") )
-    , doBSPlots_                       ( conf_.getParameter<bool>("doBeamSpotPlots") )
-    , doPVPlots_                       ( conf_.getParameter<bool>("doPrimaryVertexPlots") )
-    , doDCAPlots_                      ( conf_.getParameter<bool>("doDCAPlots") )
-    , doGeneralPropertiesPlots_        ( conf_.getParameter<bool>("doGeneralPropertiesPlots") )
-    , doMeasurementStatePlots_         ( conf_.getParameter<bool>("doMeasurementStatePlots") )
-    , doHitPropertiesPlots_            ( conf_.getParameter<bool>("doHitPropertiesPlots") )
-    , doRecHitVsPhiVsEtaPerTrack_      ( conf_.getParameter<bool>("doRecHitVsPhiVsEtaPerTrack") )
-    , doRecHitVsPtVsEtaPerTrack_       ( conf_.getParameter<bool>("doRecHitVsPtVsEtaPerTrack") )
-    , doLayersVsPhiVsEtaPerTrack_      ( conf_.getParameter<bool>("doLayersVsPhiVsEtaPerTrack") )
-    , doRecHitsPerTrackProfile_        ( conf_.getParameter<bool>("doRecHitsPerTrackProfile") )
-    , doThetaPlots_                    ( conf_.getParameter<bool>("doThetaPlots") )
-    , doTrackPxPyPlots_                ( conf_.getParameter<bool>("doTrackPxPyPlots") )
-    , doDCAwrtPVPlots_                 ( conf_.getParameter<bool>("doDCAwrtPVPlots") )
-    , doDCAwrt000Plots_                ( conf_.getParameter<bool>("doDCAwrt000Plots") )
-    , doLumiAnalysis_                  ( conf_.getParameter<bool>("doLumiAnalysis") )
-    , doTestPlots_                     ( conf_.getParameter<bool>("doTestPlots") )
-    , doHIPlots_                       ( conf_.getParameter<bool>("doHIPlots")  )
-    , doSIPPlots_                      ( conf_.getParameter<bool>("doSIPPlots") )
-    , doEffFromHitPatternVsPU_         ( conf_.getParameter<bool>("doEffFromHitPatternVsPU")   )
-    , doEffFromHitPatternVsBX_         ( conf_.getParameter<bool>("doEffFromHitPatternVsBX")   )
-    , doEffFromHitPatternVsLUMI_       ( conf_.getParameter<bool>("doEffFromHitPatternVsLUMI") )
-    , pvNDOF_                          ( conf_.getParameter<int> ("pvNDOF") )
-    , useBPixLayer1_                   ( conf_.getParameter<bool>("useBPixLayer1") )
-    , minNumberOfPixelsPerCluster_     ( conf_.getParameter<int>("minNumberOfPixelsPerCluster") )
-    , minPixelClusterCharge_           ( conf_.getParameter<double>("minPixelClusterCharge") )
-    , qualityString_                   ( conf_.getParameter<std::string>("qualityString"))
+    : conf_( nullptr )
+    , doTrackerSpecific_               ( iConfig.getParameter<bool>("doTrackerSpecific") )
+    , doAllPlots_                      ( iConfig.getParameter<bool>("doAllPlots") )
+    , doBSPlots_                       ( iConfig.getParameter<bool>("doBeamSpotPlots") )
+    , doPVPlots_                       ( iConfig.getParameter<bool>("doPrimaryVertexPlots") )
+    , doDCAPlots_                      ( iConfig.getParameter<bool>("doDCAPlots") )
+    , doGeneralPropertiesPlots_        ( iConfig.getParameter<bool>("doGeneralPropertiesPlots") )
+    , doMeasurementStatePlots_         ( iConfig.getParameter<bool>("doMeasurementStatePlots") )
+    , doHitPropertiesPlots_            ( iConfig.getParameter<bool>("doHitPropertiesPlots") )
+    , doRecHitVsPhiVsEtaPerTrack_      ( iConfig.getParameter<bool>("doRecHitVsPhiVsEtaPerTrack") )
+    , doRecHitVsPtVsEtaPerTrack_       ( iConfig.getParameter<bool>("doRecHitVsPtVsEtaPerTrack") )
+    , doLayersVsPhiVsEtaPerTrack_      ( iConfig.getParameter<bool>("doLayersVsPhiVsEtaPerTrack") )
+    , doRecHitsPerTrackProfile_        ( iConfig.getParameter<bool>("doRecHitsPerTrackProfile") )
+    , doThetaPlots_                    ( iConfig.getParameter<bool>("doThetaPlots") )
+    , doTrackPxPyPlots_                ( iConfig.getParameter<bool>("doTrackPxPyPlots") )
+    , doDCAwrtPVPlots_                 ( iConfig.getParameter<bool>("doDCAwrtPVPlots") )
+    , doDCAwrt000Plots_                ( iConfig.getParameter<bool>("doDCAwrt000Plots") )
+    , doLumiAnalysis_                  ( iConfig.getParameter<bool>("doLumiAnalysis") )
+    , doTestPlots_                     ( iConfig.getParameter<bool>("doTestPlots") )
+    , doHIPlots_                       ( iConfig.getParameter<bool>("doHIPlots")  )
+    , doSIPPlots_                      ( iConfig.getParameter<bool>("doSIPPlots") )
+    , doEffFromHitPatternVsPU_         ( iConfig.getParameter<bool>("doEffFromHitPatternVsPU")   )
+    , doEffFromHitPatternVsBX_         ( iConfig.getParameter<bool>("doEffFromHitPatternVsBX")   )
+    , doEffFromHitPatternVsLUMI_       ( iConfig.getParameter<bool>("doEffFromHitPatternVsLUMI") )
+    , pvNDOF_                          ( iConfig.getParameter<int> ("pvNDOF") )
+    , useBPixLayer1_                   ( iConfig.getParameter<bool>("useBPixLayer1") )
+    , minNumberOfPixelsPerCluster_     ( iConfig.getParameter<int>("minNumberOfPixelsPerCluster") )
+    , minPixelClusterCharge_           ( iConfig.getParameter<double>("minPixelClusterCharge") )
+    , qualityString_                   ( iConfig.getParameter<std::string>("qualityString"))
     , good_vertices_(0)
     , bx_(0)
     , pixel_lumi_(0.)
     , scal_lumi_(0.)
 {
   initHistos();
-  TopFolder_ = conf_.getParameter<std::string>("FolderName"); 
+  TopFolder_ = iConfig.getParameter<std::string>("FolderName"); 
 }
 
 TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) 
   : TrackAnalyzer(iConfig)
 {
-  edm::InputTag bsSrc                 = conf_.getParameter<edm::InputTag>("beamSpot");
-  edm::InputTag primaryVertexInputTag = conf_.getParameter<edm::InputTag>("primaryVertex");
-  edm::InputTag pixelClusterInputTag  = conf_.getParameter<edm::InputTag>("pixelCluster4lumi");
-  edm::InputTag scalInputTag          = conf_.getParameter<edm::InputTag>("scal");
+  edm::InputTag bsSrc                 = iConfig.getParameter<edm::InputTag>("beamSpot");
+  edm::InputTag primaryVertexInputTag = iConfig.getParameter<edm::InputTag>("primaryVertex");
+  edm::InputTag pixelClusterInputTag  = iConfig.getParameter<edm::InputTag>("pixelCluster4lumi");
+  edm::InputTag scalInputTag          = iConfig.getParameter<edm::InputTag>("scal");
   beamSpotToken_      = iC.consumes<reco::BeamSpot>(bsSrc);
   pvToken_            = iC.consumes<reco::VertexCollection>(primaryVertexInputTag);
   pixelClustersToken_ = iC.mayConsume<edmNew::DetSetVector<SiPixelCluster> >(pixelClusterInputTag);
@@ -160,9 +162,9 @@ TrackAnalyzer::~TrackAnalyzer()
 { 
 }
 
-void TrackAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup & iSetup)
+void TrackAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup & iSetup, const edm::ParameterSet& iConfig)
 {
-
+  conf_ = &iConfig;
   bookHistosForHitProperties(ibooker);
   bookHistosForBeamSpot(ibooker);
   bookHistosForLScertification( ibooker);
@@ -179,7 +181,7 @@ void TrackAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup
   // ---------------------------------------------------------------------------------//
   if (doMeasurementStatePlots_ || doAllPlots_) {
 
-    std::string StateName = conf_.getParameter<std::string>("MeasurementState");
+    std::string StateName = iConfig.getParameter<std::string>("MeasurementState");
     
     if (StateName == "All") {
       bookHistosForState("OuterSurface", ibooker);
@@ -196,7 +198,7 @@ void TrackAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::EventSetup
     } else {
       bookHistosForState(StateName, ibooker);
     }
-    
+    conf_ = nullptr;
   }
 }
 
@@ -207,9 +209,9 @@ void TrackAnalyzer::bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker &iboo
 
     ibooker.setCurrentFolder(TopFolder_ + "/HitEffFromHitPattern" + suffix);
     
-    int LUMIBin   = conf_.getParameter<int>("LUMIBin");
-    float LUMIMin = conf_.getParameter<double>("LUMIMin");
-    float LUMIMax = conf_.getParameter<double>("LUMIMax");
+    int LUMIBin   = conf_->getParameter<int>("LUMIBin");
+    float LUMIMin = conf_->getParameter<double>("LUMIMin");
+    float LUMIMax = conf_->getParameter<double>("LUMIMax");
     
 
     int NBINS[]        = { 50,   int(GetLumi::lastBunchCrossing),  300  , LUMIBin};
@@ -292,49 +294,49 @@ void TrackAnalyzer::bookHistosForEfficiencyFromHitPatter(DQMStore::IBooker &iboo
 void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
   
     // parameters from the configuration
-    std::string QualName       = conf_.getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_.getParameter<std::string>("AlgoName");
-    std::string MEBSFolderName = conf_.getParameter<std::string>("BSFolderName"); 
+    std::string QualName       = conf_->getParameter<std::string>("Quality");
+    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
+    std::string MEBSFolderName = conf_->getParameter<std::string>("BSFolderName"); 
 
     // use the AlgoName and Quality Name 
     std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
 
     // get binning from the configuration
-    int    TKHitBin     = conf_.getParameter<int>(   "RecHitBin");
-    double TKHitMin     = conf_.getParameter<double>("RecHitMin");
-    double TKHitMax     = conf_.getParameter<double>("RecHitMax");
+    int    TKHitBin     = conf_->getParameter<int>(   "RecHitBin");
+    double TKHitMin     = conf_->getParameter<double>("RecHitMin");
+    double TKHitMax     = conf_->getParameter<double>("RecHitMax");
 
-    int    TKLostBin    = conf_.getParameter<int>(   "RecLostBin");
-    double TKLostMin    = conf_.getParameter<double>("RecLostMin");
-    double TKLostMax    = conf_.getParameter<double>("RecLostMax");
+    int    TKLostBin    = conf_->getParameter<int>(   "RecLostBin");
+    double TKLostMin    = conf_->getParameter<double>("RecLostMin");
+    double TKLostMax    = conf_->getParameter<double>("RecLostMax");
 
-    int    TKLayBin     = conf_.getParameter<int>(   "RecLayBin");
-    double TKLayMin     = conf_.getParameter<double>("RecLayMin");
-    double TKLayMax     = conf_.getParameter<double>("RecLayMax");
+    int    TKLayBin     = conf_->getParameter<int>(   "RecLayBin");
+    double TKLayMin     = conf_->getParameter<double>("RecLayMin");
+    double TKLayMax     = conf_->getParameter<double>("RecLayMax");
 
-    int    PhiBin       = conf_.getParameter<int>(   "PhiBin");
-    double PhiMin       = conf_.getParameter<double>("PhiMin");
-    double PhiMax       = conf_.getParameter<double>("PhiMax");
+    int    PhiBin       = conf_->getParameter<int>(   "PhiBin");
+    double PhiMin       = conf_->getParameter<double>("PhiMin");
+    double PhiMax       = conf_->getParameter<double>("PhiMax");
 
-    int    EtaBin       = conf_.getParameter<int>(   "EtaBin");
-    double EtaMin       = conf_.getParameter<double>("EtaMin");
-    double EtaMax       = conf_.getParameter<double>("EtaMax");
+    int    EtaBin       = conf_->getParameter<int>(   "EtaBin");
+    double EtaMin       = conf_->getParameter<double>("EtaMin");
+    double EtaMax       = conf_->getParameter<double>("EtaMax");
 
-    int    PtBin = conf_.getParameter<int>(   "TrackPtBin");
-    double PtMin = conf_.getParameter<double>("TrackPtMin");
-    double PtMax = conf_.getParameter<double>("TrackPtMax");
+    int    PtBin = conf_->getParameter<int>(   "TrackPtBin");
+    double PtMin = conf_->getParameter<double>("TrackPtMin");
+    double PtMax = conf_->getParameter<double>("TrackPtMax");
 
-    int    VXBin        = conf_.getParameter<int>(   "VXBin");
-    double VXMin        = conf_.getParameter<double>("VXMin");
-    double VXMax        = conf_.getParameter<double>("VXMax");
+    int    VXBin        = conf_->getParameter<int>(   "VXBin");
+    double VXMin        = conf_->getParameter<double>("VXMin");
+    double VXMax        = conf_->getParameter<double>("VXMax");
 
-    int    VYBin        = conf_.getParameter<int>(   "VYBin");
-    double VYMin        = conf_.getParameter<double>("VYMin");
-    double VYMax        = conf_.getParameter<double>("VYMax");
+    int    VYBin        = conf_->getParameter<int>(   "VYBin");
+    double VYMin        = conf_->getParameter<double>("VYMin");
+    double VYMax        = conf_->getParameter<double>("VYMax");
 
-    int    VZBin        = conf_.getParameter<int>(   "VZBin");
-    double VZMin        = conf_.getParameter<double>("VZMin");
-    double VZMax        = conf_.getParameter<double>("VZMax");
+    int    VZBin        = conf_->getParameter<int>(   "VZBin");
+    double VZMin        = conf_->getParameter<double>("VZMin");
+    double VZMax        = conf_->getParameter<double>("VZMax");
 
     ibooker.setCurrentFolder(TopFolder_);
 
@@ -485,27 +487,27 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
     
     if (doGeneralPropertiesPlots_ || doAllPlots_){
       
-      int    Chi2Bin      = conf_.getParameter<int>(   "Chi2Bin");
-      double Chi2Min      = conf_.getParameter<double>("Chi2Min");
-      double Chi2Max      = conf_.getParameter<double>("Chi2Max");
+      int    Chi2Bin      = conf_->getParameter<int>(   "Chi2Bin");
+      double Chi2Min      = conf_->getParameter<double>("Chi2Min");
+      double Chi2Max      = conf_->getParameter<double>("Chi2Max");
       
-      int    Chi2NDFBin   = conf_.getParameter<int>(   "Chi2NDFBin");
-      double Chi2NDFMin   = conf_.getParameter<double>("Chi2NDFMin");
-      double Chi2NDFMax   = conf_.getParameter<double>("Chi2NDFMax");
+      int    Chi2NDFBin   = conf_->getParameter<int>(   "Chi2NDFBin");
+      double Chi2NDFMin   = conf_->getParameter<double>("Chi2NDFMin");
+      double Chi2NDFMax   = conf_->getParameter<double>("Chi2NDFMax");
       
-      int    Chi2ProbBin  = conf_.getParameter<int>(   "Chi2ProbBin");
-      double Chi2ProbMin  = conf_.getParameter<double>("Chi2ProbMin");
-      double Chi2ProbMax  = conf_.getParameter<double>("Chi2ProbMax");
+      int    Chi2ProbBin  = conf_->getParameter<int>(   "Chi2ProbBin");
+      double Chi2ProbMin  = conf_->getParameter<double>("Chi2ProbMin");
+      double Chi2ProbMax  = conf_->getParameter<double>("Chi2ProbMax");
     
 
       //HI PLOTS////                                                       
-      int TransDCABins = conf_.getParameter<int>("TransDCABins");
-      double TransDCAMin = conf_.getParameter<double>("TransDCAMin");
-      double TransDCAMax = conf_.getParameter<double>("TransDCAMax");
+      int TransDCABins = conf_->getParameter<int>("TransDCABins");
+      double TransDCAMin = conf_->getParameter<double>("TransDCAMin");
+      double TransDCAMax = conf_->getParameter<double>("TransDCAMax");
 
-      int LongDCABins = conf_.getParameter<int>("LongDCABins");
-      double LongDCAMin = conf_.getParameter<double>("LongDCAMin");
-      double LongDCAMax = conf_.getParameter<double>("LongDCAMax");
+      int LongDCABins = conf_->getParameter<int>("LongDCABins");
+      double LongDCAMin = conf_->getParameter<double>("LongDCAMin");
+      double LongDCAMax = conf_->getParameter<double>("LongDCAMax");
       ///////////////////////////////////////////////////////////////////  
 
 
@@ -661,8 +663,8 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 void TrackAnalyzer::bookHistosForLScertification(DQMStore::IBooker & ibooker) {
 
     // parameters from the configuration
-    std::string QualName       = conf_.getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_.getParameter<std::string>("AlgoName");
+    std::string QualName       = conf_->getParameter<std::string>("Quality");
+    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
     std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
@@ -673,13 +675,13 @@ void TrackAnalyzer::bookHistosForLScertification(DQMStore::IBooker & ibooker) {
     if ( doLumiAnalysis_ ) {
 
       // get binning from the configuration
-      int    TKHitBin     = conf_.getParameter<int>(   "RecHitBin");
-      double TKHitMin     = conf_.getParameter<double>("RecHitMin");
-      double TKHitMax     = conf_.getParameter<double>("RecHitMax");
+      int    TKHitBin     = conf_->getParameter<int>(   "RecHitBin");
+      double TKHitMin     = conf_->getParameter<double>("RecHitMin");
+      double TKHitMax     = conf_->getParameter<double>("RecHitMax");
 
-      int    Chi2NDFBin   = conf_.getParameter<int>(   "Chi2NDFBin");
-      double Chi2NDFMin   = conf_.getParameter<double>("Chi2NDFMin");
-      double Chi2NDFMax   = conf_.getParameter<double>("Chi2NDFMax");
+      int    Chi2NDFBin   = conf_->getParameter<int>(   "Chi2NDFBin");
+      double Chi2NDFMin   = conf_->getParameter<double>("Chi2NDFMin");
+      double Chi2NDFMax   = conf_->getParameter<double>("Chi2NDFMax");
 
       // add by Mia in order to deal w/ LS transitions  
       ibooker.setCurrentFolder(TopFolder_+"/LSanalysis");
@@ -700,8 +702,8 @@ void TrackAnalyzer::bookHistosForLScertification(DQMStore::IBooker & ibooker) {
 void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
 
     // parameters from the configuration
-    std::string QualName       = conf_.getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_.getParameter<std::string>("AlgoName");
+    std::string QualName       = conf_->getParameter<std::string>("Quality");
+    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
     std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
@@ -711,33 +713,33 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
     
     if(doDCAPlots_ || doBSPlots_ || doAllPlots_) {
 	
-      int    DxyBin       = conf_.getParameter<int>(   "DxyBin");
-      double DxyMin       = conf_.getParameter<double>("DxyMin");
-      double DxyMax       = conf_.getParameter<double>("DxyMax");
+      int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
+      double DxyMin       = conf_->getParameter<double>("DxyMin");
+      double DxyMax       = conf_->getParameter<double>("DxyMax");
       
-      int    AbsDxyBin    = conf_.getParameter<int>(   "AbsDxyBin");
-      double AbsDxyMin    = conf_.getParameter<double>("AbsDxyMin");
-      double AbsDxyMax    = conf_.getParameter<double>("AbsDxyMax");
+      int    AbsDxyBin    = conf_->getParameter<int>(   "AbsDxyBin");
+      double AbsDxyMin    = conf_->getParameter<double>("AbsDxyMin");
+      double AbsDxyMax    = conf_->getParameter<double>("AbsDxyMax");
       
-      int    PhiBin     = conf_.getParameter<int>(   "PhiBin");
-      double PhiMin     = conf_.getParameter<double>("PhiMin");
-      double PhiMax     = conf_.getParameter<double>("PhiMax");
+      int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
+      double PhiMin     = conf_->getParameter<double>("PhiMin");
+      double PhiMax     = conf_->getParameter<double>("PhiMax");
       
-      int    X0Bin        = conf_.getParameter<int>(   "X0Bin");
-      double X0Min        = conf_.getParameter<double>("X0Min");
-      double X0Max        = conf_.getParameter<double>("X0Max");
+      int    X0Bin        = conf_->getParameter<int>(   "X0Bin");
+      double X0Min        = conf_->getParameter<double>("X0Min");
+      double X0Max        = conf_->getParameter<double>("X0Max");
       
-      int    Y0Bin        = conf_.getParameter<int>(   "Y0Bin");
-      double Y0Min        = conf_.getParameter<double>("Y0Min");
-      double Y0Max        = conf_.getParameter<double>("Y0Max");
+      int    Y0Bin        = conf_->getParameter<int>(   "Y0Bin");
+      double Y0Min        = conf_->getParameter<double>("Y0Min");
+      double Y0Max        = conf_->getParameter<double>("Y0Max");
       
-      int    Z0Bin        = conf_.getParameter<int>(   "Z0Bin");
-      double Z0Min        = conf_.getParameter<double>("Z0Min");
-      double Z0Max        = conf_.getParameter<double>("Z0Max");
+      int    Z0Bin        = conf_->getParameter<int>(   "Z0Bin");
+      double Z0Min        = conf_->getParameter<double>("Z0Min");
+      double Z0Max        = conf_->getParameter<double>("Z0Max");
       
-      int    VZBinProf    = conf_.getParameter<int>(   "VZBinProf");
-      double VZMinProf    = conf_.getParameter<double>("VZMinProf");
-      double VZMaxProf    = conf_.getParameter<double>("VZMaxProf");
+      int    VZBinProf    = conf_->getParameter<int>(   "VZBinProf");
+      double VZMinProf    = conf_->getParameter<double>("VZMinProf");
+      double VZMaxProf    = conf_->getParameter<double>("VZMaxProf");
       
       
       ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
@@ -786,25 +788,25 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
     
     if(doDCAPlots_ || doPVPlots_ || doAllPlots_) {
       
-      int    DxyBin       = conf_.getParameter<int>(   "DxyBin");
-      double DxyMin       = conf_.getParameter<double>("DxyMin");
-      double DxyMax       = conf_.getParameter<double>("DxyMax");
+      int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
+      double DxyMin       = conf_->getParameter<double>("DxyMin");
+      double DxyMax       = conf_->getParameter<double>("DxyMax");
       
-      int    PhiBin     = conf_.getParameter<int>(   "PhiBin");
-      double PhiMin     = conf_.getParameter<double>("PhiMin");
-      double PhiMax     = conf_.getParameter<double>("PhiMax");
+      int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
+      double PhiMin     = conf_->getParameter<double>("PhiMin");
+      double PhiMax     = conf_->getParameter<double>("PhiMax");
       
-      int    X0Bin        = conf_.getParameter<int>(   "X0Bin");
-      double X0Min        = conf_.getParameter<double>("X0Min");
-      double X0Max        = conf_.getParameter<double>("X0Max");
+      int    X0Bin        = conf_->getParameter<int>(   "X0Bin");
+      double X0Min        = conf_->getParameter<double>("X0Min");
+      double X0Max        = conf_->getParameter<double>("X0Max");
       
-      int    Y0Bin        = conf_.getParameter<int>(   "Y0Bin");
-      double Y0Min        = conf_.getParameter<double>("Y0Min");
-      double Y0Max        = conf_.getParameter<double>("Y0Max");
+      int    Y0Bin        = conf_->getParameter<int>(   "Y0Bin");
+      double Y0Min        = conf_->getParameter<double>("Y0Min");
+      double Y0Max        = conf_->getParameter<double>("Y0Max");
       
-      int    Z0Bin        = conf_.getParameter<int>(   "Z0Bin");
-      double Z0Min        = conf_.getParameter<double>("Z0Min");
-      double Z0Max        = conf_.getParameter<double>("Z0Max");
+      int    Z0Bin        = conf_->getParameter<int>(   "Z0Bin");
+      double Z0Min        = conf_->getParameter<double>("Z0Min");
+      double Z0Max        = conf_->getParameter<double>("Z0Max");
       
       ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
       
@@ -839,13 +841,13 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
     if (doBSPlots_ || doAllPlots_) {
       if (doTestPlots_) {
 	
-	int    DxyBin       = conf_.getParameter<int>(   "DxyBin");
-	double DxyMin       = conf_.getParameter<double>("DxyMin");
-	double DxyMax       = conf_.getParameter<double>("DxyMax");
+	int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
+	double DxyMin       = conf_->getParameter<double>("DxyMin");
+	double DxyMax       = conf_->getParameter<double>("DxyMax");
       
-	int    PhiBin     = conf_.getParameter<int>(   "PhiBin");
-	double PhiMin     = conf_.getParameter<double>("PhiMin");
-	double PhiMax     = conf_.getParameter<double>("PhiMax");
+	int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
+	double PhiMin     = conf_->getParameter<double>("PhiMin");
+	double PhiMax     = conf_->getParameter<double>("PhiMax");
 
 	histname = "TESTDistanceOfClosestApproachToBS_";
 	TESTDistanceOfClosestApproachToBS = ibooker.book1D(histname+CategoryName,histname+CategoryName,DxyBin,DxyMin,DxyMax);
@@ -868,22 +870,22 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
 
       if (doDCAwrt000Plots_) {
 
-	int    EtaBin     = conf_.getParameter<int>(   "EtaBin");
-	double EtaMin     = conf_.getParameter<double>("EtaMin");
-	double EtaMax     = conf_.getParameter<double>("EtaMax");
+	int    EtaBin     = conf_->getParameter<int>(   "EtaBin");
+	double EtaMin     = conf_->getParameter<double>("EtaMin");
+	double EtaMax     = conf_->getParameter<double>("EtaMax");
 	
-	int    PhiBin     = conf_.getParameter<int>(   "PhiBin");
-	double PhiMin     = conf_.getParameter<double>("PhiMin");
-	double PhiMax     = conf_.getParameter<double>("PhiMax");
+	int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
+	double PhiMin     = conf_->getParameter<double>("PhiMin");
+	double PhiMax     = conf_->getParameter<double>("PhiMax");
 
-	int    DxyBin       = conf_.getParameter<int>(   "DxyBin");
-	double DxyMin       = conf_.getParameter<double>("DxyMin");
-	double DxyMax       = conf_.getParameter<double>("DxyMax");
+	int    DxyBin       = conf_->getParameter<int>(   "DxyBin");
+	double DxyMin       = conf_->getParameter<double>("DxyMin");
+	double DxyMax       = conf_->getParameter<double>("DxyMax");
       
 	if (doThetaPlots_) {
-	  int    ThetaBin   = conf_.getParameter<int>(   "ThetaBin");
-	  double ThetaMin   = conf_.getParameter<double>("ThetaMin");
-	  double ThetaMax   = conf_.getParameter<double>("ThetaMax");
+	  int    ThetaBin   = conf_->getParameter<int>(   "ThetaBin");
+	  double ThetaMin   = conf_->getParameter<double>("ThetaMin");
+	  double ThetaMax   = conf_->getParameter<double>("ThetaMax");
 	  
 	  ibooker.setCurrentFolder(TopFolder_+"/GeneralProperties");
 	  histname = "DistanceOfClosestApproachVsTheta_";
@@ -1233,7 +1235,7 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   }
 
   if (doMeasurementStatePlots_ || doAllPlots_){
-    std::string StateName = conf_.getParameter<std::string>("MeasurementState");
+    std::string StateName = conf_->getParameter<std::string>("MeasurementState");
 
     if (StateName == "All") {
       fillHistosForState(iSetup, track, std::string("OuterSurface"));
@@ -1318,92 +1320,92 @@ void TrackAnalyzer::bookHistosForState(std::string sname, DQMStore::IBooker & ib
 {
 
     // parameters from the configuration
-    std::string QualName       = conf_.getParameter<std::string>("Quality");
-    std::string AlgoName       = conf_.getParameter<std::string>("AlgoName");
+    std::string QualName       = conf_->getParameter<std::string>("Quality");
+    std::string AlgoName       = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
     std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
 
     // get binning from the configuration
-    double Chi2NDFMin = conf_.getParameter<double>("Chi2NDFMin");
-    double Chi2NDFMax = conf_.getParameter<double>("Chi2NDFMax");
+    double Chi2NDFMin = conf_->getParameter<double>("Chi2NDFMin");
+    double Chi2NDFMax = conf_->getParameter<double>("Chi2NDFMax");
 
-    int    RecHitBin   = conf_.getParameter<int>(   "RecHitBin");
-    double RecHitMin   = conf_.getParameter<double>("RecHitMin");
-    double RecHitMax   = conf_.getParameter<double>("RecHitMax");
+    int    RecHitBin   = conf_->getParameter<int>(   "RecHitBin");
+    double RecHitMin   = conf_->getParameter<double>("RecHitMin");
+    double RecHitMax   = conf_->getParameter<double>("RecHitMax");
 
-    int    RecLayBin   = conf_.getParameter<int>(   "RecHitBin");
-    double RecLayMin   = conf_.getParameter<double>("RecHitMin");
-    double RecLayMax   = conf_.getParameter<double>("RecHitMax");
-
-
-    int    PhiBin     = conf_.getParameter<int>(   "PhiBin");
-    double PhiMin     = conf_.getParameter<double>("PhiMin");
-    double PhiMax     = conf_.getParameter<double>("PhiMax");
-
-    int    EtaBin     = conf_.getParameter<int>(   "EtaBin");
-    double EtaMin     = conf_.getParameter<double>("EtaMin");
-    double EtaMax     = conf_.getParameter<double>("EtaMax");
-
-    int    ThetaBin   = conf_.getParameter<int>(   "ThetaBin");
-    double ThetaMin   = conf_.getParameter<double>("ThetaMin");
-    double ThetaMax   = conf_.getParameter<double>("ThetaMax");
-
-    int    TrackQBin  = conf_.getParameter<int>(   "TrackQBin");
-    double TrackQMin  = conf_.getParameter<double>("TrackQMin");
-    double TrackQMax  = conf_.getParameter<double>("TrackQMax");
-
-    int    TrackPtBin = conf_.getParameter<int>(   "TrackPtBin");
-    double TrackPtMin = conf_.getParameter<double>("TrackPtMin");
-    double TrackPtMax = conf_.getParameter<double>("TrackPtMax");
-
-    int    TrackPBin  = conf_.getParameter<int>(   "TrackPBin");
-    double TrackPMin  = conf_.getParameter<double>("TrackPMin");
-    double TrackPMax  = conf_.getParameter<double>("TrackPMax");
-
-    int    TrackPxBin = conf_.getParameter<int>(   "TrackPxBin");
-    double TrackPxMin = conf_.getParameter<double>("TrackPxMin");
-    double TrackPxMax = conf_.getParameter<double>("TrackPxMax");
-
-    int    TrackPyBin = conf_.getParameter<int>(   "TrackPyBin");
-    double TrackPyMin = conf_.getParameter<double>("TrackPyMin");
-    double TrackPyMax = conf_.getParameter<double>("TrackPyMax");
-
-    int    TrackPzBin = conf_.getParameter<int>(   "TrackPzBin");
-    double TrackPzMin = conf_.getParameter<double>("TrackPzMin");
-    double TrackPzMax = conf_.getParameter<double>("TrackPzMax");
-
-    int    ptErrBin   = conf_.getParameter<int>(   "ptErrBin");
-    double ptErrMin   = conf_.getParameter<double>("ptErrMin");
-    double ptErrMax   = conf_.getParameter<double>("ptErrMax");
-
-    int    pxErrBin   = conf_.getParameter<int>(   "pxErrBin");
-    double pxErrMin   = conf_.getParameter<double>("pxErrMin");
-    double pxErrMax   = conf_.getParameter<double>("pxErrMax");
-
-    int    pyErrBin   = conf_.getParameter<int>(   "pyErrBin");
-    double pyErrMin   = conf_.getParameter<double>("pyErrMin");
-    double pyErrMax   = conf_.getParameter<double>("pyErrMax");
-
-    int    pzErrBin   = conf_.getParameter<int>(   "pzErrBin");
-    double pzErrMin   = conf_.getParameter<double>("pzErrMin");
-    double pzErrMax   = conf_.getParameter<double>("pzErrMax");
-
-    int    pErrBin    = conf_.getParameter<int>(   "pErrBin");
-    double pErrMin    = conf_.getParameter<double>("pErrMin");
-    double pErrMax    = conf_.getParameter<double>("pErrMax");
-
-    int    phiErrBin  = conf_.getParameter<int>(   "phiErrBin");
-    double phiErrMin  = conf_.getParameter<double>("phiErrMin");
-    double phiErrMax  = conf_.getParameter<double>("phiErrMax");
-
-    int    etaErrBin  = conf_.getParameter<int>(   "etaErrBin");
-    double etaErrMin  = conf_.getParameter<double>("etaErrMin");
-    double etaErrMax  = conf_.getParameter<double>("etaErrMax");
+    int    RecLayBin   = conf_->getParameter<int>(   "RecHitBin");
+    double RecLayMin   = conf_->getParameter<double>("RecHitMin");
+    double RecLayMax   = conf_->getParameter<double>("RecHitMax");
 
 
-    double Chi2ProbMin  = conf_.getParameter<double>("Chi2ProbMin");
-    double Chi2ProbMax  = conf_.getParameter<double>("Chi2ProbMax");
+    int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
+    double PhiMin     = conf_->getParameter<double>("PhiMin");
+    double PhiMax     = conf_->getParameter<double>("PhiMax");
+
+    int    EtaBin     = conf_->getParameter<int>(   "EtaBin");
+    double EtaMin     = conf_->getParameter<double>("EtaMin");
+    double EtaMax     = conf_->getParameter<double>("EtaMax");
+
+    int    ThetaBin   = conf_->getParameter<int>(   "ThetaBin");
+    double ThetaMin   = conf_->getParameter<double>("ThetaMin");
+    double ThetaMax   = conf_->getParameter<double>("ThetaMax");
+
+    int    TrackQBin  = conf_->getParameter<int>(   "TrackQBin");
+    double TrackQMin  = conf_->getParameter<double>("TrackQMin");
+    double TrackQMax  = conf_->getParameter<double>("TrackQMax");
+
+    int    TrackPtBin = conf_->getParameter<int>(   "TrackPtBin");
+    double TrackPtMin = conf_->getParameter<double>("TrackPtMin");
+    double TrackPtMax = conf_->getParameter<double>("TrackPtMax");
+
+    int    TrackPBin  = conf_->getParameter<int>(   "TrackPBin");
+    double TrackPMin  = conf_->getParameter<double>("TrackPMin");
+    double TrackPMax  = conf_->getParameter<double>("TrackPMax");
+
+    int    TrackPxBin = conf_->getParameter<int>(   "TrackPxBin");
+    double TrackPxMin = conf_->getParameter<double>("TrackPxMin");
+    double TrackPxMax = conf_->getParameter<double>("TrackPxMax");
+
+    int    TrackPyBin = conf_->getParameter<int>(   "TrackPyBin");
+    double TrackPyMin = conf_->getParameter<double>("TrackPyMin");
+    double TrackPyMax = conf_->getParameter<double>("TrackPyMax");
+
+    int    TrackPzBin = conf_->getParameter<int>(   "TrackPzBin");
+    double TrackPzMin = conf_->getParameter<double>("TrackPzMin");
+    double TrackPzMax = conf_->getParameter<double>("TrackPzMax");
+
+    int    ptErrBin   = conf_->getParameter<int>(   "ptErrBin");
+    double ptErrMin   = conf_->getParameter<double>("ptErrMin");
+    double ptErrMax   = conf_->getParameter<double>("ptErrMax");
+
+    int    pxErrBin   = conf_->getParameter<int>(   "pxErrBin");
+    double pxErrMin   = conf_->getParameter<double>("pxErrMin");
+    double pxErrMax   = conf_->getParameter<double>("pxErrMax");
+
+    int    pyErrBin   = conf_->getParameter<int>(   "pyErrBin");
+    double pyErrMin   = conf_->getParameter<double>("pyErrMin");
+    double pyErrMax   = conf_->getParameter<double>("pyErrMax");
+
+    int    pzErrBin   = conf_->getParameter<int>(   "pzErrBin");
+    double pzErrMin   = conf_->getParameter<double>("pzErrMin");
+    double pzErrMax   = conf_->getParameter<double>("pzErrMax");
+
+    int    pErrBin    = conf_->getParameter<int>(   "pErrBin");
+    double pErrMin    = conf_->getParameter<double>("pErrMin");
+    double pErrMax    = conf_->getParameter<double>("pErrMax");
+
+    int    phiErrBin  = conf_->getParameter<int>(   "phiErrBin");
+    double phiErrMin  = conf_->getParameter<double>("phiErrMin");
+    double phiErrMax  = conf_->getParameter<double>("phiErrMax");
+
+    int    etaErrBin  = conf_->getParameter<int>(   "etaErrBin");
+    double etaErrMin  = conf_->getParameter<double>("etaErrMin");
+    double etaErrMax  = conf_->getParameter<double>("etaErrMax");
+
+
+    double Chi2ProbMin  = conf_->getParameter<double>("Chi2ProbMin");
+    double Chi2ProbMax  = conf_->getParameter<double>("Chi2ProbMax");
 
     ibooker.setCurrentFolder(TopFolder_);
 
@@ -1802,23 +1804,23 @@ void TrackAnalyzer::bookHistosForTrackerSpecific(DQMStore::IBooker & ibooker)
 {
 
     // parameters from the configuration
-    std::string QualName     = conf_.getParameter<std::string>("Quality");
-    std::string AlgoName     = conf_.getParameter<std::string>("AlgoName");
+    std::string QualName     = conf_->getParameter<std::string>("Quality");
+    std::string AlgoName     = conf_->getParameter<std::string>("AlgoName");
 
     // use the AlgoName and Quality Name 
     std::string CategoryName = QualName != "" ? AlgoName + "_" + QualName : AlgoName;
 
-    int    PhiBin     = conf_.getParameter<int>(   "PhiBin");
-    double PhiMin     = conf_.getParameter<double>("PhiMin");
-    double PhiMax     = conf_.getParameter<double>("PhiMax");
+    int    PhiBin     = conf_->getParameter<int>(   "PhiBin");
+    double PhiMin     = conf_->getParameter<double>("PhiMin");
+    double PhiMax     = conf_->getParameter<double>("PhiMax");
 
-    int    EtaBin     = conf_.getParameter<int>(   "EtaBin");
-    double EtaMin     = conf_.getParameter<double>("EtaMin");
-    double EtaMax     = conf_.getParameter<double>("EtaMax");
+    int    EtaBin     = conf_->getParameter<int>(   "EtaBin");
+    double EtaMin     = conf_->getParameter<double>("EtaMin");
+    double EtaMax     = conf_->getParameter<double>("EtaMax");
 
-    int    PtBin = conf_.getParameter<int>(   "TrackPtBin");
-    double PtMin = conf_.getParameter<double>("TrackPtMin");
-    double PtMax = conf_.getParameter<double>("TrackPtMax");
+    int    PtBin = conf_->getParameter<int>(   "TrackPtBin");
+    double PtMin = conf_->getParameter<double>("TrackPtMin");
+    double PtMax = conf_->getParameter<double>("TrackPtMax");
 
     // book hit property histograms
     // ---------------------------------------------------------------------------------//
@@ -1826,8 +1828,8 @@ void TrackAnalyzer::bookHistosForTrackerSpecific(DQMStore::IBooker & ibooker)
 
 
 
-    std::vector<std::string> subdetectors = conf_.getParameter<std::vector<std::string> >("subdetectors");
-    int detBin = conf_.getParameter<int>("subdetectorBin");
+    std::vector<std::string> subdetectors = conf_->getParameter<std::vector<std::string> >("subdetectors");
+    int detBin = conf_->getParameter<int>("subdetectorBin");
 
     for ( auto det : subdetectors ) {
       

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -19,8 +19,7 @@
 #include <iostream>
 
 TrackBuildingAnalyzer::TrackBuildingAnalyzer(const edm::ParameterSet& iConfig) 
-    : conf_( iConfig )
-    , SeedPt(NULL)
+    : SeedPt(NULL)
     , SeedEta(NULL)
     , SeedPhi(NULL)
     , SeedPhiVsEta(NULL)
@@ -41,12 +40,12 @@ TrackBuildingAnalyzer::~TrackBuildingAnalyzer()
 { 
 }
 
-void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker)
+void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::ParameterSet& iConfig)
 {
   
   // parameters from the configuration
-  std::string AlgoName       = conf_.getParameter<std::string>("AlgoName");
-  std::string MEFolderName   = conf_.getParameter<std::string>("FolderName"); 
+  std::string AlgoName       = iConfig.getParameter<std::string>("AlgoName");
+  std::string MEFolderName   = iConfig.getParameter<std::string>("FolderName"); 
 
   //  std::cout << "[TrackBuildingAnalyzer::beginRun] AlgoName: " << AlgoName << std::endl;
   
@@ -54,70 +53,70 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker)
   std::string CatagoryName = AlgoName;
   
   // get binning from the configuration
-  int    TrackPtBin = conf_.getParameter<int>(   "TrackPtBin");
-  double TrackPtMin = conf_.getParameter<double>("TrackPtMin");
-  double TrackPtMax = conf_.getParameter<double>("TrackPtMax");
+  int    TrackPtBin = iConfig.getParameter<int>(   "TrackPtBin");
+  double TrackPtMin = iConfig.getParameter<double>("TrackPtMin");
+  double TrackPtMax = iConfig.getParameter<double>("TrackPtMax");
   
-  int    PhiBin     = conf_.getParameter<int>(   "PhiBin");
-  double PhiMin     = conf_.getParameter<double>("PhiMin");
-  double PhiMax     = conf_.getParameter<double>("PhiMax");
+  int    PhiBin     = iConfig.getParameter<int>(   "PhiBin");
+  double PhiMin     = iConfig.getParameter<double>("PhiMin");
+  double PhiMax     = iConfig.getParameter<double>("PhiMax");
   
-  int    EtaBin     = conf_.getParameter<int>(   "EtaBin");
-  double EtaMin     = conf_.getParameter<double>("EtaMin");
-  double EtaMax     = conf_.getParameter<double>("EtaMax");
+  int    EtaBin     = iConfig.getParameter<int>(   "EtaBin");
+  double EtaMin     = iConfig.getParameter<double>("EtaMin");
+  double EtaMax     = iConfig.getParameter<double>("EtaMax");
   
-  int    ThetaBin   = conf_.getParameter<int>(   "ThetaBin");
-  double ThetaMin   = conf_.getParameter<double>("ThetaMin");
-  double ThetaMax   = conf_.getParameter<double>("ThetaMax");
+  int    ThetaBin   = iConfig.getParameter<int>(   "ThetaBin");
+  double ThetaMin   = iConfig.getParameter<double>("ThetaMin");
+  double ThetaMax   = iConfig.getParameter<double>("ThetaMax");
   
-  int    TrackQBin  = conf_.getParameter<int>(   "TrackQBin");
-  double TrackQMin  = conf_.getParameter<double>("TrackQMin");
-  double TrackQMax  = conf_.getParameter<double>("TrackQMax");
+  int    TrackQBin  = iConfig.getParameter<int>(   "TrackQBin");
+  double TrackQMin  = iConfig.getParameter<double>("TrackQMin");
+  double TrackQMax  = iConfig.getParameter<double>("TrackQMax");
   
-  int    SeedDxyBin = conf_.getParameter<int>(   "SeedDxyBin");
-  double SeedDxyMin = conf_.getParameter<double>("SeedDxyMin");
-  double SeedDxyMax = conf_.getParameter<double>("SeedDxyMax");
+  int    SeedDxyBin = iConfig.getParameter<int>(   "SeedDxyBin");
+  double SeedDxyMin = iConfig.getParameter<double>("SeedDxyMin");
+  double SeedDxyMax = iConfig.getParameter<double>("SeedDxyMax");
   
-  int    SeedDzBin  = conf_.getParameter<int>(   "SeedDzBin");
-  double SeedDzMin  = conf_.getParameter<double>("SeedDzMin");
-  double SeedDzMax  = conf_.getParameter<double>("SeedDzMax");
+  int    SeedDzBin  = iConfig.getParameter<int>(   "SeedDzBin");
+  double SeedDzMin  = iConfig.getParameter<double>("SeedDzMin");
+  double SeedDzMax  = iConfig.getParameter<double>("SeedDzMax");
   
-  int    SeedHitBin = conf_.getParameter<int>(   "SeedHitBin");
-  double SeedHitMin = conf_.getParameter<double>("SeedHitMin");
-  double SeedHitMax = conf_.getParameter<double>("SeedHitMax");
+  int    SeedHitBin = iConfig.getParameter<int>(   "SeedHitBin");
+  double SeedHitMin = iConfig.getParameter<double>("SeedHitMin");
+  double SeedHitMax = iConfig.getParameter<double>("SeedHitMax");
   
-  int    TCDxyBin   = conf_.getParameter<int>(   "TCDxyBin");
-  double TCDxyMin   = conf_.getParameter<double>("TCDxyMin");
-  double TCDxyMax   = conf_.getParameter<double>("TCDxyMax");
+  int    TCDxyBin   = iConfig.getParameter<int>(   "TCDxyBin");
+  double TCDxyMin   = iConfig.getParameter<double>("TCDxyMin");
+  double TCDxyMax   = iConfig.getParameter<double>("TCDxyMax");
   
-  int    TCDzBin    = conf_.getParameter<int>(   "TCDzBin");
-  double TCDzMin    = conf_.getParameter<double>("TCDzMin");
-  double TCDzMax    = conf_.getParameter<double>("TCDzMax");
+  int    TCDzBin    = iConfig.getParameter<int>(   "TCDzBin");
+  double TCDzMin    = iConfig.getParameter<double>("TCDzMin");
+  double TCDzMax    = iConfig.getParameter<double>("TCDzMax");
   
-  int    TCHitBin   = conf_.getParameter<int>(   "TCHitBin");
-  double TCHitMin   = conf_.getParameter<double>("TCHitMin");
-  double TCHitMax   = conf_.getParameter<double>("TCHitMax");
+  int    TCHitBin   = iConfig.getParameter<int>(   "TCHitBin");
+  double TCHitMin   = iConfig.getParameter<double>("TCHitMin");
+  double TCHitMax   = iConfig.getParameter<double>("TCHitMax");
   
   
-  edm::InputTag seedProducer   = conf_.getParameter<edm::InputTag>("SeedProducer");
-  edm::InputTag tcProducer     = conf_.getParameter<edm::InputTag>("TCProducer");
+  edm::InputTag seedProducer   = iConfig.getParameter<edm::InputTag>("SeedProducer");
+  edm::InputTag tcProducer     = iConfig.getParameter<edm::InputTag>("TCProducer");
   
-  doAllPlots     = conf_.getParameter<bool>("doAllPlots");
-  doAllSeedPlots = conf_.getParameter<bool>("doSeedParameterHistos");
-  doTCPlots      = conf_.getParameter<bool>("doTrackCandHistos");
-  doAllTCPlots   = conf_.getParameter<bool>("doAllTrackCandHistos");
-  doPT           = conf_.getParameter<bool>("doSeedPTHisto");
-  doETA          = conf_.getParameter<bool>("doSeedETAHisto");
-  doPHI          = conf_.getParameter<bool>("doSeedPHIHisto");
-  doPHIVsETA     = conf_.getParameter<bool>("doSeedPHIVsETAHisto");
-  doTheta        = conf_.getParameter<bool>("doSeedThetaHisto");
-  doQ            = conf_.getParameter<bool>("doSeedQHisto");
-  doDxy          = conf_.getParameter<bool>("doSeedDxyHisto");
-  doDz           = conf_.getParameter<bool>("doSeedDzHisto");
-  doNRecHits     = conf_.getParameter<bool>("doSeedNRecHitsHisto");
-  doProfPHI      = conf_.getParameter<bool>("doSeedNVsPhiProf");
-  doProfETA      = conf_.getParameter<bool>("doSeedNVsEtaProf");
-  doStopSource   = conf_.getParameter<bool>("doStopSource");
+  doAllPlots     = iConfig.getParameter<bool>("doAllPlots");
+  doAllSeedPlots = iConfig.getParameter<bool>("doSeedParameterHistos");
+  doTCPlots      = iConfig.getParameter<bool>("doTrackCandHistos");
+  doAllTCPlots   = iConfig.getParameter<bool>("doAllTrackCandHistos");
+  doPT           = iConfig.getParameter<bool>("doSeedPTHisto");
+  doETA          = iConfig.getParameter<bool>("doSeedETAHisto");
+  doPHI          = iConfig.getParameter<bool>("doSeedPHIHisto");
+  doPHIVsETA     = iConfig.getParameter<bool>("doSeedPHIVsETAHisto");
+  doTheta        = iConfig.getParameter<bool>("doSeedThetaHisto");
+  doQ            = iConfig.getParameter<bool>("doSeedQHisto");
+  doDxy          = iConfig.getParameter<bool>("doSeedDxyHisto");
+  doDz           = iConfig.getParameter<bool>("doSeedDzHisto");
+  doNRecHits     = iConfig.getParameter<bool>("doSeedNRecHitsHisto");
+  doProfPHI      = iConfig.getParameter<bool>("doSeedNVsPhiProf");
+  doProfETA      = iConfig.getParameter<bool>("doSeedNVsEtaProf");
+  doStopSource   = iConfig.getParameter<bool>("doStopSource");
   
   //    if (doAllPlots){doAllSeedPlots=true; doTCPlots=true;}
   

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -20,6 +20,7 @@
 #include "DQM/TrackingMonitor/interface/TrackingMonitor.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
@@ -38,8 +39,8 @@
 // ----------------------------------------------------------------------------------//
 
 TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig) 
-    : conf_ ( iConfig )
-    , theTrackBuildingAnalyzer( new TrackBuildingAnalyzer(conf_) )
+    : confID_ ( iConfig.id() )
+    , theTrackBuildingAnalyzer( new TrackBuildingAnalyzer(iConfig) )
     , NumberOfTracks(NULL)
     , NumberOfMeanRecHitsPerTrack(NULL)
     , NumberOfMeanLayersPerTrack(NULL)
@@ -84,64 +85,64 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
     , NumberOfTracks_lumiFlag(NULL)
 				//    , NumberOfGoodTracks_lumiFlag(NULL)
 
-    , builderName              ( conf_.getParameter<std::string>("TTRHBuilder"))
-    , doTrackerSpecific_       ( conf_.getParameter<bool>("doTrackerSpecific") )
-    , doLumiAnalysis           ( conf_.getParameter<bool>("doLumiAnalysis"))
-    , doProfilesVsLS_          ( conf_.getParameter<bool>("doProfilesVsLS"))
-    , doAllPlots               ( conf_.getParameter<bool>("doAllPlots"))
-    , doGeneralPropertiesPlots_( conf_.getParameter<bool>("doGeneralPropertiesPlots"))
-    , doHitPropertiesPlots_    ( conf_.getParameter<bool>("doHitPropertiesPlots"))
-    , doPUmonitoring_          ( conf_.getParameter<bool>("doPUmonitoring") )
+    , builderName              ( iConfig.getParameter<std::string>("TTRHBuilder"))
+    , doTrackerSpecific_       ( iConfig.getParameter<bool>("doTrackerSpecific") )
+    , doLumiAnalysis           ( iConfig.getParameter<bool>("doLumiAnalysis"))
+    , doProfilesVsLS_          ( iConfig.getParameter<bool>("doProfilesVsLS"))
+    , doAllPlots               ( iConfig.getParameter<bool>("doAllPlots"))
+    , doGeneralPropertiesPlots_( iConfig.getParameter<bool>("doGeneralPropertiesPlots"))
+    , doHitPropertiesPlots_    ( iConfig.getParameter<bool>("doHitPropertiesPlots"))
+    , doPUmonitoring_          ( iConfig.getParameter<bool>("doPUmonitoring") )
     , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig.getParameter<edm::ParameterSet>("genericTriggerEventPSet"),consumesCollector(), *this))
-    , numSelection_       (conf_.getParameter<std::string>("numCut"))
-    , denSelection_       (conf_.getParameter<std::string>("denCut"))
-    , pvNDOF_             ( conf_.getParameter<int> ("pvNDOF") )
+    , numSelection_       (iConfig.getParameter<std::string>("numCut"))
+    , denSelection_       (iConfig.getParameter<std::string>("denCut"))
+    , pvNDOF_             ( iConfig.getParameter<int> ("pvNDOF") )
 {
 
   edm::ConsumesCollector c{ consumesCollector() };
-  theTrackAnalyzer = new TrackAnalyzer( conf_,c );
+  theTrackAnalyzer = new dqm::TrackAnalyzer( iConfig,c );
 
   // input tags for collections from the configuration
-  bsSrc_ = conf_.getParameter<edm::InputTag>("beamSpot");
-  pvSrc_ = conf_.getParameter<edm::InputTag>("primaryVertex");
+  bsSrc_ = iConfig.getParameter<edm::InputTag>("beamSpot");
+  pvSrc_ = iConfig.getParameter<edm::InputTag>("primaryVertex");
   bsSrcToken_ = consumes<reco::BeamSpot>(bsSrc_);
   pvSrcToken_ = mayConsume<reco::VertexCollection>(pvSrc_);
 
-  lumiscalersToken_ = consumes<LumiScalersCollection>(conf_.getParameter<edm::InputTag>("scal") );
+  lumiscalersToken_ = consumes<LumiScalersCollection>(iConfig.getParameter<edm::InputTag>("scal") );
 
-  edm::InputTag alltrackProducer = conf_.getParameter<edm::InputTag>("allTrackProducer");
-  edm::InputTag trackProducer    = conf_.getParameter<edm::InputTag>("TrackProducer");
-  edm::InputTag tcProducer       = conf_.getParameter<edm::InputTag>("TCProducer");
-  edm::InputTag seedProducer     = conf_.getParameter<edm::InputTag>("SeedProducer");
+  edm::InputTag alltrackProducer = iConfig.getParameter<edm::InputTag>("allTrackProducer");
+  edm::InputTag trackProducer    = iConfig.getParameter<edm::InputTag>("TrackProducer");
+  edm::InputTag tcProducer       = iConfig.getParameter<edm::InputTag>("TCProducer");
+  edm::InputTag seedProducer     = iConfig.getParameter<edm::InputTag>("SeedProducer");
   allTrackToken_       = consumes<edm::View<reco::Track> >(alltrackProducer);
   trackToken_          = consumes<edm::View<reco::Track> >(trackProducer);
   trackCandidateToken_ = consumes<TrackCandidateCollection>(tcProducer); 
   seedToken_           = consumes<edm::View<TrajectorySeed> >(seedProducer);
 
-  edm::InputTag stripClusterInputTag_ = conf_.getParameter<edm::InputTag>("stripCluster");
-  edm::InputTag pixelClusterInputTag_ = conf_.getParameter<edm::InputTag>("pixelCluster");
+  edm::InputTag stripClusterInputTag_ = iConfig.getParameter<edm::InputTag>("stripCluster");
+  edm::InputTag pixelClusterInputTag_ = iConfig.getParameter<edm::InputTag>("pixelCluster");
   stripClustersToken_ = mayConsume<edmNew::DetSetVector<SiStripCluster> > (stripClusterInputTag_);
   pixelClustersToken_ = mayConsume<edmNew::DetSetVector<SiPixelCluster> > (pixelClusterInputTag_);
 
   doFractionPlot_ = true;
   if (alltrackProducer.label()==trackProducer.label()) doFractionPlot_ = false;
   
-  Quality_  = conf_.getParameter<std::string>("Quality");
-  AlgoName_ = conf_.getParameter<std::string>("AlgoName");
+  Quality_  = iConfig.getParameter<std::string>("Quality");
+  AlgoName_ = iConfig.getParameter<std::string>("AlgoName");
   
   // get flag from the configuration
-  doPlotsVsBXlumi_   = conf_.getParameter<bool>("doPlotsVsBXlumi");   
+  doPlotsVsBXlumi_   = iConfig.getParameter<bool>("doPlotsVsBXlumi");   
   if ( doPlotsVsBXlumi_ )
       theLumiDetails_ = new GetLumi( iConfig.getParameter<edm::ParameterSet>("BXlumiSetup"), c );
-  doPlotsVsGoodPVtx_ = conf_.getParameter<bool>("doPlotsVsGoodPVtx");
-  doPlotsVsLUMI_     = conf_.getParameter<bool>("doPlotsVsLUMI");
-  doPlotsVsBX_       = conf_.getParameter<bool>("doPlotsVsBX");
+  doPlotsVsGoodPVtx_ = iConfig.getParameter<bool>("doPlotsVsGoodPVtx");
+  doPlotsVsLUMI_     = iConfig.getParameter<bool>("doPlotsVsLUMI");
+  doPlotsVsBX_       = iConfig.getParameter<bool>("doPlotsVsBX");
 
   if ( doPUmonitoring_ ) {
     
-    std::vector<edm::InputTag> primaryVertexInputTags    = conf_.getParameter<std::vector<edm::InputTag> >("primaryVertexInputTags");
-    std::vector<edm::InputTag> selPrimaryVertexInputTags = conf_.getParameter<std::vector<edm::InputTag> >("selPrimaryVertexInputTags");
-    std::vector<std::string>   pvLabels                  = conf_.getParameter<std::vector<std::string> >  ("pvLabels");
+    std::vector<edm::InputTag> primaryVertexInputTags    = iConfig.getParameter<std::vector<edm::InputTag> >("primaryVertexInputTags");
+    std::vector<edm::InputTag> selPrimaryVertexInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("selPrimaryVertexInputTags");
+    std::vector<std::string>   pvLabels                  = iConfig.getParameter<std::vector<std::string> >  ("pvLabels");
      
     if (primaryVertexInputTags.size()==pvLabels.size() and primaryVertexInputTags.size()==selPrimaryVertexInputTags.size()) {
       for (size_t i=0; i<primaryVertexInputTags.size(); i++) {
@@ -149,7 +150,7 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
  	edm::InputTag iSelPVinputTag = selPrimaryVertexInputTags[i];
  	std::string   iPVlabel       = pvLabels[i];
 	
- 	theVertexMonitor.push_back(new VertexMonitor(conf_,iPVinputTag,iSelPVinputTag,iPVlabel,c) );
+ 	theVertexMonitor.push_back(new VertexMonitor(iConfig,iPVinputTag,iSelPVinputTag,iPVlabel,c) );
       }
     }
   }
@@ -179,9 +180,11 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
 				     edm::EventSetup const & iSetup) 
 {
    // parameters from the configuration
-   std::string Quality      = conf_.getParameter<std::string>("Quality");
-   std::string AlgoName     = conf_.getParameter<std::string>("AlgoName");
-   std::string MEFolderName = conf_.getParameter<std::string>("FolderName"); 
+   auto const* conf = edm::pset::Registry::instance()->getMapped(confID_);
+   assert(conf != nullptr);
+   std::string Quality      = conf->getParameter<std::string>("Quality");
+   std::string AlgoName     = conf->getParameter<std::string>("AlgoName");
+   std::string MEFolderName = conf->getParameter<std::string>("FolderName"); 
 
    // test for the Quality veriable validity
    if( Quality_ != "") {
@@ -195,31 +198,31 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
    std::string CategoryName = Quality_ != "" ? AlgoName_ + "_" + Quality_ : AlgoName_;
 
    // get binning from the configuration
-   int    TKNoBin     = conf_.getParameter<int>(   "TkSizeBin");
-   double TKNoMin     = conf_.getParameter<double>("TkSizeMin");
-   double TKNoMax     = conf_.getParameter<double>("TkSizeMax");
+   int    TKNoBin     = conf->getParameter<int>(   "TkSizeBin");
+   double TKNoMin     = conf->getParameter<double>("TkSizeMin");
+   double TKNoMax     = conf->getParameter<double>("TkSizeMax");
 
-   int    TCNoBin     = conf_.getParameter<int>(   "TCSizeBin");
-   double TCNoMin     = conf_.getParameter<double>("TCSizeMin");
-   double TCNoMax     = conf_.getParameter<double>("TCSizeMax");
+   int    TCNoBin     = conf->getParameter<int>(   "TCSizeBin");
+   double TCNoMin     = conf->getParameter<double>("TCSizeMin");
+   double TCNoMax     = conf->getParameter<double>("TCSizeMax");
 
-   int    TKNoSeedBin = conf_.getParameter<int>(   "TkSeedSizeBin");
-   double TKNoSeedMin = conf_.getParameter<double>("TkSeedSizeMin");
-   double TKNoSeedMax = conf_.getParameter<double>("TkSeedSizeMax");
+   int    TKNoSeedBin = conf->getParameter<int>(   "TkSeedSizeBin");
+   double TKNoSeedMin = conf->getParameter<double>("TkSeedSizeMin");
+   double TKNoSeedMax = conf->getParameter<double>("TkSeedSizeMax");
 
-   int    MeanHitBin  = conf_.getParameter<int>(   "MeanHitBin");
-   double MeanHitMin  = conf_.getParameter<double>("MeanHitMin");
-   double MeanHitMax  = conf_.getParameter<double>("MeanHitMax");
+   int    MeanHitBin  = conf->getParameter<int>(   "MeanHitBin");
+   double MeanHitMin  = conf->getParameter<double>("MeanHitMin");
+   double MeanHitMax  = conf->getParameter<double>("MeanHitMax");
 
-   int    MeanLayBin  = conf_.getParameter<int>(   "MeanLayBin");
-   double MeanLayMin  = conf_.getParameter<double>("MeanLayMin");
-   double MeanLayMax  = conf_.getParameter<double>("MeanLayMax");
+   int    MeanLayBin  = conf->getParameter<int>(   "MeanLayBin");
+   double MeanLayMin  = conf->getParameter<double>("MeanLayMin");
+   double MeanLayMax  = conf->getParameter<double>("MeanLayMax");
 
-   int LSBin = conf_.getParameter<int>(   "LSBin");
-   int LSMin = conf_.getParameter<double>("LSMin");
-   int LSMax = conf_.getParameter<double>("LSMax");
+   int LSBin = conf->getParameter<int>(   "LSBin");
+   int LSMin = conf->getParameter<double>("LSMin");
+   int LSMax = conf->getParameter<double>("LSMax");
 
-   std::string StateName = conf_.getParameter<std::string>("MeasurementState");
+   std::string StateName = conf->getParameter<std::string>("MeasurementState");
    if (
        StateName != "OuterSurface" &&
        StateName != "InnerSurface" &&
@@ -301,8 +304,8 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      NumberEventsOfVsLS->setAxisTitle("#Lumi section",1);
      NumberEventsOfVsLS->setAxisTitle("Number of events",2);
   
-     double GoodPVtxMin   = conf_.getParameter<double>("GoodPVtxMin");
-     double GoodPVtxMax   = conf_.getParameter<double>("GoodPVtxMax");
+     double GoodPVtxMin   = conf->getParameter<double>("GoodPVtxMin");
+     double GoodPVtxMax   = conf->getParameter<double>("GoodPVtxMax");
 
      histname = "NumberOfGoodPVtxVsLS_" + CategoryName;
      NumberOfGoodPVtxVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,GoodPVtxMin,GoodPVtxMax,"");
@@ -381,9 +384,9 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      if ( doPlotsVsGoodPVtx_ ) {
       ibooker.setCurrentFolder(MEFolderName+"/PUmonitoring");
       // get binning from the configuration
-       int    GoodPVtxBin   = conf_.getParameter<int>("GoodPVtxBin");
-       double GoodPVtxMin   = conf_.getParameter<double>("GoodPVtxMin");
-       double GoodPVtxMax   = conf_.getParameter<double>("GoodPVtxMax");
+       int    GoodPVtxBin   = conf->getParameter<int>("GoodPVtxBin");
+       double GoodPVtxMin   = conf->getParameter<double>("GoodPVtxMin");
+       double GoodPVtxMax   = conf->getParameter<double>("GoodPVtxMax");
     
        histname = "NumberOfTracksVsGoodPVtx";
        NumberOfTracksVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,TKNoMin, (TKNoMax+0.5)*3.-0.5,"");
@@ -423,16 +426,16 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
        NumberOfPVtxVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
        NumberOfPVtxVsGoodPVtx->setAxisTitle("Mean number of vertices",2);
 
-       double NClusPxMin = conf_.getParameter<double>("NClusPxMin");
-       double NClusPxMax = conf_.getParameter<double>("NClusPxMax");
+       double NClusPxMin = conf->getParameter<double>("NClusPxMin");
+       double NClusPxMax = conf->getParameter<double>("NClusPxMax");
        histname = "NumberOfPixelClustersVsGoodPVtx";
        NumberOfPixelClustersVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,NClusPxMin,NClusPxMax,"");
        NumberOfPixelClustersVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
        NumberOfPixelClustersVsGoodPVtx->setAxisTitle("Number of good PV (PU)",1);
        NumberOfPixelClustersVsGoodPVtx->setAxisTitle("Mean number of pixel clusters",2);
        
-       double NClusStrMin = conf_.getParameter<double>("NClusStrMin");
-       double NClusStrMax = conf_.getParameter<double>("NClusStrMax");
+       double NClusStrMin = conf->getParameter<double>("NClusStrMin");
+       double NClusStrMax = conf->getParameter<double>("NClusStrMax");
        histname = "NumberOfStripClustersVsGoodPVtx";
        NumberOfStripClustersVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,NClusStrMin,NClusStrMax,"");
        NumberOfStripClustersVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
@@ -444,9 +447,9 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
 
      if ( doPlotsVsLUMI_ || doAllPlots ) {
        ibooker.setCurrentFolder(MEFolderName+"/LUMIanalysis");
-       int LUMIBin = conf_.getParameter<int>("LUMIBin");
-       float LUMIMin = conf_.getParameter<double>("LUMIMin");
-       float LUMIMax = conf_.getParameter<double>("LUMIMax");
+       int LUMIBin = conf->getParameter<int>("LUMIBin");
+       float LUMIMin = conf->getParameter<double>("LUMIMin");
+       float LUMIMax = conf->getParameter<double>("LUMIMax");
        
        histname = "NumberEventsVsLUMI";
        NumberEventsOfVsLUMI = ibooker.book1D(histname,histname,LUMIBin,LUMIMin,LUMIMax);
@@ -474,8 +477,8 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
        NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
        NumberOfRecHitsPerTrackVsLUMI->setAxisTitle("Mean number of vertices",2);
 
-       double GoodPVtxMin   = conf_.getParameter<double>("GoodPVtxMin");
-       double GoodPVtxMax   = conf_.getParameter<double>("GoodPVtxMax");
+       double GoodPVtxMin   = conf->getParameter<double>("GoodPVtxMin");
+       double GoodPVtxMax   = conf->getParameter<double>("GoodPVtxMax");
        
        histname = "NumberOfGoodPVtxVsLUMI";
        NumberOfGoodPVtxVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,GoodPVtxMin,GoodPVtxMax,"");
@@ -489,16 +492,16 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
        NumberOfGoodPVtxWO0VsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
        NumberOfGoodPVtxWO0VsLUMI->setAxisTitle("Mean number of vertices",2);
 
-       double NClusPxMin = conf_.getParameter<double>("NClusPxMin");
-       double NClusPxMax = conf_.getParameter<double>("NClusPxMax");
+       double NClusPxMin = conf->getParameter<double>("NClusPxMin");
+       double NClusPxMax = conf->getParameter<double>("NClusPxMax");
        histname = "NumberOfPixelClustersVsGoodPVtx";
        NumberOfPixelClustersVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,NClusPxMin,NClusPxMax,"");
        NumberOfPixelClustersVsLUMI->getTH1()->SetCanExtend(TH1::kAllAxes);
        NumberOfPixelClustersVsLUMI->setAxisTitle("scal lumi [10e30 Hz cm^{-2}]",1);
        NumberOfPixelClustersVsLUMI->setAxisTitle("Mean number of pixel clusters",2);
        
-       double NClusStrMin = conf_.getParameter<double>("NClusStrMin");
-       double NClusStrMax = conf_.getParameter<double>("NClusStrMax");
+       double NClusStrMin = conf->getParameter<double>("NClusStrMin");
+       double NClusStrMax = conf->getParameter<double>("NClusStrMax");
        histname = "NumberOfStripClustersVsLUMI";
        NumberOfStripClustersVsLUMI = ibooker.bookProfile(histname,histname,LUMIBin,LUMIMin,LUMIMax,NClusStrMin,NClusStrMax,"");
        NumberOfStripClustersVsLUMI->getTH1()->SetCanExtend(TH1::kAllAxes);
@@ -511,7 +514,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      if ( doPlotsVsBXlumi_ ) {
        ibooker.setCurrentFolder(MEFolderName+"/PUmonitoring");
        // get binning from the configuration
-       edm::ParameterSet BXlumiParameters = conf_.getParameter<edm::ParameterSet>("BXlumiSetup");
+       edm::ParameterSet BXlumiParameters = conf->getParameter<edm::ParameterSet>("BXlumiSetup");
        int    BXlumiBin   = BXlumiParameters.getParameter<int>("BXlumiBin");
        double BXlumiMin   = BXlumiParameters.getParameter<double>("BXlumiMin");
        double BXlumiMax   = BXlumiParameters.getParameter<double>("BXlumiMax");
@@ -525,22 +528,22 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      }
    
 
-     theTrackAnalyzer->initHisto(ibooker, iSetup);
+     theTrackAnalyzer->initHisto(ibooker, iSetup, *conf);
 
    // book the Seed Property histograms
    // ---------------------------------------------------------------------------------//
 
    ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
 
-   doAllSeedPlots      = conf_.getParameter<bool>("doSeedParameterHistos");
-   doSeedNumberPlot    = conf_.getParameter<bool>("doSeedNumberHisto");
-   doSeedLumiAnalysis_ = conf_.getParameter<bool>("doSeedLumiAnalysis");
-   doSeedVsClusterPlot = conf_.getParameter<bool>("doSeedVsClusterHisto");
+   doAllSeedPlots      = conf->getParameter<bool>("doSeedParameterHistos");
+   doSeedNumberPlot    = conf->getParameter<bool>("doSeedNumberHisto");
+   doSeedLumiAnalysis_ = conf->getParameter<bool>("doSeedLumiAnalysis");
+   doSeedVsClusterPlot = conf->getParameter<bool>("doSeedVsClusterHisto");
    //    if (doAllPlots) doAllSeedPlots=true;
 
-   runTrackBuildingAnalyzerForSeed=(doAllSeedPlots || conf_.getParameter<bool>("doSeedPTHisto") ||conf_.getParameter<bool>("doSeedETAHisto") || conf_.getParameter<bool>("doSeedPHIHisto") || conf_.getParameter<bool>("doSeedPHIVsETAHisto") || conf_.getParameter<bool>("doSeedThetaHisto") || conf_.getParameter<bool>("doSeedQHisto") || conf_.getParameter<bool>("doSeedDxyHisto") || conf_.getParameter<bool>("doSeedDzHisto") || conf_.getParameter<bool>("doSeedNRecHitsHisto") || conf_.getParameter<bool>("doSeedNVsPhiProf")|| conf_.getParameter<bool>("doSeedNVsEtaProf"));
+   runTrackBuildingAnalyzerForSeed=(doAllSeedPlots || conf->getParameter<bool>("doSeedPTHisto") ||conf->getParameter<bool>("doSeedETAHisto") || conf->getParameter<bool>("doSeedPHIHisto") || conf->getParameter<bool>("doSeedPHIVsETAHisto") || conf->getParameter<bool>("doSeedThetaHisto") || conf->getParameter<bool>("doSeedQHisto") || conf->getParameter<bool>("doSeedDxyHisto") || conf->getParameter<bool>("doSeedDzHisto") || conf->getParameter<bool>("doSeedNRecHitsHisto") || conf->getParameter<bool>("doSeedNVsPhiProf")|| conf->getParameter<bool>("doSeedNVsEtaProf"));
 
-   edm::InputTag seedProducer   = conf_.getParameter<edm::InputTag>("SeedProducer");
+   edm::InputTag seedProducer   = conf->getParameter<edm::InputTag>("SeedProducer");
 
    if (doAllSeedPlots || doSeedNumberPlot){
      ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
@@ -562,18 +565,18 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
    if (doAllSeedPlots || doSeedVsClusterPlot){
      ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
 
-     ClusterLabels=  conf_.getParameter<std::vector<std::string> >("ClusterLabels");
+     ClusterLabels=  conf->getParameter<std::vector<std::string> >("ClusterLabels");
   
      std::vector<double> histoMin,histoMax;
      std::vector<int> histoBin; //these vectors are for max min and nbins in histograms 
   
-     int    NClusPxBin = conf_.getParameter<int>(   "NClusPxBin");
-     double NClusPxMin = conf_.getParameter<double>("NClusPxMin");
-     double NClusPxMax = conf_.getParameter<double>("NClusPxMax");
+     int    NClusPxBin = conf->getParameter<int>(   "NClusPxBin");
+     double NClusPxMin = conf->getParameter<double>("NClusPxMin");
+     double NClusPxMax = conf->getParameter<double>("NClusPxMax");
   
-     int    NClusStrBin = conf_.getParameter<int>(   "NClusStrBin");
-     double NClusStrMin = conf_.getParameter<double>("NClusStrMin");
-     double NClusStrMax = conf_.getParameter<double>("NClusStrMax");
+     int    NClusStrBin = conf->getParameter<int>(   "NClusStrBin");
+     double NClusStrMin = conf->getParameter<double>("NClusStrMin");
+     double NClusStrMax = conf->getParameter<double>("NClusStrMax");
   
      setMaxMinBin(histoMin,histoMax,histoBin,NClusStrMin,NClusStrMax,NClusStrBin,NClusPxMin,NClusPxMax,NClusPxBin);
   
@@ -587,13 +590,13 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
      }
    }
   
-   doTkCandPlots=conf_.getParameter<bool>("doTrackCandHistos");
+   doTkCandPlots=conf->getParameter<bool>("doTrackCandHistos");
   //    if (doAllPlots) doTkCandPlots=true;
   
   if (doTkCandPlots){
     ibooker.setCurrentFolder(MEFolderName+"/TrackBuilding");
     
-    edm::InputTag tcProducer     = conf_.getParameter<edm::InputTag>("TCProducer");
+    edm::InputTag tcProducer     = conf->getParameter<edm::InputTag>("TCProducer");
     
     histname = "NumberOfTrackCandidates_"+ tcProducer.label() + "_"+ CategoryName;
     NumberOfTrackCandidates = ibooker.book1D(histname, histname, TCNoBin, TCNoMin, TCNoMax);
@@ -601,7 +604,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
     NumberOfTrackCandidates->setAxisTitle("Number of Event", 2);
   }
   
-  theTrackBuildingAnalyzer->initHisto(ibooker);
+  theTrackBuildingAnalyzer->initHisto(ibooker,*conf);
   
   
   if (doLumiAnalysis) {
@@ -616,22 +619,22 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
   
   if (doTrackerSpecific_ || doAllPlots) {
     
-    ClusterLabels=  conf_.getParameter<std::vector<std::string> >("ClusterLabels");
+    ClusterLabels=  conf->getParameter<std::vector<std::string> >("ClusterLabels");
     
     std::vector<double> histoMin,histoMax;
     std::vector<int> histoBin; //these vectors are for max min and nbins in histograms 
     
-    int    NClusStrBin = conf_.getParameter<int>(   "NClusStrBin");
-    double NClusStrMin = conf_.getParameter<double>("NClusStrMin");
-    double NClusStrMax = conf_.getParameter<double>("NClusStrMax");
+    int    NClusStrBin = conf->getParameter<int>(   "NClusStrBin");
+    double NClusStrMin = conf->getParameter<double>("NClusStrMin");
+    double NClusStrMax = conf->getParameter<double>("NClusStrMax");
     
-    int    NClusPxBin = conf_.getParameter<int>(   "NClusPxBin");
-    double NClusPxMin = conf_.getParameter<double>("NClusPxMin");
-    double NClusPxMax = conf_.getParameter<double>("NClusPxMax");
+    int    NClusPxBin = conf->getParameter<int>(   "NClusPxBin");
+    double NClusPxMin = conf->getParameter<double>("NClusPxMin");
+    double NClusPxMax = conf->getParameter<double>("NClusPxMax");
     
-    int    NTrk2DBin     = conf_.getParameter<int>(   "NTrk2DBin");
-    double NTrk2DMin     = conf_.getParameter<double>("NTrk2DMin");
-    double NTrk2DMax     = conf_.getParameter<double>("NTrk2DMax");
+    int    NTrk2DBin     = conf->getParameter<int>(   "NTrk2DBin");
+    double NTrk2DMin     = conf->getParameter<double>("NTrk2DMin");
+    double NTrk2DMax     = conf->getParameter<double>("NTrk2DMax");
     
     setMaxMinBin(histoMin,histoMax,histoBin,
 		 NClusStrMin,NClusStrMax,NClusStrBin,


### PR DESCRIPTION
TrackingMonitor and two of its helpers (TrackAnalyzer and
TrackBuildingAnalyzer) were making copies of the module's PSet.
This PSet was quite large and making three copies per Stream is
not good. Now the module caches the PSet ID and gets the PSet
from the Registry when needed and passes the PSet to the helpers
when they need it.

The helpers also had virtual functions even though no other classes
inherited from them. These were de-virtualized.

TrackAnalyzer was not a unique name (a module with the same name
exists) so the class was moved to the dqm namespace.