### PR TITLE
initialize default wrap to false in MixingModule Adjuster

### DIFF
--- a/SimGeneral/MixingModule/plugins/Adjuster.h
+++ b/SimGeneral/MixingModule/plugins/Adjuster.h
@@ -49,7 +49,7 @@ namespace edm {
 
    private:
     InputTag tag_;
-    bool WrapT_;
+    bool WrapT_ = false;
     EDGetTokenT<T> token_;
   };
 


### PR DESCRIPTION
valgrind pointed to 
```
edm::detail::doTheOffset
edm::Adjuster<std::vector<PSimHit, std::allocator<PSimHit> > >::doOffset
```

this uninitialized WrapT_  was introduced in #17898 on Mar 29, and I have a record of randomly non-reproducible 25202/50202 results in jenkins since April 5. This looks like a good enough correlation to blame lack of initialization for occasional problems.

