### PR TITLE
Fix includes and typos inRecoJets/JetProducers

### DIFF
--- a/RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h
@@ -15,7 +15,7 @@
 namespace edm {
   class Event;
   class EventSetup;
-  class ParameterSets;
+  class ParameterSet;
 }
 // For MVA analysis
 

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -2,6 +2,8 @@
 #define JetProducers_QGTagger_h
 #include <tuple>
 
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 


### PR DESCRIPTION
We use the VertexCollection in QGTagger.h, so we also need to include VertexFwd.h here.

In PileupJPTJetIdAlgo.h we foward declare the non-existent class ParameterSet**s**, but instead we want to forward declare ParameterSet.