### PR TITLE
Fix assert condition in CSCDMBHeader::cfebAvailable

### DIFF
--- a/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h
@@ -27,7 +27,6 @@ public:
 
 
   bool cfebAvailable(unsigned icfeb) { 
-	assert (icfeb < (theFirmwareVersion==2013)?7:5);
 	return (theHeaderFormat->cfebAvailable() >> icfeb) & 1;
     }
 


### PR DESCRIPTION
This should resolve 30+ warnings from GCC 7.1.1.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>