### PR TITLE
Cleaning the Phase2TrackerDigi interface

### DIFF
--- a/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h
+++ b/DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h
@@ -30,7 +30,6 @@ public:
   // Access to digi information - pixel sensors
   unsigned int row()     const { return channelToRow(theChannel); }
   unsigned int column()  const { return channelToColumn(theChannel); }
-  uint16_t packedPosition() const { return 0x7FFF & theChannel; }
   // Access to digi information - strip sensors
   unsigned int strip()   const { return row(); }
   unsigned int edge()    const { return column(); } // CD: any better name for that? 
@@ -58,12 +57,12 @@ public:
 
 // Comparison operators
 inline bool operator<( const Phase2TrackerDigi& one, const Phase2TrackerDigi& other) {
-  return one.packedPosition() < other.packedPosition();
+  return one.channel() < other.channel();
 }
 
 // distance operators
 inline int operator-( const Phase2TrackerDigi& one, const Phase2TrackerDigi& other) {
-  return int(one.packedPosition()) - int(other.packedPosition());
+  return int(one.channel()) - int(other.channel());
 }
 
 


### PR DESCRIPTION
As discussed in the discussion of PR #19201, the packedPosition() method in Phase2TrackerDigi is not needed anymore. It is not used and now 100% similar to the channel() method.

The PR removes the method and replaces all of its occurrences by channel(). 
Absolutely no change is expected anywhere downstream.

@boudoul, @atricomi, @suchandradutta : FYI.