### PR TITLE
Fix includes in RecoLocalMuon/RPCRecHit.

### DIFF
--- a/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 
 #include <memory>
 

--- a/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 


### PR DESCRIPTION
We use DTRecSegment4DCollection and CSCSegmentCollection in the
constructors of these classes, so we also need to include the
relevant headers to make this file compile.