### PR TITLE
migrate ootPhoton to use GEDPhotonProducer

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/python/ootPhotons_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/ootPhotons_cff.py
@@ -1,5 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-from RecoEgamma.EgammaPhotonProducers.photons_cfi import *
+from RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi import gedPhotons as _gedPhotons
 
-ootPhotons = photons.clone()
-ootPhotons.photonCoreProducer = cms.InputTag('ootPhotonCore')
+ootPhotons = _gedPhotons.clone(
+    photonProducer = 'ootPhotonCore',
+    candidateP4type = "fromEcalEnergy",
+    reconstructionStep = "oot",
+    pfEgammaCandidates = "",
+    valueMapPhotons = ""
+    )
+del ootPhotons.regressionConfig

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -23,6 +23,9 @@ gedGsfElectronsTmp.maxHOverEEndcaps = cms.double(0.25)
 gedGsfElectronsTmp.maxEOverPBarrel = cms.double(2.)
 gedGsfElectronsTmp.maxEOverPEndcaps = cms.double(2.)
 
+ootPhotons.primaryVertexProducer = cms.InputTag("hiSelectedVertex")
+ootPhotons.isolationSumsCalculatorSet.trackProducer = cms.InputTag("hiGeneralTracks")
+
 from RecoParticleFlow.Configuration.RecoParticleFlow_cff import *
 
 particleFlowClusterECAL.energyCorrector.verticesLabel = cms.InputTag('hiPixelAdaptiveVertex')


### PR DESCRIPTION
Legacy PhotonProducer was not good enough for ootPhotons: important functionality (some of showerShapeVariables) was missing.
There was an attempt to update the legacy photon producer in  #19060, but it effectively lead to a copy of GEDPhotonProducer.
This PR makes needed changes to make GEDPhotonProducer work for non-GED setup (no PFEGammaCandidates on inputs)

I checked on wf 136.761 and see that only showerShapeVariables_ show up which were zero in the baseline. Kinematics of the ootPhotons and other variables did not change. The chosen workflow is not the best though (only 4 OOT photons in 200 events). 
From visual inspection (confirmed by @kmcdermo ) this PR should produce correct outputs.
