### PR TITLE
Add include for EventSetup to ObjectPairCollectionSelector.h

### DIFF
--- a/CommonTools/UtilAlgos/interface/ObjectPairCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectPairCollectionSelector.h
@@ -13,6 +13,7 @@
  *
  */
 
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"


### PR DESCRIPTION
We use EventSetup in this file, so we also need to include
the related include to make it compile on its own.