### PR TITLE
Add track selection MVA and all the input variables to TrackingNtuple

### DIFF
--- a/Validation/RecoTrack/README.md
+++ b/Validation/RecoTrack/README.md
@@ -18,7 +18,13 @@ There is also an ntuple-version of MultiTrackValidator, called
 `cmsDriver.py`-generated workflow containing `VALIDATION` sequence by
 including
 `--customise Validation/RecoTrack/customiseTrackingNtuple.customiseTrackingNtuple`
-argument to the `cmsDriver.py`. The customise function disables all
+argument to the `cmsDriver.py`, or adding the following near the end
+of an existing job configuration file
+```
+from Validation.RecoTrack.customiseTrackingNtuple import customiseTrackingNtuple
+process = customiseTrackingNtuple(process)
+```
+The customise function disables all
 output modules and replaces the validation sequence with a sequence
 producing the ntuple in `trackingNtuple.root` file. If ran without
 RECO, it needs both RECO and DIGI files as an input.
@@ -64,6 +70,30 @@ more information see
 If the "playback mode" is not enabled, an exception will be thrown in
 the C++ code for a missing SimHit.
 
+### Using tracks from a single iteration as an input
+
+The ntuple can be used to study the tracks produced by a single
+iteration (without going throught generalTracks) as well. Below is an
+example (for highPtTripletStep) what modifications need to be done in
+the job configuration file (after the `customiseTrackingNtuple()` call)
+```
+process.trackingNtuple.tracks = "highPtTripletStepTracks"
+
+# following are needed only if _includeSeeds is True
+process.trackingNtuple.seedTracks = ["seedTrackshighPtTripletStepSeeds"]
+process.trackingNtuple.trackCandidates = ["highPtTripletStepTrackCandidates"]
+
+# following is needed only if _includeMVA is True
+# it also shows how to add MVA output of multiple classifiers
+process.trackingNtuple.trackMVAs = ["highPtTripletStepClassifier1",
+                                    "highPtTripletStepClassifier2"]
+
+# Especially for iteration-specific MVA studies, it is important to
+# use firstStepPrimaryVertices instead of offlinePrimaryVertices as
+# that is the collection used in the MVA input variable calculations
+process.trackingNtuple.vertices = "firstStepPrimaryVertices"
+```
+
 ### Applications
 
 Use `--help` to check out the parameters.
@@ -76,6 +106,7 @@ Use `--help` to check out the parameters.
 * [`trackingNtupleExample.py`](test/trackingNtupleExample.py) examples of various links
 * [`analyseDuplicateFake.py`](test/analyseDuplicateFake.py) examples of printouts
 * [`fakeAnalysis/main.py`](test/fakeAnalysis/main.py) complete analysis code for fake tracks
+
 
 ### Caveats
 

--- a/Validation/RecoTrack/README.md
+++ b/Validation/RecoTrack/README.md
@@ -105,6 +105,7 @@ Use `--help` to check out the parameters.
 
 * [`trackingNtupleExample.py`](test/trackingNtupleExample.py) examples of various links
 * [`analyseDuplicateFake.py`](test/analyseDuplicateFake.py) examples of printouts
+* [`analyseMVA.py`](test/analyseMVA.py) simple analysis for debugging track MVA selection
 * [`fakeAnalysis/main.py`](test/fakeAnalysis/main.py) complete analysis code for fake tracks
 
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -307,6 +307,9 @@ private:
     Unknown = 99
   };
 
+  using MVACollection = std::vector<float>;
+  using QualityMaskCollection = std::vector<unsigned char>;
+
   struct TPHitIndex {
     TPHitIndex(unsigned int tp=0, unsigned int simHit=0, float to=0, unsigned int id=0): tpKey(tp), simHitIdx(simHit), tof(to), detId(id) {}
     unsigned int tpKey;
@@ -385,7 +388,9 @@ private:
                   const TransientTrackingRecHitBuilder& theTTRHBuilder,
                   const TrackerTopology& tTopo,
                   const std::set<edm::ProductID>& hitProductIds,
-                  const std::map<edm::ProductID, size_t>& seedToCollIndex
+                  const std::map<edm::ProductID, size_t>& seedToCollIndex,
+                  const MVACollection *mvaColl,
+                  const QualityMaskCollection *qualColl
                   );
 
   void fillSimHits(const TrackerGeometry& tracker,
@@ -443,6 +448,8 @@ private:
   std::vector<edm::EDGetTokenT<edm::View<reco::Track> > > seedTokens_;
   std::vector<edm::EDGetTokenT<std::vector<short> > > seedStopReasonTokens_;
   edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
+  edm::EDGetTokenT<MVACollection> trackMVAToken_;
+  edm::EDGetTokenT<QualityMaskCollection> trackQualMaskToken_;
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticleToken_;
   edm::EDGetTokenT<TrackingParticleRefVector> trackingParticleRefToken_;
   edm::EDGetTokenT<ClusterTPAssociation> clusterTPMapToken_;
@@ -467,6 +474,7 @@ private:
   std::string parametersDefinerName_;
   const bool includeSeeds_;
   const bool includeAllHits_;
+  const bool includeMVA_;
 
   HistoryBase tracer_;
 
@@ -507,6 +515,8 @@ private:
   std::vector<float> trk_refpoint_y;
   std::vector<float> trk_refpoint_z;
   std::vector<float> trk_nChi2    ;
+  std::vector<float> trk_mva;
+  std::vector<unsigned short> trk_qualityMask;
   std::vector<int> trk_q       ;
   std::vector<unsigned int> trk_nValid  ;
   std::vector<unsigned int> trk_nInvalid;
@@ -784,7 +794,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   builderName_(iConfig.getUntrackedParameter<std::string>("TTRHBuilder")),
   parametersDefinerName_(iConfig.getUntrackedParameter<std::string>("parametersDefiner")),
   includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
-  includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits"))
+  includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
+  includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA"))
 {
   if(includeSeeds_) {
     seedTokens_ = edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag> >("seedTracks"), [&](const edm::InputTag& tag) {
@@ -808,6 +819,12 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   }
 
   tracer_.depth(-2); // as in SimTracker/TrackHistory/src/TrackClassifier.cc
+
+  if(includeMVA_) {
+    auto mvaTag = iConfig.getUntrackedParameter<std::string>("trackMVAs");
+    trackMVAToken_ = consumes<MVACollection>(edm::InputTag(mvaTag, "MVAValues"));
+    trackQualMaskToken_ = consumes<QualityMaskCollection>(edm::InputTag(mvaTag, "QualityMasks"));
+  }
 
   usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
@@ -846,6 +863,10 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   t->Branch("trk_refpoint_y", &trk_refpoint_y);
   t->Branch("trk_refpoint_z", &trk_refpoint_z);
   t->Branch("trk_nChi2"    , &trk_nChi2);
+  if(includeMVA_) {
+    t->Branch("trk_mva"    , &trk_mva);
+    t->Branch("trk_qualityMask", &trk_qualityMask);
+  }
   t->Branch("trk_q"        , &trk_q);
   t->Branch("trk_nValid"   , &trk_nValid  );
   t->Branch("trk_nInvalid" , &trk_nInvalid);
@@ -1148,6 +1169,8 @@ void TrackingNtuple::clearVariables() {
   trk_refpoint_y.clear();
   trk_refpoint_z.clear();
   trk_nChi2    .clear();
+  trk_mva      .clear();
+  trk_qualityMask.clear();
   trk_q        .clear();
   trk_nValid   .clear();
   trk_nInvalid .clear();
@@ -1530,7 +1553,23 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   for(edm::View<Track>::size_type i=0; i<tracks.size(); ++i) {
     trackRefs.push_back(tracks.refAt(i));
   }
-  fillTracks(trackRefs, tpCollection, tpKeyToIndex, bs, associatorByHits, *theTTRHBuilder, tTopo, hitProductIds, seedCollToOffset);
+  const MVACollection *mvaColl = nullptr;
+  const QualityMaskCollection *qualColl = nullptr;
+  if(includeMVA_) {
+    edm::Handle<MVACollection> hmva;
+    iEvent.getByToken(trackMVAToken_, hmva);
+    mvaColl = hmva.product();
+    if(mvaColl->size() != tracks.size())
+      throw cms::Exception("LogicError") << "Inconsistent track collection size (" << tracks.size() << ") and MVA collection size (" << mvaColl->size() << ")";
+
+    edm::Handle<QualityMaskCollection> hqual;
+    iEvent.getByToken(trackQualMaskToken_, hqual);
+    qualColl = hqual.product();
+    if(qualColl->size() != tracks.size())
+      throw cms::Exception("LogicError") << "Inconsistent track collection size (" << tracks.size() << ") and quality mask collection size (" << qualColl->size() << ")";
+  }
+
+  fillTracks(trackRefs, tpCollection, tpKeyToIndex, bs, associatorByHits, *theTTRHBuilder, tTopo, hitProductIds, seedCollToOffset, mvaColl, qualColl);
 
   //tracking particles
   //sort association maps with simHits
@@ -2317,7 +2356,9 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
                                 const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                 const TrackerTopology& tTopo,
                                 const std::set<edm::ProductID>& hitProductIds,
-                                const std::map<edm::ProductID, size_t>& seedCollToOffset
+                                const std::map<edm::ProductID, size_t>& seedCollToOffset,
+                                const MVACollection *mvaColl,
+                                const QualityMaskCollection *qualColl
                                 ) {
   reco::RecoToSimCollection recSimColl = associatorByHits.associateRecoToSim(tracks, tpCollection);
   edm::EDConsumerBase::Labels labels;
@@ -2392,6 +2433,10 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
     trk_algoMask .push_back(itTrack->algoMaskUL());
     trk_stopReason.push_back(itTrack->stopReason());
     trk_isHP     .push_back(itTrack->quality(reco::TrackBase::highPurity));
+    if(includeMVA_) {
+      trk_mva        .push_back((*mvaColl)[iTrack]);
+      trk_qualityMask.push_back((*qualColl)[iTrack]);
+    }
     if(includeSeeds_) {
       auto offset = seedCollToOffset.find(itTrack->seedRef().id());
       if(offset == seedCollToOffset.end()) {
@@ -2756,6 +2801,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
       edm::InputTag("muonSeededTrackCandidatesOutIn")
     });
   desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+  desc.addUntracked<std::string>("trackMVAs", "generalTracks");
   desc.addUntracked<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
   desc.addUntracked<bool>("trackingParticlesRef", false);
   desc.addUntracked<edm::InputTag>("clusterTPMap", edm::InputTag("tpClusterProducer"));
@@ -2779,6 +2825,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<std::string>("parametersDefiner", "LhcParametersDefinerForTP");
   desc.addUntracked<bool>("includeSeeds", false);
   desc.addUntracked<bool>("includeAllHits", false);
+  desc.addUntracked<bool>("includeMVA", true);
   descriptions.add("trackingNtuple",desc);
 }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -475,6 +475,7 @@ private:
   const bool includeSeeds_;
   const bool includeAllHits_;
   const bool includeMVA_;
+  const bool includeTrackingParticles_;
 
   HistoryBase tracer_;
 
@@ -534,6 +535,7 @@ private:
   std::vector<short> trk_isHP    ;
   std::vector<int> trk_seedIdx ;
   std::vector<int> trk_vtxIdx;
+  std::vector<short> trk_isTrue;
   std::vector<std::vector<float> > trk_shareFrac; // second index runs through matched TrackingParticles
   std::vector<std::vector<int> > trk_simTrkIdx;   // second index runs through matched TrackingParticles
   std::vector<std::vector<int> > trk_hitIdx;      // second index runs through hits
@@ -730,6 +732,7 @@ private:
   std::vector<unsigned int> see_algo    ;
   std::vector<unsigned short> see_stopReason;
   std::vector<int> see_trkIdx;
+  std::vector<short> see_isTrue;
   std::vector<std::vector<float> > see_shareFrac; // second index runs through matched TrackingParticles
   std::vector<std::vector<int> > see_simTrkIdx;   // second index runs through matched TrackingParticles
   std::vector<std::vector<int> > see_hitIdx;      // second index runs through hits
@@ -795,7 +798,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
   parametersDefinerName_(iConfig.getUntrackedParameter<std::string>("parametersDefiner")),
   includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
   includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
-  includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA"))
+  includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
+  includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles"))
 {
   if(includeSeeds_) {
     seedTokens_ = edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag> >("seedTracks"), [&](const edm::InputTag& tag) {
@@ -886,47 +890,54 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("trk_seedIdx"  , &trk_seedIdx );
   }
   t->Branch("trk_vtxIdx"   , &trk_vtxIdx);
-  t->Branch("trk_shareFrac", &trk_shareFrac);
-  t->Branch("trk_simTrkIdx", &trk_simTrkIdx  );
+  if(includeTrackingParticles_) {
+    t->Branch("trk_shareFrac", &trk_shareFrac);
+    t->Branch("trk_simTrkIdx", &trk_simTrkIdx  );
+  }
+  else {
+    t->Branch("trk_isTrue",    &trk_isTrue);
+  }
   if(includeAllHits_) {
     t->Branch("trk_hitIdx" , &trk_hitIdx);
     t->Branch("trk_hitType", &trk_hitType);
   }
-  //sim tracks
-  t->Branch("sim_event"    , &sim_event    );
-  t->Branch("sim_bunchCrossing", &sim_bunchCrossing);
-  t->Branch("sim_pdgId"    , &sim_pdgId    );
-  t->Branch("sim_genPdgIds", &sim_genPdgIds);
-  t->Branch("sim_isFromBHadron", &sim_isFromBHadron);
-  t->Branch("sim_px"       , &sim_px       );
-  t->Branch("sim_py"       , &sim_py       );
-  t->Branch("sim_pz"       , &sim_pz       );
-  t->Branch("sim_pt"       , &sim_pt       );
-  t->Branch("sim_eta"      , &sim_eta      );
-  t->Branch("sim_phi"      , &sim_phi      );
-  t->Branch("sim_pca_pt"   , &sim_pca_pt  );
-  t->Branch("sim_pca_eta"  , &sim_pca_eta  );
-  t->Branch("sim_pca_lambda", &sim_pca_lambda);
-  t->Branch("sim_pca_cotTheta", &sim_pca_cotTheta);
-  t->Branch("sim_pca_phi"  , &sim_pca_phi  );
-  t->Branch("sim_pca_dxy"  , &sim_pca_dxy  );
-  t->Branch("sim_pca_dz"   , &sim_pca_dz   );
-  t->Branch("sim_q"        , &sim_q        );
-  t->Branch("sim_nValid"   , &sim_nValid   );
-  t->Branch("sim_nPixel"   , &sim_nPixel   );
-  t->Branch("sim_nStrip"   , &sim_nStrip   );
-  t->Branch("sim_nLay"     , &sim_nLay     );
-  t->Branch("sim_nPixelLay", &sim_nPixelLay);
-  t->Branch("sim_n3DLay"   , &sim_n3DLay   );
-  t->Branch("sim_trkIdx"   , &sim_trkIdx   );
-  t->Branch("sim_shareFrac", &sim_shareFrac);
-  if(includeSeeds_) {
-    t->Branch("sim_seedIdx"   , &sim_seedIdx   );
-  }
-  t->Branch("sim_parentVtxIdx", &sim_parentVtxIdx);
-  t->Branch("sim_decayVtxIdx", &sim_decayVtxIdx);
-  if(includeAllHits_) {
-    t->Branch("sim_simHitIdx" , &sim_simHitIdx );
+  if(includeTrackingParticles_) {
+    //sim tracks
+    t->Branch("sim_event"    , &sim_event    );
+    t->Branch("sim_bunchCrossing", &sim_bunchCrossing);
+    t->Branch("sim_pdgId"    , &sim_pdgId    );
+    t->Branch("sim_genPdgIds", &sim_genPdgIds);
+    t->Branch("sim_isFromBHadron", &sim_isFromBHadron);
+    t->Branch("sim_px"       , &sim_px       );
+    t->Branch("sim_py"       , &sim_py       );
+    t->Branch("sim_pz"       , &sim_pz       );
+    t->Branch("sim_pt"       , &sim_pt       );
+    t->Branch("sim_eta"      , &sim_eta      );
+    t->Branch("sim_phi"      , &sim_phi      );
+    t->Branch("sim_pca_pt"   , &sim_pca_pt  );
+    t->Branch("sim_pca_eta"  , &sim_pca_eta  );
+    t->Branch("sim_pca_lambda", &sim_pca_lambda);
+    t->Branch("sim_pca_cotTheta", &sim_pca_cotTheta);
+    t->Branch("sim_pca_phi"  , &sim_pca_phi  );
+    t->Branch("sim_pca_dxy"  , &sim_pca_dxy  );
+    t->Branch("sim_pca_dz"   , &sim_pca_dz   );
+    t->Branch("sim_q"        , &sim_q        );
+    t->Branch("sim_nValid"   , &sim_nValid   );
+    t->Branch("sim_nPixel"   , &sim_nPixel   );
+    t->Branch("sim_nStrip"   , &sim_nStrip   );
+    t->Branch("sim_nLay"     , &sim_nLay     );
+    t->Branch("sim_nPixelLay", &sim_nPixelLay);
+    t->Branch("sim_n3DLay"   , &sim_n3DLay   );
+    t->Branch("sim_trkIdx"   , &sim_trkIdx   );
+    t->Branch("sim_shareFrac", &sim_shareFrac);
+    if(includeSeeds_) {
+      t->Branch("sim_seedIdx"   , &sim_seedIdx   );
+    }
+    t->Branch("sim_parentVtxIdx", &sim_parentVtxIdx);
+    t->Branch("sim_decayVtxIdx", &sim_decayVtxIdx);
+    if(includeAllHits_) {
+      t->Branch("sim_simHitIdx" , &sim_simHitIdx );
+    }
   }
   if(includeAllHits_) {
     //pixels
@@ -1086,8 +1097,13 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig):
     t->Branch("see_algo"     , &see_algo    );
     t->Branch("see_stopReason", &see_stopReason);
     t->Branch("see_trkIdx"   , &see_trkIdx  );
-    t->Branch("see_shareFrac", &see_shareFrac);
-    t->Branch("see_simTrkIdx", &see_simTrkIdx  );
+    if(includeTrackingParticles_) {
+      t->Branch("see_shareFrac", &see_shareFrac);
+      t->Branch("see_simTrkIdx", &see_simTrkIdx  );
+    }
+    else {
+      t->Branch("see_isTrue", &see_isTrue);
+    }
     if(includeAllHits_) {
       t->Branch("see_hitIdx" , &see_hitIdx  );
       t->Branch("see_hitType", &see_hitType );
@@ -1188,6 +1204,7 @@ void TrackingNtuple::clearVariables() {
   trk_isHP     .clear();
   trk_seedIdx  .clear();
   trk_vtxIdx   .clear();
+  trk_isTrue   .clear();
   trk_shareFrac.clear();
   trk_simTrkIdx.clear();
   trk_hitIdx   .clear();
@@ -1365,8 +1382,10 @@ void TrackingNtuple::clearVariables() {
   see_algo    .clear();
   see_stopReason.clear();
   see_trkIdx  .clear();
-  see_shareFrac.clear();
-  see_simTrkIdx.clear();
+  if(includeTrackingParticles_) {
+    see_shareFrac.clear();
+    see_simTrkIdx.clear();
+  }
   see_hitIdx  .clear();
   see_hitType .clear();
   //seed algo offset
@@ -2199,8 +2218,13 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajPz.push_back(mom.z());
 
       see_trkIdx  .push_back(-1); // to be set correctly in fillTracks
-      see_shareFrac.push_back( sharedFraction );
-      see_simTrkIdx.push_back( tpIdx );
+      if(includeTrackingParticles_) {
+        see_shareFrac.push_back( sharedFraction );
+        see_simTrkIdx.push_back( tpIdx );
+      }
+      else {
+        see_isTrue.push_back(!tpIdx.empty());
+      }
 
       /// Hmm, the following could make sense instead of plain failing if propagation to beam line fails
       /*
@@ -2417,7 +2441,6 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
     trk_refpoint_y.push_back(itTrack->vy());
     trk_refpoint_z.push_back(itTrack->vz());
     trk_nChi2    .push_back( itTrack->normalizedChi2());
-    trk_shareFrac.push_back(sharedFraction);
     trk_q        .push_back(charge);
     trk_nValid   .push_back(hp.numberOfValidHits());
     trk_nInvalid .push_back(hp.numberOfLostHits(reco::HitPattern::TRACK_HITS));
@@ -2454,7 +2477,13 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
       see_trkIdx[seedIndex] = iTrack;
     }
     trk_vtxIdx   .push_back(-1); // to be set correctly in fillVertices
-    trk_simTrkIdx.push_back(tpIdx);
+    if(includeTrackingParticles_) {
+      trk_simTrkIdx.push_back(tpIdx);
+      trk_shareFrac.push_back(sharedFraction);
+    }
+    else {
+      trk_isTrue.push_back(!tpIdx.empty());
+    }
     LogTrace("TrackingNtuple") << "Track #" << itTrack.key() << " with q=" << charge
                                << ", pT=" << pt << " GeV, eta: " << eta << ", phi: " << phi
                                << ", chi2=" << chi2
@@ -2826,6 +2855,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("includeSeeds", false);
   desc.addUntracked<bool>("includeAllHits", false);
   desc.addUntracked<bool>("includeMVA", true);
+  desc.addUntracked<bool>("includeTrackingParticles", true);
   descriptions.add("trackingNtuple",desc);
 }
 

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -1062,6 +1062,9 @@ class Frame:
         if nrows == 2:
             yoffsetFactor *= 2
             xoffsetFactor *= 2
+        elif nrows >= 5:
+            yoffsetFactor *= 1.5
+            xoffsetFactor *= 1.5
         elif nrows >= 3:
             yoffsetFactor *= 4
             xoffsetFactor *= 3

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -23,6 +23,9 @@ _includeSeeds = True
 _includeMVA = True
 #_includeMVA = False
 
+_includeTrackingParticles = True
+#_includeTrackingParticles = False
+
 from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
 trackingParticlesIntime = _trackingParticleRefSelector.clone(
     signalOnly = False,
@@ -39,6 +42,7 @@ trackingNtuple.trackingParticlesRef = True
 trackingNtuple.includeAllHits = _includeHits
 trackingNtuple.includeSeeds = _includeSeeds
 trackingNtuple.includeMVA = _includeMVA
+trackingNtuple.includeTrackingParticles = _includeTrackingParticles
 
 def _filterForNtuple(lst):
     ret = []

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -20,6 +20,9 @@ _includeHits = True
 _includeSeeds = True
 #_includeSeeds = False
 
+_includeMVA = True
+#_includeMVA = False
+
 from CommonTools.RecoAlgos.trackingParticleRefSelector_cfi import trackingParticleRefSelector as _trackingParticleRefSelector
 trackingParticlesIntime = _trackingParticleRefSelector.clone(
     signalOnly = False,
@@ -35,6 +38,7 @@ trackingNtuple.trackingParticles = "trackingParticlesIntime"
 trackingNtuple.trackingParticlesRef = True
 trackingNtuple.includeAllHits = _includeHits
 trackingNtuple.includeSeeds = _includeSeeds
+trackingNtuple.includeMVA = _includeMVA
 
 def _filterForNtuple(lst):
     ret = []

--- a/Validation/RecoTrack/test/analyseMVA.py
+++ b/Validation/RecoTrack/test/analyseMVA.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+
+import array
+import collections
+import itertools
+
+import ROOT
+
+from Validation.RecoTrack.plotting.ntuple import *
+from Validation.RecoTrack.plotting.ntuplePlotting import *
+
+# This file is a sketch of a simple analysis for MVA debugging
+
+def selectMVA(track):
+    mva = track.mva()
+    return mva > 0.35 and mva < 0.6
+
+def selectTrue(track):
+    return track.nMatchedTrackingParticles() > 0
+
+def selectFake(track):
+    return track.nMatchedTrackingParticles() == 0
+
+def main():
+    ROOT.TH1.AddDirectory(False)
+
+    ntuple_new = TrackingNtuple("trackingNtuple.root")
+    ntuple_old = TrackingNtuple("trackingNtuple_oldMVA.root")
+
+    common = dict(
+        #ratio=True,
+    )
+    common_ylog = dict(
+        ylog=True,
+        ymin=0.5,
+    )
+    common_ylog.update(common)
+
+    opts = dict(
+        mva = dict(xtitle="MVA", **common_ylog),
+        pt  = dict(xtitle="p_{T}", xlog=True, **common_ylog),
+        eta = dict(xtitle="#eta", **common),
+        relpterr = dict(xtitle="p_{T} error / p_{T}", **common_ylog),
+        absdxy = dict(xtitle="|d_{xy}(BS)|", **common_ylog),
+        absdz = dict(xtitle="|d_{z}(BS)|", **common_ylog),
+        absdxypv = dict(xtitle="|d_{xy}(closest PV)|", **common_ylog),
+        absdzpv = dict(xtitle="|d_{z}(closest PV)|", **common_ylog),
+        nhits = dict(xtitle="hits", **common),
+        nlayers = dict(xtitle="layers", **common),
+        nlayers3D = dict(xtitle="3D layers", **common),
+        nlayersLost = dict(xtitle="lost layers", **common),
+        minlost = dict(xtitle="min(inner, outer) lost layers", **common_ylog),
+        lostmidfrac = dict(xtitle="(lost hits) / (lost + valid hits)", **common),
+        ndof = dict(xtitle="ndof", **common),
+        chi2 = dict(xtitle="chi2/ndof", **common_ylog),
+        chi2_1Dmod = dict(xtitle="chi2/ndof with 1D modification", **common_ylog),
+    )
+
+    if True:
+        histos_new = histos(ntuple_new)
+        histos_old = histos(ntuple_old)
+        drawMany("newMVA_vs_oldMVA", [histos_old, histos_new], opts=opts)
+
+    if True:
+        histos_new = histos(ntuple_new, selector=selectMVA)
+        histos_old = histos(ntuple_old, selector=selectMVA)
+        drawMany("newMVA_vs_oldMVA_mvaselected", [histos_old, histos_new], opts=opts)
+
+    if True:
+        histos_new = histos(ntuple_new, selector=selectTrue)
+        histos_old = histos(ntuple_old, selector=selectTrue)
+        drawMany("newMVA_vs_oldMVA_true", [histos_old, histos_new], opts=opts)
+
+    if True:
+        histos_new = histos(ntuple_new, selector=lambda t: selectTrue(t) and selectMVA(t))
+        histos_old = histos(ntuple_old, selector=lambda t: selectTrue(t) and selectMVA(t))
+        drawMany("newMVA_vs_oldMVA_true_mvaselected", [histos_old, histos_new], opts=opts)
+
+    if True:
+        histos_new = histos(ntuple_new, selector=selectFake)
+        histos_old = histos(ntuple_old, selector=selectFake)
+        drawMany("newMVA_vs_oldMVA_fake", [histos_old, histos_new], opts=opts)
+
+    if True:
+        histos_new = histos(ntuple_new, selector=lambda t: selectFake(t) and selectMVA(t))
+        histos_old = histos(ntuple_old, selector=lambda t: selectFake(t) and selectMVA(t))
+        drawMany("newMVA_vs_oldMVA_fake_mvaselected", [histos_old, histos_new], opts=opts)
+
+    if True:
+        (histos_old, histos_new) = histos2(ntuple_old, ntuple_new, selectMVA)
+        drawMany("newMVA_vs_oldMVA_mvaSelectedNew", [histos_old, histos_new], opts=opts)
+
+    if True:
+        (histos_old, histos_new) = histos2(ntuple_old, ntuple_new, lambda t: selectTrue(t) and selectMVA(t))
+        drawMany("newMVA_vs_oldMVA_true_mvaSelectedNew", [histos_old, histos_new], opts=opts)
+
+    if True:
+        (histos_old, histos_new) = histos2(ntuple_old, ntuple_new, lambda t: selectFake(t) and selectMVA(t))
+        drawMany("newMVA_vs_oldMVA_fake_mvaSelectedNew", [histos_old, histos_new], opts=opts)
+
+
+def makeHistos():
+    h = collections.OrderedDict()
+    def addTH(name, *args, **kwargs):
+        _h = ROOT.TH1F(name, name, *args)
+        if kwargs.get("xlog", False):
+            axis = _h.GetXaxis()
+            bins = axis.GetNbins()
+            minLog10 = math.log10(axis.GetXmin())
+            maxLog10 = math.log10(axis.GetXmax())
+            width = (maxLog10-minLog10)/bins
+            new_bins = array.array("d", [0]*(bins+1))
+            new_bins[0] = 10**minLog10
+            mult = 10**width
+            for i in xrange(1, bins+1):
+                new_bins[i] = new_bins[i-1]*mult
+            axis.Set(bins, new_bins)
+        h[name] = _h
+
+    addTH("mva", 80, -1, 1)
+    addTH("pt", 40, 0.1, 1000, xlog=True)
+    addTH("eta", 60, -3, 3)
+    addTH("relpterr", 20, 0, 1)
+
+    addTH("absdxy", 50, 0, 1)
+    addTH("absdz", 30, 0, 15)
+    addTH("absdxypv", 50, 0., 0.5)
+    addTH("absdzpv", 20, 0, 1)
+
+    addTH("nhits", 41, -0.5, 40.5)
+    addTH("nlayers", 26, -0.5, 25.5)
+    addTH("nlayers3D", 26, -0.5, 25.5)
+    addTH("nlayersLost", 6, -0.5, 5.5)
+    addTH("minlost", 6, -0.5, 5.5)
+    addTH("lostmidfrac", 20, 0, 1)
+
+    addTH("ndof", 20, 0, 20)
+    addTH("chi2", 40, 0, 20)
+    addTH("chi2_1Dmod", 40, 0, 20)
+
+    return h
+
+def fillHistos(h, track):
+    h["mva"].Fill(track.mva())
+    h["pt"].Fill(track.pt())
+    h["eta"].Fill(track.eta())
+    h["ndof"].Fill(track.ndof())
+    h["nlayers"].Fill(track.nPixelLay()+track.nStripLay())
+    h["nlayers3D"].Fill(track.n3DLay())
+    h["nlayersLost"].Fill(track.nLostLay())
+    h["chi2"].Fill(track.nChi2())
+    h["chi2_1Dmod"].Fill(track.nChi2_1Dmod())
+    h["relpterr"].Fill(track.ptErr()/track.pt())
+    h["nhits"].Fill(track.nValid())
+    h["minlost"].Fill(min(track.nInnerLost(), track.nOuterLost()))
+    h["lostmidfrac"].Fill(track.nInvalid() / (track.nValid() + track.nInvalid()))
+
+    h["absdxy"].Fill(abs(track.dxy()))
+    h["absdz"].Fill(abs(track.dz()))
+    h["absdxypv"].Fill(abs(track.dxyClosestPV()))
+    h["absdzpv"].Fill(abs(track.dzClosestPV()))
+
+def histos(ntuple, selector=None):
+    h = makeHistos()
+
+    for event in ntuple:
+        for track in event.tracks():
+            if selector is not None and not selector(track):
+                continue
+            fillHistos(h, track)
+
+    return h
+
+def histos2(ntuple1, ntuple2, selector2=None):
+    # assume the two ntuples have the very same tracks except possibly
+    # for their parameters
+    h1 = makeHistos()
+    h2 = makeHistos()
+
+    for (event1, event2) in itertools.izip(ntuple1, ntuple2):
+        #print event1.eventIdStr(), event2.eventIdStr()
+        if event1.eventId() != event2.eventId():
+            raise Exception("Inconsistent events %s != %s" % (event1.eventIdStr(), event2.eventIdStr()))
+
+        for (track1, track2) in itertools.izip(event1.tracks(), event2.tracks()):
+
+            if selector2 is not None and not selector2(track2):
+                continue
+
+            fillHistos(h1, track1)
+            fillHistos(h2, track2)
+    return (h1, h2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds the track selection MVA and all the input variables for it to the TrackingNtuple. 

A configuration flag is added to store only a boolean if a track is true or not instead of the full TrackingParticle information. This can be useful for e.g. MVA training to have a single branch telling if a track is true or fake, and to reduce the size of the ntuple.

Also an example script `analyseMVA.py` plotting the MVA and the input variables is added to serve as a starting point for further studies.

Tested in 9_1_0_pre3, no impact on standard workflows.

@rovere @VinInn @hajohajo