### PR TITLE
Geometry : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/Geometry/CaloGeometry/interface/CaloVGeometryLoader.h
+++ b/Geometry/CaloGeometry/interface/CaloVGeometryLoader.h
@@ -13,6 +13,7 @@ class CaloSubdetectorGeometry;
 class CaloVGeometryLoader 
 {
    public:
+      virtual ~CaloVGeometryLoader() = default;
       /// Load the subdetector geometry for the specified det and subdet
       virtual std::auto_ptr<CaloSubdetectorGeometry> 
                      load( DetId::Detector det, int subdet ) = 0;

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerAbstractConstruction.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerAbstractConstruction.h
@@ -11,6 +11,7 @@ class DDFilteredView;
  */
 class CmsTrackerAbstractConstruction{
  public:
+  virtual ~CmsTrackerAbstractConstruction() = default;
   virtual void build(DDFilteredView& , GeometricDet*, std::string) = 0;
 
 };


### PR DESCRIPTION
Fixes warnings like these by adding virtual destructor with default constructor.

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/cad3eea82b17ccf34f572f7928d21ee1/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-28-2300/src/Geometry/CaloGeometry/interface/CaloVGeometryLoader.h:13:7: warning: 'class CaloVGeometryLoader' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

  /build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/cad3eea82b17ccf34f572f7928d21ee1/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-28-2300/src/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerAbstractConstruction.h:12:7: warning: 'class CmsTrackerAbstractConstruction' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
