### PR TITLE
Fix includes in DigiCollectionProfiler.h

### DIFF
--- a/DPGAnalysis/SiStripTools/interface/DigiCollectionProfiler.h
+++ b/DPGAnalysis/SiStripTools/interface/DigiCollectionProfiler.h
@@ -3,19 +3,17 @@
 
 #include <vector>
 #include "CommonTools/UtilAlgos/interface/DetIdSelector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/DetSet.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 
-class TH1F;
-class TProfile;
-class TH2F;
-
-namespace edm {
-  class ParameterSet;
-}
+#include "TH1.h"
+#include "TH2.h"
+#include "TProfile.h"
 
 template <class T>
 class DigiCollectionProfiler {


### PR DESCRIPTION
We replace the forward declarations of TH1F, TH2F and TProfile with
actual includes as we call method from these classes in the lines
87-89, so a forward declaration no longer guarantees that this
header compiles. The same goes for ParameterSet in line 56.

For SiStripCluster we add the proper include as we use it in line 146.