### PR TITLE
(TIB|TOB|TID|TEC|PXB|PXF)DetId deprecation: remove unnecessary includes

### DIFF
--- a/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OverlapProblemTSOSAnalyzer.cc
@@ -49,7 +49,6 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "DataFormats/Common/interface/Ref.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"

--- a/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
+++ b/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
@@ -2,7 +2,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -31,7 +31,7 @@
       targetClass="reco::HitPattern"
       target="hitPattern"
       version="[-11]"
-      include="utility,DataFormats/SiPixelDetId/interface/PXBDetId.h,DataFormats/SiPixelDetId/interface/PXFDetId.h,DataFormats/SiStripDetId/interface/TIBDetId.h,DataFormats/SiStripDetId/interface/TIDDetId.h,DataFormats/SiStripDetId/interface/TOBDetId.h,DataFormats/SiStripDetId/interface/TECDetId.h,DataFormats/MuonDetId/interface/DTLayerId.h,DataFormats/MuonDetId/interface/CSCDetId.h,DataFormats/MuonDetId/interface/RPCDetId.h"
+      include="utility,DataFormats/SiPixelDetId/interface/PXBDetId.h,DataFormats/SiPixelDetId/interface/PXFDetId.h,DataFormats/MuonDetId/interface/DTLayerId.h,DataFormats/MuonDetId/interface/CSCDetId.h,DataFormats/MuonDetId/interface/RPCDetId.h"
       >
       <![CDATA[
             using namespace reco;

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -31,7 +31,7 @@
       targetClass="reco::HitPattern"
       target="hitPattern"
       version="[-11]"
-      include="utility,DataFormats/SiPixelDetId/interface/PXBDetId.h,DataFormats/SiPixelDetId/interface/PXFDetId.h,DataFormats/MuonDetId/interface/DTLayerId.h,DataFormats/MuonDetId/interface/CSCDetId.h,DataFormats/MuonDetId/interface/RPCDetId.h"
+      include="utility,DataFormats/MuonDetId/interface/DTLayerId.h,DataFormats/MuonDetId/interface/CSCDetId.h,DataFormats/MuonDetId/interface/RPCDetId.h"
       >
       <![CDATA[
             using namespace reco;

--- a/DataFormats/TrackerCommon/interface/ClusterSummary.h
+++ b/DataFormats/TrackerCommon/interface/ClusterSummary.h
@@ -45,10 +45,6 @@
 
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/DetId/interface/DetId.h" 
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"

--- a/DataFormats/TrackerCommon/interface/ClusterSummary.h
+++ b/DataFormats/TrackerCommon/interface/ClusterSummary.h
@@ -45,8 +45,6 @@
 
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/DetId/interface/DetId.h" 
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
 

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
@@ -24,8 +24,6 @@
 
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTPixelMatchParamObjects.h"
 
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h" 
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h" 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityProducer.cc
@@ -30,7 +30,6 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
@@ -50,7 +50,6 @@ New det-id.
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 //#include "Geometry/Surface/interface/Surface.h"
 
 

--- a/TrackingTools/TrackAssociator/src/DetIdInfo.cc
+++ b/TrackingTools/TrackAssociator/src/DetIdInfo.cc
@@ -16,10 +16,6 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
 
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 

--- a/TrackingTools/TrackAssociator/src/DetIdInfo.cc
+++ b/TrackingTools/TrackAssociator/src/DetIdInfo.cc
@@ -14,8 +14,6 @@
 
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 


### PR DESCRIPTION
Purely technical change, the deprecated classes seem not to be used in these places (and the code compiles when removing them).
Apologies for touching a bunch of unrelated packages in one pull request, we'll keep the other changes more localized.

cc @vidalm @alesaggio @OlivierBondu 