### PR TITLE
Run2-sim08 Enabling depth studies in Ecal crystal

### DIFF
--- a/SimG4CMS/Calo/interface/ECalSD.h
+++ b/SimG4CMS/Calo/interface/ECalSD.h
@@ -53,7 +53,7 @@ private:
   bool                              useWeight, storeTrack, storeRL, storeLayerTimeSim;
   bool                              useBirk, useBirkL3;
   double                            birk1, birk2, birk3, birkSlope, birkCut;
-  double                            slopeLY;
+  double                            slopeLY, scaleRL;
   std::string                       crystalMat, depth1Name, depth2Name;
   std::map<G4LogicalVolume*,double> xtalLMap;
   std::vector<G4LogicalVolume*>     useDepth1, useDepth2, noWeight;

--- a/SimG4CMS/Calo/python/CaloSimHitStudy_cfi.py
+++ b/SimG4CMS/Calo/python/CaloSimHitStudy_cfi.py
@@ -7,7 +7,8 @@ caloSimHitStudy = cms.EDAnalyzer("CaloSimHitStudy",
     EECollection = cms.untracked.string('EcalHitsEE'),
     ESCollection = cms.untracked.string('EcalHitsES'),
     HCCollection = cms.untracked.string('HcalHits'),
-    MaxEnergy = cms.untracked.double(200.0),
-    TimeCut   = cms.untracked.double(100.0),
-    MIPCut    = cms.untracked.double(0.70)
+    MaxEnergy    = cms.untracked.double(200.0),
+    TimeCut      = cms.untracked.double(100.0),
+    MIPCut       = cms.untracked.double(0.70),
+    StoreRL      = cms.untracked.bool(False)                            
 )

--- a/SimG4CMS/Calo/test/CaloSimHitStudy.cc
+++ b/SimG4CMS/Calo/test/CaloSimHitStudy.cc
@@ -17,6 +17,7 @@ CaloSimHitStudy::CaloSimHitStudy(const edm::ParameterSet& ps) {
   double maxEnergy_= ps.getUntrackedParameter<double>("MaxEnergy", 200.0);
   tmax_     = ps.getUntrackedParameter<double>("TimeCut", 100.0);
   eMIP_     = ps.getUntrackedParameter<double>("MIPCut",  0.70);
+  storeRL_  = ps.getUntrackedParameter<bool>("StoreRL", false);
 
   muonLab[0]  = "MuonRPCHits";
   muonLab[1]  = "MuonCSCHits";
@@ -267,8 +268,10 @@ void CaloSimHitStudy::analyzeHits (std::vector<PCaloHit>& hits, int indx) {
     }
     int idx = -1;
     if (indx != 3) {
-      if (indx == 0)  idx = hits[i].depth();
-      else            idx = indx+2;
+      if (indx == 0) {
+	if (storeRL_)  idx = 0;
+	else           idx = hits[i].depth();
+      } else           idx = indx+2;
       time_[idx]->Fill(time);
       edep_[idx]->Fill(edep);
       edepEM_[idx]->Fill(edepEM);

--- a/SimG4CMS/Calo/test/CaloSimHitStudy.h
+++ b/SimG4CMS/Calo/test/CaloSimHitStudy.h
@@ -58,6 +58,7 @@ private:
   edm::EDGetTokenT<edm::PSimHitContainer> toks_tkLow_[6];
   std::string    muonLab[3], tkHighLab[6], tkLowLab[6];
   double         tmax_, eMIP_;
+  bool           storeRL_;
 
   TH1F           *hit_[9],  *time_[9], *edepEM_[9], *edepHad_[9], *edep_[9];
   TH1F           *etot_[9], *etotg_[9], *timeAll_[9], *hitMu, *hitHigh;

--- a/SimG4CMS/Calo/test/python/runWithGun_cfg.py
+++ b/SimG4CMS/Calo/test/python/runWithGun_cfg.py
@@ -27,7 +27,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     cout = cms.untracked.PSet(
 #        threshold = cms.untracked.string('DEBUG'),
         INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
+            limit = cms.untracked.int32(0)
         ),
         DEBUG = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
@@ -39,7 +39,7 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(-1)
         ),
         SimTrackManager = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
+            limit = cms.untracked.int32(0)
         ),
         SimG4CoreApplication = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
@@ -63,7 +63,7 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         ),
         HcalSim = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+            limit = cms.untracked.int32(-1)
         )
     )
 )
@@ -110,10 +110,10 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
     ignoreTotal = cms.untracked.int32(1)
 )
 
-process.Tracer = cms.Service("Tracer")
+#process.Tracer = cms.Service("Tracer")
 
 process.TFileService = cms.Service("TFileService",
-    fileName = cms.string('runWithGun_QGSP_FTFP_BERT_EML.root')
+    fileName = cms.string('runWithGun_FTFP_BERT_EMM.root')
 )
 
 process.generation_step = cms.Path(process.pgen)
@@ -122,17 +122,20 @@ process.analysis_step   = cms.Path(process.caloSimHitStudy)
 process.out_step = cms.EndPath(process.output)
 
 process.caloSimHitStudy.MaxEnergy = 1000.0
-#process.g4SimHits.Physics.type = 'SimG4Core/Physics/QGSP_FTFP_BERT_EML'
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/FTFP_BERT_EMM'
 process.g4SimHits.Physics.MonopoleCharge = 1
 process.g4SimHits.Physics.Verbosity = 0
 process.g4SimHits.CaloSD.UseResponseTables = [1,1,0,1]
 process.g4SimHits.CaloSD.EminHits[0] = 0
 process.g4SimHits.ECalSD.StoreSecondary = True
+process.g4SimHits.ECalSD.StoreRadLength = True
+process.g4SimHits.ECalSD.ScaleRadLength = 100.0
 process.g4SimHits.CaloTrkProcessing.PutHistory = True
 process.g4SimHits.CaloResponse.UseResponseTable  = True
 process.g4SimHits.CaloResponse.ResponseScale = 1.0
 process.g4SimHits.CaloResponse.ResponseFile = 'SimG4CMS/Calo/data/responsTBpim50.dat'
 process.g4SimHits.G4Commands = ['/run/verbose 2']
+process.caloSimHitStudy.StoreRL = True
 process.common_maximum_timex = cms.PSet(
     MaxTrackTime  = cms.double(1000.0),
     MaxTimeNames  = cms.vstring(),
@@ -182,20 +185,20 @@ process.g4SimHits.SteppingAction = cms.PSet(
     EkinParticles           = cms.vstring(),
     Verbosity               = cms.untracked.int32(2)
 )
-process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
-    CheckForHighEtPhotons = cms.untracked.bool(False),
-    TrackMin     = cms.untracked.int32(0),
-    TrackMax     = cms.untracked.int32(0),
-    TrackStep    = cms.untracked.int32(1),
-    EventMin     = cms.untracked.int32(0),
-    EventMax     = cms.untracked.int32(0),
-    EventStep    = cms.untracked.int32(1),
-    PDGids       = cms.untracked.vint32(),
-    VerboseLevel = cms.untracked.int32(0),
-    G4Verbose    = cms.untracked.bool(True),
-    DEBUG        = cms.untracked.bool(False),
-    type      = cms.string('TrackingVerboseAction')
-))
+#process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+#    CheckForHighEtPhotons = cms.untracked.bool(False),
+#    TrackMin     = cms.untracked.int32(0),
+#    TrackMax     = cms.untracked.int32(0),
+#    TrackStep    = cms.untracked.int32(1),
+#    EventMin     = cms.untracked.int32(0),
+#    EventMax     = cms.untracked.int32(0),
+#    EventStep    = cms.untracked.int32(1),
+#    PDGids       = cms.untracked.vint32(),
+#    VerboseLevel = cms.untracked.int32(0),
+#    G4Verbose    = cms.untracked.bool(True),
+#    DEBUG        = cms.untracked.bool(False),
+#    type      = cms.string('TrackingVerboseAction')
+#))
 
 # Schedule definition
 process.schedule = cms.Schedule(process.generation_step,

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -278,6 +278,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         TestBeam        = cms.untracked.bool(False),
         NullNumbering   = cms.untracked.bool(False),
         StoreRadLength  = cms.untracked.bool(False),
+        ScaleRadLength  = cms.untracked.double(1.0),
         AgeingWithSlopeLY  = cms.untracked.bool(False)
     ),
     HCalSD = cms.PSet(


### PR DESCRIPTION
There was ambiguity of depth index in earlier version. Now if StoreRadiationLength is set true, it stores # of radiation lengths in unit of ScaleRadiationLength as depth; else if StoreLayerTimeSim is set true, it stores time in units of TimeSliceUnit; else it stores 0, 1, 2 for crystal volume, primary & secondary APD volumes