### PR TITLE
Fix for dt "no daq" message

### DIFF
--- a/DQM/DTMonitorClient/src/DTBlockedROChannelsTest.cc
+++ b/DQM/DTMonitorClient/src/DTBlockedROChannelsTest.cc
@@ -59,8 +59,9 @@ void DTBlockedROChannelsTest::fillChamberMap( DQMStore::IGetter & igetter, const
   // get the RO mapping
   context.get<DTReadOutMappingRcd>().get(mapping);
 
-  // fill the map of the robs per chamber
-  for(int dduId = FEDNumbering::MINDTFEDID; dduId<=FEDNumbering::MAXDTFEDID; ++dduId) { //loop over DDUs
+  // fill the map of the robs per chamber 
+  // //FIXME: monitoring only real used FEDs
+  for(int dduId = FEDNumbering::MINDTFEDID; dduId<=774; ++dduId) { //loop over DDUs
     for(int ros = 1; ros != 13; ++ros) { // loop over ROSs
       for(int rob = 1; rob != 26; ++rob) { // loop over ROBs	
         int wheel = 0;

--- a/DQM/DTMonitorClient/src/DTDAQInfo.cc
+++ b/DQM/DTMonitorClient/src/DTDAQInfo.cc
@@ -99,7 +99,7 @@ DTDAQInfo::~DTDAQInfo() {}
 
     // the range of DT feds
     const int FEDIDmin = FEDNumbering::MINDTFEDID;
-    const int FEDIDMax = FEDNumbering::MAXDTFEDID;
+    const int FEDIDMax = 774; //FEDNumbering::MAXDTFEDID; Monitoring only real used FEDs
 
     // loop on all active feds
     for(vector<int>::const_iterator fed = fedInIDs.begin();

--- a/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
+++ b/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
@@ -100,7 +100,8 @@ DTDataIntegrityTest::~DTDataIntegrityTest(){
   counter++;
 
   //Loop on FED id
-  for (int dduId=FEDNumbering::MINDTFEDID; dduId<=FEDNumbering::MAXDTFEDID; ++dduId){
+  //Monitoring only real used FEDs
+  for (int dduId=FEDNumbering::MINDTFEDID; dduId<=774; ++dduId){
     LogTrace ("DTDQM|DTRawToDigi|DTMonitorClient|DTDataIntegrityTest")
       <<"[DTDataIntegrityTest]:FED Id: "<<dduId;
  

--- a/DQM/DTMonitorClient/src/DTSummaryClients.cc
+++ b/DQM/DTMonitorClient/src/DTSummaryClients.cc
@@ -97,7 +97,7 @@ void DTSummaryClients::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter 
   for(int wheel = 1; wheel != 6; ++wheel) { // loop over the wheels
     int nDisablesROS = 0;
     for(int sect = 1; sect != 13; ++sect) { // loop over sectors
-      if(dataIntegritySummary->getBinContent(sect,wheel) == 1) {
+      if(dataIntegritySummary->getBinContent(sect,wheel) == 0) {
 	nDisablesROS++;
       }
     }

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -40,7 +40,7 @@ DTDataIntegrityTask::DTDataIntegrityTask(const edm::ParameterSet& ps) : nevents(
   neventsROS25 = 0;
 
   FEDIDmin = FEDNumbering::MINDTFEDID;
-  FEDIDMax = FEDNumbering::MAXDTFEDID;
+  FEDIDMax = 774; // FEDNumbering::MAXDTFEDID; Monitoring only real used FEDs
 
 //   If you want info VS time histos
 //   doTimeHisto =  ps.getUntrackedParameter<bool>("doTimeHisto", false);


### PR DESCRIPTION
This PR fixes the DT "No DAQ" message appearing in DQM Online summary page as reported in eLog entry: http://cmsonline.cern.ch/cms-elog/985586

The PR involves also the disappearance of the following plots/folders from the DQM online to comply with the actual current DT FED reading:
-  DT / 00-DataIntegrity / FED775,  FED776, FED777, FED778, FED779
- All the plots in  DT / 00-DataIntegrity with the name including the FED ids listed above
