### PR TITLE
trim the size of these luts

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -77,7 +77,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
         if (isHBHE) {
            for (unsigned int i = threshold; i < lutsize; ++i)
               outputLUT_[index][i] = analyticalLUT[i];
-        } else {
+	} else {
            for (unsigned int i = threshold; i < lutsize; ++i)
               outputLUT_[index][i] = version == 0 ? linearRctLUT[i] : linearNctLUT[i];
         }
@@ -112,6 +112,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	    }
 	}
     }
+
 }
 
 HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, int fineGrain) const {
@@ -264,5 +265,5 @@ void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTo
     }
     else {
 	throw cms::Exception("Not Implemented") << "setup of CaloTPGTranscoderULUT from text files";
-   }
+    }
 }

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -54,8 +54,8 @@ public:
   static const unsigned int TPGMAX = 256;
 
   // Typedef
-  typedef unsigned int LUT;
-  typedef std::array<double, TPGMAX> RCTdecompression;
+  typedef uint8_t LUT;
+  typedef std::array<float, TPGMAX> RCTdecompression;
 
   const HcalTopology* theTopology;
   static const bool newHFphi = true;


### PR DESCRIPTION
reduce a vector of uint32 to uint8 as its maximum value is 255
reduce a vector of doubles to floats as there is no way we know the location of hcal eta locations to a double precision.

saves 35MB in 2017 workflows.