### PR TITLE
update Z because of cogging adjustment by LHC

### DIFF
--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -553,7 +553,7 @@ Realistic25ns13TeV2016CollisionVtxSmearingParameters = cms.PSet(
 # BS parameters extracted from run 295463 (from offline DQM, i.e. PCL):
 # X0         =  0.08497  [cm]
 # Y0         = -0.03976  [cm]
-# Z0         =  1.6      [cm]
+# Z0         =  1.6      [cm] ==> 0.5 adjusted after cogging tuning by LHC, see  https://hypernews.cern.ch/HyperNews/CMS/get/beamspot/159/1.html
 # sigmaZ0    =  3.5      [cm]
 #
 # From LHC calculator, emittance is 3.319e-8 cm 
@@ -572,7 +572,7 @@ Reaslistic25ns13TeVEarly2017CollisionVtxSmearingParameters = cms.PSet(
     TimeOffset = cms.double(0.0),
     X0 = cms.double(-0.024755),
     Y0 = cms.double(0.069233 ),
-    Z0 = cms.double(1.92054  )
+    Z0 = cms.double(0.82054  )
 )
 
 # Test HF offset


### PR DESCRIPTION
follow up to this comment https://github.com/cms-sw/cmssw/pull/19077#issuecomment-306884384

@arunhep @franzoni 

For clarity, even though the nominal adjustment is -1.2 cm, we do measure Z = 0.5 cm, which is -1.1 cm away from the previous value. It's intended.  