### PR TITLE
FastTimerService: make plots per path optional

### DIFF
--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -375,7 +375,7 @@ private:
     void reset();
     void book(DQMStore::IBooker &, ProcessCallGraph const&, ProcessCallGraph::ProcessType const&,
         PlotRanges const& event_ranges, PlotRanges const& path_ranges,
-        unsigned int lumisections, bool byls);
+        unsigned int lumisections, bool bypath, bool byls);
     void fill(ProcessCallGraph::ProcessType const&, ResourcesPerJob const&, ResourcesPerProcess const&, unsigned int ls);
 
   private:
@@ -393,7 +393,7 @@ private:
     void book(DQMStore::IBooker &, ProcessCallGraph const&, std::vector<GroupOfModules> const&,
         PlotRanges const&  event_ranges, PlotRanges const&  path_ranges,
         PlotRanges const&  module_ranges, unsigned int lumisections,
-        bool bymodule, bool byls);
+        bool bymodule, bool bypath, bool byls);
     void fill(ProcessCallGraph const&, ResourcesPerJob const&, unsigned int ls);
 
   private:
@@ -448,6 +448,7 @@ private:
 
   bool                          enable_dqm_;                    // non const, depends on the availability of the DQMStore
   const bool                    enable_dqm_bymodule_;
+  const bool                    enable_dqm_bypath_;
   const bool                    enable_dqm_byls_;
   const bool                    enable_dqm_bynproc_;
 

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -623,6 +623,7 @@ FastTimerService::PlotsPerProcess::book(
     PlotRanges const& event_ranges,
     PlotRanges const& path_ranges,
     unsigned int lumisections,
+    bool bypath,
     bool byls)
 {
   const std::string basedir = booker.pwd();
@@ -631,24 +632,26 @@ FastTimerService::PlotsPerProcess::book(
       event_ranges,
       lumisections,
       byls);
-  booker.setCurrentFolder(basedir + "/process " + process.name_ + " paths");
-  for (unsigned int id: boost::irange(0ul, paths_.size()))
-  {
-    paths_[id].book(booker,"path ",
-        job, process.paths_[id],
-        path_ranges,
-        lumisections,
-        byls);
+  if (bypath) {
+    booker.setCurrentFolder(basedir + "/process " + process.name_ + " paths");
+    for (unsigned int id: boost::irange(0ul, paths_.size()))
+    {
+      paths_[id].book(booker,"path ",
+          job, process.paths_[id],
+          path_ranges,
+          lumisections,
+          byls);
+    }
+    for (unsigned int id: boost::irange(0ul, endpaths_.size()))
+    {
+      endpaths_[id].book(booker,"endpath ",
+          job, process.endPaths_[id],
+          path_ranges,
+          lumisections,
+          byls);
+    }
+    booker.setCurrentFolder(basedir);
   }
-  for (unsigned int id: boost::irange(0ul, endpaths_.size()))
-  {
-    endpaths_[id].book(booker,"endpath ",
-        job, process.endPaths_[id],
-        path_ranges,
-        lumisections,
-        byls);
-  }
-  booker.setCurrentFolder(basedir);
 }
 
 void
@@ -699,6 +702,7 @@ FastTimerService::PlotsPerJob::book(
     PlotRanges const& module_ranges,
     unsigned int lumisections,
     bool bymodule,
+    bool bypath,
     bool byls)
 {
   const std::string basedir = booker.pwd();
@@ -734,6 +738,7 @@ FastTimerService::PlotsPerJob::book(
         event_ranges,
         path_ranges,
         lumisections,
+        bypath,
         byls);
 
     if (bymodule) {
@@ -787,6 +792,7 @@ FastTimerService::FastTimerService(const edm::ParameterSet & config, edm::Activi
   module_id_(                   edm::ModuleDescription::invalidID() ),
   enable_dqm_(                  config.getUntrackedParameter<bool>(     "enableDQM"                ) ),
   enable_dqm_bymodule_(         config.getUntrackedParameter<bool>(     "enableDQMbyModule"        ) ),
+  enable_dqm_bypath_(           config.getUntrackedParameter<bool>(     "enableDQMbyPath"          ) ),
   enable_dqm_byls_(             config.getUntrackedParameter<bool>(     "enableDQMbyLumiSection"   ) ),
   enable_dqm_bynproc_(          config.getUntrackedParameter<bool>(     "enableDQMbyProcesses"     ) ),
   dqm_event_ranges_(          { config.getUntrackedParameter<double>(   "dqmTimeRange"             ),              // ms
@@ -1049,6 +1055,7 @@ FastTimerService::preStreamBeginRun(edm::StreamContext const& sc)
             dqm_module_ranges_,
             dqm_lumisections_range_,
             enable_dqm_bymodule_,
+            enable_dqm_bypath_,
             enable_dqm_byls_);
       };
 
@@ -1751,6 +1758,7 @@ FastTimerService::fillDescriptions(edm::ConfigurationDescriptions & descriptions
   desc.addUntracked<bool>(        "printJobSummary",          true);
   desc.addUntracked<bool>(        "enableDQM",                true);
   desc.addUntracked<bool>(        "enableDQMbyModule",        false);
+  desc.addUntracked<bool>(        "enableDQMbyPath",          false);
   desc.addUntracked<bool>(        "enableDQMbyLumiSection",   false);
   desc.addUntracked<bool>(        "enableDQMbyProcesses",     false);
   desc.addUntracked<double>(      "dqmTimeRange",             1000. );   // ms


### PR DESCRIPTION
Make the plots per Path and EndPath optional, and disabled by default.

They can be enabled with
```python
FastTimerService.enableDQMbyPath = True
```