### PR TITLE
Handle case where a pointer is used in a template argument for friend…

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -24,6 +24,7 @@ namespace edm {
     static boost::regex const reComma(",");
     static boost::regex const reTemplateArgs("[^<]*<(.*)>$");
     static boost::regex const reTemplateClass("([^<>,]+<[^<>]*>)");
+    static boost::regex const rePointer("\\*");
     static std::string const emptyString("");
 
     std::string handleNamespaces(std::string const& iIn) {
@@ -78,6 +79,7 @@ namespace edm {
        using boost::regex_replace;
        using boost::regex;
        std::string name = regex_replace(iIn, reWrapper, "$1");
+       name = regex_replace(name,rePointer,"ptr");
        name = regex_replace(name,reAIKR,"");
        name = regex_replace(name,reclangabi,"std::");
        name = regex_replace(name,reCXX11,"std::");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -92,7 +92,9 @@ void testfriendlyName::test()
                                  "recoCandidateedmRefToBaseProdTodoublesAssociationVector"));
   classToFriendly.insert( Values("edm::RefVector<edm::AssociationMap<edm::OneToOne<std::vector<reco::BasicCluster>,std::vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> >,edm::Ref<std::vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<std::vector<reco::BasicCluster>,std::vector<reco::ClusterShape>,unsigned int> >::Find>",
                                  "recoBasicClustersToOnerecoClusterShapesAssociationRefs"));
-                                 
+  classToFriendly.insert( Values("std::vector<std::pair<const pat::Muon *, TLorentzVector>>","constpatMuonptrTLorentzVectorstdpairs") );
+  
+  
   for(std::map<std::string, std::string>::iterator itInfo = classToFriendly.begin(),
       itInfoEnd = classToFriendly.end();
       itInfo != itInfoEnd;


### PR DESCRIPTION
…lyClassName

Passing a class name containing '*' to the friendly class name algorithm caused an infinite loop. Now the '*' is replaced with 'ptr' very early in the algorithm.