### PR TITLE
Add include to PhysicsList to PhysicsListMakerBase.h

### DIFF
--- a/SimG4Core/Physics/interface/PhysicsListMakerBase.h
+++ b/SimG4Core/Physics/interface/PhysicsListMakerBase.h
@@ -24,6 +24,7 @@
 
 // user include files
 #include "HepPDT/ParticleDataTable.hh"
+#include "SimG4Core/Physics/interface/PhysicsList.h"
 
 // forward declarations
 class SimActivityRegistry;


### PR DESCRIPTION
The make method returns a PhysicsList, so we also need the definition
to compile this header.