### PR TITLE
Fix includes in RecoLocalCalo/HGCalRecAlgos.

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitSimpleAlgo.h
@@ -8,6 +8,7 @@
   *  \author Valeri Andreev
   */
 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/HGCalRecHitAbsAlgo.h"
 #include "DataFormats/HGCDigi/interface/HGCDataFrame.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"

--- a/RecoLocalCalo/HGCalRecAlgos/interface/KDTreeLinkerToolsT.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/KDTreeLinkerToolsT.h
@@ -2,6 +2,7 @@
 #define KDTreeLinkerToolsTemplated_h
 
 #include <array>
+#include <vector>
 
 // Box structure used to define 2D field.
 // It's used in KDTree building step to divide the detector


### PR DESCRIPTION
We use std::vector in KDTreeLinkerTools.h, so we also need to
include the corresponding STL header to make this header compile.

In HGCalRecHitSimpleAlgo.h we use cms::Exception, so here we also
need to include the relevant header Exception.h.