### PR TITLE
Fix || operator usage in conditional statements

### DIFF
--- a/CalibTracker/SiPixelConnectivity/src/PixelToLNKAssociateFromAscii.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelToLNKAssociateFromAscii.cc
@@ -204,7 +204,7 @@ void PixelToLNKAssociateFromAscii::addConnections(
        // fix for type-B modules in barrel
        edm::LogInfo(" roc ")<<rocDetId<<" "<<rocLnkId<<" "<<name->isHalfModule()<<endl;
        if (name->isHalfModule() && (rocDetIds.min()>7)  
-           && (part==PixelBarrelName::mO || PixelBarrelName::mI) ) {
+           && (part==PixelBarrelName::mO || part==PixelBarrelName::mI) ) {
 	 //cablingRocId.rocLinkId = 9-rocLnkId;
 	 // rocDetId=8,...,15
 	 edm::LogInfo(" special for half modules ");

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -684,7 +684,7 @@ void SiStripGainFromCalibTree::algoBeginJob(const edm::EventSetup& iSetup)
 	for(unsigned int i=0;i<Det.size();i++){  //Make two loop such that the Pixel information is added at the end --> make transition simpler
 		DetId  Detid  = Det[i]->geographicalId();
 		int    SubDet = Detid.subdetId();
-		if( SubDet == PixelSubdetector::PixelBarrel || PixelSubdetector::PixelEndcap ){
+		if( SubDet == PixelSubdetector::PixelBarrel || SubDet == PixelSubdetector::PixelEndcap ){
 			auto DetUnit     = dynamic_cast<const PixelGeomDetUnit*> (Det[i]);
 			if(!DetUnit) continue;
        

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -513,7 +513,7 @@ SiStripGainsPCLHarvester::checkBookAPVColls(const edm::EventSetup& es){
     for(unsigned int i=0;i<Det.size();i++){  //Make two loop such that the Pixel information is added at the end --> make transition simpler
       DetId  Detid  = Det[i]->geographicalId();
       int    SubDet = Detid.subdetId();
-      if( SubDet == PixelSubdetector::PixelBarrel || PixelSubdetector::PixelEndcap ){
+      if( SubDet == PixelSubdetector::PixelBarrel || SubDet == PixelSubdetector::PixelEndcap ){
 	auto DetUnit     = dynamic_cast<const PixelGeomDetUnit*> (Det[i]);
 	if(!DetUnit) continue;
 	

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -422,7 +422,7 @@ SiStripGainsPCLWorker::checkBookAPVColls(const edm::EventSetup& es){
     for(unsigned int i=0;i<Det.size();i++){  //Make two loop such that the Pixel information is added at the end --> make transition simpler
       DetId  Detid  = Det[i]->geographicalId();
       int    SubDet = Detid.subdetId();
-      if( SubDet == PixelSubdetector::PixelBarrel || PixelSubdetector::PixelEndcap ){
+      if( SubDet == PixelSubdetector::PixelBarrel || SubDet == PixelSubdetector::PixelEndcap ){
 	auto DetUnit     = dynamic_cast<const PixelGeomDetUnit*> (Det[i]);
 	if(!DetUnit) continue;
 	


### PR DESCRIPTION
This resolves 4 warnings from GCC 7.1.1 where we most likely have a
wrong usage of || operator in our conditional statements.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>