### PR TITLE
Fix undefined references (Clang)

### DIFF
--- a/Calibration/Tools/src/EcalRingCalibrationTools.cc
+++ b/Calibration/Tools/src/EcalRingCalibrationTools.cc
@@ -14,7 +14,7 @@
 std::atomic<bool> EcalRingCalibrationTools::isInitializedFromGeometry_(false);
 short EcalRingCalibrationTools::endcapRingIndex_[EEDetId::IX_MAX][EEDetId::IY_MAX];
 std::once_flag EcalRingCalibrationTools::once_;
-
+const short EcalRingCalibrationTools::N_RING_TOTAL;
 
 short EcalRingCalibrationTools::getRingIndex(DetId id) 
 {


### PR DESCRIPTION
The patch resolves issue noticed by Clang compiler.
N4296 (C++14 standard), 9.4.2 Static data members, 3rd paragraph.

    .. The member shall still be defined in a namespace scope if it is
    odr-used (3.2) in the program and the namespace scope definition shall
    not contain an initializer.

Also standard says that no diagnostic is required by compiler.

This will resolve `RecoParticleFlow/PFClusterProducer` build errors with Clang.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>