### PR TITLE
Make CandidatePtr qualified in TopProjectorAlgo.h

### DIFF
--- a/CommonTools/ParticleFlow/interface/TopProjectorAlgo.h
+++ b/CommonTools/ParticleFlow/interface/TopProjectorAlgo.h
@@ -258,7 +258,7 @@ TopProjectorAlgo<Top,Bottom>::ptrToAncestor( reco::CandidatePtr candPtr,
 
   for(unsigned i=0; i<nSources; i++) {
     
-    CandidatePtr mother = candPtr->sourceCandidatePtr(i);
+    reco::CandidatePtr mother = candPtr->sourceCandidatePtr(i);
 /*     if( verbose_ ) { */
 /*       const Provenance& motherProv = iEvent.getProvenance(mother.id()); */
 /*       cout<<"  mother id "<<mother.id()<<endl */


### PR DESCRIPTION
We are not in the reco namespace and don't have a using in this
header, so we need to specify what CandidatePtr we want to use here
to make this file compile on its own.

This is also now more consistent with how the rest of the file
refers to reco::CandidatePtr.