### PR TITLE
Add missing fwd decls to ESDataCertificationTask.h

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/interface/ESDataCertificationTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESDataCertificationTask.h
@@ -5,6 +5,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+class DQMStore;
+class MonitorElement;
+
 class ESDataCertificationTask: public edm::EDAnalyzer{
 
  public:


### PR DESCRIPTION
We have member variables of type pointer to DQMStore/MonitorElement
in this header, so we also need to forward declare those types to
make sure this header compiles on its own.