### PR TITLE
Foward declare TH1F in APVGainStruct.h

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
@@ -1,6 +1,8 @@
 #ifndef CALIBTRACKER_SISTRIPCHANNELGAIN_STAPVGAIN_H
 #define CALIBTRACKER_SISTRIPCHANNELGAIN_STAPVGAIN_H
 
+class TH1F;
+
 struct stAPVGain{
   unsigned int Index; 
   int          Bin;


### PR DESCRIPTION
We have a pointer to TH1F in this header, but we don't have any
includes. This causes this files not to compile as a C++ module.
This patch just adds the missing forward declaration to TH1F to
fix this.