### PR TITLE
initial pr for the sistrip control view dqm plots

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -142,6 +142,9 @@ private:
     bool ok
   );
 
+  bool fillControlViewHistos(const edm::Event& ev, const edm::EventSetup& es);
+  void return2DME(MonitorElement* input, int binx, int biny, double value);
+
   // fill monitorables
 //  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, const uint32_t detid, const LocalVector LV);
 //  void fillMEs(SiStripClusterInfo*,const uint32_t detid, float,enum ClusterFlags,  const LocalVector LV, const Det2MEs& MEs);
@@ -288,5 +291,19 @@ private:
   SiStripDCSStatus* dcsStatus_;
   GenericTriggerEventFlag* genTriggerEventFlag_;
   SiStripFolderOrganizer folderOrganizer_;
+
+
+  // control view plots
+  MonitorElement* ClusterStoNCorr_OnTrack_TIBTID = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_TOB    = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_TECM   = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_TECP   = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_FECCratevsFECSlot = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TOB    = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECM   = 0;
+  MonitorElement* ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP   = 0;
+
+
 };
 #endif

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -1207,15 +1207,14 @@ bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev, const edm:
   if( !tracks.isValid() )     return false;
 
   // loop over the tracks
-  for( reco::TrackCollection::const_iterator track = tracks->begin();
-       track != tracks->end(); ++track ) {
+  for ( const auto & track : *tracks) {
 
     // loop over the rechits of this track
-    for (trackingRecHit_iterator hit = track->recHitsBegin(), ehit = track->recHitsEnd();
+    for (trackingRecHit_iterator hit = track.recHitsBegin(), ehit = track.recHitsEnd();
          hit!=ehit; ++hit) {
 
       uint32_t thedetid = (*hit)->rawId();
-      if ( !(SiStripDetId(thedetid).subDetector() >=3 &&  SiStripDetId(thedetid).subDetector() <=6) ) { continue; }
+      if ( !(DetId(thedetid).subdetId() >=3 &&  DetId(thedetid).subdetId() <=6) ) { continue; }
 
       if (!(*hit)->isValid()) continue;
 
@@ -1243,45 +1242,46 @@ bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev, const edm:
       }
 
 
-      std::vector<const FedChannelConnection *> getFedChanConnections; getFedChanConnections.clear();
+      std::vector<const FedChannelConnection *> getFedChanConnections; 
       getFedChanConnections = SiStripDetCabling_->getConnections(thedetid);
 
-      SiStripFolderOrganizer folder_organizer;
-      TString sistripsubdet = folder_organizer.getSubDetFolderAndTag(thedetid, tTopo).second;
+      //      SiStripFolderOrganizer folder_organizer;
+      //      std::string sistripsubdet = folder_organizer.getSubDetFolderAndTag(thedetid, tTopo).second;
 
       // loop over the fed chan connections
-      for (unsigned int i0=0; i0<getFedChanConnections.size(); ++i0) {
+      for ( const auto & getFedChanConnection : getFedChanConnections ) {
 
-        if (getFedChanConnections[i0]==0) { continue; }
+        if (getFedChanConnection==0) { continue; }
 
-        int binfeccrate = getFedChanConnections[i0]->fecCrate();
-        int binfecslot  = getFedChanConnections[i0]->fecSlot();
-        int binfecring  = getFedChanConnections[i0]->fecRing();
+        int binfeccrate = getFedChanConnection->fecCrate();
+        int binfecslot  = getFedChanConnection->fecSlot();
+        int binfecring  = getFedChanConnection->fecRing();
         //int binccuchan  = getFedChanConnections[i0]->ccuChan(); //will be used in a new PR
         //int binccuadd   = getFedChanConnections[i0]->ccuAddr(); //will be used in a new PR
 
         return2DME(ClusterStoNCorr_OnTrack_FECCratevsFECSlot,binfecslot,binfeccrate,sovn);
 
 	// TIB/TID
-        if ((sistripsubdet.Contains("TIB")) || (sistripsubdet.Contains("TID"))) {
-          ClusterStoNCorr_OnTrack_TIBTID->Fill(sovn);
+	//        if ((sistripsubdet.find("TIB")) || (sistripsubdet.find("TID"))) {
+        if ((DetId(thedetid).subdetId()==SiStripDetId::TIB) || ((DetId(thedetid).subdetId()==SiStripDetId::TID)) ) {
+	  ClusterStoNCorr_OnTrack_TIBTID->Fill(sovn);
           return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID,binfecring,binfecslot,sovn);
         }
 
 	// TOB
-        if (sistripsubdet.Contains("TOB")) {
+        if ( DetId(thedetid).subdetId()==SiStripDetId::TOB ) {
           ClusterStoNCorr_OnTrack_TOB->Fill(sovn);
           return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TOB,binfecring,binfecslot,sovn);
         }
 
         // TECM
-        if (sistripsubdet.Contains("TEC__MINUS")) {
+        if ( (DetId(thedetid).subdetId()==SiStripDetId::TEC) && (tTopo->tecSide(thedetid)==1) ) {
           ClusterStoNCorr_OnTrack_TECM->Fill(sovn);
           return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECM,binfecring,binfecslot,sovn);
         }
 
 	// TECP
-        if (sistripsubdet.Contains("TEC__PLUS")) {
+        if ( (DetId(thedetid).subdetId()==SiStripDetId::TEC) && (tTopo->tecSide(thedetid)==2) ) {
           ClusterStoNCorr_OnTrack_TECP->Fill(sovn);
           return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP,binfecring,binfecslot,sovn);
         }

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -123,6 +123,8 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es
   std::map<std::string, MonitorElement*>::iterator iME;
   std::map<std::string, LayerMEs>::iterator        iLayerME;
 
+  fillControlViewHistos(e,es);
+
   if (Trend_On_) {
  // for (std::map<std::string, SubDetMEs>::iterator iSubDet = SubDetMEsMap.begin(), iterEnd=SubDetMEsMaps.end();
  //      iSubDet != iterEnd; ++iSubDet) {
@@ -269,6 +271,58 @@ void SiStripMonitorTrack::book(DQMStore::IBooker & ibooker , const TrackerTopolo
       }
     }//end loop on detectors detid
   }
+
+
+  //book control view plots
+  ibooker.setCurrentFolder(topFolderName_+"/ControlView/");
+
+  ClusterStoNCorr_OnTrack_TIBTID =
+    ibooker.book1D("ClusterStoNCorr_OnTrack_TIBTID","TIB/TID [FECCrate=1] (OnTrack)",100,0.,100.);
+  ClusterStoNCorr_OnTrack_TIBTID->setAxisTitle("S/N",1);
+
+  ClusterStoNCorr_OnTrack_TOB =
+    ibooker.book1D("ClusterStoNCorr_OnTrack_TOB","TOB [FECCrate=4] (OnTrack)",100,0.,100.);
+  ClusterStoNCorr_OnTrack_TOB->setAxisTitle("S/N",1);
+
+  ClusterStoNCorr_OnTrack_TECM =
+    ibooker.book1D("ClusterStoNCorr_OnTrack_TECM","TECM [FECCrate=3] (OnTrack)",100,0.,100.);
+  ClusterStoNCorr_OnTrack_TECM->setAxisTitle("S/N",1);
+
+  ClusterStoNCorr_OnTrack_TECP =
+    ibooker.book1D("ClusterStoNCorr_OnTrack_TECP","TECP [FECCrate=2] (OnTrack)",100,0.,100.);
+  ClusterStoNCorr_OnTrack_TECP->setAxisTitle("S/N",1);
+
+
+  ClusterStoNCorr_OnTrack_FECCratevsFECSlot =
+    ibooker.book2D("ClusterStoNCorr_OnTrack_FECCratevsFECSlot"," S/N (On track)",22,0.5,22.5,4,0.5,4.5);
+  ClusterStoNCorr_OnTrack_FECCratevsFECSlot->setAxisTitle("FEC Slot",1);
+  ClusterStoNCorr_OnTrack_FECCratevsFECSlot->setAxisTitle("FEC Crate (TTC partition)",2);
+  ClusterStoNCorr_OnTrack_FECCratevsFECSlot->setBinLabel(1,"TIB/TID",2);
+  ClusterStoNCorr_OnTrack_FECCratevsFECSlot->setBinLabel(2,"TEC+",2);
+  ClusterStoNCorr_OnTrack_FECCratevsFECSlot->setBinLabel(3,"TEC-",2);
+  ClusterStoNCorr_OnTrack_FECCratevsFECSlot->setBinLabel(4,"TOB",2);
+
+ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID =
+  ibooker.book2D("ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID","TIB/TID [FECCrate=1] (OnTrack)",10,-0.5,9.5,22,0.5,22.5)\
+  ;
+ ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID->setAxisTitle("FEC Ring",1);
+ ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID->setAxisTitle("FEC Slot",2);
+
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TOB =
+    ibooker.book2D("ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TOB","TOB [FECCrate=4] (OnTrack)",10,-0.5,9.5,22,0.5,22.5);
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TOB->setAxisTitle("FEC Ring",1);
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TOB->setAxisTitle("FEC Slot",2);
+
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECM =
+    ibooker.book2D("ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECM","TEC- [FECCrate=3] (OnTrack)",10,-0.5,9.5,22,0.5,22.5);
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECM->setAxisTitle("FEC Ring",1);
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECM->setAxisTitle("FEC Slot",2);
+
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP =
+    ibooker.book2D("ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP","TEC- [FECCrate=2] (OnTrack)",10,-0.5,9.5,22,0.5,22.5);
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP->setAxisTitle("FEC Ring",1);
+  ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP->setAxisTitle("FEC Slot",2);
+
 }
 
 //--------------------------------------------------------------------------------
@@ -1142,6 +1196,111 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 
   return me;
 }
+
+
+bool SiStripMonitorTrack::fillControlViewHistos(const edm::Event& ev, const edm::EventSetup& es) {
+
+  edm::Handle<reco::TrackCollection > tracks;
+  ev.getByToken(trackToken_, tracks);//takes the track collection
+
+  //check that tracks are valid
+  if( !tracks.isValid() )     return false;
+
+  // loop over the tracks
+  for( reco::TrackCollection::const_iterator track = tracks->begin();
+       track != tracks->end(); ++track ) {
+
+    // loop over the rechits of this track
+    for (trackingRecHit_iterator hit = track->recHitsBegin(), ehit = track->recHitsEnd();
+         hit!=ehit; ++hit) {
+
+      uint32_t thedetid = (*hit)->rawId();
+      if ( !(SiStripDetId(thedetid).subDetector() >=3 &&  SiStripDetId(thedetid).subDetector() <=6) ) { continue; }
+
+      if (!(*hit)->isValid()) continue;
+
+      const TrackingRecHit* theHit = (*hit);
+      if ( theHit == NULL ) { continue; }
+
+      edm::ESHandle<TrackerTopology> tTopoHandle;
+      es.get<TrackerTopologyRcd>().get(tTopoHandle);
+      const TrackerTopology* const tTopo = tTopoHandle.product();
+
+      const SiStripRecHit1D* hit1D = dynamic_cast<const SiStripRecHit1D*>( theHit );
+      const SiStripRecHit2D* hit2D = dynamic_cast<const SiStripRecHit2D*>( theHit );
+
+      float sovn = -1.;
+      if (hit1D && !hit2D) {
+        const SiStripCluster* SiStripCluster_ = &*(hit1D->cluster());
+        SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_,es,thedetid);
+        sovn = SiStripClusterInfo_.signalOverNoise();
+      }
+
+      else if (!hit1D && hit2D) {
+        const SiStripCluster* SiStripCluster_ = &*(hit2D->cluster());
+        SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_,es,thedetid);
+        sovn = SiStripClusterInfo_.signalOverNoise();
+      }
+
+
+      std::vector<const FedChannelConnection *> getFedChanConnections; getFedChanConnections.clear();
+      getFedChanConnections = SiStripDetCabling_->getConnections(thedetid);
+
+      SiStripFolderOrganizer folder_organizer;
+      TString sistripsubdet = folder_organizer.getSubDetFolderAndTag(thedetid, tTopo).second;
+
+      // loop over the fed chan connections
+      for (unsigned int i0=0; i0<getFedChanConnections.size(); ++i0) {
+
+        if (getFedChanConnections[i0]==0) { continue; }
+
+        int binfeccrate = getFedChanConnections[i0]->fecCrate();
+        int binfecslot  = getFedChanConnections[i0]->fecSlot();
+        int binfecring  = getFedChanConnections[i0]->fecRing();
+        //int binccuchan  = getFedChanConnections[i0]->ccuChan(); //will be used in a new PR
+        //int binccuadd   = getFedChanConnections[i0]->ccuAddr(); //will be used in a new PR
+
+        return2DME(ClusterStoNCorr_OnTrack_FECCratevsFECSlot,binfecslot,binfeccrate,sovn);
+
+	// TIB/TID
+        if ((sistripsubdet.Contains("TIB")) || (sistripsubdet.Contains("TID"))) {
+          ClusterStoNCorr_OnTrack_TIBTID->Fill(sovn);
+          return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TIBTID,binfecring,binfecslot,sovn);
+        }
+
+	// TOB
+        if (sistripsubdet.Contains("TOB")) {
+          ClusterStoNCorr_OnTrack_TOB->Fill(sovn);
+          return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TOB,binfecring,binfecslot,sovn);
+        }
+
+        // TECM
+        if (sistripsubdet.Contains("TEC__MINUS")) {
+          ClusterStoNCorr_OnTrack_TECM->Fill(sovn);
+          return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECM,binfecring,binfecslot,sovn);
+        }
+
+	// TECP
+        if (sistripsubdet.Contains("TEC__PLUS")) {
+          ClusterStoNCorr_OnTrack_TECP->Fill(sovn);
+          return2DME(ClusterStoNCorr_OnTrack_FECSlotVsFECRing_TECP,binfecring,binfecslot,sovn);
+        }
+
+      } // end of looping over the fed chan connections
+    } // end of looping over the rechits of the track
+  } // end of looping over the tracks
+
+  return true;
+}
+
+
+void SiStripMonitorTrack::return2DME(MonitorElement* input, int binx, int biny, double value) {
+
+  if (input->getBinContent(binx,biny)==0.) { input->setBinContent(binx,biny,value); }
+  else { input->setBinContent(binx,biny,((input->getBinContent(binx,biny)+value)/2.)); }
+
+}
+
 
 //------------------------------------------------------------------------
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"


### PR DESCRIPTION
This PR produces a set of DQM plots for the SiStrip subdetector. The plots currently in DQM are organized based on the "Mechanical View" [i.e. physical subdetectors: TEC+/-, TID, TOB, TIB]. This is not always very useful to spot issues on the Control side. Hence I ve put a new dir in the SiSTrip DQM directory that is organized based on the SiStrip partiions seen in the DAQ [TEC+, TEC-, TOB, TIB/TOB] The first set of plots inlcudes: S/N for each TTC partition, FECSlot vs FEC Ring and FECCratevsFECSlot