### PR TITLE
Fix the Phase2 Tracker digis (for MC truth matching)

### DIFF
--- a/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h
+++ b/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h
@@ -35,7 +35,7 @@ public:
   unsigned int strip()   const { return row(); }
   unsigned int edge()    const { return column(); } // CD: any better name for that? 
   // Access to the (raw) channel number
-  unsigned int channel() const { return theChannel; }
+  unsigned int channel() const { return 0x7FFF & theChannel; }
   // Access Overthreshold bit
   bool overThreshold() const { return (otBit(theChannel) ? true : false); }
 


### PR DESCRIPTION
A bug was found in the tracker digi dataformat. The channel() should only return the encoded channel, not the otbit encoded in the same integer. Failing do to so induces problem when matching with the simhits because the channel from the digis and from the digisimlink may differ. Indeed there is no ot_flag in the digisimlink class.

Applying a mask to get the encoded channel was already available in a dedicated method, but not in the channel() method used all over the place.

Thanks to Roberto Rossin for pointing this bug and @sviret for locating the problem.

@boudoul, @suchandradutta, @atricomi  FYI...

I join a [plot](https://github.com/cms-sw/cmssw/files/1074581/FixedDigiMuPU0-1.pdf) making the comparison for PU0 muons. I show the number of layers with stubs (nhits) with (black) and without (red) the fix. 
