### PR TITLE
Adding useful channel id mappings

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalDetIdTransform.h
+++ b/CondFormats/HcalObjects/interface/HcalDetIdTransform.h
@@ -13,6 +13,8 @@ namespace HcalDetIdTransform
         IETA,         // ieta() + shift
         IETAABS,      // ietaAbs()
         SUBDET,       // subdetId()
+        IETADEPTH,    // maps ieta() and depth() into a unique number
+        IETAABSDEPTH, // maps ietaAbs() and depth() into a unique number
         N_TRANSFORMS
     };
 

--- a/CondFormats/HcalObjects/src/HcalDetIdTransform.cc
+++ b/CondFormats/HcalObjects/src/HcalDetIdTransform.cc
@@ -8,6 +8,7 @@ namespace HcalDetIdTransform
     unsigned transform(const HcalDetId& id, const unsigned transformCode)
     {
         static const int ietaShift = 1024;
+        static const int maxHcalDepth = 64;
 
         if (transformCode >= N_TRANSFORMS)
             throw cms::Exception("In HcalDetIdTransform::transform:"
@@ -29,6 +30,14 @@ namespace HcalDetIdTransform
 
         case SUBDET:
             t = id.subdetId();
+            break;
+
+        case IETADEPTH:
+            t = (id.ieta() + ietaShift)*maxHcalDepth + id.depth();
+            break;
+
+        case IETAABSDEPTH:
+            t = id.ietaAbs()*maxHcalDepth + id.depth();
             break;
 
         default:


### PR DESCRIPTION
This modification allows to group Hcal channels by eta and depth for writing calibration constants with "HcalItemCollById" collections.

There are no such entries in the CMS database yet, so this modification will not change any existing relval results.
