### PR TITLE
Fix decoding of filter labels

### DIFF
--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -368,7 +368,7 @@ void TriggerObjectStandAlone::unpackFilterLabels(const std::vector<std::string> 
     std::vector<std::string> mylabels(filterLabels_);
     for (unsigned int i = 0, n = filterLabelIndices_.size(), m = labels.size(); i < n; ++i) {
         if (filterLabelIndices_[i] >= m) throw cms::Exception("RuntimeError", "Error, filter label index out of bounds");
-        mylabels.push_back(labels[i]);
+        mylabels.push_back(labels[filterLabelIndices_[i]]);
     }
     filterLabelIndices_.clear();
     filterLabels_.swap(mylabels);


### PR DESCRIPTION
Fix bug in #18739 when unpacking trigger filter labels from miniAOD (wrong index being used in the list of filter labels, leading to bogus data)

The bug affects the analysis of miniAODs, not their production, so there is no hurry to update the release being used to reconstruct the data or MC, but we should integrate this fix in the release for people who analyze the data.
