### PR TITLE
Add missing include to ostream to Track/VertexCategories.h

### DIFF
--- a/SimTracker/TrackHistory/interface/TrackCategories.h
+++ b/SimTracker/TrackHistory/interface/TrackCategories.h
@@ -2,6 +2,7 @@
 #ifndef TrackCategories_h
 #define TrackCategories_h
 
+#include <ostream>
 #include <vector>
 
 class TrackCategories

--- a/SimTracker/TrackHistory/interface/VertexCategories.h
+++ b/SimTracker/TrackHistory/interface/VertexCategories.h
@@ -3,6 +3,7 @@
 #define VertexCategories_h
 
 #include <vector>
+#include <ostream>
 
 class VertexCategories
 {


### PR DESCRIPTION
At the end of these files we provide a printing function for std::ostream,
but we also need to include the ostream header before that.
