### PR TITLE
Fix theMaxElement in PixelTriplet{HLT,LargeTip}Generator

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -312,6 +312,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, Ordered
 	
 	if (theMaxElement!=0 && result.size() >= theMaxElement){
 	  result.clear();
+	  if(tripletLastLayerIndex) tripletLastLayerIndex->clear();
 	  edm::LogError("TooManyTriplets")<<" number of triples exceeds maximum. no triplets produced.";
 	  return;
 	}

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -411,6 +411,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region, Or
 
 	if (theMaxElement!=0 && result.size() >= theMaxElement) {
 	  result.clear();
+	  if(tripletLastLayerIndex) tripletLastLayerIndex->clear();
 	  edm::LogError("TooManyTriplets")<<" number of triples exceed maximum. no triplets produced.";
 	  return;
 	}


### PR DESCRIPTION
The `tripletLastLayerIndex` was not cleared in case `theMaxElement` limit was reached leading a consistency check to fail. This PR adds the `clear()` call fixing the problem reported in
https://hypernews.cern.ch/HyperNews/CMS/get/recoData/122.html

Tested in 9_2_1, no other changes expected.

@rovere @VinInn 