### PR TITLE
Add vector include to EventVariables.h

### DIFF
--- a/Alignment/APEEstimation/interface/EventVariables.h
+++ b/Alignment/APEEstimation/interface/EventVariables.h
@@ -1,6 +1,7 @@
 #ifndef Alignment_APEEstimation_EventVariables_h
 #define Alignment_APEEstimation_EventVariables_h
 
+#include <vector>
 
 struct TrackStruct{
   


### PR DESCRIPTION
The v_sector member is using std::vector, so we need the definition of std::vector
in this header.