### PR TITLE
Add include for Trajectory.h to TrajGsfTrackAssociation.h

### DIFF
--- a/TrackingTools/GsfTracking/interface/TrajGsfTrackAssociation.h
+++ b/TrackingTools/GsfTracking/interface/TrajGsfTrackAssociation.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
 
 typedef edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>,
                                           reco::GsfTrackCollection,unsigned short> > TrajGsfTrackAssociationCollection;


### PR DESCRIPTION
We use the Trajectory class in this header, but we didn't include
the relevant header, which prevents this header from compiling.