### PR TITLE
Add missing forward decls to SimG4Forward.

### DIFF
--- a/SimG4CMS/Forward/interface/CastorTestAnalysis.h
+++ b/SimG4CMS/Forward/interface/CastorTestAnalysis.h
@@ -61,6 +61,7 @@ class BeginOfRun;
 class EndOfRun;
 class BeginOfEvent;
 class EndOfEvent;
+class CaloG4HitCollection;
 
 class CastorTestAnalysis : public SimWatcher,
 			public Observer<const BeginOfJob *>, 

--- a/SimG4CMS/Forward/interface/TotemSD.h
+++ b/SimG4CMS/Forward/interface/TotemSD.h
@@ -38,6 +38,7 @@
 #include <string>
 
 class TrackingSlaveSD;
+class SimTrackManager;
 
 class TotemSD : public SensitiveTkDetector,
 		public Observer<const BeginOfEvent*>,


### PR DESCRIPTION
In TotemSD.h we need a forward declaration for SimTrackManager
because a we use a ptr to this class in the constructor.

In CastorTestAnalysis.h we need to have a forward declaration to
CaloG4HitCollection because we use a ptr to this class in the
getCastorBranchData signature.