### PR TITLE
Add include for Event.h to StoreManagerTrait.h

### DIFF
--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -11,6 +11,7 @@
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/PtrVector.h"
+#include "FWCore/Framework/interface/Event.h"
 #include <memory>
 #include "boost/static_assert.hpp"
 #include "boost/type_traits.hpp"


### PR DESCRIPTION
We use Event in this file, so we also need to include its related
header to make this header compile on its own.