### PR TITLE
Fix HCAL premixing with QIE8 and uHTR

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRawPreMixing_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawPreMixing_cff.py
@@ -23,6 +23,7 @@ ecalPacker.InstanceEB = 'ebDigis'
 ecalPacker.InstanceEE = 'eeDigis'
 ecalPacker.labelEBSRFlags = "simEcalDigis:ebSrFlags"
 ecalPacker.labelEESRFlags = "simEcalDigis:eeSrFlags"
+hcalRawDatauHTR.premix = cms.bool(True)
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toReplaceWith(DigiToRaw, DigiToRaw.copyAndExclude([castorRawData]))

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -41,11 +41,13 @@ class HcalUHTRData {
   public:
     const_iterator(const uint16_t* ptr, const uint16_t* limit=0);
     
-    bool isHeader() const { return ((*m_ptr)&0x8000)!=0; }    
-    int flavor() const { return ((*m_ptr)>>12)&0x7; }    
-    int errFlags() const { return ((*m_ptr)>>10)&0x3; }    
-    int capid0() const { return ((*m_ptr)>>8)&0x3; }    
-    int channelid() const { return ((*m_ptr))&0xFF; }    
+    bool isHeader() const { return ((*m_ptr)&0x8000)!=0; }
+    int flavor() const { return ((*m_ptr)>>12)&0x7; }
+    int errFlags() const;
+    bool dataValid() const;
+    int capid0() const { return ((*m_ptr)>>8)&0x3; }
+    int channelid() const { return ((*m_ptr))&0xFF; }
+    int technicalDataType() const;
 
     uint16_t value() const { return *m_ptr; }
 
@@ -72,7 +74,8 @@ class HcalUHTRData {
     int m_microstep;
     int m_stepclass;
     int m_flavor;
-  };    
+    int m_technicalDataType;
+  };
 
   const_iterator begin() const;
   const_iterator end() const;

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -77,29 +77,6 @@ class HcalUHTRData {
   const_iterator begin() const;
   const_iterator end() const;
 
-  class packer {
-  public:
-    packer(uint16_t* baseptr);
-    void addHeader(int flavor, int errf, int cap0, int channelid);
-    void addSample(int adc, bool soi=false, int retdc=0, int fetdc=0, int tdcstat=0);
-    void addTP(int tpword, bool soi=false);
-  private:
-    uint16_t* m_baseptr;
-    int m_ptr;
-    int m_flavor;
-    int m_ministep;
-  };
-
-  packer pack();
-
-
-  /** \brief pack header and trailer (call _after_ pack)*/
-  void packHeaderTrailer(int L1Anumber, int bcn, int submodule, int
-			 orbitn, int pipeline, int ndd, int nps, int firmwareRev=0);
-
-  /** \brief pack trailer with Mark and Pass bits */
-  void packUnsuppressed(const bool* mp);
-    
   /** \brief Get the HTR event number */
   inline uint32_t l1ANumber() const {  return uint32_t(m_raw64[0]>>32)&0xFFFFFF; }
   /** \brief Get the HTR bunch number */

--- a/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalDigiToRawuHTR.cc
@@ -64,6 +64,7 @@ private:
   edm::Handle<HcalTrigPrimDigiCollection> tpDigiCollection;
 
   edm::InputTag qie10Tag_, qie11Tag_, hbheqie8Tag_, hfqie8Tag_, trigTag_;
+  bool premix_;
 };
 
 HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig) :
@@ -73,7 +74,8 @@ HcalDigiToRawuHTR::HcalDigiToRawuHTR(const edm::ParameterSet& iConfig) :
   qie11Tag_(iConfig.getParameter<edm::InputTag>("QIE11")),
   hbheqie8Tag_(iConfig.getParameter<edm::InputTag>("HBHEqie8")),
   hfqie8Tag_(iConfig.getParameter<edm::InputTag>("HFqie8")),
-  trigTag_(iConfig.getParameter<edm::InputTag>("TP"))
+  trigTag_(iConfig.getParameter<edm::InputTag>("TP")),
+  premix_(iConfig.getParameter<bool>("premix"))
 {
   produces<FEDRawDataCollection>("");
   tok_QIE10DigiCollection_ = consumes<HcalDataFrameContainer<QIE10DataFrame> >(qie10Tag_);
@@ -174,7 +176,7 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       if( ! uhtrs.exist(uhtrIndex) ){
 	uhtrs.newUHTR( uhtrIndex , presamples );
       }
-      uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
+      uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,premix_,_verbosity);
     }
   }
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - 
@@ -195,7 +197,7 @@ void HcalDigiToRawuHTR::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       if( ! uhtrs.exist(uhtrIndex) ){
 	uhtrs.newUHTR( uhtrIndex , presamples );
       }
-      uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,_verbosity);
+      uhtrs.addChannel(uhtrIndex,qiedf,readoutMap,premix_,_verbosity);
     }
   }
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - 
@@ -280,6 +282,7 @@ void HcalDigiToRawuHTR::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<edm::InputTag>("HBHEqie8", edm::InputTag("simHcalDigis"));
   desc.add<edm::InputTag>("HFqie8", edm::InputTag("simHcalDigis"));
   desc.add<edm::InputTag>("TP", edm::InputTag("simHcalTriggerPrimitiveDigis"));
+  desc.add<bool>("premix", false);
   descriptions.add("hcalDigiToRawuHTR",desc);
   descriptions.addDefault(desc);
 }

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -93,6 +93,8 @@ namespace QIE8HeaderSpec{
   static const int MASK_FLAVOR = 0x7;
   static const int OFFSET_HEADER_BIT = 15;
   static const int MASK_HEADER_BIT = 0x1;
+  static const int OFFSET_TECHNICAL_DATA_TYPE = 8;
+  static const int MASK_TECHNICAL_DATA_TYPE = 0xF;
 }
 
 namespace QIE10HeaderSpec{
@@ -142,6 +144,17 @@ namespace TPHeaderSpec{
   static const int MASK_FLAVOR = 0x7;
   static const int OFFSET_HEADER_BIT = 15;
   static const int MASK_HEADER_BIT = 0x1;
+}
+
+namespace QIE8SampleSpec{
+  static const int OFFSET_ADC = 0;
+  static const int MASK_ADC = 0x7F;
+  static const int OFFSET_CAPID = 8;
+  static const int MASK_CAPID = 0x3;
+  static const int OFFSET_DV = 10;
+  static const int MASK_DV = 0x1;
+  static const int OFFSET_ER = 11;
+  static const int MASK_ER = 0x1;
 }
 
 class HCalFED{
@@ -331,7 +344,8 @@ public:
     return uhtrs.count(uhtrIndex) != 0  ; 
   };
 
-  uint16_t packQIE8header(const HcalQIESample &qieSample, const HcalElectronicsId &eid){
+  // flavor should be 5, or 7 (only for premixing in sim)
+  uint16_t packQIE8header(const HcalQIESample &qieSample, const HcalElectronicsId &eid, int flavor){
      uint16_t header =0;
 
      int fiber = eid.fiberIndex()+1;
@@ -341,12 +355,33 @@ public:
 
      header |= (fiberchan & QIE8HeaderSpec::MASK_FIBERCHAN)<<QIE8HeaderSpec::OFFSET_FIBERCHAN;
      header |= ((fiber-1) & QIE8HeaderSpec::MASK_FIBER)<<QIE8HeaderSpec::OFFSET_FIBER;
-     header |= (capid0 & QIE8HeaderSpec::MASK_CAPID)<<QIE8HeaderSpec::OFFSET_CAPID;
-     header |= (fiberErr & QIE8HeaderSpec::MASK_FIBERERR)<<QIE8HeaderSpec::OFFSET_FIBERERR;
-     header |= (0x5 & QIE8HeaderSpec::MASK_FLAVOR)<<QIE8HeaderSpec::OFFSET_FLAVOR; //flavor
+     if(flavor==7){
+       header |= (15 & QIE8HeaderSpec::MASK_TECHNICAL_DATA_TYPE)<<QIE8HeaderSpec::OFFSET_TECHNICAL_DATA_TYPE;
+     }
+     else {
+       header |= (capid0 & QIE8HeaderSpec::MASK_CAPID)<<QIE8HeaderSpec::OFFSET_CAPID;
+       header |= (fiberErr & QIE8HeaderSpec::MASK_FIBERERR)<<QIE8HeaderSpec::OFFSET_FIBERERR;
+     }
+     header |= (flavor & QIE8HeaderSpec::MASK_FLAVOR)<<QIE8HeaderSpec::OFFSET_FLAVOR; //flavor
      header |= (0x1 & QIE8HeaderSpec::MASK_HEADER_BIT)<<QIE8HeaderSpec::OFFSET_HEADER_BIT;
 
      return header;
+  }
+
+  uint16_t packQIE8sample(const HcalQIESample &qieSample){
+     uint16_t sample = 0;
+
+     int adc = qieSample.adc();
+     int capid = qieSample.capid();
+     int dv = qieSample.dv();
+     int er = qieSample.er();
+
+     sample |= (adc & QIE8SampleSpec::MASK_ADC)<<QIE8SampleSpec::OFFSET_ADC;
+     sample |= (capid & QIE8SampleSpec::MASK_CAPID)<<QIE8SampleSpec::OFFSET_CAPID;
+     sample |= (dv & QIE8SampleSpec::MASK_DV)<<QIE8SampleSpec::OFFSET_DV;
+     sample |= (er & QIE8SampleSpec::MASK_ER)<<QIE8SampleSpec::OFFSET_ER;
+
+     return sample;
   }
 
   uint16_t packTPheader(const HcalTriggerPrimitiveSample &tpSample, int channelid){
@@ -459,37 +494,51 @@ public:
     uhtr->push_back( 0 );
   };
 
-  void addChannel( int uhtrIndex , edm::SortedCollection<HFDataFrame>::const_iterator& qiedf , const HcalElectronicsMap* readoutMap, int verbosity = 0 ){
+  void addChannel( int uhtrIndex , edm::SortedCollection<HFDataFrame>::const_iterator& qiedf , const HcalElectronicsMap* readoutMap, bool premix, int verbosity = 0 ){
     if( qiedf->size() == 0 ) return;
     DetId detid = qiedf->id();
     HcalElectronicsId eid(readoutMap->lookup(detid));
-    uint16_t header = packQIE8header(qiedf->sample(0), eid);
+    uint16_t header = packQIE8header(qiedf->sample(0), eid, premix ? 7 : 5);
     uhtrs[uhtrIndex].push_back(header);
     // loop over words in dataframe
-    for(int iTS = 0; iTS < qiedf->size(); iTS +=2 ){
-       uint16_t cont =0;
-       int adc0 = qiedf->sample(iTS).adc();
-       int adc1 = qiedf->sample(iTS+1).adc();
-       cont |= adc0&0xFF;
-       cont |= (adc1&0xFF)<<8;
-       uhtrs[uhtrIndex].push_back(cont);
+    if(premix){
+      for(int iTS = 0; iTS < qiedf->size(); ++iTS){
+         uhtrs[uhtrIndex].push_back(packQIE8sample(qiedf->sample(iTS)));
+      }
+    }
+    else {
+      for(int iTS = 0; iTS < qiedf->size(); iTS +=2 ){
+         uint16_t cont =0;
+         int adc0 = qiedf->sample(iTS).adc();
+         int adc1 = qiedf->sample(iTS+1).adc();
+         cont |= adc0&0xFF;
+         cont |= (adc1&0xFF)<<8;
+         uhtrs[uhtrIndex].push_back(cont);
+      }
     }// end loop over dataframe words
   };
 
-  void addChannel( int uhtrIndex , edm::SortedCollection<HBHEDataFrame>::const_iterator qiedf , const HcalElectronicsMap* readoutMap, int verbosity = 0 ){
+  void addChannel( int uhtrIndex , edm::SortedCollection<HBHEDataFrame>::const_iterator qiedf , const HcalElectronicsMap* readoutMap, bool premix, int verbosity = 0 ){
     if( qiedf->size() == 0 ) return;
     DetId detid = qiedf->id();
     HcalElectronicsId eid(readoutMap->lookup(detid));
-    uint16_t header = packQIE8header(qiedf->sample(0), eid);
+    uint16_t header = packQIE8header(qiedf->sample(0), eid, premix ? 7 : 5);
     uhtrs[uhtrIndex].push_back(header);
     // loop over words in dataframe
-    for(int iTS = 0; iTS < qiedf->size(); iTS +=2 ){
-       uint16_t cont =0;
-       int adc0 = qiedf->sample(iTS).adc();
-       int adc1 = qiedf->sample(iTS+1).adc();
-       cont |= adc0&0xFF;
-       cont |= (adc1&0xFF)<<8;
-       uhtrs[uhtrIndex].push_back(cont);
+    if(premix){
+      for(int iTS = 0; iTS < qiedf->size(); ++iTS){
+         uhtrs[uhtrIndex].push_back(packQIE8sample(qiedf->sample(iTS)));
+      }
+    }
+    else {
+      for(int iTS = 0; iTS < qiedf->size(); iTS +=2 ){
+         uint16_t cont =0;
+         int adc0 = qiedf->sample(iTS).adc();
+         int adc1 = qiedf->sample(iTS+1).adc();
+         cont |= adc0&0xFF;
+         cont |= (adc1&0xFF)<<8;
+         uhtrs[uhtrIndex].push_back(cont);
+      }
     }// end loop over dataframe words
   };
 
@@ -508,7 +557,7 @@ public:
     DetId detid = qiedf.detid();
     HcalElectronicsId eid(readoutMap->lookup(detid));
     // loop over words in dataframe
-    for(edm::DataFrame::iterator dfi=qiedf.begin() ; dfi!=qiedf.end(); ++dfi){      
+    for(edm::DataFrame::iterator dfi=qiedf.begin() ; dfi!=qiedf.end(); ++dfi){
       if( dfi >= qiedf.end()-QIE11DataFrame::FLAG_WORDS ){
          continue;
       }

--- a/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
+++ b/EventFilter/HcalRawToDigi/plugins/PackerHelp.h
@@ -387,8 +387,8 @@ public:
 
      header |= (fiberchan & QIE11HeaderSpec::MASK_FIBERCHAN)<<QIE11HeaderSpec::OFFSET_FIBERCHAN;
      header |= (fiber & QIE11HeaderSpec::MASK_FIBER)<<QIE11HeaderSpec::OFFSET_FIBER;
-     header |= (capid0 & QIE11HeaderSpec::MASK_CAPID)<<QIE8HeaderSpec::OFFSET_CAPID;
-     header |= (0x0 & QIE11HeaderSpec::MASK_FIBERERR)<<QIE8HeaderSpec::OFFSET_FIBERERR;
+     header |= (capid0 & QIE11HeaderSpec::MASK_CAPID)<<QIE11HeaderSpec::OFFSET_CAPID;
+     header |= (0x0 & QIE11HeaderSpec::MASK_FIBERERR)<<QIE11HeaderSpec::OFFSET_FIBERERR;
      header |= (0x0 & QIE11HeaderSpec::MASK_FLAVOR)<<QIE11HeaderSpec::OFFSET_FLAVOR; //flavor
      header |= (0x1 & QIE11HeaderSpec::MASK_HEADER_BIT)<<QIE11HeaderSpec::OFFSET_HEADER_BIT;
 

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -82,46 +82,6 @@ HcalUHTRData::const_iterator HcalUHTRData::end() const {
   return HcalUHTRData::const_iterator(m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t),m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t));
 }
 
-HcalUHTRData::packer::packer(uint16_t* baseptr) : m_baseptr(baseptr),m_ptr(0),m_flavor(0),m_ministep(0) {
-}
-
-void HcalUHTRData::packer::addHeader(int flavor, int errf, int cap0, int channelid) {
-  m_baseptr[m_ptr]=0x8000 | 
-    ((flavor&0x7)<<12) |
-    ((errf&0x3)<<10) |
-    ((cap0&0x3)<<8) | 
-    (channelid&0xFF);
-  m_flavor=flavor; 
-  m_ministep=0;
-  m_ptr++;
-}
-
-void HcalUHTRData::packer::addSample(int adc, bool soi, int retdc, int fetdc, int tdcstat) {
-  if (m_flavor==0x5) {
-    if (m_ministep==0) m_baseptr[m_ptr]=adc&0x7F;
-    else m_baseptr[m_ptr]|=((adc&0x7f)<<8);
-    if (m_ministep==1) m_ptr++;
-    m_ministep=(m_ministep+1)%2;
-  } else if ((m_flavor&0x6)==0x0) {
-    m_baseptr[m_ptr]=(adc&0xFF) | ((retdc&0x3F)<<8);
-    if (soi) m_baseptr[m_ptr]|=0x4000;
-    m_ptr++;
-  } else if ((m_flavor&0x6)==0x1) {
-    m_baseptr[m_ptr]=(adc&0xFF);
-    m_baseptr[m_ptr+1]=0x4000| ((tdcstat&0x3)<<10) | ((fetdc&0xF)<<6) | ((retdc)<<8);    
-    if (soi) m_baseptr[m_ptr]|=0x2000;
-    m_ptr+=2;
-  }
-}
-
-void HcalUHTRData::packer::addTP(int tpword, bool soi) {
-  if (m_flavor==0x4) {
-    m_baseptr[m_ptr]=tpword&0xFFF;
-    if (soi) m_baseptr[m_ptr]|=0x4000;
-    m_ptr++;
-  }
-}
-
 HcalUHTRData::HcalUHTRData() : m_formatVersion(-2), m_rawLength64(0), m_raw64(0), m_raw16(0), m_ownData(0) { }
 
 HcalUHTRData::HcalUHTRData(const uint64_t* data, int length) : m_rawLength64(length),m_raw64(data),m_raw16((const uint16_t*)(data)),m_ownData(0) {

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -3,7 +3,9 @@
 
 static const int HEADER_LENGTH_16BIT=2*sizeof(uint64_t)/sizeof(uint16_t);
 
-HcalUHTRData::const_iterator::const_iterator(const uint16_t* ptr, const uint16_t* limit) : m_ptr(ptr), m_limit(limit), m_stepclass(0) {
+HcalUHTRData::const_iterator::const_iterator(const uint16_t* ptr, const uint16_t* limit) : 
+  m_ptr(ptr), m_limit(limit), m_stepclass(0), m_technicalDataType(0)
+{
   if (isHeader()) determineMode();
 }
 
@@ -33,21 +35,38 @@ void HcalUHTRData::const_iterator::determineMode() {
   m_stepclass=0;
   if (m_flavor==5) { m_stepclass=1; m_microstep=0; }
   else if (m_flavor == 2) { m_stepclass=2; }
+  if (m_flavor==7) { m_technicalDataType = technicalDataType(); }
+}
+
+int HcalUHTRData::const_iterator::errFlags() const {
+  if ((m_flavor==7 && m_technicalDataType==15) && !isHeader()) return ((*m_ptr)>>11)&0x1;
+  else return ((*m_ptr)>>10)&0x3;
+}
+
+bool HcalUHTRData::const_iterator::dataValid() const {
+  if ((m_flavor==7 && m_technicalDataType==15) && !isHeader()) return ((*m_ptr)>>10)&0x1;
+  else return !(errFlags()&0x2);
+}
+
+int HcalUHTRData::const_iterator::technicalDataType() const {
+  if (m_flavor==7) return ((*m_ptr)>>8)&0xF;
+  else return 0;
 }
 
 uint8_t HcalUHTRData::const_iterator::adc() const {
-  if (m_flavor==0x5 && m_microstep==0) return ((*m_ptr)>>8)&0x7F;
+  if (m_flavor==5 && m_microstep==0) return ((*m_ptr)>>8)&0x7F;
+  else if (m_flavor==7 && m_technicalDataType==15) return (*m_ptr)&0x7F;
   else return (*m_ptr)&0xFF;
 }
 
 uint8_t HcalUHTRData::const_iterator::le_tdc() const {
-  if (m_flavor==0x5) return 0x80;
+  if (m_flavor==5 || (m_flavor==7 && m_technicalDataType==15)) return 0x80;
   else if (m_flavor == 2) return (m_ptr[1]&0x3F);
   else return (((*m_ptr)&0x3F00)>>8);
 }
 
 bool HcalUHTRData::const_iterator::soi() const {
-  if (m_flavor==0x5) return false;
+  if (m_flavor==5 || (m_flavor==7 && m_technicalDataType==15)) return false;
   else if (m_flavor == 2) return (m_ptr[0]&0x2000);
   else return (((*m_ptr)&0x4000));
 }
@@ -59,6 +78,9 @@ uint8_t HcalUHTRData::const_iterator::te_tdc() const {
 
 uint8_t HcalUHTRData::const_iterator::capid() const {
   if (m_flavor==2) return(m_ptr[1]>>12)&0x3;
+  else if (m_flavor==7 && m_technicalDataType==15) {
+    return ((*m_ptr)>>8)&0x3;
+  }
   else if (m_flavor == 1 || m_flavor == 0) {
     // For flavor 0,1 we only get the first capid in the header, and so we need
     // to count the number of data rows and figure out which cap we want,

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -629,7 +629,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
           }
           else if (colls.qie11->samples() != ns) {
               // This is horrible
-              edm::LogError("Invalid Data") << "Collection has " << colls.qie11->samples() << " samples per digi, raw data has " << ns << "!";
+              edm::LogError("Invalid Data") << "QIE11 Collection has " << colls.qie11->samples() << " samples per digi, raw data has " << ns << "!";
               return;
           }
 
@@ -671,7 +671,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	}
 	else if (colls.qie10ZDC->samples() != ns) {
 	  // This is horrible
-	  edm::LogError("Invalid Data") << "Collection has " << colls.qie10ZDC->samples() << " samples per digi, raw data has " << ns << "!";
+	  edm::LogError("Invalid Data") << "QIE10ZDC Collection has " << colls.qie10ZDC->samples() << " samples per digi, raw data has " << ns << "!";
 	  return;
 	}
 	
@@ -680,7 +680,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	}
 	else if (colls.qie10->samples() != ns) {
 	  // This is horrible
-	  edm::LogError("Invalid Data") << "Collection has " << colls.qie10->samples() << " samples per digi, raw data has " << ns << "!";
+	  edm::LogError("Invalid Data") << "QIE10 Collection has " << colls.qie10->samples() << " samples per digi, raw data has " << ns << "!";
 	  return;
 	}
 


### PR DESCRIPTION
In 9_1_0_pre3, it was observed that HCAL premixing did not match well with classic mixing for the 2017 Era. This was somewhat puzzling, since the problem was even evident in HB, which should be the exact same detector in 2016 and 2017.

However, there was one important change: the electronics map used in the global tag, which corresponds to the backend electronics. 2016 used the old VME/HTR setup, while 2017 uses the new uTCA/uHTR setup (but still the old QIE8 for HB and most of HE). There is a different packer/unpacker for uHTR, which discarded the per-sample error bit in the QIE8 format. Premixing uses the error bit to denote how the ADC counts in premixed digis should be interpreted, so this caused the observed regression.

To fix this, simulated QIE8 digis in premix stage 1 (creation of the premixed input file) will be packed into the old VME-style format, which keeps all the bits. To handle this in the uHTR code, flavor 7 datatype 15 (technical data, currently unused) is employed. The unpacker is correspondingly updated to handle this case correctly. (This was the agreed solution after some discussion between me and @jmmans.)

I also cleaned up some of the packer/unpacker code while I was there.

Proof that it works (ADC counts in HB; red = classic, blue = premix):

**Before**:
![ADC counts before fix](http://kjplanet.com/pr/premix_910pre3_before.png)

**After**:
![ADC counts after fix](http://kjplanet.com/pr/premix_910pre3_after.png)
