### PR TITLE
DropBox Metadata: document adding HP beamspot by run

### DIFF
--- a/CondFormats/Common/test/BeamSpotObjectsRcdHPbyRun_prep.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdHPbyRun_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS",
+    "destinationTags": {
+        "BeamSpotObjectsHP_PCL_byRun_v0_prompt": {}
+    },
+    "inputTag": "BeamSpotObjectHP_ByRun",
+    "since": null,
+    "userText": "Tier0 PCL Upload for high performance BS byRun"
+}

--- a/CondFormats/Common/test/BeamSpotObjectsRcdHPbyRun_prod.json
+++ b/CondFormats/Common/test/BeamSpotObjectsRcdHPbyRun_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS",
+    "destinationTags": {
+        "BeamSpotObjectsHP_PCL_byRun_v0_prompt": {}
+    },
+    "inputTag": "BeamSpotObjectHP_ByRun",
+    "since": null,
+    "userText": "Tier0 PCL Upload for high performance BS byRun"
+}

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -37,6 +37,10 @@ BeamSpotObjectsRcdByLumi_prep_str = encodeJsonInString("BeamSpotObjectsRcdByLumi
 BeamSpotObjectsRcdHPByLumi_prod_str = encodeJsonInString("BeamSpotObjectsRcdHPbyLumi_prod.json")
 BeamSpotObjectsRcdHPByLumi_prep_str = encodeJsonInString("BeamSpotObjectsRcdHPbyLumi_prep.json")
 
+# beamspot High Perf by run
+BeamSpotObjectsRcdHPByRun_prod_str = encodeJsonInString("BeamSpotObjectsRcdHPbyRun_prod.json")
+BeamSpotObjectsRcdHPByRun_prep_str = encodeJsonInString("BeamSpotObjectsRcdHPbyRun_prep.json")
+
 #SiStripBadStripRcd
 SiStripBadStripRcd_prod_str = encodeJsonInString("SiStripBadStripRcd_prod.json")
 SiStripBadStripRcd_prep_str = encodeJsonInString("SiStripBadStripRcd_prep.json")
@@ -63,7 +67,7 @@ EcalPedestalsRcd_prep_str = encodeJsonInString("EcalPedestal_prep.json")
 # given a set of .json files in the current dir, ProduceDropBoxMetadata produces a sqlite containign the payload with the prod/and/prep metadata
 process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                   # set to True if you want to write out a sqlite.db translating the json's into a payload
-                                  write = cms.untracked.bool(False),
+                                  write = cms.untracked.bool(True),
 
                                   # toWrite holds a list of Pset's, one for each workflow you want to produce DropBoxMetadata for; you need to have 2 .json files for each PSet
                                   toWrite = cms.VPSet(cms.PSet(record              = cms.untracked.string("BeamSpotObjectsRcdByRun"), 
@@ -83,6 +87,12 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                FileClass           = cms.untracked.string("ALCA"),
                                                                prodMetaData        = cms.untracked.string(BeamSpotObjectsRcdHPByLumi_prod_str),
                                                                prepMetaData        = cms.untracked.string(BeamSpotObjectsRcdHPByLumi_prep_str),
+                                                               ),
+                                                      cms.PSet(record              = cms.untracked.string('BeamSpotObjectsRcdHPByRun'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(BeamSpotObjectsRcdHPByRun_prod_str),
+                                                               prepMetaData        = cms.untracked.string(BeamSpotObjectsRcdHPByRun_prep_str),
                                                                ),
                                                       cms.PSet(record              = cms.untracked.string('SiStripBadStripRcd'),
                                                                Source              = cms.untracked.string("AlcaHarvesting"),
@@ -124,10 +134,11 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                ),
                                                       ),
                                   # this boolean will read the content of whichever payload is available and print its content to stoutput
-                                  read = cms.untracked.bool(True),
+                                  # set this to false if you write out a sqlite.db translating the json's into a payload
+                                  read = cms.untracked.bool(False),
 
                                   # toRead lists of record naemes to be sought inside the DropBoxMetadataRcd payload avaialble to the ProduceDropBoxMetadata; for instance, if write is True, you're reading back the metadata you've just entered in the payload from the .json files
-                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','SiStripApvGainRcdAAG','EcalPedestalsRcd') # same strings as fType
+                                  toRead = cms.untracked.vstring('BeamSpotObjectsRcdByRun','BeamSpotObjectsRcdByLumi','BeamSpotObjectsRcdHPByLumi','BeamSpotObjectsRcdHPByRun','SiStripBadStripRcd','SiStripApvGainRcd','TrackerAlignmentRcd','SiStripApvGainRcdAfterAbortGap','SiStripApvGainRcdAAG','EcalPedestalsRcd') # same strings as fType
                                   )
 
 process.p = cms.Path(process.mywriter)
@@ -135,7 +146,7 @@ process.p = cms.Path(process.mywriter)
 if process.mywriter.write:
 
     from CondCore.CondDB.CondDB_cfi import CondDB
-    CondDB.connect = "sqlite_file:DropBoxMetadata_addAAG.db"
+    CondDB.connect = "sqlite_file:DropBoxMetadata_addHPbyRun.db"
 
     process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                               CondDB,
@@ -150,18 +161,18 @@ if process.mywriter.write:
                                               )
     
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = '91X_dataRun2_Express_Queue'
+process.GlobalTag.globaltag = '92X_dataRun2_Express_Queue'
 
 #process.GlobalTag.connect   = 'frontier://PromptProd/CMS_CONDITIONS'
 #process.GlobalTag.connect   = 'sqlite_file:/data/franzoni/92x/CMSSW_9_2_X_2017-05-16-1100_metadata/src/CondFormats/Common/test/last-iov-DropBoxMetadata_v5.1_express.db'
 
 # Set to True if you want to read a DropBoxMetadata payload from a local sqlite
 # specify the name of the sqlitefile.db and the tag name; the payload loaded will be for run 300000
-readsqlite = True
+readsqlite = False
 if readsqlite:
     process.GlobalTag.toGet = cms.VPSet(
         cms.PSet(record = cms.string("DropBoxMetadataRcd"),
                  tag = cms.string("DropBoxMetadata"),
-                 connect = cms.string("sqlite_file:DropBoxMetadata_addAAG.db")
+                 connect = cms.string("sqlite_file:DropBoxMetadata_addHPbyRun.db")
                 )
         )


### PR DESCRIPTION
+ the prompt calibration loop will host soon a second workflow to measure the beam spot which will use a high rate (80 Hz) of JetHT -like events from a novel dedicate stream
+ this new workflow will, like the existing beamspot PCL workflow, produce measurements per run as well as results with IOV's that fragment the runs
+ in this PR we document the inclusion in DB of the DropBox Metadata that will steer the release to the conditions database of the beamspot results by run

These changes don't affect any of the standard sequences.