### PR TITLE
Add missing includes to CategoryCriteria.h

### DIFF
--- a/SimTracker/TrackHistory/interface/CategoryCriteria.h
+++ b/SimTracker/TrackHistory/interface/CategoryCriteria.h
@@ -1,6 +1,9 @@
 #ifndef CategoryCriteria_h
 #define CategoryCriteria_h
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 


### PR DESCRIPTION
We use Event, EventSetup and ParameterSet in this header, but we
didn't include the necessary headers. This patch adds the missing
includes.