### PR TITLE
HGCal clustering: label border hits with rho = rho_b as Halo instead of core

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
@@ -103,7 +103,7 @@ std::vector<reco::HGCalMultiCluster> HGCal3DClustering::makeClusters(const reco:
       }
       if( temp.size() > minClusters ) {
 	math::XYZPoint position = clusterTools->getMultiClusterPosition(temp);
-	if (abs(position.z()) <= 0.) continue;
+	if (std::abs(position.z()) <= 0.) continue;
 	// only store multiclusters that pass the energy threshold in getMultiClusterPosition
 	// giving them a position inside the HGCal
 	thePreClusters.push_back(temp);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
@@ -102,9 +102,13 @@ std::vector<reco::HGCalMultiCluster> HGCal3DClustering::makeClusters(const reco:
 
       }
       if( temp.size() > minClusters ) {
+	math::XYZPoint position = clusterTools->getMultiClusterPosition(temp);
+	if (abs(position.z()) < 100) continue;
+	// only store multiclusters that pass the energy threshold in getMultiClusterPosition
+	// giving them a position inside the HGCal
 	thePreClusters.push_back(temp);
 	auto& back = thePreClusters.back();
-	back.setPosition(clusterTools->getMultiClusterPosition(back));
+	back.setPosition(position);
 	back.setEnergy(clusterTools->getMultiClusterEnergy(back));
       }
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
@@ -103,7 +103,7 @@ std::vector<reco::HGCalMultiCluster> HGCal3DClustering::makeClusters(const reco:
       }
       if( temp.size() > minClusters ) {
 	math::XYZPoint position = clusterTools->getMultiClusterPosition(temp);
-	if (abs(position.z()) < 100) continue;
+	if (abs(position.z()) <= 0.) continue;
 	// only store multiclusters that pass the energy threshold in getMultiClusterPosition
 	// giving them a position inside the HGCal
 	thePreClusters.push_back(temp);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -197,7 +197,7 @@ math::XYZPoint HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v){
 			 z/total_weight );
     }
   }
-  else {
+  else if (v_size > 0) {
     // return position of hit with maximum energy
     return math::XYZPoint(v[maxEnergyIndex].data.x, v[maxEnergyIndex].data.y, v[maxEnergyIndex].data.z);
   }

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -366,7 +366,7 @@ int HGCalImagingAlgo::findAndAssignClusters(std::vector<KDNode> &nd,KDTree &lp, 
   //flag points in cluster with density < rho_b as halo points, then fill the cluster vector
   for(unsigned int i = 0; i < nd_size; ++i){
     int ci = nd[i].data.clusterIndex;
-    if(ci!=-1 && nd[i].data.rho < rho_b[ci])
+    if(ci!=-1 && nd[i].data.rho <= rho_b[ci])
       nd[i].data.isHalo = true;
     if(nd[i].data.clusterIndex!=-1){
       current_v[ci+cluster_offset].push_back(nd[i]);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -385,9 +385,8 @@ int HGCalImagingAlgo::findAndAssignClusters(std::vector<KDNode> &nd,KDTree &lp, 
   //flag points in cluster with density < rho_b as halo points, then fill the cluster vector
   for(unsigned int i = 0; i < nd_size; ++i){
     int ci = nd[i].data.clusterIndex;
-    if(ci!=-1 && nd[i].data.rho <= rho_b[ci])
-      nd[i].data.isHalo = true;
-    if(nd[i].data.clusterIndex!=-1){
+    if(ci!=-1) {
+      if (nd[i].data.rho <= rho_b[ci]) nd[i].data.isHalo = true;
       current_v[ci+cluster_offset].push_back(nd[i]);
       if (verbosity < pINFO)
 	  {

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -167,20 +167,36 @@ math::XYZPoint HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v){
   float y = 0.;
   float z = 0.;
   unsigned int v_size = v.size();
+  bool haloOnlyCluster = true;
 
+  // check if haloOnlyCluster
   for (unsigned int i = 0; i < v_size; i++){
     if(!v[i].data.isHalo){
-      total_weight += v[i].data.weight;
-      x += v[i].data.x*v[i].data.weight;
-      y += v[i].data.y*v[i].data.weight;
-      z += v[i].data.z*v[i].data.weight;
+      haloOnlyCluster = false;
     }
   }
 
-  if (total_weight != 0) {
-  return math::XYZPoint( x/total_weight,
+  if (!haloOnlyCluster) {
+    for (unsigned int i = 0; i < v_size; i++){
+      if(!v[i].data.isHalo){
+        total_weight += v[i].data.weight;
+        x += v[i].data.x*v[i].data.weight;
+        y += v[i].data.y*v[i].data.weight;
+        z += v[i].data.z*v[i].data.weight;
+      }
+    }
+
+    if (total_weight != 0) {
+      return math::XYZPoint( x/total_weight,
 			 y/total_weight,
 			 z/total_weight );
+     }
+  } // end !haloOnlyCluster
+  else {
+    // return position of hit with maximum energy
+    auto it = std::max_element(v.begin(), v.end(),
+    [](const KDNode& x, const KDNode& y) {  return x.data.weight < y.data.weight; });
+    return math::XYZPoint(it->data.x, it->data.y, it->data.z);
   }
   return math::XYZPoint(0, 0, 0);
 }


### PR DESCRIPTION
There was a typo in one of the if statements, which had been there a long time. After fixing the overall clustering in the previous pull request #18236, this is just a minor correction. The effect is documented in 2-5 in
https://indico.cern.ch/event/644587/contributions/2619127/attachments/1471418/2276984/hgc_cluster_issues_v2.pdf

