### PR TITLE
Fix includes in SingleElementCollectionRefSelector headers

### DIFF
--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
@@ -16,12 +16,19 @@
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
 #include "DataFormats/Common/interface/View.h"
+
 namespace reco {
   namespace modules {
     template<typename S> struct SingleElementCollectionRefSelectorEventSetupInit;
   }
 }
+namespace edm {
+  class Event;
+  class EventSetup;
+}
+
 template<typename InputType, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<edm::View<InputType> >::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
@@ -16,11 +16,18 @@
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
+
 namespace reco {
   namespace modules {
     template<typename S> struct SingleElementCollectionSelectorEventSetupInit;
   }
 }
+namespace edm {
+  class Event;
+  class EventSetup;
+}
+
 template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<InputCollection>::type,
 	 typename StoreContainer = typename ::helper::StoreContainerTrait<OutputCollection>::type,

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelectorPlusEvent.h
@@ -16,6 +16,12 @@
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
+
+namespace edm {
+  class Event;
+  class EventSetup;
+}
 
 template<typename InputCollection, typename Selector,
 	 typename OutputCollection = typename helper::SelectedOutputCollectionTrait<InputCollection>::type,

--- a/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SortCollectionSelector.h
@@ -17,9 +17,14 @@
 #include "CommonTools/UtilAlgos/interface/SelectionAdderTrait.h"
 #include "CommonTools/UtilAlgos/interface/StoreContainerTrait.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
 #include <algorithm>
 #include <utility>
-namespace edm { class Event; }
+
+namespace edm {
+  class Event;
+  class EventSetup;
+}
 
 template<typename InputCollection, typename Comparator,
 	 typename OutputCollection = typename helper::SelectedOutputCollectionTrait<InputCollection>::type,


### PR DESCRIPTION
We use SelectedOutputCollectionTrait in these headers, so we also
need to include the related header to make these file compile
on its own.

Same goes for Event and EventSetup, but in this case we can just
forward declare them.