### PR TITLE
Injection of workflows without approving them

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -533,8 +533,6 @@ class MatrixInjector(object):
                 print pprint.pprint(d)
                 print "Submitting",n,"..........."
                 workFlow=makeRequest(self.wmagent,d,encodeDict=True)
-# Changed: DO NOT APPROVE REQUEST, approval will be done via reqmgr2 interface
-#                approveRequest(self.wmagent,workFlow)
                 print "...........",n,"submitted"
                 random_sleep()
             

--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -533,7 +533,8 @@ class MatrixInjector(object):
                 print pprint.pprint(d)
                 print "Submitting",n,"..........."
                 workFlow=makeRequest(self.wmagent,d,encodeDict=True)
-                approveRequest(self.wmagent,workFlow)
+# Changed: DO NOT APPROVE REQUEST, approval will be done via reqmgr2 interface
+#                approveRequest(self.wmagent,workFlow)
                 print "...........",n,"submitted"
                 random_sleep()
             


### PR DESCRIPTION
We inject workflows without approving at the same time. Approval of workflows will be done by the submitter via reqmgr2 interface. This procedure comes with removal of 4h "grace" period in Unified before assigning the workflows.