### PR TITLE
Add missing includes PdgIdPFCandidateSelectorDefinition.h

### DIFF
--- a/CommonTools/ParticleFlow/interface/PdgIdPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/PdgIdPFCandidateSelectorDefinition.h
@@ -1,7 +1,10 @@
 #ifndef CommonTools_ParticleFlow_PdgIdPFCandidateSelectorDefinition
 #define CommonTools_ParticleFlow_PdgIdPFCandidateSelectorDefinition
 
+#include "FWCore/Common/interface/EventBase.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "CommonTools/ParticleFlow/interface/PFCandidateSelectorDefinition.h"


### PR DESCRIPTION
We use EventBase, EventSetup and ParameterSet in this file, so we
also need to include the related headers to make it compile on its
own.