### PR TITLE
adding new selection on the number of crystals in photon 3x3 matrix cl…

### DIFF
--- a/HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h
+++ b/HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h
@@ -105,7 +105,8 @@ class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<>
       int diff_nphi_s(int,int);
       
       
-      static float DeltaPhi(float phi1, float phi2); 
+      // use function in DataFormats/Math/interface/deltaPhi.h
+      //static float DeltaPhi(float phi1, float phi2); 
       static float GetDeltaR(float eta1, float eta2, float phi1, float phi2); 
       
       // Input hits & clusters
@@ -135,12 +136,14 @@ class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<>
       double selePtPairBarrel_region1_;
       double seleS4S9GammaBarrel_region1_;
       double seleIsoBarrel_region1_;
+      double seleNxtalBarrel_region1_;
 
       // EB region 2
       double selePtGammaBarrel_region2_; 
       double selePtPairBarrel_region2_;
       double seleS4S9GammaBarrel_region2_;
       double seleIsoBarrel_region2_;
+      double seleNxtalBarrel_region2_;
 
       double seleMinvMaxBarrel_;
       double seleMinvMinBarrel_;
@@ -169,6 +172,7 @@ class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<>
       double selePtPairEndCap_region1_;
       double seleS4S9GammaEndCap_region1_;
       double seleIsoEndCap_region1_;
+      double seleNxtalEndCap_region1_;
 
       // EE region 2
       double region2_EndCap_;
@@ -176,6 +180,7 @@ class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<>
       double selePtPairEndCap_region2_;
       double seleS4S9GammaEndCap_region2_;
       double seleIsoEndCap_region2_;
+      double seleNxtalEndCap_region2_;
 
       // EE region 3
       double selePtGammaEndCap_region3_; 
@@ -183,6 +188,7 @@ class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<>
       double selePtPairMaxEndCap_region3_;
       double seleS4S9GammaEndCap_region3_;
       double seleIsoEndCap_region3_;
+      double seleNxtalEndCap_region3_;
 
       double seleMinvMaxEndCap_;
       double seleMinvMinEndCap_;

--- a/HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h
+++ b/HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h
@@ -103,12 +103,7 @@ class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<>
       void convxtalid(int & , int &);
       int diff_neta_s(int,int);
       int diff_nphi_s(int,int);
-      
-      
-      // use function in DataFormats/Math/interface/deltaPhi.h
-      //static float DeltaPhi(float phi1, float phi2); 
-      static float GetDeltaR(float eta1, float eta2, float phi1, float phi2); 
-      
+            
       // Input hits & clusters
       edm::InputTag barrelHits_;
       edm::InputTag endcapHits_;

--- a/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
+++ b/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
@@ -3,10 +3,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "DataFormats/Math/interface/Vector3D.h"  // to use math::XYZVector
+#include "DataFormats/Math/interface/deltaPhi.h" // use already existing deltaPhi function to return deltaPhi in [-pi, pi]
 
 using namespace std;
 using namespace edm;
-
 
 HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::ParameterSet& iConfig)
 {
@@ -32,12 +32,14 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairBarrel_region1_ = barrelSelection.getParameter<double> ("selePtPairBarrel_region1");   
     seleS4S9GammaBarrel_region1_ = barrelSelection.getParameter<double> ("seleS4S9GammaBarrel_region1");  
     seleIsoBarrel_region1_ = barrelSelection.getParameter<double> ("seleIsoBarrel_region1");  
+    seleNxtalBarrel_region1_ = barrelSelection.getParameter<int> ("seleNxtalBarrel_region1");  
 
     // EB region 2
     selePtGammaBarrel_region2_ = barrelSelection.getParameter<double> ("selePtGammaBarrel_region2");  
     selePtPairBarrel_region2_ = barrelSelection.getParameter<double> ("selePtPairBarrel_region2");   
     seleS4S9GammaBarrel_region2_ = barrelSelection.getParameter<double> ("seleS4S9GammaBarrel_region2");  
     seleIsoBarrel_region2_ = barrelSelection.getParameter<double> ("seleIsoBarrel_region2");  
+    seleNxtalBarrel_region2_ = barrelSelection.getParameter<int> ("seleNxtalBarrel_region2");  
 
     // other
     seleS9S25Gamma_ = barrelSelection.getParameter<double> ("seleS9S25Gamma");  
@@ -85,6 +87,7 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairEndCap_region1_ = endcapSelection.getParameter<double> ("selePtPairEndCap_region1");   
     seleS4S9GammaEndCap_region1_ = endcapSelection.getParameter<double> ("seleS4S9GammaEndCap_region1");  
     seleIsoEndCap_region1_ = endcapSelection.getParameter<double> ("seleIsoEndCap_region1");  
+    seleNxtalEndCap_region1_ = endcapSelection.getParameter<int> ("seleNxtalEndCap_region1");  
     
     // EE region 2
     region2_EndCap_ = endcapSelection.getParameter<double> ("region2_EndCap"); //eta dividing between region 2 and region 3
@@ -92,6 +95,7 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairEndCap_region2_ = endcapSelection.getParameter<double> ("selePtPairEndCap_region2");   
     seleS4S9GammaEndCap_region2_ = endcapSelection.getParameter<double> ("seleS4S9GammaEndCap_region2");  
     seleIsoEndCap_region2_ = endcapSelection.getParameter<double> ("seleIsoEndCap_region2");  
+    seleNxtalEndCap_region2_ = endcapSelection.getParameter<int> ("seleNxtalEndCap_region2");  
 
     // EE region 3 (available but not yet used)
     selePtGammaEndCap_region3_ = endcapSelection.getParameter<double> ("selePtGammaEndCap_region3");  
@@ -99,6 +103,7 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairMaxEndCap_region3_ = endcapSelection.getParameter<double> ("selePtPairMaxEndCap_region3");
     seleS4S9GammaEndCap_region3_ = endcapSelection.getParameter<double> ("seleS4S9GammaEndCap_region3");  
     seleIsoEndCap_region3_ = endcapSelection.getParameter<double> ("seleIsoEndCap_region3");  
+    seleNxtalEndCap_region3_ = endcapSelection.getParameter<int> ("seleNxtalEndCap_region3");  
 
     seleS9S25GammaEndCap_ = endcapSelection.getParameter<double> ("seleS9S25GammaEndCap");  
 
@@ -189,12 +194,14 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   barrelSelection.add<double>("selePtGammaBarrel_region1", 1.0);
   barrelSelection.add<double>("selePtPairBarrel_region1", 2.0);
   barrelSelection.add<double>("seleIsoBarrel_region1", 0.5);  
+  barrelSelection.add<int>("seleNxtalBarrel_region1", 6);  
   barrelSelection.add<double>("seleS4S9GammaBarrel_region1", 0.83);
   
   //EB region 2
   barrelSelection.add<double>("selePtGammaBarrel_region2", 1.0);
   barrelSelection.add<double>("selePtPairBarrel_region2", 2.0);
   barrelSelection.add<double>("seleIsoBarrel_region2", 0.5);  
+  barrelSelection.add<int>("seleNxtalBarrel_region2", 6);  
   barrelSelection.add<double>("seleS4S9GammaBarrel_region2", 0.83);
 
   //EB Isolation configuration
@@ -235,6 +242,7 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   endcapSelection.add<double>("selePtPairEndCap_region1", 3.0);
   endcapSelection.add<double>("seleS4S9GammaEndCap_region1", 0.9);
   endcapSelection.add<double>("seleIsoEndCap_region1", 0.5);
+  endcapSelection.add<int>("seleNxtalEndCap_region1", 6);
 
   // EE region 2
   endcapSelection.add<double>("region2_EndCap", 2.5); // eta division between endcap region 2 and 3
@@ -242,6 +250,7 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   endcapSelection.add<double>("selePtPairEndCap_region2", 2.0);
   endcapSelection.add<double>("seleS4S9GammaEndCap_region2", 0.9);
   endcapSelection.add<double>("seleIsoEndCap_region2", 0.5);
+  endcapSelection.add<int>("seleNxtalEndCap_region2", 6);
 
   // EE region 3
   endcapSelection.add<double>("selePtGammaEndCap_region3", 0.3);
@@ -249,6 +258,7 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   endcapSelection.add<double>("selePtPairMaxEndCap_region3", 2.5);
   endcapSelection.add<double>("seleS4S9GammaEndCap_region3", 0.9);
   endcapSelection.add<double>("seleIsoEndCap_region3", 0.5);
+  endcapSelection.add<int>("seleNxtalEndCap_region3", 6);
 
   // other
   endcapSelection.add<double>("seleS9S25GammaEndCap", 0.);
@@ -288,7 +298,6 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
 // ------------ method called to produce the data  ------------
 bool HLTRegionalEcalResonanceFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-   
   //Create empty output collections
   std::unique_ptr< EBRecHitCollection > selEBRecHitCollection( new EBRecHitCollection );
   //Create empty output collections
@@ -722,6 +731,40 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
 	int ind3 = int(it_bc3 - clusterCollection->begin());  /// remember which Iso cluster used 
 	IsoClus.push_back( ind3);
       }
+      
+      //-------------------------------------
+      // Region Based Nxtal Cut: Nxtal of the clusters
+      //-------------------------------------
+
+      int Nxtal_pho1 = static_cast<int>(it_bc->size());     
+      int Nxtal_pho2 = static_cast<int>(it_bc2->size());     
+
+      // BARREL
+      if(  detector == EcalBarrel ){
+	//EB region 1
+	if(etapair <= region1_Barrel_){ //EB region 1
+	  if(Nxtal_pho1 < seleNxtalBarrel_region1_ || Nxtal_pho2 < seleNxtalBarrel_region1_) continue; 
+	}
+	//EB region 2
+	else{ 	  
+	  if(Nxtal_pho1 < seleNxtalBarrel_region2_ || Nxtal_pho2 < seleNxtalBarrel_region2_) continue; 
+	}
+      }
+      // ENDCAP
+      else{
+	//EE region 1
+	if(etapair <= region1_EndCap_){
+	  if(Nxtal_pho1 < seleNxtalEndCap_region1_ || Nxtal_pho2 < seleNxtalEndCap_region1_) continue; 
+	}
+	//EE region 2
+	else if( etapair <= region2_EndCap_){
+	  if(Nxtal_pho1 < seleNxtalEndCap_region2_ || Nxtal_pho2 < seleNxtalEndCap_region2_) continue; 
+	}
+	//EE region 3
+	else{
+	  if(Nxtal_pho1 < seleNxtalEndCap_region3_ || Nxtal_pho2 < seleNxtalEndCap_region3_) continue; 
+	}
+      }
 
       //-------------------------------------
       // Region Based Isolation Cut: pt of the diphoton system and pt of each photon
@@ -1076,23 +1119,23 @@ bool HLTRegionalEcalResonanceFilter::checkStatusOfEcalRecHit(const EcalChannelSt
   return true; 
 }
 
+// use function in DataFormats/Math/interface/deltaPhi.h
 
-float HLTRegionalEcalResonanceFilter::DeltaPhi(float phi1, float phi2){
-
-  float diff = fabs(phi2 - phi1);
+// float HLTRegionalEcalResonanceFilter::DeltaPhi(float phi1, float phi2){
   
-  while (diff >acos(-1)) diff -= 2*acos(-1);
-  while (diff <= -acos(-1)) diff += 2*acos(-1);
-  
-  return diff; 
+//   float diff = phi2 - phi1;
+//   while (diff > M_PI) diff -= 2.*M_PI;
+//   while (diff <= -M_PI) diff += 2.*M_PI;
 
-}
+//   return diff; 
+
+// }
 
 
 float HLTRegionalEcalResonanceFilter::GetDeltaR(float eta1, float eta2, float phi1, float phi2){
   
   return sqrt( (eta1-eta2)*(eta1-eta2) 
-	       + DeltaPhi(phi1, phi2)*DeltaPhi(phi1, phi2) );
+	       + deltaPhi(phi1, phi2)*deltaPhi(phi1, phi2) );
   
 }
 

--- a/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
+++ b/HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
@@ -32,14 +32,14 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairBarrel_region1_ = barrelSelection.getParameter<double> ("selePtPairBarrel_region1");   
     seleS4S9GammaBarrel_region1_ = barrelSelection.getParameter<double> ("seleS4S9GammaBarrel_region1");  
     seleIsoBarrel_region1_ = barrelSelection.getParameter<double> ("seleIsoBarrel_region1");  
-    seleNxtalBarrel_region1_ = barrelSelection.getParameter<int> ("seleNxtalBarrel_region1");  
+    seleNxtalBarrel_region1_ = barrelSelection.getParameter<uint32_t> ("seleNxtalBarrel_region1");  
 
     // EB region 2
     selePtGammaBarrel_region2_ = barrelSelection.getParameter<double> ("selePtGammaBarrel_region2");  
     selePtPairBarrel_region2_ = barrelSelection.getParameter<double> ("selePtPairBarrel_region2");   
     seleS4S9GammaBarrel_region2_ = barrelSelection.getParameter<double> ("seleS4S9GammaBarrel_region2");  
     seleIsoBarrel_region2_ = barrelSelection.getParameter<double> ("seleIsoBarrel_region2");  
-    seleNxtalBarrel_region2_ = barrelSelection.getParameter<int> ("seleNxtalBarrel_region2");  
+    seleNxtalBarrel_region2_ = barrelSelection.getParameter<uint32_t> ("seleNxtalBarrel_region2");  
 
     // other
     seleS9S25Gamma_ = barrelSelection.getParameter<double> ("seleS9S25Gamma");  
@@ -87,7 +87,7 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairEndCap_region1_ = endcapSelection.getParameter<double> ("selePtPairEndCap_region1");   
     seleS4S9GammaEndCap_region1_ = endcapSelection.getParameter<double> ("seleS4S9GammaEndCap_region1");  
     seleIsoEndCap_region1_ = endcapSelection.getParameter<double> ("seleIsoEndCap_region1");  
-    seleNxtalEndCap_region1_ = endcapSelection.getParameter<int> ("seleNxtalEndCap_region1");  
+    seleNxtalEndCap_region1_ = endcapSelection.getParameter<uint32_t> ("seleNxtalEndCap_region1");  
     
     // EE region 2
     region2_EndCap_ = endcapSelection.getParameter<double> ("region2_EndCap"); //eta dividing between region 2 and region 3
@@ -95,7 +95,7 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairEndCap_region2_ = endcapSelection.getParameter<double> ("selePtPairEndCap_region2");   
     seleS4S9GammaEndCap_region2_ = endcapSelection.getParameter<double> ("seleS4S9GammaEndCap_region2");  
     seleIsoEndCap_region2_ = endcapSelection.getParameter<double> ("seleIsoEndCap_region2");  
-    seleNxtalEndCap_region2_ = endcapSelection.getParameter<int> ("seleNxtalEndCap_region2");  
+    seleNxtalEndCap_region2_ = endcapSelection.getParameter<uint32_t> ("seleNxtalEndCap_region2");  
 
     // EE region 3 (available but not yet used)
     selePtGammaEndCap_region3_ = endcapSelection.getParameter<double> ("selePtGammaEndCap_region3");  
@@ -103,7 +103,7 @@ HLTRegionalEcalResonanceFilter::HLTRegionalEcalResonanceFilter(const edm::Parame
     selePtPairMaxEndCap_region3_ = endcapSelection.getParameter<double> ("selePtPairMaxEndCap_region3");
     seleS4S9GammaEndCap_region3_ = endcapSelection.getParameter<double> ("seleS4S9GammaEndCap_region3");  
     seleIsoEndCap_region3_ = endcapSelection.getParameter<double> ("seleIsoEndCap_region3");  
-    seleNxtalEndCap_region3_ = endcapSelection.getParameter<int> ("seleNxtalEndCap_region3");  
+    seleNxtalEndCap_region3_ = endcapSelection.getParameter<uint32_t> ("seleNxtalEndCap_region3");  
 
     seleS9S25GammaEndCap_ = endcapSelection.getParameter<double> ("seleS9S25GammaEndCap");  
 
@@ -194,14 +194,14 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   barrelSelection.add<double>("selePtGammaBarrel_region1", 1.0);
   barrelSelection.add<double>("selePtPairBarrel_region1", 2.0);
   barrelSelection.add<double>("seleIsoBarrel_region1", 0.5);  
-  barrelSelection.add<int>("seleNxtalBarrel_region1", 6);  
+  barrelSelection.add<uint32_t>("seleNxtalBarrel_region1", 6);  
   barrelSelection.add<double>("seleS4S9GammaBarrel_region1", 0.83);
   
   //EB region 2
   barrelSelection.add<double>("selePtGammaBarrel_region2", 1.0);
   barrelSelection.add<double>("selePtPairBarrel_region2", 2.0);
   barrelSelection.add<double>("seleIsoBarrel_region2", 0.5);  
-  barrelSelection.add<int>("seleNxtalBarrel_region2", 6);  
+  barrelSelection.add<uint32_t>("seleNxtalBarrel_region2", 6);  
   barrelSelection.add<double>("seleS4S9GammaBarrel_region2", 0.83);
 
   //EB Isolation configuration
@@ -242,7 +242,7 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   endcapSelection.add<double>("selePtPairEndCap_region1", 3.0);
   endcapSelection.add<double>("seleS4S9GammaEndCap_region1", 0.9);
   endcapSelection.add<double>("seleIsoEndCap_region1", 0.5);
-  endcapSelection.add<int>("seleNxtalEndCap_region1", 6);
+  endcapSelection.add<uint32_t>("seleNxtalEndCap_region1", 6);
 
   // EE region 2
   endcapSelection.add<double>("region2_EndCap", 2.5); // eta division between endcap region 2 and 3
@@ -250,7 +250,7 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   endcapSelection.add<double>("selePtPairEndCap_region2", 2.0);
   endcapSelection.add<double>("seleS4S9GammaEndCap_region2", 0.9);
   endcapSelection.add<double>("seleIsoEndCap_region2", 0.5);
-  endcapSelection.add<int>("seleNxtalEndCap_region2", 6);
+  endcapSelection.add<uint32_t>("seleNxtalEndCap_region2", 6);
 
   // EE region 3
   endcapSelection.add<double>("selePtGammaEndCap_region3", 0.3);
@@ -258,7 +258,7 @@ HLTRegionalEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions&
   endcapSelection.add<double>("selePtPairMaxEndCap_region3", 2.5);
   endcapSelection.add<double>("seleS4S9GammaEndCap_region3", 0.9);
   endcapSelection.add<double>("seleIsoEndCap_region3", 0.5);
-  endcapSelection.add<int>("seleNxtalEndCap_region3", 6);
+  endcapSelection.add<uint32_t>("seleNxtalEndCap_region3", 6);
 
   // other
   endcapSelection.add<double>("seleS9S25GammaEndCap", 0.);
@@ -722,7 +722,7 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
       float Iso = 0;
       for( auto it_bc3 = clusterCollection->begin(); it_bc3 != clusterCollection->end();it_bc3++){
 	if( it_bc3->seed() == it_bc->seed() || it_bc3->seed() == it_bc2->seed()) continue; 
-	float drcl = GetDeltaR(eta_pair,it_bc3->eta(),phi_pair,it_bc3->phi()); 
+	float drcl = std::hypot(eta_pair - it_bc3->eta(), deltaPhi(phi_pair, it_bc3->phi())); 
 	float dretacl = fabs( eta_pair - it_bc3->eta()); 
 	if( drcl > isoBeltdrCut ||  dretacl > isoBeltdetaCut ) continue; 
 	float pt3 = it_bc3->energy()*sin(it_bc3->position().theta()) ; 
@@ -736,8 +736,8 @@ void HLTRegionalEcalResonanceFilter::doSelection(int detector, const reco::Basic
       // Region Based Nxtal Cut: Nxtal of the clusters
       //-------------------------------------
 
-      int Nxtal_pho1 = static_cast<int>(it_bc->size());     
-      int Nxtal_pho2 = static_cast<int>(it_bc2->size());     
+      uint32_t Nxtal_pho1 = it_bc->size();
+      uint32_t Nxtal_pho2 = it_bc2->size();
 
       // BARREL
       if(  detector == EcalBarrel ){
@@ -1117,26 +1117,6 @@ bool HLTRegionalEcalResonanceFilter::checkStatusOfEcalRecHit(const EcalChannelSt
   }
   
   return true; 
-}
-
-// use function in DataFormats/Math/interface/deltaPhi.h
-
-// float HLTRegionalEcalResonanceFilter::DeltaPhi(float phi1, float phi2){
-  
-//   float diff = phi2 - phi1;
-//   while (diff > M_PI) diff -= 2.*M_PI;
-//   while (diff <= -M_PI) diff += 2.*M_PI;
-
-//   return diff; 
-
-// }
-
-
-float HLTRegionalEcalResonanceFilter::GetDeltaR(float eta1, float eta2, float phi1, float phi2){
-  
-  return sqrt( (eta1-eta2)*(eta1-eta2) 
-	       + deltaPhi(phi1, phi2)*deltaPhi(phi1, phi2) );
-  
 }
 
 


### PR DESCRIPTION
…uster and using deltaPhi function from /DataFormats/Math

- The main change is the implementation of a selection on the number of crystals in the 3x3 matrix that defines a photon according to the dedicated ECAL pi0/eta stream clustering algorithm.
- A minor fix is about using the deltaPhi() function in DataFormats/Math/interface/deltaPhi.h

These affect:
- HLTrigger/special/src/HLTRegionalEcalResonanceFilter.cc
- HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h