### PR TITLE
Add missing includes to TTHelpers.h

### DIFF
--- a/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
@@ -1,5 +1,9 @@
 #ifndef TTHelper_s
 #define TTHelper_s
+
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+
 namespace tthelpers{
 inline reco::TransientTrack buildTT(edm::Handle<reco::TrackCollection> & tracks, edm::ESHandle<TransientTrackBuilder> &trackbuilder, unsigned int k) 
 {


### PR DESCRIPTION
We use both TransientTrack and TransientTrackBuilder in this header,
so we also need to include the header for those classes. The other
definitions needed to compile this header (e.g. TrackRef) are also
provided by this header, so this should compile now.