### PR TITLE
Propagate EDAnalyzer to EDProducer to DQMEDHarvester changes to HcalOnli…

### DIFF
--- a/DQM/HcalTasks/python/HcalOnlineHarvesting.py
+++ b/DQM/HcalTasks/python/HcalOnlineHarvesting.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-hcalOnlineHarvesting = cms.EDAnalyzer(
+hcalOnlineHarvesting = DQMEDHarvester(
 	"HcalOnlineHarvesting",
 
 	name = cms.untracked.string("HcalOnlineHarvesting"),


### PR DESCRIPTION
…neHarvesting

Following up on #18751, HcalOnlineHarvesting needs to be a DQMEDHarvester instead of an EDAnalyzer.
