### PR TITLE
initialise variables in FastMonitoringService

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -245,8 +245,8 @@ namespace evf{
       Encoding encModule_;
       std::vector<Encoding> encPath_;
       FedRawDataInputSource * inputSource_ = nullptr;
-      std::atomic<FastMonitoringThread::InputState> inputState_;
-      std::atomic<FastMonitoringThread::InputState> inputSupervisorState_;
+      std::atomic<FastMonitoringThread::InputState> inputState_           { FastMonitoringThread::InputState::inInit };
+      std::atomic<FastMonitoringThread::InputState> inputSupervisorState_ { FastMonitoringThread::InputState::inInit };
 
       unsigned int nStreams_;
       unsigned int nThreads_;


### PR DESCRIPTION
Running offline a configuration with the `FastMonitoringService` I get a segmentation fault near th beginning of the job.

Initialising these variables cures the issue,  and let the job run successfully.