### PR TITLE
Add missing include to AlphaTVarProducer.h

### DIFF
--- a/DQM/DataScouting/interface/AlphaTVarProducer.h
+++ b/DQM/DataScouting/interface/AlphaTVarProducer.h
@@ -9,6 +9,7 @@
 
 #include "TLorentzVector.h"
 #include "DataFormats/METReco/interface/CaloMETFwd.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
 
 #include <vector>
 


### PR DESCRIPTION
We use CaloJetCollection in this header, so we also need to include
the related header to make this file compile on it's own.