### PR TITLE
Fix includes of ESDaqInfoTask.h

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/interface/ESDaqInfoTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESDaqInfoTask.h
@@ -5,7 +5,11 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-//class ESElectronicsMapper;
+#include "Geometry/EcalMapping/interface/ESElectronicsMapper.h" // definition in line 75
+
+class DQMStore;
+class MonitorElement;
+
 class ESDaqInfoTask: public edm::EDAnalyzer{
 
    public:


### PR DESCRIPTION
We need to include ESElectronicsMapper.h because we access the
ESElectronicsMapper in the `getFedNumber` method of this file.

We also forward declare DQMStore and MonitorElement because we
have pointers to those classes as member variables.