### PR TITLE
Fix T0 DQM crash. Remove online uGT DQM module from the offline

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -311,7 +311,9 @@ Stage2l1TriggerOnline = cms.Sequence(
                                 * l1tStage2OnlineDQM
                                 * dqmEnvL1T
                                )
-
+# Do not include the uGT online DQM module in the offline sequence
+# since the large 2D histograms cause crashes at the T0.
+l1tStage2OnlineDQM.remove(l1tStage2uGt)
 
 
 


### PR DESCRIPTION
Remove the online uGT DQM module from the offline sequence to avoid crashes at the T0.

The large histograms used too much memory and caused crashes.
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1532/1/1.html