### PR TITLE
Fix filter logic error: redundant produce (92X)

### DIFF
--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -91,7 +91,7 @@ HLTEgammaGenericQuadraticEtaFilter::HLTEgammaGenericQuadraticEtaFilter(const edm
   }
 
   //register your products
-  produces<trigger::TriggerFilterObjectWithRefs>();
+  //produces<trigger::TriggerFilterObjectWithRefs>();
 }
 
 void

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -89,9 +89,6 @@ HLTEgammaGenericQuadraticEtaFilter::HLTEgammaGenericQuadraticEtaFilter(const edm
         throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order. \n";
     }
   }
-
-  //register your products
-  //produces<trigger::TriggerFilterObjectWithRefs>();
 }
 
 void


### PR DESCRIPTION
Hi,

This commit is to fix the logic error in the filter. Otherwise it gives [1]. Probably escaped attention as this filter isn't in use in the current menu.

Cheers,
Afiq

[1]
----- Begin Fatal Exception 13-Jun-2017 17:32:55 CEST-----------------------
An exception of category 'LogicError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=HLTEgammaGenericQuadraticEtaFilter label='hltEle27WPTight1HEFilter'
Exception Message:
Duplicate Product The produced product Branch Type = Event
Process Name = MYHLT
ModuleLabel = hltEle27WPTight1HEFilter
Branch ID = 1294368331
Class Name = trigger::TriggerFilterObjectWithRefs
Friendly Class Name = triggerTriggerFilterObjectWithRefs
Product Instance Name =
 is registered more than once.
Please remove the redundant 'produces' call(s).
----- End Fatal Exception -------------------------------------------------