### PR TITLE
Use modern way to initialize ROOT for multi-threading

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1966,11 +1966,6 @@ namespace edm {
     }
 
     ServiceRegistry::Operate operate(serviceToken_);
-    if(preallocations_.numberOfThreads()>1) {
-      edm::Service<RootHandlers> handler;
-      handler->initializeThisThreadForUse();
-    }
-
     try {
       //need to use lock in addition to the serial task queue because
       // of delayed provenance reading and reading data in response to

--- a/FWCore/Utilities/interface/RootHandlers.h
+++ b/FWCore/Utilities/interface/RootHandlers.h
@@ -30,7 +30,6 @@ namespace edm {
     
   private:
     virtual void willBeUsingThreads() = 0;
-    virtual void initializeThisThreadForUse() = 0;
     
     virtual void enableWarnings_() = 0;
     virtual void ignoreWarnings_() = 0;


### PR DESCRIPTION
ROOT no longer needs to be told about each thread being used. Now one just needs to call ROOT::EnableThreadSafety.