### PR TITLE
Finish conversion of DQMEDHarvester to EDProducers

### DIFF
--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_harvesting_cff.py
@@ -12,7 +12,7 @@ siPixelPhase1OfflineDQM_harvesting = cms.Sequence(SiPixelPhase1RawDataHarvester
                                                 + SiPixelPhase1TrackEfficiencyHarvester
                                                 + SiPixelPhase1RawDataHarvester
                                                 + RunQTests_offline
-                                                + SiPixelPhase1Summary_Offline
+                                                + SiPixelPhase1SummaryOffline
                                                   )
 
 siPixelPhase1OfflineDQM_harvesting_cosmics = siPixelPhase1OfflineDQM_harvesting.copyAndExclude([
@@ -20,4 +20,4 @@ siPixelPhase1OfflineDQM_harvesting_cosmics = siPixelPhase1OfflineDQM_harvesting.
 ])
 
 siPixelPhase1OfflineDQM_harvesting_cosmics.replace(RunQTests_offline, RunQTests_cosmics)
-siPixelPhase1OfflineDQM_harvesting_cosmics.replace(SiPixelPhase1Summary_Offline, SiPixelPhase1Summary_Cosmics)
+siPixelPhase1OfflineDQM_harvesting_cosmics.replace(SiPixelPhase1SummaryOffline, SiPixelPhase1SummaryCosmics)

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -106,11 +106,11 @@ siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
  + SiPixelPhase1ClustersHarvester
  + SiPixelPhase1RawDataHarvester
  + RunQTests_online
- + SiPixelPhase1Summary_Online
+ + SiPixelPhase1SummaryOnline
 # + SiPixelPhase1GeometryDebugHarvester
 )
 
 siPixelPhase1OnlineDQM_timing_harvesting = siPixelPhase1OnlineDQM_harvesting.copyAndExclude([
  RunQTests_online,
- SiPixelPhase1Summary_Online,
+ SiPixelPhase1SummaryOnline,
 ])

--- a/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
+++ b/DQM/SiPixelPhase1Summary/python/SiPixelPhase1Summary_cfi.py
@@ -5,7 +5,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 # This object is used to make changes for different running scenarios
 #
 
-SiPixelPhase1Summary_Online = DQMEDHarvester("SiPixelPhase1Summary",
+SiPixelPhase1SummaryOnline = DQMEDHarvester("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(True),
     RunOnEndJob = cms.bool(True),
@@ -33,7 +33,7 @@ SiPixelPhase1Summary_Online = DQMEDHarvester("SiPixelPhase1Summary",
         )
 )
 
-SiPixelPhase1Summary_Offline = DQMEDHarvester("SiPixelPhase1Summary",
+SiPixelPhase1SummaryOffline = DQMEDHarvester("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(False),
     RunOnEndJob = cms.bool(True),
@@ -61,7 +61,7 @@ SiPixelPhase1Summary_Offline = DQMEDHarvester("SiPixelPhase1Summary",
         )
 )
 
-SiPixelPhase1Summary_Cosmics = DQMEDHarvester("SiPixelPhase1Summary",
+SiPixelPhase1SummaryCosmics = DQMEDHarvester("SiPixelPhase1Summary",
     TopFolderName = cms.string('PixelPhase1/Phase1_MechanicalView/'),
     RunOnEndLumi = cms.bool(False),
     RunOnEndJob = cms.bool(True),

--- a/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEfficiencyHarvesting_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-l1tEfficiencyMuons_Harvesting = DQMEDHarvester("L1TEfficiency_Harvesting",
+l1tEfficiencyMuonsHarvesting = DQMEDHarvester("L1TEfficiency_Harvesting",
     verbose  = cms.untracked.bool(False),
     plotCfgs = cms.untracked.VPSet(
         cms.untracked.PSet( dqmBaseDir = cms.untracked.string("L1T/Efficiency/Muons"),

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -358,7 +358,7 @@ Stage2l1TriggerDqmOfflineClient = cms.Sequence(
                                 l1tStage2EmulatorMonitorClient *
                                 l1tStage2MonitorClient *
                                 DQMHarvestL1Trigger *
-                                l1tEfficiencyMuons_Harvesting
+                                l1tEfficiencyMuonsHarvesting
                                 )
 
 

--- a/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
+++ b/DQMOffline/L1Trigger/test/runDQMOffline_step2_L1TStage2CaloLayer2_cfg.py
@@ -47,7 +47,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  # for MC
 
 
 # Path and EndPath definitions
-process.myHarvesting = cms.Path(process.DQMExample_Step2)
+process.myHarvesting = cms.Path(process.DQMExampleStep2)
 process.myEff = cms.Path(
     process.l1tStage2CaloLayer2Efficiency * process.l1tStage2CaloLayer2EmuDiff +
     process. l1tEGammaEfficiency * process.l1tEGammaEmuDiff

--- a/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
+++ b/DQMOffline/Muon/python/EfficencyPlotter_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-effPlotter_Loose = DQMEDHarvester("EfficiencyPlotter",
+effPlotterLoose = DQMEDHarvester("EfficiencyPlotter",
                                   folder = cms.string("Muons/EfficiencyAnalyzer"),
                                   phiMin = cms.double(-3.2),
                                   etaMin = cms.double(-2.5),
@@ -19,7 +19,7 @@ effPlotter_Loose = DQMEDHarvester("EfficiencyPlotter",
                                   )
 
 
-effPlotter_Medium = DQMEDHarvester("EfficiencyPlotter",
+effPlotterMedium = DQMEDHarvester("EfficiencyPlotter",
                                    folder = cms.string("Muons/EfficiencyAnalyzer"),
                                    phiMin = cms.double(-3.2),
                                    etaMin = cms.double(-2.5),
@@ -37,7 +37,7 @@ effPlotter_Medium = DQMEDHarvester("EfficiencyPlotter",
                                    )
 
 
-effPlotter_Tight = DQMEDHarvester("EfficiencyPlotter",
+effPlotterTight = DQMEDHarvester("EfficiencyPlotter",
                                   folder = cms.string("Muons/EfficiencyAnalyzer"),
                                   phiMin = cms.double(-3.2),
                                   etaMin = cms.double(-2.5),
@@ -53,7 +53,7 @@ effPlotter_Tight = DQMEDHarvester("EfficiencyPlotter",
                                   vtxMax = cms.double(40.5),
                                   MuonID = cms.string("Tight")
                                   )
-effPlotter_Loose_miniAOD = DQMEDHarvester("EfficiencyPlotter",
+effPlotterLooseMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                           folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer"),
                                           phiMin = cms.double(-3.2),
                                           etaMin = cms.double(-2.5),
@@ -71,7 +71,7 @@ effPlotter_Loose_miniAOD = DQMEDHarvester("EfficiencyPlotter",
                                           )
 
 
-effPlotter_Medium_miniAOD = DQMEDHarvester("EfficiencyPlotter",
+effPlotterMediumMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                            folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer"),
                                            phiMin = cms.double(-3.2),
                                            etaMin = cms.double(-2.5),
@@ -89,7 +89,7 @@ effPlotter_Medium_miniAOD = DQMEDHarvester("EfficiencyPlotter",
                                            )
 
 
-effPlotter_Tight_miniAOD = DQMEDHarvester("EfficiencyPlotter",
+effPlotterTightMiniAOD = DQMEDHarvester("EfficiencyPlotter",
                                           folder = cms.string("Muons_miniAOD/EfficiencyAnalyzer"),
                                           phiMin = cms.double(-3.2),
                                           etaMin = cms.double(-2.5),

--- a/DQMOffline/Muon/python/muonQualityTests_cff.py
+++ b/DQMOffline/Muon/python/muonQualityTests_cff.py
@@ -39,9 +39,9 @@ cosmicMuonQualityTests = cms.Sequence(ClientTrackEfficiencyTkTracks*
 
 muonQualityTests = cms.Sequence(muonSourcesQualityTests*
                                 muTrackResidualsTest*
-                                effPlotter_Loose*
-                                effPlotter_Medium*
-                                effPlotter_Tight*
+                                effPlotterLoose*
+                                effPlotterMedium*
+                                effPlotterTight*
                                 muRecoTest*
                                 muonClientsQualityTests*
                                 muonComp2RefQualityTests*
@@ -50,9 +50,9 @@ muonQualityTests = cms.Sequence(muonSourcesQualityTests*
 
 muonQualityTests_miniAOD = cms.Sequence(muonSourcesQualityTests*
                                         muTrackResidualsTest*
-                                        effPlotter_Loose_miniAOD*
-                                        effPlotter_Medium_miniAOD*
-                                        effPlotter_Tight_miniAOD*
+                                        effPlotterLooseMiniAOD*
+                                        effPlotterMediumMiniAOD*
+                                        effPlotterTightMiniAOD*
                                         muRecoTest*
                                         muonClientsQualityTests*
                                         muonComp2RefQualityTests*

--- a/DQMOffline/PFTau/python/PFClient_cfi.py
+++ b/DQMOffline/PFTau/python/PFClient_cfi.py
@@ -12,7 +12,7 @@ pfClient = DQMEDHarvester("PFClient",
                           )
 
 # need a different Client to store the slices  
-pfClient_JetRes = DQMEDHarvester("PFClient_JetRes",
+pfClientJetRes = DQMEDHarvester("PFClient_JetRes",
                                   FolderNames = cms.vstring("PFJet/CompWithGenJet","PFJet/CompWithCaloJet"),
                                   HistogramNames = cms.vstring( "delta_et_Over_et_VS_et_"),
                                   CreateEfficiencyPlots = cms.bool(False),

--- a/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
@@ -70,12 +70,12 @@ def makePFTauAnalyzer(monitorModule):
     return (m1, m2)
 
 
-(HLTTauPostAnalysis_Inclusive, HLTTauPostAnalysis_Inclusive2) = makeInclusiveAnalyzer(hltTauOfflineMonitor_Inclusive)
-(HLTTauPostAnalysis_PFTaus, HLTTauPostAnalysis_PFTaus2) = makePFTauAnalyzer(hltTauOfflineMonitor_PFTaus)
-(HLTTauPostAnalysis_TP, HLTTauPostAnalysis_TP2) = makePFTauAnalyzer(hltTauOfflineMonitor_TagAndProbe)
+(HLTTauPostAnalysisInclusive, HLTTauPostAnalysisInclusive2) = makeInclusiveAnalyzer(hltTauOfflineMonitor_Inclusive)
+(HLTTauPostAnalysisPFTaus, HLTTauPostAnalysisPFTaus2) = makePFTauAnalyzer(hltTauOfflineMonitor_PFTaus)
+(HLTTauPostAnalysisTP, HLTTauPostAnalysisTP2) = makePFTauAnalyzer(hltTauOfflineMonitor_TagAndProbe)
 
 HLTTauPostSeq = cms.Sequence(
-    HLTTauPostAnalysis_Inclusive+HLTTauPostAnalysis_Inclusive2+
-    HLTTauPostAnalysis_PFTaus+HLTTauPostAnalysis_PFTaus2+
-    HLTTauPostAnalysis_TP+HLTTauPostAnalysis_TP2
+    HLTTauPostAnalysisInclusive+HLTTauPostAnalysisInclusive2+
+    HLTTauPostAnalysisPFTaus+HLTTauPostAnalysisPFTaus2+
+    HLTTauPostAnalysisTP+HLTTauPostAnalysisTP2
 )

--- a/DQMServices/Components/plugins/MEtoEDMConverter.cc
+++ b/DQMServices/Components/plugins/MEtoEDMConverter.cc
@@ -12,6 +12,7 @@
 #include "DQMServices/Components/plugins/MEtoEDMConverter.h"
 #include "classlib/utils/StringList.h"
 #include "classlib/utils/StringOps.h"
+#include "DataFormats/Histograms/interface/DQMToken.h"
 
 using namespace lat;
 
@@ -78,9 +79,9 @@ MEtoEDMConverter::MEtoEDMConverter(const edm::ParameterSet & iPSet) :
   produces<MEtoEDM<long long>, edm::Transition::EndLuminosityBlock>(sName);
   produces<MEtoEDM<TString>, edm::Transition::EndLuminosityBlock>(sName);
 
-  iCount.clear();
+  consumesMany<DQMToken>();
 
-  assert(sizeof(int64_t) == sizeof(long long));
+  static_assert(sizeof(int64_t) == sizeof(long long),"type int64_t is not the same length as long long");
 
 }
 

--- a/DQMServices/Core/BuildFile.xml
+++ b/DQMServices/Core/BuildFile.xml
@@ -1,4 +1,5 @@
 <flags   CPPFLAGS="-DWITHOUT_CMS_FRAMEWORK=0"/>
+<use   name="DataFormats/Histograms"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>

--- a/DQMServices/Core/BuildFile.xml
+++ b/DQMServices/Core/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags   CPPFLAGS="-DWITHOUT_CMS_FRAMEWORK=0"/>
-<use   name="DataFormats/Histograms"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>

--- a/DQMServices/Core/interface/DQMEDHarvester.h
+++ b/DQMServices/Core/interface/DQMEDHarvester.h
@@ -2,7 +2,6 @@
 #define CORE_DQMED_HARVESTER_H
 
 //<<<<<< INCLUDES                                                       >>>>>>
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDProducer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
@@ -19,23 +18,22 @@ edm::EndLuminosityBlockProducer>
 {
 public:
   DQMEDHarvester(void);
-#ifdef __INTEL_COMPILER
   virtual ~DQMEDHarvester() = default;
-#endif
+
   // implicit copy constructor
   // implicit assignment operator
   // implicit destructor
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override {};
   virtual void produce(edm::Event&, edm::EventSetup const&) override final {};
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override {};
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final {};
-  virtual void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) final;
-  virtual void endJob() final;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) override final {};
+  virtual void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const&) override final;
+  virtual void endJob() override final;
   virtual void dqmEndLuminosityBlock(DQMStore::IBooker &, DQMStore::IGetter &, edm::LuminosityBlock const &, edm::EventSetup const&) {};
   virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) = 0;
-  void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override final;
 
 private:
+  virtual void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override final;
 
 };
 

--- a/DQMServices/Core/src/DQMEDHarvester.cc
+++ b/DQMServices/Core/src/DQMEDHarvester.cc
@@ -8,7 +8,7 @@
 
 DQMEDHarvester::DQMEDHarvester() {
   usesResource("DQMStore");
-  produces<DQMToken>();
+  produces<DQMToken,edm::Transition::EndLuminosityBlock>();
 }
 
 void DQMEDHarvester::endJob() {

--- a/DQMServices/Core/src/DQMEDHarvester.cc
+++ b/DQMServices/Core/src/DQMEDHarvester.cc
@@ -1,9 +1,14 @@
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "DataFormats/Histograms/interface/DQMToken.h"
+
+#include <memory>
 
 DQMEDHarvester::DQMEDHarvester() {
   usesResource("DQMStore");
+  produces<DQMToken>();
 }
 
 void DQMEDHarvester::endJob() {
@@ -21,5 +26,6 @@ void DQMEDHarvester::endLuminosityBlock(edm::LuminosityBlock const& iLumi,
     });
 }
 
-void DQMEDHarvester::endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) {}
-
+void DQMEDHarvester::endLuminosityBlockProduce(edm::LuminosityBlock& iLumi, edm::EventSetup const&) {
+  iLumi.put(std::make_unique<DQMToken>());
+}

--- a/DQMServices/Examples/python/test/DQMExample_GenericClient_cfi.py
+++ b/DQMServices/Examples/python/test/DQMExample_GenericClient_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-DQMExample_GenericClient = DQMEDHarvester("DQMGenericClient",
+DQMExampleGenericClient = DQMEDHarvester("DQMGenericClient",
                                           subDirs = cms.untracked.vstring("Physics/TopTest"),
                                           efficiency = cms.vstring(
                                               "myEfficiencyEta 'Efficiency vs Eta' EleEta_leading_HLT_matched EleEta_leading",

--- a/DQMServices/Examples/python/test/DQMExample_Step2_cfg.py
+++ b/DQMServices/Examples/python/test/DQMExample_Step2_cfg.py
@@ -37,8 +37,8 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')  #for MC
 
 
 # Path and EndPath definitions
-process.myHarvesting = cms.Path(process.DQMExample_Step2)
-process.myEff = cms.Path(process.DQMExample_GenericClient)
+process.myHarvesting = cms.Path(process.DQMExampleStep2)
+process.myEff = cms.Path(process.DQMExampleGenericClient)
 process.myTest = cms.Path(process.DQMExample_qTester)
 process.dqmsave_step = cms.Path(process.DQMSaver)
 

--- a/DQMServices/Examples/python/test/DQMExample_Step2_cfi.py
+++ b/DQMServices/Examples/python/test/DQMExample_Step2_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-DQMExample_Step2 = DQMEDHarvester("DQMExample_Step2",
+DQMExampleStep2 = DQMEDHarvester("DQMExample_Step2",
                                   numMonitorName = cms.string("Physics/TopTest/ElePt_leading_HLT_matched"),
                                   denMonitorName = cms.string("Physics/TopTest/ElePt_leading")
                                   )

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -608,7 +608,8 @@ DQMRootOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptio
     ->setComment("Only write the run with this run number. 0 means write all runs.");
   desc.addOptionalUntracked<int>("splitLevel", 99)
     ->setComment("UNUSED Only here to allow older configurations written for PoolOutputModule to work.");
-  edm::OutputModule::fillDescription(desc, std::vector<std::string>(1U, std::string("drop *")));
+  const std::vector<std::string> keep = {"drop *", "keep DQMToken_*_*_*"};
+  edm::OutputModule::fillDescription(desc, keep);
 
   edm::ParameterSetDescription dataSet;
   dataSet.setAllowAnything();

--- a/DataFormats/Histograms/interface/DQMToken.h
+++ b/DataFormats/Histograms/interface/DQMToken.h
@@ -1,0 +1,29 @@
+#ifndef DataFormats_Histograms_DQMToken_h
+#define DataFormats_Histograms_DQMToken_h
+// -*- C++ -*-
+//
+// Package:     DataFormats/Histograms
+// Class  :     DQMToken
+// 
+/**\class DQMToken DQMToken.h "DataFormats/Histograms/interface/DQMToken.h"
+
+ Description: Token to put in Run or LuminosityBlock to designate that a EDProducer fills DQM MonitorElements
+
+ Usage:
+    
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 14 Jun 2017 13:48:54 GMT
+//
+
+class DQMToken
+{
+
+   public:
+      DQMToken() {}
+};
+
+
+#endif

--- a/DataFormats/Histograms/src/classes.h
+++ b/DataFormats/Histograms/src/classes.h
@@ -18,6 +18,7 @@
 #include "TProfile2D.h"
 #include "TProfile3D.h"
 #include "DataFormats/Histograms/interface/MEtoEDMFormat.h"
+#include "DataFormats/Histograms/interface/DQMToken.h"
 #include "TString.h"
 #include <stdint.h>
 

--- a/DataFormats/Histograms/src/classes_def.xml
+++ b/DataFormats/Histograms/src/classes_def.xml
@@ -70,4 +70,7 @@
  <class name="edm::Wrapper<MEtoEDM<int> >"/>
  <class name="edm::Wrapper<MEtoEDM<long long> >"/>
  <class name="edm::Wrapper<MEtoEDM<TString> >"/>
+
+ <class name="DQMToken" ClassVersion="0"/>
+ <class name="edm::Wrapper<DQMToken>" persistent="false"/>
 </lcgdict>

--- a/GeneratorInterface/RivetInterface/python/PostProcessor_cff.py
+++ b/GeneratorInterface/RivetInterface/python/PostProcessor_cff.py
@@ -294,7 +294,7 @@ postCMS_2011_S9086218 = cms.EDAnalyzer(
 ###################
 #CMS_2011_S9088458
 ###################
-postCMS_2011_S9088458 = DQMEDHarvester(
+postCMSo2011oS9088458 = DQMEDHarvester(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("Rivet/CMS_2011_S9088458"),
     efficiencyProfile = cms.untracked.vstring("d01-x01-y01 d01-x01-y01 trijet dijet"),
@@ -312,5 +312,5 @@ RivetDQMPostProcessor = cms.Sequence( postCMS_2011_S8968497 +
                                       postCMS_2011_S8957746 + 
                                       postCMS_2011_S8968497 +
                                       postCMS_2011_S9086218 +
-                                      postCMS_2011_S9088458 )
+                                      postCMSo2011oS9088458 )
 

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -211,9 +211,9 @@ for type in plot_types:
 efficiency_strings = get_reco_strings(efficiency_strings)
 efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 
-hltHiggsPostVBFHbb_2btag = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb_2btag.subDirs = ['HLT/Higgs/VBFHbb_2btag']
-hltHiggsPostVBFHbb_2btag.efficiencyProfile = efficiency_strings
+hltHiggsPostVBFHbb2btag = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb2btag.subDirs = ['HLT/Higgs/VBFHbb_2btag']
+hltHiggsPostVBFHbb2btag.efficiencyProfile = efficiency_strings
 
 #Specific plots for VBFHbb_1btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
@@ -235,9 +235,9 @@ for type in plot_types:
 efficiency_strings = get_reco_strings(efficiency_strings)
 efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
     
-hltHiggsPostVBFHbb_1btag = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb_1btag.subDirs = ['HLT/Higgs/VBFHbb_1btag']
-hltHiggsPostVBFHbb_1btag.efficiencyProfile = efficiency_strings
+hltHiggsPostVBFHbb1btag = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb1btag.subDirs = ['HLT/Higgs/VBFHbb_1btag']
+hltHiggsPostVBFHbb1btag.efficiencyProfile = efficiency_strings
 
 #Specific plots for VBFHbb_0btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
@@ -259,9 +259,9 @@ for type in plot_types:
 efficiency_strings = get_reco_strings(efficiency_strings)
 efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 
-hltHiggsPostVBFHbb_0btag = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb_0btag.subDirs = ['HLT/Higgs/VBFHbb_0btag']
-hltHiggsPostVBFHbb_0btag.efficiencyProfile = efficiency_strings
+hltHiggsPostVBFHbb0btag = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb0btag.subDirs = ['HLT/Higgs/VBFHbb_0btag']
+hltHiggsPostVBFHbb0btag.efficiencyProfile = efficiency_strings
 
 
 #Specific plots for ZnnHbb
@@ -384,9 +384,9 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostH2tau+
         hltHiggsPostTTHbbej+
         hltHiggsPostAHttH+
-        hltHiggsPostVBFHbb_0btag+
-        hltHiggsPostVBFHbb_1btag+
-        hltHiggsPostVBFHbb_2btag+
+        hltHiggsPostVBFHbb0btag+
+        hltHiggsPostVBFHbb1btag+
+        hltHiggsPostVBFHbb2btag+
         hltHiggsPostZnnHbb+
         hltHiggsPostDoubleHinTaus+
         hltHiggsPostHiggsDalitz+

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_DiJet_MET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_DiJet_MET_cff.py
@@ -20,7 +20,7 @@ SUSY_HLT_DiJet_MET = cms.EDAnalyzer("SUSY_HLT_DiJet_MET",
   OfflineMetCut = cms.untracked.double(250.0),
 )
 
-SUSY_HLT_DiJet_MET_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToDiJetMEToPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DiCentralPFJet55_PFMET110_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Ele_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                    csvThreshold = cms.untracked.double(0.898)
                                                    )
 
-SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToEleHToBTagSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                   subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_BTagCSV_p067_PFHT400'),
                                                                   efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Ele_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                       csvThreshold = cms.untracked.double(-1.0)
                                                       )
 
-SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToEleHToControlSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                      subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT350'),
                                                                      efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Ele15_HT350_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton'
                                                   csvThreshold = cms.untracked.double(-1.0)
                                                   )
 
-SUSY_HLT_Ele15_HT350_MET50_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToEle15oHT350oMET50oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT350_PFMET50'),
                                                                  efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -94,7 +94,7 @@ SUSY_HLT_Ele15_HT400_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton'
                                                   csvThreshold = cms.untracked.double(-1.0)
                                                   )
 
-SUSY_HLT_Ele15_HT400_MET50_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToEle15oHT400oMET50oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT400_PFMET50'),
                                                                  efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -114,6 +114,6 @@ SUSY_HLT_Ele_HT_MET_SingleLepton = cms.Sequence( SUSY_HLT_Ele15_HT350_MET50_Sing
                                                  + SUSY_HLT_Ele15_HT400_MET50_SingleLepton
 )
 
-SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Ele15_HT350_MET50_SingleLepton_POSTPROCESSING
-                                                                + SUSY_HLT_Ele15_HT400_MET50_SingleLepton_POSTPROCESSING
+SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING = cms.Sequence( SUSYoHLToEle15oHT350oMET50oSingleLeptonPOSTPROCESSING
+                                                                + SUSYoHLToEle15oHT400oMET50oSingleLeptonPOSTPROCESSING
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Ele15_HT600_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               csvThreshold = cms.untracked.double(-1.0)
                                               )
 
-SUSY_HLT_Ele15_HT600_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToEle15oHT600oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                              subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT600'),
                                                              efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -93,7 +93,7 @@ SUSY_HLT_Ele15_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               csvThreshold = cms.untracked.double(-1.0)
                                               )
 
-SUSY_HLT_Ele15_HT400_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToEle15oHT400oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                              subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT400'),
                                                              efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -143,7 +143,7 @@ SUSY_HLT_Ele50_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               csvThreshold = cms.untracked.double(-1.0)
                                               )
 
-SUSY_HLT_Ele50_HT400_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToEle50oHT400oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                              subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele50_IsoVVVL_PFHT400'),
                                                              efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -163,7 +163,7 @@ SUSY_HLT_Ele_HT_SingleLepton = cms.Sequence( SUSY_HLT_Ele15_HT600_SingleLepton
                                              + SUSY_HLT_Ele50_HT400_SingleLepton
 )
 
-SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Ele15_HT600_SingleLepton_POSTPROCESSING
-                                                            + SUSY_HLT_Ele15_HT400_SingleLepton_POSTPROCESSING
-                                                            + SUSY_HLT_Ele50_HT400_SingleLepton_POSTPROCESSING
+SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING = cms.Sequence( SUSYoHLToEle15oHT600oSingleLeptonPOSTPROCESSING
+                                                            + SUSYoHLToEle15oHT400oSingleLeptonPOSTPROCESSING
+                                                            + SUSYoHLToEle50oHT400oSingleLeptonPOSTPROCESSING
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_ElecFakes_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_ElecFakes_cff.py
@@ -9,7 +9,7 @@ SUSY_HLT_Ele8_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle8CaloIdLTrackIdLIsoVLTrackIsoFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle8PFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele8_IdL_Iso_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle8oIdLoIsoJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -24,7 +24,7 @@ SUSY_HLT_Ele12_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle12CaloIdLTrackIdLIsoVLTrackIsoFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle12PFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele12_IdL_Iso_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle12oIdLoIsoJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -40,7 +40,7 @@ SUSY_HLT_Ele17_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerJetFilter = cms.InputTag('hltEle17PFJet30EleCleaned', '', 'HLT'), #the last filter in the path
 )
 
-SUSY_HLT_Ele17_IdL_Iso_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle17oIdLoIsoJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele17_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -56,7 +56,7 @@ SUSY_HLT_Ele23_IdL_Iso_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerJetFilter = cms.InputTag('hltEle23PFJet30EleCleaned', '', 'HLT'), #the last filter in the path
 )
 
-SUSY_HLT_Ele23_IdL_Iso_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle23oIdLoIsoJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -72,7 +72,7 @@ SUSY_HLT_Ele8_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle8CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle8NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele8_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle8oJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -87,7 +87,7 @@ SUSY_HLT_Ele12_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle12CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle12NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele12_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle12oJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele12_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -102,7 +102,7 @@ SUSY_HLT_Ele17_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle17CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle17NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele17_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle17oJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -117,7 +117,7 @@ SUSY_HLT_Ele23_Jet30 = cms.EDAnalyzer("SUSY_HLT_ElecFakes",
   TriggerFilter = cms.InputTag('hltEle23CaloIdMGsfTrackIdMDphiFilter', '', 'HLT'), #the last filter in the path
   TriggerJetFilter = cms.InputTag('hltEle23NoIsoPFJet30EleCleaned', '', 'HLT'), #the last filter in the path                                      
 )
-SUSY_HLT_Ele23_Jet30_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToEle23oJet30oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs   = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v"),
     verbose    = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution = cms.vstring(""),
@@ -133,11 +133,11 @@ SUSY_HLT_ElecFakes = cms.Sequence(SUSY_HLT_Ele8_IdL_Iso_Jet30+
                                   SUSY_HLT_Ele17_Jet30+
                                   SUSY_HLT_Ele23_Jet30)
 
-SUSY_HLT_ElecFakes_POSTPROCESSING = cms.Sequence(SUSY_HLT_Ele8_IdL_Iso_Jet30_POSTPROCESSING+
-                                                 SUSY_HLT_Ele12_IdL_Iso_Jet30_POSTPROCESSING+
-                                                 SUSY_HLT_Ele17_IdL_Iso_Jet30_POSTPROCESSING+
-                                                 SUSY_HLT_Ele23_IdL_Iso_Jet30_POSTPROCESSING+
-                                                 SUSY_HLT_Ele8_Jet30_POSTPROCESSING+
-                                                 SUSY_HLT_Ele12_Jet30_POSTPROCESSING+
-                                                 SUSY_HLT_Ele17_Jet30_POSTPROCESSING+
-                                                 SUSY_HLT_Ele23_Jet30_POSTPROCESSING)
+SUSY_HLT_ElecFakes_POSTPROCESSING = cms.Sequence(SUSYoHLToEle8oIdLoIsoJet30oPOSTPROCESSING+
+                                                 SUSYoHLToEle12oIdLoIsoJet30oPOSTPROCESSING+
+                                                 SUSYoHLToEle17oIdLoIsoJet30oPOSTPROCESSING+
+                                                 SUSYoHLToEle23oIdLoIsoJet30oPOSTPROCESSING+
+                                                 SUSYoHLToEle8oJet30oPOSTPROCESSING+
+                                                 SUSYoHLToEle12oJet30oPOSTPROCESSING+
+                                                 SUSYoHLToEle17oJet30oPOSTPROCESSING+
+                                                 SUSYoHLToEle23oJet30oPOSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Electron_BJet_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Electron_BJet_cff.py
@@ -15,7 +15,7 @@ SUSY_HLT_Electron_BJet = cms.EDAnalyzer("SUSY_HLT_Electron_BJet",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_Electron_BJet_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToElectronBJetPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Ele10_CaloIdM_TrackIdM_CentralPFJet30_BTagCSV_p13_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleElectron_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleElectron_cff.py
@@ -35,7 +35,7 @@ SUSY_HLT_HT250_DoubleEle = cms.EDAnalyzer("SUSY_HLT_DoubleEle_Hadronic",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT_DoubleEle_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHToDoubleElePOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -45,7 +45,7 @@ SUSY_HLT_HT_DoubleEle_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     )
 )
 
-SUSY_HLT_HT250_DoubleEle_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHT250oDoubleElePOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT250_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleMuon_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_DoubleMuon_cff.py
@@ -32,7 +32,7 @@ SUSY_HLT_HT250_DoubleMuon = cms.EDAnalyzer("SUSY_HLT_DoubleMuon_Hadronic",
 )
 
 
-SUSY_HLT_HT_DoubleMuon_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHToDoubleMuonPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu8_Mass8_PFHT300_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -42,7 +42,7 @@ SUSY_HLT_HT_DoubleMuon_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     )
 )
 
-SUSY_HLT_HT250_DoubleMuon_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHT250oDoubleMuonPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu8_Mass8_PFHT250_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_MuEle_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_HT_MuEle_cff.py
@@ -38,7 +38,7 @@ SUSY_HLT_HT250_MuEle = cms.EDAnalyzer("SUSY_HLT_MuEle_Hadronic",
 )
 
 
-SUSY_HLT_HT_MuEle_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHToMuElePOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -49,7 +49,7 @@ SUSY_HLT_HT_MuEle_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     )
 )
 
-SUSY_HLT_HT250_MuEle_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHT250oMuElePOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT250_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Muon_BJet_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_Muon_BJet_cff.py
@@ -16,7 +16,7 @@ SUSY_HLT_Muon_BJet = cms.EDAnalyzer("SUSY_HLT_Muon_BJet",
 )
 
 
-SUSY_HLT_Muon_BJet_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMuonBJetPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu10_CentralPFJet30_BTagCSV_p13_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_PhotonMET_cff.py
@@ -37,7 +37,7 @@ SUSY_HLT_PhotonMET_pt75 = cms.EDAnalyzer("SUSY_HLT_PhotonMET",
    metThrOffline = cms.untracked.double(100),
 )
 
-SUSY_HLT_PhotonMET_pt36_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToPhotonMETpt36oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon36_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
    resolution     = cms.vstring(""),
@@ -47,7 +47,7 @@ SUSY_HLT_PhotonMET_pt36_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
    )
 )
 
-SUSY_HLT_PhotonMET_pt50_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToPhotonMETpt50oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon50_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
    resolution     = cms.vstring(""),
@@ -57,7 +57,7 @@ SUSY_HLT_PhotonMET_pt50_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
    )
 )
 
-SUSY_HLT_PhotonMET_pt75_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToPhotonMETpt75oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon75_R9Id90_HE10_Iso40_EBOnly_PFMET40_v"),
    verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
    resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
@@ -30,7 +30,7 @@ SUSY_HLT_Mu10_VBF = cms.EDAnalyzer("SUSY_HLT_VBF_Mu10",
                                  
                                  )
 
-SUSY_HLT_Mu10_VBF_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMu10oVBFoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
                                                 subDirs        = cms.untracked.vstring("HLT/SUSYBSM/SUSY_HLT_VBF_Mu10_v"),
                                                 verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
                                                 resolution     = cms.vstring(""),
@@ -71,7 +71,7 @@ SUSY_HLT_Mu8_VBF = cms.EDAnalyzer("SUSY_HLT_VBF_Mu8",
                                  
                                  )
 
-SUSY_HLT_Mu8_VBF_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMu8oVBFoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
                                                 subDirs        = cms.untracked.vstring("HLT/SUSYBSM/SUSY_HLT_VBF_Mu8_v"),
                                                 verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
                                                 resolution     = cms.vstring(""),
@@ -87,6 +87,6 @@ SUSY_HLT_Mu_VBF = cms.Sequence( SUSY_HLT_Mu10_VBF +
                                 SUSY_HLT_Mu8_VBF
                                 )
 
-SUSY_HLT_Mu_VBF_POSTPROCESSING = cms.Sequence( SUSY_HLT_Mu10_VBF_POSTPROCESSING +
-                                               SUSY_HLT_Mu8_VBF_POSTPROCESSING
+SUSY_HLT_Mu_VBF_POSTPROCESSING = cms.Sequence( SUSYoHLToMu10oVBFoPOSTPROCESSING +
+                                               SUSYoHLToMu8oVBFoPOSTPROCESSING
                                                )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HT_MET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HT_MET_cff.py
@@ -14,7 +14,7 @@ SUSY_HLT_HT350_MET100 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT350_MET100_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHT350oMET100oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT350_PFMET100_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -36,7 +36,7 @@ SUSY_HLT_HT300_MET100 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT300_MET100_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHT300oMET100oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT300_PFMET100_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -58,7 +58,7 @@ SUSY_HLT_HT300_MET110 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_HT300_MET110_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToHT300oMET110oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT300_PFMET110_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -72,7 +72,7 @@ SUSY_HLT_HT_MET = cms.Sequence(SUSY_HLT_HT350_MET100 +
                                 SUSY_HLT_HT300_MET110
 )
 
-SUSY_HLT_HT_MET_POSTPROCESSING = cms.Sequence(SUSY_HLT_HT350_MET100_POSTPROCESSING +
-                              SUSY_HLT_HT300_MET100_POSTPROCESSING +
-                              SUSY_HLT_HT300_MET110_POSTPROCESSING
+SUSY_HLT_HT_MET_POSTPROCESSING = cms.Sequence(SUSYoHLToHT350oMET100oPOSTPROCESSING +
+                              SUSYoHLToHT300oMET100oPOSTPROCESSING +
+                              SUSYoHLToHT300oMET110oPOSTPROCESSING
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_BTAG_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_BTAG_cff.py
@@ -14,7 +14,7 @@ SUSY_HLT_MET_BTAG = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_MET_BTAG_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMEToBTAGoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET120_BTagCSV_p067_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_BTAG_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_BTAG_cff.py
@@ -24,7 +24,7 @@ SUSY_HLT_MET_HT_MUON_BTAG = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_HT_MUON_BTAG_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMEToHToMUONoBTAGoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu6_PFHT200_PFMET80_BTagCSV_p067_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_ER_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_ER_cff.py
@@ -22,7 +22,7 @@ SUSY_HLT_MET_HT_MUON_ER = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_HT_MUON_ER_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMEToHToMUONoERoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu3er_PFHT140_PFMET125_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_HT_MUON_cff.py
@@ -22,7 +22,7 @@ SUSY_HLT_MET_HT_MUON = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_HT_MUON_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMEToHToMUONoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu6_PFHT200_PFMET100_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_ER_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_ER_cff.py
@@ -22,7 +22,7 @@ SUSY_HLT_MET_MUON_ER = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET_MUON_ER_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMEToMUONoERoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLTriggerOffline/SUSYBSM/HLT_Mu14er_PFMET100_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MET_MUON_cff.py
@@ -22,7 +22,7 @@ SUSY_HLT_MET120_MUON5 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET120_MUON5_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMET120oMUON5oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET120_Mu5_v"),
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(
@@ -53,7 +53,7 @@ SUSY_HLT_MET50_DIMUON3 = cms.EDAnalyzer("SUSY_HLT_Muon_Hadronic",
 )
 
 
-SUSY_HLT_MET50_DIMUON3_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMET50oDIMUON3oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_DoubleMu3_PFMET50_v"),
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(
@@ -67,6 +67,6 @@ SUSY_HLT_MET_MUON = cms.Sequence( SUSY_HLT_MET120_MUON5 +
                                   SUSY_HLT_MET50_DIMUON3
 )
 
-SUSY_HLT_MET_MUON_POSTPROCESSING = cms.Sequence( SUSY_HLT_MET120_MUON5_POSTPROCESSING +
-                                                 SUSY_HLT_MET50_DIMUON3_POSTPROCESSING            
+SUSY_HLT_MET_MUON_POSTPROCESSING = cms.Sequence( SUSYoHLToMET120oMUON5oPOSTPROCESSING +
+                                                 SUSYoHLToMET50oDIMUON3oPOSTPROCESSING            
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Mu_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                   csvThreshold = cms.untracked.double(0.898)
                                                   )
 
-SUSY_HLT_Mu_HT_BTag_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToMuHToBTagSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_BTagCSV_p067_PFHT400'),
                                                                  efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Mu_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                      csvThreshold = cms.untracked.double(-1.0)
                                                      )
 
-SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToMuHToControlSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                     subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT350_v'),
                                                                     efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
@@ -44,7 +44,7 @@ SUSY_HLT_Mu15_HT350_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                  )
 
 
-SUSY_HLT_Mu15_HT350_MET50_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToMu15oHT350oMET50oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT350_PFMET50_v'),
                                                                 efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -96,7 +96,7 @@ SUSY_HLT_Mu15_HT400_MET50_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                  )
 
 
-SUSY_HLT_Mu15_HT400_MET50_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToMu15oHT400oMET50oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT400_PFMET50_v'),
                                                                 efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -111,6 +111,6 @@ SUSY_HLT_Mu_HT_MET_SingleLepton = cms.Sequence( SUSY_HLT_Mu15_HT350_MET50_Single
                                                 + SUSY_HLT_Mu15_HT400_MET50_SingleLepton
 )
 
-SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Mu15_HT350_MET50_SingleLepton_POSTPROCESSING
-                                                               + SUSY_HLT_Mu15_HT400_MET50_SingleLepton_POSTPROCESSING
+SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING = cms.Sequence( SUSYoHLToMu15oHT350oMET50oSingleLeptonPOSTPROCESSING
+                                                               + SUSYoHLToMu15oHT400oMET50oSingleLeptonPOSTPROCESSING
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
@@ -43,7 +43,7 @@ SUSY_HLT_Mu15_HT600_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              csvThreshold = cms.untracked.double(-1.0)
                                              )
 
-SUSY_HLT_Mu15_HT600_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToMu15oHT600oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT600_v'),
                                                             efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -93,7 +93,7 @@ SUSY_HLT_Mu15_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              csvThreshold = cms.untracked.double(-1.0)
                                              )
 
-SUSY_HLT_Mu15_HT400_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToMu15oHT400oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT400_v'),
                                                             efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -143,7 +143,7 @@ SUSY_HLT_Mu50_HT400_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              csvThreshold = cms.untracked.double(-1.0)
                                              )
 
-SUSY_HLT_Mu50_HT400_SingleLepton_POSTPROCESSING = DQMEDHarvester('DQMGenericClient',
+SUSYoHLToMu50oHT400oSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient',
                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu50_IsoVVVL_PFHT400_v'),
                                                             efficiency = cms.vstring(
         "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
@@ -158,8 +158,8 @@ SUSY_HLT_Mu_HT_SingleLepton = cms.Sequence( SUSY_HLT_Mu15_HT600_SingleLepton
                                              + SUSY_HLT_Mu50_HT400_SingleLepton
 )
 
-SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING = cms.Sequence( SUSY_HLT_Mu15_HT600_SingleLepton_POSTPROCESSING
-                                                            + SUSY_HLT_Mu15_HT400_SingleLepton_POSTPROCESSING
-                                                            + SUSY_HLT_Mu50_HT400_SingleLepton_POSTPROCESSING
+SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING = cms.Sequence( SUSYoHLToMu15oHT600oSingleLeptonPOSTPROCESSING
+                                                            + SUSYoHLToMu15oHT400oSingleLeptonPOSTPROCESSING
+                                                            + SUSYoHLToMu50oHT400oSingleLeptonPOSTPROCESSING
 
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MuonFakes_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_MuonFakes_cff.py
@@ -9,7 +9,7 @@ SUSY_HLT_Mu8_TrkIsoVVL = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f5L3Filtered8TkIsoFiltered0p4', '', 'HLT'), #the last filter in the path                                        
 )
 
-SUSY_HLT_Mu8_TrkIsoVVL_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMu8oTrkIsoVVLoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_TrkIsoVVL_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -24,7 +24,7 @@ SUSY_HLT_Mu8 = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f5L3Filtered8', '', 'HLT'), #the last filter in the path                                        
 )
 
-SUSY_HLT_Mu8_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMu8oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu8_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -39,7 +39,7 @@ SUSY_HLT_Mu17_TrkIsoVVL = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu1lqL1f0L2f10L3Filtered17TkIsoFiltered0p4', '', 'HLT'), #the last filter in the path                                 
 )
 
-SUSY_HLT_Mu17_TrkIsoVVL_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMu17oTrkIsoVVLoPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu17_TrkIsoVVL_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -54,7 +54,7 @@ SUSY_HLT_Mu17 = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu10lqL1f0L2f10L3Filtered17', '', 'HLT'), #the last filter in the path                                 
 )
 
-SUSY_HLT_Mu17_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToMu17oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Mu17_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -69,7 +69,7 @@ SUSY_HLT_TkMu17 = cms.EDAnalyzer("SUSY_HLT_MuonFakes",
   TriggerFilter = cms.InputTag('hltL3fL1sMu10lqTkFiltered17Q', '', 'HLT'), #the last filter in the path                                 
 )
 
-SUSY_HLT_TkMu17_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToTkMu17oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_TkMu17_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
@@ -83,8 +83,8 @@ SUSY_HLT_MuonFakes = cms.Sequence(SUSY_HLT_Mu8 +
                                   SUSY_HLT_Mu8_TrkIsoVVL+
                                   SUSY_HLT_Mu17_TrkIsoVVL)
 
-SUSY_HLT_MuonFakes_POSTPROCESSING = cms.Sequence(SUSY_HLT_Mu8_POSTPROCESSING +
-                                                 SUSY_HLT_Mu17_POSTPROCESSING+
-                                                 SUSY_HLT_TkMu17_POSTPROCESSING+
-                                                 SUSY_HLT_Mu8_TrkIsoVVL_POSTPROCESSING+ 
-                                                 SUSY_HLT_Mu17_TrkIsoVVL_POSTPROCESSING)
+SUSY_HLT_MuonFakes_POSTPROCESSING = cms.Sequence(SUSYoHLToMu8oPOSTPROCESSING +
+                                                 SUSYoHLToMu17oPOSTPROCESSING+
+                                                 SUSYoHLToTkMu17oPOSTPROCESSING+
+                                                 SUSYoHLToMu8oTrkIsoVVLoPOSTPROCESSING+ 
+                                                 SUSYoHLToMu17oTrkIsoVVLoPOSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_PhotonHT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_PhotonHT_cff.py
@@ -15,7 +15,7 @@ SUSY_HLT_PhotonHT = cms.EDAnalyzer("SUSY_HLT_PhotonHT",
   htThrOffline = cms.untracked.double( 600 ),
 )
 
-SUSY_HLT_PhotonHT_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToPhotonHToPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_Photon90_CaloIdL_PFHT500_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Razor_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Razor_cff.py
@@ -222,7 +222,7 @@ SUSY_HLT_Razor_DM_Calo_Rsq0p25 = cms.EDAnalyzer("SUSY_HLT_Razor",
   hemispheres = cms.InputTag('caloHemispheres')
 )
 
-SUSY_HLT_Razor_PostVal_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToRazorPostValPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_RsqMR300_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR300_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_Rsq0p36_v", "HLT/SUSYBSM/HLT_RsqMR270_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR270_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_Rsq0p30_v", "HLT/SUSYBSM/HLT_RsqMR260_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR260_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_4jet_v", "HLT/SUSYBSM/HLT_Rsq0p25_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_Calo_v", "HLT/SUSYBSM/HLT_RsqMR240_Rsq0p09_MR200_4jet_Calo_v", "HLT/SUSYBSM/HLT_Rsq0p25_Calo_v", "HLT/SUSYBSM/HLT_Rsq0p02_MR300_TriPFJet80_60_40_BTagCSV_p063_p20_Mbb60_200_v", "HLT/SUSYBSM/HLT_Rsq0p02_MR300_TriPFJet80_60_40_DoubleBTagCSV_p063_Mbb60_200_v"),
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
@@ -203,7 +203,7 @@ SUSY_HLT_HT400_alphaT0p52 = cms.EDAnalyzer("SUSY_HLT_alphaT",
   caloHtThrTurnon = cms.untracked.double(400),
 )
 
-SUSY_HLT_alphaT_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLTalphaToPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring(
         "HLT/SUSYBSM/HLT_PFHT200_DiPFJetAve90_PFAlphaT0p51_v"
         "HLT/SUSYBSM/HLT_PFHT200_DiPFJetAve90_PFAlphaT0p57_v",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_caloHT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_caloHT_cff.py
@@ -67,7 +67,7 @@ SUSY_HLT_CaloHT400 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
 )
 
 
-SUSY_HLT_CaloHT_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToCaloHToPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring(
   "HLT/SUSYBSM/HLT_HT200_v",
   "HLT/SUSYBSM/HLT_HT250_v",

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveHT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveHT_cff.py
@@ -14,7 +14,7 @@ SUSY_HLT_InclusiveHT_800 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_800_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHTo800oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT800_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -36,7 +36,7 @@ SUSY_HLT_InclusiveHT_900 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_900_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHTo900oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT900_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -58,7 +58,7 @@ SUSY_HLT_InclusiveHT_aux125 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux125_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux125oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT125_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -80,7 +80,7 @@ SUSY_HLT_InclusiveHT_aux200 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux200_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux200oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT200_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -102,7 +102,7 @@ SUSY_HLT_InclusiveHT_aux250 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux250_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux250oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT250_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -124,7 +124,7 @@ SUSY_HLT_InclusiveHT_aux300 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux300_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux300oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT300_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -146,7 +146,7 @@ SUSY_HLT_InclusiveHT_aux350 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux350_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux350oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT350_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -168,7 +168,7 @@ SUSY_HLT_InclusiveHT_aux400 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux400_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux400oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT400_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -190,7 +190,7 @@ SUSY_HLT_InclusiveHT_aux475 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux475_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux475oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT475_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -212,7 +212,7 @@ SUSY_HLT_InclusiveHT_aux600 = cms.EDAnalyzer("SUSY_HLT_InclusiveHT",
   EtaThrJet = cms.untracked.double(3.0)
 )
 
-SUSY_HLT_InclusiveHT_aux600_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveHToAux600oPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT600_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -234,14 +234,14 @@ SUSY_HLT_InclusiveHT = cms.Sequence(SUSY_HLT_InclusiveHT_aux125 +
                                     SUSY_HLT_InclusiveHT_900
 )
 
-SUSY_HLT_InclusiveHT_POSTPROCESSING = cms.Sequence(SUSY_HLT_InclusiveHT_aux125_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_aux200_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_aux250_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_aux300_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_aux350_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_aux400_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_aux475_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_aux600_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_800_POSTPROCESSING +
-                                                   SUSY_HLT_InclusiveHT_900_POSTPROCESSING
+SUSY_HLT_InclusiveHT_POSTPROCESSING = cms.Sequence(SUSYoHLToInclusiveHToAux125oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHToAux200oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHToAux250oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHToAux300oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHToAux350oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHToAux400oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHToAux475oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHToAux600oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHTo800oPOSTPROCESSING +
+                                                   SUSYoHLToInclusiveHTo900oPOSTPROCESSING
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveMET_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_inclusiveMET_cff.py
@@ -88,7 +88,7 @@ SUSY_HLT_InclusiveType1PFMET_HBHE_BeamHaloCleaned = cms.EDAnalyzer("SUSY_HLT_Inc
 
 
 
-SUSY_HLT_InclusiveMET_HBHE_BeamHaloCleaned_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveMEToHBHEoBeamHaloCleanedPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_HBHE_BeamHaloCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -97,7 +97,7 @@ SUSY_HLT_InclusiveMET_HBHE_BeamHaloCleaned_POSTPROCESSING = DQMEDHarvester("DQMG
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveMET_Default_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveMEToDefaultPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -106,7 +106,7 @@ SUSY_HLT_InclusiveMET_Default_POSTPROCESSING = DQMEDHarvester("DQMGenericClient"
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveMET_HBHECleaned_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveMEToHBHECleanedPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_HBHECleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -115,7 +115,7 @@ SUSY_HLT_InclusiveMET_HBHECleaned_POSTPROCESSING = DQMEDHarvester("DQMGenericCli
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveMET_BeamHaloCleaned_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveMEToBeamHaloCleanedPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_BeamHaloCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -125,7 +125,7 @@ SUSY_HLT_InclusiveMET_BeamHaloCleaned_POSTPROCESSING = DQMEDHarvester("DQMGeneri
 )
 
 
-SUSY_HLT_InclusiveMET_NotCleaned_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveMEToNotCleanedPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMET170_NotCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -134,7 +134,7 @@ SUSY_HLT_InclusiveMET_NotCleaned_POSTPROCESSING = DQMEDHarvester("DQMGenericClie
   resolution = cms.vstring("")
 )
 
-SUSY_HLT_InclusiveType1PFMET_HBHE_BeamHaloCleaned_POSTPROCESSING = DQMEDHarvester("DQMGenericClient",
+SUSYoHLToInclusiveType1PFMEToHBHEoBeamHaloCleanedPOSTPROCESSING = DQMEDHarvester("DQMGenericClient",
   subDirs = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFMETTypeOne190_HBHE_BeamHaloCleaned_v"),
   efficiency = cms.vstring(
     "pfMetTurnOn_eff 'Efficiency vs PFMET' pfMetTurnOn_num pfMetTurnOn_den",
@@ -152,11 +152,11 @@ SUSY_HLT_InclusiveMET = cms.Sequence(SUSY_HLT_InclusiveMET_Default +
                                      SUSY_HLT_InclusiveType1PFMET_HBHE_BeamHaloCleaned
 )
 
-SUSY_HLT_InclusiveMET_POSTPROCESSING = cms.Sequence(SUSY_HLT_InclusiveMET_Default_POSTPROCESSING +
-                                                    SUSY_HLT_InclusiveMET_HBHE_BeamHaloCleaned_POSTPROCESSING +
-                                                    SUSY_HLT_InclusiveMET_HBHECleaned_POSTPROCESSING +
-                                                    SUSY_HLT_InclusiveMET_BeamHaloCleaned_POSTPROCESSING +
-                                                    SUSY_HLT_InclusiveMET_NotCleaned_POSTPROCESSING +
-                                                    SUSY_HLT_InclusiveType1PFMET_HBHE_BeamHaloCleaned_POSTPROCESSING
+SUSY_HLT_InclusiveMET_POSTPROCESSING = cms.Sequence(SUSYoHLToInclusiveMEToDefaultPOSTPROCESSING +
+                                                    SUSYoHLToInclusiveMEToHBHEoBeamHaloCleanedPOSTPROCESSING +
+                                                    SUSYoHLToInclusiveMEToHBHECleanedPOSTPROCESSING +
+                                                    SUSYoHLToInclusiveMEToBeamHaloCleanedPOSTPROCESSING +
+                                                    SUSYoHLToInclusiveMEToNotCleanedPOSTPROCESSING +
+                                                    SUSYoHLToInclusiveType1PFMEToHBHEoBeamHaloCleanedPOSTPROCESSING
 )
 

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
@@ -33,38 +33,38 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_ElecFakes_cff import *
 SusyExoPostVal = cms.Sequence(SUSY_HLT_HT_MET_POSTPROCESSING +
                               SUSY_HLT_InclusiveHT_POSTPROCESSING +
                               SUSY_HLT_InclusiveMET_POSTPROCESSING +
-                              SUSY_HLT_MET_BTAG_POSTPROCESSING + 
+                              SUSYoHLToMEToBTAGoPOSTPROCESSING + 
                               SUSY_HLT_MET_MUON_POSTPROCESSING +
-                              SUSY_HLT_MET_MUON_ER_POSTPROCESSING +
-                              SUSY_HLT_MET_HT_MUON_POSTPROCESSING +
-                              SUSY_HLT_MET_HT_MUON_ER_POSTPROCESSING +
-                              SUSY_HLT_MET_HT_MUON_BTAG_POSTPROCESSING + 
-                              SUSY_HLT_Razor_PostVal_POSTPROCESSING + 
-                              SUSY_HLT_CaloHT_POSTPROCESSING + 
-                              SUSY_HLT_PhotonHT_POSTPROCESSING +                             
-                              SUSY_HLT_PhotonMET_pt36_POSTPROCESSING +
-                              SUSY_HLT_PhotonMET_pt50_POSTPROCESSING +
-                              SUSY_HLT_PhotonMET_pt75_POSTPROCESSING +
-                              SUSY_HLT_HT_DoubleMuon_POSTPROCESSING +
-                              SUSY_HLT_HT_DoubleEle_POSTPROCESSING +
-                              SUSY_HLT_HT_MuEle_POSTPROCESSING +
-							  SUSY_HLT_HT250_DoubleMuon_POSTPROCESSING +
-                              SUSY_HLT_HT250_DoubleEle_POSTPROCESSING +
-                              SUSY_HLT_HT250_MuEle_POSTPROCESSING +
-                              SUSY_HLT_Muon_BJet_POSTPROCESSING +
-                              SUSY_HLT_Electron_BJet_POSTPROCESSING +
+                              SUSYoHLToMEToMUONoERoPOSTPROCESSING +
+                              SUSYoHLToMEToHToMUONoPOSTPROCESSING +
+                              SUSYoHLToMEToHToMUONoERoPOSTPROCESSING +
+                              SUSYoHLToMEToHToMUONoBTAGoPOSTPROCESSING + 
+                              SUSYoHLToRazorPostValPOSTPROCESSING + 
+                              SUSYoHLToCaloHToPOSTPROCESSING + 
+                              SUSYoHLToPhotonHToPOSTPROCESSING +                             
+                              SUSYoHLToPhotonMETpt36oPOSTPROCESSING +
+                              SUSYoHLToPhotonMETpt50oPOSTPROCESSING +
+                              SUSYoHLToPhotonMETpt75oPOSTPROCESSING +
+                              SUSYoHLToHToDoubleMuonPOSTPROCESSING +
+                              SUSYoHLToHToDoubleElePOSTPROCESSING +
+                              SUSYoHLToHToMuElePOSTPROCESSING +
+							  SUSYoHLToHT250oDoubleMuonPOSTPROCESSING +
+                              SUSYoHLToHT250oDoubleElePOSTPROCESSING +
+                              SUSYoHLToHT250oMuElePOSTPROCESSING +
+                              SUSYoHLToMuonBJetPOSTPROCESSING +
+                              SUSYoHLToElectronBJetPOSTPROCESSING +
                               SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING +
                               SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING +
-                              SUSY_HLT_Mu_HT_BTag_SingleLepton_POSTPROCESSING +
-                              SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING +
+                              SUSYoHLToMuHToBTagSingleLeptonPOSTPROCESSING +
+                              SUSYoHLToMuHToControlSingleLeptonPOSTPROCESSING +
                               SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING +
                               SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING +
-                              SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING +
-                              SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING +
-                              SUSY_HLT_alphaT_POSTPROCESSING +
-                              SUSY_HLT_DiJet_MET_POSTPROCESSING +
-                              SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING+
-                              SUSY_HLT_alphaT_POSTPROCESSING+
+                              SUSYoHLToEleHToBTagSingleLeptonPOSTPROCESSING +
+                              SUSYoHLToEleHToControlSingleLeptonPOSTPROCESSING +
+                              SUSYoHLTalphaToPOSTPROCESSING +
+                              SUSYoHLToDiJetMEToPOSTPROCESSING +
+                              SUSYoHLToEleHToControlSingleLeptonPOSTPROCESSING+
+                              SUSYoHLTalphaToPOSTPROCESSING+
                               SUSY_HLT_Mu_VBF_POSTPROCESSING+
                               SUSY_HLT_ElecFakes_POSTPROCESSING+
                               SUSY_HLT_MuonFakes_POSTPROCESSING

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauPostValidation_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauPostValidation_cfi.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from HLTriggerOffline.Tau.Validation.HLTTauValidation_cfi import *
 import DQMOffline.Trigger.HLTTauPostProcessor_cfi as postProcessor
 
-(HLTTauValPostAnalysis_MC, HLTTauValPostAnalysis_MC2) = postProcessor.makePFTauAnalyzer(hltTauValIdealMonitorMC)
-(HLTTauValPostAnalysis_PF, HLTTauValPostAnalysis_PF2) = postProcessor.makePFTauAnalyzer(hltTauValIdealMonitorPF)
-(HLTTauValPostAnalysis_TP, HLTTauValPostAnalysis_TP2) = postProcessor.makePFTauAnalyzer(hltTauValTagAndProbe)
+(HLTTauValPostAnalysisMC, HLTTauValPostAnalysisMC2) = postProcessor.makePFTauAnalyzer(hltTauValIdealMonitorMC)
+(HLTTauValPostAnalysisPF, HLTTauValPostAnalysisPF2) = postProcessor.makePFTauAnalyzer(hltTauValIdealMonitorPF)
+(HLTTauValPostAnalysisTP, HLTTauValPostAnalysisTP2) = postProcessor.makePFTauAnalyzer(hltTauValTagAndProbe)
 HLTTauPostVal = cms.Sequence(
-    HLTTauValPostAnalysis_MC+HLTTauValPostAnalysis_MC2+
-    HLTTauValPostAnalysis_PF+HLTTauValPostAnalysis_PF2+
-    HLTTauValPostAnalysis_TP+HLTTauValPostAnalysis_TP2
+    HLTTauValPostAnalysisMC+HLTTauValPostAnalysisMC2+
+    HLTTauValPostAnalysisPF+HLTTauValPostAnalysisPF2+
+    HLTTauValPostAnalysisTP+HLTTauValPostAnalysisTP2
 )

--- a/Validation/RecoMuon/python/NewPostProcessor_RecoMuonValidator_cff.py
+++ b/Validation/RecoMuon/python/NewPostProcessor_RecoMuonValidator_cff.py
@@ -34,26 +34,26 @@ NEWpostProcessorRecoMuon = DQMEDHarvester("DQMGenericClient",
 )
 
 # for each type monitored
-NEWpostProcessorRecoMuon_Glb = NEWpostProcessorRecoMuon.clone()
-NEWpostProcessorRecoMuon_Glb.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Glb")
+NEWpostProcessorRecoMuonGlb = NEWpostProcessorRecoMuon.clone()
+NEWpostProcessorRecoMuonGlb.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Glb")
 
-NEWpostProcessorRecoMuon_Trk = NEWpostProcessorRecoMuon.clone()
-NEWpostProcessorRecoMuon_Trk.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Trk")
+NEWpostProcessorRecoMuonTrk = NEWpostProcessorRecoMuon.clone()
+NEWpostProcessorRecoMuonTrk.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Trk")
 
-NEWpostProcessorRecoMuon_Sta = NEWpostProcessorRecoMuon.clone()
-NEWpostProcessorRecoMuon_Sta.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Sta")
+NEWpostProcessorRecoMuonSta = NEWpostProcessorRecoMuon.clone()
+NEWpostProcessorRecoMuonSta.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Sta")
 
-NEWpostProcessorRecoMuon_Tgt = NEWpostProcessorRecoMuon.clone()
-NEWpostProcessorRecoMuon_Tgt.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Tgt")
+NEWpostProcessorRecoMuonTgt = NEWpostProcessorRecoMuon.clone()
+NEWpostProcessorRecoMuonTgt.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_Tgt")
 
-NEWpostProcessorRecoMuon_GlbPF = NEWpostProcessorRecoMuon.clone()
-NEWpostProcessorRecoMuon_GlbPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_GlbPF")
+NEWpostProcessorRecoMuonGlbPF = NEWpostProcessorRecoMuon.clone()
+NEWpostProcessorRecoMuonGlbPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_GlbPF")
 
-NEWpostProcessorRecoMuon_TrkPF = NEWpostProcessorRecoMuon.clone()
-NEWpostProcessorRecoMuon_TrkPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_TrkPF")
+NEWpostProcessorRecoMuonTrkPF = NEWpostProcessorRecoMuon.clone()
+NEWpostProcessorRecoMuonTrkPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_TrkPF")
 
-NEWpostProcessorRecoMuon_StaPF = NEWpostProcessorRecoMuon.clone()
-NEWpostProcessorRecoMuon_StaPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_StaPF")
+NEWpostProcessorRecoMuonStaPF = NEWpostProcessorRecoMuon.clone()
+NEWpostProcessorRecoMuonStaPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/NewRecoMuon_MuonAssoc_StaPF")
 
 #not sure about this one, which types are monitored
 NEWpostProcessorRecoMuonComp = DQMEDHarvester(
@@ -86,12 +86,12 @@ NEWpostProcessorRecoMuonCompPF = DQMEDHarvester(
     outputFileName = cms.untracked.string("")
 )
 
-NEWpostProcessorsRecoMuonValidator_seq = cms.Sequence( NEWpostProcessorRecoMuon_Glb 
-                                                    * NEWpostProcessorRecoMuon_Trk 
-                                                    * NEWpostProcessorRecoMuon_Sta 
-                                                    * NEWpostProcessorRecoMuon_Tgt 
-                                                    * NEWpostProcessorRecoMuon_GlbPF 
-                                                    * NEWpostProcessorRecoMuon_TrkPF 
-                                                    * NEWpostProcessorRecoMuon_StaPF 
+NEWpostProcessorsRecoMuonValidator_seq = cms.Sequence( NEWpostProcessorRecoMuonGlb 
+                                                    * NEWpostProcessorRecoMuonTrk 
+                                                    * NEWpostProcessorRecoMuonSta 
+                                                    * NEWpostProcessorRecoMuonTgt 
+                                                    * NEWpostProcessorRecoMuonGlbPF 
+                                                    * NEWpostProcessorRecoMuonTrkPF 
+                                                    * NEWpostProcessorRecoMuonStaPF 
                                                     * NEWpostProcessorRecoMuonComp 
                                                     * NEWpostProcessorRecoMuonCompPF )

--- a/Validation/RecoMuon/python/PostProcessor_cff.py
+++ b/Validation/RecoMuon/python/PostProcessor_cff.py
@@ -112,26 +112,26 @@ postProcessorRecoMuon = DQMEDHarvester("DQMGenericClient",
 )
 
 # for each type monitored
-postProcessorRecoMuon_Glb = postProcessorRecoMuon.clone()
-postProcessorRecoMuon_Glb.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Glb")
+postProcessorRecoMuonGlb = postProcessorRecoMuon.clone()
+postProcessorRecoMuonGlb.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Glb")
 
-postProcessorRecoMuon_Trk = postProcessorRecoMuon.clone()
-postProcessorRecoMuon_Trk.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Trk")
+postProcessorRecoMuonTrk = postProcessorRecoMuon.clone()
+postProcessorRecoMuonTrk.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Trk")
 
-postProcessorRecoMuon_Sta = postProcessorRecoMuon.clone()
-postProcessorRecoMuon_Sta.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Sta")
+postProcessorRecoMuonSta = postProcessorRecoMuon.clone()
+postProcessorRecoMuonSta.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Sta")
 
-postProcessorRecoMuon_Tgt = postProcessorRecoMuon.clone()
-postProcessorRecoMuon_Tgt.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Tgt")
+postProcessorRecoMuonTgt = postProcessorRecoMuon.clone()
+postProcessorRecoMuonTgt.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Tgt")
 
-postProcessorRecoMuon_GlbPF = postProcessorRecoMuon.clone()
-postProcessorRecoMuon_GlbPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_GlbPF")
+postProcessorRecoMuonGlbPF = postProcessorRecoMuon.clone()
+postProcessorRecoMuonGlbPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_GlbPF")
 
-postProcessorRecoMuon_TrkPF = postProcessorRecoMuon.clone()
-postProcessorRecoMuon_TrkPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_TrkPF")
+postProcessorRecoMuonTrkPF = postProcessorRecoMuon.clone()
+postProcessorRecoMuonTrkPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_TrkPF")
 
-postProcessorRecoMuon_StaPF = postProcessorRecoMuon.clone()
-postProcessorRecoMuon_StaPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_StaPF")
+postProcessorRecoMuonStaPF = postProcessorRecoMuon.clone()
+postProcessorRecoMuonStaPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_StaPF")
 
 #not sure about this one, which types are monitored
 postProcessorRecoMuonComp = DQMEDHarvester(
@@ -165,4 +165,4 @@ postProcessorRecoMuonCompPF = DQMEDHarvester(
 )
         
 
-recoMuonPostProcessors = cms.Sequence(postProcessorMuonMultiTrack*postProcessorRecoMuon_Glb*postProcessorRecoMuon_Trk*postProcessorRecoMuon_Sta*postProcessorRecoMuon_Tgt*postProcessorRecoMuon_GlbPF*postProcessorRecoMuon_TrkPF*postProcessorRecoMuon_StaPF*postProcessorMuonMultiTrackComp*postProcessorRecoMuonComp*postProcessorRecoMuonCompPF)
+recoMuonPostProcessors = cms.Sequence(postProcessorMuonMultiTrack*postProcessorRecoMuonGlb*postProcessorRecoMuonTrk*postProcessorRecoMuonSta*postProcessorRecoMuonTgt*postProcessorRecoMuonGlbPF*postProcessorRecoMuonTrkPF*postProcessorRecoMuonStaPF*postProcessorMuonMultiTrackComp*postProcessorRecoMuonComp*postProcessorRecoMuonCompPF)

--- a/Validation/RecoParticleFlow/python/PFValidationClient_cff.py
+++ b/Validation/RecoParticleFlow/python/PFValidationClient_cff.py
@@ -15,7 +15,7 @@ pfMETClient.HistogramNames = cms.vstring( "delta_et_Over_et_VS_et_")
 pfMETClient.CreateProfilePlots = cms.bool(True)
 pfMETClient.HistogramNamesForProfilePlots = cms.vstring("delta_et_Over_et_VS_et_","delta_et_VS_et_","delta_eta_VS_et_","delta_phi_VS_et_")
 
-pfJetResClient = pfClient_JetRes.clone()
+pfJetResClient = pfClientJetRes.clone()
 pfJetResClient.FolderNames = cms.vstring("ElectronValidation/JetPtRes")
 pfJetResClient.HistogramNames = cms.vstring("delta_et_Over_et_VS_et_", "BRdelta_et_Over_et_VS_et_", "ERdelta_et_Over_et_VS_et_")
 #pfJetResClient.HistogramNames = cms.vstring("") # use this if slicingOn is true in PFJetResDQMAnalyzer


### PR DESCRIPTION
This finishes the transformation began in #18751 by having the DQMEDHarvesters put a DQMToken into the LuminosityBlock once the module has finished. DQMRootOutputModule and MEtoEDMConverter both consume the DQMToken to guarantee proper run ordering of the modules.
