### PR TITLE
MC GT updates with Reco BeamSpot, JECs for HLT and SiPixelQuality along with GEN-SIM samples update for RelVals

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -39,19 +39,19 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '91X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '92X_upgrade2017_design_IdealBS_v1',
+    'phase1_2017_design'       :  '92X_upgrade2017_design_IdealBS_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    : '92X_upgrade2017_realistic_v1',
+    'phase1_2017_realistic'    : '92X_upgrade2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      : '92X_upgrade2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      : '92X_upgrade2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' : '92X_upgrade2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' : '92X_upgrade2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       : '92X_upgrade2018_design_IdealBS_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    : '92X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    : '92X_upgrade2018_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '92X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '92X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'       : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1741,7 +1741,7 @@ steps['DBLMINIAODMCUP15NODQM'] = merge([{'--conditions':'auto:run2_mc',
 from  Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
 
 defaultDataSets={}
-defaultDataSets['2017']='CMSSW_9_2_1-92X_upgrade2017_realistic_v1-v'
+defaultDataSets['2017']='CMSSW_9_2_3-92X_upgrade2017_realistic_v1_earlyBS2017-v'
 defaultDataSets['2017Design']='CMSSW_9_2_1-92X_upgrade2017_design_IdealBS_v1-v'
 #defaultDataSets['2018']='CMSSW_8_1_0_pre16-81X_upgrade2017_realistic_v22-v'
 #defaultDataSets['2018Design']='CMSSW_8_1_0_pre16-81X_upgrade2017_design_IdealBS_v6-v'
@@ -1808,7 +1808,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     upgradeStepDict['GenSimFull'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
-                                       '--beamspot' : 'Realistic50ns13TeVCollision',
+                                       '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
                                        '--datatier' : 'GEN-SIM',
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom


### PR DESCRIPTION
This PR contains the MC GT updates explained below as well as update of Gen-SIM samples for relvals with new BeamSpot measurement.
# Summary of changes in Global Tags

## Upgrade

   * **PhaseI 2017 cosmics peak scenario** : [92X_upgrade2017cosmics_realistic_peak_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017cosmics_realistic_peak_v2) as [92X_upgrade2017cosmics_realistic_peak_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017cosmics_realistic_peak_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_upgrade2017cosmics_realistic_peak_v2/92X_upgrade2017cosmics_realistic_peak_v1):
      * RECO Beamspot update
      * JECS for HLT
      * SiPixel channel quality to v4 announced here https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2995/1/2.html

   * **PhaseI 2017 cosmics scenario** : [92X_upgrade2017cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017cosmics_realistic_deco_v2) as [92X_upgrade2017cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017cosmics_realistic_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_upgrade2017cosmics_realistic_deco_v2/92X_upgrade2017cosmics_realistic_deco_v1):
      * RECO Beamspot update for 2017
      * JECs for HLT
      * SiPixel channel quality to v4 announced here https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2995/1/2.html

   * **PhaseI 2017 design scenario** : [92X_upgrade2017_design_IdealBS_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017_design_IdealBS_v2) as [92X_upgrade2017_design_IdealBS_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017_design_IdealBS_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_upgrade2017_design_IdealBS_v2/92X_upgrade2017_design_IdealBS_v1):
      * JECs for HLT

   * **PhaseI 2017 realistic scenario** : [92X_upgrade2017_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017_realistic_v2) as [92X_upgrade2017_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2017_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_upgrade2017_realistic_v2/92X_upgrade2017_realistic_v1):
      * RECO Beamspot update
      * JECS for HLT
      * SiPixel channel quality to v4 announced here https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2995/1/2.html

   * **PhaseI 2018 cosmics scenario** : [92X_upgrade2018cosmics_realistic_deco_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2018cosmics_realistic_deco_v2) as [92X_upgrade2018cosmics_realistic_deco_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2018cosmics_realistic_deco_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_upgrade2018cosmics_realistic_deco_v2/92X_upgrade2018cosmics_realistic_deco_v1):
      * RECO Beamspot update for 2017
      * SiPixel channel quality to v4 announced here https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2995/1/2.html

   * **PhaseI 2018 realistic scenario** : [92X_upgrade2018_realistic_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2018_realistic_v2) as [92X_upgrade2018_realistic_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/92X_upgrade2018_realistic_v1) with the following [changes](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/92X_upgrade2018_realistic_v2/92X_upgrade2018_realistic_v1):
      * RECO Beamspot update
      * SiPixel channel quality to v4 announced here https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/2995/1/2.html
