### PR TITLE
Add missing include for BaseDeDxEstimator.h to RecoTracker/DeDx headers.

### DIFF
--- a/RecoTracker/DeDx/interface/ASmirnovDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/ASmirnovDeDxDiscriminator.h
@@ -1,6 +1,7 @@
 #ifndef RecoTrackerDeDx_ASmirnovDeDxDiscriminator_h
 #define RecoTrackerDeDx_ASmirnovDeDxDiscriminator_h
 
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 

--- a/RecoTracker/DeDx/interface/BTagLikeDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/BTagLikeDeDxDiscriminator.h
@@ -1,6 +1,7 @@
 #ifndef RecoTrackerDeDx_BTagLikeDeDxDiscriminator_h
 #define RecoTrackerDeDx_BTagLikeDeDxDiscriminator_h
 
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 

--- a/RecoTracker/DeDx/interface/GenericAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/GenericAverageDeDxEstimator.h
@@ -1,6 +1,7 @@
 #ifndef RecoTrackerDeDx_GenericAverageDeDxEstimator_h
 #define RecoTrackerDeDx_GenericAverageDeDxEstimator_h
 
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 

--- a/RecoTracker/DeDx/interface/MedianDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/MedianDeDxEstimator.h
@@ -1,6 +1,7 @@
 #ifndef RecoTrackerDeDx_MedianDeDxEstimator_h
 #define RecoTrackerDeDx_MedianDeDxEstimator_h
 
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 

--- a/RecoTracker/DeDx/interface/ProductDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/ProductDeDxDiscriminator.h
@@ -1,6 +1,7 @@
 #ifndef RecoTrackerDeDx_ProductDeDxDiscriminator_h
 #define RecoTrackerDeDx_ProductDeDxDiscriminator_h
 
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 

--- a/RecoTracker/DeDx/interface/SmirnovDeDxDiscriminator.h
+++ b/RecoTracker/DeDx/interface/SmirnovDeDxDiscriminator.h
@@ -1,6 +1,7 @@
 #ifndef RecoTrackerDeDx_SmirnovDeDxDiscriminator_h
 #define RecoTrackerDeDx_SmirnovDeDxDiscriminator_h
 
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 

--- a/RecoTracker/DeDx/interface/TruncatedAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/TruncatedAverageDeDxEstimator.h
@@ -1,6 +1,7 @@
 #ifndef RecoTrackerDeDx_TruncatedAverageDeDxEstimator_h
 #define RecoTrackerDeDx_TruncatedAverageDeDxEstimator_h
 
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
 #include <numeric>

--- a/RecoTracker/DeDx/interface/UnbinnedFitDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/UnbinnedFitDeDxEstimator.h
@@ -2,6 +2,7 @@
 #define RecoTrackerDeDx_UnbinnedFitDeDxEstimator_h
 
 #include "DataFormats/TrackReco/interface/DeDxHit.h"
+#include "RecoTracker/DeDx/interface/BaseDeDxEstimator.h"
 #include "RecoTracker/DeDx/interface/DeDxTools.h"
 #include "RecoTracker/DeDx/interface/UnbinnedLikelihoodFit.h"
 


### PR DESCRIPTION
Those headers all have classes who inherit from BaseDeDxEstimator, so
they also need to include the appropriate header.