### PR TITLE
Deprecating T(IB|OB|ID|EC)DetId types in RecoMuon/TrackerSeedGenerator

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -163,8 +163,8 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 }
 
 void TSGForOI::findSeedsOnLayer(
-                const edm::ESHandle<TrackerTopology> tTopo,
-                const GeometricSearchDet &layer,
+				const edm::ESHandle<TrackerTopology> tTopo,
+				const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				const Propagator& propagatorAlong,
 				const Propagator& propagatorOpposite,
@@ -243,8 +243,8 @@ double TSGForOI::calculateSFFromL2(const reco::TrackRef track){
 
 
 int TSGForOI::makeSeedsFromHits(
-                const edm::ESHandle<TrackerTopology> tTopo,
-                const GeometricSearchDet &layer,
+				const edm::ESHandle<TrackerTopology> tTopo,
+				const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				std::vector<TrajectorySeed> &out,
 				const Propagator& propagatorAlong,
@@ -288,7 +288,7 @@ int TSGForOI::makeSeedsFromHits(
     if (useStereoLayersInTEC_) { 
       DetId detid = ((*it).recHit()->hit())->geographicalId();
       if (detid.subdetId() == StripSubdetector::TEC) {
-    if (!tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
+		if (!tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
       }
     }
     

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -5,7 +5,7 @@
  */
 
 #include "RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include <memory>
 
@@ -68,6 +68,8 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<BarrelDetLayer const*> const& tob = measurementTracker_->geometricSearchTracker()->tobLayers();
   std::vector<ForwardDetLayer const*> const& tecPositive = measurementTracker_->geometricSearchTracker()->posTecLayers();
   std::vector<ForwardDetLayer const*> const& tecNegative = measurementTracker_->geometricSearchTracker()->negTecLayers();
+  edm::ESHandle<TrackerTopology> tTopo;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo);
 
   //	Get the suitable propagators:
   std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlong_,alongMomentum);
@@ -124,7 +126,7 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       layerCount_ = 0;
       for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	//This goes from outermost to innermost layer
 	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TOB layer " << layerCount_ << endl; 
-	findSeedsOnLayer(**it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
       }
     }
     
@@ -138,7 +140,7 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       layerCount_ = 0;
       for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
 	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC+ layer " << layerCount_ << endl; 
-	findSeedsOnLayer(**it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
       }
     }
 
@@ -147,7 +149,7 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       layerCount_ = 0;
       for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
 	LogTrace("TSGForOI") << "TSGForOI::produce: looping in TEC- layer " << layerCount_ << endl; 
-	findSeedsOnLayer(**it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+	findSeedsOnLayer(tTopo, **it, tsosAtIP,  *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
       }
     }
 
@@ -160,7 +162,9 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.put(std::move(result));
 }
 
-void TSGForOI::findSeedsOnLayer(const GeometricSearchDet &layer,
+void TSGForOI::findSeedsOnLayer(
+                const edm::ESHandle<TrackerTopology> tTopo,
+                const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				const Propagator& propagatorAlong,
 				const Propagator& propagatorOpposite,
@@ -209,7 +213,7 @@ void TSGForOI::findSeedsOnLayer(const GeometricSearchDet &layer,
   // Hits:
   if (layerCount_>numOfLayersToTry_) return;
   LogTrace("TSGForOI") << "TSGForOI::findSeedsOnLayer: Start Hits" <<endl;  
-  if (makeSeedsFromHits(layer, tsosAtIP, *out, propagatorAlong, *measurementTracker_, errorSFHits_))  ++layerCount_; 
+  if (makeSeedsFromHits(tTopo, layer, tsosAtIP, *out, propagatorAlong, *measurementTracker_, errorSFHits_))  ++layerCount_; 
   numSeedsMade_=out->size();
 }
 
@@ -238,7 +242,9 @@ double TSGForOI::calculateSFFromL2(const reco::TrackRef track){
 }
 
 
-int TSGForOI::makeSeedsFromHits(const GeometricSearchDet &layer,
+int TSGForOI::makeSeedsFromHits(
+                const edm::ESHandle<TrackerTopology> tTopo,
+                const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				std::vector<TrajectorySeed> &out,
 				const Propagator& propagatorAlong,
@@ -282,8 +288,7 @@ int TSGForOI::makeSeedsFromHits(const GeometricSearchDet &layer,
     if (useStereoLayersInTEC_) { 
       DetId detid = ((*it).recHit()->hit())->geographicalId();
       if (detid.subdetId() == StripSubdetector::TEC) {
-	TECDetId myDet(detid.rawId());
-	if (!myDet.isStereo()) break;  //try another Layer 
+    if (!tTopo->tecIsStereo(detid.rawId())) break;  // try another layer
       }
     }
     

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -68,8 +68,9 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<BarrelDetLayer const*> const& tob = measurementTracker_->geometricSearchTracker()->tobLayers();
   std::vector<ForwardDetLayer const*> const& tecPositive = measurementTracker_->geometricSearchTracker()->posTecLayers();
   std::vector<ForwardDetLayer const*> const& tecNegative = measurementTracker_->geometricSearchTracker()->negTecLayers();
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo_handle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
+  const TrackerTopology* tTopo = tTopo_handle.product();
 
   //	Get the suitable propagators:
   std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlong_,alongMomentum);
@@ -163,7 +164,7 @@ void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 }
 
 void TSGForOI::findSeedsOnLayer(
-				const edm::ESHandle<TrackerTopology> tTopo,
+				const TrackerTopology* tTopo,
 				const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				const Propagator& propagatorAlong,
@@ -243,7 +244,7 @@ double TSGForOI::calculateSFFromL2(const reco::TrackRef track){
 
 
 int TSGForOI::makeSeedsFromHits(
-				const edm::ESHandle<TrackerTopology> tTopo,
+				const TrackerTopology* tTopo,
 				const GeometricSearchDet &layer,
 				const TrajectoryStateOnSurface &tsosAtIP,
 				std::vector<TrajectorySeed> &out,

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -105,8 +105,8 @@ private:
 
 	/// Function to find seeds on a given layer
 	void findSeedsOnLayer(
-                  const edm::ESHandle<TrackerTopology> tTopo,
-                  const GeometricSearchDet &layer,
+			      const edm::ESHandle<TrackerTopology> tTopo,
+			      const GeometricSearchDet &layer,
 			      const TrajectoryStateOnSurface &tsosAtIP,
 			      const Propagator& propagatorAlong,
 			      const Propagator& propagatorOpposite,
@@ -118,8 +118,8 @@ private:
 
 	/// Function to find hits on layers and create seeds from updated TSOS
 	int makeSeedsFromHits(
-            const edm::ESHandle<TrackerTopology> tTopo,
-            const GeometricSearchDet &layer,
+			const edm::ESHandle<TrackerTopology> tTopo,
+			const GeometricSearchDet &layer,
 			const TrajectoryStateOnSurface &state,
 			std::vector<TrajectorySeed> &out,
 			const Propagator& propagatorAlong,

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -104,7 +104,9 @@ private:
 	edm::ESHandle<Chi2MeasurementEstimatorBase>   estimator_;
 
 	/// Function to find seeds on a given layer
-	void findSeedsOnLayer(const GeometricSearchDet &layer,
+	void findSeedsOnLayer(
+                  const edm::ESHandle<TrackerTopology> tTopo,
+                  const GeometricSearchDet &layer,
 			      const TrajectoryStateOnSurface &tsosAtIP,
 			      const Propagator& propagatorAlong,
 			      const Propagator& propagatorOpposite,
@@ -115,7 +117,9 @@ private:
 	double calculateSFFromL2(const reco::TrackRef track);
 
 	/// Function to find hits on layers and create seeds from updated TSOS
-	int makeSeedsFromHits(const GeometricSearchDet &layer,
+	int makeSeedsFromHits(
+            const edm::ESHandle<TrackerTopology> tTopo,
+            const GeometricSearchDet &layer,
 			const TrajectoryStateOnSurface &state,
 			std::vector<TrajectorySeed> &out,
 			const Propagator& propagatorAlong,

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -105,7 +105,7 @@ private:
 
 	/// Function to find seeds on a given layer
 	void findSeedsOnLayer(
-			      const edm::ESHandle<TrackerTopology> tTopo,
+			      const TrackerTopology* tTopo,
 			      const GeometricSearchDet &layer,
 			      const TrajectoryStateOnSurface &tsosAtIP,
 			      const Propagator& propagatorAlong,
@@ -118,7 +118,7 @@ private:
 
 	/// Function to find hits on layers and create seeds from updated TSOS
 	int makeSeedsFromHits(
-			const edm::ESHandle<TrackerTopology> tTopo,
+			const TrackerTopology* tTopo,
 			const GeometricSearchDet &layer,
 			const TrajectoryStateOnSurface &state,
 			std::vector<TrajectorySeed> &out,


### PR DESCRIPTION
cc @alesaggio @vidalm @pieterdavid 

Removing the deprecated
`DataFormats/SiStripDetId/interface/T(IB|OB|ID|EC)DetId.h`

and replacing it with 
`DataFormats/TrackerCommon/interface/TrackerTopology.h`