### PR TITLE
Deprecation of T**DetID and PX*DetID in Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc

### DIFF
--- a/Alignment/TrackerAlignment/plugins/BuildFile.xml
+++ b/Alignment/TrackerAlignment/plugins/BuildFile.xml
@@ -67,6 +67,7 @@
   <use   name="DataFormats/Common"/>
   <use   name="DataFormats/RecoCandidate"/>
   <use   name="DataFormats/TrackReco"/>
+  <use   name="Geometry/TrackerNumberingBuilder"/>
   <use   name="root"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -49,6 +49,7 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLatency.h"                
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "DataFormats/Provenance/interface/Timestamp.h"
 
@@ -56,10 +57,6 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
@@ -230,6 +227,9 @@ CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
    edm::ESHandle<MagneticField> magfield;
    iSetup.get<IdealMagneticFieldRecord>().get(magfield);
 
+   edm::ESHandle<TrackerTopology> tTopo;
+   iSetup.get<TrackerTopologyRcd>().get(tTopo);
+
    edm::Timestamp ts_begin = iEvent.getRun().beginTime();
    double t_begin = stampToReal(ts_begin);
    edm::Timestamp ts_end = iEvent.getRun().endTime();
@@ -299,8 +299,8 @@ CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
           else if (SiStripDetId::TEC == subdetId1)
           { 
              ++nhitinTEC;
-             TECDetId tecId1(detId1);
-             if (tecId1.isZMinusSide()) 
+ 
+             if (tTopo->tecIsZMinusSide(detId1))
              {
                 ++nhitinTECminus;
              }
@@ -315,7 +315,6 @@ CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
           else if (SiStripDetId::TOB == subdetId1)
           {
              ++nhitinTOB;
-             TOBDetId tobId1(detId1);
           }
 //////////////////////////////////////////////////////////////////////////////////////////////////
 //			Hit information in TIB		                                	//
@@ -323,7 +322,6 @@ CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
           else if (SiStripDetId::TIB == subdetId1)
           { 
              ++nhitinTIB;
-             TIBDetId tibId1(detId1);
           }
 //////////////////////////////////////////////////////////////////////////////////////////////////
 //			Hit information in TID		                                	//
@@ -331,17 +329,17 @@ CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
           else if (SiStripDetId::TID == subdetId1)
           { 
              ++nhitinTID;
-             TIDDetId tidId1(detId1);
-             if (tidId1.isZMinusSide())
+
+             if (tTopo->tidIsZMinusSide(detId1))
              {
                 ++nhitinTIDminus;
              }
-             else 
+             else
              {
                 ++nhitinTIDplus;
              }
           }
-			
+
           countHit++;
       } // for Loop over Hits
 

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -57,8 +57,6 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "MagneticField/Engine/interface/MagneticField.h"


### PR DESCRIPTION
Changed to use TrackerTopology

cc @vidalm @OlivierBondu @pieterdavid 