### PR TITLE
FED Digis trend plot fix

### DIFF
--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -27,6 +27,9 @@ SiPixelPhase1Geometry = cms.PSet(
   onlineblock = cms.int32(20),    # #LS after which histograms are reset
   n_onlineblocks = cms.int32(100),  # #blocks to keep for histograms with history
 
+  # lumiblock -  for coarse temporal splitting 
+  lumiblock = cms.int32(5),       # Number of LS to include in a block
+
   # other geometry parameters (n_layers, n_ladders per layer, etc.) are inferred.
   # there are lots of geometry assuptions in the code.
 )

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -28,7 +28,7 @@ SiPixelPhase1Geometry = cms.PSet(
   n_onlineblocks = cms.int32(100),  # #blocks to keep for histograms with history
 
   # lumiblock -  for coarse temporal splitting 
-  lumiblock = cms.int32(5),       # Number of LS to include in a block
+  lumiblock = cms.int32(10),       # Number of LS to include in a block
 
   # other geometry parameters (n_layers, n_ladders per layer, etc.) are inferred.
   # there are lots of geometry assuptions in the code.

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -352,9 +352,11 @@ void GeometryInterface::loadTimebased(edm::EventSetup const& iSetup, const edm::
   addExtractor(intern("LumiBlock"),
     [lumiblock] (InterestingQuantities const& iq) {
       if(!iq.sourceEvent) return UNDEFINED;
-      return Value( (iq.sourceEvent->luminosityBlock()-1) / lumiblock );
+      // The '-1' is for making 1-10 the same block rather than 0-9
+      // The '+0.5' makes the block span an integer range rather n.5-m.5 
+      return Value( ((iq.sourceEvent->luminosityBlock()-1)/lumiblock) + 0.5  );
     },
-    0, iConfig.getParameter<int>("max_lumisection")/lumiblock
+    -0.5, iConfig.getParameter<int>("max_lumisection")/lumiblock
   );
  
   addExtractor(intern("BX"),

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -335,6 +335,7 @@ void GeometryInterface::loadTimebased(edm::EventSetup const& iSetup, const edm::
     },
     1, iConfig.getParameter<int>("max_lumisection")
   );
+  
   int onlineblock = iConfig.getParameter<int>("onlineblock");
   int n_onlineblocks = iConfig.getParameter<int>("n_onlineblocks");
   addExtractor(intern("OnlineBlock"),
@@ -346,6 +347,16 @@ void GeometryInterface::loadTimebased(edm::EventSetup const& iSetup, const edm::
     // but the strange range allows the RenderPlugin to know the block size.
     onlineblock, onlineblock+n_onlineblocks-1
   );
+  
+  int lumiblock = iConfig.getParameter<int>("lumiblock");
+  addExtractor(intern("LumiBlock"),
+    [lumiblock] (InterestingQuantities const& iq) {
+      if(!iq.sourceEvent) return UNDEFINED;
+      return Value( (iq.sourceEvent->luminosityBlock()-1) / lumiblock );
+    },
+    0, iConfig.getParameter<int>("max_lumisection")/lumiblock
+  );
+ 
   addExtractor(intern("BX"),
     [] (InterestingQuantities const& iq) {
       if(!iq.sourceEvent) return UNDEFINED;

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -121,8 +121,8 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
   dimensions = 0,
   specs = VPSet(
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row/col")
-                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_X")
-                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_Y")
+                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_Y")
+                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
                    .save(),
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/col")
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
@@ -131,8 +131,8 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row/col")
-                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_X")
-                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_Y")
+                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_Y")
+                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_X")
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/col")
                    .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_X")

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -121,8 +121,8 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
   dimensions = 0,
   specs = VPSet(
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row/col")
-                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_Y")
-                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
+                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/row", "EXTEND_X")
+                   .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_Y")
                    .save(),
     Specification(PerModule).groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName/col")
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
@@ -131,8 +131,8 @@ SiPixelPhase1DigisHitmap = DefaultHistoDigiCluster.clone(
                    .groupBy("PXBarrel/Shell/PXLayer/SignedLadder/PXModuleName", "EXTEND_X")
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row/col")
-                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_Y")
-                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_X")
+                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/row", "EXTEND_X")
+                   .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_Y")
                    .save(),
     Specification(PerModule).groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName/col")
                    .groupBy("PXForward/HalfCylinder/PXRing/PXDisk/SignedBlade/PXModuleName", "EXTEND_X")

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -93,7 +93,7 @@ SiPixelPhase1DigisNdigisPerFEDtrend = DefaultHisto.clone(
                    .save(),
   Specification().groupBy("FED/Event") #produce the mean number of digis per event and FED per lumisection
                    .reduce("COUNT")
-                   .groupBy("Lumisection")
+                   .groupBy("LumiBlock")
                    .reduce("MEAN")
                    .groupBy("", "EXTEND_X")
                    .save()

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -82,11 +82,11 @@ SiPixelPhase1DigisNdigisPerFEDtrend = DefaultHisto.clone(
   range_max = 1000,
   range_nbins = 200,
   dimensions = 0,
-  enabled = False,
+  #enabled = False,
   specs = VPSet(
   Specification().groupBy("FED/Event") #produce the mean number of digis per event and FED per lumisection
                    .reduce("COUNT")
-                   .groupBy("FED/Lumisection")
+                   .groupBy("FED/LumiBlock")
                    .reduce("MEAN")
                    .groupBy("FED", "EXTEND_X")
                    .groupBy("", "EXTEND_Y")


### PR DESCRIPTION
Previously the FED trend plot was causing issue with the GUI server, and it was identified that the TProfile object used to produce the plot was too large due to the fine binning being used for the lumisections, with 1 bin for every lumisection and FED. 
The fix defines the "Lumiblock" range for filling the histograms, which allows for 1 bin every 10 lumisection instead, greatly reducing the plot size. Due to the way the plots axis are automatically named in the PixelPhase1 framework, this update should be partnered with a DQMGUI update.