### PR TITLE
L1muon offline dqm harvesting config fix

### DIFF
--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2BMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2BMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2BMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2EMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2EMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2EMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2OMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2OMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # directory path shortening
 ugmtDqmDir = 'L1T/L1TStage2uGMT'
@@ -9,7 +10,7 @@ errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
 
 # Muons
-l1tStage2uGMTOutVsuGTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2uGMTOutVsuGTInRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput'),
     inputNum = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistNumStr),
     inputDen = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistDenStr),

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # directories
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
@@ -9,7 +10,7 @@ errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
 
 # Muons
-l1tStage2uGMTEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2uGMTEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtEmuDEDqmDir),
     inputNum = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistNumStr),
     inputDen = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistDenStr),

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -78,8 +78,6 @@ DQMOffline_SecondStepPOGMC = cms.Sequence( dqmRefHistoRootFileGetter *
                                            DQMOffline_SecondStep_PrePOGMC *
                                            DQMMessageLoggerClientSeq )
 
-from DQMOffline.L1Trigger.L1TriggerDqmOffline_SecondStep_cff import *
-
 DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  DQMMessageLoggerClientSeq *
                                  dqmDcsInfoClient *
@@ -92,7 +90,7 @@ DQMHarvestCommon = cms.Sequence( dqmRefHistoRootFileGetter *
                                  alcaBeamMonitorClient *
                                  runTauEff *
                                  dqmFastTimerServiceClient *
-                                 DQMHarvestL1Trigger
+                                 l1TriggerDqmOfflineClient
                                 )
 DQMHarvestCommonSiStripZeroBias = cms.Sequence(dqmRefHistoRootFileGetter *
                                                DQMMessageLoggerClientSeq *

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -274,6 +274,7 @@ from DQMOffline.L1Trigger.L1TEfficiencyMuons_Offline_cfi import *
 
 from Configuration.StandardSequences.Eras import eras
 from DQM.L1TMonitor.L1TStage2_cff import *
+from DQMOffline.L1Trigger.L1TriggerDqmOffline_SecondStep_cff import *
 from DQMOffline.L1Trigger.L1TEfficiencyHarvesting_cfi import *
 
 stage2UnpackPath = cms.Sequence(
@@ -354,6 +355,7 @@ Stage2l1TriggerDqmOffline = cms.Sequence(
 Stage2l1TriggerDqmOfflineClient = cms.Sequence(
                                 l1tStage2EmulatorMonitorClient *
                                 l1tStage2MonitorClient *
+                                DQMHarvestL1Trigger *
                                 l1tEfficiencyMuons_Harvesting
                                 )
 

--- a/DQMOffline/L1Trigger/src/L1TEfficiency_Harvesting.cc
+++ b/DQMOffline/L1Trigger/src/L1TEfficiency_Harvesting.cc
@@ -39,20 +39,20 @@ L1TEfficiencyPlotHandler::L1TEfficiencyPlotHandler(const L1TEfficiencyPlotHandle
 
 void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
 
-    cout << "[L1TEfficiencyMuons_Harvesting:] Booking efficiency histo for " << m_dir << " and " << m_plotName << endl;
+    edm::LogInfo("L1TEfficiency_Harvesting") << "Booking efficiency histo for " << m_dir << " and " << m_plotName;
 
     MonitorElement *num = igetter.get(m_dir+"/"+m_plotName+"Num");
     MonitorElement *den = igetter.get(m_dir+"/"+m_plotName+"Den");
 
     if (!num || !den) {
-        cout << "[L1TEfficiencyMuons_Harvesting:] " << (!num && !den ? "Num && Den" : !num ? "Num" : "Den") << " not gettable. Quitting booking" << endl;
+        edm::LogInfo("L1TEfficiency_Harvesting") << (!num && !den ? "Num && Den" : !num ? "Num" : "Den") << " not gettable. Quitting booking";
         return;
     }
     TH1F *numH = num->getTH1F();
     TH1F *denH = den->getTH1F();
 
     if (!numH || !denH) {
-        cout << "[L1TEfficiencyMuons_Harvesting:] " << (!numH && !denH ? "Num && Den" : !numH ? "Num" : "Den") << " is not TH1F. Quitting booking" << endl;
+        edm::LogInfo("L1TEfficiency_Harvesting") << (!numH && !denH ? "Num && Den" : !numH ? "Num" : "Den") << " is not TH1F. Quitting booking";
         return;
     }
 
@@ -60,7 +60,7 @@ void L1TEfficiencyPlotHandler::book(DQMStore::IBooker &ibooker, DQMStore::IGette
     int nBinsDen = denH->GetNbinsX();
 
     if (nBinsNum != nBinsDen) {
-        cout << "[L1TEfficiencyMuons_Harvesting:] # bins in num and den is different. Quitting booking" << endl;
+        edm::LogInfo("L1TEfficiency_Harvesting") << "# bins in num and den is different. Quitting booking";
         return;
     }
 
@@ -136,7 +136,7 @@ void L1TEfficiencyPlotHandler::computeEfficiency(DQMStore::IBooker &ibooker, DQM
 
     if (!m_effHisto) return;
 
-    cout << "[L1TEfficiencyMuons_Harvesting:] Computing efficiency for " << m_plotName << endl;
+    edm::LogInfo("L1TEfficiency_Harvesting") << "Computing efficiency for " << m_plotName;
 
     MonitorElement *num = igetter.get(m_dir+"/"+m_plotName+"Num");
     MonitorElement *den = igetter.get(m_dir+"/"+m_plotName+"Den");
@@ -225,11 +225,13 @@ void L1TEfficiencyPlotHandler::computeEfficiency(DQMStore::IBooker &ibooker, DQM
 }
 
 //___________DQM_analyzer_class________________________________________
-L1TEfficiency_Harvesting::L1TEfficiency_Harvesting(const ParameterSet & ps){
+L1TEfficiency_Harvesting::L1TEfficiency_Harvesting(const ParameterSet & ps) :
+    m_verbose(ps.getUntrackedParameter<bool>("verbose"))
+{
   // Initializing Variables
     if (m_verbose) {
-        cout << "[L1TEfficiency_Harvesting:] ____________ Storage inicialization ____________ " << endl;
-        cout << "[L1TEfficiency_Harvesting:] Setting up dbe folder: L1T/Efficiency" << endl;
+        edm::LogInfo("L1TEfficiency_Harvesting") << "____________ Storage initialization ____________ ";
+        edm::LogInfo("L1TEfficiency_Harvesting") << "Setting up dbe folder: L1T/Efficiency";
     }
     vector<ParameterSet> plotCfgs = ps.getUntrackedParameter<vector<ParameterSet>>("plotCfgs");
     vector<ParameterSet>::const_iterator plotCfgIt  = plotCfgs.begin();
@@ -250,7 +252,9 @@ L1TEfficiency_Harvesting::~L1TEfficiency_Harvesting(){ m_plotHandlers.clear(); }
 
 //_____________________________________________________________________
 void L1TEfficiency_Harvesting::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter){
-    if (m_verbose) {cout << "[L1TEfficiency_Harvesting:] Called endRun." << endl;}
+    if (m_verbose) {
+        edm::LogInfo("L1TEfficiency_Harvesting") << "Called endRun.";
+    }
 
     vector<L1TEfficiencyPlotHandler>::iterator plotHandlerIt  = m_plotHandlers.begin();
     vector<L1TEfficiencyPlotHandler>::iterator plotHandlerEnd = m_plotHandlers.end();
@@ -263,7 +267,9 @@ void L1TEfficiency_Harvesting::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::I
 
 //_____________________________________________________________________
 void L1TEfficiency_Harvesting::dqmEndLuminosityBlock(DQMStore::IGetter &igetter, LuminosityBlock const& lumiBlock, EventSetup const& c) {
-    if(m_verbose) cout << "[L1TEfficiency_Harvesting:] Called endLuminosityBlock at LS=" << lumiBlock.id().luminosityBlock() << endl;
+    if (m_verbose) {
+        edm::LogInfo("L1TEfficiency_Harvesting") << "Called endLuminosityBlock at LS=" << lumiBlock.id().luminosityBlock();
+    }
 }
 
 //define this as a plug-in


### PR DESCRIPTION
This fixes the issue that the L1 muon offline DQM harvesting module was not run in the common DQM workflow.

The L1TEgamma harvesting was moved into the Stage2l1TriggerDqmOfflineClient sequence since it does not need to run for legacy workflows.

cms.EDAnalyzer harvesting modules that were merged after the change to DQMEDHarvester have been migrated.

Replacement of couts with LogInfo.