### PR TITLE
Fix needed by classes derived from virtual jet producer

### DIFF
--- a/RecoJets/JetProducers/interface/PileUpSubtractor.h
+++ b/RecoJets/JetProducers/interface/PileUpSubtractor.h
@@ -32,7 +32,6 @@ class PileUpSubtractor{
   PileUpSubtractor(const edm::ParameterSet& iConfig,  edm::ConsumesCollector && iC); 
   virtual ~PileUpSubtractor(){;}
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  static void fillDescriptionsFromPileUpSubtractor(edm::ParameterSetDescription& desc);
 
   virtual void setDefinition(JetDefPtr const & jetDef);
   virtual void reset(std::vector<edm::Ptr<reco::Candidate> >& input,

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -19,8 +19,6 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 
-#include "RecoJets/JetProducers/interface/PileUpSubtractor.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -464,10 +462,9 @@ void FastjetJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
 	////// From FastjetJetProducer
 	fillDescriptionsFromFastJetProducer(descFastjetJetProducer);
 	///// From VirtualJetProducer
-	descFastjetJetProducer.add<string>("jetCollInstanceName", ""	);
 	VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(descFastjetJetProducer);
-	///// From PileUpSubtractor
-	PileUpSubtractor::fillDescriptionsFromPileUpSubtractor(descFastjetJetProducer);
+        ////
+	descFastjetJetProducer.add<string>("jetCollInstanceName", ""	);
 	descFastjetJetProducer.add<bool> ("sumRecHits", false);
 
 	/////////////////////

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -122,6 +122,8 @@ void VirtualJetProducer::makeProduces( std::string alias, std::string tag )
 VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 
 	moduleLabel_   		= iConfig.getParameter<string>  ("@module_label");
+        src_                    = iConfig.getParameter<edm::InputTag>("src");
+        srcPVs_                 = iConfig.getParameter<edm::InputTag>("srcPVs");
 	jetType_       		= iConfig.getParameter<string> 	("jetType");
 	jetAlgorithm_  		= iConfig.getParameter<string>  ("jetAlgorithm");
 	rParam_        		= iConfig.getParameter<double>  ("rParam");
@@ -154,8 +156,8 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 
 	anomalousTowerDef_ = auto_ptr<AnomalousTower>(new AnomalousTower(iConfig));
 
-	input_vertex_token_ = consumes<reco::VertexCollection>(iConfig.getParameter<InputTag>("srcPVs"));
-	input_candidateview_token_ = consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("src"));
+	input_vertex_token_ = consumes<reco::VertexCollection>(srcPVs_);
+	input_candidateview_token_ = consumes<reco::CandidateView>(src_);
 	input_candidatefwdptr_token_ = consumes<vector<edm::FwdPtr<reco::PFCandidate> > >(iConfig.getParameter<edm::InputTag>("src"));
 	input_packedcandidatefwdptr_token_ = consumes<vector<edm::FwdPtr<pat::PackedCandidate> > >(iConfig.getParameter<edm::InputTag>("src"));
 	//

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -867,6 +867,9 @@ void VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(edm::ParameterSe
 	desc.add<bool> 	("doAreaFastjet",	false );
 	desc.add<bool>  ("doRhoFastjet",	false );
 	desc.add<bool> 	("doPUOffsetCorr", 	false	);
+	desc.add<double>("puPtMin",             10.);
+        desc.add<double>("nSigmaPU",            1.0 );
+        desc.add<double>("radiusPU",            0.5 );
 	desc.add<string>("subtractorName", 	""	);
 	desc.add<bool> 	("useExplicitGhosts", 	false	);
 	desc.add<bool> 	("doAreaDiskApprox", 	false 	);

--- a/RecoJets/JetProducers/src/PileUpSubtractor.cc
+++ b/RecoJets/JetProducers/src/PileUpSubtractor.cc
@@ -378,15 +378,10 @@ void PileUpSubtractor::fillDescriptions(edm::ConfigurationDescriptions& descript
 	desc.add<double> ("Ghost_EtaMax", 5);
 	desc.add<double> ("GhostArea", 0.01);
 	desc.add<int> ("Active_Area_Repeats", 1);
-	fillDescriptionsFromPileUpSubtractor(desc);
-	descriptions.addDefault(desc);
-}
-
-void PileUpSubtractor::fillDescriptionsFromPileUpSubtractor(edm::ParameterSetDescription& desc)
-{
 	desc.add<double> ("puPtMin", 	10.);
 	desc.add<double> ("nSigmaPU", 	1.);
 	desc.add<double> ("radiusPU", 	0.5);
+	descriptions.addDefault(desc);
 }
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"


### PR DESCRIPTION
bug-fix of #19098

This should fix the errors in the HI Jet Producers which inherits from VirtualJetProducer by:
- adding the missing parameters in the fillDescription() method of the base class;
- restoring the local src_ variable in VirtualJetProducer, which is needed in the derived classes

@alefisico @Martin-Grunewald @fwyzard @silviodonato 