### PR TITLE
Support of externally-produced image plot in conddb payload inspector

### DIFF
--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -10,6 +10,9 @@
 #include <vector>
 #include <boost/python/list.hpp>
 #include <boost/python/extract.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 namespace cond {
 
@@ -109,6 +112,16 @@ namespace cond {
         first = false;
       }
       ss << "]";
+      ss << "}";
+      return ss.str();
+    }
+
+    std::string serialize( const PlotAnnotations& annotations, const std::string& imageFileName ){
+      std::stringstream ss;
+      ss << "{";
+      ss << serializeAnnotations( annotations );
+      ss <<",";
+      ss << "\"file\": \""<<imageFileName<<"\"";
       ss << "}";
       return ss.str();
     }
@@ -525,6 +538,36 @@ namespace cond {
       size_t m_nybins; 
       float m_ymin;
       float m_ymax;
+    };
+
+    // 
+    template <typename PayloadType> class PlotImage : public PlotBase {
+    public:
+      explicit PlotImage( const std::string& title ) : 
+	PlotBase(){
+	m_plotAnnotations.m[PlotAnnotations::PLOT_TYPE_K] = "Image";
+        m_plotAnnotations.m[PlotAnnotations::TITLE_K] = title;
+	std::string payloadTypeName = cond::demangledName( typeid(PayloadType) );
+        m_plotAnnotations.m[PlotAnnotations::PAYLOAD_TYPE_K] = payloadTypeName;
+	m_imageFileName = boost::lexical_cast<std::string>( ( boost::uuids::random_generator())() )+".png";
+      }
+
+      std::string serializeData(){
+	return serialize( m_plotAnnotations, m_imageFileName);
+      }
+
+      std::string processData( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override {
+	fill( iovs );
+	return serializeData();
+      }
+
+      std::shared_ptr<PayloadType> fetchPayload( const cond::Hash& payloadHash ){
+      	return PlotBase::fetchPayload<PayloadType>( payloadHash );
+      }
+
+      virtual bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) = 0;
+    protected:
+      std::string m_imageFileName;
     };
 
   }

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -6,6 +6,11 @@
 #include <memory>
 #include <sstream>
 
+#include "TH2D.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TLatex.h"
+
 namespace {
 
   class BasicPayload_data0 : public cond::payloadInspector::HistoryPlot<cond::BasicPayload,float> {
@@ -91,6 +96,88 @@ namespace {
     }
   };
 
+  class BasicPayload_data6 : public cond::payloadInspector::PlotImage<cond::BasicPayload> {
+  public:
+    BasicPayload_data6() : cond::payloadInspector::PlotImage<cond::BasicPayload>( "Example delivery picture" ){
+      setSingleIov( true );
+    }
+
+    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ){
+      auto iov = iovs.front();
+      std::shared_ptr<cond::BasicPayload> payload = fetchPayload( std::get<1>(iov) );
+  
+      double xmax(100.),ymax(100.);
+
+      TH2D *h2D = new TH2D("h2D","Example",100,0.,xmax,100,0.,ymax);
+
+      if( payload.get() ){
+	std::cout <<" size="<<payload->m_vec.size()<<std::endl;
+	if(payload->m_vec.size()==10000){
+          for( size_t i=0;i<100;i++ )
+	    for( size_t j=0;j<100;j++ ) {
+	      std::cout <<"X="<<i<<" Y="<<j<<" z="<<payload->m_vec[i*100+j]<<std::endl;
+              h2D->Fill(i,j,payload->m_vec[i*100+j]);
+	    }
+          h2D->SetStats(0);
+	}
+      }
+         
+      TCanvas *c = new TCanvas("c","",10,10,900,500);
+      c->cd();
+      c->SetLogz();
+      h2D->SetNdivisions(18, "X");
+      h2D->GetXaxis()->SetTickLength(0.00);
+      h2D->GetYaxis()->SetTickLength(0.00);
+      h2D->GetXaxis()->SetTitle("iphi");
+      h2D->GetYaxis()->SetTitle("ieta");
+      h2D->Draw("col");
+
+      //======= drawing lines ========
+      ///// this is quite specific to the line style they need
+
+      TLine l;
+      l.SetLineStyle(2);
+      l.DrawLine(0., ymax/2., xmax, ymax/2.);
+      for(int m = 0; m < int(xmax); m+=10) {
+	l.DrawLine(m, 0., m, 100.);
+      }
+
+      c->RedrawAxis();
+
+      //========== writing text in the canvas==============
+      //// This is again quite specific part. I just tried to emulate what is there in DQM for EB. 
+
+      TLatex Tl;
+      TLatex Tll;
+      Tl.SetTextAlign(23);
+      Tl.SetTextSize(0.04);
+
+      Tll.SetTextAlign(23);
+      Tll.SetTextSize(0.04);
+
+      int j = 0;
+      for(int i = 1; i <=10; i++){
+	std::string s = "+" + std::to_string(i);
+	char const *pchar = s.c_str();
+	j+=10;
+	Tl.DrawLatex(j-5,int(ymax)/1.33,pchar);
+      }
+
+      int z = 0;
+      for(int g = -10; g <0; g++){
+	std::string ss = std::to_string(g);
+	char const *pchar1 = ss.c_str();
+	z+= 10;
+	Tll.DrawLatex(z-5,int(ymax)/4,pchar1);
+      }
+      //=========================
+      
+      std::string fileName(m_imageFileName);
+      c->SaveAs(fileName.c_str());
+
+      return true;
+    }
+  };
 
 }
 
@@ -101,4 +188,5 @@ PAYLOAD_INSPECTOR_MODULE( BasicPayload ){
   PAYLOAD_INSPECTOR_CLASS( BasicPayload_data3 );
   PAYLOAD_INSPECTOR_CLASS( BasicPayload_data4 );
   PAYLOAD_INSPECTOR_CLASS( BasicPayload_data5 );
+  PAYLOAD_INSPECTOR_CLASS( BasicPayload_data6 );
 }

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -108,29 +108,27 @@ namespace {
   
       double xmax(100.),ymax(100.);
 
-      TH2D *h2D = new TH2D("h2D","Example",100,0.,xmax,100,0.,ymax);
+      TH2D h2D("h2D","Example",100,0.,xmax,100,0.,ymax);
 
       if( payload.get() ){
-	std::cout <<" size="<<payload->m_vec.size()<<std::endl;
 	if(payload->m_vec.size()==10000){
           for( size_t i=0;i<100;i++ )
 	    for( size_t j=0;j<100;j++ ) {
-	      std::cout <<"X="<<i<<" Y="<<j<<" z="<<payload->m_vec[i*100+j]<<std::endl;
-              h2D->Fill(i,j,payload->m_vec[i*100+j]);
+              h2D.Fill(i,j,payload->m_vec[i*100+j]);
 	    }
-          h2D->SetStats(0);
+          h2D.SetStats(0);
 	}
       }
          
-      TCanvas *c = new TCanvas("c","",10,10,900,500);
-      c->cd();
-      c->SetLogz();
-      h2D->SetNdivisions(18, "X");
-      h2D->GetXaxis()->SetTickLength(0.00);
-      h2D->GetYaxis()->SetTickLength(0.00);
-      h2D->GetXaxis()->SetTitle("iphi");
-      h2D->GetYaxis()->SetTitle("ieta");
-      h2D->Draw("col");
+      TCanvas c("c","",10,10,900,500);
+      c.cd();
+      c.SetLogz();
+      h2D.SetNdivisions(18, "X");
+      h2D.GetXaxis()->SetTickLength(0.00);
+      h2D.GetYaxis()->SetTickLength(0.00);
+      h2D.GetXaxis()->SetTitle("iphi");
+      h2D.GetYaxis()->SetTitle("ieta");
+      h2D.Draw("col");
 
       //======= drawing lines ========
       ///// this is quite specific to the line style they need
@@ -142,7 +140,7 @@ namespace {
 	l.DrawLine(m, 0., m, 100.);
       }
 
-      c->RedrawAxis();
+      c.RedrawAxis();
 
       //========== writing text in the canvas==============
       //// This is again quite specific part. I just tried to emulate what is there in DQM for EB. 
@@ -173,7 +171,7 @@ namespace {
       //=========================
       
       std::string fileName(m_imageFileName);
-      c->SaveAs(fileName.c_str());
+      c.SaveAs(fileName.c_str());
 
       return true;
     }

--- a/CondCore/Utilities/plugins/BuildFile.xml
+++ b/CondCore/Utilities/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
   <use   name="CondCore/CondDB"/>
   <use   name="CondFormats/Common"/>
   <use   name="boost_python"/>
+  <use   name="root"/>
 </library>
 <library   file="Module_PayloadInspector.cc" name="Module_PayloadInspector">
   <use   name="CondCore/Utilities"/>

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -7,3 +7,5 @@
 </bin>
 <bin   file="testHistograms.cpp" name="testHistograms">
 </bin>
+<bin   file="testPngHistograms.cpp" name="testPngHistograms">
+</bin>

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -8,4 +8,5 @@
 <bin   file="testHistograms.cpp" name="testHistograms">
 </bin>
 <bin   file="testPngHistograms.cpp" name="testPngHistograms">
+  <flags NO_TESTRUN="1"/>
 </bin>

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -8,5 +8,4 @@
 <bin   file="testHistograms.cpp" name="testHistograms">
 </bin>
 <bin   file="testPngHistograms.cpp" name="testPngHistograms">
-  <flags NO_TESTRUN="1"/>
 </bin>

--- a/CondCore/Utilities/test/testBasicPayload.cpp
+++ b/CondCore/Utilities/test/testBasicPayload.cpp
@@ -11,10 +11,11 @@
 #include <iomanip>
 #include <cstdlib>
 #include <iostream>
+#include <random>
 
 using namespace cond::persistency;
 
-int run( const std::string& connectionString ){
+int run( const std::string& connectionString, bool generate ){
   try{
 
     //*************
@@ -27,16 +28,28 @@ int run( const std::string& connectionString ){
     if( !session.existsDatabase() || !session.existsIov( "BasicPayload_v0" ) ){
       editor = session.createIov<cond::BasicPayload>( "BasicPayload_v0", cond::runnumber ); 
       editor.setDescription("Test for timestamp selection");
-    }
+    } 
     for( int i=0;i<10;i++ ){
-      cond::BasicPayload  p( i*10.1, i+1.,100 );
-      for( size_t j=0;j<100;j++ ) p.m_vec[j]= 1;
-      for( size_t j=3;j<7;j++ )
-	for( size_t i=3;i<7;i++) p.m_vec[j*10+i]= 0;
+      cond::BasicPayload  p;
+      if ( !generate ){
+	cond::BasicPayload  p0( i*10.1, i+1.,100 );
+	for( size_t j=0;j<100;j++ ) p0.m_vec[j]= 1;
+	for( size_t j=3;j<7;j++ )
+	  for( size_t i=3;i<7;i++) p0.m_vec[j*10+i]= 0;
+        p = p0;
+      } else {
+	cond::BasicPayload  p1( i*10.1, i+1.,10000 );
+	std::random_device rd;
+	std::mt19937 mt(rd());
+	std::uniform_real_distribution<float> dist(0.,1.);
+	for (int i=0; i<10000; ++i) p1.m_vec[i] =  dist(mt);
+        p = p1;
+      }
       auto pid = session.storePayload( p );
       editor.insert( i*100+1, pid );
       p.print();
     }
+    std::cout <<"flushing..."<<std::endl;
     editor.flush();
     std::cout <<"> iov changes flushed..."<<std::endl;
     session.transaction().commit();
@@ -53,11 +66,18 @@ int run( const std::string& connectionString ){
 
 int main (int argc, char** argv)
 {
+
+  bool generate = false;
+  if (argc > 1) {
+    std::string option = std::string(argv[1]);
+    generate = (option.compare("generate")==0);
+  }
+
   int ret = 0;
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   std::string connectionString0("sqlite_file:BasicPayload_v0.db");
-  ret = run( connectionString0 );
+  ret = run( connectionString0, generate );
   return ret;
 }
 

--- a/CondCore/Utilities/test/testPngHistograms.cpp
+++ b/CondCore/Utilities/test/testPngHistograms.cpp
@@ -1,0 +1,40 @@
+#include<iostream>
+#include<sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "../plugins/BasicP_PayloadInspector.cc"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  
+  if (argc < 3) {
+    std::cout << "Not enough arguments given." << std::endl;
+    return 1;
+  }
+
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type",std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("oracle://cms_orcon_adg/CMS_CONDITIONS");
+
+  std::string tag = std::string(argv[1]);
+  std::string runTimeType = cond::time::timeTypeName(cond::runnumber);
+  cond::Time_t since = boost::lexical_cast<unsigned long long>(argv[2]);
+
+  std::cout <<"## PNG Histo"<<std::endl;
+  
+  BasicPayload_data6 histo1;
+  histo1.process( connectionString, tag, runTimeType, since, since );
+  std::cout <<histo1.data()<<std::endl;
+
+}

--- a/CondCore/Utilities/test/testPngHistograms.cpp
+++ b/CondCore/Utilities/test/testPngHistograms.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
   
   if (argc < 3) {
     std::cout << "Not enough arguments given." << std::endl;
-    return 1;
+    return 0;
   }
 
   edmplugin::PluginManager::Config config;


### PR DESCRIPTION
This PR is adding a new functionality to the Conddb Payload Inspector:

- A new type of plot base class: "PlotImage" allows to create plot of type "Image" that can be produced with technologies external to the PI framework.
An example of implementation is provided in the BasicPayload plugin.