### PR TITLE
Remove warnings from CalibTracker ESSource provider

### DIFF
--- a/CalibTracker/Configuration/python/Common/PoolDBESSource_cfi.py
+++ b/CalibTracker/Configuration/python/Common/PoolDBESSource_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from CondCore.DBCommon.CondDBCommon_cfi import *
+from CondCore.CondDB.CondDB_cfi import *
 poolDBESSource = cms.ESSource("PoolDBESSource",
-    CondDBCommon,
+    CondDB,
     BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     appendToDataLabel = cms.string(''),
     toGet = cms.VPSet(cms.PSet(


### PR DESCRIPTION
This instance of `PoolDBESSource` is used in an handful of configuration files in the `Alignment` and `CalibTracker` areas: see [gitHub](https://github.com/cms-sw/cmssw/search?l=Python&p=4&q=PoolDBESSource_cfi&type=&utf8=%E2%9C%93).
Modernizing the configuration to avoid the annoying disclaimer about the deprecated module. 