### PR TITLE
DataFormats/L1Trigger: fix to allow dictionary library to compile on macOS with gcc6.3.0

### DIFF
--- a/DataFormats/L1Trigger/interface/Jet.h
+++ b/DataFormats/L1Trigger/interface/Jet.h
@@ -36,7 +36,7 @@ namespace l1t {
   void setRawEt(short int et);    // raw (uncalibrated) cluster sum
   void setSeedEt(short int et);
   void setPUEt(short int et);
-  void setPUDonutEt(uint i, short int et);
+  void setPUDonutEt(unsigned int i, short int et);
 
   short int towerIEta() const;
   short int towerIPhi() const;

--- a/DataFormats/L1Trigger/src/Jet.cc
+++ b/DataFormats/L1Trigger/src/Jet.cc
@@ -55,7 +55,7 @@ void Jet::setPUEt(short int et) {
   puEt_ = et;
 }
 
-void Jet::setPUDonutEt(uint i, short int et) {
+void Jet::setPUDonutEt(unsigned int i, short int et) {
   if (i<4) puDonutEt_[i] = et;
 }
 


### PR DESCRIPTION
On macOS uint is not defined for gcc6. Change uint to unsigned int to allow genereflex to work. Updated classes_def.xml because function signature changed. Found while compiling fwlite on macOS 10.10 and 10.12 with gcc 6.3.0.