### PR TITLE
Fix for dt "no daq" message (92X version)

### DIFF
--- a/DQM/DTMonitorClient/src/DTBlockedROChannelsTest.cc
+++ b/DQM/DTMonitorClient/src/DTBlockedROChannelsTest.cc
@@ -59,8 +59,9 @@ void DTBlockedROChannelsTest::fillChamberMap( DQMStore::IGetter & igetter, const
   // get the RO mapping
   context.get<DTReadOutMappingRcd>().get(mapping);
 
-  // fill the map of the robs per chamber
-  for(int dduId = FEDNumbering::MINDTFEDID; dduId<=FEDNumbering::MAXDTFEDID; ++dduId) { //loop over DDUs
+  // fill the map of the robs per chamber 
+  // //FIXME: monitoring only real used FEDs
+  for(int dduId = FEDNumbering::MINDTFEDID; dduId<=774; ++dduId) { //loop over DDUs
     for(int ros = 1; ros != 13; ++ros) { // loop over ROSs
       for(int rob = 1; rob != 26; ++rob) { // loop over ROBs	
         int wheel = 0;

--- a/DQM/DTMonitorClient/src/DTDAQInfo.cc
+++ b/DQM/DTMonitorClient/src/DTDAQInfo.cc
@@ -99,7 +99,7 @@ DTDAQInfo::~DTDAQInfo() {}
 
     // the range of DT feds
     const int FEDIDmin = FEDNumbering::MINDTFEDID;
-    const int FEDIDMax = FEDNumbering::MAXDTFEDID;
+    const int FEDIDMax = 774; //FEDNumbering::MAXDTFEDID; Monitoring only real used FEDs
 
     // loop on all active feds
     for(vector<int>::const_iterator fed = fedInIDs.begin();

--- a/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
+++ b/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
@@ -100,7 +100,8 @@ DTDataIntegrityTest::~DTDataIntegrityTest(){
   counter++;
 
   //Loop on FED id
-  for (int dduId=FEDNumbering::MINDTFEDID; dduId<=FEDNumbering::MAXDTFEDID; ++dduId){
+  //Monitoring only real used FEDs
+  for (int dduId=FEDNumbering::MINDTFEDID; dduId<=774; ++dduId){
     LogTrace ("DTDQM|DTRawToDigi|DTMonitorClient|DTDataIntegrityTest")
       <<"[DTDataIntegrityTest]:FED Id: "<<dduId;
  

--- a/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
+++ b/DQM/DTMonitorClient/src/DTDataIntegrityTest.cc
@@ -123,7 +123,7 @@ DTDataIntegrityTest::~DTDataIntegrityTest(){
     MonitorElement * FED_EvLenght = igetter.get(fedEvLenName);
 
     // Get the histos for FED integrity
-    string fedIntegrityFolder = "DT/FEDIntegrity/";
+    string fedIntegrityFolder = "DT/00-DataIntegrity/";
     MonitorElement * hFEDEntry = igetter.get(fedIntegrityFolder+"FEDEntries");
     MonitorElement * hFEDFatal = igetter.get(fedIntegrityFolder+"FEDFatal");
     MonitorElement * hFEDNonFatal = igetter.get(fedIntegrityFolder+"FEDNonFatal");

--- a/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.cc
+++ b/DQM/DTMonitorClient/src/DTSegmentAnalysisTest.cc
@@ -186,18 +186,17 @@ void DTSegmentAnalysisTest::performClientDiagnostic(DQMStore::IGetter & igetter)
       }
 
       TH2F * summary2_histo_root = summaryHistos[3]->getTH2F();
-      
+      float weight = 0.001; 
       if(hSegmOcc_root->GetBinContent(sector,chID.station())==0){
 	summaryHistos[chID.wheel()]->setBinContent(sector, chID.station(),2);
 	if(summary2_histo_root->GetBinContent(sector, chID.wheel()+3)<2)
 	  summaryHistos[3]->setBinContent(sector, chID.wheel()+3,2);
       } else {
 	// Fill the percentage of segment occupancy
-	float weight = 1./4.;
+	weight = 1./4.;
 	if((sector == 4 || sector == 10) && chID.station() == 4) weight = 1./8.;
-	summaryHistos[4]->Fill(sector, chID.wheel(),weight);
       }
-      
+      summaryHistos[4]->Fill(sector, chID.wheel(),weight);
     } else {
       LogVerbatim ("DTDQM|DTMonitorClient|DTSegmentAnalysisTest")
 	<< "[DTSegmentAnalysisTest]: histos not found!!"; // FIXME

--- a/DQM/DTMonitorClient/src/DTSummaryClients.cc
+++ b/DQM/DTMonitorClient/src/DTSummaryClients.cc
@@ -97,7 +97,7 @@ void DTSummaryClients::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::IGetter 
   for(int wheel = 1; wheel != 6; ++wheel) { // loop over the wheels
     int nDisablesROS = 0;
     for(int sect = 1; sect != 13; ++sect) { // loop over sectors
-      if(dataIntegritySummary->getBinContent(sect,wheel) == 1) {
+      if(dataIntegritySummary->getBinContent(sect,wheel) == 0) {
 	nDisablesROS++;
       }
     }

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cff.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_EvF_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 dtunpacker = cms.EDProducer("DTUnpackingModule",
     dataType = cms.string('DDU'),
-    inputLabel = cms.InputTag('source'),
+    inputLabel = cms.InputTag('rawDataCollector'),
     fedbyType = cms.bool(False),
     useStandardFEDid = cms.bool(True),
     dqmOnly = cms.bool(True),                       
@@ -22,8 +22,6 @@ dtunpacker = cms.EDProducer("DTUnpackingModule",
 )
 
 from DQM.DTMonitorModule.dtDataIntegrityTask_cfi import *
-DTDataIntegrityTask.processingMode = "HLT"
 
-dtDQMEvF = cms.Sequence(dtunpacker)
 
 

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
@@ -4,8 +4,8 @@ DTDataIntegrityTask = cms.EDAnalyzer("DTDataIntegrityTask",
                                      getSCInfo = cms.untracked.bool(True),
                                      fedIntegrityFolder = cms.untracked.string("DT/FEDIntegrity"),
                                      processingMode     = cms.untracked.string("Online"),
-                                     dtDDULabel         = cms.InputTag("dtDataIntegrityUnpacker"),
-                                     dtROS25Label       = cms.InputTag("dtDataIntegrityUnpacker")
+                                     dtDDULabel         = cms.InputTag("dtunpacker"),
+                                     dtROS25Label       = cms.InputTag("dtunpacker")
 )
 
 

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -99,6 +99,7 @@ void DTDataIntegrityTask::bookHistograms(DQMStore::IBooker & ibooker, edm::Run c
   // book FED integrity histos
   bookHistos(ibooker, FEDIDmin, FEDIDMax);
 
+  if(mode == 0 || mode ==2){
   // static booking of the histograms
   for(int fed = FEDIDmin; fed <= FEDIDMax; ++fed) { // loop over the FEDs in the readout
     DTROChainCoding code;
@@ -113,6 +114,7 @@ void DTDataIntegrityTask::bookHistograms(DQMStore::IBooker & ibooker, edm::Run c
       bookHistosROS25(ibooker, code);
     }
   }
+  } //Not in HLT or SM mode
 }
 
 void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, const int fedMin, const int fedMax) {
@@ -129,6 +131,7 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, const int fedM
   hFEDFatal = ibooker.book1D("FEDFatal","# fatal errors DT FED",nFED,fedMin,fedMax+1);
   hFEDNonFatal = ibooker.book1D("FEDNonFatal","# NON fatal errors DT FED",nFED,fedMin,fedMax+1);
 
+  if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
 
   ibooker.setCurrentFolder(topFolder(false));
   hTTSSummary = ibooker.book2D("TTSSummary","Summary Status TTS",nFED,fedMin,fedMax+1,9,1,10);
@@ -188,7 +191,7 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, string folder,
     histoTitle = "Event Lenght (Bytes) FED " +  dduID_s.str();
     (dduHistos[histoType])[code.getDDUID()] = ibooker.book1D(histoName,histoTitle,501,0,16032);
 
-    if(mode > 2) return;
+    if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
 
     histoType = "ROSStatus";
     histoName = "FED" + dduID_s.str() + "_" + histoType;
@@ -220,7 +223,7 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, string folder,
     histo->setBinLabel(11,"ROS 11",2);
     histo->setBinLabel(12,"ROS 12",2);
 
-    if(mode > 1) return;
+    if(mode > 0) return; //Info for Online only
 
     histoType = "FEDAvgEvLenghtvsLumi";
     histoName = "FED" + dduID_s.str() + "_" + histoType;
@@ -278,6 +281,8 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, string folder,
   if ( folder == "ROS_S" ) { // The summary of the error of the ROS on the same FED
     ibooker.setCurrentFolder(topFolder(false));
 
+    if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
+
     histoType = "ROSSummary";
     histoName = "FED" + dduID_s.str() + "_ROSSummary";
     string histoTitle = "Summary Wheel" + wheel_s.str() + " (FED " + dduID_s.str() + ")";
@@ -324,11 +329,12 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, string folder,
   if ( folder == "ROS" ) {
     ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s.str() + "/" + folder + rosID_s.str());
 
+    if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
 
     histoType = "ROSError";
     histoName = "FED" + dduID_s.str() + "_" + folder + rosID_s.str() + "_ROSError";
     histoTitle = histoName + " (ROBID error summary)";
-    if(mode <= 1)
+    if(mode < 1) //Online only
       (rosHistos[histoType])[code.getROSID()] = ibooker.book2D(histoName,histoTitle,17,0,17,26,0,26);
     else
       (rosHistos[histoType])[code.getROSID()] = ibooker.book2D(histoName,histoTitle,11,0,11,26,0,26);
@@ -346,7 +352,7 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, string folder,
     histo->setBinLabel(9,"Ch. blocked",1);
     histo->setBinLabel(10,"Ev. Id. Mis.",1);
     histo->setBinLabel(11,"CEROS blocked",1);
-    if(mode <= 1) {
+    if(mode < 1) { //Online only
       // TDC error bins
       histo->setBinLabel(12,"TDC Fatal",1);
       histo->setBinLabel(13,"TDC RO FIFO ov.",1);
@@ -465,7 +471,7 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, string folder,
   if ( folder == "SC" ) {
     // The plots are per wheel
     ibooker.setCurrentFolder(topFolder(false) + "FED" + dduID_s.str());
-
+    if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
     // SC data Size
     histoType = "SCSizeVsROSSize";
     histoName = "FED" + dduID_s.str() + "_SCSizeVsROSSize";
@@ -480,7 +486,7 @@ void DTDataIntegrityTask::bookHistos(DQMStore::IBooker & ibooker, string folder,
 void DTDataIntegrityTask::bookHistosROS25(DQMStore::IBooker & ibooker, DTROChainCoding code) {
   bookHistos(ibooker, string("ROS"), code);
 
-    if(mode <= 1)
+    if(mode < 1)
       if(getSCInfo)
 	bookHistos(ibooker, string("SC"), code);
 }
@@ -497,6 +503,8 @@ void DTDataIntegrityTask::processROS25(DTROS25Data & data, int ddu, int ros) {
   DTROChainCoding code;
   code.setDDU(ddu);
   code.setROS(ros);
+
+  if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
 
   MonitorElement* ROSSummary = rosSHistos["ROSSummary"][code.getDDUID()];
 
@@ -641,7 +649,7 @@ void DTDataIntegrityTask::processROS25(DTROS25Data & data, int ddu, int ros) {
   }
 
 
-  if(mode <= 1) { // produce only when not in HLT
+  if(mode < 1) { // produce only when not in HLT or SM
     // ROB Trailer
     for (vector<DTROBTrailerWord>::const_iterator robt_it = data.getROBTrailers().begin();
 	 robt_it != data.getROBTrailers().end(); robt_it++) { // loop over ROB trailers
@@ -760,7 +768,7 @@ void DTDataIntegrityTask::processROS25(DTROS25Data & data, int ddu, int ros) {
   }
 
   // Read SC data
-  if (mode <= 1 && getSCInfo) {
+  if (mode < 1 && getSCInfo) {
     // NumberOf16bitWords counts the # of words + 1 subheader
     // the SC includes the SC "private header" and the ROS header and trailer (= NumberOf16bitWords +3)
     rosHistos["SCSizeVsROSSize"][code.getSCID()]->Fill(ros,data.getSCTrailer().wordCount());
@@ -804,6 +812,8 @@ void DTDataIntegrityTask::processFED(DTDDUData & data, const std::vector<DTROS25
     hFEDFatal->Fill(code.getDDUID());
     hCorruptionSummary->Fill(code.getDDUID(), 6);
   }
+
+ if(mode == 3 || mode ==1) return; //Avoid duplication of Info in FEDIntegrity_EvF
 
   DTDDUSecondStatusWord secondWord = data.getSecondStatusWord();
 
@@ -883,7 +893,7 @@ void DTDataIntegrityTask::processFED(DTDDUData & data, const std::vector<DTROS25
     ttsCodeValue = 7;
   }
   }
-  if(mode <= 1) dduHistos["TTSValues"][code.getDDUID()]->Fill(ttsCodeValue);
+  if(mode < 1) dduHistos["TTSValues"][code.getDDUID()]->Fill(ttsCodeValue);
   if(ttsSummaryBin != -1) {
     hTTSSummary->Fill(ddu, ttsSummaryBin);
   }
@@ -1081,8 +1091,8 @@ std::string DTDataIntegrityTask::topFolder(bool isFEDIntegrity) const {
 
   string folder = isFEDIntegrity ? fedIntegrityFolder : "DT/00-DataIntegrity/";
 
-//  if (!isFEDIntegrity)
-//    folder += (mode==1) ? "_SM/" : (mode==3) ? "_EvF/" : "/";
+  if (mode == 0 || mode == 2)
+    folder = "DT/00-DataIntegrity/"; //Move everything from FEDIntegrity except for SM and HLT modes
 
   return folder;
 

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -40,7 +40,7 @@ DTDataIntegrityTask::DTDataIntegrityTask(const edm::ParameterSet& ps) : nevents(
   neventsROS25 = 0;
 
   FEDIDmin = FEDNumbering::MINDTFEDID;
-  FEDIDMax = FEDNumbering::MAXDTFEDID;
+  FEDIDMax = 774; // FEDNumbering::MAXDTFEDID; Monitoring only real used FEDs
 
 //   If you want info VS time histos
 //   doTimeHisto =  ps.getUntrackedParameter<bool>("doTimeHisto", false);


### PR DESCRIPTION
This PR fixes the DT "No DAQ" message appearing in DQM Online summary page as reported in eLog entry: http://cmsonline.cern.ch/cms-elog/985586

The PR involves also the disappearance of the following plots/folders from the DQM online to comply with the actual current DT FED reading:

-DT / 00-DataIntegrity / FED775, FED776, FED777, FED778, FED779
-All the plots in DT / 00-DataIntegrity with the name including the FED ids listed above