### PR TITLE
Enabling tracktrigger sequence for phase2 Tracker (T5)

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -173,7 +173,7 @@ upgradeProperties[2023] = {
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic',
         'Era' : 'Phase2C2_timing_layer',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
     },
     '2023D9' : {
         'Geom' : 'Extended2023D9',
@@ -187,28 +187,28 @@ upgradeProperties[2023] = {
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic',
         'Era' : 'Phase2C2',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullGlobal', 'HARVESTFullGlobal']
+        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal']
      },
     '2023D14' : {
         'Geom' : 'Extended2023D14',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic',
         'Era' : 'Phase2C2',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
      },
     '2023D16' : {
         'Geom' : 'Extended2023D16',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic',
         'Era' : 'Phase2C2',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
      },
     '2023D17' : {
         'Geom' : 'Extended2023D17',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic',
         'Era' : 'Phase2C2',
-        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullGlobal', 'HARVESTFullGlobal'],
+        'ScenToRun' : ['GenSimHLBeamSpotFull','DigiFullTrigger','RecoFullGlobal', 'HARVESTFullGlobal'],
      },
 }
 
@@ -218,15 +218,15 @@ upgradeProperties[2023] = {
 upgradeProperties[2023]['2023D10PU'] = deepcopy(upgradeProperties[2023]['2023D10'])
 upgradeProperties[2023]['2023D10PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 upgradeProperties[2023]['2023D18PU'] = deepcopy(upgradeProperties[2023]['2023D18'])
-upgradeProperties[2023]['2023D18PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D18PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 upgradeProperties[2023]['2023D11PU'] = deepcopy(upgradeProperties[2023]['2023D11'])
-upgradeProperties[2023]['2023D11PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D11PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 upgradeProperties[2023]['2023D14PU'] = deepcopy(upgradeProperties[2023]['2023D14'])
-upgradeProperties[2023]['2023D14PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D14PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 upgradeProperties[2023]['2023D16PU'] = deepcopy(upgradeProperties[2023]['2023D16'])
-upgradeProperties[2023]['2023D16PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D16PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 upgradeProperties[2023]['2023D17PU'] = deepcopy(upgradeProperties[2023]['2023D17'])
-upgradeProperties[2023]['2023D17PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
+upgradeProperties[2023]['2023D17PU']['ScenToRun'] = ['GenSimHLBeamSpotFull','DigiFullTriggerPU','RecoFullGlobalPU', 'HARVESTFullGlobalPU']
 
 
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -61,7 +61,6 @@ if __name__ == '__main__':
                      10042.0, #2017 ZMM
                      10024.0, #2017 ttbar
                      10824.0, #2018 ttbar
-                     20434.0, #2023D10 to exercise tracktrigger but will be removed 
                      27434.0, #2023D17 ttbar (TDR baseline Muon/Barrel)
                      23234.0, #2023D18 to exercise timing layer
                      ],

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -6,20 +6,23 @@ import FWCore.ParameterSet.Config as cms
 #
 # http://sviret.web.cern.ch/sviret/docs/CMS/SLHC/L1TT_XX1215.pdf
 #
-# Extension to the tilted geometry is discused here:
+# Extension to the tilted geometry is discussed here:
 #
 # https://indico.cern.ch/event/536881/contributions/2219856/
 #
+# This script is adapted to the very last Tilted Tracker geometry to date (tracker T5)
+#
+# 
 
 # Tab2013 hit matching algorithm
 TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",
-   zMatchingPS = cms.bool(False),
+   zMatchingPS = cms.bool(True),
    zMatching2S = cms.bool(True),
    BarrelCut = cms.vdouble( 0, 1.5, 1.5, 2.5, 4.0, 5.0, 6.5), #Use 0 as dummy to have direct access using DetId to the correct element 
-   NTiltedRings = cms.vdouble( 0., 11., 12., 13., 0., 0., 0.), #Number of tilted rings per side in barrel layers (for tilted geom only)
+   NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), #Number of tilted rings per side in barrel layers (for tilted geom only)
    TiltedBarrelCutSet = cms.VPSet(
 	cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-	cms.PSet( TiltedCut = cms.vdouble( 0, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1, 1, 1, 1, 1) ), #TBPS L1 rings
+	cms.PSet( TiltedCut = cms.vdouble( 0, 1.5,1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1, 1, 1, 1, 1) ), #TBPS L1 rings
 	cms.PSet( TiltedCut = cms.vdouble( 0, 2, 2, 2, 2, 2, 1.5, 1.5, 2, 2, 1.5, 1.5, 1.5) ), #TBPS L2 rings
 	cms.PSet( TiltedCut = cms.vdouble( 0, 2.5, 2.5, 2.5, 2.5, 2, 2, 2, 2, 2, 2, 2, 2, 1.5) ), #TBPS L3 rings
 	),
@@ -35,7 +38,7 @@ TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_of
 
 # CBC3 hit matching algorithm
 TTStubAlgorithm_cbc3_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_cbc3_Phase2TrackerDigi_",
-   zMatchingPS = cms.bool(False),
+   zMatchingPS = cms.bool(True),
    zMatching2S = cms.bool(True),
 )
 

--- a/L1Trigger/TrackTrigger/python/TkOnlyFlatGeom_cff.py
+++ b/L1Trigger/TrackTrigger/python/TkOnlyFlatGeom_cff.py
@@ -5,7 +5,7 @@
 # This script is used for processing fast stub building in the tracker only geometry
 # See the available scripts in the test directory
 # Based on the following geom script:
-# https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_X/Geometry/CMSCommonData/python/cmsExtendedGeometry2023D10XML_cfi.py
+# https://github.com/cms-sw/cmssw/blob/CMSSW_9_2_X/Geometry/CMSCommonData/python/cmsExtendedGeometry2023D10XML_cfi.py
 #
 # S.Viret (viret_at_ipnl.in2p3.fr): 04/07/16
 #
@@ -30,16 +30,16 @@ trackerGeometry.applyAlignment = cms.bool(False)
 
 XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
     geomXMLFiles = cms.vstring(
-        'Geometry/CMSCommonData/data/materials.xml',
+       'Geometry/CMSCommonData/data/materials.xml',
         'Geometry/CMSCommonData/data/rotations.xml',
         'Geometry/CMSCommonData/data/extend/cmsextent.xml',
-        'Geometry/CMSCommonData/data/PostLS2/cms.xml',             
+        'Geometry/CMSCommonData/data/cms/2019/v1/cms.xml',
         'Geometry/CMSCommonData/data/cmsMother.xml',
         'Geometry/CMSCommonData/data/cmsTracker.xml',
         'Geometry/CMSCommonData/data/eta3/etaMax.xml',   
         'Geometry/CMSCommonData/data/mgnt.xml',
-        'Geometry/CMSCommonData/data/PostLS2/beampipe.xml',
-        'Geometry/CMSCommonData/data/PostLS2/cmsBeam.xml',
+        'Geometry/CMSCommonData/data/beampipe/2023/v1/beampipe.xml',
+        'Geometry/CMSCommonData/data/cmsBeam/2023/v1/cmsBeam.xml',
         'Geometry/CMSCommonData/data/cavern.xml',
         'Geometry/TrackerCommonData/data/PhaseII/trackerParameters.xml',
         'Geometry/TrackerCommonData/data/pixfwdCommon.xml',

--- a/L1Trigger/TrackTrigger/python/TkOnlyTiltedGeom_cff.py
+++ b/L1Trigger/TrackTrigger/python/TkOnlyTiltedGeom_cff.py
@@ -6,7 +6,7 @@
 # See the available scripts in the test dir
 #
 # GEOM is based on:
-# https://github.com/cms-sw/cmssw/blob/CMSSW_9_0_X/Geometry/CMSCommonData/python/cmsExtendedGeometry2023D4XML_cfi.py
+# https://github.com/cms-sw/cmssw/blob/CMSSW_9_2_X/Geometry/CMSCommonData/python/cmsExtendedGeometry2023D11XML_cfi.py
 #
 # S.Viret (viret_at_ipnl.in2p3.fr): 04/07/16
 #
@@ -31,33 +31,33 @@ trackerGeometry.applyAlignment = cms.bool(False)
 
 XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
     geomXMLFiles = cms.vstring(
-        'Geometry/CMSCommonData/data/materials.xml',
+       'Geometry/CMSCommonData/data/materials.xml',
         'Geometry/CMSCommonData/data/rotations.xml',
         'Geometry/CMSCommonData/data/extend/cmsextent.xml',
-        'Geometry/CMSCommonData/data/PostLS2/cms.xml',             
+        'Geometry/CMSCommonData/data/cms/2019/v1/cms.xml',
         'Geometry/CMSCommonData/data/cmsMother.xml',
         'Geometry/CMSCommonData/data/cmsTracker.xml',
         'Geometry/CMSCommonData/data/eta3/etaMax.xml',   
         'Geometry/CMSCommonData/data/mgnt.xml',
-        'Geometry/CMSCommonData/data/PostLS2/beampipe.xml',
-        'Geometry/CMSCommonData/data/PostLS2/cmsBeam.xml',
+        'Geometry/CMSCommonData/data/beampipe/2023/v1/beampipe.xml',
+        'Geometry/CMSCommonData/data/cmsBeam/2023/v1/cmsBeam.xml',
         'Geometry/CMSCommonData/data/cavern.xml',
         'Geometry/TrackerCommonData/data/PhaseII/trackerParameters.xml',
         'Geometry/TrackerCommonData/data/pixfwdCommon.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/pixfwd.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/pixbar.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/pixfwd.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/pixbar.xml',
         'Geometry/TrackerCommonData/data/trackermaterial.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/tracker.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/pixel.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/trackerbar.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/trackerfwd.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/trackerStructureTopology.xml',
-        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4026/pixelStructureTopology.xml',
-        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4026/trackersens.xml',
-        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4026/pixelsens.xml',
-        'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker4026/trackerRecoMaterial.xml',
-        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4026/trackerProdCuts.xml',
-        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4026/pixelProdCuts.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/tracker.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/pixel.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/trackerbar.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/trackerfwd.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/trackerStructureTopology.xml',
+        'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/pixelStructureTopology.xml',
+        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4025/trackersens.xml',
+        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4025/pixelsens.xml',
+        'Geometry/TrackerRecoData/data/PhaseII/TiltedTracker4025/trackerRecoMaterial.xml',
+        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4025/trackerProdCuts.xml',
+        'Geometry/TrackerSimData/data/PhaseII/TiltedTracker4025/pixelProdCuts.xml',
         'Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml',
         'Geometry/CMSCommonData/data/FieldParameters.xml'
         ),


### PR DESCRIPTION
Greetings 
This PR aims to reintroduce the track trigger sequence for the tracker T5 in the WFs taking into account the new rings belonging to this tracker T5.
At the same time , the local python files used for tracker studies (tracker only configs)  have been updated with all the latest ingredients of the geometries .
Thanks to @sviret for having done all the work 