### PR TITLE
Add include for AlgebraicObjects.h to HIPUserVariables.h

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/interface/HIPUserVariables.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/HIPUserVariables.h
@@ -1,5 +1,6 @@
 
 #include "Alignment/CommonAlignment/interface/AlignmentUserVariables.h"
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
 
 class HIPUserVariables : public AlignmentUserVariables {
 


### PR DESCRIPTION
We use AlgebraicSymMatrix in this header, so we also need to
include the header that provides this class to make this file
compile on it's own.