### PR TITLE
Update to 2017 METplusTrack paths

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 METplusTrackPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        #"HLT_MET80_v",                 # For debugging 
-        #"HLT_MET85_Track50_dEdx3p6_v", # For debugging
-        "HLT_MET75_IsoTrk50_v", 
-        "HLT_MET90_IsoTrk50_v", 
-        "HLT_MET60_IsoTrk35_Loose_v" 
+        #"HLT_MET75_IsoTrk50_v",       # 2015-6 proposal
+        #"HLT_MET90_IsoTrk50_v",       # 2015-6 proposal
+        #"HLT_MET60_IsoTrk35_Loose_v", # 2016-6 proposal
+        "HLT_MET105_IsoTrk50_v",       # 2017 proposal
+        "HLT_MET120_IsoTrk50_v"        # 2017 proposal
     ),
     recPFMETLabel = cms.InputTag("pfMet"),
     #recMETLabel   = cms.InputTag("hltPFMETProducer"),


### PR DESCRIPTION
This PR updates the path names in the offline exotica validation for the METXX_IsoTrk50 triggers, to be included in the 2017 pp collision menu.

TSG approval slides: https://indico.cern.ch/event/646747/contributions/2626978/attachments/1476569/2287752/bfrancis_OSU_TSG.pdf