### PR TITLE
CommonTools/RecoUtils : fix gcc700 warning: class  has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

### DIFF
--- a/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
+++ b/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h
@@ -87,6 +87,8 @@ class PF_PU_AssoMapAlgos{
    PF_PU_AssoMapAlgos(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) :
      PF_PU_AssoMapAlgos(iConfig, iC) {};
    PF_PU_AssoMapAlgos(const edm::ParameterSet&, edm::ConsumesCollector &);
+   // virtual destructor needed when virtual functions declared
+   virtual ~PF_PU_AssoMapAlgos() noexcept(false) {};
 
    //get all needed collections at the beginning
    virtual void GetInputCollections(edm::Event&, const edm::EventSetup&);


### PR DESCRIPTION


Fixes warnings like these by adding virtual destructor with default constructor.

/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/cad3eea82b17ccf34f572f7928d21ee1/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-28-2300/src/CommonTools/RecoUtils/interface/PF_PU_AssoMapAlgos.h:82:7: warning: 'class PF_PU_AssoMapAlgos' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

/build/cmsbld/jenkins-workarea/workspace/build-any-ib/w/tmp/BUILDROOT/cad3eea82b17ccf34f572f7928d21ee1/opt/cmssw/slc6_amd64_gcc700/cms/cmssw/CMSSW_9_2_X_2017-05-28-2300/src/CommonTools/RecoUtils/interface/PF_PU_AssoMap.h:41:7: warning: base class 'class PF_PU_AssoMapAlgos' has accessible non-virtual destructor [-Wnon-virtual-dtor]