### PR TITLE
Add include for string to Collections.h

### DIFF
--- a/DQM/EcalMonitorTasks/interface/Collections.h
+++ b/DQM/EcalMonitorTasks/interface/Collections.h
@@ -1,6 +1,8 @@
 #ifndef EcalDQMonitorTaskCollections_H
 #define EcalDQMonitorTaskCollections_H
 
+#include <string>
+
 namespace ecaldqm {
 
   enum Collections {


### PR DESCRIPTION
We have std::string[] variable in this header, so we also need to
include the string header to make this header compile on its own.