### PR TITLE
New feature in ME0 simulation: ME0PadDigiCluster

### DIFF
--- a/DataFormats/GEMDigi/BuildFile.xml
+++ b/DataFormats/GEMDigi/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/MuonDetId"/>
-<use   name="boost"/>
 
 <export>
   <lib   name="1"/>

--- a/DataFormats/GEMDigi/interface/GEMCoPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMCoPadDigi.h
@@ -9,7 +9,7 @@
  *
  */
 
-#include <DataFormats/GEMDigi/interface/GEMPadDigi.h>
+#include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include <cstdint>
 #include <iosfwd>
 

--- a/DataFormats/GEMDigi/interface/GEMCoPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMCoPadDigi.h
@@ -10,7 +10,7 @@
  */
 
 #include <DataFormats/GEMDigi/interface/GEMPadDigi.h>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 
 class GEMCoPadDigi{

--- a/DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h
@@ -5,9 +5,9 @@
  *  \author Sven Dildick
  */
 
-#include <DataFormats/MuonDetId/interface/GEMDetId.h>
-#include <DataFormats/GEMDigi/interface/GEMCoPadDigi.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMDigi/interface/GEMCoPadDigi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 // GEMDetId is detId of pad in 1st layer
 typedef MuonDigiCollection<GEMDetId, GEMCoPadDigi> GEMCoPadDigiCollection;

--- a/DataFormats/GEMDigi/interface/GEMDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMDigi.h
@@ -9,7 +9,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 
 class GEMDigi{

--- a/DataFormats/GEMDigi/interface/GEMDigiCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMDigiCollection.h
@@ -6,9 +6,9 @@
  *  \author Vadim Khotilovich
  */
 
-#include <DataFormats/MuonDetId/interface/GEMDetId.h>
-#include <DataFormats/GEMDigi/interface/GEMDigi.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMDigi/interface/GEMDigi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<GEMDetId, GEMDigi> GEMDigiCollection;
 

--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -9,7 +9,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 
 class GEMPadDigi{

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -10,7 +10,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 #include <vector>
 

--- a/DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h
@@ -3,12 +3,12 @@
 
 /** \class GEMPadDigiClusterCollection
  *  
- *  \author SVen Dildick
+ *  \author Sven Dildick
  */
 
-#include <DataFormats/MuonDetId/interface/GEMDetId.h>
-#include <DataFormats/GEMDigi/interface/GEMPadDigiCluster.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<GEMDetId, GEMPadDigiCluster> GEMPadDigiClusterCollection;
 

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCollection.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCollection.h
@@ -6,9 +6,9 @@
  *  \author Vadim Khotilovich
  */
 
-#include <DataFormats/MuonDetId/interface/GEMDetId.h>
-#include <DataFormats/GEMDigi/interface/GEMPadDigi.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<GEMDetId, GEMPadDigi> GEMPadDigiCollection;
 

--- a/DataFormats/GEMDigi/interface/ME0Digi.h
+++ b/DataFormats/GEMDigi/interface/ME0Digi.h
@@ -9,7 +9,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 
 class ME0Digi{

--- a/DataFormats/GEMDigi/interface/ME0DigiCollection.h
+++ b/DataFormats/GEMDigi/interface/ME0DigiCollection.h
@@ -6,9 +6,9 @@
  *  \author Sven Dildick
  */
 
-#include <DataFormats/MuonDetId/interface/ME0DetId.h>
-#include <DataFormats/GEMDigi/interface/ME0Digi.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/GEMDigi/interface/ME0Digi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<ME0DetId, ME0Digi> ME0DigiCollection;
 

--- a/DataFormats/GEMDigi/interface/ME0DigiPreReco.h
+++ b/DataFormats/GEMDigi/interface/ME0DigiPreReco.h
@@ -9,7 +9,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 
 class ME0DigiPreReco{

--- a/DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h
+++ b/DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h
@@ -6,9 +6,9 @@
  *  \author Marcello Maggi
  */
 
-#include <DataFormats/MuonDetId/interface/ME0DetId.h>
-#include <DataFormats/GEMDigi/interface/ME0DigiPreReco.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/GEMDigi/interface/ME0DigiPreReco.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<ME0DetId, ME0DigiPreReco> ME0DigiPreRecoCollection;
 typedef MuonDigiCollection<ME0DetId, int > ME0DigiPreRecoMap;

--- a/DataFormats/GEMDigi/interface/ME0PadDigi.h
+++ b/DataFormats/GEMDigi/interface/ME0PadDigi.h
@@ -9,7 +9,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 
 class ME0PadDigi{

--- a/DataFormats/GEMDigi/interface/ME0PadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/ME0PadDigiCluster.h
@@ -10,7 +10,7 @@
  *
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 #include <vector>
 

--- a/DataFormats/GEMDigi/interface/ME0PadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/ME0PadDigiCluster.h
@@ -1,0 +1,40 @@
+#ifndef DataFormats_GEMDigi_ME0PadDigiCluster_h
+#define DataFormats_GEMDigi_ME0PadDigiCluster_h
+
+/** \class ME0PadDigiCluster
+ *
+ * Cluster of maximal 8 adjacent ME0 pad digis
+ * with the same BX
+ *  
+ * \author Sven Dildick
+ *
+ */
+
+#include <boost/cstdint.hpp>
+#include <iosfwd>
+#include <vector>
+
+class ME0PadDigiCluster{
+
+public:
+  explicit ME0PadDigiCluster (std::vector<uint16_t> pads, int bx);
+  ME0PadDigiCluster ();
+
+  bool operator==(const ME0PadDigiCluster& digi) const;
+  bool operator!=(const ME0PadDigiCluster& digi) const;
+  bool operator<(const ME0PadDigiCluster& digi) const;
+
+  const std::vector<uint16_t>& pads() const { return v_; }
+  int bx() const { return bx_; }
+
+  void print() const;
+
+private:
+  std::vector<uint16_t> v_;
+  int32_t  bx_;
+};
+
+std::ostream & operator<<(std::ostream & o, const ME0PadDigiCluster& digi);
+
+#endif
+

--- a/DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h
+++ b/DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h
@@ -1,0 +1,16 @@
+#ifndef DataFormats_GEMDigi_ME0PadDigiClusterCollection_h
+#define DataFormats_GEMDigi_ME0PadDigiClusterCollection_h
+
+/** \class ME0PadDigiClusterCollection
+ *  
+ *  \author Sven Dildick
+ */
+
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCluster.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
+
+typedef MuonDigiCollection<ME0DetId, ME0PadDigiCluster> ME0PadDigiClusterCollection;
+
+#endif
+

--- a/DataFormats/GEMDigi/interface/ME0PadDigiCollection.h
+++ b/DataFormats/GEMDigi/interface/ME0PadDigiCollection.h
@@ -6,9 +6,9 @@
  *  \author Sven Dildick
  */
 
-#include <DataFormats/MuonDetId/interface/ME0DetId.h>
-#include <DataFormats/GEMDigi/interface/ME0PadDigi.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<ME0DetId, ME0PadDigi> ME0PadDigiCollection;
 

--- a/DataFormats/GEMDigi/interface/ME0TriggerDigi.h
+++ b/DataFormats/GEMDigi/interface/ME0TriggerDigi.h
@@ -8,7 +8,7 @@
  * \author Sven Dildick (TAMU)
  */
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <iosfwd>
 
 class ME0TriggerDigi 

--- a/DataFormats/GEMDigi/interface/ME0TriggerDigi.h
+++ b/DataFormats/GEMDigi/interface/ME0TriggerDigi.h
@@ -17,9 +17,10 @@ class ME0TriggerDigi
   
   /// Constructors
   ME0TriggerDigi(const int trknmb, const int quality,
-	     const int strip, const int pattern,
-	     const int bend, const int bx);
-
+		 const int strip, const int partition, 
+		 const int pattern,
+		 const int bend, const int bx);
+  
   /// default
   ME0TriggerDigi();                               
 
@@ -32,51 +33,58 @@ class ME0TriggerDigi
   { return !(this->operator==(rhs)); }
 
   /// return track number
-  int getTrknmb()  const { return trknmb; }
+  int getTrknmb()  const { return trknmb_; }
 
   /// return the Quality
-  int getQuality() const { return quality; }
+  int getQuality() const { return quality_; }
 
   /// return the key strip
-  int getStrip()   const { return strip; }
+  int getStrip()   const { return strip_; }
+
+  /// return the key "partition"
+  int getPartition()   const { return partition_; }
 
   /// return pattern
-  int getPattern() const { return pattern; }
+  int getPattern() const { return pattern_; }
 
   /// return bend
-  int getBend()    const { return bend; }
+  int getBend()    const { return bend_; }
 
   /// return BX
-  int getBX()      const { return bx; }
+  int getBX()      const { return bx_; }
 	
   /// is valid?
-  bool isValid() const { return pattern!=0; }
+  bool isValid() const { return pattern_!=0; }
 
   /// Set track number.
-  void setTrknmb(const uint16_t number) {trknmb = number;}
+  void setTrknmb(const uint16_t number) {trknmb_ = number;}
 
   /// set quality code
-  void setQuality(unsigned int q) {quality=q;}
+  void setQuality(unsigned int q) {quality_=q;}
 
   /// set strip
-  void setStrip(unsigned int s) {strip=s;}
+  void setStrip(unsigned int s) {strip_=s;}
+
+  /// set partition
+  void setPartition(unsigned int s) {partition_=s;}
 
   /// set pattern
-  void setPattern(unsigned int p) {pattern=p;}
+  void setPattern(unsigned int p) {pattern_=p;}
 
   /// set bend
-  void setBend(unsigned int b) {bend=b;}
+  void setBend(unsigned int b) {bend_=b;}
 
   /// set bx
-  void setBX(unsigned int b) {bx=b;}
+  void setBX(unsigned int b) {bx_=b;}
 
  private:
-  uint16_t trknmb;
-  uint16_t quality;
-  uint16_t strip;
-  uint16_t pattern;
-  uint16_t bend;
-  uint16_t bx;
+  uint16_t trknmb_;
+  uint16_t quality_;
+  uint16_t strip_;
+  uint16_t partition_;
+  uint16_t pattern_;
+  uint16_t bend_;
+  uint16_t bx_;
 };
 
 std::ostream & operator<<(std::ostream & o, const ME0TriggerDigi& digi);

--- a/DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h
+++ b/DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h
@@ -7,9 +7,9 @@
  *
  */
 
-#include <DataFormats/MuonDetId/interface/ME0DetId.h>
-#include <DataFormats/GEMDigi/interface/ME0TriggerDigi.h>
-#include <DataFormats/MuonData/interface/MuonDigiCollection.h>
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include "DataFormats/GEMDigi/interface/ME0TriggerDigi.h"
+#include "DataFormats/MuonData/interface/MuonDigiCollection.h"
 
 typedef MuonDigiCollection<ME0DetId,ME0TriggerDigi> ME0TriggerDigiCollection;
 

--- a/DataFormats/GEMDigi/src/ME0PadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/ME0PadDigiCluster.cc
@@ -1,0 +1,53 @@
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCluster.h"
+#include <iostream>
+
+ME0PadDigiCluster::ME0PadDigiCluster (std::vector<uint16_t> pads, int bx) :
+  v_(pads),
+  bx_(bx)
+{}
+
+ME0PadDigiCluster::ME0PadDigiCluster ():
+  v_(std::vector<uint16_t>()),
+  bx_(0)
+{}
+
+
+// Comparison
+bool ME0PadDigiCluster::operator == (const ME0PadDigiCluster& digi) const
+{
+  return v_ == digi.pads() and bx_ == digi.bx();
+}
+
+
+// Comparison
+bool ME0PadDigiCluster::operator != (const ME0PadDigiCluster& digi) const
+{
+  return v_ != digi.pads() or bx_ != digi.bx();
+}
+
+
+///Precedence operator
+bool ME0PadDigiCluster::operator<(const ME0PadDigiCluster& digi) const
+{
+  if(digi.bx() == bx_)
+    return digi.pads().front() < v_.front();
+  else 
+    return digi.bx() < bx_;
+}
+
+
+std::ostream & operator<<(std::ostream & o, const ME0PadDigiCluster& digi)
+{
+  o << " bx: " << digi.bx() << " pads: ";
+  for (auto p: digi.pads()) o << " " << p;
+  o << std::endl;
+  return o;
+}
+
+
+void ME0PadDigiCluster::print() const
+{
+  std::cout << " bx: " << bx() << " pads: ";
+  for (auto p: pads()) std::cout << " " << p;
+  std::cout << std::endl;
+}

--- a/DataFormats/GEMDigi/src/ME0TriggerDigi.cc
+++ b/DataFormats/GEMDigi/src/ME0TriggerDigi.cc
@@ -5,15 +5,17 @@
 ME0TriggerDigi::ME0TriggerDigi(const int itrknmb,
 			       const int iquality,
 			       const int istrip,
+			       const int ipartition,
 			       const int ipattern, 
 			       const int ibend,
 			       const int ibx):
-  trknmb(itrknmb),
-  quality(iquality),
-  strip(istrip),
-  pattern(ipattern),
-  bend(ibend),
-  bx(ibx)
+  trknmb_(itrknmb),
+  quality_(iquality),
+  strip_(istrip),
+  partition_(ipartition),
+  pattern_(ipattern),
+  bend_(ibend),
+  bx_(ibx)
 {}
 
 ME0TriggerDigi::ME0TriggerDigi() {
@@ -21,18 +23,20 @@ ME0TriggerDigi::ME0TriggerDigi() {
 }
 
 void ME0TriggerDigi::clear() {
-  trknmb  = 0;
-  quality = 0;
-  strip   = 0;
-  pattern = 0;
-  bend    = 0;
-  bx      = 0;
+  trknmb_  = 0;
+  quality_ = 0;
+  strip_   = 0;
+  partition_   = 0;
+  pattern_ = 0;
+  bend_    = 0;
+  bx_      = 0;
 }
 
 bool ME0TriggerDigi::operator==(const ME0TriggerDigi &rhs) const {
-  return ((trknmb == rhs.trknmb) && (quality == rhs.quality) &&
-	  (strip == rhs.strip)   && (pattern == rhs.pattern) && 
-	  (bend == rhs.bend)     && (bx == rhs.bx) );
+  return ((trknmb_ == rhs.trknmb_) && (quality_ == rhs.quality_) &&
+	  (strip_ == rhs.strip_)   && (partition_ == rhs.partition_)   && 
+	  (pattern_ == rhs.pattern_) && 
+	  (bend_ == rhs.bend_)     && (bx_ == rhs.bx_) );
 }
 
 std::ostream & operator<<(std::ostream & o,
@@ -40,6 +44,7 @@ std::ostream & operator<<(std::ostream & o,
   return o << "ME0 Trigger #" << digi.getTrknmb()
            << ": Quality = "  << digi.getQuality()
            << " Strip = "     << digi.getStrip()
+           << " Partition = "     << digi.getPartition()
 	   << " Pattern = "   << digi.getPattern()
            << " Bend = "      << ((digi.getBend() == 0) ? 'L' : 'R') << "\n"
            << " BX = "        << digi.getBX()

--- a/DataFormats/GEMDigi/src/classes.h
+++ b/DataFormats/GEMDigi/src/classes.h
@@ -1,31 +1,31 @@
-#include <DataFormats/GEMDigi/interface/GEMDigi.h>
-#include <DataFormats/GEMDigi/interface/GEMDigiCollection.h>
+#include "DataFormats/GEMDigi/interface/GEMDigi.h"
+#include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 
-#include <DataFormats/GEMDigi/interface/GEMPadDigi.h>
-#include <DataFormats/GEMDigi/interface/GEMPadDigiCollection.h>
+#include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
 
-#include <DataFormats/GEMDigi/interface/GEMPadDigiCluster.h>
-#include <DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h>
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 
-#include <DataFormats/GEMDigi/interface/GEMCoPadDigi.h>
-#include <DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h>
+#include "DataFormats/GEMDigi/interface/GEMCoPadDigi.h"
+#include "DataFormats/GEMDigi/interface/GEMCoPadDigiCollection.h"
 
-#include <DataFormats/GEMDigi/interface/ME0DigiPreReco.h>
-#include <DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h>
+#include "DataFormats/GEMDigi/interface/ME0DigiPreReco.h"
+#include "DataFormats/GEMDigi/interface/ME0DigiPreRecoCollection.h"
 
-#include <DataFormats/GEMDigi/interface/ME0Digi.h>
-#include <DataFormats/GEMDigi/interface/ME0DigiCollection.h>
+#include "DataFormats/GEMDigi/interface/ME0Digi.h"
+#include "DataFormats/GEMDigi/interface/ME0DigiCollection.h"
 
-#include <DataFormats/GEMDigi/interface/ME0PadDigi.h>
-#include <DataFormats/GEMDigi/interface/ME0PadDigiCollection.h>
+#include "DataFormats/GEMDigi/interface/ME0PadDigi.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
 
-#include <DataFormats/GEMDigi/interface/ME0PadDigiCluster.h>
-#include <DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h>
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCluster.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
 
-#include <DataFormats/GEMDigi/interface/ME0TriggerDigi.h>
-#include <DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h>
+#include "DataFormats/GEMDigi/interface/ME0TriggerDigi.h"
+#include "DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h"
 
-#include <DataFormats/Common/interface/Wrapper.h>
+#include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
 namespace DataFormats_GEMDigi {

--- a/DataFormats/GEMDigi/src/classes.h
+++ b/DataFormats/GEMDigi/src/classes.h
@@ -19,6 +19,9 @@
 #include <DataFormats/GEMDigi/interface/ME0PadDigi.h>
 #include <DataFormats/GEMDigi/interface/ME0PadDigiCollection.h>
 
+#include <DataFormats/GEMDigi/interface/ME0PadDigiCluster.h>
+#include <DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h>
+
 #include <DataFormats/GEMDigi/interface/ME0TriggerDigi.h>
 #include <DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h>
 
@@ -71,6 +74,12 @@ namespace DataFormats_GEMDigi {
     std::vector<std::vector<ME0PadDigi> >  vvmp;
     ME0PadDigiCollection mpcol;
     edm::Wrapper<ME0PadDigiCollection> wmp;
+
+    ME0PadDigiCluster mpc;
+    std::vector<ME0PadDigiCluster>  vmpc;
+    std::vector<std::vector<ME0PadDigiCluster> >  vvmpc;
+    ME0PadDigiClusterCollection mpccol;
+    edm::Wrapper<ME0PadDigiClusterCollection> wmpc;
 
     ME0TriggerDigi ml;
     std::vector<ME0TriggerDigi>  vml;

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -72,8 +72,9 @@
 <class name="MuonDigiCollection<ME0DetId,ME0PadDigiCluster>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0PadDigiCluster> >" splitLevel="0"/> 
 
-<class name="ME0TriggerDigi" ClassVersion="10">
+<class name="ME0TriggerDigi" ClassVersion="11">
  <version ClassVersion="10" checksum="2020160691"/>
+ <version ClassVersion="11" checksum="4080659697"/>
 </class>
 <class name="std::vector<ME0TriggerDigi>"/>
 <class name="std::map<ME0DetId,std::vector<ME0TriggerDigi> >"/>

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -64,6 +64,14 @@
 <class name="MuonDigiCollection<ME0DetId,ME0PadDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0PadDigi> >" splitLevel="0"/> 
 
+<class name="ME0PadDigiCluster" ClassVersion="10">
+ <version ClassVersion="10" checksum="3867685231"/>
+</class>
+<class name="std::vector<ME0PadDigiCluster>"/>
+<class name="std::map<ME0DetId,std::vector<ME0PadDigiCluster> >"/>
+<class name="MuonDigiCollection<ME0DetId,ME0PadDigiCluster>"/> 
+<class name="edm::Wrapper<MuonDigiCollection<ME0DetId,ME0PadDigiCluster> >" splitLevel="0"/> 
+
 <class name="ME0TriggerDigi" ClassVersion="10">
  <version ClassVersion="10" checksum="2020160691"/>
 </class>

--- a/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.cc
+++ b/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.cc
@@ -9,8 +9,8 @@
 
 ME0TriggerProducer::ME0TriggerProducer(const edm::ParameterSet& conf) 
 {
-  me0PadDigiProducer_ = conf.getParameter<edm::InputTag>("ME0PadDigiProducer");
-  me0_pad_token_ = consumes<ME0PadDigiCollection>(me0PadDigiProducer_);
+  me0PadDigiClusterProducer_ = conf.getParameter<edm::InputTag>("ME0PadDigiClusterProducer");
+  me0_pad_token_ = consumes<ME0PadDigiClusterCollection>(me0PadDigiClusterProducer_);
   config_ = conf;
 
   // register what this produces
@@ -26,9 +26,9 @@ void ME0TriggerProducer::produce(edm::StreamID, edm::Event& ev, const edm::Event
   edm::ESHandle<ME0Geometry> h_me0;
   setup.get<MuonGeometryRecord>().get(h_me0);
 
-  edm::Handle<ME0PadDigiCollection> me0PadDigis; 
-  ev.getByToken(me0_pad_token_, me0PadDigis);
-  const ME0PadDigiCollection *me0Pads = me0PadDigis.product();
+  edm::Handle<ME0PadDigiClusterCollection> me0PadDigiClusters; 
+  ev.getByToken(me0_pad_token_, me0PadDigiClusters);
+  const ME0PadDigiClusterCollection *me0Pads = me0PadDigiClusters.product();
   
   // Create empty collection
   std::unique_ptr<ME0TriggerDigiCollection> oc_trig(new ME0TriggerDigiCollection);
@@ -37,7 +37,7 @@ void ME0TriggerProducer::produce(edm::StreamID, edm::Event& ev, const edm::Event
   trigBuilder->setME0Geometry(&*h_me0);
 
   // Fill output collections if valid input collection is available.
-  if (me0PadDigis.isValid()) {   
+  if (me0PadDigiClusters.isValid()) {   
     trigBuilder->build(me0Pads, *oc_trig);
   }
   

--- a/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.h
+++ b/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.h
@@ -3,6 +3,9 @@
 
 /** \class ME0TriggerProducer
  *
+ * Takes ME0 pad clusters as input
+ * Produces ME0 trigger objects
+ *
  * \author Sven Dildick (TAMU).
  *
  */

--- a/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.h
+++ b/L1Trigger/ME0Trigger/plugins/ME0TriggerProducer.h
@@ -7,7 +7,7 @@
  *
  */
 
-#include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -27,8 +27,8 @@ class ME0TriggerProducer : public edm::global::EDProducer<>
   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
  private:
-  edm::InputTag me0PadDigiProducer_;
-  edm::EDGetTokenT<ME0PadDigiCollection> me0_pad_token_;
+  edm::InputTag me0PadDigiClusterProducer_;
+  edm::EDGetTokenT<ME0PadDigiClusterCollection> me0_pad_token_;
   edm::ParameterSet config_;
 };
 

--- a/L1Trigger/ME0Trigger/python/me0TriggerDigis_cfi.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerDigis_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 me0TriggerDigis = cms.EDProducer("ME0TriggerProducer",
-    ME0PadDigiProducer = cms.InputTag("simMuonME0PadDigis"),
+    ME0PadDigiClusterProducer = cms.InputTag("simMuonME0PadDigiClusters"),
     tmbParam = cms.PSet()
 )

--- a/L1Trigger/ME0Trigger/src/ME0Motherboard.cc
+++ b/L1Trigger/ME0Trigger/src/ME0Motherboard.cc
@@ -49,8 +49,9 @@ std::vector<ME0TriggerDigi> ME0Motherboard::readoutTriggers()
   std::vector<ME0TriggerDigi> tmpV;
   
   std::vector<ME0TriggerDigi> all_trigs = getTriggers();
-  for (auto ptrig = all_trigs.begin(); ptrig != all_trigs.end(); ptrig++) {
-    tmpV.push_back(*ptrig);
+  for (const auto& ptrig : all_trigs) {
+    // in the future, add a selection on the BX
+    tmpV.push_back(ptrig);
   }
   return tmpV;
 }
@@ -60,7 +61,6 @@ std::vector<ME0TriggerDigi> ME0Motherboard::getTriggers()
 {
   std::vector<ME0TriggerDigi> tmpV;
   
-  // Do not report Triggers found in ME1/A if mpc_block_me1/a is set.
   for (int bx = 0; bx < MAX_TRIGGER_BINS; bx++) {
     for (int i = 0; i < MAX_TRIGGERS; i++) {
       tmpV.push_back(Triggers[bx][i]);
@@ -89,12 +89,11 @@ bool ME0Motherboard::sortByME0Dphi(const ME0TriggerDigi& trig1, const ME0Trigger
 void ME0Motherboard::declusterize(const ME0PadDigiClusterCollection* in_clusters,
 				  ME0PadDigiCollection& out_pads)
 {
-  ME0PadDigiClusterCollection::DigiRangeIterator detUnitIt;
-  for (detUnitIt = in_clusters->begin();detUnitIt != in_clusters->end(); ++detUnitIt) {
+  for (auto detUnitIt = in_clusters->begin();detUnitIt != in_clusters->end(); ++detUnitIt) {
     const ME0DetId& id = (*detUnitIt).first;
-    const ME0PadDigiClusterCollection::Range& range = (*detUnitIt).second;
-    for (ME0PadDigiClusterCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt) {
-      for (auto p: digiIt->pads()){
+    const auto& range = (*detUnitIt).second;
+    for (auto digiIt = range.first; digiIt!=range.second; ++digiIt) {
+      for (const auto& p: digiIt->pads()){
 	out_pads.insertDigi(id, ME0PadDigi(p, digiIt->bx()));
       }
     }

--- a/L1Trigger/ME0Trigger/src/ME0Motherboard.cc
+++ b/L1Trigger/ME0Trigger/src/ME0Motherboard.cc
@@ -29,8 +29,14 @@ void ME0Motherboard::clear()
   }
 }
 
-void
-ME0Motherboard::run(const ME0PadDigiCollection*) 
+void ME0Motherboard::run(const ME0PadDigiClusterCollection* me0Clusters)
+{
+  std::unique_ptr<ME0PadDigiCollection> me0Pads(new ME0PadDigiCollection());
+  declusterize(me0Clusters, *me0Pads);
+  run(me0Pads.get());
+}
+
+void ME0Motherboard::run(const ME0PadDigiCollection*) 
 {
   clear();
 }
@@ -76,4 +82,21 @@ bool ME0Motherboard::sortByME0Dphi(const ME0TriggerDigi& trig1, const ME0Trigger
   // That function will derive the bending angle from the pattern. 
   // The ME0TriggerDigi pattterns are at this point not defined yet.  
   return true;
+}
+
+
+
+void ME0Motherboard::declusterize(const ME0PadDigiClusterCollection* in_clusters,
+				  ME0PadDigiCollection& out_pads)
+{
+  ME0PadDigiClusterCollection::DigiRangeIterator detUnitIt;
+  for (detUnitIt = in_clusters->begin();detUnitIt != in_clusters->end(); ++detUnitIt) {
+    const ME0DetId& id = (*detUnitIt).first;
+    const ME0PadDigiClusterCollection::Range& range = (*detUnitIt).second;
+    for (ME0PadDigiClusterCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt) {
+      for (auto p: digiIt->pads()){
+	out_pads.insertDigi(id, ME0PadDigi(p, digiIt->bx()));
+      }
+    }
+  }
 }

--- a/L1Trigger/ME0Trigger/src/ME0Motherboard.h
+++ b/L1Trigger/ME0Trigger/src/ME0Motherboard.h
@@ -1,7 +1,16 @@
 #ifndef L1Trigger_ME0TriggerPrimitives_ME0Motherboard_h
 #define L1Trigger_ME0TriggerPrimitives_ME0Motherboard_h
 
+/** \class ME0TriggerBuilder
+ *
+ * Does pattern recognition of ME0 pads to build ME0 triggers
+ *
+ * \author Sven Dildick (TAMU)
+ *
+ */
+
 #include "DataFormats/GEMDigi/interface/ME0TriggerDigi.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -26,6 +35,9 @@ class ME0Motherboard
   /** Run function for normal usage. */
   void run(const ME0PadDigiCollection*);
 
+  /** Build Triggers from single pads in each chamber and fill them into output collections. */
+  void run(const ME0PadDigiClusterCollection*);
+  
   /** Returns vector of Triggers in the read-out time window, if any. */
   std::vector<ME0TriggerDigi> readoutTriggers();
 
@@ -34,6 +46,9 @@ class ME0Motherboard
 
   /** Clears Triggers. */
   void clear();
+
+  // declusterizes the clusters into single pad digis
+  void declusterize(const ME0PadDigiClusterCollection*, ME0PadDigiCollection&);
 
  private:
 

--- a/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
@@ -31,15 +31,7 @@ ME0TriggerBuilder::~ME0TriggerBuilder()
 {
 }
 
-void ME0TriggerBuilder::build(const ME0PadDigiClusterCollection* me0Clusters,
-			      ME0TriggerDigiCollection& oc_trig)
-{
-  std::unique_ptr<ME0PadDigiCollection> me0Pads(new ME0PadDigiCollection());
-  declusterize(me0Clusters, *me0Pads);
-  build(me0Pads.get(), oc_trig);
-}
-
-void ME0TriggerBuilder::build(const ME0PadDigiCollection* me0Pads,
+void ME0TriggerBuilder::build(const ME0PadDigiClusterCollection* me0Pads,
 			      ME0TriggerDigiCollection& oc_trig)
 {
   for (int endc = 0; endc < 2; endc++)
@@ -72,18 +64,3 @@ void ME0TriggerBuilder::build(const ME0PadDigiCollection* me0Pads,
   }
 }
 
-void
-ME0TriggerBuilder::declusterize(const ME0PadDigiClusterCollection* in_clusters,
-				ME0PadDigiCollection& out_pads)
-{
-  ME0PadDigiClusterCollection::DigiRangeIterator detUnitIt;
-  for (detUnitIt = in_clusters->begin();detUnitIt != in_clusters->end(); ++detUnitIt) {
-    const ME0DetId& id = (*detUnitIt).first;
-    const ME0PadDigiClusterCollection::Range& range = (*detUnitIt).second;
-    for (ME0PadDigiClusterCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt) {
-      for (auto p: digiIt->pads()){
-	out_pads.insertDigi(id, ME0PadDigi(p, digiIt->bx()));
-      }
-    }
-  }
-}

--- a/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.cc
@@ -31,6 +31,14 @@ ME0TriggerBuilder::~ME0TriggerBuilder()
 {
 }
 
+void ME0TriggerBuilder::build(const ME0PadDigiClusterCollection* me0Clusters,
+			      ME0TriggerDigiCollection& oc_trig)
+{
+  std::unique_ptr<ME0PadDigiCollection> me0Pads(new ME0PadDigiCollection());
+  declusterize(me0Clusters, *me0Pads);
+  build(me0Pads.get(), oc_trig);
+}
+
 void ME0TriggerBuilder::build(const ME0PadDigiCollection* me0Pads,
 			      ME0TriggerDigiCollection& oc_trig)
 {
@@ -61,5 +69,21 @@ void ME0TriggerBuilder::build(const ME0PadDigiCollection* me0Pads,
 	oc_trig.put(std::make_pair(trigV.begin(),trigV.end()), detid);
       }
     } 
+  }
+}
+
+void
+ME0TriggerBuilder::declusterize(const ME0PadDigiClusterCollection* in_clusters,
+				ME0PadDigiCollection& out_pads)
+{
+  ME0PadDigiClusterCollection::DigiRangeIterator detUnitIt;
+  for (detUnitIt = in_clusters->begin();detUnitIt != in_clusters->end(); ++detUnitIt) {
+    const ME0DetId& id = (*detUnitIt).first;
+    const ME0PadDigiClusterCollection::Range& range = (*detUnitIt).second;
+    for (ME0PadDigiClusterCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt) {
+      for (auto p: digiIt->pads()){
+	out_pads.insertDigi(id, ME0PadDigi(p, digiIt->bx()));
+      }
+    }
   }
 }

--- a/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.h
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.h
@@ -3,12 +3,13 @@
 
 /** \class ME0TriggerBuilder
  *
- * \author Sven Dildick, TAMU.
+ * Builds ME0 trigger objects from ME0 pad clusters
+ *
+ * \author Sven Dildick (TAMU)
  *
  */
 
 #include "DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h"
-#include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -27,17 +28,11 @@ class ME0TriggerBuilder
 
   ~ME0TriggerBuilder();
 
-  /** Build Triggers in each chamber and fill them into output collections. */
+  /** Build Triggers from clusters in each chamber and fill them into output collections. */
   void build(const ME0PadDigiClusterCollection* me0Pads, ME0TriggerDigiCollection& oc_trig);
 
-  /** Build Triggers in each chamber and fill them into output collections. */
-  void build(const ME0PadDigiCollection* me0Pads, ME0TriggerDigiCollection& oc_trig);
-  
   /** set geometry for the matching needs */
   void setME0Geometry(const ME0Geometry *g) { me0_g = g; }
-
-  // declusterizes the clusters into single pad digis
-  void declusterize(const ME0PadDigiClusterCollection*, ME0PadDigiCollection&);
 
   /** Max values of trigger labels for all ME0s; 
    *  used to construct TMB processors. 

--- a/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.h
+++ b/L1Trigger/ME0Trigger/src/ME0TriggerBuilder.h
@@ -9,6 +9,7 @@
 
 #include "DataFormats/GEMDigi/interface/ME0TriggerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class ME0Motherboard;
@@ -27,10 +28,16 @@ class ME0TriggerBuilder
   ~ME0TriggerBuilder();
 
   /** Build Triggers in each chamber and fill them into output collections. */
+  void build(const ME0PadDigiClusterCollection* me0Pads, ME0TriggerDigiCollection& oc_trig);
+
+  /** Build Triggers in each chamber and fill them into output collections. */
   void build(const ME0PadDigiCollection* me0Pads, ME0TriggerDigiCollection& oc_trig);
   
   /** set geometry for the matching needs */
   void setME0Geometry(const ME0Geometry *g) { me0_g = g; }
+
+  // declusterizes the clusters into single pad digis
+  void declusterize(const ME0PadDigiClusterCollection*, ME0PadDigiCollection&);
 
   /** Max values of trigger labels for all ME0s; 
    *  used to construct TMB processors. 

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -49,6 +49,7 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( SimMuonFEVTDEBUG, outputCommands = SimMuonFEVTDEBUG.outputCommands + ['keep *_simMuonME0PseudoDigis_*_*',
                                                                                             'keep *_simMuonME0PseudoReDigis_*_*',
                                                                                             'keep *_simMuonME0Digis_*_*',
-                                                                                            'keep *_simMuonME0PadDigis_*_*'] )
+                                                                                            'keep *_simMuonME0PadDigis_*_*',
+                                                                                            'keep *_simMuonME0PadDigiClusters_*_*'] )
 phase2_muon.toModify( SimMuonRAW, outputCommands = SimMuonRAW.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )
 phase2_muon.toModify( SimMuonRECO, outputCommands = SimMuonRECO.outputCommands + ['keep StripDigiSimLinkedmDetSetVector_simMuonME0Digis_*_*'] )

--- a/SimMuon/GEMDigitizer/BuildFile.xml
+++ b/SimMuon/GEMDigitizer/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="CondCore/CondDB"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="CondCore/PopCon"/>

--- a/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
@@ -8,7 +8,7 @@
  *  Clusters are used downstream in the CSC local trigger to build 
  *  GEM-CSC triggers and in the muon trigger to build EMTF tracks
  *   
- *  \author Sven Dildick
+ *  \author Sven Dildick (TAMU)
  */
 
 #include <FWCore/Framework/interface/ConsumesCollector.h>

--- a/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
@@ -11,7 +11,7 @@
  *  \author Sven Dildick (TAMU)
  */
 
-#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/GEMPadDigiClusterProducer.h
@@ -1,6 +1,16 @@
 #ifndef SimMuon_GEMDigitizer_GEMPadDigiClusterProducer_h
 #define SimMuon_GEMDigitizer_GEMPadDigiClusterProducer_h
 
+/** 
+ *  \class ME0PadDigiClusterProducer
+ *
+ *  Produces GEM pad clusters from at most 8 adjacent GEM pads.
+ *  Clusters are used downstream in the CSC local trigger to build 
+ *  GEM-CSC triggers and in the muon trigger to build EMTF tracks
+ *   
+ *  \author Sven Dildick
+ */
+
 #include <FWCore/Framework/interface/ConsumesCollector.h>
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/SimMuon/GEMDigitizer/interface/GEMPadDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/GEMPadDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef SimMuon_GEMDigitizer_GEMPadDigiProducer_h
 #define SimMuon_GEMDigitizer_GEMPadDigiProducer_h
 
-#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
@@ -1,0 +1,43 @@
+#ifndef SimMuon_GEMDigitizer_ME0PadDigiClusterProducer_h
+#define SimMuon_GEMDigitizer_ME0PadDigiClusterProducer_h
+
+#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/GEMDigi/interface/ME0PadDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/ME0PadDigiClusterCollection.h"
+
+class ME0Geometry;
+
+class ME0PadDigiClusterProducer : public edm::stream::EDProducer<>
+{
+public:
+
+  explicit ME0PadDigiClusterProducer(const edm::ParameterSet& ps);
+
+  virtual ~ME0PadDigiClusterProducer();
+
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  
+  void buildClusters(const ME0PadDigiCollection &pads, ME0PadDigiClusterCollection &out_clusters);
+
+  /// Name of input digi Collection
+  edm::EDGetTokenT<ME0PadDigiCollection> pad_token_;
+  edm::InputTag pads_;
+
+  unsigned int maxClusters_;
+  unsigned int maxClusterSize_;
+
+  const ME0Geometry * geometry_;
+};
+
+#endif
+

--- a/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
@@ -1,6 +1,15 @@
 #ifndef SimMuon_GEMDigitizer_ME0PadDigiClusterProducer_h
 #define SimMuon_GEMDigitizer_ME0PadDigiClusterProducer_h
 
+/** 
+ *  \class ME0PadDigiClusterProducer
+ *
+ *  Produces ME0 pad clusters from at most 8 adjacent ME0 pads.
+ *  Clusters are used downstream to build triggers. 
+ *  
+ *  \author Sven Dildick
+ */
+
 #include <FWCore/Framework/interface/ConsumesCollector.h>
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
@@ -7,7 +7,7 @@
  *  Produces ME0 pad clusters from at most 8 adjacent ME0 pads.
  *  Clusters are used downstream to build triggers. 
  *  
- *  \author Sven Dildick
+ *  \author Sven Dildick (TAMU)
  */
 
 #include <FWCore/Framework/interface/ConsumesCollector.h>

--- a/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h
@@ -10,7 +10,7 @@
  *  \author Sven Dildick (TAMU)
  */
 
-#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/SimMuon/GEMDigitizer/interface/ME0PadDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0PadDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef SimMuon_GEMDigitizer_ME0PadDigiProducer_h
 #define SimMuon_GEMDigitizer_ME0PadDigiProducer_h
 
-#include <FWCore/Framework/interface/ConsumesCollector.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from SimMuon.GEMDigitizer.muonME0Digis_cfi import *
 from SimMuon.GEMDigitizer.muonME0PadDigis_cfi import *
+from SimMuon.GEMDigitizer.muonME0PadDigiClusters_cfi import *
 from SimMuon.GEMDigitizer.muonME0PseudoDigis_cfi import *
 from SimMuon.GEMDigitizer.muonME0PseudoReDigis_cfi import *
 
-muonME0RealDigi = cms.Sequence(simMuonME0Digis * simMuonME0PadDigis)
+muonME0RealDigi = cms.Sequence(simMuonME0Digis * simMuonME0PadDigis + simMuonME0PadDigiClusters)
 
 muonME0PseudoDigi = cms.Sequence(simMuonME0PseudoDigis * simMuonME0PseudoReDigis)
 

--- a/SimMuon/GEMDigitizer/python/muonME0PadDigiClusters_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0PadDigiClusters_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# Module to create ME0 pad digi clusters
+simMuonME0PadDigiClusters = cms.EDProducer("ME0PadDigiClusterProducer",
+    InputCollection = cms.InputTag('simMuonME0PadDigis'),
+    maxClusters = cms.uint32(8),
+    maxClusterSize = cms.uint32(8)
+)

--- a/SimMuon/GEMDigitizer/python/muonME0PadDigiClusters_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0PadDigiClusters_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 # Module to create ME0 pad digi clusters
 simMuonME0PadDigiClusters = cms.EDProducer("ME0PadDigiClusterProducer",
     InputCollection = cms.InputTag('simMuonME0PadDigis'),
-    maxClusters = cms.uint32(24),
+    maxClusters = cms.uint32(8),
     maxClusterSize = cms.uint32(8)
 )

--- a/SimMuon/GEMDigitizer/python/muonME0PadDigiClusters_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0PadDigiClusters_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 # Module to create ME0 pad digi clusters
 simMuonME0PadDigiClusters = cms.EDProducer("ME0PadDigiClusterProducer",
     InputCollection = cms.InputTag('simMuonME0PadDigis'),
-    maxClusters = cms.uint32(8),
+    maxClusters = cms.uint32(24),
     maxClusterSize = cms.uint32(8)
 )

--- a/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/GEMPadDigiClusterProducer.cc
@@ -62,7 +62,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection &det_pa
       std::vector<uint16_t> cl;
       int startBX = 99;
       for (auto d = pads.first; d != pads.second; ++d) {
-        if (cl.size() == 0) {
+        if (cl.empty()) {
           cl.push_back((*d).pad());
         }
         else {

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -56,7 +56,6 @@ void ME0PadDigiClusterProducer::produce(edm::Event& e, const edm::EventSetup& ev
 void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pads, ME0PadDigiClusterCollection &out_clusters)
 {
   for (const auto& ch: geometry_->chambers()) {
-    unsigned int nClusters = 0;
     for (const auto& part: ch->etaPartitions()) {
       auto pads = det_pads.get(part->id());
       std::vector<uint16_t> cl;
@@ -74,7 +73,6 @@ void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pa
             out_clusters.insertDigi(part->id(), pad_cluster);
             cl.clear();
             cl.push_back((*d).pad());
-            nClusters++;
           }
         }
         startBX = (*d).bx();
@@ -82,7 +80,6 @@ void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pa
       if (pads.first != pads.second){
         ME0PadDigiCluster pad_cluster(cl, startBX);
         out_clusters.insertDigi(part->id(), pad_cluster);
-        nClusters++;
       }
     }
   }

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -1,0 +1,89 @@
+#include "SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "Geometry/GEMGeometry/interface/ME0Geometry.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <string>
+#include <map>
+#include <vector>
+
+
+ME0PadDigiClusterProducer::ME0PadDigiClusterProducer(const edm::ParameterSet& ps)
+: geometry_(nullptr)
+{
+  pads_ = ps.getParameter<edm::InputTag>("InputCollection");
+  maxClusters_ = ps.getParameter<unsigned int>("maxClusters");
+  maxClusterSize_ = ps.getParameter<unsigned int>("maxClusterSize");
+
+  pad_token_ = consumes<ME0PadDigiCollection>(pads_);
+
+  produces<ME0PadDigiClusterCollection>();
+  consumes<ME0PadDigiCollection>(pads_);
+}
+
+
+ME0PadDigiClusterProducer::~ME0PadDigiClusterProducer()
+{}
+
+
+void ME0PadDigiClusterProducer::beginRun(const edm::Run& run, const edm::EventSetup& eventSetup)
+{
+  edm::ESHandle<ME0Geometry> hGeom;
+  eventSetup.get<MuonGeometryRecord>().get(hGeom);
+  geometry_ = &*hGeom;
+}
+
+
+void ME0PadDigiClusterProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup)
+{
+  edm::Handle<ME0PadDigiCollection> hpads;
+  e.getByToken(pad_token_, hpads);
+
+  // Create empty output
+  std::unique_ptr<ME0PadDigiClusterCollection> pClusters(new ME0PadDigiClusterCollection());
+
+  // build the clusters
+  buildClusters(*(hpads.product()), *pClusters);
+
+  // store them in the event
+  e.put(std::move(pClusters));
+}
+
+
+void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pads, ME0PadDigiClusterCollection &out_clusters)
+{
+  for (const auto& ch: geometry_->chambers()) {
+    unsigned int nClusters = 0;
+    for (const auto& part: ch->etaPartitions()) {
+      auto pads = det_pads.get(part->id());
+      std::vector<uint16_t> cl;
+      int startBX = 99;
+      for (auto d = pads.first; d != pads.second; ++d) {
+        if (cl.size() == 0) {
+          cl.push_back((*d).pad());
+        }
+        else {
+          if ((*d).bx() == startBX and (*d).pad() == cl.back() + 1) {
+            cl.push_back((*d).pad());
+          }
+          else {
+            ME0PadDigiCluster pad_cluster(cl, startBX);
+            out_clusters.insertDigi(part->id(), pad_cluster);
+            cl.clear();
+            cl.push_back((*d).pad());
+            nClusters++;
+          }
+        }
+        startBX = (*d).bx();
+      }
+      if (pads.first != pads.second){
+        ME0PadDigiCluster pad_cluster(cl, startBX);
+        out_clusters.insertDigi(part->id(), pad_cluster);
+        nClusters++;
+      }
+    }
+  }
+}

--- a/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0PadDigiClusterProducer.cc
@@ -61,7 +61,7 @@ void ME0PadDigiClusterProducer::buildClusters(const ME0PadDigiCollection &det_pa
       std::vector<uint16_t> cl;
       int startBX = 99;
       for (auto d = pads.first; d != pads.second; ++d) {
-        if (cl.size() == 0) {
+        if (cl.empty()) {
           cl.push_back((*d).pad());
         }
         else {

--- a/SimMuon/GEMDigitizer/src/SealModule.cc
+++ b/SimMuon/GEMDigitizer/src/SealModule.cc
@@ -39,3 +39,6 @@ DEFINE_EDM_PLUGIN(ME0DigiModelFactory, ME0SimpleModel, "ME0SimpleModel");
 
 #include "SimMuon/GEMDigitizer/interface/ME0PadDigiProducer.h"
 DEFINE_FWK_MODULE(ME0PadDigiProducer);
+
+#include "SimMuon/GEMDigitizer/interface/ME0PadDigiClusterProducer.h"
+DEFINE_FWK_MODULE(ME0PadDigiClusterProducer);

--- a/SimMuon/GEMDigitizer/test/BuildFile.xml
+++ b/SimMuon/GEMDigitizer/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/GEMDigi"/>
 <use   name="FWCore/Framework"/>

--- a/SimMuon/GEMDigitizer/test/GEMDigiReader.cc
+++ b/SimMuon/GEMDigitizer/test/GEMDigiReader.cc
@@ -123,6 +123,6 @@ void GEMDigiReader::analyze(const edm::Event & event, const edm::EventSetup& eve
   LogDebug("GEMDigiReader")<<"--------------"<<endl;
 }
 
-#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(GEMDigiReader);
 

--- a/SimMuon/GEMDigitizer/test/GEMDigiSimLinkReader.cc
+++ b/SimMuon/GEMDigitizer/test/GEMDigiSimLinkReader.cc
@@ -463,6 +463,6 @@ void GEMDigiSimLinkReader::analyze(const edm::Event & event, const edm::EventSet
   }        //end given detector
 }
 
-#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE (GEMDigiSimLinkReader);
 

--- a/SimMuon/GEMDigitizer/test/GEMPadDigiReader.cc
+++ b/SimMuon/GEMDigitizer/test/GEMPadDigiReader.cc
@@ -119,5 +119,5 @@ void GEMPadDigiReader::analyze(const edm::Event & event, const edm::EventSetup& 
   }// for (detids with pads)
 }
 
-#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(GEMPadDigiReader);

--- a/SimMuon/GEMDigitizer/test/ME0DigiReader.cc
+++ b/SimMuon/GEMDigitizer/test/ME0DigiReader.cc
@@ -241,6 +241,6 @@ void ME0DigiReader::endJob() {
 
 }
 
-#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(ME0DigiReader);
 

--- a/SimMuon/GEMDigitizer/test/ME0DigiSimLinkReader.cc
+++ b/SimMuon/GEMDigitizer/test/ME0DigiSimLinkReader.cc
@@ -221,5 +221,5 @@ void ME0DigiSimLinkReader::analyze(const edm::Event & event, const edm::EventSet
   }
 }
 
-#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE (ME0DigiSimLinkReader);

--- a/SimMuon/RPCDigitizer/BuildFile.xml
+++ b/SimMuon/RPCDigitizer/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="CondCore/CondDB"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="CondCore/PopCon"/>

--- a/SimMuon/RPCDigitizer/src/RPCSim.h
+++ b/SimMuon/RPCDigitizer/src/RPCSim.h
@@ -9,7 +9,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/EventSetup.h>
+#include "FWCore/Framework/interface/EventSetup.h"
 
 #include <map>
 #include <set>

--- a/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
@@ -10,17 +10,17 @@
 
 #include <cmath>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
@@ -29,7 +29,7 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.cc
@@ -24,12 +24,12 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
-#include<cstring>
-#include<iostream>
-#include<fstream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAsymmetricCls.h
@@ -15,8 +15,8 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include<cstdlib>
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverage.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverage.cc
@@ -22,12 +22,12 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
-#include<cstring>
-#include<iostream>
-#include<fstream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverage.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverage.cc
@@ -8,17 +8,17 @@
 
 #include <cmath>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
@@ -27,7 +27,7 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverage.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverage.h
@@ -15,8 +15,8 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include<cstdlib>
+#include "FWCore/Framework/interface/EventSetup.h"
 
 
 class RPCGeometry;

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.cc
@@ -22,12 +22,12 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
-#include<cstring>
-#include<iostream>
-#include<fstream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.cc
@@ -8,17 +8,17 @@
 
 #include <cmath>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
@@ -27,7 +27,7 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoise.h
@@ -15,8 +15,8 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include<cstdlib>
+#include "FWCore/Framework/interface/EventSetup.h"
 
 
 class RPCGeometry;

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.cc
@@ -10,17 +10,17 @@
 
 #include <cmath>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
@@ -29,7 +29,7 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.cc
@@ -24,12 +24,12 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
-#include<cstring>
-#include<iostream>
-#include<fstream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEff.h
@@ -15,8 +15,8 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include<cstdlib>
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
 class RPCGeometry;

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.cc
@@ -10,17 +10,17 @@
 
 #include <cmath>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
@@ -29,7 +29,7 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.cc
@@ -24,12 +24,12 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
-#include<cstring>
-#include<iostream>
-#include<fstream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimAverageNoiseEffCls.h
@@ -15,8 +15,8 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include<cstdlib>
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
 class RPCGeometry;

--- a/SimMuon/RPCDigitizer/src/RPCSimModelTiming.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimModelTiming.cc
@@ -10,17 +10,17 @@
 
 #include <cmath>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
@@ -29,7 +29,7 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimModelTiming.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimModelTiming.cc
@@ -24,12 +24,12 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 
-#include<cstring>
-#include<iostream>
-#include<fstream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimModelTiming.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimModelTiming.h
@@ -17,8 +17,8 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include<cstdlib>
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/SimMuon/RPCDigitizer/src/RPCSimParam.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimParam.h
@@ -8,7 +8,7 @@
  *  \author Marcello Maggi -- INFN Bari
  */
 #include "SimMuon/RPCDigitizer/src/RPCSim.h"
-#include <FWCore/Framework/interface/EventSetup.h>
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "SimMuon/RPCDigitizer/src/RPCSynchronizer.h"
 
 class RPCGeometry;

--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
@@ -25,10 +25,10 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
-#include<cstring>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
@@ -28,7 +28,7 @@
 #include<cstring>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.h
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.h
@@ -18,7 +18,7 @@
 #include <iostream>
 #include<cstring>
 #include<string>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 
 class RPCDigitizer;

--- a/SimMuon/RPCDigitizer/src/RPCSimSimple.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSimple.cc
@@ -9,11 +9,11 @@
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandPoissonQ.h"
 
-#include<cstring>
-#include<iostream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSimSimple.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSimple.cc
@@ -13,7 +13,7 @@
 #include<iostream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <utility>
 #include <map>
 

--- a/SimMuon/RPCDigitizer/src/RPCSynchronizer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSynchronizer.cc
@@ -21,12 +21,12 @@
 
 #include "CLHEP/Random/RandGaussQ.h"
 
-#include<cstring>
-#include<iostream>
-#include<fstream>
-#include<string>
-#include<vector>
-#include<cstdlib>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstdlib>
 #include <cmath>
 
 using namespace std;

--- a/SimMuon/RPCDigitizer/src/RPCSynchronizer.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSynchronizer.cc
@@ -4,17 +4,17 @@
 #include "Geometry/CommonTopologies/interface/RectangularStripTopology.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "SimMuon/RPCDigitizer/src/RPCSimSetUp.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -26,7 +26,7 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 #include <cmath>
 
 using namespace std;

--- a/SimMuon/RPCDigitizer/src/RPCSynchronizer.h
+++ b/SimMuon/RPCDigitizer/src/RPCSynchronizer.h
@@ -13,11 +13,11 @@
 #include<fstream>
 #include<string>
 #include<vector>
-#include<stdlib.h>
+#include<cstdlib>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include <set>

--- a/SimMuon/RPCDigitizer/test/BuildFile.xml
+++ b/SimMuon/RPCDigitizer/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="boost"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/RPCDigi"/>
 <use   name="FWCore/Framework"/>

--- a/SimMuon/RPCDigitizer/test/RPCDigiReader.cc
+++ b/SimMuon/RPCDigitizer/test/RPCDigiReader.cc
@@ -7,16 +7,16 @@
  *  \authors: M. Maggi -- INFN Bari
  */
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h"
@@ -114,6 +114,6 @@ private:
   std::string label;
 };
 #endif    
-#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(RPCDigiReader);
 

--- a/SimMuon/RPCDigitizer/test/RPCEventDump.cc
+++ b/SimMuon/RPCDigitizer/test/RPCEventDump.cc
@@ -4,7 +4,7 @@
 
 
 
-#include <DataFormats/RPCDigi/interface/RPCDigiCollection.h>
+#include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/SimMuon/RPCDigitizer/test/RPCEventDump.h
+++ b/SimMuon/RPCDigitizer/test/RPCEventDump.h
@@ -6,8 +6,8 @@
  *
  *  \author Marcello Maggi -- INFN Bari
  */
-#include <FWCore/Framework/interface/MakerMacros.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 
 class RPCEventDump : public edm::EDProducer {

--- a/SimMuon/RPCDigitizer/test/RPCFakeEvent.h
+++ b/SimMuon/RPCDigitizer/test/RPCFakeEvent.h
@@ -6,8 +6,8 @@
  *
  *  \author Marcello Maggi -- INFN Bari
  */
-#include <FWCore/Framework/interface/MakerMacros.h>
-#include <FWCore/Framework/interface/EDProducer.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDProducer.h"
 
 
 class RPCFakeEvent : public edm::EDProducer {


### PR DESCRIPTION
The ME0 optohybrid concentrator card (on-detector electronics) compresses trigger bits in the same way as for GEM. It will combine at most 8 adjacent ME0 pads into a cluster (ME0PadDigiCluster). Clusters will be sent to a CTP7 (which actually handles 3 ME0 super chambers). The CTP7 declusterizes them into single pads to be used as inputs for the ME0 pattern finding. This will be done in the ME0Motherboard in simulation.

Unlike GEM, ME0PadDigiCluster will not be sent to the track-finder directly nor to the nearby CSC optical trigger motherboard. ME0TriggerDigis will only be sent to the track-finder. 

I also added the field "partition" to the ME0TriggerDigi dataformat. From the single pads in each layer it will be possible to the partition in the 3rd layer (which is likely going to be reference layer).

More information on the ME0 trigger system can be found here: https://indico.cern.ch/event/640240/contributions/2605361/attachments/1476748/2288198/MuonEndcap_SvenDildick_HLLHC_Trigger_Upgrade_20170614.pdf, slides 12-19

@calabria FYI