### PR TITLE
Add include for RPFlatParams.h to LoadEPDB.h

### DIFF
--- a/RecoHI/HiEvtPlaneAlgos/interface/LoadEPDB.h
+++ b/RecoHI/HiEvtPlaneAlgos/interface/LoadEPDB.h
@@ -7,6 +7,8 @@
 #include <string>
 
 // user include files
+#include "CondFormats/HIObjects/interface/RPFlatParams.h"
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 


### PR DESCRIPTION
We use the RPFlatParams class in this file, so we also need
to include it's corresponding header to make this header compile
on it's own.