### PR TITLE
Add include for string to EScales.h

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/interface/EScales.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/EScales.h
@@ -1,6 +1,8 @@
 #ifndef EScales_h
 #define EScales_h
 
+#include <string>
+
 struct EScales{
   double HBPiOvere=0;
   double HESPiOvere=0;


### PR DESCRIPTION
We use std::string here, so we also need to include the string
header to make this file compile.