### PR TITLE
Added missing includes to PFRecoTauClusterVariables.h

### DIFF
--- a/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauClusterVariables.h
@@ -8,6 +8,11 @@
  *                                                                                                                                                                                   
  */
 
+
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+
 class TauIdMVAAuxiliaries {
   public:
     /// default constructor


### PR DESCRIPTION
We use PFTau, Tau and PFCandidatePtr in this header, so we also
need to include the relevant headers to make it compile.