### PR TITLE
Filter invalid hcal upgrade data

### DIFF
--- a/EventFilter/HcalRawToDigi/BuildFile.xml
+++ b/EventFilter/HcalRawToDigi/BuildFile.xml
@@ -4,6 +4,8 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="CondFormats/HcalObjects"/>
 <use   name="FWCore/Utilities"/>
+<use   name="CalibFormats/HcalObjects"/>
+<use   name="CalibFormats/CaloObjects"/>
 <use   name="boost"/>
 <export>
   <lib   name="1"/>

--- a/EventFilter/HcalRawToDigi/interface/HcalDataFrameFilter.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalDataFrameFilter.h
@@ -28,6 +28,10 @@ public:
   HcalCalibDigiCollection filter(const HcalCalibDigiCollection& incol, HcalUnpackerReport& r);
   /// filter ZDC data frames
   ZDCDigiCollection filter(const ZDCDigiCollection& incol, HcalUnpackerReport& r);
+  /// filter QIE10 data frames
+  QIE10DigiCollection filter(const QIE10DigiCollection& incol, HcalUnpackerReport& r);
+  /// filter QIE11 data frames
+  QIE11DigiCollection filter(const QIE11DigiCollection& incol, HcalUnpackerReport& r);
   /// whether any filters are on
   bool active() const;
 private:

--- a/EventFilter/HcalRawToDigi/interface/HcalDataFrameFilter.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalDataFrameFilter.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/HcalDigi/interface/HcalUnpackerReport.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 
 /** \class HcalDataFrameFilter
     
@@ -34,12 +35,15 @@ public:
   QIE11DigiCollection filter(const QIE11DigiCollection& incol, HcalUnpackerReport& r);
   /// whether any filters are on
   bool active() const;
+  /// get conditions
+  void setConditions(const HcalDbService* conditions);
 private:
   bool requireCapid_;
   bool requireDVER_;
   bool energyFilter_;
   int firstSample_, lastSample_;
   double minimumAmplitude_;
+  const HcalDbService* conditions_;
 };
 
 

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -107,6 +107,7 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   edm::ESHandle<HcalElectronicsMap> item;
   es.get<HcalElectronicsMapRcd>().get(electronicsMapLabel_, item);
   const HcalElectronicsMap* readoutMap = item.product();
+  filter_.setConditions(pSetup.product());
   
   // Step B: Create empty output  : three vectors for three classes...
   std::vector<HBHEDataFrame> hbhe;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -223,10 +223,14 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
     HBHEDigiCollection filtered_hbhe=filter_.filter(*hbhe_prod,*report);
     HODigiCollection filtered_ho=filter_.filter(*ho_prod,*report);
     HFDigiCollection filtered_hf=filter_.filter(*hf_prod,*report);
+    QIE10DigiCollection filtered_qie10=filter_.filter(*qie10_prod,*report);
+    QIE11DigiCollection filtered_qie11=filter_.filter(*qie11_prod,*report);
     
     hbhe_prod->swap(filtered_hbhe);
     ho_prod->swap(filtered_ho);
     hf_prod->swap(filtered_hf);    
+    qie10_prod->swap(filtered_qie10);
+    qie11_prod->swap(filtered_qie11);
   }
 
 

--- a/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
@@ -1,4 +1,8 @@
 #include "EventFilter/HcalRawToDigi/interface/HcalDataFrameFilter.h"
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/CaloObjects/interface/CaloSamples.h"
+#include "CondFormats/HcalObjects/interface/HcalQIECoder.h"
+#include "CondFormats/HcalObjects/interface/HcalQIEShape.h"
 
 namespace HcalDataFrameFilter_impl {
 
@@ -43,46 +47,15 @@ namespace HcalDataFrameFilter_impl {
     return es;
   }
 
-  double const adc2fC_QIE11[256] = {
-    1.58, 4.73, 7.88, 11.0, 14.2, 17.3, 20.5, 23.6,
-    26.8, 29.9, 33.1, 36.2, 39.4, 42.5, 45.7, 48.8,
-    53.6, 60.1, 66.6, 73.0, 79.5, 86.0, 92.5, 98.9,
-    105, 112, 118, 125, 131, 138, 144, 151,
-    157, 164, 170, 177, 186, 199, 212, 225,
-    238, 251, 264, 277, 289, 302, 315, 328,
-    341, 354, 367, 380, 393, 406, 418, 431,
-    444, 464, 490, 516, 542, 568, 594, 620,
-    569, 594, 619, 645, 670, 695, 720, 745,
-    771, 796, 821, 846, 871, 897, 922, 947,
-    960, 1010, 1060, 1120, 1170, 1220, 1270, 1320,
-    1370, 1430, 1480, 1530, 1580, 1630, 1690, 1740,
-    1790, 1840, 1890, 1940,  2020, 2120, 2230, 2330,
-    2430, 2540, 2640, 2740, 2850, 2950, 3050, 3150,
-    3260, 3360, 3460, 3570, 3670, 3770, 3880, 3980,
-    4080, 4240, 4450, 4650, 4860, 5070, 5280, 5490,
-
-    5080, 5280, 5480, 5680, 5880, 6080, 6280, 6480,
-    6680, 6890, 7090, 7290, 7490, 7690, 7890, 8090,
-    8400, 8810, 9220, 9630, 10000, 10400, 10900, 11300,
-    11700, 12100, 12500, 12900, 13300, 13700, 14100, 14500,
-    15000, 15400, 15800, 16200, 16800, 17600, 18400, 19300,
-    20100, 20900, 21700, 22500, 23400, 24200, 25000, 25800,
-    26600, 27500, 28300, 29100, 29900, 30700, 31600, 32400,
-    33200, 34400, 36100, 37700, 39400, 41000, 42700, 44300,
-    41100, 42700, 44300, 45900, 47600, 49200, 50800, 52500,
-    54100, 55700, 57400, 59000, 60600, 62200, 63900, 65500,
-    68000, 71300, 74700, 78000, 81400, 84700, 88000, 91400,
-    94700, 98100, 101000, 105000, 108000, 111000, 115000, 118000,
-    121000, 125000, 128000, 131000, 137000, 145000, 152000, 160000,
-    168000, 176000, 183000, 191000, 199000, 206000, 214000, 222000,
-    230000, 237000, 245000, 253000, 261000, 268000, 276000, 284000,
-    291000, 302000, 316000, 329000, 343000, 356000, 370000, 384000
-  };
-
-  double energySumQIE11(const QIE11DataFrame& df, unsigned int fs, unsigned int ls) {
+  double energySumQIE11(const QIE11DataFrame& df, unsigned int fs, unsigned int ls, const HcalDbService* conditions) {
+    const HcalQIECoder* channelCoder = conditions->getHcalCoder(df.id());
+    const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
+    CaloSamples tool;
+    HcalCoderDb coder(*channelCoder, *shape);
+    coder.adc2fC(df, tool);
     double es=0;
     for (unsigned int i=fs; i<=ls && i<=df.size(); i++)
-      es+=adc2fC_QIE11[df[i].adc()];
+      es+=tool[i];
     return es;
   }
 
@@ -91,7 +64,11 @@ namespace HcalDataFrameFilter_impl {
 
 HcalDataFrameFilter::HcalDataFrameFilter(bool requireCapid, bool requireDVER, bool energyFilter, int firstSample, int lastSample, double minAmpl) :
   requireCapid_(requireCapid), requireDVER_(requireDVER), energyFilter_(energyFilter),
-  firstSample_(firstSample), lastSample_(lastSample), minimumAmplitude_(minAmpl) {
+  firstSample_(firstSample), lastSample_(lastSample), minimumAmplitude_(minAmpl), conditions_(nullptr) {
+}
+
+void HcalDataFrameFilter::setConditions(const HcalDbService* conditions) {
+  conditions_ = conditions;
 }
 
 HBHEDigiCollection HcalDataFrameFilter::filter(const HBHEDigiCollection& incol, HcalUnpackerReport& r) {
@@ -169,7 +146,7 @@ QIE11DigiCollection HcalDataFrameFilter::filter(const QIE11DigiCollection& incol
   for (QIE11DigiCollection::const_iterator i=incol.begin(); i!=incol.end(); i++) {
     if (!HcalDataFrameFilter_impl::checkQIE11(*i,requireCapid_,requireDVER_))
       r.countBadQualityDigi(i->id());
-    else if (!energyFilter_ || minimumAmplitude_<HcalDataFrameFilter_impl::energySumQIE11(*i,firstSample_,lastSample_))
+    else if (!energyFilter_ || minimumAmplitude_<HcalDataFrameFilter_impl::energySumQIE11(*i,firstSample_,lastSample_,conditions_))
       output.push_back(*i);
   }
   return output;

--- a/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
@@ -130,7 +130,7 @@ ZDCDigiCollection HcalDataFrameFilter::filter(const ZDCDigiCollection& incol, Hc
 }
 
 QIE10DigiCollection HcalDataFrameFilter::filter(const QIE10DigiCollection& incol, HcalUnpackerReport& r) {
-  QIE10DigiCollection output;
+  QIE10DigiCollection output(incol.samples());
   for (QIE10DigiCollection::const_iterator i=incol.begin(); i!=incol.end(); i++) {
     if (!HcalDataFrameFilter_impl::checkQIE10(*i,requireCapid_,requireDVER_))
       r.countBadQualityDigi(i->id());
@@ -142,7 +142,7 @@ QIE10DigiCollection HcalDataFrameFilter::filter(const QIE10DigiCollection& incol
 }
 
 QIE11DigiCollection HcalDataFrameFilter::filter(const QIE11DigiCollection& incol, HcalUnpackerReport& r) {
-  QIE11DigiCollection output;
+  QIE11DigiCollection output(incol.samples());
   for (QIE11DigiCollection::const_iterator i=incol.begin(); i!=incol.end(); i++) {
     if (!HcalDataFrameFilter_impl::checkQIE11(*i,requireCapid_,requireDVER_))
       r.countBadQualityDigi(i->id());

--- a/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
@@ -22,7 +22,8 @@ namespace HcalDataFrameFilter_impl {
     return true;
   }
 
-  bool checkQIE10(const QIE10DataFrame& df, bool capcheck, bool linkerrcheck) {
+  template<>
+  bool check<QIE10DataFrame>(const QIE10DataFrame& df, bool capcheck, bool linkerrcheck) {
     if (linkerrcheck && df.linkError()) return false;
     if (capcheck) {
       for (int i=0; i<df.samples(); i++) {
@@ -32,7 +33,8 @@ namespace HcalDataFrameFilter_impl {
     return true;
   }
 
-  bool checkQIE11(const QIE11DataFrame& df, bool capcheck, bool linkerrcheck) {
+  template<>
+  bool check<QIE11DataFrame>(const QIE11DataFrame& df, bool capcheck, bool linkerrcheck) {
     if (linkerrcheck && df.linkError()) return false;
     if (capcheck && df.capidError()) return false;
     return true;
@@ -40,21 +42,22 @@ namespace HcalDataFrameFilter_impl {
 
 
   template <class DataFrame> 
-  double energySum(const DataFrame& df, int fs, int ls) {
+  double energySum(const DataFrame& df, int fs, int ls, const HcalDbService* conditions=nullptr) {
     double es=0;
     for (int i=fs; i<=ls && i<=df.size(); i++) 
       es+=df[i].nominal_fC();
     return es;
   }
 
-  double energySumQIE11(const QIE11DataFrame& df, unsigned int fs, unsigned int ls, const HcalDbService* conditions) {
+  template <>
+  double energySum<QIE11DataFrame>(const QIE11DataFrame& df, int fs, int ls, const HcalDbService* conditions) {
     const HcalQIECoder* channelCoder = conditions->getHcalCoder(df.id());
     const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
     CaloSamples tool;
     HcalCoderDb coder(*channelCoder, *shape);
     coder.adc2fC(df, tool);
     double es=0;
-    for (unsigned int i=fs; i<=ls && i<=df.size(); i++)
+    for (int i=fs; i<=ls && i<=(int)df.samples(); i++)
       es+=tool[i];
     return es;
   }
@@ -132,11 +135,12 @@ ZDCDigiCollection HcalDataFrameFilter::filter(const ZDCDigiCollection& incol, Hc
 QIE10DigiCollection HcalDataFrameFilter::filter(const QIE10DigiCollection& incol, HcalUnpackerReport& r) {
   QIE10DigiCollection output(incol.samples());
   for (QIE10DigiCollection::const_iterator i=incol.begin(); i!=incol.end(); i++) {
-    if (!HcalDataFrameFilter_impl::checkQIE10(*i,requireCapid_,requireDVER_))
+    QIE10DataFrame df(*i);
+    if (!HcalDataFrameFilter_impl::check(df,requireCapid_,requireDVER_))
       r.countBadQualityDigi(i->id());
     // Never exclude QIE10 digis as their absence would be
     // treated as a digi with zero charged deposited in that channel
-    output.push_back(*i);
+    output.push_back(df);
   }
   return output;
 }
@@ -144,10 +148,11 @@ QIE10DigiCollection HcalDataFrameFilter::filter(const QIE10DigiCollection& incol
 QIE11DigiCollection HcalDataFrameFilter::filter(const QIE11DigiCollection& incol, HcalUnpackerReport& r) {
   QIE11DigiCollection output(incol.samples());
   for (QIE11DigiCollection::const_iterator i=incol.begin(); i!=incol.end(); i++) {
-    if (!HcalDataFrameFilter_impl::checkQIE11(*i,requireCapid_,requireDVER_))
+    QIE11DataFrame df(*i);
+    if (!HcalDataFrameFilter_impl::check(df,requireCapid_,requireDVER_))
       r.countBadQualityDigi(i->id());
-    else if (!energyFilter_ || minimumAmplitude_<HcalDataFrameFilter_impl::energySumQIE11(*i,firstSample_,lastSample_,conditions_))
-      output.push_back(*i);
+    else if (!energyFilter_ || minimumAmplitude_<HcalDataFrameFilter_impl::energySum(df,firstSample_,lastSample_,conditions_))
+      output.push_back(df);
   }
   return output;
 }

--- a/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDataFrameFilter.cc
@@ -18,11 +18,71 @@ namespace HcalDataFrameFilter_impl {
     return true;
   }
 
+  bool checkQIE10(const QIE10DataFrame& df, bool capcheck, bool linkerrcheck) {
+    if (linkerrcheck && df.linkError()) return false;
+    if (capcheck) {
+      for (int i=0; i<df.samples(); i++) {
+	if (!df[i].ok()) return false;
+      }
+    }
+    return true;
+  }
+
+  bool checkQIE11(const QIE11DataFrame& df, bool capcheck, bool linkerrcheck) {
+    if (linkerrcheck && df.linkError()) return false;
+    if (capcheck && df.capidError()) return false;
+    return true;
+  }
+
+
   template <class DataFrame> 
   double energySum(const DataFrame& df, int fs, int ls) {
     double es=0;
     for (int i=fs; i<=ls && i<=df.size(); i++) 
       es+=df[i].nominal_fC();
+    return es;
+  }
+
+  double const adc2fC_QIE11[256] = {
+    1.58, 4.73, 7.88, 11.0, 14.2, 17.3, 20.5, 23.6,
+    26.8, 29.9, 33.1, 36.2, 39.4, 42.5, 45.7, 48.8,
+    53.6, 60.1, 66.6, 73.0, 79.5, 86.0, 92.5, 98.9,
+    105, 112, 118, 125, 131, 138, 144, 151,
+    157, 164, 170, 177, 186, 199, 212, 225,
+    238, 251, 264, 277, 289, 302, 315, 328,
+    341, 354, 367, 380, 393, 406, 418, 431,
+    444, 464, 490, 516, 542, 568, 594, 620,
+    569, 594, 619, 645, 670, 695, 720, 745,
+    771, 796, 821, 846, 871, 897, 922, 947,
+    960, 1010, 1060, 1120, 1170, 1220, 1270, 1320,
+    1370, 1430, 1480, 1530, 1580, 1630, 1690, 1740,
+    1790, 1840, 1890, 1940,  2020, 2120, 2230, 2330,
+    2430, 2540, 2640, 2740, 2850, 2950, 3050, 3150,
+    3260, 3360, 3460, 3570, 3670, 3770, 3880, 3980,
+    4080, 4240, 4450, 4650, 4860, 5070, 5280, 5490,
+
+    5080, 5280, 5480, 5680, 5880, 6080, 6280, 6480,
+    6680, 6890, 7090, 7290, 7490, 7690, 7890, 8090,
+    8400, 8810, 9220, 9630, 10000, 10400, 10900, 11300,
+    11700, 12100, 12500, 12900, 13300, 13700, 14100, 14500,
+    15000, 15400, 15800, 16200, 16800, 17600, 18400, 19300,
+    20100, 20900, 21700, 22500, 23400, 24200, 25000, 25800,
+    26600, 27500, 28300, 29100, 29900, 30700, 31600, 32400,
+    33200, 34400, 36100, 37700, 39400, 41000, 42700, 44300,
+    41100, 42700, 44300, 45900, 47600, 49200, 50800, 52500,
+    54100, 55700, 57400, 59000, 60600, 62200, 63900, 65500,
+    68000, 71300, 74700, 78000, 81400, 84700, 88000, 91400,
+    94700, 98100, 101000, 105000, 108000, 111000, 115000, 118000,
+    121000, 125000, 128000, 131000, 137000, 145000, 152000, 160000,
+    168000, 176000, 183000, 191000, 199000, 206000, 214000, 222000,
+    230000, 237000, 245000, 253000, 261000, 268000, 276000, 284000,
+    291000, 302000, 316000, 329000, 343000, 356000, 370000, 384000
+  };
+
+  double energySumQIE11(const QIE11DataFrame& df, unsigned int fs, unsigned int ls) {
+    double es=0;
+    for (unsigned int i=fs; i<=ls && i<=df.size(); i++)
+      es+=adc2fC_QIE11[df[i].adc()];
     return es;
   }
 
@@ -88,6 +148,29 @@ ZDCDigiCollection HcalDataFrameFilter::filter(const ZDCDigiCollection& incol, Hc
       r.countBadQualityDigi(i->id());
     else if (!energyFilter_ || minimumAmplitude_<HcalDataFrameFilter_impl::energySum(*i,firstSample_,lastSample_))
       output.push_back(*i);    
+  }
+  return output;
+}
+
+QIE10DigiCollection HcalDataFrameFilter::filter(const QIE10DigiCollection& incol, HcalUnpackerReport& r) {
+  QIE10DigiCollection output;
+  for (QIE10DigiCollection::const_iterator i=incol.begin(); i!=incol.end(); i++) {
+    if (!HcalDataFrameFilter_impl::checkQIE10(*i,requireCapid_,requireDVER_))
+      r.countBadQualityDigi(i->id());
+    // Never exclude QIE10 digis as their absence would be
+    // treated as a digi with zero charged deposited in that channel
+    output.push_back(*i);
+  }
+  return output;
+}
+
+QIE11DigiCollection HcalDataFrameFilter::filter(const QIE11DigiCollection& incol, HcalUnpackerReport& r) {
+  QIE11DigiCollection output;
+  for (QIE11DigiCollection::const_iterator i=incol.begin(); i!=incol.end(); i++) {
+    if (!HcalDataFrameFilter_impl::checkQIE11(*i,requireCapid_,requireDVER_))
+      r.countBadQualityDigi(i->id());
+    else if (!energyFilter_ || minimumAmplitude_<HcalDataFrameFilter_impl::energySumQIE11(*i,firstSample_,lastSample_))
+      output.push_back(*i);
   }
   return output;
 }


### PR DESCRIPTION
The new HCAL digis (QIE10 and QIE11) need to be added to the `HcalUnpackerReport`, so DQM can track the presence of invalid data.

Specific points:
* QIE10 digis are never excluded from the output collections (even if invalid), because it would mess up the HF dual anode reconstruction.
* To allow for an energy threshold for QIE11 unpacking, the QIE11 calibrations are obtained from the database (a hardcoded "nominal" set of calibrations would become completely inappropriate if the shunt setting were changed).

attn: @christopheralanwest 