### PR TITLE
Run2-hcx132 Correct the python script for HCAL pedestal to make it work for different scenario

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -69,14 +69,13 @@ horecoPedestal.firstSample = cms.int32(0)
 horecoPedestal.samplesToAdd = cms.int32(4)
 horecoPedestal.dropZSmarkedPassed = cms.bool(False)
 
-hcalLocalRecoSequencePedestal = cms.Sequence(hbherecoPedestal*hfrecoPedestal*horecoPedestal) 
+seqALCARECOHcalCalPedestal = cms.Sequence(hbherecoPedestal*hfrecoPedestal*horecoPedestal) 
 
-seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestalHLT*
-                                          hcalCalibPedestal*
-                                          hcalDigiAlCaPedestal*
-                                          qie10Digis*
-                                          gtDigisAlCaPedestal*
-                                          hcalLocalRecoSequencePedestal)
+seqALCARECOHcalCalPedestalDigi = cms.Sequence(hcalCalibPedestalHLT*
+                                              hcalCalibPedestal*
+                                              hcalDigiAlCaPedestal*
+                                              qie10Digis*
+                                              gtDigisAlCaPedestal)
 
 import RecoLocalCalo.HcalRecProducers.hfprereco_cfi
 hfprerecoPedestal = RecoLocalCalo.HcalRecProducers.hfprereco_cfi.hfprereco.clone(

--- a/Configuration/StandardSequences/python/AlCaRecoStream_Specials_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStream_Specials_cff.py
@@ -60,7 +60,7 @@ ALCARECOStreamHcalCalMinBias = cms.FilteredStream(
 # HCAL Pedestals
 from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_cff import *
 
-pathALCARECOHcalCalPedestal = cms.Path(seqALCARECOHcalCalPedestal*ALCARECOHcalCalPhisymDQM)
+pathALCARECOHcalCalPedestal = cms.Path(seqALCARECOHcalCalPedestalDigi*seqALCARECOHcalCalPedestal*ALCARECOHcalCalPhisymDQM)
 
 from Configuration.EventContent.AlCaRecoOutput_cff import *
 


### PR DESCRIPTION
The sequence is split into two and era dependent changes are made to only the reconstruction part