### PR TITLE
Update online bs with pv information master

### DIFF
--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -763,40 +763,47 @@ void Vx3DHLTAnalyzer::writeToFile (vector<double>* vals,
       outputFile << "Z0 " << BufferString.str().c_str() << endl;
       BufferString.str("");
 
-      BufferString << *(it+3);
+      BufferString << *(it+5);
       outputFile << "sigmaZ0 " << BufferString.str().c_str() << endl;
       BufferString.str("");
 
-      BufferString << *(it+4);
+      BufferString << *(it+6);
       outputFile << "dxdz " << BufferString.str().c_str() << endl;
       BufferString.str("");
 
-      BufferString << *(it+5);
+      BufferString << *(it+7);
       outputFile << "dydz " << BufferString.str().c_str() << endl;
       BufferString.str("");
 
-      BufferString << *(it+6);
+      BufferString << *(it+3);
       outputFile << "BeamWidthX " << BufferString.str().c_str() << endl;
       BufferString.str("");
 
-      BufferString << *(it+7);
+      BufferString << *(it+4);
       outputFile << "BeamWidthY " << BufferString.str().c_str() << endl;
       BufferString.str("");
 
-      outputFile << "Cov(0,j) " << *(it+8) << " 0.0 0.0 0.0 0.0 0.0 0.0" << endl;
-      outputFile << "Cov(1,j) 0.0 " << *(it+9) << " 0.0 0.0 0.0 0.0 0.0" << endl;
-      outputFile << "Cov(2,j) 0.0 0.0 " << *(it+10) << " 0.0 0.0 0.0 0.0" << endl;
-      outputFile << "Cov(3,j) 0.0 0.0 0.0 " << *(it+11) << " 0.0 0.0 0.0" << endl;
-      outputFile << "Cov(4,j) 0.0 0.0 0.0 0.0 " << *(it+12) << " 0.0 0.0" << endl;
-      outputFile << "Cov(5,j) 0.0 0.0 0.0 0.0 0.0 " << *(it+13) << " 0.0" << endl;
-      outputFile << "Cov(6,j) 0.0 0.0 0.0 0.0 0.0 0.0 " << ((*(it+14)) + (*(it+15)) + 2.*std::sqrt((*(it+14))*(*(it+15)))) / 4. << endl;
+      outputFile << "Cov(0,j) " << *(it+8)  << " 0 0 0 0 0 0" << endl;
+      outputFile << "Cov(1,j) 0 " << *(it+9)  << " 0 0 0 0 0" << endl;
+      outputFile << "Cov(2,j) 0 0 " << *(it+10) << " 0 0 0 0" << endl;
+      outputFile << "Cov(3,j) 0 0 0 " << *(it+13) << " 0 0 0" << endl;
+      outputFile << "Cov(4,j) 0 0 0 0 " << *(it+14) << " 0 0" << endl;
+      outputFile << "Cov(5,j) 0 0 0 0 0 " << *(it+15) << " 0" << endl;
+      outputFile << "Cov(6,j) 0 0 0 0 0 0 " << ((*(it+11)) + (*(it+12)) + 2.*std::sqrt((*(it+11))*(*(it+12)))) / 4. << endl;
 
-      outputFile << "EmittanceX 0.0" << endl;
-      outputFile << "EmittanceY 0.0" << endl;
-      outputFile << "BetaStar 0.0" << endl;
+      outputFile << "EmittanceX 0" << endl;
+      outputFile << "EmittanceY 0" << endl;
+      outputFile << "BetaStar 0"   << endl;
+      outputFile << "events 0"     << endl;
+      outputFile << "meanPV 0"     << endl;
+      outputFile << "meanErrPV 0"  << endl;
+      outputFile << "rmsPV 0"      << endl;
+      outputFile << "rmsErrPV 0"   << endl;
+      outputFile << "maxPV 0"      << endl;
+      outputFile << "nPV 0"        << endl;
     }
   outputFile.close();
-
+  
   if ((debugMode == true) && (outputDebugFile.is_open() == true) && (vals != NULL) && (vals->size() == (nParams-1)*2))
     {
       vector<double>::const_iterator it = vals->begin();
@@ -822,37 +829,44 @@ void Vx3DHLTAnalyzer::writeToFile (vector<double>* vals,
       outputDebugFile << "Z0 " << BufferString.str().c_str() << endl;
       BufferString.str("");
 	  
-      BufferString << *(it+3);
+      BufferString << *(it+5);
       outputDebugFile << "sigmaZ0 " << BufferString.str().c_str() << endl;
       BufferString.str("");
 	  
-      BufferString << *(it+4);
+      BufferString << *(it+6);
       outputDebugFile << "dxdz " << BufferString.str().c_str() << endl;
       BufferString.str("");
 	  
-      BufferString << *(it+5);
+      BufferString << *(it+7);
       outputDebugFile << "dydz " << BufferString.str().c_str() << endl;
       BufferString.str("");
 	  
-      BufferString << *(it+6);
+      BufferString << *(it+3);
       outputDebugFile << "BeamWidthX " << BufferString.str().c_str() << endl;
       BufferString.str("");
 	  
-      BufferString << *(it+7);
+      BufferString << *(it+4);
       outputDebugFile << "BeamWidthY " << BufferString.str().c_str() << endl;
       BufferString.str("");
 	  
-      outputDebugFile << "Cov(0,j) " << *(it+8) << " 0.0 0.0 0.0 0.0 0.0 0.0" << endl;
-      outputDebugFile << "Cov(1,j) 0.0 " << *(it+9) << " 0.0 0.0 0.0 0.0 0.0" << endl;
-      outputDebugFile << "Cov(2,j) 0.0 0.0 " << *(it+10) << " 0.0 0.0 0.0 0.0" << endl;
-      outputDebugFile << "Cov(3,j) 0.0 0.0 0.0 " << *(it+11) << " 0.0 0.0 0.0" << endl;
-      outputDebugFile << "Cov(4,j) 0.0 0.0 0.0 0.0 " << *(it+12) << " 0.0 0.0" << endl;
-      outputDebugFile << "Cov(5,j) 0.0 0.0 0.0 0.0 0.0 " << *(it+13) << " 0.0" << endl;
-      outputDebugFile << "Cov(6,j) 0.0 0.0 0.0 0.0 0.0 0.0 " << ((*(it+14)) + (*(it+15)) + 2.*std::sqrt((*(it+14))*(*(it+15)))) / 4. << endl;
+      outputDebugFile << "Cov(0,j) " << *(it+8)  << " 0 0 0 0 0 0" << endl;
+      outputDebugFile << "Cov(1,j) 0 " << *(it+9)  << " 0 0 0 0 0" << endl;
+      outputDebugFile << "Cov(2,j) 0 0 " << *(it+10) << " 0 0 0 0" << endl;
+      outputDebugFile << "Cov(3,j) 0 0 0 " << *(it+13) << " 0 0 0" << endl;
+      outputDebugFile << "Cov(4,j) 0 0 0 0 " << *(it+14) << " 0 0" << endl;
+      outputDebugFile << "Cov(5,j) 0 0 0 0 0 " << *(it+15) << " 0" << endl;
+      outputDebugFile << "Cov(6,j) 0 0 0 0 0 0 " << ((*(it+11)) + (*(it+12)) + 2.*std::sqrt((*(it+11))*(*(it+12)))) / 4. << endl;
 	  
-      outputDebugFile << "EmittanceX 0.0" << endl;
-      outputDebugFile << "EmittanceY 0.0" << endl;
-      outputDebugFile << "BetaStar 0.0" << endl;
+      outputDebugFile << "EmittanceX 0" << endl;
+      outputDebugFile << "EmittanceY 0" << endl;
+      outputDebugFile << "BetaStar 0" << endl;
+      outputDebugFile << "events 0" << endl;
+      outputDebugFile << "meanPV 0" << endl;
+      outputDebugFile << "meanErrPV 0" << endl;
+      outputDebugFile << "rmsPV 0" << endl;
+      outputDebugFile << "rmsErrPV 0" << endl;
+      outputDebugFile << "maxPV 0" << endl;
+      outputDebugFile << "nPV 0" << endl;
 
       outputDebugFile << "\n" << "Used vertices: " << counterVx << "\n" << endl;
     }
@@ -946,20 +960,20 @@ void Vx3DHLTAnalyzer::endLuminosityBlock (const LuminosityBlock& lumiBlock, cons
 	      vals.push_back(fitResults[6]);
 	      vals.push_back(fitResults[7]);
 	      vals.push_back(fitResults[8]);
+	      vals.push_back(std::sqrt(std::fabs(fitResults[0])));
+	      vals.push_back(std::sqrt(std::fabs(fitResults[1])));
 	      vals.push_back(std::sqrt(std::fabs(fitResults[2])));
 	      vals.push_back(fitResults[5]);
 	      vals.push_back(fitResults[4]);
-	      vals.push_back(std::sqrt(std::fabs(fitResults[0])));
-	      vals.push_back(std::sqrt(std::fabs(fitResults[1])));
 
 	      vals.push_back(std::pow(fitResults[6+nParams],2.));
 	      vals.push_back(std::pow(fitResults[7+nParams],2.));
 	      vals.push_back(std::pow(fitResults[8+nParams],2.));
+	      vals.push_back(std::pow(std::fabs(fitResults[0+nParams]) / (2.*std::sqrt(std::fabs(fitResults[0]))),2.));
+	      vals.push_back(std::pow(std::fabs(fitResults[1+nParams]) / (2.*std::sqrt(std::fabs(fitResults[1]))),2.));
 	      vals.push_back(std::pow(std::fabs(fitResults[2+nParams]) / (2.*std::sqrt(std::fabs(fitResults[2]))),2.));
 	      vals.push_back(std::pow(fitResults[5+nParams],2.));
 	      vals.push_back(std::pow(fitResults[4+nParams],2.));
-	      vals.push_back(std::pow(std::fabs(fitResults[0+nParams]) / (2.*std::sqrt(std::fabs(fitResults[0]))),2.));
-	      vals.push_back(std::pow(std::fabs(fitResults[1+nParams]) / (2.*std::sqrt(std::fabs(fitResults[1]))),2.));
 	    }
 	  else for (unsigned int i = 0; i < (nParams-1)*2; i++) vals.push_back(0.0);
 
@@ -976,20 +990,20 @@ void Vx3DHLTAnalyzer::endLuminosityBlock (const LuminosityBlock& lumiBlock, cons
 	    vals.push_back(Vx_X->getTH1F()->GetMean());
 	    vals.push_back(Vx_Y->getTH1F()->GetMean());
 	    vals.push_back(Vx_Z->getTH1F()->GetMean());
+	    vals.push_back(Vx_X->getTH1F()->GetRMS());
+	    vals.push_back(Vx_Y->getTH1F()->GetRMS());
 	    vals.push_back(Vx_Z->getTH1F()->GetRMS());
 	    vals.push_back(0.0);
 	    vals.push_back(0.0);
-	    vals.push_back(Vx_X->getTH1F()->GetRMS());
-	    vals.push_back(Vx_Y->getTH1F()->GetRMS());
 	    
 	    vals.push_back(std::pow(Vx_X->getTH1F()->GetMeanError(),2.));
 	    vals.push_back(std::pow(Vx_Y->getTH1F()->GetMeanError(),2.));
 	    vals.push_back(std::pow(Vx_Z->getTH1F()->GetMeanError(),2.));
+	    vals.push_back(std::pow(Vx_X->getTH1F()->GetRMSError(),2.));
+	    vals.push_back(std::pow(Vx_Y->getTH1F()->GetRMSError(),2.));
 	    vals.push_back(std::pow(Vx_Z->getTH1F()->GetRMSError(),2.));
 	    vals.push_back(0.0);
 	    vals.push_back(0.0);
-	    vals.push_back(std::pow(Vx_X->getTH1F()->GetRMSError(),2.));
-	    vals.push_back(std::pow(Vx_Y->getTH1F()->GetRMSError(),2.));
 	    }
 	  else
 	    {
@@ -1001,20 +1015,20 @@ void Vx3DHLTAnalyzer::endLuminosityBlock (const LuminosityBlock& lumiBlock, cons
       // vals[0]  = X0
       // vals[1]  = Y0
       // vals[2]  = Z0
-      // vals[3]  = sigmaZ0
-      // vals[4]  = dxdz
-      // vals[5]  = dydz
-      // vals[6]  = BeamWidthX
-      // vals[7]  = BeamWidthY
+      // vals[3]  = sigmaX0
+      // vals[4]  = sigmaY0
+      // vals[5]  = sigmaZ0
+      // vals[6]  = dxdz
+      // vals[7]  = dydz
 
       // vals[8]  = err^2 X0
       // vals[9]  = err^2 Y0
       // vals[10] = err^2 Z0
-      // vals[11] = err^2 sigmaZ0
-      // vals[12] = err^2 dxdz
-      // vals[13] = err^2 dydz
-      // vals[14] = err^2 BeamWidthX
-      // vals[15] = err^2 BeamWidthY
+      // vals[11] = err^2 sigmaX0
+      // vals[12] = err^2 sigmaY0
+      // vals[13] = err^2 sigmaZ0
+      // vals[14] = err^2 dxdz
+      // vals[15] = err^2 dydz
 
       numberFits++;
       writeToFile(&vals, beginTimeOfFit, endTimeOfFit, beginLumiOfFit, endLumiOfFit, 3);
@@ -1094,32 +1108,32 @@ void Vx3DHLTAnalyzer::endLuminosityBlock (const LuminosityBlock& lumiBlock, cons
       myLinFit->SetParameter(1, 0.0);
       mZlumi->getTH1()->Fit(myLinFit,"QR");
 
-      sXlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[6]);
-      sXlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[14]));
+      sXlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[3]);
+      sXlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[11]));
       myLinFit->SetParameter(0, sXlumi->getTH1()->GetMean(2));
       myLinFit->SetParameter(1, 0.0);
       sXlumi->getTH1()->Fit(myLinFit,"QR");
 
-      sYlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[7]);
-      sYlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[15]));
+      sYlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[4]);
+      sYlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[12]));
       myLinFit->SetParameter(0, sYlumi->getTH1()->GetMean(2));
       myLinFit->SetParameter(1, 0.0);
       sYlumi->getTH1()->Fit(myLinFit,"QR");
 
-      sZlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[3]);
-      sZlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[11]));
+      sZlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[5]);
+      sZlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[13]));
       myLinFit->SetParameter(0, sZlumi->getTH1()->GetMean(2));
       myLinFit->SetParameter(1, 0.0);
       sZlumi->getTH1()->Fit(myLinFit,"QR");
 
-      dxdzlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[4]);
-      dxdzlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[12]));
+      dxdzlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[6]);
+      dxdzlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[14]));
       myLinFit->SetParameter(0, dxdzlumi->getTH1()->GetMean(2));
       myLinFit->SetParameter(1, 0.0);
       dxdzlumi->getTH1()->Fit(myLinFit,"QR");
 
-      dydzlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[5]);
-      dydzlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[13]));
+      dydzlumi->getTH1()->SetBinContent(lastLumiOfFit, vals[7]);
+      dydzlumi->getTH1()->SetBinError(lastLumiOfFit, std::sqrt(vals[15]));
       myLinFit->SetParameter(0, dydzlumi->getTH1()->GetMean(2));
       myLinFit->SetParameter(1, 0.0);
       dydzlumi->getTH1()->Fit(myLinFit,"QR");
@@ -1283,11 +1297,11 @@ void Vx3DHLTAnalyzer::bookHistograms(DQMStore::IBooker & ibooker, Run const & iR
   fitResults->setBinLabel(9, "X[cm]", 2);
   fitResults->setBinLabel(8, "Y[cm]", 2);
   fitResults->setBinLabel(7, "Z[cm]", 2);
-  fitResults->setBinLabel(6, "#sigma_{Z}[cm]", 2);
-  fitResults->setBinLabel(5, "#frac{dX}{dZ}[rad]", 2);
-  fitResults->setBinLabel(4, "#frac{dY}{dZ}[rad]", 2);
-  fitResults->setBinLabel(3, "#sigma_{X}[cm]", 2);
-  fitResults->setBinLabel(2, "#sigma_{Y}[cm]", 2);
+  fitResults->setBinLabel(6, "#sigma_{X}[cm]", 2);
+  fitResults->setBinLabel(5, "#sigma_{Y}[cm]", 2);
+  fitResults->setBinLabel(4, "#sigma_{Z}[cm]", 2);
+  fitResults->setBinLabel(3, "#frac{dX}{dZ}[rad]", 2);
+  fitResults->setBinLabel(2, "#frac{dY}{dZ}[rad]", 2);
   fitResults->setBinLabel(1, "Vtx[#]", 2);
   fitResults->setBinLabel(1, "Value", 1);
   fitResults->setBinLabel(2, "Error (stat)", 1);

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -227,6 +227,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
         process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
         process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
         process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
+        process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.
         process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 
         process.dqmBeamMonitor.PVFitter.errorScale = 1.22 #keep checking this with new release expected close to 1.2

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -73,21 +73,16 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 # Change Beam Monitor variables
-if process.dqmRunConfig.type.value() is "playback":
-  process.dqmBeamMonitor.BeamFitter.WriteAscii = False
-  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
-  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
-  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmdev/BeamMonitorDQM/BeamFitResults.txt'
-else:
+if process.dqmRunConfig.type.value() is "production":
   process.dqmBeamMonitor.BeamFitter.WriteAscii = True
   process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
   process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
   process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmpro/BeamMonitorDQM/BeamFitResults.txt'
-  #process.dqmBeamMonitor.BeamFitter.SaveFitResults = False
-  #process.dqmBeamMonitor.BeamFitter.OutputFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.root'
-  #process.dqmBeamMonitorBx.BeamFitter.WriteAscii = False
-  #process.dqmBeamMonitorBx.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults_Bx.txt'
-
+else:
+  process.dqmBeamMonitor.BeamFitter.WriteAscii = False
+  process.dqmBeamMonitor.BeamFitter.AsciiFileName = '/nfshome0/yumiceva/BeamMonitorDQM/BeamFitResults.txt'
+  process.dqmBeamMonitor.BeamFitter.WriteDIPAscii = True
+  process.dqmBeamMonitor.BeamFitter.DIPFileName = '/nfshome0/dqmdev/BeamMonitorDQM/BeamFitResults.txt'
 
 ## TKStatus
 process.dqmTKStatus = cms.EDAnalyzer("TKStatus",

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -224,6 +224,9 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
         process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
         process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
         process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
+        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
+        process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
+        process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
         process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 
         process.dqmBeamMonitor.PVFitter.errorScale = 1.22 #keep checking this with new release expected close to 1.2

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -229,6 +229,8 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
         process.dqmBeamMonitor.PVFitter.errorScale = 1.22 #keep checking this with new release expected close to 1.2
  
         process.tracking_FirstStep  = cms.Sequence(process.siPixelDigis* 
+                                                   process.siStripDigis *
+                                                   process.striptrackerlocalreco *
                                                    process.offlineBeamSpot*
                                                    process.siPixelClustersPreSplitting*
                                                    process.siPixelRecHitsPreSplitting*

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("BeamPixel")
+process = cms.Process("BeamPixel", eras.Run2_2017)
 
 
 #----------------------------
@@ -75,7 +76,6 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.ecalPreshowerDigis.sourceTag     = cms.InputTag("rawDataCollector")
     process.gctDigis.inputLabel              = cms.InputTag("rawDataCollector")
     process.gtDigis.DaqGtInputTag            = cms.InputTag("rawDataCollector")
-    process.gtEvmDigis.EvmGtInputTag         = cms.InputTag("rawDataCollector")
     process.hcalDigis.InputLabel             = cms.InputTag("rawDataCollector")
     process.muonCSCDigis.InputObjects        = cms.InputTag("rawDataCollector")
     process.muonDTDigis.inputLabel           = cms.InputTag("rawDataCollector")
@@ -84,8 +84,13 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.siPixelDigis.InputLabel          = cms.InputTag("rawDataCollector")
     process.siStripDigis.ProductLabel        = cms.InputTag("rawDataCollector")
 
-    process.load("Configuration.StandardSequences.Reconstruction_Data_cff")
-
+    process.load("RecoLocalTracker.Configuration.RecoLocalTracker_cff")
+    process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+    from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
+    process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(
+        src = 'siPixelClustersPreSplitting'
+    )
+    process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
 
     #----------------------------
     # pixelVertexDQM Config
@@ -122,18 +127,12 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     #----------------------------
     # Pixel-Tracks&Vertices Config
     #----------------------------
-    process.load("RecoPixelVertexing.Configuration.RecoPixelVertexing_cff")
+    process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
+    process.load("RecoPixelVertexing.PixelTrackFitting.PixelTracks_2017_cff")
+    process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
+    process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
     process.pixelVertices.TkFilterParameters.minPt = cms.double(0.9)
-
-    from RecoTracker.TkTrackingRegions.globalTrackingRegion_cfi import globalTrackingRegion
-    process.pixelTracksTrackingRegions = globalTrackingRegion.clone(RegionPSet = dict(originRadius = cms.double(0.4)))
-
-    from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
-    process.PixelLayerTriplets.BPix.HitProducer = cms.string("siPixelRecHitsPreSplitting")
-    process.PixelLayerTriplets.FPix.HitProducer = cms.string("siPixelRecHitsPreSplitting")
-
-    process.pixelTracksHitTriplets.SeedComparitorPSet.clusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCachePreSplitting")
-
+    process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
 
     #----------------------------
     # Pixel-Tracks&Vertices Reco
@@ -167,7 +166,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.ecalPreshowerDigis.sourceTag     = cms.InputTag("rawDataRepacker")
     process.gctDigis.inputLabel              = cms.InputTag("rawDataRepacker")
     process.gtDigis.DaqGtInputTag            = cms.InputTag("rawDataRepacker")
-    process.gtEvmDigis.EvmGtInputTag         = cms.InputTag("rawDataRepacker")
     process.hcalDigis.InputLabel             = cms.InputTag("rawDataRepacker")
     process.muonCSCDigis.InputObjects        = cms.InputTag("rawDataRepacker")
     process.muonDTDigis.inputLabel           = cms.InputTag("rawDataRepacker")

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -132,7 +132,10 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
     process.pixelVertices.TkFilterParameters.minPt = cms.double(0.9)
     process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-
+    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
+    process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
+    process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
+    process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.
     #----------------------------
     # Pixel-Tracks&Vertices Reco
     #----------------------------

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -205,10 +205,10 @@ if (process.runType.getRunType() == process.runType.hi_run):
                                             minVxDoF           = cms.double(10.0),
                                             minVxWgt           = cms.double(0.5),
                                             fileName           = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt"))
-    if process.dqmRunConfig.type.value() is "playback":
-        process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
-    else:
+    if process.dqmRunConfig.type.value() is "production":
         process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt")
+    else:
+        process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
     print "[beampixel_dqm_sourceclient-live_cfg]::saving DIP file into " + str(process.pixelVertexDQM.fileName)
 
 

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -117,10 +117,10 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
                                             minVxDoF           = cms.double(10.0),
                                             minVxWgt           = cms.double(0.5),
                                             fileName           = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt"))
-    if process.dqmRunConfig.type.value() is "playback":
-        process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
-    else:
+    if process.dqmRunConfig.type.value() is "production":
         process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt")
+    else:
+        process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
     print "[beampixel_dqm_sourceclient-live_cfg]::saving DIP file into " + str(process.pixelVertexDQM.fileName)
 
 

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -117,7 +117,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
                                             minVxDoF           = cms.double(10.0),
                                             minVxWgt           = cms.double(0.5),
                                             fileName           = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt"))
-    if process.dqmSaver.producer.value() is "Playback":
+    if process.dqmRunConfig.type.value() is "playback":
         process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
     else:
         process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt")
@@ -127,7 +127,6 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     #----------------------------
     # Pixel-Tracks&Vertices Config
     #----------------------------
-    process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
     process.load("RecoPixelVertexing.PixelTrackFitting.PixelTracks_2017_cff")
     process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
@@ -138,9 +137,8 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     # Pixel-Tracks&Vertices Reco
     #----------------------------
     process.reconstructionStep = cms.Sequence(process.siPixelDigis*
-                                              process.siStripDigis *
-                                              process.striptrackerlocalreco *
-                                              process.offlineBeamSpot*
+                                              process.siStripDigis*
+                                              process.striptrackerlocalreco*
                                               process.siPixelClustersPreSplitting*
                                               process.siPixelRecHitsPreSplitting*
                                               process.siPixelClusterShapeCachePreSplitting*
@@ -204,7 +202,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
                                             minVxDoF           = cms.double(10.0),
                                             minVxWgt           = cms.double(0.5),
                                             fileName           = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt"))
-    if process.dqmSaver.producer.value() is "Playback":
+    if process.dqmRunConfig.type.value() is "playback":
         process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
     else:
         process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt")

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -138,6 +138,8 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     # Pixel-Tracks&Vertices Reco
     #----------------------------
     process.reconstructionStep = cms.Sequence(process.siPixelDigis*
+                                              process.siStripDigis *
+                                              process.striptrackerlocalreco *
                                               process.offlineBeamSpot*
                                               process.siPixelClustersPreSplitting*
                                               process.siPixelRecHitsPreSplitting*

--- a/DQM/Integration/python/config/fileinputsource_cfi.py
+++ b/DQM/Integration/python/config/fileinputsource_cfi.py
@@ -78,6 +78,7 @@ print "Got %d files." % len(readFiles)
 runstr = str(options.runNumber)
 runpattern = "*" + runstr[0:3] + "/" + runstr[3:] + "*"
 readFiles = cms.untracked.vstring([f for f in readFiles if fnmatch.fnmatch(f, runpattern)])
+secFiles = cms.untracked.vstring([f for f in secFiles if fnmatch.fnmatch(f, runpattern)])
 lumirange =  cms.untracked.VLuminosityBlockRange(
   [ str(options.runNumber) + ":" + str(ls) 
       for ls in range(options.minLumi, options.maxLumi+1)

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
@@ -1,0 +1,134 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoLocalTracker.SiPixelRecHits.PixelCPEParmError_cfi import *
+from RecoLocalTracker.SiStripRecHitConverter.StripCPEfromTrackAngle_cfi import *
+from RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitMatcher_cfi import *
+from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi import *
+import RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi
+myTTRHBuilderWithoutAngle = RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi.ttrhbwr.clone(
+    StripCPE = 'Fake',
+    ComponentName = 'PixelTTRHBuilderWithoutAngle'
+)
+from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
+from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
+from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjections_cfi import pixelFitterByHelixProjections
+from RecoPixelVertexing.PixelTrackFitting.pixelTrackFilterByKinematics_cfi import pixelTrackFilterByKinematics
+from RecoPixelVertexing.PixelTrackFitting.pixelTrackCleanerBySharedHits_cfi import pixelTrackCleanerBySharedHits
+from RecoPixelVertexing.PixelTrackFitting.pixelTracks_cfi import pixelTracks as _pixelTracks
+from RecoTracker.TkTrackingRegions.globalTrackingRegion_cfi import globalTrackingRegion as _globalTrackingRegion
+from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
+from RecoPixelVertexing.PixelTriplets.pixelTripletHLTEDProducer_cfi import pixelTripletHLTEDProducer as _pixelTripletHLTEDProducer
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
+from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
+from RecoTracker.IterativeTracking.InitialStep_cff import initialStepSeedLayers, initialStepHitDoublets, initialStepHitQuadruplets
+from RecoTracker.IterativeTracking.HighPtTripletStep_cff import highPtTripletStepClusters, highPtTripletStepSeedLayers, highPtTripletStepHitDoublets, highPtTripletStepHitTriplets
+
+# TrackingRegion
+pixelTracksTrackingRegions = _globalTrackingRegion.clone()
+
+
+# Pixel Quadruplets Tracking
+pixelTracksQuadSeedLayers = initialStepSeedLayers.clone(
+    BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
+    FPix = dict(HitProducer = "siPixelRecHitsPreSplitting")
+)
+
+pixelTracksQuadHitDoublets = initialStepHitDoublets.clone(
+    clusterCheck = "",
+    seedingLayers = "pixelTracksQuadSeedLayers",
+    trackingRegions = "pixelTracksTrackingRegions"
+)
+
+pixelTracksQuadHitQuadruplets = initialStepHitQuadruplets.clone(
+    doublets = "pixelTracksQuadHitDoublets",
+    SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
+)
+
+pixelTracksQuad = _pixelTracks.clone(
+    SeedingHitSets = "pixelTracksQuadHitQuadruplets"
+)
+
+pixelTracksQuadSequence = cms.Sequence(
+    pixelTracksQuadSeedLayers +
+    pixelTracksQuadHitDoublets +
+    pixelTracksQuadHitQuadruplets +
+    pixelTracksQuad
+)
+
+# Pixel Triplets Tracking
+pixelTracksTripletSeedLayers = highPtTripletStepSeedLayers.clone(
+    BPix = dict(skipClusters = cms.InputTag('pixelTracksTripletClusters'), HitProducer = "siPixelRecHitsPreSplitting"),
+    FPix = dict(skipClusters = cms.InputTag('pixelTracksTripletClusters'), HitProducer = "siPixelRecHitsPreSplitting")
+)
+
+pixelTracksTripletClusters = highPtTripletStepClusters.clone(
+    trackClassifier = cms.InputTag( '','QualityMasks' ),
+    maxChi2 = cms.double( 3000.0 ),
+    trajectories = cms.InputTag( "pixelTracksQuad" ),
+    oldClusterRemovalInfo = cms.InputTag( "" ),
+    pixelClusters = cms.InputTag( "siPixelClustersPreSplitting" ),
+)
+
+pixelTracksTripletHitDoublets = highPtTripletStepHitDoublets.clone(
+    clusterCheck = "",
+    seedingLayers = "pixelTracksTripletSeedLayers",
+    trackingRegions = "pixelTracksTrackingRegions"
+)
+
+pixelTracksTripletHitTriplets = highPtTripletStepHitTriplets.clone(
+    doublets = "pixelTracksTripletHitDoublets",
+    SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
+)
+
+pixelTracksTriplet = _pixelTracks.clone(
+    SeedingHitSets = "pixelTracksTripletHitTriplets"
+)
+
+pixelTracksTripletSequence = cms.Sequence(
+    pixelTracksTripletClusters +
+    pixelTracksTripletSeedLayers +
+    pixelTracksTripletHitDoublets +
+    pixelTracksTripletHitTriplets +
+    pixelTracksTriplet
+)
+
+
+
+pixelTracks = cms.EDProducer( "TrackListMerger",
+                              ShareFrac = cms.double( 0.19 ),
+                              writeOnlyTrkQuals = cms.bool( False ),
+                              MinPT = cms.double( 0.05 ),
+                              allowFirstHitShare = cms.bool( True ),
+                              copyExtras = cms.untracked.bool( True ),
+                              Epsilon = cms.double( -0.001 ),
+                              selectedTrackQuals = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
+                              indivShareFrac = cms.vdouble( 1.0, 1.0 ),
+                              MaxNormalizedChisq = cms.double( 1000.0 ),
+                              copyMVA = cms.bool( False ),
+                              FoundHitBonus = cms.double( 5.0 ),
+                              setsToMerge = cms.VPSet(
+                                  cms.PSet(  pQual = cms.bool( False ),
+                                             tLists = cms.vint32( 0, 1 )
+                                  )
+                              ),
+                              MinFound = cms.int32( 3 ),
+                              hasSelector = cms.vint32( 0, 0 ),
+                              TrackProducers = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
+                              LostHitPenalty = cms.double( 20.0 ),
+                              newQuality = cms.string( "confirmed" ),
+                              trackAlgoPriorityOrder = cms.string("trackAlgoPriorityOrder")
+)
+
+pixelTracksSequence = cms.Sequence(
+    pixelTracksTrackingRegions +
+    pixelFitterByHelixProjections +
+    pixelTrackFilterByKinematics +
+    pixelTracksQuadSequence +
+    pixelTracksTripletSequence +
+    pixelTracks
+)


### PR DESCRIPTION
This will bring master inline with the 920patchX branch for everything related to the online BS. Namely:

* it introduces a proper pixel tracking and vertexing based on 2017 tracking and detector
* it updates the output file of the beampixel application to be compatible with DIP usage
* it rewrites the logic with which the online BS output files are written to disk.
* it tunes the global tracking region for pixel tracking in order to be able to compute the BS position using the canonical d0-phi fit.

It includes #19012 so I'd suggest integrating this one that goes beyond that one.