### PR TITLE
Fixing a bug to not try to take a L2 track when no L2 is available

### DIFF
--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -215,7 +215,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	      L2toL3s[staTrack].push_back(RecoChargedCandidateRef(cand));
 	  }
 	  else if (not previousCandIsL2_){
-	      L2toL3s[staTrack].push_back(RecoChargedCandidateRef(cand));
+	      L2toL3s[tk].push_back(RecoChargedCandidateRef(cand));
 	  }
         } //MTL loop
      } //RCC loop


### PR DESCRIPTION
This fixes a typo in the PR #18602 