### PR TITLE
Add missing include to PixelMatchNextLayers.h

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelMatchNextLayers.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelMatchNextLayers.h
@@ -18,6 +18,7 @@
 //
 //
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h" 
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "CLHEP/Vector/ThreeVector.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/BarrelMeasurementEstimator.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ForwardMeasurementEstimator.h"


### PR DESCRIPTION
We use TransientTrackingRecHit::RecHitContainer in this header, so we
also need to include the related header to make this header compile
on it's own.