### PR TITLE
Summary map hotfixes

### DIFF
--- a/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
@@ -68,6 +68,7 @@
        bool firstLumi;
 
        std::map<std::string,MonitorElement*> summaryMap_;
+       MonitorElement * reportSummary; //Float value of the average of the ins in the grand summary
 
        std::map<std::string,std::string> summaryPlotName_;
 

--- a/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
+++ b/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
@@ -11,10 +11,6 @@ SiPixelPhase1Summary_Online = DQMEDHarvester("SiPixelPhase1Summary",
     RunOnEndJob = cms.bool(True),
     SummaryMaps = cms.VPSet(
         cms.PSet(
-            MapName = cms.string("Grand"),
-            MapHist = cms.string("")
-            ),
-        cms.PSet(
             MapName = cms.string("Digi"),
             MapHist = cms.string("mean_num_digis")
             ),
@@ -43,10 +39,6 @@ SiPixelPhase1Summary_Offline = DQMEDHarvester("SiPixelPhase1Summary",
     RunOnEndJob = cms.bool(True),
     SummaryMaps = cms.VPSet(
         cms.PSet(
-            MapName = cms.string("Grand"),
-            MapHist = cms.string("")
-            ),
-        cms.PSet(
             MapName = cms.string("Digi"),
             MapHist = cms.string("mean_num_digis")
             ),
@@ -74,10 +66,6 @@ SiPixelPhase1Summary_Cosmics = DQMEDHarvester("SiPixelPhase1Summary",
     RunOnEndLumi = cms.bool(False),
     RunOnEndJob = cms.bool(True),
     SummaryMaps = cms.VPSet(
-        cms.PSet(
-            MapName = cms.string("Grand"),
-            MapHist = cms.string("")
-            ),
         cms.PSet(
             MapName = cms.string("Digi"),
             MapHist = cms.string("mean_num_digis")

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -119,7 +119,7 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker & iBooker){
   std::vector<std::string> xAxisLabels_ = {"BMO","BMI","BPO ","BPI","HCMO_1","HCMO_2","HCMI_1","HCMI_2","HCPO_1","HCPO_2","HCPI_1","HCPI_2"}; // why not having a global variable !?!?!?! 
   std::vector<std::string> yAxisLabels_ = {"1","2","3","4"}; // why not having a global variable ?!?!?!!? - I originally did, but was told not to by David Lange!
     
-  iBooker.setCurrentFolder("PixelPhase1/Summary");
+    iBooker.setCurrentFolder("PixelPhase1/Summary");
   //Book the summary plots for the variables as described in the config file  
   for (auto mapInfo: summaryPlotName_){
     auto name = mapInfo.first;

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -114,12 +114,12 @@ void SiPixelPhase1Summary::dqmEndJob(DQMStore::IBooker & iBooker, DQMStore::IGet
 //------------------------------------------------------------------
 void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker & iBooker){
 
-  iBooker.cd();
+  //  iBooker.cd();
 
   std::vector<std::string> xAxisLabels_ = {"BMO","BMI","BPO ","BPI","HCMO_1","HCMO_2","HCMI_1","HCMI_2","HCPO_1","HCPO_2","HCPI_1","HCPI_2"}; // why not having a global variable !?!?!?! 
   std::vector<std::string> yAxisLabels_ = {"1","2","3","4"}; // why not having a global variable ?!?!?!!? - I originally did, but was told not to by David Lange!
-    
-    iBooker.setCurrentFolder("PixelPhase1/Summary");
+  
+  iBooker.setCurrentFolder("PixelPhase1/Summary");
   //Book the summary plots for the variables as described in the config file  
   for (auto mapInfo: summaryPlotName_){
     auto name = mapInfo.first;
@@ -129,7 +129,7 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker & iBooker){
   //Now book the overall summary map
   iBooker.setCurrentFolder("PixelPhase1/EventInfo");
   summaryMap_["Grand"] = iBooker.book2D("reportSummaryMap","Pixel Summary Map",12,0,12,4,0,4);
-  reportSummary = iBooker.bookFloat("reportSummary","reportSummary");
+  reportSummary = iBooker.bookFloat("reportSummary");
 
   //Now set up axis and bin labels
   for (auto summaryMapEntry: summaryMap_){

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -114,7 +114,7 @@ void SiPixelPhase1Summary::dqmEndJob(DQMStore::IBooker & iBooker, DQMStore::IGet
 //------------------------------------------------------------------
 void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker & iBooker){
 
-  //  iBooker.cd();
+  iBooker.cd();
 
   std::vector<std::string> xAxisLabels_ = {"BMO","BMI","BPO ","BPI","HCMO_1","HCMO_2","HCMI_1","HCMI_2","HCPO_1","HCPO_2","HCPI_1","HCPI_2"}; // why not having a global variable !?!?!?! 
   std::vector<std::string> yAxisLabels_ = {"1","2","3","4"}; // why not having a global variable ?!?!?!!? - I originally did, but was told not to by David Lange!
@@ -123,7 +123,6 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker & iBooker){
   //Book the summary plots for the variables as described in the config file  
   for (auto mapInfo: summaryPlotName_){
     auto name = mapInfo.first;
-    if (name == "Grand") iBooker.setCurrentFolder("PixelPhase1/EventInfo");
     summaryMap_[name] = iBooker.book2D("pixel"+name+"Summary","Pixel "+name+" Summary",12,0,12,4,0,4);
   }
   //Now book the overall summary map

--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -119,25 +119,38 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker & iBooker){
   std::vector<std::string> xAxisLabels_ = {"BMO","BMI","BPO ","BPI","HCMO_1","HCMO_2","HCMI_1","HCMI_2","HCPO_1","HCPO_2","HCPI_1","HCPI_2"}; // why not having a global variable !?!?!?! 
   std::vector<std::string> yAxisLabels_ = {"1","2","3","4"}; // why not having a global variable ?!?!?!!? - I originally did, but was told not to by David Lange!
     
+  iBooker.setCurrentFolder("PixelPhase1/Summary");
+  //Book the summary plots for the variables as described in the config file  
   for (auto mapInfo: summaryPlotName_){
     auto name = mapInfo.first;
     if (name == "Grand") iBooker.setCurrentFolder("PixelPhase1/EventInfo");
-    else iBooker.setCurrentFolder("PixelPhase1/Summary");
     summaryMap_[name] = iBooker.book2D("pixel"+name+"Summary","Pixel "+name+" Summary",12,0,12,4,0,4);
+  }
+  //Now book the overall summary map
+  iBooker.setCurrentFolder("PixelPhase1/EventInfo");
+  summaryMap_["Grand"] = iBooker.book2D("reportSummaryMap","Pixel Summary Map",12,0,12,4,0,4);
+  reportSummary = iBooker.bookFloat("reportSummary","reportSummary");
+
+  //Now set up axis and bin labels
+  for (auto summaryMapEntry: summaryMap_){
+    auto summaryMap = summaryMapEntry.second;
     for (unsigned int i = 0; i < xAxisLabels_.size(); i++){
-      summaryMap_[name]->setBinLabel(i+1, xAxisLabels_[i],1);
+      summaryMap->setBinLabel(i+1, xAxisLabels_[i],1);
     }
     for (unsigned int i = 0; i < yAxisLabels_.size(); i++){
-      summaryMap_[name]->setBinLabel(i+1,yAxisLabels_[i],2);
+      summaryMap->setBinLabel(i+1,yAxisLabels_[i],2);
     }
-    summaryMap_[name]->setAxisTitle("Subdetector",1);
-    summaryMap_[name]->setAxisTitle("Layer/disk",2);
+    summaryMap->setAxisTitle("Subdetector",1);
+    summaryMap->setAxisTitle("Layer/disk",2);
     for (int i = 0; i < 12; i++){ // !??!?!? xAxisLabels_.size() ?!?!
       for (int j = 0; j < 4; j++){ // !??!?!? yAxisLabels_.size() ?!?!?!
-	summaryMap_[name]->Fill(i,j,-1.);
+	summaryMap->Fill(i,j,-1.);
       }
     }
   }
+  reportSummary->Fill(-1.);
+  //Reset the iBooker
+  iBooker.setCurrentFolder("PixelPhase1/");
 }
 
 //------------------------------------------------------------------
@@ -145,6 +158,7 @@ void SiPixelPhase1Summary::bookSummaries(DQMStore::IBooker & iBooker){
 //------------------------------------------------------------------
 void SiPixelPhase1Summary::bookTrendPlots(DQMStore::IBooker & iBooker){
   //We need different plots depending on if we're online (runOnEndLumi) or offline (!runOnEndLumi)
+  iBooker.setCurrentFolder("PixelPhase1/");
   if (runOnEndLumi_){
     deadROCTrends_[bpix] = iBooker.book1D("deadRocTrendBPix","BPIX dead ROC trend",500,0.,5000);
     deadROCTrends_[bpix]->setAxisTitle("Lumisection",1);
@@ -176,7 +190,6 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker & iBooker, DQMStore::
   //Firstly, we will fill the regular summary maps.
   for (auto mapInfo: summaryPlotName_){
     auto name = mapInfo.first;
-    if (name == "Grand") continue;
     std::ostringstream histNameStream;
     std::string histName;
 
@@ -206,6 +219,8 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker & iBooker, DQMStore::
       }  
     }    
   }
+  //Sum of non-negative bins for the reportSummary
+  float sumOfNonNegBins = 0.;
   //Now we will use the other summary maps to create the overall map.
   for (int i = 0; i < 12; i++){ // !??!?!? xAxisLabels_.size() ?!?!
     if (!summaryMap_["Grand"]){
@@ -216,15 +231,16 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker & iBooker, DQMStore::
       summaryMap_["Grand"]->setBinContent(i+1,j+1,1); // This resets the map to be good. We only then set it to 0 if there has been a problem in one of the other summaries.
       for (auto const mapInfo: summaryPlotName_){ //Check summary maps
 	auto name = mapInfo.first;
-	if (name == "Grand") continue;
 	if (!summaryMap_[name]){
 	  edm::LogWarning("SiPixelPhase1Summary") << "Summary " << name << " does not exist!";
 	  continue;
 	}
 	if (summaryMap_["Grand"]->getBinContent(i+1,j+1) > summaryMap_[name]->getBinContent(i+1,j+1)) summaryMap_["Grand"]->setBinContent(i+1,j+1,summaryMap_[name]->getBinContent(i+1,j+1));
       }
+      if (summaryMap_["Grand"]->getBinContent(i+1,j+1) > -0.1) sumOfNonNegBins += summaryMap_["Grand"]->getBinContent(i+1,j+1);
     }
   }
+  reportSummary->Fill(sumOfNonNegBins/40.); // The average of the 40 useful bins in the summary map.
 
 }
 


### PR DESCRIPTION
Updates to the summary maps:
1) Grand Summary Map renamed to reportSummaryMap. This is achieved by hard coding the grand summary (as it should always be there) and removing it from the python configuration file. This also removes the checks for "Grand" later in the code.
2) Adding in a float ME 'reportSummary' to the EventInfo directory. This contains the mean of the non-negative bins in the reportSummaryMap.
3) Moved ROC counting trend plots from the EventInfo directory to the PixelPhase1/ directory so they can actually be found.