### PR TITLE
Add missing include to HITRegionalPixelSeedGenerator.h

### DIFF
--- a/Calibration/HcalIsolatedTrackReco/src/HITRegionalPixelSeedGenerator.h
+++ b/Calibration/HcalIsolatedTrackReco/src/HITRegionalPixelSeedGenerator.h
@@ -22,6 +22,7 @@
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidateFwd.h"
 
 // Math
 #include "Math/GenVector/VectorUtil.h"


### PR DESCRIPTION
This header uses IsolatedPixelTrackCandidateCollection, so we also
need to include the related header to make this file compile on
it's own.