### PR TITLE
Use std::min instead of TMath::Min in JetUtil.h

### DIFF
--- a/HLTrigger/HLTanalyzers/interface/JetUtil.h
+++ b/HLTrigger/HLTanalyzers/interface/JetUtil.h
@@ -2,6 +2,7 @@
 #define JET_JETUTIL_H 1
 
 #include <cmath>
+#include <algorithm>
 
 class PtGreater {
   public:
@@ -46,7 +47,7 @@ static double radius(double eta1, double phi1,double eta2, double phi2){
   phi2=Phi_0_2pi(phi2);
  
   double dphi=Phi_0_2pi(phi1-phi2);
-  dphi = TMath::Min(dphi,TWOPI-dphi);
+  dphi = std::min(dphi,TWOPI-dphi);
   double deta = eta1-eta2;
  
   return sqrt(deta*deta+dphi*dphi);


### PR DESCRIPTION
TMath::Min doesn't compile because there is no include for ROOT's
math header in this file. So instead we just use the STL min function.