### PR TITLE
Pixel Cluster Counting ALCARECO: separate content for random and zerobias

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandomFromRECO_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandomFromRECO_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCRandomFromRECO_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCRandomFromRECO')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducerRandom_*_*') 
+        'keep *_*alcaPCCProducerRandom_*_*')
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandomFromRECO_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandomFromRECO_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCRandomFromRECO_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCRandomFromRECO')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducer*_*_*') 
+        'keep *_*alcaPCCProducerRandom_*_*') 
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCRandom_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCRandom')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducerRandom*_*_*') 
+        'keep *_*alcaPCCProducerRandom*_*_*')
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCRandom_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCRandom')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducer*_*_*') 
+        'keep *_*alcaPCCProducerRandom*_*_*') 
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBiasFromRECO_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBiasFromRECO_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCZeroBiasFromRECO_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCZeroBiasFromRECO')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducerZeroBias*_*_*') 
+        'keep *_*alcaPCCProducerZeroBias*_*_*')
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBiasFromRECO_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBiasFromRECO_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCZeroBiasFromRECO_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCZeroBiasFromRECO')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducer*_*_*') 
+        'keep *_*alcaPCCProducerZeroBias*_*_*') 
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCZeroBias_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCZeroBias')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducerZeroBias_*_*') 
+        'keep *_*alcaPCCProducerZeroBias_*_*')
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_Output_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_Output_cff.py
@@ -6,7 +6,7 @@ OutALCARECOAlCaPCCZeroBias_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOAlCaPCCZeroBias')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_*alcaPCCProducer*_*_*') 
+        'keep *_*alcaPCCProducerZeroBias_*_*') 
 )
 
 


### PR DESCRIPTION
There are two trigger flavor of Pixel Cluster Counting ALCARECO:
+ on ZeroBias events
+ on Random events
Each ALCARECO flavor ought to store pixel counts only from the event type it cares about.
This PR specializes the output module of the PCC alcareco to do that
(to this point, the output configuration was inclusive and kept both ZB and Ran cunts for both ALCARECO)

original finding by @capalmer85 using replay data https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1626/1/1/1/1/1/1/1.html
 
Local test carried out using the relval:
`runTheMatrix.py -l 1020 --command='-n 100000'`
with outcome (-Base stants for vanilla 9_2_1 ):
<img width="820" alt="screen shot 2017-06-08 at 00 23 16" src="https://user-images.githubusercontent.com/4729828/26904492-6e6be538-4be2-11e7-83ac-cd5779e50dfe.png">
