### PR TITLE
fix some ranges/binning of plots in Phase 1 DQM

### DIFF
--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -5,7 +5,7 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 SiPixelPhase1ClustersCharge = DefaultHistoDigiCluster.clone(
   name = "charge",
   title = "Cluster Charge",
-  range_min = 0, range_max = 200e3, range_nbins = 200,
+  range_min = 0, range_max = 300e3, range_nbins = 150,
   xlabel = "Charge (electrons)",
 
   specs = VPSet(
@@ -20,7 +20,7 @@ SiPixelPhase1ClustersCharge = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersSize = DefaultHistoDigiCluster.clone(
   name = "size",
   title = "Total Cluster Size",
-  range_min = 0, range_max = 30, range_nbins = 30,
+  range_min = 0, range_max = 50, range_nbins = 50,
   xlabel = "size[pixels]",
   specs = VPSet(
     StandardSpecification2DProfile,
@@ -34,7 +34,7 @@ SiPixelPhase1ClustersSize = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersSizeX = DefaultHistoDigiCluster.clone(
   name = "sizeX",
   title = "Cluster Size in X",
-  range_min = 0, range_max = 30, range_nbins = 30,
+  range_min = 0, range_max = 50, range_nbins = 50,
   xlabel = "size[pixels]",
   specs = VPSet(
     #StandardSpecification2DProfile,
@@ -48,7 +48,7 @@ SiPixelPhase1ClustersSizeX = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersSizeY = DefaultHistoDigiCluster.clone(
   name = "sizeY",
   title = "Cluster Size in Y",
-  range_min = 0, range_max = 30, range_nbins = 30,
+  range_min = 0, range_max = 50, range_nbins = 50,
   xlabel = "size[pixels]",
   specs = VPSet(
     #StandardSpecification2DProfile,
@@ -62,7 +62,7 @@ SiPixelPhase1ClustersSizeY = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersNClusters = DefaultHistoDigiCluster.clone(
   name = "clusters",
   title = "Clusters",
-  range_min = 0, range_max = 10, range_nbins = 10,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "clusters",
   dimensions = 0,
 
@@ -75,11 +75,11 @@ SiPixelPhase1ClustersNClusters = DefaultHistoDigiCluster.clone(
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
                              .reduce("COUNT")    
                              .groupBy("PXBarrel/PXLayer")
-                             .save(nbins=100, xmin=0, xmax=3000),
+                             .save(nbins=100, xmin=0, xmax=20000),
     Specification().groupBy("PXForward/PXDisk/Event")
                              .reduce("COUNT")    
                              .groupBy("PXForward/PXDisk/")
-                             .save(nbins=100, xmin=0, xmax=3000),
+                             .save(nbins=100, xmin=0, xmax=10000),
   )
 )
 
@@ -87,7 +87,7 @@ SiPixelPhase1ClustersNClusters = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersNClustersInclusive = DefaultHistoDigiCluster.clone(
   name = "clusters",
   title = "Clusters",
-  range_min = 0, range_max = 10000, range_nbins = 200,
+  range_min = 0, range_max = 30000, range_nbins = 150,
   xlabel = "clusters",
   dimensions = 0,
   specs = VPSet(
@@ -114,7 +114,7 @@ SiPixelPhase1ClustersEventrate = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersPositionB = DefaultHistoDigiCluster.clone(
   name = "clusterposition_zphi",
   title = "Cluster Positions",
-  range_min   =  -60, range_max   =  60, range_nbins   = 600,
+  range_min   =  -60, range_max   =  60, range_nbins   = 300,
   range_y_min = -3.2, range_y_max = 3.2, range_y_nbins = 200,
   xlabel = "Global Z", ylabel = "Global \phi",
   dimensions = 2,
@@ -194,7 +194,7 @@ SiPixelPhase1ClustersReadoutCharge = DefaultHistoReadout.clone(
 SiPixelPhase1ClustersReadoutNClusters = DefaultHistoReadout.clone(
   name = "clusters",
   title = "Clusters",
-  range_min = 0, range_max = 10, range_nbins = 10,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "clusters",
   dimensions = 0,
   specs = VPSet(

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -296,7 +296,7 @@ StandardSpecificationTrend_Num = [
                    .groupBy("PXBarrel/PXLayer","EXTEND_X")
                    .groupBy("PXBarrel", "EXTEND_Y")
                    .save(),
-    Specification().groupBy("PXBarrel/PXLayer/Event")
+    Specification().groupBy("PXBarrel/Event")
                    .reduce("COUNT")
                    .groupBy("PXBarrel/Lumisection")
                    .reduce("MEAN")
@@ -309,7 +309,7 @@ StandardSpecificationTrend_Num = [
                    .groupBy("PXForward/PXDisk","EXTEND_X")
                    .groupBy("PXForward", "EXTEND_Y")
                    .save(),
-    Specification().groupBy("PXForward/PXDisk/Event")
+    Specification().groupBy("PXForward/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward/Lumisection")
                    .reduce("MEAN")
@@ -325,6 +325,7 @@ StandardSpecificationTrend_Num = [
 
 
 StandardSpecification2DProfile_Num = [
+
     Specification(PerLayer2D)
        .groupBy("PXBarrel/PXLayer/SignedLadder/SignedModule" + "/DetId/Event")
        .reduce("COUNT")

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -8,9 +8,9 @@ SiPixelPhase1DigisADC = DefaultHistoDigiCluster.clone(
   name = "adc",
   title = "Digi ADC values",
   xlabel = "adc readout",
-  range_min = 0,
-  range_max = 300,
-  range_nbins = 300,
+  range_min = -0.5,
+  range_max = 300.5,
+  range_nbins = 301,
   specs = VPSet(
     StandardSpecificationTrend,
     StandardSpecificationTrend2D,
@@ -25,8 +25,8 @@ SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
   title = "Digis",
   xlabel = "digis",
   range_min = 0,
-  range_max = 30,
-  range_nbins = 30,
+  range_max = 100,
+  range_nbins = 100,
   dimensions = 0, # this is a count
 
   specs = VPSet(
@@ -37,11 +37,11 @@ SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
                              .reduce("COUNT")    
                              .groupBy("PXBarrel/PXLayer")
-                             .save(nbins=100, xmin=0, xmax=6000),
+                             .save(nbins=150, xmin=0, xmax=30000),
     Specification().groupBy("PXForward/PXDisk/Event")
                              .reduce("COUNT")    
                              .groupBy("PXForward/PXDisk/")
-                             .save(nbins=100, xmin=0, xmax=6000),
+                             .save(nbins=150, xmin=0, xmax=15000),
   )
 )
 
@@ -49,7 +49,7 @@ SiPixelPhase1DigisNdigis = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersNdigisInclusive = DefaultHistoDigiCluster.clone(
   name = "digis",
   title = "Digis",
-  range_min = 0, range_max = 20000, range_nbins = 100,
+  range_min = 0, range_max = 100000, range_nbins = 100,
   xlabel = "digis",
   dimensions = 0,
   specs = VPSet(
@@ -63,7 +63,7 @@ SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone( #to be removed?
   title = "Digis",   # should allow setting the range per spec, but OTOH a 
   xlabel = "digis",  # HistogramManager is almost free.
   range_min = 0,
-  range_max = 1000,
+  range_max = 2000,
   range_nbins = 200,
   dimensions = 0, 
   specs = VPSet(

--- a/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
+++ b/DQM/SiPixelPhase1RecHits/python/SiPixelPhase1RecHits_cfi.py
@@ -5,7 +5,7 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 SiPixelPhase1RecHitsNRecHits = DefaultHistoTrack.clone(
   name = "rechits",
   title = "RecHits",
-  range_min = 0, range_max = 10, range_nbins = 10,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "rechits",
   dimensions = 0,
   specs = VPSet(
@@ -20,7 +20,7 @@ SiPixelPhase1RecHitsNRecHits = DefaultHistoTrack.clone(
 SiPixelPhase1RecHitsClustX = DefaultHistoTrack.clone(
   name = "rechitsize_x",
   title = "X size of RecHit clusters",
-  range_min = 0, range_max = 10, range_nbins = 10,
+  range_min = 0, range_max = 50, range_nbins = 50,
   xlabel = "RecHit X-Size",
   dimensions = 1,
   specs = VPSet(

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -5,7 +5,7 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
   name = "charge",
   title = "Corrected Cluster Charge (OnTrack)",
-  range_min = 0, range_max = 200e3, range_nbins = 200,
+  range_min = 0, range_max = 300e3, range_nbins = 150,
   xlabel = "Charge (electrons)",
 
   specs = VPSet(
@@ -30,7 +30,7 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
 SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
   name = "size",
   title = "Total Cluster Size (OnTrack)",
-  range_min = 0, range_max = 30, range_nbins = 30,
+  range_min = 0, range_max = 50, range_nbins = 50,
   xlabel = "size[pixels]",
 
   specs = VPSet(
@@ -43,7 +43,7 @@ SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
 SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
   name = "clusters_ontrack",
   title = "Clusters_onTrack",
-  range_min = 0, range_max = 10, range_nbins = 10,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "clusters",
   dimensions = 0,
 
@@ -63,24 +63,24 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer/Event") #this will produce inclusive counts per Layer/Disk
                              .reduce("COUNT")    
                              .groupBy("PXBarrel/PXLayer")
-                             .save(nbins=100, xmin=0, xmax=3000),
+                             .save(nbins=100, xmin=0, xmax=20000),
     Specification().groupBy("PXForward/PXDisk/Event")
                              .reduce("COUNT")    
                              .groupBy("PXForward/PXDisk/")
-                             .save(nbins=100, xmin=0, xmax=3000),
+                             .save(nbins=100, xmin=0, xmax=10000),
 
     Specification().groupBy("PXBarrel/Event")
                    .reduce("COUNT")
                    .groupBy("PXBarrel")
-                   .save(nbins=200, xmin=0, xmax=10000),
+                   .save(nbins=150, xmin=0, xmax=30000),
     Specification().groupBy("PXForward/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward")
-                   .save(nbins=200, xmin=0, xmax=10000),
+                   .save(nbins=150, xmin=0, xmax=30000),
     Specification().groupBy("PXAll/Event")
                    .reduce("COUNT")
                    .groupBy("PXAll")
-                   .save(nbins=200, xmin=0, xmax=10000),
+                   .save(nbins=150, xmin=0, xmax=30000),
 
     #below is for timing client
     Specification(OverlayCurvesForTiming).groupBy("DetId/Event")
@@ -99,7 +99,7 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
 SiPixelPhase1TrackClustersOnTrackPositionB = DefaultHistoTrack.clone(
   name = "clusterposition_zphi_ontrack",
   title = "Cluster_onTrack Positions",
-  range_min   =  -60, range_max   =  60, range_nbins   = 600,
+  range_min   =  -60, range_max   =  60, range_nbins   = 300,
   range_y_min = -3.2, range_y_max = 3.2, range_y_nbins = 200,
   xlabel = "Global Z", ylabel = "Global \phi",
   dimensions = 2,

--- a/DQM/SiPixelPhase1TrackEfficiency/src/SiPixelPhase1TrackEfficiency.cc
+++ b/DQM/SiPixelPhase1TrackEfficiency/src/SiPixelPhase1TrackEfficiency.cc
@@ -95,7 +95,10 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
       const SiPixelRecHit* pixhit = dynamic_cast<const SiPixelRecHit*>(hit);
       const PixelGeomDetUnit* geomdetunit = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(id) );
       const PixelTopology& topol = geomdetunit->specificTopology();
+
+      /* this commented part is useful if one wants ROC level maps of hits, however the local position may fall out of a ROC and the ROC maps will look very strange (with no white cross)
       LocalPoint lp;
+
       if (pixhit) {
         lp = pixhit->localPosition();
       } else {
@@ -105,14 +108,15 @@ void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::
       MeasurementPoint mp = topol.measurementPosition(lp);
       int row = (int) mp.x();
       int col = (int) mp.y();
+      */
 
       if (isHitValid)   {
-        histo[VALID].fill(id, &iEvent, col, row);
-        histo[EFFICIENCY].fill(1, id, &iEvent, col, row);
+        histo[VALID].fill(id, &iEvent);
+        histo[EFFICIENCY].fill(1, id, &iEvent);
       }
       if (isHitMissing) {
-        histo[MISSING].fill(id, &iEvent, col, row);
-        histo[EFFICIENCY].fill(0, id, &iEvent, col, row);
+        histo[MISSING].fill(id, &iEvent);
+        histo[EFFICIENCY].fill(0, id, &iEvent);
       }
     }
   }

--- a/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1TrackResiduals/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -5,7 +5,7 @@ from DQM.SiPixelPhase1Common.HistogramManager_cfi import *
 SiPixelPhase1TrackResidualsResidualsX = DefaultHistoTrack.clone(
   name = "residual_x",
   title = "Track Residuals X",
-  range_min = -0.5, range_max = 0.5, range_nbins = 200,
+  range_min = -0.15, range_max = 0.15, range_nbins = 150,
   xlabel = "(x_rec - x_pred) [cm]",
   dimensions = 1,
   specs = VPSet(

--- a/DQM/SiPixelPhase1TrackResiduals/src/SiPixelPhase1TrackResiduals.cc
+++ b/DQM/SiPixelPhase1TrackResiduals/src/SiPixelPhase1TrackResiduals.cc
@@ -64,8 +64,8 @@ void SiPixelPhase1TrackResiduals::analyze(const edm::Event& iEvent, const edm::E
       int row = (int) mp.x();
       int col = (int) mp.y();
 
-      histo[RESIDUAL_X].fill(it.resXprime, id, &iEvent, col, row);
-      histo[RESIDUAL_Y].fill(it.resYprime, id, &iEvent, col, row);
+      histo[RESIDUAL_X].fill(it.resXprime, id, &iEvent);
+      histo[RESIDUAL_Y].fill(it.resYprime, id, &iEvent);
     }
   }
 


### PR DESCRIPTION
This PR adjust some ranges to match the present and future running conditions.

Also disable the computation of row and col starting by the rec-hit position, that couse some jittering effect in the bin population