### PR TITLE
Fix precise setting for CaloSamplesAnalyzer with HPDs

### DIFF
--- a/SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h
@@ -12,7 +12,7 @@ public:
   CaloShapes(): theShape(0) {}
   // doesn't take ownership of the pointer
   CaloShapes(const CaloVShape * shape) : theShape(shape) {}
-  virtual const CaloVShape * shape(const DetId & detId) const {return theShape;}
+  virtual const CaloVShape * shape(const DetId & detId, bool precise=false) const {return theShape;}
   virtual ~CaloShapes() = default;
 private:
   const CaloVShape * theShape;

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -123,7 +123,7 @@ CaloSamples CaloHitResponse::makeAnalogSignal(const PCaloHit & hit, CLHEP::HepRa
 
   const CaloVShape * shape = theShape;
   if(!shape) {
-    shape = theShapes->shape(detId);
+    shape = theShapes->shape(detId,storePrecise);
   }
   // assume bins count from zero, go for center of bin
   const double tzero = ( shape->timeToRise()

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -25,15 +25,17 @@ public:
   void beginRun(edm::EventSetup const & es);
   void endRun();
 
-  virtual const CaloVShape * shape(const DetId & detId) const;
+  virtual const CaloVShape * shape(const DetId & detId, bool precise=false) const;
 
 private:
+  typedef std::map<int, const CaloVShape *> ShapeMap;
   // hardcoded, if we can't figure it out from the DB
-  const CaloVShape * defaultShape(const DetId & detId) const;
+  const CaloVShape * defaultShape(const DetId & detId, bool precise=false) const;
+  const ShapeMap& getShapeMap(bool precise) const;
   HcalMCParams * theMCParams;
   const HcalTopology * theTopology;
-  typedef std::map<int, const CaloVShape *> ShapeMap;
   ShapeMap theShapes;
+  ShapeMap theShapesPrecise;
   ZDCShape theZDCShape;
   //   list of vShapes.
   HcalShape theHcalShape101;

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalShapes.h
@@ -9,6 +9,7 @@
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloShapes.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalShape.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/ZDCShape.h"
+#include <vector>
 #include <map>
 class CaloVShape;
 class DetId;
@@ -38,20 +39,7 @@ private:
   ShapeMap theShapesPrecise;
   ZDCShape theZDCShape;
   //   list of vShapes.
-  HcalShape theHcalShape101;
-  HcalShape theHcalShape102;
-  HcalShape theHcalShape103;
-  HcalShape theHcalShape104;
-  HcalShape theHcalShape105;
-  HcalShape theHcalShape123;
-  HcalShape theHcalShape124;
-  HcalShape theHcalShape125;
-  HcalShape theHcalShape201;
-  HcalShape theHcalShape202;
-  HcalShape theHcalShape203;
-  HcalShape theHcalShape205;
-  HcalShape theHcalShape301;
-  HcalShape theHcalShape401;
+  std::vector<HcalShape> theHcalShapes;
 
 };
 

--- a/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalShapes.cc
@@ -10,24 +10,8 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 HcalShapes::HcalShapes()
-: theMCParams(0),
-  theShapes(),
-  theShapesPrecise(),
-  theZDCShape(),
-  theHcalShape101(),
-  theHcalShape102(),
-  theHcalShape103(),
-  theHcalShape104(),
-  theHcalShape105(),
-  theHcalShape123(),
-  theHcalShape124(),
-  theHcalShape125(),
-  theHcalShape201(),
-  theHcalShape202(),
-  theHcalShape203(),
-  theHcalShape205(),
-  theHcalShape301(),
-  theHcalShape401()
+: theMCParams(nullptr),
+  theTopology(nullptr)
  {
 /*
          00 - not used (reserved)
@@ -40,62 +24,27 @@ HcalShapes::HcalShapes()
         401 - regular ZDC shape
   */
 
-  theHcalShape101.setShape(101); 
-  theShapesPrecise[101] = &theHcalShape101;
-  theShapes[101] = new CaloCachedShapeIntegrator(&theHcalShape101);
-  theHcalShape102.setShape(102);                  
-  theShapesPrecise[102] = &theHcalShape102;
-  theShapes[102] = new CaloCachedShapeIntegrator(&theHcalShape102);
-  theHcalShape103.setShape(103);                  
-  theShapesPrecise[103] = &theHcalShape103;
-  theShapes[103] = new CaloCachedShapeIntegrator(&theHcalShape103);
-  theHcalShape104.setShape(104);                  
-  theShapesPrecise[104] = &theHcalShape104;
-  theShapes[104] = new CaloCachedShapeIntegrator(&theHcalShape104);
-  theHcalShape105.setShape(105);
-  theShapesPrecise[105] = &theHcalShape105;
-  theShapes[105] = new CaloCachedShapeIntegrator(&theHcalShape105); // HPD reco
-  theHcalShape123.setShape(123);                  
-  theShapesPrecise[123] = &theHcalShape123;
-  theShapes[123] = new CaloCachedShapeIntegrator(&theHcalShape123);
-  theHcalShape124.setShape(124);                  
-  theShapesPrecise[124] = &theHcalShape124;
-  theShapes[124] = new CaloCachedShapeIntegrator(&theHcalShape124);
-  theHcalShape125.setShape(125);
-  theShapesPrecise[125] = &theHcalShape125;
-  theShapes[125] = new CaloCachedShapeIntegrator(&theHcalShape125);
-  theHcalShape201.setShape(201);                  
-  theShapesPrecise[201] = &theHcalShape201;
-  theShapes[201] = new CaloCachedShapeIntegrator(&theHcalShape201);
-  theHcalShape202.setShape(202);                  
-  theShapesPrecise[202] = &theHcalShape202;
-  theShapes[202] = new CaloCachedShapeIntegrator(&theHcalShape202);
-  theHcalShape203.setShape(203);
-  theShapesPrecise[203] = &theHcalShape203;
-  theShapes[203] = new CaloCachedShapeIntegrator(&theHcalShape203);
-  theHcalShape205.setShape(205);
-  theShapesPrecise[205] = &theHcalShape205;
-  theShapes[205] = new CaloCachedShapeIntegrator(&theHcalShape205);
-  theHcalShape301.setShape(301);
-  theShapesPrecise[301] = &theHcalShape301;
-  theShapes[301] = new CaloCachedShapeIntegrator(&theHcalShape301);
-  //    ZDC not yet defined in CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
-  // theHcalShape401(401);
-  // theShapes[401] = new CaloCachedShapeIntegrator(&theHcalShape401);
+  std::vector<int> theHcalShapeNums = {101,102,103,104,105,123,124,125,201,202,203,205,301};
+  // use resize so vector won't invalidate pointers by reallocating memory while filling
+  theHcalShapes.resize(theHcalShapeNums.size());
+  for(unsigned inum = 0; inum < theHcalShapeNums.size(); ++inum){
+    int num = theHcalShapeNums[inum];
+    theHcalShapes[inum].setShape(num);
+    theShapesPrecise[num] = &theHcalShapes[inum];
+    theShapes[num] = new CaloCachedShapeIntegrator(&theHcalShapes[inum]);
+  }
+
+  // ZDC not yet defined in CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
   theShapesPrecise[ZDC] = &theZDCShape;
   theShapes[ZDC] = new CaloCachedShapeIntegrator(&theZDCShape);
-
-  theMCParams=0;
-  theTopology=0;
 }
 
 
 HcalShapes::~HcalShapes()
 {
-  for(ShapeMap::const_iterator shapeItr = theShapes.begin();
-      shapeItr != theShapes.end();  ++shapeItr)
+  for(auto& shapeItr : theShapes)
   {
-    delete shapeItr->second;
+    delete shapeItr.second;
   }
   theShapes.clear();
   if (theMCParams!=0) delete theMCParams;
@@ -134,7 +83,7 @@ const CaloVShape * HcalShapes::shape(const DetId & detId, bool precise) const
   }
   int shapeType = theMCParams->getValues(detId)->signalShape();
   const auto& myShapes = getShapeMap(precise);
-  ShapeMap::const_iterator shapeMapItr = myShapes.find(shapeType);
+  auto shapeMapItr = myShapes.find(shapeType);
   if(shapeMapItr == myShapes.end()) {
        edm::LogWarning("HcalShapes") << "HcalShapes::shape - shapeType ?  = "
 				     << shapeType << std::endl;


### PR DESCRIPTION
In #16907, I added a tool called [CaloSamplesAnalyzer](https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/HcalSimAlgos/test/CaloSamplesAnalyzer.cc) to help debug intermediate stages of the HCAL digitization simulation. This included a special "precise" option for the HPD simulation, to get per-nanosecond `CaloSamples` (instead of just per-timeslice=per-25ns).

However, it was recently pointed out to me that activating this debugging option caused the output digis to change. This is because the HPD pulse shape is integrated over 25ns by the `CaloCachedShapeIntegrator` *before* it is used by the simulation - so the "precise" setting was effectively integrating the pulse twice. To resolve this, I made a separate map of un-integrated pulses to be used in "precise" mode. I also cleaned up the `HcalShapes` code, to make it more maintainable and modern.

This PR should not change any standard results. The observed problem was only seen in a special debugging mode.