### PR TITLE
Include FWEventItem.h instead of using forward decl. FWEventItem

### DIFF
--- a/Fireworks/Core/interface/FWProxyBuilderTemplate.h
+++ b/Fireworks/Core/interface/FWProxyBuilderTemplate.h
@@ -24,8 +24,7 @@
 // user include files
 #include "Fireworks/Core/interface/FWProxyBuilderBase.h"
 #include "Fireworks/Core/interface/FWSimpleProxyHelper.h"
-
-class FWEventItem;
+#include "Fireworks/Core/interface/FWEventItem.h"
 
 template <typename T>
 class FWProxyBuilderTemplate : public FWProxyBuilderBase

--- a/Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h
+++ b/Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h
@@ -22,6 +22,7 @@
 
 // user include files
 #include "Fireworks/Core/interface/FWSimpleProxyBuilder.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
 
 // forward declarations
 


### PR DESCRIPTION
We cannot use FWEventItem via forward declaration in these two cases as
we call method on FWEventItem. For that you need a complete type.

This resolves majority of warnings in Fireworks under GCC 7.1.1.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>