### PR TITLE
Small fixes in GC tool

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -633,7 +633,7 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 		lWtotal.set(0.,0.,0.);
 
 		for (int i = 0; i < 100; i++){
-			AlgebraicVector diff = align::diffAlignables(refAli,curAli, _weightBy, _weightById, _weightByIdVector);
+			AlgebraicVector diff = align::diffAlignables(curAli,refAli, _weightBy, _weightById, _weightByIdVector);
 			CLHEP::Hep3Vector dR(diff[0],diff[1],diff[2]);
 			Rtotal+=dR;
 			CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);
@@ -645,9 +645,9 @@ void TrackerGeometryCompare::compareGeometries(Alignable* refAli, Alignable* cur
 			lRtotal.set(diff[6],diff[7],diff[8]);
 			lWtotal.set(diff[9],diff[10],diff[11]);
 			
-			align::moveAlignable(curAli, diff);
+			align::moveAlignable(refAli, diff);
 			float tolerance = 1e-7;
-			AlgebraicVector check = align::diffAlignables(refAli,curAli, _weightBy, _weightById, _weightByIdVector);
+			AlgebraicVector check = align::diffAlignables(curAli,refAli, _weightBy, _weightById, _weightByIdVector);
 			align::GlobalVector checkR(check[0],check[1],check[2]);
 			align::GlobalVector checkW(check[3],check[4],check[5]);
 			if ((checkR.mag() > tolerance)||(checkW.mag() > tolerance)){
@@ -731,7 +731,7 @@ void TrackerGeometryCompare::diffCommonTrackerSystem(Alignable *refAli, Alignabl
 		CLHEP::Hep3Vector Rtotal, Wtotal;
 		Rtotal.set(0.,0.,0.); Wtotal.set(0.,0.,0.);
 		
-		AlgebraicVector diff = align::diffAlignables(refAli,curAli, _weightBy, _weightById, _weightByIdVector);
+		AlgebraicVector diff = align::diffAlignables(curAli,refAli, _weightBy, _weightById, _weightByIdVector);
 		CLHEP::Hep3Vector dR(diff[0],diff[1],diff[2]);
 		Rtotal+=dR;
 		CLHEP::Hep3Vector dW(diff[3],diff[4],diff[5]);

--- a/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.cc
+++ b/Alignment/OfflineValidation/scripts/GeometryComparisonPlotter.cc
@@ -1244,7 +1244,7 @@ void GeometryComparisonPlotter::MakeTables (vector<TString> x, // axes to combin
 	else if (_module_plot_option == "good") tableCaption = "Means and standard deviations of "+_alignment_name+" - "+_reference_name+" for each subdetector, only good modules used.";
 	else if (_module_plot_option == "list") tableCaption = "Means and standard deviations of "+_alignment_name+" - "+_reference_name+" for each subdetector, good modules and those in given list used.";
 	
-	WriteTable(x,NB_SUBLEVELS*NB_Z_SLICES*NB_X_SLICES,meanValue,RMS,"0",tableCaption,tableFileName);
+	WriteTable(y,NB_SUBLEVELS*NB_Z_SLICES*NB_X_SLICES,meanValue,RMS,"0",tableCaption,tableFileName);
 		
 		
 	//~ // table using  Gaussian fit, round to integers in µm etc.
@@ -1254,7 +1254,7 @@ void GeometryComparisonPlotter::MakeTables (vector<TString> x, // axes to combin
 	else if (_module_plot_option == "list") tableCaption = "Means and standard deviations for Gaussian fit of "+_alignment_name+" - "+_reference_name+" for each subdetector, good modules and those in given list used.";
 	
 	
-	WriteTable(x,NB_SUBLEVELS*NB_Z_SLICES*NB_X_SLICES,meanValueGaussian,RMSGaussian,"0",tableCaption,tableFileName);
+	WriteTable(y,NB_SUBLEVELS*NB_Z_SLICES*NB_X_SLICES,meanValueGaussian,RMSGaussian,"0",tableCaption,tableFileName);
 	      
 
 


### PR DESCRIPTION
- Sign switch for y-range in GC plots reversed that was unintentionally introduced in PR 18699. (Switched input files for comparison to change display on x-axis, but forgot to switch the input for the differences plotted on the y-axis accordingly)

- Fixed the labels of the difference tables in the GC tool, which were showing the labels for the absolute positions