### PR TITLE
PixelGainCalibrations for DB, no usage

### DIFF
--- a/CondCore/CTPPSPlugins/src/plugin.cc
+++ b/CondCore/CTPPSPlugins/src/plugin.cc
@@ -3,7 +3,9 @@
 #include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelAnalysisMask.h"
 #include "CondFormats/DataRecord/interface/CTPPSPixelAnalysisMaskRcd.h"
-
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
+#include "CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h"
  
 REGISTER_PLUGIN(CTPPSPixelDAQMappingRcd,CTPPSPixelDAQMapping);
 REGISTER_PLUGIN(CTPPSPixelAnalysisMaskRcd,CTPPSPixelAnalysisMask);
+REGISTER_PLUGIN(CTPPSPixelGainCalibrationsRcd,CTPPSPixelGainCalibrations);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -52,6 +52,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE( CSCRecoDigiParameters )
       FETCH_PAYLOAD_CASE( CTPPSPixelDAQMapping )
       FETCH_PAYLOAD_CASE( CTPPSPixelAnalysisMask )
+      FETCH_PAYLOAD_CASE( CTPPSPixelGainCalibrations )
       FETCH_PAYLOAD_CASE( CastorChannelQuality )
       FETCH_PAYLOAD_CASE( CastorElectronicsMap )
       FETCH_PAYLOAD_CASE( CastorGainWidths )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -66,6 +66,7 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( CSCRecoDigiParameters )
       IMPORT_PAYLOAD_CASE( CTPPSPixelDAQMapping )
       IMPORT_PAYLOAD_CASE( CTPPSPixelAnalysisMask )
+      IMPORT_PAYLOAD_CASE( CTPPSPixelGainCalibrations  )
       IMPORT_PAYLOAD_CASE( CastorChannelQuality )
       IMPORT_PAYLOAD_CASE( CastorElectronicsMap )
       IMPORT_PAYLOAD_CASE( CastorGainWidths )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -28,6 +28,7 @@
 #include "CondFormats/CSCObjects/interface/CSCL1TPParameters.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelDAQMapping.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelAnalysisMask.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
 #include "CondFormats/DTObjects/interface/DTDeadFlag.h"
 #include "CondFormats/DTObjects/interface/DTHVStatus.h"

--- a/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibration.h
@@ -1,0 +1,95 @@
+#ifndef CondFormats_CTPPSReadoutObjects_CTPPSPixelGainCalibration_h
+#define CondFormats_CTPPSReadoutObjects_CTPPSPixelGainCalibration_h
+// -*- C++ -*-
+//
+// Package:    CTPPSReadoutObjects
+// Class:      CTPPSPixelGainCalibration
+// 
+/**\class CTPPSPixelGainCalibration CTPPSPixelGainCalibration.h CondFormats/CTPPSRedoutObjects/src/CTPPSPixelGainCalibration.cc
+
+ Description: Gain calibration object for the CTPPS 3D Pixels.  Store gain/pedestal information at pixel granularity
+
+ Implementation:
+     <Notes on implementation>
+*/
+// Loosely based on SiPixelObjects/SiPixelGainCalibration 
+// Original Author:  Vincenzo Chiochia
+//         Created:  Tue 8 12:31:25 CEST 2007
+//         Modified: Evan Friis
+// $Id: CTPPSPixelGainCalibration.h,v 1.8 2009/02/10 17:25:42 rougny Exp $
+//  Adapted for CTPPS : Clemencia Mora Herrera       November 2016
+//
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include<vector>
+
+class CTPPSPixelGainCalibration {
+ friend class CTPPSPixelGainCalibrations;
+
+ public:
+  
+  struct DetRegistry{ //to index the channels in each sensor 
+    uint32_t detid ;
+    uint32_t ibegin;
+    uint32_t iend  ;
+    uint32_t ncols ;
+    
+    COND_SERIALIZABLE;
+  };
+  
+  
+  // Constructors
+  CTPPSPixelGainCalibration();
+  CTPPSPixelGainCalibration(const uint32_t & detId, const uint32_t & sensorSize, const uint32_t & nCols);
+  CTPPSPixelGainCalibration(float minPed, float maxPed, float minGain, float maxGain);
+  CTPPSPixelGainCalibration(const uint32_t& detid, const std::vector<float>& peds, const std::vector<float>& gains, 
+			    float minPed=0., float maxPed=255., float minGain=0., float maxGain=255.);
+  ~CTPPSPixelGainCalibration(){}
+
+  void initialize(){}
+
+  void setGainsPeds(const uint32_t& detId, const std::vector<float>& peds, const std::vector<float>& gains);
+
+  double getGainLow() const { return minGain_; }
+  double getGainHigh() const { return maxGain_; }
+  double getPedLow() const { return minPed_; }
+  double getPedHigh() const { return maxPed_; }
+
+  // Set and get public methods
+
+  void  setDeadPixel(int ipix)  { putData(ipix, -999., 0. ); } // dead flag is pedestal = -999.
+  void  setNoisyPixel(int ipix) { putData(ipix, 0., -9999. ); } // noisy flat is gain= -9999.
+
+
+  void putData(uint32_t ipix, float ped, float gain);
+
+  float getPed   (const int& col, const int& row , bool& isDead, bool& isNoisy) const;
+  float getGain  (const int& col, const int& row , bool& isDead, bool& isNoisy) const;
+  float getPed   (const uint32_t ipix, bool& isDead, bool& isNoisy)const;
+  float getGain  (const uint32_t ipix, bool& isDead, bool& isNoisy)const;
+  float getPed   (const int& col, const int& row ) const;
+  float getGain  (const int& col, const int& row ) const;
+  float getPed   (const uint32_t ipix )const;
+  float getGain  (const uint32_t ipix )const;
+
+  //get information related to indexes
+  uint32_t getDetId () const {return indexes.detid;}
+  uint32_t getNCols () const {return indexes.ncols;}
+  uint32_t getIBegin() const {return indexes.ibegin;}
+  uint32_t getIEnd  () const {return indexes.iend;}
+
+ private:
+  void setIndexes(const uint32_t& detId);
+  void resetPixData(uint32_t ipix, float ped, float gain);
+
+  std::vector<float> v_pedestals; 
+  std::vector<float> v_gains;
+  DetRegistry indexes;
+  // a single detRegistry w/ detID and collection of indices 
+  float  minPed_, maxPed_, minGain_, maxGain_; //not really used
+
+ COND_SERIALIZABLE;
+};
+    
+#endif

--- a/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibration.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibration.h
@@ -34,7 +34,7 @@ class CTPPSPixelGainCalibration {
     uint32_t ibegin;
     uint32_t iend  ;
     uint32_t ncols ;
-    
+    uint32_t nrows ;
     COND_SERIALIZABLE;
   };
   
@@ -58,26 +58,28 @@ class CTPPSPixelGainCalibration {
 
   // Set and get public methods
 
-  void  setDeadPixel(int ipix)  { putData(ipix, -999., 0. ); } // dead flag is pedestal = -999.
+  void  setDeadPixel(int ipix)  { putData(ipix, -9999., 0. ); } // dead flag is pedestal = -9999.
   void  setNoisyPixel(int ipix) { putData(ipix, 0., -9999. ); } // noisy flat is gain= -9999.
 
 
   void putData(uint32_t ipix, float ped, float gain);
 
-  float getPed   (const int& col, const int& row , bool& isDead, bool& isNoisy) const;
-  float getGain  (const int& col, const int& row , bool& isDead, bool& isNoisy) const;
-  float getPed   (const uint32_t ipix, bool& isDead, bool& isNoisy)const;
-  float getGain  (const uint32_t ipix, bool& isDead, bool& isNoisy)const;
+  /* float getPed   (const int& col, const int& row , bool& isDead, bool& isNoisy) const; */
+  /* float getGain  (const int& col, const int& row , bool& isDead, bool& isNoisy) const; */
+  /* float getPed   (const uint32_t ipix, bool& isDead, bool& isNoisy)const; */
+  /* float getGain  (const uint32_t ipix, bool& isDead, bool& isNoisy)const; */
   float getPed   (const int& col, const int& row ) const;
   float getGain  (const int& col, const int& row ) const;
-  float getPed   (const uint32_t ipix )const;
-  float getGain  (const uint32_t ipix )const;
-
+  float getPed   (const uint32_t ipix )const{return v_pedestals[ipix];}
+  float getGain  (const uint32_t ipix )const{return v_gains[ipix];}
+  bool  isDead   (const uint32_t ipix)const{return (v_pedestals[ipix]==-9999.);}
+  bool  isNoisy  (const uint32_t ipix)const{return (v_gains[ipix]==-9999.);}
   //get information related to indexes
   uint32_t getDetId () const {return indexes.detid;}
   uint32_t getNCols () const {return indexes.ncols;}
   uint32_t getIBegin() const {return indexes.ibegin;}
   uint32_t getIEnd  () const {return indexes.iend;}
+  uint32_t getNRows () const {return indexes.nrows;}
 
  private:
   void setIndexes(const uint32_t& detId);
@@ -87,7 +89,7 @@ class CTPPSPixelGainCalibration {
   std::vector<float> v_gains;
   DetRegistry indexes;
   // a single detRegistry w/ detID and collection of indices 
-  float  minPed_, maxPed_, minGain_, maxGain_; //not really used
+  float  minPed_, maxPed_, minGain_, maxGain_; //not really used yet
 
  COND_SERIALIZABLE;
 };

--- a/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
@@ -5,21 +5,20 @@
 #include <map>
 #include <vector>
 
-using namespace std;
 
 class CTPPSPixelGainCalibrations{
  public:
-  typedef map<uint32_t,CTPPSPixelGainCalibration> calibmap;
+  typedef std::map<uint32_t,CTPPSPixelGainCalibration> CalibMap;
 
   CTPPSPixelGainCalibrations(){}
   virtual ~CTPPSPixelGainCalibrations(){}
 
   void setGainCalibration(const uint32_t& DetId, const CTPPSPixelGainCalibration & PixGains);
-  void setGainCalibration(const uint32_t& DetId, const vector<float>& peds, const vector<float>& gains);
-  void setGainCalibrations(const calibmap & PixGainsCalibs);
-  void setGainCalibrations(const vector<uint32_t>& detidlist, const vector<vector<float>>& peds, const vector<vector<float>>& gains);
+  void setGainCalibration(const uint32_t& DetId, const std::vector<float>& peds, const std::vector<float>& gains);
+  void setGainCalibrations(const CalibMap & PixGainsCalibs);
+  void setGainCalibrations(const std::vector<uint32_t>& detidlist, const std::vector<std::vector<float>>& peds, const std::vector<std::vector<float>>& gains);
 
-  const calibmap & getCalibmap()const { return m_calibrations;}
+  const CalibMap & getCalibMap()const { return m_calibrations;}
 
   CTPPSPixelGainCalibration getGainCalibration(const uint32_t & detid) const;
   CTPPSPixelGainCalibration & getGainCalibration(const uint32_t & detid);
@@ -29,7 +28,7 @@ class CTPPSPixelGainCalibrations{
   int size() const {return m_calibrations.size();}
 
  private:
-  calibmap m_calibrations;
+  CalibMap m_calibrations;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
+++ b/CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h
@@ -1,0 +1,37 @@
+#ifndef CondFormats_CTPPSReadoutObjects_CTPPSPixelGainCalibrations_h
+#define CondFormats_CTPPSReadoutObjects_CTPPSPixelGainCalibrations_h
+
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibration.h"
+#include <map>
+#include <vector>
+
+using namespace std;
+
+class CTPPSPixelGainCalibrations{
+ public:
+  typedef map<uint32_t,CTPPSPixelGainCalibration> calibmap;
+
+  CTPPSPixelGainCalibrations(){}
+  virtual ~CTPPSPixelGainCalibrations(){}
+
+  void setGainCalibration(const uint32_t& DetId, const CTPPSPixelGainCalibration & PixGains);
+  void setGainCalibration(const uint32_t& DetId, const vector<float>& peds, const vector<float>& gains);
+  void setGainCalibrations(const calibmap & PixGainsCalibs);
+  void setGainCalibrations(const vector<uint32_t>& detidlist, const vector<vector<float>>& peds, const vector<vector<float>>& gains);
+
+  const calibmap & getCalibmap()const { return m_calibrations;}
+
+  CTPPSPixelGainCalibration getGainCalibration(const uint32_t & detid) const;
+  CTPPSPixelGainCalibration & getGainCalibration(const uint32_t & detid);
+
+  
+  
+  int size() const {return m_calibrations.size();}
+
+ private:
+  calibmap m_calibrations;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibration.cc
@@ -1,0 +1,193 @@
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibration.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include <algorithm>
+#include <cstring>
+
+//
+// Constructors
+//
+CTPPSPixelGainCalibration::CTPPSPixelGainCalibration() :
+  minPed_(0.),
+  maxPed_(255.),
+  minGain_(0.),
+  maxGain_(255.)
+{
+  DetRegistry myreg;
+  myreg.detid=0;
+  myreg.ibegin=0;
+  myreg.iend=0;
+  myreg.ncols=0; 
+  indexes = myreg;
+  edm::LogInfo("CTPPSPixelGainCalibration")<< "Default instance of CTPPSPixelGainCalibration" ;
+}
+
+CTPPSPixelGainCalibration::CTPPSPixelGainCalibration(const uint32_t &detId, const uint32_t  & sensorSize=24960, const uint32_t & nCols=156) :
+  minPed_(0.),
+  maxPed_(255.),
+  minGain_(0.),
+  maxGain_(255.)
+{
+  DetRegistry myreg;
+  myreg.detid=detId;
+  myreg.ibegin=0;
+  myreg.iend=sensorSize;
+  myreg.ncols=nCols;
+  indexes = myreg;
+  edm::LogInfo("CTPPSPixelGainCalibration") << "Instance of CTPPSPixelGainCalibration setting  detId = " << detId << " and  npix = " << sensorSize << "and ncols = " << nCols ;
+
+}
+
+
+//
+CTPPSPixelGainCalibration::CTPPSPixelGainCalibration(float minPed, float maxPed, float minGain, float maxGain) :
+  minPed_(minPed),
+  maxPed_(maxPed),
+  minGain_(minGain),
+  maxGain_(maxGain) 
+{
+  DetRegistry myreg;
+  myreg.detid=0;
+  myreg.ibegin=0;
+  myreg.iend=0;
+  myreg.ncols=0;
+  indexes = myreg;
+  edm::LogInfo("CTPPSPixelGainCalibration")<<"Instance of CTPPSPixelGainCalibration setting mininums and maximums";
+}
+
+
+CTPPSPixelGainCalibration::CTPPSPixelGainCalibration(const uint32_t& detid, const std::vector<float> & peds, const std::vector<float>& gains, float minPed, float maxPed,float minGain, float maxGain) :
+  minPed_(minPed),
+  maxPed_(maxPed),
+  minGain_(minGain),
+  maxGain_(maxGain)
+{
+  setGainsPeds(detid,peds,gains);
+  edm::LogInfo("CTPPSPixelGainCalibration")<<"Instance of CTPPSPixelGainCalibration setting  detId = "<< detid <<"and vectors of peds and gains";
+
+}
+
+void CTPPSPixelGainCalibration::setGainsPeds(const uint32_t& detid, const std::vector<float> & peds, const std::vector<float>& gains){
+  int sensorSize=peds.size();
+  int gainsSize=gains.size();
+  if(gainsSize!=sensorSize)
+    throw cms::Exception("CTPPSPixelGainCalibration payload configuration error") 
+      <<  "[CTPPSPixelGainCalibration::CTPPSPixelGainCalibration]  peds and gains vector sizes don't match for detid "
+      << detid << " size peds = " << sensorSize << " size gains = " << gainsSize; 
+  DetRegistry myreg;
+  myreg.detid=detid;
+  myreg.ibegin=0;
+  myreg.iend=sensorSize;
+  myreg.ncols=sensorSize/160; // each ROC is made of 80 rows and 52 columns, each sensor is made of 160 rows and either 104 or 156 columns (2x2 or 2x3 ROCs)
+  indexes = myreg;
+  for(int i = 0 ; i<sensorSize ; ++i)  
+    putData(i,peds[i],gains[i]);
+}
+
+void CTPPSPixelGainCalibration::putData(uint32_t ipix, float ped, float gain){
+  if (v_pedestals.size()>ipix) //if the vector is too big, this pixel has already been set
+    {
+      if (ped>=0 && gain>=0)
+	throw cms::Exception("CTPPSPixelGainCalibration fill error")
+	  << "[CTPPSPixelGainCalibration::putData] attempting to fill the vectors that are already filled detid = " << indexes.detid << " ipix " << ipix;
+      else   // in case it is for setting the noisy or dead flag of already filled pixel you are allowed to reset it
+	{
+	  edm::LogInfo("CTPPSPixelGainCalibration")<<"resetting pixel calibration for noisy or dead flag";
+	  resetPixData(ipix,ped,gain);
+	}
+    }
+  else if (v_pedestals.size()<ipix)
+    throw cms::Exception("CTPPSPixelGainCalibration fill error")
+      << "[CTPPSPixelGainCalibration::putData] the order got scrambled detid = "<< indexes.detid << " ipix " << ipix;
+  else{ //the size has to match exactly the index, the index - 0 pixel starts the vector, the one with index 1 should be pushed back in a vector of size== 1 (to become size==2) so on and o forth
+    v_pedestals.push_back(ped);
+    v_gains.push_back(gain);
+  }
+}
+
+void CTPPSPixelGainCalibration::setIndexes(const uint32_t &detid){
+  indexes.detid  = detid;
+  indexes.ibegin = 0 ;
+  indexes.iend   = v_pedestals.size();
+  indexes.ncols  = indexes.iend/ 160 ; // nrows is 160 in CTPPS
+}
+
+void CTPPSPixelGainCalibration::resetPixData(uint32_t ipix, float ped, float gain){
+  if (v_pedestals.size()<=ipix){
+    edm::LogError("CTPPSPixelGainCalibration")<<"this element ipix = " << ipix << " has not been set yet"; 
+    return;
+  }
+  v_pedestals[ipix]=ped; //modify value to already exisiting element
+  v_gains[ipix]=gain;
+}
+
+float CTPPSPixelGainCalibration::getPed(const int& col, const int& row ) const {
+  int nCols=indexes.ncols;
+  int nRows=v_pedestals.size()/nCols;
+  if (col >= nCols || row >= nRows){
+    throw cms::Exception("CorruptedData")
+      << "[CTPPSPixelGainCalibration::getPed] Pixel out of range: col " << col << " row " << row;
+  }
+  bool  isDead = false;
+  bool  isNoisy= false;
+  int   ipix = col + row * nCols;
+  float tmpped  = getPed(ipix,isDead,isNoisy);
+  if (isDead || isNoisy)
+    edm::LogWarning("CTPPSPixelGainCalibration")<<"Using noisy or dead pixel";
+  return tmpped;
+}
+
+float CTPPSPixelGainCalibration::getPed(const int& col, const int& row, bool& isDead, bool& isNoisy) const {
+  int nCols=indexes.ncols;
+  int nRows=v_pedestals.size()/nCols;
+  if (col >= nCols || row >= nRows){
+    throw cms::Exception("CorruptedData")
+      << "[CTPPSPixelGainCalibration::getPed] Pixel out of range: col " << col << " row " << row;
+  }  
+  int ipix = col + row * nCols;
+  return   getPed(ipix,isDead,isNoisy);
+}
+
+
+float CTPPSPixelGainCalibration::getPed(const uint32_t ipix,bool& isDead, bool&isNoisy) const {
+  if (v_pedestals[ipix] == -999.0)
+    isDead = true;  
+  if (v_gains[ipix] == -9999.0)
+    isNoisy = true;
+  return v_pedestals[ipix];  
+}
+
+
+float CTPPSPixelGainCalibration::getGain(const int& col, const int& row ) const {
+  int nCols=indexes.ncols;
+  int nRows=v_pedestals.size()/nCols;
+  if (col >= nCols || row >= nRows){
+    throw cms::Exception("CorruptedData")
+      << "[CTPPSPixelGainCalibration::getGain] Pixel out of range: col " << col << " row " << row;
+  }  
+  bool  isDead  = false;
+  bool  isNoisy = false;  
+  int   ipix = col + row * nCols;
+  float tmpgain = getGain(ipix,isDead,isNoisy);
+  if (isDead || isNoisy)
+    edm::LogWarning("CTPPSPixelGainCalibration")<<"Using noisy or dead pixel";
+  return tmpgain;
+}
+
+float CTPPSPixelGainCalibration::getGain(const int& col, const int& row, bool& isDead, bool& isNoisy) const {
+  int nCols=indexes.ncols;
+  int nRows=v_pedestals.size()/nCols;
+  if (col >= nCols || row >= nRows){
+    throw cms::Exception("CorruptedData")
+      << "[CTPPSPixelGainCalibration::getGain] Pixel out of range: col " << col << " row " << row;
+  }  
+  int ipix = col + row * nCols;
+  return getGain(ipix,isDead,isNoisy);
+}
+
+float CTPPSPixelGainCalibration::getGain(const uint32_t ipix,bool& isDead, bool&isNoisy) const {
+  if (v_pedestals[ipix] == -999. )
+     isDead = true;  
+  if (v_gains[ipix] == -9999.)
+     isNoisy = true;
+  return v_gains[ipix];
+}

--- a/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
@@ -1,0 +1,68 @@
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+
+void CTPPSPixelGainCalibrations::setGainCalibration(const uint32_t& detid, const CTPPSPixelGainCalibration & PixGains){
+
+  if(detid!=PixGains.getDetId()){ // if no detid set in the pixgains
+    CTPPSPixelGainCalibration newPixGains =    PixGains; //maybe the copy works?
+    newPixGains.setIndexes(detid); //private accessor, only friend class can use it
+    edm::LogInfo("CTPPSPixelGainCalibrations") << "newPixGains detId = "<< newPixGains.getDetId() 
+	      << " ; iBegin = "<< newPixGains.getIBegin()
+	      << " ; iEnd = "<< newPixGains.getIEnd()
+	      << " ; nCols = "<< newPixGains.getNCols() ;
+
+    int npix = newPixGains.getIEnd() ; 
+    bool dead,noisy;
+    if(npix!=0 )
+      edm::LogInfo("CTPPSPixelGainCalibrations") << "newPixGains Ped[0] = "<< newPixGains.getPed(0,dead,noisy)
+		<< " ; Gain[0] = " << newPixGains.getGain(0,dead,noisy)
+		<< " ; dead = " << dead << " ; noisy = "<< noisy ;
+    else 
+      edm::LogError("CTPPSPixelGainCalibrations") << "looks like setting gain calibrations did not work, npix is "<< npix ;
+
+    m_calibrations[detid]=newPixGains;
+  }
+
+  else
+    m_calibrations[detid] = PixGains;
+}
+
+void CTPPSPixelGainCalibrations::setGainCalibration(const uint32_t& detid, const vector<float> & peds, const vector<float> & gains){
+  m_calibrations[detid] =  CTPPSPixelGainCalibration(detid,peds,gains);
+}
+
+void CTPPSPixelGainCalibrations::setGainCalibrations(const calibmap & PixGainsCalibs){
+  m_calibrations = PixGainsCalibs;
+}
+
+void CTPPSPixelGainCalibrations::setGainCalibrations(const vector<uint32_t>& detidlist, const vector<vector<float>>& peds, const vector<vector<float>>& gains){
+  int nids=detidlist.size();
+  for (int detid=0; detid<nids ; ++detid){
+    const  vector<float>& pedsvec  = peds[detid];
+    const  vector<float>& gainsvec = gains[detid];
+    m_calibrations[detid]=  CTPPSPixelGainCalibration(detid,pedsvec,gainsvec);
+  }
+}
+
+
+CTPPSPixelGainCalibration & CTPPSPixelGainCalibrations::getGainCalibration(const uint32_t & detid) { // returns the ref and if does not exist it creates
+  return m_calibrations[detid];
+}
+
+CTPPSPixelGainCalibration  CTPPSPixelGainCalibrations::getGainCalibration(const uint32_t & detid) const{ // returns the object does not change the map
+  calibmap::const_iterator it = m_calibrations.find(detid);
+  if (it != m_calibrations.end())
+    return it->second;
+
+  else
+    edm::LogError("CTPPSPixelGainCalibrations")<< "No gain calibrations defined for detid " << detid << "\n";
+
+  CTPPSPixelGainCalibration a;
+  return a;
+
+}
+
+
+

--- a/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/CTPPSPixelGainCalibrations.cc
@@ -11,14 +11,17 @@ void CTPPSPixelGainCalibrations::setGainCalibration(const uint32_t& detid, const
     edm::LogInfo("CTPPSPixelGainCalibrations") << "newPixGains detId = "<< newPixGains.getDetId() 
 	      << " ; iBegin = "<< newPixGains.getIBegin()
 	      << " ; iEnd = "<< newPixGains.getIEnd()
-	      << " ; nCols = "<< newPixGains.getNCols() ;
+	      << " ; nCols = "<< newPixGains.getNCols() 
+	      << " ; nRows ="<<newPixGains.getNRows();
 
     int npix = newPixGains.getIEnd() ; 
-    bool dead,noisy;
+    //bool dead,noisy;
     if(npix!=0 )
-      edm::LogInfo("CTPPSPixelGainCalibrations") << "newPixGains Ped[0] = "<< newPixGains.getPed(0,dead,noisy)
-		<< " ; Gain[0] = " << newPixGains.getGain(0,dead,noisy)
-		<< " ; dead = " << dead << " ; noisy = "<< noisy ;
+      edm::LogInfo("CTPPSPixelGainCalibrations") 
+	<< "newPixGains Ped[0] = "<< newPixGains.getPed(0)
+	<< " ; Gain[0] = " << newPixGains.getGain(0)
+	<< " ; dead = " << newPixGains.isDead(0) 
+	<< " ; noisy = "<< newPixGains.isNoisy(0) ;
     else 
       edm::LogError("CTPPSPixelGainCalibrations") << "looks like setting gain calibrations did not work, npix is "<< npix ;
 
@@ -29,19 +32,19 @@ void CTPPSPixelGainCalibrations::setGainCalibration(const uint32_t& detid, const
     m_calibrations[detid] = PixGains;
 }
 
-void CTPPSPixelGainCalibrations::setGainCalibration(const uint32_t& detid, const vector<float> & peds, const vector<float> & gains){
+void CTPPSPixelGainCalibrations::setGainCalibration(const uint32_t& detid, const std::vector<float> & peds, const std::vector<float> & gains){
   m_calibrations[detid] =  CTPPSPixelGainCalibration(detid,peds,gains);
 }
 
-void CTPPSPixelGainCalibrations::setGainCalibrations(const calibmap & PixGainsCalibs){
+void CTPPSPixelGainCalibrations::setGainCalibrations(const CalibMap & PixGainsCalibs){
   m_calibrations = PixGainsCalibs;
 }
 
-void CTPPSPixelGainCalibrations::setGainCalibrations(const vector<uint32_t>& detidlist, const vector<vector<float>>& peds, const vector<vector<float>>& gains){
+void CTPPSPixelGainCalibrations::setGainCalibrations(const std::vector<uint32_t>& detidlist, const std::vector<std::vector<float>>& peds, const std::vector<std::vector<float>>& gains){
   int nids=detidlist.size();
   for (int detid=0; detid<nids ; ++detid){
-    const  vector<float>& pedsvec  = peds[detid];
-    const  vector<float>& gainsvec = gains[detid];
+    const  std::vector<float>& pedsvec  = peds[detid];
+    const  std::vector<float>& gainsvec = gains[detid];
     m_calibrations[detid]=  CTPPSPixelGainCalibration(detid,pedsvec,gainsvec);
   }
 }
@@ -52,7 +55,7 @@ CTPPSPixelGainCalibration & CTPPSPixelGainCalibrations::getGainCalibration(const
 }
 
 CTPPSPixelGainCalibration  CTPPSPixelGainCalibrations::getGainCalibration(const uint32_t & detid) const{ // returns the object does not change the map
-  calibmap::const_iterator it = m_calibrations.find(detid);
+  CalibMap::const_iterator it = m_calibrations.find(detid);
   if (it != m_calibrations.end())
     return it->second;
 

--- a/CondFormats/CTPPSReadoutObjects/src/T_EventSetup_CTPPSPixelGainCalibration.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/T_EventSetup_CTPPSPixelGainCalibration.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibration.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(CTPPSPixelGainCalibration);

--- a/CondFormats/CTPPSReadoutObjects/src/T_EventSetup_CTPPSPixelGainCalibrations.cc
+++ b/CondFormats/CTPPSReadoutObjects/src/T_EventSetup_CTPPSPixelGainCalibrations.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(CTPPSPixelGainCalibrations);

--- a/CondFormats/CTPPSReadoutObjects/src/classes.h
+++ b/CondFormats/CTPPSReadoutObjects/src/classes.h
@@ -2,7 +2,10 @@
 
 namespace CondFormats_CTPPSPixelObjects {
    struct dictionary {
-   std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> ROCMapping; 
-   std::map<uint32_t, CTPPSPixelROCAnalysisMask> analysisMask;
+     std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> ROCMapping; 
+     std::map<uint32_t, CTPPSPixelROCAnalysisMask> analysisMask;
+     std::vector< CTPPSPixelGainCalibration::DetRegistry >::iterator p3;
+     std::vector< CTPPSPixelGainCalibration::DetRegistry >::const_iterator p4;
+     std::map<uint32_t,CTPPSPixelGainCalibration> mycalibmap; 
  };
 }     

--- a/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
+++ b/CondFormats/CTPPSReadoutObjects/src/classes_def.xml
@@ -11,4 +11,13 @@
     <class name="CTPPSPixelROCAnalysisMask"  class_version="0"/>
     <class name="std::map<uint32_t, CTPPSPixelROCAnalysisMask>"/>
 
+    <class name="CTPPSPixelGainCalibration" class_version="0">
+      <field name="v_pedestals" mapping="blob"/>
+      <field name="v_gains" mapping="blob"/>
+      <field name="indexes" mapping="blob"/>
+    </class>
+    <class name="std::map<uint32_t,CTPPSPixelGainCalibration>"/>
+    <class name="CTPPSPixelGainCalibration::DetRegistry"/>
+    <class name="std::vector<CTPPSPixelGainCalibration::DetRegistry>"/>
+    <class name="CTPPSPixelGainCalibrations" class_version="0"/>
 </lcgdict>

--- a/CondFormats/CTPPSReadoutObjects/src/headers.h
+++ b/CondFormats/CTPPSReadoutObjects/src/headers.h
@@ -1,2 +1,3 @@
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelDAQMapping.h"
 #include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelAnalysisMask.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelGainCalibrations.h"

--- a/CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h
+++ b/CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h
@@ -1,0 +1,25 @@
+#ifndef CTPPSPixelGainCalibrationsRcd_CTPPSPixelGainCalibrationsRcd_h
+#define CTPPSPixelGainCalibrationsRcd_CTPPSPixelGainCalibrationsRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     CTPPSPixelGainCalibrationsRcd
+// 
+/**\class CTPPSPixelGainCalibrationsRcd CTPPSPixelGainCalibrationsRcd.h CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Clemencia Mora Herrera
+// Created:     Fri, 17 Feb 2017 16:13:16 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class CTPPSPixelGainCalibrationsRcd : public edm::eventsetup::EventSetupRecordImplementation<CTPPSPixelGainCalibrationsRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/CTPPSPixelGainCalibrationsRcd.cc
+++ b/CondFormats/DataRecord/src/CTPPSPixelGainCalibrationsRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     CTPPSPixelGainCalibrationsRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Clemencia Mora Herrera
+// Created:     Fri, 17 Feb 2017 16:13:16 GMT
+
+#include "CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(CTPPSPixelGainCalibrationsRcd);


### PR DESCRIPTION
Separation of Conditions DB class implementations and declarations for CTPPS pixel gain calibrations, but without the usage by CTPPS pixel clusterization of PR #19008. 

new classes:
CTPPSPixelGainCalibration
CTPPSPixelGainCalibrations
CTPPSPixelGainCalibrationsRcd
