### PR TITLE
OnlineDQM : Add Quality Tests for L1T Muons

### DIFF
--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
@@ -4,7 +4,7 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="BMTFDEMismatchRatioMax0p05">
+  <QTEST name="BMTFDE_MismatchRatioMax0p05">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
     <PARAM name="ymax">0.05</PARAM>
@@ -14,7 +14,7 @@
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2BMTF/mismatchRatio">
-      <TestName activate="true">BMTFDEMismatchRatioMax0p05</TestName>
+      <TestName activate="true">BMTFDE_MismatchRatioMax0p05</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
@@ -1,0 +1,20 @@
+<TESTSCONFIGURATION>
+
+  <!-- BMTF Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="BMTFDEMismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2BMTF/mismatchRatio">
+      <TestName activate="true">BMTFDEMismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
@@ -1,0 +1,48 @@
+<TESTSCONFIGURATION>
+
+  <!-- BMTF HW pT -->
+
+  <QTEST name="BMTFhwPtRange">
+    <TYPE>ContentsXRange</TYPE> 
+    <PARAM name="xmin">6</PARAM>
+    <PARAM name="xmax">511</PARAM>
+    <PARAM name="error">0.98</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  <QTEST name="BMTFhwPtSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2BMTF/bmtf_hwPt">
+      <TestName activate="true">BMTFhwPtRange</TestName>
+      <TestName activate="true">BMTFhwPtSpectrum</TestName>
+  </LINK>
+
+  <!-- BMTF WEDGE vs BX -->
+
+  <QTEST name="BMTFWedgeBXSpectrum">
+    <TYPE>Comp2Ref2DChi2</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+    <PARAM name="minEntries">60</PARAM>
+  </QTEST>
+
+  <QTEST name="BMTFWedgeBXNoisyWedge">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">10</PARAM>
+    <PARAM name="neighbours">1</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2BMTF/bmtf_wedge_bx">
+      <TestName activate="true">BMTFWedgeBXSpectrum</TestName>
+      <TestName activate="true">BMTFWedgeBXNoisyWedge</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
@@ -2,7 +2,7 @@
 
   <!-- BMTF HW pT -->
 
-  <QTEST name="BMTFhwPtRange">
+  <QTEST name="BMTF_hwPtRange">
     <TYPE>ContentsXRange</TYPE> 
     <PARAM name="xmin">6</PARAM>
     <PARAM name="xmax">511</PARAM>
@@ -10,7 +10,7 @@
     <PARAM name="warning">0.99</PARAM>
   </QTEST>
 
-  <QTEST name="BMTFhwPtSpectrum">
+  <QTEST name="BMTF_hwPtSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.01</PARAM>
@@ -18,13 +18,13 @@
   </QTEST>
   
   <LINK name="*/L1TStage2BMTF/bmtf_hwPt">
-      <TestName activate="true">BMTFhwPtRange</TestName>
-      <TestName activate="true">BMTFhwPtSpectrum</TestName>
+      <TestName activate="true">BMTF_hwPtRange</TestName>
+      <TestName activate="true">BMTF_hwPtSpectrum</TestName>
   </LINK>
 
   <!-- BMTF WEDGE vs BX -->
 
-  <QTEST name="BMTFWedgeBXSpectrum">
+  <QTEST name="BMTF_WedgeBXSpectrum">
     <TYPE>Comp2Ref2DChi2</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.01</PARAM>
@@ -32,7 +32,7 @@
     <PARAM name="minEntries">60</PARAM>
   </QTEST>
 
-  <QTEST name="BMTFWedgeBXNoisyWedge">
+  <QTEST name="BMTF_WedgeBXNoisyWedge">
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">10</PARAM>
     <PARAM name="neighbours">1</PARAM>
@@ -41,8 +41,8 @@
   </QTEST>
   
   <LINK name="*/L1TStage2BMTF/bmtf_wedge_bx">
-      <TestName activate="true">BMTFWedgeBXSpectrum</TestName>
-      <TestName activate="true">BMTFWedgeBXNoisyWedge</TestName>
+      <TestName activate="true">BMTF_WedgeBXSpectrum</TestName>
+      <TestName activate="true">BMTF_WedgeBXNoisyWedge</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
@@ -1,0 +1,20 @@
+<TESTSCONFIGURATION>
+
+  <!-- EMTF Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="EMTFDEMismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2EMTF/mismatchRatio">
+      <TestName activate="true">EMTFDEMismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
@@ -4,7 +4,7 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="EMTFDEMismatchRatioMax0p05">
+  <QTEST name="EMTFDE_MismatchRatioMax0p05">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
     <PARAM name="ymax">0.05</PARAM>
@@ -14,7 +14,7 @@
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2EMTF/mismatchRatio">
-      <TestName activate="true">EMTFDEMismatchRatioMax0p05</TestName>
+      <TestName activate="true">EMTFDE_MismatchRatioMax0p05</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
@@ -1,0 +1,48 @@
+<TESTSCONFIGURATION>
+
+  <!-- EMTF Hit Occupancy -->
+
+  <QTEST name="EMTFHitOccupancyDeadChamber">
+    <TYPE>DeadChannel</TYPE>	
+    <PARAM name="threshold">0</PARAM>
+    <PARAM name="error">0.60</PARAM>
+    <PARAM name="warning">0.80</PARAM>
+  </QTEST>
+
+  <QTEST name="EMTFHitOccupancyNoisyChamber">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">20</PARAM>
+    <PARAM name="neighbours">9</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2EMTF/emtfHitOccupancy">
+      <TestName activate="true">EMTFHitOccupancyDeadChamber</TestName>
+      <TestName activate="true">EMTFHitOccupancyNoisyChamber</TestName>
+  </LINK>
+
+  <!-- EMTF Track BX -->
+
+  <QTEST name="EMTFTrackBXSpectrum">
+    <TYPE>Comp2Ref2DChi2</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+    <PARAM name="minEntries">96</PARAM>
+  </QTEST>
+
+  <QTEST name="EMTFTrackBXNoisyTrack">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">10</PARAM>
+    <PARAM name="neighbours">1</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2EMTF/emtfTrackBX">
+      <TestName activate="true">EMTFTrackBXSpectrum</TestName>
+      <TestName activate="true">EMTFTrackBXNoisyTrack</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
@@ -2,14 +2,14 @@
 
   <!-- EMTF Hit Occupancy -->
 
-  <QTEST name="EMTFHitOccupancyDeadChamber">
+  <QTEST name="EMTF_HitOccupancyDeadChamber">
     <TYPE>DeadChannel</TYPE>	
     <PARAM name="threshold">0</PARAM>
     <PARAM name="error">0.60</PARAM>
     <PARAM name="warning">0.80</PARAM>
   </QTEST>
 
-  <QTEST name="EMTFHitOccupancyNoisyChamber">
+  <QTEST name="EMTF_HitOccupancyNoisyChamber">
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">20</PARAM>
     <PARAM name="neighbours">9</PARAM>
@@ -18,13 +18,13 @@
   </QTEST>
   
   <LINK name="*/L1TStage2EMTF/emtfHitOccupancy">
-      <TestName activate="true">EMTFHitOccupancyDeadChamber</TestName>
-      <TestName activate="true">EMTFHitOccupancyNoisyChamber</TestName>
+      <TestName activate="true">EMTF_HitOccupancyDeadChamber</TestName>
+      <TestName activate="true">EMTF_HitOccupancyNoisyChamber</TestName>
   </LINK>
 
   <!-- EMTF Track BX -->
 
-  <QTEST name="EMTFTrackBXSpectrum">
+  <QTEST name="EMTF_TrackBXSpectrum">
     <TYPE>Comp2Ref2DChi2</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.01</PARAM>
@@ -32,7 +32,7 @@
     <PARAM name="minEntries">96</PARAM>
   </QTEST>
 
-  <QTEST name="EMTFTrackBXNoisyTrack">
+  <QTEST name="EMTF_TrackBXNoisyTrack">
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">10</PARAM>
     <PARAM name="neighbours">1</PARAM>
@@ -41,8 +41,8 @@
   </QTEST>
   
   <LINK name="*/L1TStage2EMTF/emtfTrackBX">
-      <TestName activate="true">EMTFTrackBXSpectrum</TestName>
-      <TestName activate="true">EMTFTrackBXNoisyTrack</TestName>
+      <TestName activate="true">EMTF_TrackBXSpectrum</TestName>
+      <TestName activate="true">EMTF_TrackBXNoisyTrack</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
@@ -1,0 +1,20 @@
+<TESTSCONFIGURATION>
+
+  <!-- OMTF Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="OMTFDEMismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2OMTF/mismatchRatio">
+      <TestName activate="true">OMTFDEMismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
@@ -4,7 +4,7 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="OMTFDEMismatchRatioMax0p05">
+  <QTEST name="OMTFDE_MismatchRatioMax0p05">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
     <PARAM name="ymax">0.05</PARAM>
@@ -14,7 +14,7 @@
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2OMTF/mismatchRatio">
-      <TestName activate="true">OMTFDEMismatchRatioMax0p05</TestName>
+      <TestName activate="true">OMTFDE_MismatchRatioMax0p05</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2OMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2OMTFQualityTests.xml
@@ -1,0 +1,6 @@
+<TESTSCONFIGURATION>
+
+  <!-- Placeholder for OMTF Quality Tests -->
+
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
@@ -1,0 +1,20 @@
+<TESTSCONFIGURATION>
+
+  <!-- uGMT Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="uGMTDEMismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio">
+      <TestName activate="true">uGMTDEMismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
@@ -4,7 +4,7 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="uGMTDEMismatchRatioMax0p05">
+  <QTEST name="uGMTDE_MismatchRatioMax0p05">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
     <PARAM name="ymax">0.05</PARAM>
@@ -14,7 +14,22 @@
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio">
-      <TestName activate="true">uGMTDEMismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTDE_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- Intermediate Muons QTest -->
+
+  <QTEST name="InterMuonsDE_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2uGMT/intermediate_muons/*/data_vs_emulator_comparison/mismatchRatio">
+      <TestName activate="true">InterMuonsDE_MismatchRatioMax0p05</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -4,7 +4,7 @@
 
   <!-- uGMT Muon BX -->
 
-  <QTEST name="uGMTMuonBXPeakAtBX0">
+  <QTEST name="uGMT_MuonBXPeakAtBX0">
     <TYPE>ContentsXRange</TYPE>	
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
@@ -12,7 +12,7 @@
     <PARAM name="warning">0.60</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTMuonBXMeanAtBX0">
+  <QTEST name="uGMT_MuonBXMeanAtBX0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -26,20 +26,20 @@
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/ugmtMuonBX">
-      <TestName activate="true">uGMTMuonBXPeakAtBX0</TestName>
-      <TestName activate="true">uGMTMuonBXMeanAtBX0</TestName>
+      <TestName activate="true">uGMT_MuonBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_MuonBXMeanAtBX0</TestName>
   </LINK>
 
   <!-- uGMT Muon Eta -->
 
-  <QTEST name="uGMTMuonEtaSpectrum">
+  <QTEST name="uGMT_MuonEtaSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.30</PARAM>
     <PARAM name="warning">0.70</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTMuonEtaMeanAt0">
+  <QTEST name="uGMT_MuonEtaMeanAt0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -53,13 +53,13 @@
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/ugmtMuonEta">
-      <TestName activate="true">uGMTMuonEtaSpectrum</TestName>
-      <TestName activate="true">uGMTMuonEtaMeanAt0</TestName>
+      <TestName activate="true">uGMT_MuonEtaSpectrum</TestName>
+      <TestName activate="true">uGMT_MuonEtaMeanAt0</TestName>
   </LINK>
 
   <!-- uGMT Muon pT -->
 
-  <QTEST name="uGMTMuonPtRange">
+  <QTEST name="uGMT_MuonPtRange">
     <TYPE>ContentsXRange</TYPE> 
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">256</PARAM>
@@ -67,7 +67,7 @@
     <PARAM name="warning">0.99</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTMuonPtSpectrum">
+  <QTEST name="uGMT_MuonPtSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.01</PARAM>
@@ -76,13 +76,13 @@
 
   
   <LINK name="*/L1TStage2uGMT/ugmtMuonPt">
-      <TestName activate="true">uGMTMuonPtRange</TestName>
-      <TestName activate="true">uGMTMuonPtSpectrum</TestName>
+      <TestName activate="true">uGMT_MuonPtRange</TestName>
+      <TestName activate="true">uGMT_MuonPtSpectrum</TestName>
   </LINK>
 
   <!-- uGMT Muon Phi-Eta -->
 
-  <QTEST name="uGMTMuonPhivsEtaSpectrum">
+  <QTEST name="uGMT_MuonPhivsEtaSpectrum">
     <TYPE>Comp2Ref2DChi2</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.01</PARAM>
@@ -91,7 +91,7 @@
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/ugmtMuonPhivsEta">
-      <TestName activate="true">uGMTMuonPhivsEtaSpectrum</TestName>
+      <TestName activate="true">uGMT_MuonPhivsEtaSpectrum</TestName>
   </LINK>
 
 
@@ -99,7 +99,7 @@
 
   <!-- uGMT BMTF BX -->
 
-  <QTEST name="uGMTBMTFBXPeakAtBX0">
+  <QTEST name="uGMT_BMTFBXPeakAtBX0">
     <TYPE>ContentsXRange</TYPE>	
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
@@ -108,7 +108,7 @@
   </QTEST>
   <TestName activate="true">uGMTBMTFBXPeakAtBX0</TestName>
 
-  <QTEST name="uGMTBMTFBXMeanAtBX0">
+  <QTEST name="uGMT_BMTFBXMeanAtBX0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -122,14 +122,14 @@
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/*/ugmtBMTFBX">
-      <TestName activate="true">uGMTBMTFBXPeakAtBX0</TestName>
-      <TestName activate="true">uGMTBMTFBXMeanAtBX0</TestName>
+      <TestName activate="true">uGMT_BMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_BMTFBXMeanAtBX0</TestName>
   </LINK>
 
 
   <!-- uGMT BMTF Global HW Phi -->
 
-  <QTEST name="uGMTBMTFhwPhiSpectrum">
+  <QTEST name="uGMT_BMTFhwPhiSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.30</PARAM>
@@ -138,19 +138,19 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtBMTFglbhwPhi">
-      <TestName activate="true">uGMTBMTFhwPhiSpectrum</TestName>
+      <TestName activate="true">uGMT_BMTFhwPhiSpectrum</TestName>
   </LINK>
 
   <!-- uGMT BMTF HW Eta -->
 
-  <QTEST name="uGMTBMTFhwEtaSpectrum">
+  <QTEST name="uGMT_BMTFhwEtaSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.30</PARAM>
     <PARAM name="warning">0.70</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTBMTFhwEtaMeanAt0">
+  <QTEST name="uGMT_BMTFhwEtaMeanAt0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -165,13 +165,13 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtBMTFhwEta">
-      <TestName activate="true">uGMTBMTFhwEtaSpectrum</TestName>
-      <TestName activate="true">uGMTBMTFhwEtaMeanAt0</TestName>
+      <TestName activate="true">uGMT_BMTFhwEtaSpectrum</TestName>
+      <TestName activate="true">uGMT_BMTFhwEtaMeanAt0</TestName>
   </LINK>
 
   <!-- uGMT BMTF HW Sign -->
 
-  <QTEST name="uGMTBMTFhwSignUniform">
+  <QTEST name="uGMT_BMTFhwSignUniform">
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">0.3</PARAM>
     <PARAM name="neighbours">2</PARAM>
@@ -181,7 +181,7 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtBMTFhwSign">
-      <TestName activate="true">uGMTBMTFhwSignUniform</TestName>
+      <TestName activate="true">uGMT_BMTFhwSignUniform</TestName>
   </LINK>
 
 
@@ -189,7 +189,7 @@
 
   <!-- uGMT OMTF BX -->
 
-  <QTEST name="uGMTOMTFBXPeakAtBX0">
+  <QTEST name="uGMT_OMTFBXPeakAtBX0">
     <TYPE>ContentsXRange</TYPE>	
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
@@ -197,7 +197,7 @@
     <PARAM name="warning">0.60</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTOMTFBXMeanAtBX0">
+  <QTEST name="uGMT_OMTFBXMeanAtBX0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -212,13 +212,13 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtOMTFBX">
-      <TestName activate="true">uGMTOMTFBXPeakAtBX0</TestName>
-      <TestName activate="true">uGMTOMTFBXMeanAtBX0</TestName>
+      <TestName activate="true">uGMT_OMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_OMTFBXMeanAtBX0</TestName>
   </LINK>
 
   <!-- uGMT OMTF Global HW Phi Negative Side -->
 
-  <QTEST name="uGMTOMTFhwPhiNegSpectrum">
+  <QTEST name="uGMT_OMTFhwPhiNegSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.30</PARAM>
@@ -227,12 +227,12 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtOMTFglbhwPhiNeg">
-      <TestName activate="true">uGMTOMTFhwPhiNegSpectrum</TestName>
+      <TestName activate="true">uGMT_OMTFhwPhiNegSpectrum</TestName>
   </LINK>
 
   <!-- uGMT OMTF Global HW Phi Positive Side -->
 
-  <QTEST name="uGMTOMTFhwPhiPosSpectrum" activate="true">
+  <QTEST name="uGMT_OMTFhwPhiPosSpectrum" activate="true">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.30</PARAM>
@@ -241,19 +241,19 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtOMTFglbhwPhiPos">
-      <TestName activate="true">uGMTOMTFhwPhiPosSpectrum</TestName>
+      <TestName activate="true">uGMT_OMTFhwPhiPosSpectrum</TestName>
   </LINK>
 
   <!-- uGMT OMTF HW Eta -->
 
-  <QTEST name="uGMTOMTFhwEtaSpectrum">
+  <QTEST name="uGMT_OMTFhwEtaSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.30</PARAM>
     <PARAM name="warning">0.70</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTOMTFhwEtaMeanAt0">
+  <QTEST name="uGMT_OMTFhwEtaMeanAt0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -268,13 +268,13 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwEta">
-      <TestName activate="true">uGMTOMTFhwEtaSpectrum</TestName>
-      <TestName activate="true">uGMTOMTFhwEtaMeanAt0</TestName>
+      <TestName activate="true">uGMT_OMTFhwEtaSpectrum</TestName>
+      <TestName activate="true">uGMT_OMTFhwEtaMeanAt0</TestName>
   </LINK>
 
   <!-- uGMT OMTF HW pT -->
 
-  <QTEST name="uGMTOMTFhwPtRange">
+  <QTEST name="uGMT_OMTFhwPtRange">
     <TYPE>ContentsXRange</TYPE>	
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">511</PARAM>
@@ -282,7 +282,7 @@
     <PARAM name="warning">0.99</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTOMTFhwPtSpectrum">
+  <QTEST name="uGMT_OMTFhwPtSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.30</PARAM>
@@ -290,13 +290,13 @@
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwPt">
-      <TestName activate="true">uGMTOMTFhwPtRange</TestName>
-      <TestName activate="true">uGMTOMTFhwPtSpectrum</TestName>
+      <TestName activate="true">uGMT_OMTFhwPtRange</TestName>
+      <TestName activate="true">uGMT_OMTFhwPtSpectrum</TestName>
   </LINK>
 
   <!-- uGMT OMTF HW Sign -->
 
-  <QTEST name="uGMTOMTFhwSignUniform">
+  <QTEST name="uGMT_OMTFhwSignUniform">
     <TYPE>NoisyChannel</TYPE>	
     <PARAM name="tolerance">0.3</PARAM>
     <PARAM name="neighbours">2</PARAM>
@@ -306,7 +306,7 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwSign">
-      <TestName activate="true">uGMTOMTFhwSignUniform</TestName>
+      <TestName activate="true">uGMT_OMTFhwSignUniform</TestName>
   </LINK>
 
 
@@ -314,7 +314,7 @@
 
   <!-- uGMT EMTF BX -->
 
-  <QTEST name="uGMTEMTFBXPeakAtBX0">
+  <QTEST name="uGMT_EMTFBXPeakAtBX0">
     <TYPE>ContentsXRange</TYPE>	
     <PARAM name="xmin">0</PARAM>
     <PARAM name="xmax">0</PARAM>
@@ -322,7 +322,7 @@
     <PARAM name="warning">0.60</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTEMTFBXMeanAtBX0">
+  <QTEST name="uGMT_EMTFBXMeanAtBX0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -337,20 +337,20 @@
 
   
   <LINK name="*/L1TStage2uGMT/*/ugmtEMTFBX">
-      <TestName activate="true">uGMTEMTFBXPeakAtBX0</TestName>
-      <TestName activate="true">uGMTEMTFBXMeanAtBX0</TestName>
+      <TestName activate="true">uGMT_EMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_EMTFBXMeanAtBX0</TestName>
   </LINK>
 
   <!-- uGMT EMTF Muon Phi -->
 
-  <QTEST name="uGMTEMTFMuonPhiSpectrum">
+  <QTEST name="uGMT_EMTFMuonPhiSpectrum">
     <TYPE>Comp2RefKolmogorov</TYPE>	
     <PARAM name="testparam">0</PARAM>
     <PARAM name="error">0.10</PARAM>
     <PARAM name="warning">0.50</PARAM>
   </QTEST>
 
-  <QTEST name="uGMTEMTFMuonPhiMeanAt0">
+  <QTEST name="uGMT_EMTFMuonPhiMeanAt0">
     <TYPE>MeanWithinExpected</TYPE>
     <PARAM name="mean">0.0</PARAM>
     <PARAM name="useRMS">0</PARAM>
@@ -365,8 +365,8 @@
 
   
   <LINK name="*/L1TStage2uGMT/ugmtMuonPhiEmtf">
-      <TestName activate="true">uGMTEMTFMuonPhiSpectrum</TestName>
-      <TestName activate="true">uGMTEMTFMuonPhiMeanAt0</TestName>
+      <TestName activate="true">uGMT_EMTFMuonPhiSpectrum</TestName>
+      <TestName activate="true">uGMT_EMTFMuonPhiMeanAt0</TestName>
   </LINK>
 
   <!-- uGMT Mismatch Summary QTest -->

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -371,7 +371,39 @@
 
   <!-- uGMT Mismatch Summary QTest -->
 
-  <QTEST name="MismatchRatioMax0p05">
+  <!-- uGMT Output vs uGT Input -->
+
+  <QTEST name="uGMTvsuGT_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio">
+      <TestName activate="true">uGMTvsuGT_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- BMTF Output vs uGMT Input -->
+
+  <QTEST name="BMTFvsuGMT_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio">
+      <TestName activate="true">BMTFvsuGMT_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- EMTF Output vs uGMT Input -->
+
+  <QTEST name="EMTFvsuGMT_MismatchRatioMax0p05">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
     <PARAM name="ymax">0.05</PARAM>
@@ -380,32 +412,38 @@
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
 
-  <!-- uGMT Output vs uGT Input -->
-  
-  <LINK name="*/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio">
-      <TestName activate="true">MismatchRatioMax0p05</TestName>
-  </LINK>
-
-  <!-- Track Finder Output vs uGMT Input -->
-  
-  <LINK name="*/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio">
-      <TestName activate="true">MismatchRatioMax0p05</TestName>
-  </LINK>
-
   <LINK name="*/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio">
-      <TestName activate="true">MismatchRatioMax0p05</TestName>
+      <TestName activate="true">EMTFvsuGMT_MismatchRatioMax0p05</TestName>
   </LINK>
 
   <!-- uGMT Muon Copy vs uGMT Muon -->
+
+  <QTEST name="uGMTCopies_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
   
   <LINK name="*/L1TStage2uGMT/uGMTMuonCopies/*/mismatchRatio">
-      <TestName activate="true">MismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTCopies_MismatchRatioMax0p05</TestName>
   </LINK>
 
   <!-- Bad Zero Suppression Rates -->
+
+  <QTEST name="zeroSupp_MismatchRatioMax0">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
   
   <LINK name="*/L1TStage2uGMT/zeroSuppression/*/mismatchRatio">
-      <TestName activate="true">MismatchRatioMax0p05</TestName>
+      <TestName activate="true">zeroSupp_MismatchRatioMax0</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -1,0 +1,411 @@
+<TESTSCONFIGURATION>
+
+  <!-- uGMT Muon Quality Tests -->
+
+  <!-- uGMT Muon BX -->
+
+  <QTEST name="uGMTMuonBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTMuonBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
+    <PARAM name="error">0.4</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="minEntries">20</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonBX">
+      <TestName activate="true">uGMTMuonBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMTMuonBXMeanAtBX0</TestName>
+  </LINK>
+
+  <!-- uGMT Muon Eta -->
+
+  <QTEST name="uGMTMuonEtaSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTMuonEtaMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">200</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonEta">
+      <TestName activate="true">uGMTMuonEtaSpectrum</TestName>
+      <TestName activate="true">uGMTMuonEtaMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT Muon pT -->
+
+  <QTEST name="uGMTMuonPtRange">
+    <TYPE>ContentsXRange</TYPE> 
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">256</PARAM>
+    <PARAM name="error">0.98</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTMuonPtSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonPt">
+      <TestName activate="true">uGMTMuonPtRange</TestName>
+      <TestName activate="true">uGMTMuonPtSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT Muon Phi-Eta -->
+
+  <QTEST name="uGMTMuonPhivsEtaSpectrum">
+    <TYPE>Comp2Ref2DChi2</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+    <PARAM name="minEntries">3100</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonPhivsEta">
+      <TestName activate="true">uGMTMuonPhivsEtaSpectrum</TestName>
+  </LINK>
+
+
+  <!-- uGMT BMTF Quality Tests -->
+
+  <!-- uGMT BMTF BX -->
+
+  <QTEST name="uGMTBMTFBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+  <TestName activate="true">uGMTBMTFBXPeakAtBX0</TestName>
+
+  <QTEST name="uGMTBMTFBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
+    <PARAM name="error">0.4</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="minEntries">10</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFBX">
+      <TestName activate="true">uGMTBMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMTBMTFBXMeanAtBX0</TestName>
+  </LINK>
+
+
+  <!-- uGMT BMTF Global HW Phi -->
+
+  <QTEST name="uGMTBMTFhwPhiSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFglbhwPhi">
+      <TestName activate="true">uGMTBMTFhwPhiSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT BMTF HW Eta -->
+
+  <QTEST name="uGMTBMTFhwEtaSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTBMTFhwEtaMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-5.0</PARAM>
+    <PARAM name="xmax">5.0</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">200</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFhwEta">
+      <TestName activate="true">uGMTBMTFhwEtaSpectrum</TestName>
+      <TestName activate="true">uGMTBMTFhwEtaMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT BMTF HW Sign -->
+
+  <QTEST name="uGMTBMTFhwSignUniform">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">0.3</PARAM>
+    <PARAM name="neighbours">2</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFhwSign">
+      <TestName activate="true">uGMTBMTFhwSignUniform</TestName>
+  </LINK>
+
+
+  <!-- uGMT OMTF Quality Tests -->
+
+  <!-- uGMT OMTF BX -->
+
+  <QTEST name="uGMTOMTFBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTOMTFBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.05</PARAM>
+    <PARAM name="xmax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">20</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFBX">
+      <TestName activate="true">uGMTOMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMTOMTFBXMeanAtBX0</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF Global HW Phi Negative Side -->
+
+  <QTEST name="uGMTOMTFhwPhiNegSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFglbhwPhiNeg">
+      <TestName activate="true">uGMTOMTFhwPhiNegSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF Global HW Phi Positive Side -->
+
+  <QTEST name="uGMTOMTFhwPhiPosSpectrum" activate="true">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFglbhwPhiPos">
+      <TestName activate="true">uGMTOMTFhwPhiPosSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF HW Eta -->
+
+  <QTEST name="uGMTOMTFhwEtaSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTOMTFhwEtaMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-5.0</PARAM>
+    <PARAM name="xmax">5.0</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">200</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwEta">
+      <TestName activate="true">uGMTOMTFhwEtaSpectrum</TestName>
+      <TestName activate="true">uGMTOMTFhwEtaMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF HW pT -->
+
+  <QTEST name="uGMTOMTFhwPtRange">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">511</PARAM>
+    <PARAM name="error">0.98</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTOMTFhwPtSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwPt">
+      <TestName activate="true">uGMTOMTFhwPtRange</TestName>
+      <TestName activate="true">uGMTOMTFhwPtSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF HW Sign -->
+
+  <QTEST name="uGMTOMTFhwSignUniform">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">0.3</PARAM>
+    <PARAM name="neighbours">2</PARAM>
+    <PARAM name="error">0.96</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwSign">
+      <TestName activate="true">uGMTOMTFhwSignUniform</TestName>
+  </LINK>
+
+
+  <!-- uGMT EMTF Quality Tests -->
+
+  <!-- uGMT EMTF BX -->
+
+  <QTEST name="uGMTEMTFBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTEMTFBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.05</PARAM>
+    <PARAM name="xmax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">20</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtEMTFBX">
+      <TestName activate="true">uGMTEMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMTEMTFBXMeanAtBX0</TestName>
+  </LINK>
+
+  <!-- uGMT EMTF Muon Phi -->
+
+  <QTEST name="uGMTEMTFMuonPhiSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.10</PARAM>
+    <PARAM name="warning">0.50</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMTEMTFMuonPhiMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.2</PARAM>
+    <PARAM name="xmax">0.2</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">128</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonPhiEmtf">
+      <TestName activate="true">uGMTEMTFMuonPhiSpectrum</TestName>
+      <TestName activate="true">uGMTEMTFMuonPhiMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT Mismatch Summary QTest -->
+
+  <QTEST name="MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+
+  <!-- uGMT Output vs uGT Input -->
+  
+  <LINK name="*/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio">
+      <TestName activate="true">MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- Track Finder Output vs uGMT Input -->
+  
+  <LINK name="*/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio">
+      <TestName activate="true">MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <LINK name="*/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio">
+      <TestName activate="true">MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- uGMT Muon Copy vs uGMT Muon -->
+  
+  <LINK name="*/L1TStage2uGMT/uGMTMuonCopies/*/mismatchRatio">
+      <TestName activate="true">MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- Bad Zero Suppression Rates -->
+  
+  <LINK name="*/L1TStage2uGMT/zeroSuppression/*/mismatchRatio">
+      <TestName activate="true">MismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 BMTF Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2BMTFDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2BMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2BMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2BMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 BMTF 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2BMTFQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 EMTF Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2EMTFDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2EMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2EMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2EMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 EMTF 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2EMTFQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
@@ -1,0 +1,350 @@
+# L1 Trigger Event Info client cfi
+#
+#   The cfi can be used, with appropriate settings, for both L1T and L1TEMU.
+#   Default version in cfi: L1T event client
+#
+#   authors previous versions - see CVS
+#
+#   V.M. Ghete 2010-10-22 revised version of L1T DQM and L1TEMU DQM
+
+
+
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
+    monitorDir = cms.untracked.string("L1TEMU"),
+
+    # decide when to run and update the results of the quality tests
+    # retrieval of quality test results must be consistent with the event / LS / Run execution
+    #
+    runInEventLoop=cms.untracked.bool(False),
+    runInEndLumi=cms.untracked.bool(True),
+    runInEndRun=cms.untracked.bool(True),
+    runInEndJob=cms.untracked.bool(False),
+
+    #
+    # for each L1 system, give:
+    #     - SystemLabel:  system label
+    #     - HwValLabel:   system label as used in hardware validation package
+    #                     (the package producing the ErrorFlag histogram)
+    #     - SystemDisable:   system disabled: if 1, all quality tests for the system
+    #                     are disabled in the summary plot
+    #     - for each quality test:
+    #         - QualityTestName: name of quality test
+    #         - QualityTestHist: histogram (full path)
+    #         - QualityTestSummaryEnabled: 0 if disabled, 1 if enabled in summary plot
+    #
+    # the position in the parameter set gives, in reverse order, the position in the reportSummaryMap
+    # in the emulator column (left column)
+    L1Systems = cms.VPSet(
+                    cms.PSet(
+                        SystemLabel = cms.string("ECAL_TPG"),
+                        HwValLabel = cms.string("ETP"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("HCAL_TPG"),
+                        HwValLabel = cms.string("HTP"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("Calo Layer1"),
+                        HwValLabel = cms.string("Stage2CaloLayer1"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("Calo Layer2"),
+                        HwValLabel = cms.string("Stage2CaloLayer2"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("BMTF"),
+                        HwValLabel = cms.string("Stage2BMTF"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTFDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2BMTF/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("OMTF"),
+                        HwValLabel = cms.string("Stage2OMTF"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("OMTFDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2OMTF/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("EMTF"),
+                        HwValLabel = cms.string("Stage2EMTF"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTFDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2EMTF/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("uGMT"),
+                        HwValLabel = cms.string("Stage2uGMT"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/BMTF/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("uGT"),
+                        HwValLabel = cms.string("Stage2uGT"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    ),
+
+    #
+    # for each L1 trigger object, give:
+    #     - ObjectLabel:  object label as used in enum L1GtObject
+    #     - ObjectDisable: emulator mask: if 1, the system is masked in the summary plot
+    #
+    # the position in the parameter set gives, in reverse order, the position in the reportSummaryMap
+    # in the trigger object column (right column)
+    L1Objects = cms.VPSet(
+                    cms.PSet(
+                        ObjectLabel = cms.string("TechTrig"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("GtExternal"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HfRingEtSums"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HfBitCounts"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HTM"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("HTT"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("ETM"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("ETT"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("Tau"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("ForJet"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("CenJet"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("IsoEG"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("NoIsoEG"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        ),
+                    cms.PSet(
+                        ObjectLabel = cms.string("Mu"),
+                        ObjectDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                )
+                            )
+                        )
+                    ),
+    #
+    # fast over-mask a system: if the name of the system is in the list, the system will be masked
+    # (the default mask value is given in L1Systems VPSet)
+    #
+    DisableL1Systems = cms.vstring(),
+    #
+    # fast over-mask an object: if the name of the object is in the list, the object will be masked
+    # (the default mask value is given in L1Objects VPSet)
+    #
+    DisableL1Objects =  cms.vstring()
+
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
@@ -1,4 +1,4 @@
-# L1 Trigger Event Info client cfi
+# L1 Emulator Trigger Event Info client cfi
 #
 #   The cfi can be used, with appropriate settings, for both L1T and L1TEMU.
 #   Default version in cfi: L1T event client
@@ -6,6 +6,7 @@
 #   authors previous versions - see CVS
 #
 #   V.M. Ghete 2010-10-22 revised version of L1T DQM and L1TEMU DQM
+#   A.G. Stahl 2017-06-02 first implementation for L1TEMU Stage2 DQM
 
 
 
@@ -180,162 +181,7 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
     #
     # the position in the parameter set gives, in reverse order, the position in the reportSummaryMap
     # in the trigger object column (right column)
-    L1Objects = cms.VPSet(
-                    cms.PSet(
-                        ObjectLabel = cms.string("TechTrig"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("GtExternal"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("HfRingEtSums"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("HfBitCounts"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("HTM"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("HTT"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("ETM"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("ETT"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("Tau"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("ForJet"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("CenJet"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("IsoEG"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("NoIsoEG"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        ),
-                    cms.PSet(
-                        ObjectLabel = cms.string("Mu"),
-                        ObjectDisable  = cms.uint32(0),
-                        QualityTests = cms.VPSet(
-                            cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
-                                )
-                            )
-                        )
-                    ),
+    L1Objects = cms.VPSet(),
     #
     # fast over-mask a system: if the name of the system is in the list, the system will be masked
     # (the default mask value is given in L1Systems VPSet)

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -14,8 +14,7 @@ import FWCore.ParameterSet.Config as cms
 #                       
 
 # DQM quality tests 
-# TODO: emulator QT
-#from DQM.L1TMonitorClient.L1TStage2EmulatorQualityTests_cff import *
+from DQM.L1TMonitorClient.L1TStage2EmulatorQualityTests_cff import *
 
 # Calo trigger layer2 client
 from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClient_cfi import *
@@ -52,7 +51,7 @@ l1TStage2EmulatorClients = cms.Sequence(
                         )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
-                        # l1TStage2EmulatorQualityTests +
+                        l1TStage2EmulatorQualityTests +
                         l1TStage2EmulatorClients
                         )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -32,8 +32,7 @@ from DQM.L1TMonitorClient.L1TStage2OMTFEmulatorClient_cff import *
 from DQM.L1TMonitorClient.L1TStage2EMTFEmulatorClient_cff import *
 
 # L1 emulator event info DQM client 
-# TODO: emulator summaryMap
-#from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
+from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
 
 
 #
@@ -47,7 +46,7 @@ l1TStage2EmulatorClients = cms.Sequence(
                       + l1tStage2BMTFEmulatorClient
                       + l1tStage2OMTFEmulatorClient
                       + l1tStage2EMTFEmulatorClient
-                        # l1tStage2EmulatorEventInfoClient 
+                      + l1tStage2EmulatorEventInfoClient 
                         )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorQualityTests_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorQualityTests_cff.py
@@ -1,0 +1,32 @@
+# Quality tests for L1 Emulator DQM (L1T)
+
+import FWCore.ParameterSet.Config as cms
+
+# L1 systems quality tests
+
+# Stage 2 L1 Emulator Quality tests
+from DQM.L1TMonitorClient.L1TStage2uGMTDEQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2BMTFDEQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2OMTFDEQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2EMTFDEQualityTests_cfi import *
+
+# L1 objects quality tests
+
+# sequence for L1 systems
+l1TEmulatorSystemQualityTests = cms.Sequence(
+                                  l1TStage2uGMTDEQualityTests +
+                                  l1TStage2BMTFDEQualityTests +
+                                  l1TStage2OMTFDEQualityTests +
+                                  l1TStage2EMTFDEQualityTests
+                                  )
+
+# sequence for L1 objects
+l1TEmulatorObjectQualityTests = cms.Sequence(
+                                  )
+
+
+# general sequence
+l1TStage2EmulatorQualityTests = cms.Sequence(
+                                              l1TEmulatorSystemQualityTests + 
+                                              l1TEmulatorObjectQualityTests
+                                              )

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -10,8 +10,9 @@
 
 
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-l1tStage2EventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
+l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
     monitorDir = cms.untracked.string("L1T"),
 
     # decide when to run and update the results of the quality tests

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -107,14 +107,24 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
+                                QualityTestName = cms.string("BMTF_hwPtRange"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_hwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("BMTF_hwPtSpectrum"),
                                 QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_hwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTF_WedgeBXNoisyWedge"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("BMTF_WedgeBXSpectrum"),
                                 QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
+                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             )
                         ),
@@ -136,14 +146,24 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
+                                QualityTestName = cms.string("EMTF_HitOccupancyDeadChambe"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfHitOccupancy"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("EMTF_HitOccupancyNoisyChamber"),
                                 QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfHitOccupancy"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("EMTF_TrackBXSpectrum"),
+                                QualityTestName = cms.string("EMTF_TrackBXNoisyTrack"),
                                 QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfTrackBX"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTF_TrackBXSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfTrackBX"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             )
                         ),
@@ -163,14 +183,19 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMT_MuonPtSpectrum"),
+                                QualityTestName = cms.string("uGMT_MuonPtRange"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
                                 QualityTestName = cms.string("uGMT_MuonPhivsEtaSpectrum"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhivsEta"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
+                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFBXMeanAtBX0"),
@@ -180,7 +205,7 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFhwPhiSpectrum"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFglbhwPhi"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
+                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_BMTFhwEtaMeanAt0"),
@@ -200,7 +225,7 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_OMTFhwPhiPosSpectrum"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiPos"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
+                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_OMTFhwEtaMeanAt0"),
@@ -208,9 +233,14 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMT_OMTFhwPtSpectrum"),
+                                QualityTestName = cms.string("uGMT_OMTFhwPtRange"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMT_OMTFhwSignUniform"),
@@ -244,27 +274,27 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy1/mismatchRatio"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/GMTMuonCopy1/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy2/mismatchRatio"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy3/mismatchRatio"),
-                                QualityTestSummaryEnabled = cms.uint32(1)
-                                ),
-                            cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_uGMTCopies_MismatchRatioMax0p05"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy4/mismatchRatio"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
                                 QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
-                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy5/mismatchRatio"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -10,9 +10,8 @@
 
 
 import FWCore.ParameterSet.Config as cms
-from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
+l1tStage2EventInfoClient = cms.EDAnalyzer("L1TEventInfoClient",
     monitorDir = cms.untracked.string("L1T"),
 
     # decide when to run and update the results of the quality tests
@@ -107,9 +106,14 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
+                                QualityTestName = cms.string("BMTF_hwPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_hwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTF_WedgeBXSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )
                         ),
@@ -131,9 +135,14 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
+                                QualityTestName = cms.string("EMTF_HitOccupancyNoisyChamber"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfHitOccupancy"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTF_TrackBXSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfTrackBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )
                         ),
@@ -143,9 +152,129 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
-                                QualityTestSummaryEnabled = cms.uint32(0)
+                                QualityTestName = cms.string("uGMT_MuonBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonEtaMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEta"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonPhivsEtaSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhivsEta"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFhwPhiSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFglbhwPhi"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFhwEtaMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFhwEta"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFhwSignUniform"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFhwSign"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwPhiPosSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiPos"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwEtaMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwEta"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwSignUniform"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwSign"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_EMTFBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_EMTFMuonPhiMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhiEmtf"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTvsuGT_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy1/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy2/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy3/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy4/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopy5/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )
                         ),

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 OMTF Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2OMTFDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2OMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2OMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 OMTF 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2OMTFQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2OMTFQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2QualityTests_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2QualityTests_cff.py
@@ -6,12 +6,18 @@ import FWCore.ParameterSet.Config as cms
 
 # Stage 2 L1 Trigger Quality tests
 from DQM.L1TMonitorClient.L1TStage2CaloLayer1QualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2uGMTQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2BMTFQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2EMTFQualityTests_cfi import *
 
 # L1 objects quality tests
 
 # sequence for L1 systems
 l1TriggerSystemQualityTests = cms.Sequence(
-                                l1TStage2CaloLayer1QualityTests
+                                l1TStage2CaloLayer1QualityTests +
+                                l1TStage2uGMTQualityTests +
+                                l1TStage2BMTFQualityTests +
+                                l1TStage2EMTFQualityTests
                                 )
 
 # sequence for L1 objects

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # directory path shortening
 ugmtDqmDir = 'L1T/L1TStage2uGMT'
@@ -9,7 +10,7 @@ errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
 
 # Muons
-l1tStage2uGMTOutVsuGTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2uGMTOutVsuGTInRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput'),
     inputNum = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistNumStr),
     inputDen = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistDenStr),

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 uGMT Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2uGMTDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # directories
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
@@ -9,7 +10,7 @@ errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
 
 # Muons
-l1tStage2uGMTEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2uGMTEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtEmuDEDqmDir),
     inputNum = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistNumStr),
     inputDen = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistDenStr),

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 uGMT 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2uGMTQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQMServices/ClientConfig/interface/QTestConfigure.h
+++ b/DQMServices/ClientConfig/interface/QTestConfigure.h
@@ -65,6 +65,10 @@ class QTestConfigure{
  void EnableComp2RefChi2Test(std::string testName, 
                      const std::map<std::string, std::string>& params,DQMStore * bei); 
 
+///Creates Comp2Ref2DChi2 test
+ void EnableComp2Ref2DChi2Test(std::string testName, 
+                     const std::map<std::string, std::string>& params,DQMStore * bei); 
+
  ///Creates EnableComp2RefKolmogorov test
  void EnableComp2RefKolmogorovTest(std::string testName, 
                      const std::map<std::string, std::string>& params,DQMStore * bei); 

--- a/DQMServices/ClientConfig/src/QTestConfigure.cc
+++ b/DQMServices/ClientConfig/src/QTestConfigure.cc
@@ -50,6 +50,8 @@ bool QTestConfigure::enableTests(
       this->EnableComp2RefEqualHTest(testName, params,bei);
     if(!std::strcmp(testType.c_str(),  Comp2RefChi2::getAlgoName().c_str()))
       this->EnableComp2RefChi2Test(testName, params,bei);
+    if(!std::strcmp(testType.c_str(),  Comp2Ref2DChi2::getAlgoName().c_str()))
+      this->EnableComp2Ref2DChi2Test(testName, params,bei);
     if(!std::strcmp(testType.c_str(),Comp2RefKolmogorov::getAlgoName().c_str()))
       this->EnableComp2RefKolmogorovTest(testName, params,bei);
     if(!std::strcmp(testType.c_str(),ContentsWithinExpected::getAlgoName().c_str()))
@@ -98,6 +100,25 @@ void QTestConfigure::EnableComp2RefChi2Test(std::string testName,
   me_qc1->setErrorProb(error);
 }
 
+void QTestConfigure::EnableComp2Ref2DChi2Test(std::string testName,
+                                              const std::map<std::string, std::string> & params,
+                                              DQMStore *bei) {
+  QCriterion * qc1;
+  if (! bei->getQCriterion(testName)) {
+    testsConfigured.push_back(testName);
+    qc1 = bei->createQTest(Comp2Ref2DChi2::getAlgoName(), testName);
+  } else {
+    qc1 = bei->getQCriterion(testName);
+  }
+  Comp2Ref2DChi2 * me_qc1 = (Comp2Ref2DChi2 *) qc1;
+  double warning = atof(findOrDefault(params, "warning", "0"));
+  double error   = atof(findOrDefault(params, "error", "0"));
+  int minEntries = atoi(findOrDefault(params, "minEntries", "0"));
+  me_qc1->setWarningProb(warning);
+  me_qc1->setErrorProb(error);
+  if ( minEntries != 0 )
+    me_qc1->setMinimumEntries(minEntries);
+}
 
 void QTestConfigure::EnableComp2RefKolmogorovTest(std::string testName,
                                                   const std::map<std::string, std::string> & params,

--- a/DQMServices/ClientConfig/src/QTestParameterNames.cc
+++ b/DQMServices/ClientConfig/src/QTestParameterNames.cc
@@ -21,6 +21,7 @@ QTestParameterNames::QTestParameterNames(){
 	//======================== new quality tests in the parser =====================//
         this->constructMap(Comp2RefEqualHROOT::getAlgoName(), "testparam");
         this->constructMap(Comp2RefChi2ROOT::getAlgoName(), "testparam");
+        this->constructMap(Comp2Ref2DChi2ROOT::getAlgoName(), "testparam");
         this->constructMap(Comp2RefKolmogorovROOT::getAlgoName(), "testparam");
 
 //        this->constructMap(MostProbableLandauROOT::getAlgoName(), "xmin", "xmax","normalization", "mostprobable", "sigma");

--- a/DQMServices/ClientConfig/test/QT_Comp2Ref2DChi2.xml
+++ b/DQMServices/ClientConfig/test/QT_Comp2Ref2DChi2.xml
@@ -1,0 +1,16 @@
+<TESTSCONFIGURATION>
+
+<QTEST name="exampleQTest">
+        <TYPE>Comp2Ref2DChi2</TYPE>	
+        <PARAM name="testparam">0</PARAM>
+        <PARAM name="minEntries">0</PARAM>
+        <PARAM name="error">0.10</PARAM>
+        <PARAM name="warning">0.40</PARAM>
+</QTEST>
+
+<!-- <LINK name="*clientHisto*"> -->
+ <LINK name="*myHisto1*">
+	<TestName activate="true">exampleQTest</TestName>
+</LINK>
+
+</TESTSCONFIGURATION>

--- a/DQMServices/Core/interface/QTest.h
+++ b/DQMServices/Core/interface/QTest.h
@@ -13,6 +13,7 @@
 //#include "DQMServices/Core/interface/DQMStore.h"
 
 class Comp2RefChi2;			typedef Comp2RefChi2 Comp2RefChi2ROOT;
+class Comp2Ref2DChi2;			typedef Comp2Ref2DChi2 Comp2Ref2DChi2ROOT;
 class Comp2RefKolmogorov;		typedef Comp2RefKolmogorov Comp2RefKolmogorovROOT;
 class Comp2RefEqualH;			typedef Comp2RefEqualH Comp2RefEqualHROOT;
 class ContentsXRange;			typedef ContentsXRange ContentsXRangeROOT;
@@ -188,6 +189,34 @@ public:
     setAlgoName(getAlgoName()); 
   }
   static std::string getAlgoName(void) { return "Comp2RefChi2"; }
+  float runTest(const MonitorElement*me);
+  
+protected:
+
+  void setMessage(void) 
+  {
+    std::ostringstream message;
+    message << "chi2/Ndof = " << chi2_ << "/" << Ndof_
+	    << ", minimum needed statistics = " << minEntries_
+	    << " warning threshold = " << this->warningProb_
+	    << " error threshold = " << this->errorProb_;
+    message_ = message.str();
+  }
+
+  // # of degrees of freedom and chi^2 for test
+  int Ndof_; double chi2_;
+};
+
+//===================== Comp2Ref2DChi2 =================//
+// comparison to reference using the 2D chi^2 algorithm
+class Comp2Ref2DChi2 : public SimpleTest
+{
+public:
+  Comp2Ref2DChi2(const std::string &name) :SimpleTest(name)
+  { 
+    setAlgoName(getAlgoName()); 
+  }
+  static std::string getAlgoName(void) { return "Comp2Ref2DChi2"; }
   float runTest(const MonitorElement*me);
   
 protected:

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -609,6 +609,7 @@ DQMStore::initializeFrom(const edm::ParameterSet& pset) {
   }
 
   initQCriterion<Comp2RefChi2>(qalgos_);
+  initQCriterion<Comp2Ref2DChi2>(qalgos_);
   initQCriterion<Comp2RefKolmogorov>(qalgos_);
   initQCriterion<ContentsXRange>(qalgos_);
   initQCriterion<ContentsYRange>(qalgos_);


### PR DESCRIPTION
Description:

This PR add to CMSSW a set of new Quality Tests applied on each L1T Muon subsystem, and it includes the following list of features:

- Add Quality Tests for each shifter plot in L1T directory related to BMTF, OMTF, EMTF and UGMT.
- Add Quality Tests for each data/emulator mismatch ratio plot in L1TEMU directory related to BMTF, OMTF, EMTF and UGMT.
- Propagate the new L1T Muon QTs to the L1T Summary Plot (EventInfoClient)
- Creates a new L1TEMU Summary Plot for L1T Emulator and propagate the L1TEMU Muon QTs to it.
- Change each L1T Muon Emulator Client from EDAnalyzer to DQMEDHarvester, in order to make them compatible with the merged PR 18751.

NOTE: Since some of the QTs make use of the 2D Chi2 Quality Test introduce in CMSSW PR 18965, this PR depends on 18965 and will require to be **tested with cmsswPR https://github.com/cms-sw/cmssw/pull/18965** , or otherwise the tests will most likely fail.

@thomreis @bortigno 