### PR TITLE
Add missing include for DOMNode.hpp to MiscalibReaderFromXMLDomUtils.h

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/dom/DOMNamedNodeMap.hpp>
+#include <xercesc/dom/DOMNode.hpp>
 
 /** a collection of some XML reading utilities */
 class MiscalibReaderFromXMLDomUtils


### PR DESCRIPTION
The MiscalibReaderFromXMLDomUtils.icc file we include in this file
tries to access the getNodeValue() method of a DOMNode, so we also
need to include the related header to make this header compile
on it's own.