### PR TITLE
CTPPS: fix of event-bound adjustment (foward-port of #19261)

### DIFF
--- a/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CondFormats/CTPPSReadoutObjects/plugins/TotemDAQMappingESSourceXML.cc
@@ -236,9 +236,11 @@ void TotemDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetu
 
     edm::EventRange range = bl.validityRange;
 
-    // event id "1:min" has a special meaning and is translated to a truly minimal event id (1:0:0)
-    if (range.startEventID()==edm::EventID(1, 0, 1))
-      range = edm::EventRange(edm::EventID(1, 0, 0), range.endEventID());
+    // If "<run>:min" is specified in python config, it is translated into event <run>:0:1.
+    // However, the truly minimal event id often found in data is <run>:0:0. Therefore the
+    // adjustment below is needed.
+    if (range.startEventID().luminosityBlock() == 0 && range.startEventID().event() == 1)
+      range = edm::EventRange(edm::EventID(range.startEventID().run(), 0, 0), range.endEventID());
 
     if (edm::contains(range, iosv.eventID()))
     {


### PR DESCRIPTION
This is a forward-port of #19261 to address an issue reported during reprocessing of Run2016H:
  https://hypernews.cern.ch/HyperNews/CMS/get/prep-ops/3940/1/1/1/1/1/1/1.html

The functionality was verified with `RecoCTPPS/Configuration/test/raw_data_test.py` reading in `/store/data/Run2016H/MuonEG/RAW/v1/000/283/820/00000/CEC46E92-CF9A-E611-B8A9-FA163EBBFF25.root`.

