### PR TITLE
Add missing includes to PFEcalEndcapRecHitCreator.h

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -9,7 +9,7 @@
 
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
-
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -21,6 +21,7 @@
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 #include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
+#include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
 #include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"


### PR DESCRIPTION
We use the EESrFlagCollection in this header, so we also need to
include EcalDigiCollections.h which defines this.

The eTTmap_ member is also of the type EcalTrigTowerConstituentsMap,
so we need to include EcalTrigTowerConstituentsMap.h.