### PR TITLE
Fix places were sprintf overflows buffer

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
@@ -388,11 +388,11 @@ void BeamMonitorBx::FitAndFill(const LuminosityBlock& lumiSeg,
       firstlumi_ = LSRange.first;
 
     if (resetFitNLumi_ > 0 ) {
-      char tmpTitle1[50];
+      char tmpTitle1[60];
       if ( countGoodFit_ > 1)
-	sprintf(tmpTitle1,"%s %i %s %i %s"," [cm] (LS: ",firstlumi_," to ",LSRange.second,") [weighted average]");
+	snprintf(tmpTitle1,sizeof(tmpTitle1),"%s %i %s %i %s"," [cm] (LS: ",firstlumi_," to ",LSRange.second,") [weighted average]");
       else
-	sprintf(tmpTitle1,"%s","Need at least two fits to calculate weighted average");
+	snprintf(tmpTitle1,sizeof(tmpTitle1),"%s","Need at least two fits to calculate weighted average");
       for (std::map<std::string,std::string>::const_iterator varName = varMap.begin();
 	   varName != varMap.end(); ++varName) {
 	TString tmpName = varName->first + "_all";

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -805,10 +805,10 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker & iBooker, const edm::EventSet
     averageDigiOccupancy = iBooker.bookProfile("averageDigiOccupancy",title7,40,-0.5,39.5,0.,3.);
     averageDigiOccupancy->setLumiFlag();
     avgfedDigiOccvsLumi = iBooker.book2D ("avgfedDigiOccvsLumi", title8, 640,0., 3200., 40, -0.5, 39.5);
-    char title9[80];  sprintf(title9, "Average Barrel FED digi occupancy (<NDigis>) vs LumiSections;Lumi Section;Average digi occupancy per FED");
-    avgBarrelFedOccvsLumi = iBooker.book1D ("avgBarrelFedOccvsLumi", title9, 320,0., 3200.);
-    char title10[80];  sprintf(title10, "Average Endcap FED digi occupancy (<NDigis>) vs LumiSections;Lumi Section;Average digi occupancy per FED");
-    avgEndcapFedOccvsLumi = iBooker.book1D ("avgEndcapFedOccvsLumi", title10, 320,0., 3200.);
+    avgBarrelFedOccvsLumi = iBooker.book1D ("avgBarrelFedOccvsLumi",
+      "Average Barrel FED digi occupancy (<NDigis>) vs LumiSections;Lumi Section;Average digi occupancy per FED", 320,0., 3200.);
+    avgEndcapFedOccvsLumi = iBooker.book1D ("avgEndcapFedOccvsLumi",
+      "Average Endcap FED digi occupancy (<NDigis>) vs LumiSections;Lumi Section;Average digi occupancy per FED", 320,0., 3200.);
   }
   if (!modOn){
     averageDigiOccupancy = iBooker.book1D("averageDigiOccupancy",title7,40,-0.5,39.5); //Book as TH1 for offline to ensure thread-safe behaviour


### PR DESCRIPTION
We should avoid using sprintf, instead a safer option -- snprintf --
should be prefered. It would be better to use std::string and friends
where possible.

These locations were reported by GCC 7.1.1 as overflowing. E.g., we have
a static array of 80 chars, but we write out 105 bytes with sprintf.
It's even just a plain string, not formatting involved.

DQMStore::book1D also supports std::string.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>