### PR TITLE
(TIB|TOB|TID|TEC|PXB|PXF)DetId deprecation: Geometry package

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h
+++ b/Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h
@@ -1,10 +1,11 @@
 #ifndef TrackerGeomBuilder_TrackerHierarchy
 #define TrackerGeomBuilder_TrackerHierarchy
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include<string>
 
 
 // return a string describing trakcer geometry hierarchy
-std::string trackerHierarchy(unsigned int id);
+std::string trackerHierarchy(const TrackerTopology *tTopo, unsigned int id);
 
 #endif // TrackerGeomBuilder_TrackerHierarchy

--- a/Geometry/TrackerGeometryBuilder/src/trackerHierarchy.cc
+++ b/Geometry/TrackerGeometryBuilder/src/trackerHierarchy.cc
@@ -1,51 +1,43 @@
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
+#include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
 
 #include<string>
 #include<vector>
 
-std::string trackerHierarchy(unsigned int rawid) {
+std::string trackerHierarchy(const TrackerTopology* tTopo, unsigned int rawid) {
   DetId id(rawid);
   int subdetid = id.subdetId();
   switch (subdetid) {
     
     // PXB
-  case 1:
+  case PixelSubdetector::PixelBarrel:
     {
-      PXBDetId module(rawid);
-      char theLayer  = module.layer();
-      char theLadder = module.ladder();
-      char theModule = module.module();
+      char theLayer  = tTopo->pxbLayer(id);
+      char theLadder = tTopo->pxbLadder(id);
+      char theModule = tTopo->pxbModule(id);
       char key[] = { 1, theLayer , theLadder, theModule};
       return std::string(key,4);
     }
     
     // P1XF
-  case 2:
+  case PixelSubdetector::PixelEndcap:
     {
-      PXFDetId module(rawid);
-      char thePanel  = module.panel();
-      char theDisk   = module.disk();
-      char theBlade  = module.blade();
-      char theModule = module.module();
+      char thePanel  = tTopo->pxfPanel(id);
+      char theDisk   = tTopo->pxfDisk(id);
+      char theBlade  = tTopo->pxfBlade(id);
+      char theModule = tTopo->pxfModule(id);
       char key[] = { 2,
-		     char(module.side()),
+		     char(tTopo->pxfSide(id)),
 		     thePanel , theDisk, 
 		     theBlade, theModule};
       return std::string(key,6);
     }
   
   // TIB
-  case 3:
+  case StripSubdetector::TIB:
     {
-      TIBDetId module(rawid);
-      char            theLayer  = module.layer();
-      std::vector<unsigned int> theString = module.string();
-      char             theModule = module.module();
+      char            theLayer  = tTopo->tibLayer(id);
+      std::vector<unsigned int> theString = tTopo->tibStringInfo(id);
+      char             theModule = tTopo->tibModule(id);
       //side = (theString[0] == 1 ) ? "-" : "+";
       //part = (theString[1] == 1 ) ? "int" : "ext";
       char key[] = { 3, 
@@ -54,70 +46,64 @@ std::string trackerHierarchy(unsigned int rawid) {
 		     char(theString[1]), 
 		     char(theString[2]), 
 		     theModule,
-		     char(module.glued() ? module.stereo()+1 : 0)
+		     char(tTopo->tibGlued(id) ? tTopo->tibIsStereo(id)+1 : 0)
       };
-      return std::string(key, module.glued() ? 7 : 6);
+      return std::string(key, tTopo->tibGlued(id) ? 7 : 6);
     }
     
     // TID
-  case 4:
+  case StripSubdetector::TID:
     {
-      TIDDetId module(rawid);
-      unsigned int         theDisk   = module.wheel();
-      unsigned int         theRing   = module.ring();
-      std::vector<unsigned int> theModule = module.module();
-      // side = (module.side() == 1 ) ? "-" : "+";
-      // part = (theModule[0] == 1 ) ? "back" : "front";
+      unsigned int         theDisk   = tTopo->tidWheel(id);
+      unsigned int         theRing   = tTopo->tidRing(id);
+      // side = (tTopo->tidSide(id) == 1 ) ? "-" : "+";
+      // part = (tTopo->tidOrder(id) == 1 ) ? "back" : "front";
       char key[] = { 4, 
-		     char(module.side()),
+		     char(tTopo->tidSide(id)),
 		     char(theDisk) , 
 		     char(theRing),
-		     char(theModule[0]), 
-		     char(theModule[1]),
-		     char(module.glued() ? module.stereo()+1 : 0)
+		     char(tTopo->tidOrder(id)), 
+		     char(tTopo->tidModule(id)),
+		     char(tTopo->tidGlued(id) ? tTopo->tidIsStereo(id)+1 : 0)
       };
-      return std::string(key,module.glued() ? 7 : 6);
+      return std::string(key,tTopo->tidGlued(id) ? 7 : 6);
     }
     
     // TOB
-  case 5:
+  case StripSubdetector::TOB:
     {
-      TOBDetId module(rawid);
-      unsigned int              theLayer  = module.layer();
-      std::vector<unsigned int> theRod    = module.rod();
-      unsigned int              theModule = module.module();
-      //	side = (theRod[0] == 1 ) ? "-" : "+";
+      unsigned int              theLayer  = tTopo->tobLayer(id);
+      unsigned int              theModule = tTopo->tobModule(id);
+      //	side = (tTopo->side(id) == 1 ) ? "-" : "+";
       char key[] = { 5, char(theLayer) , 
-		     char(theRod[0]), 
-		     char(theRod[1]), 
+		     char(tTopo->tobSide(id)), 
+		     char(tTopo->tobRod(id)), 
 		     char(theModule),
-		     char(module.glued() ? module.stereo()+1 : 0)
+		     char(tTopo->tobGlued(id) ? tTopo->tobIsStereo(id)+1 : 0)
       };
-      return std::string(key, module.glued() ?  6 : 5);
+      return std::string(key, tTopo->tobGlued(id) ?  6 : 5);
     }
     
     // TEC
-  case 6:
+  case StripSubdetector::TEC:
     {
-      TECDetId module(rawid);
-      unsigned int              theWheel  = module.wheel();
-      unsigned int              theModule = module.module();
-      std::vector<unsigned int> thePetal  = module.petal();
-      unsigned int              theRing   = module.ring();
-      //	side  = (module.side() == 1 ) ? "-" : "+";
-      //	petal = (thePetal[0] == 1 ) ? "back" : "front";
-      // int out_side  = (module.side() == 1 ) ? -1 : 1;
+      unsigned int              theWheel  = tTopo->tecWheel(id);
+      unsigned int              theModule = tTopo->tecModule(id);
+      unsigned int              theRing   = tTopo->tecRing(id);
+      //	side  = (tTopo->tecSide(id) == 1 ) ? "-" : "+";
+      //	petal = (tTopo->tecOrder(id) == 1 ) ? "back" : "front";
+      // int out_side  = (tTopo->tecSide(id) == 1 ) ? -1 : 1;
       
       char key[] = { 6, 
-		     char(module.side()),
+		     char(tTopo->tecSide(id)),
 		     char(theWheel),
-		     char(thePetal[0]), 
-		     char(thePetal[1]),
+		     char(tTopo->tecOrder(id)), 
+		     char(tTopo->tecPetalNumber(id)),
 		     char(theRing),
 		     char(theModule),
-		     char(module.glued() ? module.stereo()+1 : 0)
+		     char(tTopo->tecGlued(id) ? tTopo->tecIsStereo(id)+1 : 0)
       };
-      return std::string(key, module.glued() ? 8 : 7);
+      return std::string(key, tTopo->tecGlued(id) ? 8 : 7);
     }
   default:
     return std::string();

--- a/Geometry/TrackerGeometryBuilder/test/GeoHierarchyTest.cc
+++ b/Geometry/TrackerGeometryBuilder/test/GeoHierarchyTest.cc
@@ -40,6 +40,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
 
 #include "DataFormats/Common/interface/Trie.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 
 #include<string>
@@ -52,7 +53,7 @@ struct Print {
     if (!det) return; 
     for (size_t i=0; i<label.size();++i)
       std::cout << int(label[i]) <<'/';
-    std::cout << " " << det->geographicalId() << std::endl;
+    std::cout << " " << det->geographicalId().rawId() << std::endl;
   }
   
 };
@@ -82,7 +83,7 @@ GeoHierarchy::~GeoHierarchy()
 {}
 
 template<typename Iter>
-void constructAndDumpTrie(Iter b, Iter e) {
+void constructAndDumpTrie(const TrackerTopology* tTopo, Iter b, Iter e) {
   typedef typename std::iterator_traits<Iter>::value_type Det;
   edm::Trie<Det> trie(0);
   typedef edm::TrieNode<Det> Node;
@@ -96,7 +97,7 @@ void constructAndDumpTrie(Iter b, Iter e) {
     for(;b!=e; ++b) {
       last = b;
       unsigned int rawid = (*b)->geographicalId().rawId();
-      trie.insert(trackerHierarchy(rawid), *b); 
+      trie.insert(trackerHierarchy(tTopo, rawid), *b); 
     }
   }
   catch(edm::Exception const & ex) {
@@ -154,16 +155,19 @@ GeoHierarchy::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
   //first instance tracking geometry
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord> ().get (pDD);
+  edm::ESHandle<TrackerTopology> tTopo_handle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
+  const TrackerTopology* tTopo = tTopo_handle.product();
   //
   GeometricDet const * rDD = pDD->trackerDet();
   std::vector<const GeometricDet*> modules; 
   (*rDD).deepComponents(modules);
   
   std::cout << "\nGeometricDet Hierarchy\n" << std::endl;
-  constructAndDumpTrie(modules.begin(),modules.end());
+  constructAndDumpTrie(tTopo, modules.begin(),modules.end());
   
   std::cout << "\nGDet Hierarchy\n" << std::endl;
-  constructAndDumpTrie(pDD->dets().begin(),pDD->dets().end());
+  constructAndDumpTrie(tTopo, pDD->dets().begin(),pDD->dets().end());
   
 
 

--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -42,12 +42,7 @@
 
 #include "Geometry/TrackerNumberingBuilder/interface/CmsTrackerDebugNavigator.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/TrackerNumberingBuilder/interface/CmsTrackerStringToEnum.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DetectorDescription/Core/interface/DDRoot.h"
@@ -120,6 +115,9 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
   //first instance tracking geometry
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord> ().get (pDD);
+  edm::ESHandle<TrackerTopology> tTopo_handle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
+  const TrackerTopology* tTopo = tTopo_handle.product();
   //
   
   // counters
@@ -189,6 +187,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
   std::vector<GeometricDetExtra>::const_iterator gdei(rDDE->begin()), gdeEnd(rDDE->end());
   for(unsigned int i=0; i<modules.size();i++){
     unsigned int rawid = modules[i]->geographicalID().rawId();
+    DetId id(rawid);
     gdei = rDDE->begin();
     for (; gdei != gdeEnd; ++gdei) {
       if (gdei->geographicalId() == modules[i]->geographicalId()) break;
@@ -217,7 +216,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
     switch (subdetid) {
       
       // PXB
-    case 1:
+    case PixelSubdetector::PixelBarrel:
       {
 	pxbN++;
 	volume_pxb+=volume;
@@ -226,10 +225,9 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	std::string name = modules[i]->name().name();
 	if(name == "PixelBarrelActiveFull") pxb_fullN++;
 	if(name == "PixelBarrelActiveHalf") pxb_halfN++;
-	PXBDetId module(rawid);
-	unsigned int theLayer  = module.layer();
-	unsigned int theLadder = module.ladder();
-	unsigned int theModule = module.module();
+	unsigned int theLayer  = tTopo->pxbLayer(id);
+	unsigned int theLadder = tTopo->pxbLadder(id);
+	unsigned int theModule = tTopo->pxbModule(id);
 	
 	Output << " PXB" << "\t" << "Layer " << theLayer << " Ladder " << theLadder
 	       << "\t" << " module " << theModule << " " << name << "\t";
@@ -242,7 +240,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
       }
       
       // PXF
-    case 2:
+    case PixelSubdetector::PixelEndcap:
       {
 	pxfN++;
 	volume_pxf+=volume;
@@ -254,13 +252,12 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	if(name == "PixelForwardActive2x3") pxf_2x3N++;
 	if(name == "PixelForwardActive2x4") pxf_2x4N++;
 	if(name == "PixelForwardActive2x5") pxf_2x5N++;
-	PXFDetId module(rawid);
-	unsigned int thePanel  = module.panel();
-	unsigned int theDisk   = module.disk();
-	unsigned int theBlade  = module.blade();
-	unsigned int theModule = module.module();
+	unsigned int thePanel  = tTopo->pxfPanel(id);
+	unsigned int theDisk   = tTopo->pxfDisk(id);
+	unsigned int theBlade  = tTopo->pxfBlade(id);
+	unsigned int theModule = tTopo->pxfModule(id);
 	std::string side;
-	side = (module.side() == 1 ) ? "-" : "+";
+	side = (tTopo->pxfSide(id) == 1 ) ? "-" : "+";
 	Output << " PXF" << side << "\t" << "Disk " << theDisk << " Blade " << theBlade << " Panel " << thePanel
 	       << "\t" << " module " << theModule << "\t" << name << "\t";
 	if ( fromDDD_ && printDDD_ ) {
@@ -272,7 +269,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
       }
       
       // TIB
-    case 3:
+    case StripSubdetector::TIB:
       {
 	tibN++;
 	volume_tib+=volume;
@@ -282,10 +279,9 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	if(name == "TIBActiveRphi0") tib_L12_rphiN++;
 	if(name == "TIBActiveSter0") tib_L12_sterN++;
 	if(name == "TIBActiveRphi2") tib_L34_rphiN++;
-	TIBDetId module(rawid);
-	unsigned int              theLayer  = module.layer();
-	std::vector<unsigned int> theString = module.string();
-	unsigned int              theModule = module.module();
+	unsigned int              theLayer  = tTopo->tibLayer(id);
+	std::vector<unsigned int> theString = tTopo->tibStringInfo(id);
+	unsigned int              theModule = tTopo->tibModule(id);
 	std::string side;
 	std::string part;
 	side = (theString[0] == 1 ) ? "-" : "+";
@@ -303,7 +299,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
       }
       
       // TID
-    case 4:
+    case StripSubdetector::TID:
       {
 	tidN++;      
 	volume_tid+=volume;
@@ -315,16 +311,14 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	if(name == "TIDModule1RphiActive")   tid_r2_rphiN++;
 	if(name == "TIDModule1StereoActive") tid_r2_sterN++;
 	if(name == "TIDModule2RphiActive")   tid_r3_rphiN++;
-	TIDDetId module(rawid);
-	unsigned int         theDisk   = module.wheel();
-	unsigned int         theRing   = module.ring();
-	std::vector<unsigned int> theModule = module.module();
+	unsigned int         theDisk   = tTopo->tidWheel(id);
+	unsigned int         theRing   = tTopo->tidRing(id);
 	std::string side;
 	std::string part;
-	side = (module.side() == 1 ) ? "-" : "+";
-	part = (theModule[0] == 1 ) ? "back" : "front";
+	side = (tTopo->tidSide(id) == 1 ) ? "-" : "+";
+	part = (tTopo->tidOrder(id) == 1 ) ? "back" : "front";
 	Output << " TID" << side << "\t" << "Disk " << theDisk << " Ring " << theRing << " " << part
-	       << "\t" << " module " << theModule[1] << "\t" << name << "\t";
+	       << "\t" << " module " << tTopo->tidModule(id) << "\t" << name << "\t";
 	if ( fromDDD_ && printDDD_ ) {
 	  Output << "son of " << gdei->parents()[gdei->parents().size()-3].logicalPart().name();
 	} else {
@@ -335,7 +329,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
       }
       
       // TOB
-    case 5:
+    case StripSubdetector::TOB:
       {
 	tobN++;
 	volume_tob+=volume;
@@ -346,16 +340,14 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	if(name == "TOBActiveSter0") tob_L12_sterN++;
 	if(name == "TOBActiveRphi2") tob_L34_rphiN++;
 	if(name == "TOBActiveRphi4") tob_L56_rphiN++;
-	TOBDetId module(rawid);
-	unsigned int              theLayer  = module.layer();
-	std::vector<unsigned int> theRod    = module.rod();
-	unsigned int              theModule = module.module();
+	unsigned int              theLayer  = tTopo->tobLayer(id);
+	unsigned int              theModule = tTopo->tobModule(id);
 	std::string side;
 	std::string part;
-	side = (theRod[0] == 1 ) ? "-" : "+";
+	side = (tTopo->tobSide(id) == 1 ) ? "-" : "+";
 	
 	Output << " TOB" << side << "\t" << "Layer " << theLayer 
-	       << "\t" << "rod " << theRod[1] << " module " << theModule << "\t" << name << "\t" ;
+	       << "\t" << "rod " << tTopo->tobRod(id) << " module " << theModule << "\t" << name << "\t" ;
 	if ( fromDDD_ && printDDD_ ) {
 	  Output << "son of " << gdei->parents()[gdei->parents().size()-3].logicalPart().name();
 	} else {
@@ -366,7 +358,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
       }
       
       // TEC
-    case 6:
+    case StripSubdetector::TEC:
       {
 	tecN++;      
 	volume_tec+=volume;
@@ -383,16 +375,14 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	if(name == "TECModule4StereoActive") tec_r5_sterN++;
 	if(name == "TECModule5RphiActive")   tec_r6_rphiN++;
 	if(name == "TECModule6RphiActive")   tec_r7_rphiN++;
-	TECDetId module(rawid);
-	unsigned int              theWheel  = module.wheel();
-	unsigned int              theModule = module.module();
-	std::vector<unsigned int> thePetal  = module.petal();
-	unsigned int              theRing   = module.ring();
+	unsigned int              theWheel  = tTopo->tecWheel(id);
+	unsigned int              theModule = tTopo->tecModule(id);
+	unsigned int              theRing   = tTopo->tecRing(id);
 	std::string side;
 	std::string petal;
-	side  = (module.side() == 1 ) ? "-" : "+";
-	petal = (thePetal[0] == 1 ) ? "back" : "front";
-	Output << " TEC" << side << "\t" << "Wheel " << theWheel << " Petal " << thePetal[1] << " " << petal << " Ring " << theRing << "\t"
+	side  = (tTopo->tecSide(id) == 1 ) ? "-" : "+";
+	petal = (tTopo->tecOrder(id) == 1 ) ? "back" : "front";
+	Output << " TEC" << side << "\t" << "Wheel " << theWheel << " Petal " << tTopo->tecPetalNumber(id) << " " << petal << " Ring " << theRing << "\t"
 	       << "\t" << " module " << theModule << "\t" << name << "\t";
 	if ( fromDDD_ && printDDD_ ) {
 	  Output << "son of " << gdei->parents()[gdei->parents().size()-3].logicalPart().name();
@@ -402,10 +392,10 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	Output << " " << modules[i]->translation().X() << "   \t" << modules[i]->translation().Y() << "   \t" << modules[i]->translation().Z() << std::endl;
 	
 	// TEC output as Martin Weber's
-	int out_side  = (module.side() == 1 ) ? -1 : 1;
-	unsigned int out_disk = module.wheel();
-	unsigned int out_sector = thePetal[1];
-	int out_petal = (thePetal[0] == 1 ) ? 1 : -1;
+	int out_side  = (tTopo->tecSide(id) == 1 ) ? -1 : 1;
+	unsigned int out_disk = tTopo->tecWheel(id);
+	unsigned int out_sector = tTopo->tecPetalNumber(id);
+	int out_petal = (tTopo->tecOrder(id) == 1 ) ? 1 : -1;
 	// swap sector numbers for TEC-
 	if (out_side == -1) {
 	  // fine for back petals, substract 1 for front petals
@@ -413,7 +403,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	    out_sector = (out_sector+6) % 8 + 1;
 	  }
 	}
-	unsigned int out_ring = module.ring();
+	unsigned int out_ring = tTopo->tecRing(id);
 	int out_sensor = 0;
 	if(name == "TECModule0RphiActive")   out_sensor = -1;
 	if(name == "TECModule0StereoActive") out_sensor =  1;
@@ -429,7 +419,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	if (out_ring == 1 || out_ring == 2 || out_ring == 5) {
 	  // rings with stereo modules
 	  // create number odd by default
-	  out_module = 2*(module.module()-1)+1;
+	  out_module = 2*(tTopo->tecModule(id)-1)+1;
 	  if (out_sensor == 1) {
 	    // in even rings, stereo modules are the even ones
 	    if (out_ring == 2)
@@ -441,7 +431,7 @@ ModuleInfo::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 	      out_module += 1;
 	}
 	else {
-	  out_module = module.module();
+	  out_module = tTopo->tecModule(id);
 	}
 	double out_x = modules[i]->translation().X();
 	double out_y = modules[i]->translation().Y();

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
@@ -100,8 +100,9 @@ TkDetLayersAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
     << " Top node is  "<< &(*pDD) << "\n"
     << " And Contains  Daughters: "<< (*pDD).components().size() ;   
 
-  ESHandle<TrackerTopology> tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  ESHandle<TrackerTopology> tTopo_handle;
+  iSetup.get<TrackerTopologyRcd>().get(tTopo_handle);
+  const TrackerTopology* tTopo = tTopo_handle.product();
 
   /*
 
@@ -139,7 +140,7 @@ TkDetLayersAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
 
    /*
   TOBLayerBuilder myTOBBuilder;
-  TOBLayer* testTOBLayer = myTOBBuilder.build(geometricDetTOBlayer,&(*pTrackerGeometry),&(*tTopo));
+  TOBLayer* testTOBLayer = myTOBBuilder.build(geometricDetTOBlayer,&(*pTrackerGeometry),&(*tTopo_handle));
   edm::LogInfo("TkDetLayersAnalyzer") << "testTOBLayer: " << testTOBLayer;
 
   */
@@ -165,7 +166,7 @@ TkDetLayersAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
       for(;b!=e; ++b) {
         last = b;
         unsigned int rawid = (*b)->geographicalId().rawId();
-        trie.insert(trackerHierarchy(rawid), *b); 
+        trie.insert(trackerHierarchy(tTopo, rawid), *b); 
       }
     }
     catch(edm::Exception const & e) {
@@ -208,7 +209,7 @@ TkDetLayersAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
   
   // -------- here it constructs the whole GeometricSearchTracker --------------
   GeometricSearchTrackerBuilder myTrackerBuilder;
-  GeometricSearchTracker* testTracker = myTrackerBuilder.build( &(*pDD),&(*pTrackerGeometry), &(*tTopo));
+  GeometricSearchTracker* testTracker = myTrackerBuilder.build( &(*pDD),&(*pTrackerGeometry), &(*tTopo_handle));
   edm::LogInfo("TkDetLayersAnalyzer") << "testTracker: " << testTracker ;
 
   for (auto const & l : testTracker->allLayers()) {


### PR DESCRIPTION
cc @alesaggio @vidalm @pieterdavid

Removing the deprecated
`DataFormats/SiStripDetId/interface/T(IB|OB|ID|EC)DetId.h` and `DataFormats/SiPixelDetId/interface/(PXB|PXF)DetId.h`

and replacing it with
`DataFormats/TrackerCommon/interface/TrackerTopology.h`

Note: we're not quite sure of what the `GeoHierarchyTest.cc` is supposed to do exactly... so hopefully the change in the `struct Print` matches what it was supposed to print