### PR TITLE
update das-selected-lumis script to match the new das server format

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
+++ b/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
@@ -29,8 +29,12 @@ def check_lumi_ranges(given_lumi_list , sub_range):
 
 def process_lumi(data):
   for lumi_info in data:
-    lumi_nums = lumi_info['lumi'][0]['number']
-    lumi_file = lumi_info['file'][0]['name']
+    if type(lumi_info['lumi']) is list:
+      lumi_nums = lumi_info['lumi'][0]['number']
+      lumi_file = lumi_info['file'][0]['name']
+    else:
+      lumi_nums = lumi_info['lumi']['number']
+      lumi_file = lumi_info['file']['name']
     if not type(lumi_nums[0]) is list: lumi_rang = [ [n,n] for n in lumi_nums ]
     else: lumi_rang = lumi_nums
     for sub_list in lumi_rang:


### PR DESCRIPTION
Looks like DAS server now returns 
"data": [{"lumi":{"number":[]}}]
instead of 
"data": [{"lumi":[{"number":[]}]}]
adopt the das-selected-lumis.py script to handle both cases