### PR TITLE
Fix missing includes/forward decls in OnlineDB/EcalCondDB

### DIFF
--- a/OnlineDB/EcalCondDB/interface/IRunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/IRunIOV.h
@@ -8,6 +8,8 @@
 
 typedef int run_t;
 
+class IIOV;
+
 class IRunIOV {
  public:
   virtual void fetchAt(IIOV* fillIOV, const run_t run, ITag* tag) const noexcept(false) =0;

--- a/OnlineDB/EcalCondDB/interface/LMFSextuple.h
+++ b/OnlineDB/EcalCondDB/interface/LMFSextuple.h
@@ -1,6 +1,7 @@
 #ifndef LMFSEXTUPLE_H
 #define LMFSEXTUPLE_H
 
+#include "OnlineDB/EcalCondDB/interface/Tm.h"
 
 /*
  Last updated by  Giovanni.Organtini@roma1.infn.it 2010


### PR DESCRIPTION
The header IRunIOV.h is using a pointer to IIOV as a parameter
to fetchAT, so we also need to forward declare this declaration
to make this header compile on its own.

In the LMFSextuple.h header we have a member variable of the type
Tm, so we also need to include to related header to provide the
definition of Tm as this header would otherwise not compile on
its own.