### PR TITLE
New CaloL{1,2} LUTs are taken care of by the L1T O2O

### DIFF
--- a/CondFormats/DataRecord/interface/L1TCaloParamsO2ORcd.h
+++ b/CondFormats/DataRecord/interface/L1TCaloParamsO2ORcd.h
@@ -14,8 +14,8 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
 #include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
-#include "CondFormats/DataRecord/interface/L1TCaloStage2ParamsRcd.h"
-class L1TCaloParamsO2ORcd : public edm::eventsetup::DependentRecordImplementation<L1TCaloParamsO2ORcd, boost::mpl::vector<L1TriggerKeyListExtRcd,L1TriggerKeyExtRcd,L1TCaloStage2ParamsRcd> > {};
+#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
+class L1TCaloParamsO2ORcd : public edm::eventsetup::DependentRecordImplementation<L1TCaloParamsO2ORcd, boost::mpl::vector<L1TriggerKeyListExtRcd,L1TriggerKeyExtRcd,L1TCaloParamsRcd> > {};
 
 
 #endif

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
@@ -9,7 +9,7 @@ l1caloparProtodb = cms.ESSource("PoolDBESSource",
        CondDB,
        toGet   = cms.VPSet(
             cms.PSet(
-                 record = cms.string('L1TCaloStage2ParamsRcd'),
+                 record = cms.string('L1TCaloParamsRcd'),
                  tag = cms.string("L1TCaloParamsPrototype_Stage2v0_hlt")
             )
        )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
@@ -18,6 +18,7 @@ l1caloparProtodb = cms.ESSource("PoolDBESSource",
 L1TCaloParamsOnlineProd = cms.ESProducer("L1TCaloParamsOnlineProd",
     onlineAuthentication = cms.string('.'),
     forceGeneration = cms.bool(False),
-    onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R')
+    onlineDB = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
+    exclusiveLayer = cms.uint32(0)
 )
 

--- a/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
+++ b/L1TriggerConfig/L1TConfigProducers/src/CaloParamsHelperO2O.h
@@ -1,0 +1,472 @@
+#include <iostream>
+
+#include "CondFormats/L1TObjects/interface/CaloParams.h"
+
+#include "CondFormats/L1TObjects/interface/L1CaloEtScale.h"
+#include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1JetEtScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1HtMissScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1HfRingEtScaleRcd.h"
+
+#ifndef CaloParamsHelperO2O_h
+#define CaloParamsHelperO2O_h
+
+namespace l1t {
+
+  class CaloParamsHelperO2O : public CaloParams {
+
+  public:
+    // DO NOT ADD ENTRIES ANYWHERE BUT DIRECTLY BEFORE "NUM_CALOPARAMNODES"
+    // DO NOT CHANGE NUMERICAL VALUES OF ANY ALREADY EXISTING FIELDS, YOU CAN ONLY EXTEND, AT THE END.
+    enum { regionPUS=0,
+	   egTrimming=1, egMaxHOverE=2, egCompressShapes=3, egShapeId=4, egCalibration=5, egPUS=6, egIsolation=7,
+	   tauCalibration=8, tauPUS=9, tauIsolation=10,
+	   jetPUS=11, jetCalibration=12,
+	   hiCentrality=13, hiQ2=14,
+	   tauEtToHFRingEt=15,
+           tauCompress=16,
+           layer1ECal=17,
+           layer1HCal=18,
+           layer1HF=19,
+	   jetCompressEta=20, jetCompressPt=21,
+	   etSumXCalibration=22, etSumYCalibration=23, etSumEttCalibration=24, etSumEcalSumCalibration=25,
+	   tauIsolation2=26,
+           egBypassEGVetosFlag=27,
+           jetBypassPUSFlag=28,
+           egHOverEBarrel=29,
+           egHOverEEndcap=30,
+	   etSumMetPUS=31,
+	   etSumBypassMetPUSFlag=32,
+	   egBypassExtHoE=33,
+	   egIsolation2=34,
+	   etSumEttPUS=35,
+	   etSumBypassEttPUSFlag=36,
+	   etSumEcalSumPUS=37,
+	   etSumBypassEcalSumPUSFlag=38,
+	   layer1HOverE=39,
+	   PUTowerThreshold=40,
+	   tauTrimmingShapeVeto=41,
+	   NUM_CALOPARAMNODES=42
+    };
+
+    CaloParamsHelperO2O() { pnode_.resize(NUM_CALOPARAMNODES); }
+    CaloParamsHelperO2O(const CaloParams &p) : CaloParams(p) {
+        if (pnode_.size() < NUM_CALOPARAMNODES){
+            pnode_.resize(NUM_CALOPARAMNODES);
+            // at version 2, tauCompress was added, we can add a default version here if necessary...
+        }
+    };
+    ~CaloParamsHelperO2O() {}
+
+    bool isValidForStage1() {return 1; } 
+    bool isValidForStage2() {return (version_ >= 2); }
+
+    L1CaloEtScale emScale() { return emScale_; }
+    void setEmScale(L1CaloEtScale emScale) { emScale_ = emScale; }
+    L1CaloEtScale jetScale() { return jetScale_; }
+    void setJetScale(L1CaloEtScale jetScale) { jetScale_ = jetScale; }
+    L1CaloEtScale HtMissScale() {return HtMissScale_;}
+    L1CaloEtScale HfRingScale() {return HfRingScale_;}
+    void setHtMissScale(L1CaloEtScale HtMissScale){HtMissScale_ = HtMissScale;}
+    void setHfRingScale(L1CaloEtScale HfRingScale){HfRingScale_ = HfRingScale;}
+
+    // towers
+    double towerLsbH() const { return towerp_.lsbH_; }
+    double towerLsbE() const { return towerp_.lsbE_; }
+    double towerLsbSum() const { return towerp_.lsbSum_; }
+    int towerNBitsH() const { return towerp_.nBitsH_; }
+    int towerNBitsE() const { return towerp_.nBitsE_; }
+    int towerNBitsSum() const { return towerp_.nBitsSum_; }
+    int towerNBitsRatio() const { return towerp_.nBitsRatio_; }
+    int towerMaskE() const { return towerp_.maskE_; }
+    int towerMaskH() const { return towerp_.maskH_; }
+    int towerMaskSum() const { return towerp_.maskSum_; }
+    int towerMaskRatio() const { return towerp_.maskRatio_; }
+    bool doTowerEncoding() const { return towerp_.doEncoding_; }
+
+    void setTowerLsbH(double lsb) { towerp_.lsbH_ = lsb; }
+    void setTowerLsbE(double lsb) { towerp_.lsbE_ = lsb; }
+    void setTowerLsbSum(double lsb) { towerp_.lsbSum_ = lsb; }
+    void setTowerNBitsH(int n) { towerp_.nBitsH_ = n; towerp_.maskH_ = std::pow(2,n)-1; }
+    void setTowerNBitsE(int n) { towerp_.nBitsE_ = n; towerp_.maskE_ = std::pow(2,n)-1; }
+    void setTowerNBitsSum(int n) { towerp_.nBitsSum_ = n; towerp_.maskSum_ = std::pow(2,n)-1; }
+    void setTowerNBitsRatio(int n) { towerp_.nBitsRatio_ = n; towerp_.maskRatio_ = std::pow(2,n)-1; }
+    void setTowerEncoding(bool doit) { towerp_.doEncoding_ = doit; }
+
+
+    // regions
+    double regionLsb() const { return regionLsb_; }
+    std::string regionPUSType() const { return pnode_[regionPUS].type_; }
+    std::vector<double> regionPUSParams() { return pnode_[regionPUS].dparams_; }
+    l1t::LUT* regionPUSLUT() {return &pnode_[regionPUS].LUT_; }
+
+    int regionPUSValue(int PUM0, int eta)
+    {
+      int puSub = ceil(regionPUSParams()[18*eta+PUM0]*2);
+      return puSub;
+    }
+
+    void setRegionLsb(double lsb) { regionLsb_ = lsb; }
+    void setRegionPUSType(std::string type) { pnode_[regionPUS].type_ = type; }
+    void setRegionPUSParams(const std::vector<double> & params) { pnode_[regionPUS].dparams_ = params; }
+    void setRegionPUSLUT(const l1t::LUT & lut) { pnode_[regionPUS].LUT_ = lut; }
+
+    int pileUpTowerThreshold() const {return pnode_[PUTowerThreshold].iparams_[0]; }
+    void setPileUpTowerThreshold(int thresh) { 
+      pnode_[PUTowerThreshold].iparams_.resize(1);
+      pnode_[PUTowerThreshold].iparams_[0] = thresh; 
+    }
+
+    // EG
+    int egEtaCut() const {
+      if (pnode_[egPUS].version_ ==1)
+	return pnode_[egPUS].iparams_[0];
+      else
+	return 0;
+    }
+    double egLsb() const { return egp_.lsb_; }
+    double egSeedThreshold() const { return egp_.seedThreshold_; }
+    double egNeighbourThreshold() const { return egp_.neighbourThreshold_; }
+    double egHcalThreshold() const { return egp_.hcalThreshold_; }
+    l1t::LUT* egTrimmingLUT() { return &pnode_[egTrimming].LUT_; }
+    double egMaxHcalEt() const { return egp_.maxHcalEt_; }
+    double egMaxPtHOverE() const {return egp_.maxPtHOverE_;}
+    l1t::LUT* egMaxHOverELUT() { return &pnode_[egMaxHOverE].LUT_; }
+    l1t::LUT* egCompressShapesLUT() { return &pnode_[egCompressShapes].LUT_; }
+    l1t::LUT* egShapeIdLUT() { return &pnode_[egShapeId].LUT_; }
+    int egMinPtJetIsolation() const { return egp_.minPtJetIsolation_; }
+    int egMaxPtJetIsolation() const { return egp_.maxPtJetIsolation_; }
+    int egMinPtHOverEIsolation() const { return egp_.minPtHOverEIsolation_; }
+    int egMaxPtHOverEIsolation() const { return egp_.maxPtHOverEIsolation_; }
+    unsigned egBypassEGVetos() { return pnode_[egBypassEGVetosFlag].uparams_[0]; }
+    unsigned egBypassExtHOverE() { return pnode_[egBypassExtHoE].uparams_[0]; }
+    int egHOverEcutBarrel() const {return pnode_[egHOverEBarrel].iparams_[0]; }
+    int egHOverEcutEndcap() const {return pnode_[egHOverEEndcap].iparams_[0]; }
+
+    unsigned egIsoAreaNrTowersEta()const{return egp_.isoAreaNrTowersEta_;}
+    unsigned egIsoAreaNrTowersPhi()const{return egp_.isoAreaNrTowersPhi_;}
+    unsigned egIsoVetoNrTowersPhi()const{return egp_.isoVetoNrTowersPhi_;}
+    const std::string & egPUSType() const { return pnode_[egPUS].type_; }
+    const std::vector<double> & egPUSParams() const { return pnode_[egPUS].dparams_; }
+    double egPUSParam(int ipar) const { return pnode_[egPUS].dparams_.at(ipar); }
+
+    std::string egIsolationType() const { return pnode_[egIsolation].type_; }
+    l1t::LUT* egIsolationLUT() { return &pnode_[egIsolation].LUT_; }
+    l1t::LUT* egIsolationLUT2() { return &pnode_[egIsolation2].LUT_; }
+    std::string egCalibrationType() const { return pnode_[egCalibration].type_; }
+    std::vector<double> egCalibrationParams() { return pnode_[egCalibration].dparams_; }
+    l1t::LUT* egCalibrationLUT() { return &pnode_[egCalibration].LUT_; }
+
+    void setEgEtaCut(int mask) {
+      pnode_[egPUS].iparams_.resize(1);
+      pnode_[egPUS].iparams_[0] = mask;
+    }
+    void setEgLsb(double lsb) { egp_.lsb_ = lsb; }
+    void setEgSeedThreshold(double thresh) { egp_.seedThreshold_ = thresh; }
+    void setEgNeighbourThreshold(double thresh) { egp_.neighbourThreshold_ = thresh; }
+    void setEgHcalThreshold(double thresh) { egp_.hcalThreshold_ = thresh; }
+    void setEgTrimmingLUT(const l1t::LUT & lut) { pnode_[egTrimming].LUT_ = lut; }
+    void setEgMaxHcalEt(double cut) { egp_.maxHcalEt_ = cut; }
+    void setEgMaxPtHOverE(double thresh) { egp_.maxPtHOverE_ = thresh;}
+    void setEgMaxHOverELUT(const l1t::LUT & lut) { pnode_[egMaxHOverE].LUT_ = lut; }
+    void setEgCompressShapesLUT(const l1t::LUT & lut) { pnode_[egCompressShapes].LUT_ = lut; }
+    void setEgShapeIdLUT(const l1t::LUT & lut) { pnode_[egShapeId].LUT_ = lut; }
+    void setEgMinPtJetIsolation(int cutValue) { egp_.minPtJetIsolation_ = cutValue; }
+    void setEgMaxPtJetIsolation(int cutValue) { egp_.maxPtJetIsolation_ = cutValue; }
+    void setEgMinPtHOverEIsolation(int cutValue) { egp_.minPtHOverEIsolation_ = cutValue; }
+    void setEgMaxPtHOverEIsolation(int cutValue) { egp_.maxPtHOverEIsolation_ = cutValue; }
+    void setEgBypassEGVetos(unsigned flag) { 
+      pnode_[egBypassEGVetosFlag].uparams_.resize(1);
+      pnode_[egBypassEGVetosFlag].uparams_[0] = flag; 
+    }
+    void setEgBypassExtHOverE(unsigned flag) {
+      pnode_[egBypassExtHoE].uparams_.resize(1);
+      pnode_[egBypassExtHoE].uparams_[0] = flag;
+    }
+    void setEgHOverEcutBarrel(int cut) { 
+      pnode_[egHOverEBarrel].iparams_.resize(1);
+      pnode_[egHOverEBarrel].iparams_[0] = cut; 
+    }
+    void setEgHOverEcutEndcap(int cut) { 
+      pnode_[egHOverEEndcap].iparams_.resize(1);
+      pnode_[egHOverEEndcap].iparams_[0] = cut; 
+    }
+
+    void setEgIsoAreaNrTowersEta(unsigned iEgIsoAreaNrTowersEta){egp_.isoAreaNrTowersEta_=iEgIsoAreaNrTowersEta;}
+    void setEgIsoAreaNrTowersPhi(unsigned iEgIsoAreaNrTowersPhi){egp_.isoAreaNrTowersPhi_=iEgIsoAreaNrTowersPhi;}
+    void setEgIsoVetoNrTowersPhi(unsigned iEgIsoVetoNrTowersPhi){egp_.isoVetoNrTowersPhi_=iEgIsoVetoNrTowersPhi;}
+    void setEgPUSType(std::string type) { pnode_[egPUS].type_ = type; }
+    void setEgPUSParams(const std::vector<double> & params) { pnode_[egPUS].dparams_ = params; }
+    void setEgIsolationType(std::string type) { pnode_[egIsolation].type_ = type; }
+    void setEgIsolationLUT(const l1t::LUT & lut) { pnode_[egIsolation].LUT_ = lut; }
+    void setEgIsolationLUT2(const l1t::LUT & lut) { pnode_[egIsolation2].LUT_ = lut; }
+    void setEgCalibrationType(std::string type) { pnode_[egCalibration].type_ = type; }
+    void setEgCalibrationParams(std::vector<double> params) { pnode_[egCalibration].dparams_ = params; }
+    void setEgCalibrationLUT(const l1t::LUT & lut) { pnode_[egCalibration].LUT_ = lut; }
+
+    // - recently imported:
+    std::string egShapeIdType() const { return pnode_[egShapeId].type_; }
+    void setEgShapeIdType(std::string type) { pnode_[egShapeId].type_ = type; }
+    unsigned egShapeIdVersion() const { return pnode_[egShapeId].version_; }
+    void setEgShapeIdVersion(unsigned version) { pnode_[egShapeId].version_ = version; }
+    unsigned egCalibrationVersion() const { return pnode_[egCalibration].version_; }
+    void setEgCalibrationVersion(unsigned version) { pnode_[egCalibration].version_ = version; }
+
+    // tau
+    int tauRegionMask() const {
+      if (pnode_[tauPUS].version_ ==1)
+	return pnode_[tauPUS].iparams_[0];
+      else
+	return 0;
+    }
+    double tauLsb() const { return taup_.lsb_; }
+    double tauSeedThreshold() const { return taup_.seedThreshold_; }
+    double tauNeighbourThreshold() const { return taup_.neighbourThreshold_; }
+    double tauMaxPtTauVeto() const { return taup_.maxPtTauVeto_;}
+    double tauMinPtJetIsolationB() const { return taup_.minPtJetIsolationB_;}
+    double tauMaxJetIsolationB() const { return taup_.maxJetIsolationB_; }
+    double tauMaxJetIsolationA() const { return taup_.maxJetIsolationA_; }
+    int    isoTauEtaMin() const { return taup_.isoEtaMin_; }
+    int    isoTauEtaMax() const { return taup_.isoEtaMax_; }
+    std::string tauPUSType() const { return pnode_[tauPUS].type_; }
+    const  std::vector<double> & tauPUSParams() const { return pnode_[tauPUS].dparams_; }
+    double tauPUSParam(int ipar) const { return pnode_[tauPUS].dparams_.at(ipar); }
+
+    l1t::LUT* tauIsolationLUT() { return &pnode_[tauIsolation].LUT_; }
+    l1t::LUT* tauIsolationLUT2() { return &pnode_[tauIsolation2].LUT_; }
+    l1t::LUT* tauTrimmingShapeVetoLUT() {return &pnode_[tauTrimmingShapeVeto].LUT_; }
+
+    std::string tauCalibrationType() const { return pnode_[tauCalibration].type_; }
+    std::vector<double> tauCalibrationParams() { return pnode_[tauCalibration].dparams_; }
+    l1t::LUT* tauCalibrationLUT() { return &pnode_[tauCalibration].LUT_; }
+    l1t::LUT* tauCompressLUT() { return &pnode_[tauCompress].LUT_; }
+
+    l1t::LUT* tauEtToHFRingEtLUT() { return &pnode_[tauEtToHFRingEt].LUT_; }
+
+    unsigned tauIsoAreaNrTowersEta()const{return taup_.isoAreaNrTowersEta_;}
+    unsigned tauIsoAreaNrTowersPhi()const{return taup_.isoAreaNrTowersPhi_;}
+    unsigned tauIsoVetoNrTowersPhi()const{return taup_.isoVetoNrTowersPhi_;}
+
+    void setTauRegionMask(int mask) {
+      pnode_[tauPUS].iparams_.resize(1);
+      pnode_[tauPUS].iparams_[0] = mask;
+    }
+    void setTauLsb(double lsb) { taup_.lsb_ = lsb; }
+    void setTauSeedThreshold(double thresh) { taup_.seedThreshold_ = thresh; }
+    void setTauNeighbourThreshold(double thresh) { taup_.neighbourThreshold_ = thresh; }
+    void setTauMaxPtTauVeto(double limit) { taup_.maxPtTauVeto_ = limit; }
+    void setTauMinPtJetIsolationB(double limit) { taup_.minPtJetIsolationB_ = limit; }
+    void setTauMaxJetIsolationB(double limit) { taup_.maxJetIsolationB_ = limit; }
+    void setTauMaxJetIsolationA(double cutValue) { taup_.maxJetIsolationA_ = cutValue; }
+    void setIsoTauEtaMin(int value) { taup_.isoEtaMin_ = value; }
+    void setIsoTauEtaMax(int value) { taup_.isoEtaMax_ = value; }
+    void setTauPUSType(std::string type) { pnode_[tauPUS].type_ = type; }
+    void setTauIsolationLUT(const l1t::LUT & lut) { pnode_[tauIsolation].LUT_ = lut; }
+    void setTauIsolationLUT2(const l1t::LUT & lut) { pnode_[tauIsolation2].LUT_ = lut; }
+    void setTauTrimmingShapeVetoLUT(const l1t::LUT & lut) { pnode_[tauTrimmingShapeVeto].LUT_ = lut; }
+
+    void setTauCalibrationType(std::string type) { pnode_[tauCalibration].type_ = type; }
+    void setTauIsoAreaNrTowersEta(unsigned iTauIsoAreaNrTowersEta){taup_.isoAreaNrTowersEta_=iTauIsoAreaNrTowersEta;}
+    void setTauIsoAreaNrTowersPhi(unsigned iTauIsoAreaNrTowersPhi){taup_.isoAreaNrTowersPhi_=iTauIsoAreaNrTowersPhi;}
+    void setTauIsoVetoNrTowersPhi(unsigned iTauIsoVetoNrTowersPhi){taup_.isoVetoNrTowersPhi_=iTauIsoVetoNrTowersPhi;}
+
+    void setTauCalibrationParams(std::vector<double> params) { pnode_[tauCalibration].dparams_ = params; }
+    void setTauCalibrationLUT(const l1t::LUT & lut) { pnode_[tauCalibration].LUT_ = lut; }
+    void setTauCompressLUT(const l1t::LUT & lut) { pnode_[tauCompress].LUT_ = lut; }
+    void setTauPUSParams(const std::vector<double> & params) { pnode_[tauPUS].dparams_ = params; }
+
+    void setTauEtToHFRingEtLUT(const l1t::LUT & lut) { pnode_[tauEtToHFRingEt].LUT_ = lut; }
+
+    // jets
+    double jetLsb() const { return jetp_.lsb_; }
+    double jetSeedThreshold() const { return jetp_.seedThreshold_; }
+    double jetNeighbourThreshold() const { return jetp_.neighbourThreshold_; }
+    int jetRegionMask() const {
+      if (pnode_[jetPUS].version_ ==1)
+	return pnode_[jetPUS].iparams_[0];
+      else
+	return 0;
+    }
+
+    unsigned jetBypassPUS() const { return pnode_[jetBypassPUSFlag].uparams_[0]; }
+
+    std::string jetPUSType() const { return pnode_[jetPUS].type_; }
+    std::vector<double> jetPUSParams() { return pnode_[jetPUS].dparams_; }
+    std::string jetCalibrationType() const { return pnode_[jetCalibration].type_; }
+    std::vector<double> jetCalibrationParams() { return pnode_[jetCalibration].dparams_; }
+
+    l1t::LUT* jetCalibrationLUT() { return &pnode_[jetCalibration].LUT_; }
+    l1t::LUT* jetCompressPtLUT() { return &pnode_[jetCompressPt].LUT_; }
+    l1t::LUT* jetCompressEtaLUT() { return &pnode_[jetCompressEta].LUT_; }
+
+    void setJetLsb(double lsb) { jetp_.lsb_ = lsb; }
+    void setJetSeedThreshold(double thresh) { jetp_.seedThreshold_ = thresh; }
+    void setJetNeighbourThreshold(double thresh) { jetp_.neighbourThreshold_ = thresh; }
+    void setJetRegionMask(int mask) {
+      pnode_[jetPUS].iparams_.resize(1);
+      pnode_[jetPUS].iparams_[0] = mask;
+    }
+    void setJetPUSType(std::string type) { pnode_[jetPUS].type_ = type; }
+    void setJetPUSParams(std::vector<double> params) { pnode_[jetPUS].dparams_ = params; }
+    void setJetCalibrationType(std::string type) { pnode_[jetCalibration].type_ = type; }
+    void setJetCalibrationParams(std::vector<double> params) { pnode_[jetCalibration].dparams_ = params; }
+    void setJetCalibrationLUT(const l1t::LUT & lut) { pnode_[jetCalibration].LUT_ = lut; }
+    void setJetCompressEtaLUT(const l1t::LUT & lut) { pnode_[jetCompressEta].LUT_ = lut; }
+    void setJetCompressPtLUT(const l1t::LUT & lut) { pnode_[jetCompressPt].LUT_ = lut; }
+    void setJetBypassPUS(unsigned flag) { 
+      pnode_[jetBypassPUSFlag].uparams_.resize(1);
+      pnode_[jetBypassPUSFlag].uparams_[0] = flag; 
+    }
+    
+    // sums
+
+    double etSumLsb() const { return etSumLsb_; }
+    int etSumEtaMin(unsigned isum) const {
+        if (etSumEtaMin_.size()>isum) return etSumEtaMin_.at(isum);
+        else return 0;
+    }
+    int etSumEtaMax(unsigned isum) const {
+        if (etSumEtaMax_.size()>isum) return etSumEtaMax_.at(isum);
+        else return 0;
+    }
+    double etSumEtThreshold(unsigned isum) const {
+        if (etSumEtThreshold_.size()>isum) return etSumEtThreshold_.at(isum);
+        else return 0.;
+    }
+    unsigned etSumBypassMetPUS() const { return pnode_[etSumBypassMetPUSFlag].uparams_[0]; }
+    unsigned etSumBypassEttPUS() const { return pnode_[etSumBypassEttPUSFlag].uparams_[0]; }
+    unsigned etSumBypassEcalSumPUS() const { return pnode_[etSumBypassEcalSumPUSFlag].uparams_[0]; }
+    std::string etSumMetPUSType() const { return pnode_[etSumMetPUS].type_; }
+    std::string etSumEttPUSType() const { return pnode_[etSumEttPUS].type_; }
+    std::string etSumEcalSumPUSType() const { return pnode_[etSumEcalSumPUS].type_; }
+    std::string etSumXCalibrationType() const { return pnode_[etSumXCalibration].type_; }
+    std::string etSumYCalibrationType() const { return pnode_[etSumYCalibration].type_; }
+    std::string etSumEttCalibrationType() const { return pnode_[etSumEttCalibration].type_; }
+    std::string etSumEcalSumCalibrationType() const { return pnode_[etSumEcalSumCalibration].type_; }
+
+    l1t::LUT* etSumMetPUSLUT() { return &pnode_[etSumMetPUS].LUT_; }
+    l1t::LUT* etSumEttPUSLUT() { return &pnode_[etSumEttPUS].LUT_; }
+    l1t::LUT* etSumEcalSumPUSLUT() { return &pnode_[etSumEcalSumPUS].LUT_; }
+    l1t::LUT* etSumXCalibrationLUT() { return &pnode_[etSumXCalibration].LUT_; }
+    l1t::LUT* etSumYCalibrationLUT() { return &pnode_[etSumYCalibration].LUT_; }
+    l1t::LUT* etSumEttCalibrationLUT() { return &pnode_[etSumEttCalibration].LUT_; }
+    l1t::LUT* etSumEcalSumCalibrationLUT() { return &pnode_[etSumEcalSumCalibration].LUT_; }
+
+    void setEtSumLsb(double lsb) { etSumLsb_ = lsb; }
+    void setEtSumEtaMin(unsigned isum, int eta){
+        if (etSumEtaMin_.size()<=isum) etSumEtaMin_.resize(isum+1);
+        etSumEtaMin_.at(isum) = eta;
+    }
+    void setEtSumEtaMax(unsigned isum, int eta){
+        if (etSumEtaMax_.size()<=isum) etSumEtaMax_.resize(isum+1);
+        etSumEtaMax_.at(isum) = eta;
+    }
+    void setEtSumEtThreshold(unsigned isum, double thresh){
+        if (etSumEtThreshold_.size()<=isum) etSumEtThreshold_.resize(isum+1);
+        etSumEtThreshold_.at(isum) = thresh;
+    }
+    void setEtSumMetPUSType(std::string type) { pnode_[etSumMetPUS].type_ = type; }
+    void setEtSumEttPUSType(std::string type) { pnode_[etSumEttPUS].type_ = type; }
+    void setEtSumEcalSumPUSType(std::string type) { pnode_[etSumEcalSumPUS].type_ = type; }
+    void setEtSumXCalibrationType(std::string type) { pnode_[etSumXCalibration].type_ = type; }
+    void setEtSumYCalibrationType(std::string type) { pnode_[etSumYCalibration].type_ = type; }
+    void setEtSumEttCalibrationType(std::string type) { pnode_[etSumEttCalibration].type_ = type; }
+    void setEtSumEcalSumCalibrationType(std::string type) { pnode_[etSumEcalSumCalibration].type_ = type; }
+    void setEtSumBypassMetPUS(unsigned flag) { 
+      pnode_[etSumBypassMetPUSFlag].uparams_.resize(1);
+      pnode_[etSumBypassMetPUSFlag].uparams_[0] = flag; 
+    }
+    void setEtSumBypassEttPUS(unsigned flag) { 
+      pnode_[etSumBypassEttPUSFlag].uparams_.resize(1);
+      pnode_[etSumBypassEttPUSFlag].uparams_[0] = flag; 
+    }
+    void setEtSumBypassEcalSumPUS(unsigned flag) { 
+      pnode_[etSumBypassEcalSumPUSFlag].uparams_.resize(1);
+      pnode_[etSumBypassEcalSumPUSFlag].uparams_[0] = flag; 
+    }
+
+
+    void setEtSumMetPUSLUT(const l1t::LUT & lut) { pnode_[etSumMetPUS].LUT_ = lut; }
+    void setEtSumEttPUSLUT(const l1t::LUT & lut) { pnode_[etSumEttPUS].LUT_ = lut; }
+    void setEtSumEcalSumPUSLUT(const l1t::LUT & lut) { pnode_[etSumEcalSumPUS].LUT_ = lut; }
+    void setEtSumXCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumXCalibration].LUT_ = lut; }
+    void setEtSumYCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumYCalibration].LUT_ = lut; }
+    void setEtSumEttCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEttCalibration].LUT_ = lut; }
+    void setEtSumEcalSumCalibrationLUT(const l1t::LUT & lut) { pnode_[etSumEcalSumCalibration].LUT_ = lut; }
+
+
+    // HI centrality
+    int centralityRegionMask() const {
+      if(pnode_[hiCentrality].version_ == 1)
+	return pnode_[hiCentrality].iparams_[0] ;
+      else
+	return 0;
+    }
+    std::vector<int> minimumBiasThresholds() const {
+      if(pnode_[hiCentrality].version_ == 1 && pnode_[hiCentrality].iparams_.size()==5) {
+	std::vector<int> newVec;
+	for(int i = 0; i<4; i++) {
+	  newVec.push_back(pnode_[hiCentrality].iparams_.at(i+1));
+	}
+	return newVec;
+      } else {
+	std::vector<int> newVec;
+	return newVec;
+      }
+    }
+    l1t::LUT * centralityLUT() { return &pnode_[hiCentrality].LUT_; }
+    void setCentralityRegionMask(int mask) {
+      pnode_[hiCentrality].iparams_.resize(5);
+      pnode_[hiCentrality].iparams_[0] = mask;
+    }
+    void setMinimumBiasThresholds(std::vector<int> thresholds) {
+      pnode_[hiCentrality].iparams_.resize(5);
+      for(int i = 0; i<4; i++) {
+	pnode_[hiCentrality].iparams_[i+1] = thresholds.at(i);
+      }
+    }
+    void setCentralityLUT(const l1t::LUT & lut) { pnode_[hiCentrality].LUT_ = lut; }
+
+    // HI Q2
+    l1t::LUT * q2LUT() { return &pnode_[hiQ2].LUT_; }
+    void setQ2LUT(const l1t::LUT & lut) { pnode_[hiQ2].LUT_ = lut; }
+
+    // HI parameters
+
+    // Layer 1 LUT specification
+    std::vector<double> layer1ECalScaleFactors() { return pnode_[layer1ECal].dparams_; }
+    std::vector<double> layer1HCalScaleFactors() { return pnode_[layer1HCal].dparams_; }
+    std::vector<double> layer1HFScaleFactors()   { return pnode_[layer1HF  ].dparams_; }
+    std::vector<int> layer1ECalScaleETBins() { return pnode_[layer1ECal].iparams_; }
+    std::vector<int> layer1HCalScaleETBins() { return pnode_[layer1HCal].iparams_; }
+    std::vector<int> layer1HFScaleETBins()   { return pnode_[layer1HF  ].iparams_; }
+    std::vector<unsigned> layer1ECalScalePhiBins() { return pnode_[layer1ECal].uparams_; }
+    std::vector<unsigned> layer1HCalScalePhiBins() { return pnode_[layer1HCal].uparams_; }
+    std::vector<unsigned> layer1HFScalePhiBins()   { return pnode_[layer1HF  ].uparams_; }
+    void setLayer1ECalScaleFactors(const std::vector<double> params) { pnode_[layer1ECal].dparams_ = params; }
+    void setLayer1HCalScaleFactors(const std::vector<double> params) { pnode_[layer1HCal].dparams_ = params; }
+    void setLayer1HFScaleFactors(const std::vector<double> params)   { pnode_[layer1HF  ].dparams_ = params; }
+    void setLayer1ECalScaleETBins(const std::vector<int> params) { pnode_[layer1ECal].iparams_ = params; }
+    void setLayer1HCalScaleETBins(const std::vector<int> params) { pnode_[layer1HCal].iparams_ = params; }
+    void setLayer1HFScaleETBins(const std::vector<int> params)   { pnode_[layer1HF  ].iparams_ = params; }
+    void setLayer1ECalScalePhiBins(const std::vector<unsigned> params) { pnode_[layer1ECal].uparams_ = params; }
+    void setLayer1HCalScalePhiBins(const std::vector<unsigned> params) { pnode_[layer1HCal].uparams_ = params; }
+    void setLayer1HFScalePhiBins(const std::vector<unsigned> params)   { pnode_[layer1HF  ].uparams_ = params; }
+
+    l1t::LUT* layer1HOverELUT() { return &pnode_[layer1HOverE].LUT_; }
+    void setLayer1HOverELUT(const l1t::LUT & lut) { pnode_[layer1HOverE].LUT_ = lut; }
+
+
+  private:
+    L1CaloEtScale emScale_;
+    L1CaloEtScale jetScale_;
+    L1CaloEtScale HtMissScale_;
+    L1CaloEtScale HfRingScale_;
+  };
+
+}
+
+
+
+#endif
+

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -5,7 +5,7 @@
 
 #include "CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h"
 #include "CondFormats/L1TObjects/interface/CaloParams.h"
-#include "CondFormats/DataRecord/interface/L1TCaloStage2ParamsRcd.h"
+#include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
 #include "CondFormats/DataRecord/interface/L1TCaloParamsO2ORcd.h"
 #include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
 #include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -154,7 +154,7 @@ L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfi
 std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) {
     using namespace edm::es;
 
-    const L1TCaloStage2ParamsRcd& baseRcd = record.template getRecord< L1TCaloStage2ParamsRcd >() ;
+    const L1TCaloParamsRcd& baseRcd = record.template getRecord< L1TCaloParamsRcd >() ;
     edm::ESHandle< l1t::CaloParams > baseSettings ;
     baseRcd.get( baseSettings ) ;
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -10,7 +10,8 @@
 #include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
 #include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
 #include "L1Trigger/L1TCommon/interface/ConvertToLUT.h"
-#include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
+//#include "L1Trigger/L1TCalorimeter/interface/CaloParamsHelper.h"
+#include "CaloParamsHelperO2O.h"
 #include "OnlineDBqueryHelper.h"
 
 #include "xercesc/util/PlatformUtils.hpp"
@@ -18,6 +19,12 @@ using namespace XERCES_CPP_NAMESPACE;
 
 class L1TCaloParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd,l1t::CaloParams> {
 private:
+    unsigned int exclusiveLayer; // 0 - process calol1 and calol2, 1 - only calol1, 2 - only calol2
+
+    bool readCaloLayer1OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper, std::map<std::string, l1t::Parameter>& conf, std::map<std::string, 
+l1t::Mask>& );
+    bool readCaloLayer2OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper, std::map<std::string, l1t::Parameter>& conf, std::map<std::string, 
+l1t::Mask>& );
 public:
     virtual std::shared_ptr<l1t::CaloParams> newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) override ;
 
@@ -26,7 +33,8 @@ public:
 };
 
 bool
-readCaloLayer1OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::string, l1t::Parameter>& conf, std::map<std::string, l1t::Mask>& ) {
+L1TCaloParamsOnlineProd::readCaloLayer1OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper, std::map<std::string, l1t::Parameter>& conf, 
+std::map<std::string, l1t::Mask>& ) {
   const char * expectedParams[] = {
     "layer1ECalScaleFactors",
     "layer1HCalScaleFactors",
@@ -34,6 +42,11 @@ readCaloLayer1OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
     "layer1ECalScaleETBins",
     "layer1HCalScaleETBins",
     "layer1HFScaleETBins"
+    // Optional params
+    //"layer1ECalScalePhiBins",
+    //"layer1HCalScalePhiBins",
+    //"layer1HFScalePhiBins",
+    //"layer1SecondStageLUT"
   };
   for (const auto param : expectedParams) {
     if ( conf.find(param) == conf.end() ) {
@@ -48,15 +61,22 @@ readCaloLayer1OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
   paramsHelper.setLayer1ECalScaleETBins(conf["layer1ECalScaleETBins"].getVector<int>());
   paramsHelper.setLayer1HCalScaleETBins(conf["layer1HCalScaleETBins"].getVector<int>());
   paramsHelper.setLayer1HFScaleETBins  (conf["layer1HFScaleETBins"]  .getVector<int>());
-  paramsHelper.setLayer1ECalScalePhiBins(conf.find("layer1ECalScalePhiBins") != conf.end() ? conf["layer1ECalScalePhiBins"].getVector<unsigned int>() : std::vector<unsigned>(36,0));
-  paramsHelper.setLayer1HCalScalePhiBins(conf.find("layer1HCalScalePhiBins") != conf.end() ? conf["layer1HCalScalePhiBins"].getVector<unsigned int>() : std::vector<unsigned>(36,0));
-  paramsHelper.setLayer1HFScalePhiBins  (conf.find("layer1HFScalePhiBins") != conf.end() ? conf["layer1HFScalePhiBins"]  .getVector<unsigned int>() : std::vector<unsigned>(36,0));
+
+  if( conf.find("layer1ECalScalePhiBins") != conf.end() )
+      paramsHelper.setLayer1ECalScalePhiBins(conf["layer1ECalScalePhiBins"].getVector<unsigned int>()); // std::vector<unsigned>(36,0)
+  if( conf.find("layer1HCalScalePhiBins") != conf.end() )
+      paramsHelper.setLayer1HCalScalePhiBins(conf["layer1HCalScalePhiBins"].getVector<unsigned int>());
+  if( conf.find("layer1HFScalePhiBins") != conf.end() )
+      paramsHelper.setLayer1HFScalePhiBins  (conf["layer1HFScalePhiBins"]  .getVector<unsigned int>());
+  if( conf.find("layer1SecondStageLUT") != conf.end() )
+      paramsHelper.setLayer1HOverELUT( l1t::convertToLUT( conf["layer1SecondStageLUT"]  .getVector<unsigned int>()) );
 
   return true;
 }
 
 bool
-readCaloLayer2OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::string, l1t::Parameter>& conf, std::map<std::string, l1t::Mask>& ) {
+L1TCaloParamsOnlineProd::readCaloLayer2OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper, std::map<std::string, l1t::Parameter>& conf, 
+std::map<std::string, l1t::Mask>& ) {
   const char * expectedParams[] = {
     "leptonSeedThreshold",
     "leptonTowerThreshold",
@@ -75,19 +95,22 @@ readCaloLayer2OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
     "egammaRelaxationThreshold",
     "egammaMaxEta",
     "egammaEnergyCalibLUT",
-    "egammaIsoLUT",
+    "egammaIsoLUT1",
+    "egammaIsoLUT2",
     "tauMaxEta",
     "tauEnergyCalibLUT",
     "tauIsoLUT1",
-    "tauIsoLUT2",
+///    "tauIsoLUT2",
     "towerCountThreshold",
     "towerCountMaxEta",
-    "ET_towerThreshold",
-    "MET_towerThreshold",
+    "ET_towerThresholdLUT",
+    "MET_towerThresholdLUT",
+    "ecalET_towerThresholdLUT",
     "jetBypassPileUpSub",
     "egammaBypassCuts",
     "egammaHOverECut_iEtaLT15",
-    "egammaHOverECut_iEtaGTEq15"
+    "egammaHOverECut_iEtaGTEq15",
+    "egammaBypassExtendedHOverE"
   };
   for (const auto param : expectedParams) {
     if ( conf.find(param) == conf.end() ) {
@@ -120,9 +143,9 @@ readCaloLayer2OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
   etSumEtaMax.push_back(conf["HTMHT_maxJetEta"].getValue<int>());
   etSumEtaMax.push_back(conf["towerCountMaxEta"].getValue<int>());
   
-  etSumEtThresh.push_back(conf["ET_towerThreshold"].getValue<int>()/2); // ETT tower threshold
+  etSumEtThresh.push_back(0); //conf["ET_towerThreshold"].getValue<int>()/2); // ETT tower threshold
   etSumEtThresh.push_back(conf["HT_jetThreshold"].getValue<int>()/2);
-  etSumEtThresh.push_back(conf["MET_towerThreshold"].getValue<int>()/2); // ETM tower threshold
+  etSumEtThresh.push_back(0); //conf["MET_towerThreshold"].getValue<int>()/2); // ETM tower threshold
   etSumEtThresh.push_back(conf["MHT_jetThreshold"].getValue<int>()/2);
   etSumEtThresh.push_back(conf["ET_towerThreshold"].getValue<int>()/2);
 
@@ -132,24 +155,41 @@ readCaloLayer2OnlineSettings(l1t::CaloParamsHelper& paramsHelper, std::map<std::
   }
 
   paramsHelper.setJetCalibrationLUT ( l1t::convertToLUT( conf["jetEnergyCalibLUT"].getVector<uint32_t>() ) );
+
+  paramsHelper.setEtSumMetPUSLUT    ( l1t::convertToLUT( conf["MET_towerThresholdLUT"].getVector<int>() ) );
+  paramsHelper.setEtSumEttPUSLUT    ( l1t::convertToLUT( conf["ET_towerThresholdLUT"].getVector<int>() ) );
+  paramsHelper.setEtSumEcalSumPUSLUT( l1t::convertToLUT( conf["ecalET_towerThresholdLUT"].getVector<int>() ) );
+
   paramsHelper.setEtSumEttCalibrationLUT    ( l1t::convertToLUT( conf["ET_energyCalibLUT"].getVector<int>() ) );
   paramsHelper.setEtSumEcalSumCalibrationLUT( l1t::convertToLUT( conf["ecalET_energyCalibLUT"].getVector<int>() ) );
   paramsHelper.setEtSumXCalibrationLUT      ( l1t::convertToLUT( conf["METX_energyCalibLUT"].getVector<int>() ) );
+
   paramsHelper.setEgMaxPtHOverE((conf["egammaRelaxationThreshold"].getValue<int>())/2.);
   paramsHelper.setEgEtaCut((conf["egammaMaxEta"].getValue<int>()));
   paramsHelper.setEgCalibrationLUT  ( l1t::convertToLUT( conf["egammaEnergyCalibLUT"].getVector<int>() ) );
-  paramsHelper.setEgIsolationLUT    ( l1t::convertToLUT( conf["egammaIsoLUT"].getVector<int>() ) );
+  paramsHelper.setEgIsolationLUT    ( l1t::convertToLUT( conf["egammaIsoLUT1"].getVector<int>() ) );
+  paramsHelper.setEgIsolationLUT2   ( l1t::convertToLUT( conf["egammaIsoLUT2"].getVector<int>() ) );
 
   paramsHelper.setIsoTauEtaMax((conf["tauMaxEta"].getValue<int>()));
 
   paramsHelper.setTauCalibrationLUT( l1t::convertToLUT( conf["tauEnergyCalibLUT"].getVector<int>() ) );
   paramsHelper.setTauIsolationLUT  ( l1t::convertToLUT( conf["tauIsoLUT1"].getVector<int>() ) );
-  paramsHelper.setTauIsolationLUT2 ( l1t::convertToLUT( conf["tauIsoLUT2"].getVector<int>() ) );
+  if( conf.find("tauIsoLUT2") != conf.end() )
+    paramsHelper.setTauIsolationLUT2 ( l1t::convertToLUT( conf["tauIsoLUT2"].getVector<int>() ) );
+
+  paramsHelper.setEgBypassExtHOverE( conf["egammaBypassExtendedHOverE"].getValue<bool>() );
+
+  if( conf.find("P_TauTrimming_13to8.mif") != conf.end() )
+    paramsHelper.setTauTrimmingShapeVetoLUT( l1t::convertToLUT( conf["P_TauTrimming_13to8.mif"].getVector<int>() ) );
 
   return true;
 }
 
-L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfig) : L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd,l1t::CaloParams>(iConfig) {}
+L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfig) : 
+    L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd,l1t::CaloParams>(iConfig)
+{
+    exclusiveLayer = iConfig.getParameter<uint32_t>("exclusiveLayer");
+}
 
 std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey, const L1TCaloParamsO2ORcd& record) {
     using namespace edm::es;
@@ -167,43 +207,41 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
     std::string tscKey = objectKey.substr(0, objectKey.find(":") );
     std::string  rsKey = objectKey.substr(   objectKey.find(":")+1, std::string::npos );
 
-    edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Producing L1TCaloParamsOnlineProd with TSC key = " << tscKey << " and RS key = " << rsKey ;
+    edm::LogInfo( "L1-O2O: L1TCaloParamsOnlineProd" ) << "Producing L1TCaloParamsOnlineProd with TSC key = " << tscKey << " and RS key = " << rsKey 
+;
 
-    std::string calol1_top_key, calol1_algo_key, calol1_hw_key;
-    std::string calol1_hw_payload, calol1_algo_payload;
+    std::string calol1_top_key, calol1_algo_key;
+    std::string calol1_algo_payload;
     std::string calol2_top_key, calol2_algo_key, calol2_hw_key;
     std::string calol2_hw_payload;
     std::map<std::string,std::string> calol2_algo_payloads;  // key -> XML payload
     try {
+
         std::map<std::string,std::string> topKeys =
             l1t::OnlineDBqueryHelper::fetch( {"CALOL1_KEY","CALOL2_KEY"},
                                              "L1_TRG_CONF_KEYS",
                                              tscKey,
                                              m_omdsReader
                                            );
+
+      if( exclusiveLayer == 0 || exclusiveLayer == 1 ){
+
         calol1_top_key = topKeys["CALOL1_KEY"];
 
-        std::map<std::string,std::string> calol1_keys =
-            l1t::OnlineDBqueryHelper::fetch( {"ALGO","HW"},
-                                             "CALOL1_KEYS",
-                                             calol1_top_key,
-                                             m_omdsReader
-                                           );
-
-        calol1_hw_key = calol1_keys["HW"];
-        calol1_hw_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
-                                                             "CALOL1_CLOBS",
-                                                              calol1_hw_key,
-                                                              m_omdsReader
-                                                           ) ["CONF"];
-
-        calol1_algo_key = calol1_keys["ALGO"];
+        calol1_algo_key = l1t::OnlineDBqueryHelper::fetch( {"ALGO"},
+                                                           "CALOL1_KEYS",
+                                                           calol1_top_key,
+                                                           m_omdsReader
+                                                         ) ["ALGO"];
 
         calol1_algo_payload = l1t::OnlineDBqueryHelper::fetch( {"CONF"},
                                                                "CALOL1_CLOBS",
                                                                 calol1_algo_key,
                                                                 m_omdsReader
                                                              ) ["CONF"];
+      }
+
+      if( exclusiveLayer == 0 || exclusiveLayer == 2 ){
 
         calol2_top_key = topKeys["CALOL2_KEY"];
 
@@ -237,87 +275,52 @@ std::shared_ptr<l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::s
                                                  key.second,
                                                  m_omdsReader
                                                ) ["CONF"];
+      }
 
     } catch ( std::runtime_error &e ) {
         edm::LogError( "L1-O2O: L1TCaloParamsOnlineProd" ) << e.what();
         throw std::runtime_error("Broken key");
     }
 
-    // for debugging purposes dump the configs to local files
-    for(auto &conf : calol2_algo_payloads){ 
-        std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
-        output<<conf.second;
-        output.close();
-    }
-    { 
+    if( exclusiveLayer == 0 || exclusiveLayer == 2 ){
+        // for debugging purposes dump the configs to local files
+        for(auto &conf : calol2_algo_payloads){ 
+            std::ofstream output(std::string("/tmp/").append(conf.first.substr(0,conf.first.find("/"))).append(".xml"));
+            output<<conf.second;
+            output.close();
+        }
         std::ofstream output(std::string("/tmp/").append(calol2_hw_key.substr(0,calol2_hw_key.find("/"))).append(".xml"));
         output << calol2_hw_payload;
         output.close();
     }
+    if( exclusiveLayer == 0 || exclusiveLayer == 1 )
     { 
         std::ofstream output(std::string("/tmp/").append(calol1_algo_key.substr(0,calol1_algo_key.find("/"))).append(".xml"));
         output << calol1_algo_payload;
         output.close();
     }
 
+    l1t::CaloParamsHelperO2O m_params_helper( *(baseSettings.product()) );
 
+
+  if( exclusiveLayer == 0 || exclusiveLayer == 1 ){
     l1t::XmlConfigParser xmlReader1;
-    l1t::TriggerSystem calol1;
-
-if( true ){
-    xmlReader1.readDOMFromString( calol1_hw_payload );
-    xmlReader1.readRootElement  ( calol1, "calol1"  );
-} else {
-    // explicitly make the parser aware of the processors
-    calol1.addProcessor("CTP7_Phi0", "Layer1Processor","-2","-0");
-    calol1.addProcessor("CTP7_Phi1", "Layer1Processor","-2","-1");
-    calol1.addProcessor("CTP7_Phi2", "Layer1Processor","-2","-2");
-    calol1.addProcessor("CTP7_Phi3", "Layer1Processor","-2","-3");
-    calol1.addProcessor("CTP7_Phi4", "Layer1Processor","-2","-4");
-    calol1.addProcessor("CTP7_Phi5", "Layer1Processor","-2","-5");
-    calol1.addProcessor("CTP7_Phi6", "Layer1Processor","-2","-6");
-    calol1.addProcessor("CTP7_Phi7", "Layer1Processor","-2","-7");
-    calol1.addProcessor("CTP7_Phi8", "Layer1Processor","-2","-8");
-    calol1.addProcessor("CTP7_Phi9", "Layer1Processor","-2","-9");
-    calol1.addProcessor("CTP7_Phi10","Layer1Processor","-2","-10");
-    calol1.addProcessor("CTP7_Phi11","Layer1Processor","-2","-11");
-    calol1.addProcessor("CTP7_Phi12","Layer1Processor","-2","-12");
-    calol1.addProcessor("CTP7_Phi13","Layer1Processor","-2","-13");
-    calol1.addProcessor("CTP7_Phi14","Layer1Processor","-2","-14");
-    calol1.addProcessor("CTP7_Phi15","Layer1Processor","-2","-15");
-    calol1.addProcessor("CTP7_Phi16","Layer1Processor","-2","-16");
-}
-    calol1.addProcessor("defaultProc", "processors","-2","0");
-
-    //// the block of lines below allows to manage broken CaloL1 configurations
-    calol1.addProcessor("processor0", "processors","-1","-1");
-    calol1.addProcessor("processor1", "processors","-1","-2");
-    calol1.addProcessor("processor2", "processors","-1","-3");
-    calol1.addProcessor("processor3", "processors","-1","-4");
-    calol1.addProcessor("processor4", "processors","-1","-5");
-    calol1.addProcessor("processor5", "processors","-1","-6");
-    calol1.addProcessor("processor6", "processors","-1","-7");
-    calol1.addProcessor("processor7", "processors","-1","-8");
-    calol1.addProcessor("processor8", "processors","-1","-9");
-    calol1.addProcessor("processor9", "processors","-1","-10");
-    calol1.addProcessor("processor10", "processors","-1","-11");
-    calol1.addProcessor("processor11", "processors","-1","-12");
-    calol1.addProcessor("processor12", "processors","-1","-13");
-    calol1.addProcessor("processor13", "processors","-1","-14");
-    calol1.addProcessor("processor14", "processors","-1","-15");
-    calol1.addProcessor("processor15", "processors","-1","-16");
-    calol1.addProcessor("processor16", "processors","-1","-17");
-    calol1.addProcessor("processor17", "processors","-1","-18");
-    ////
-
     xmlReader1.readDOMFromString( calol1_algo_payload );
-    xmlReader1.readRootElement( calol1, "calol1" );
 
+    l1t::TriggerSystem calol1;
+    calol1.addProcessor("processors", "processors","-1","-1");
+    xmlReader1.readRootElement( calol1, "calol1" );
     calol1.setConfigured();
 
-    std::map<std::string, l1t::Parameter> calol1_conf = calol1.getParameters("defaultProc");
+    std::map<std::string, l1t::Parameter> calol1_conf = calol1.getParameters("processors");
     std::map<std::string, l1t::Mask>      calol1_rs   ;//= calol1.getMasks   ("processors");
 
+    if( !readCaloLayer1OnlineSettings(m_params_helper, calol1_conf, calol1_rs) )
+        throw std::runtime_error("Parsing error for CaloLayer1");
+  }
+
+
+  if( exclusiveLayer == 0 || exclusiveLayer == 2 ){
     l1t::TriggerSystem calol2;
 
     l1t::XmlConfigParser xmlReader2;
@@ -335,13 +338,11 @@ if( true ){
     // Perhaps layer 2 has to look at settings for demux and mp separately? // => No demux settings required
     std::map<std::string, l1t::Parameter> calol2_conf = calol2.getParameters("MP1");
     std::map<std::string, l1t::Mask>      calol2_rs   ;//= calol2.getMasks   ("processors");
-    
-    l1t::CaloParamsHelper m_params_helper( *(baseSettings.product()) );
 
-    if( !readCaloLayer1OnlineSettings(m_params_helper, calol1_conf, calol1_rs) )
-        throw std::runtime_error("Parsing error for CaloLayer1");
     if( !readCaloLayer2OnlineSettings(m_params_helper, calol2_conf, calol2_rs) )
         throw std::runtime_error("Parsing error for CaloLayer2");
+  }
+    
 
     std::shared_ptr< l1t::CaloParams > retval = std::make_shared< l1t::CaloParams >( m_params_helper ) ;
     return retval;
@@ -349,4 +350,5 @@ if( true ){
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(L1TCaloParamsOnlineProd);
+
 

--- a/L1TriggerConfig/Utilities/test/uploadCaloParams.py
+++ b/L1TriggerConfig/Utilities/test/uploadCaloParams.py
@@ -9,12 +9,12 @@ process.MessageLogger.debugModules = cms.untracked.vstring('*')
 process.source = cms.Source("EmptySource", firstRun = cms.untracked.uint32(3))
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
-process.load("L1Trigger.L1TCalorimeter.caloStage2Params_2016_v3_3_cfi")
+process.load("L1Trigger.L1TCalorimeter.caloStage2Params_2017_v1_7_cfi")
 
 process.getter = cms.EDAnalyzer("EventSetupRecordDataGetter",
    toGet = cms.VPSet(
        cms.PSet(
-           record = cms.string('L1TCaloStage2ParamsRcd'),
+           record = cms.string('L1TCaloParamsRcd'),
            data   = cms.vstring('CaloParams')
        )
    ),
@@ -29,7 +29,7 @@ outputDB = cms.Service("PoolDBOutputService",
                        CondDB,
                        toPut   = cms.VPSet(
                            cms.PSet(
-                               record = cms.string('L1TCaloStage2ParamsRcd'),
+                               record = cms.string('L1TCaloParamsRcd'),
                                tag = cms.string('L1TCaloParamsPrototype_Stage2v0_hlt')
                            )
                        )


### PR DESCRIPTION
This PR supersedes PR #18872.
It includes recent development of CaloL2 including tauTrimmingVeto LUT and several commits for removing  Stage2 from CaloParams record names.