### PR TITLE
Fix include in HCalTB02HistoClass.h

### DIFF
--- a/SimG4CMS/HcalTestBeam/interface/HcalTB02HistoClass.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB02HistoClass.h
@@ -1,1 +1,1 @@
-include "SimDataFormats/HcalTestBeam/interface/HcalTB02HistoClass.h"
+#include "SimDataFormats/HcalTestBeam/interface/HcalTB02HistoClass.h"

--- a/SimG4Core/Physics/interface/PhysicsListMakerBase.h
+++ b/SimG4Core/Physics/interface/PhysicsListMakerBase.h
@@ -24,6 +24,7 @@
 
 // user include files
 #include "HepPDT/ParticleDataTable.hh"
+#include "SimG4Core/Physics/interface/PhysicsList.h"
 
 // forward declarations
 class SimActivityRegistry;


### PR DESCRIPTION
There's a # missing to make this a proper preprocessor directive.
No idea how this code ever compiled, but it seems to be used by
other headers and in classes.h, so maybe let's just fix it.