### PR TITLE
Also forward declare EventSetup in EventWithHistoryFilter.h

### DIFF
--- a/DPGAnalysis/SiStripTools/interface/EventWithHistoryFilter.h
+++ b/DPGAnalysis/SiStripTools/interface/EventWithHistoryFilter.h
@@ -11,6 +11,7 @@
 namespace edm {
   class ParameterSet;
   class Event;
+  class EventSetup;
 }
 class EventWithHistory;
 


### PR DESCRIPTION
Someone forgot to forward declare this class in the same way as
we do with the rest. This causes that this header won't compile
on its own.