### PR TITLE
setup to run miniAOD on legacy 80X AOD inputs

### DIFF
--- a/Configuration/Eras/python/Modifier_run2_miniAOD_80XLegacy_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_miniAOD_80XLegacy_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_miniAOD_80XLegacy = cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -43,7 +43,7 @@ class Eras (object):
                            'phase2_hgcal', 'phase2_muon', 'phase2_timing',
                            'phase2_timing_layer','phase2_hcal',
                            'trackingLowPU', 'trackingPhase1', 'trackingPhase1QuadProp', 'ctpps_2016', 'trackingPhase2PU140',
-                           'tracker_apv_vfp30_2016']
+                           'tracker_apv_vfp30_2016', 'run2_miniAOD_80XLegacy']
         internalUseModChains = ['run2_2017_noTrackingModifier']
 
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
@@ -18,3 +18,19 @@ makePatJetsTask = cms.Task(
     patJets
     )
 makePatJets = cms.Sequence(makePatJetsTask)
+
+from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import * #pfImpactParameterTagInfos
+from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import * #pfSecondaryVertexTagInfos
+from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import * #pfInclusiveSecondaryVertexFinderTagInfos
+from RecoBTag.Combined.deepFlavour_cff import * #pfDeepFlavourTask
+
+makeDeepCSVForMiniAOD = pfDeepFlavourTask.copy()
+makeDeepCSVForMiniAOD.add(pfImpactParameterTagInfos)
+makeDeepCSVForMiniAOD.add(pfSecondaryVertexTagInfos)
+makeDeepCSVForMiniAOD.add(pfInclusiveSecondaryVertexFinderTagInfos)
+makeDeepCSVForMiniAOD.add(patJets)
+
+makePatJetsAndDeepCSVTask = makePatJets.copy()
+makePatJetsAndDeepCSVTask.replace(patJets, makeDeepCSVForMiniAOD)
+run2_miniAOD_80XLegacy.toReplaceWith(makePatJetsTask, makePatJetsAndDeepCSVTask)
+

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
@@ -23,20 +23,19 @@ from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import * #pfImpactPa
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import * #pfSecondaryVertexTagInfos
 from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import * #pfInclusiveSecondaryVertexFinderTagInfos
 from RecoBTag.Combined.deepFlavour_cff import * #pfDeepFlavourTask
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 
 #make a copy to avoid labels and substitution problems
-_makePatJetsCopy = makePatJets.copy()
+_makePatJetsWithDeepFlavorTask = makePatJetsTask.copy()
+_makePatJetsWithDeepFlavorTask.add(
+    pfImpactParameterTagInfos, 
+    pfSecondaryVertexTagInfos,
+    pfInclusiveSecondaryVertexFinderTagInfos,
+    pfDeepFlavourTask
+)
 
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toReplaceWith(
-    makePatJets, 
-    cms.Sequence(
-      pfImpactParameterTagInfos *
-      pfSecondaryVertexTagInfos *
-      pfInclusiveSecondaryVertexFinderTagInfos *
-      pfDeepFlavour *
-      _makePatJetsCopy
-      )
+    makePatJetsTask, _makePatJetsWithDeepFlavorTask
 )
 
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
@@ -23,14 +23,20 @@ from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import * #pfImpactPa
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import * #pfSecondaryVertexTagInfos
 from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import * #pfInclusiveSecondaryVertexFinderTagInfos
 from RecoBTag.Combined.deepFlavour_cff import * #pfDeepFlavourTask
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 
-makeDeepCSVForMiniAOD = pfDeepFlavourTask.copy()
-makeDeepCSVForMiniAOD.add(pfImpactParameterTagInfos)
-makeDeepCSVForMiniAOD.add(pfSecondaryVertexTagInfos)
-makeDeepCSVForMiniAOD.add(pfInclusiveSecondaryVertexFinderTagInfos)
-makeDeepCSVForMiniAOD.add(patJets)
+#make a copy to avoid labels and substitution problems
+_makePatJetsCopy = makePatJets.copy()
 
-makePatJetsAndDeepCSVTask = makePatJets.copy()
-makePatJetsAndDeepCSVTask.replace(patJets, makeDeepCSVForMiniAOD)
-run2_miniAOD_80XLegacy.toReplaceWith(makePatJetsTask, makePatJetsAndDeepCSVTask)
+run2_miniAOD_80XLegacy.toReplaceWith(
+    makePatJets, 
+    cms.Sequence(
+      pfImpactParameterTagInfos *
+      pfSecondaryVertexTagInfos *
+      pfInclusiveSecondaryVertexFinderTagInfos *
+      pfDeepFlavour *
+      _makePatJetsCopy
+      )
+)
+
 

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -25,3 +25,5 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(packedPFCandidates, covarianceVersion =1 )
 
+from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+run2_miniAOD_80XLegacy.toModify(packedPFCandidates, chargedHadronIsolation = "" )


### PR DESCRIPTION
- run2_miniAOD_80XLegacy modifier (to be added to the list of eras with Run2_2016 or related)
- updates from #18828 for deep flavor 
- disable chargedHadronIsolation reading in packedPFCandidates (it is not available in 80X)

Tested in CMSSW_9_2_3_patch1 with the following:

for MC:
```
cmsDriver.py step3  --conditions auto:run2_mc --mc --scenario pp --process PAT --era Run2_2016,run2_miniAOD_80XLegacy --eventcontent MINIAODSIM,DQM --runUnscheduled  -s PAT,VALIDATION:@miniAODValidation,DQM:@miniAODDQM --datatier MINIAODSIM,DQMIO  -n 3000 --filein /store/mc/RunIISummer16DR80Premix/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/AODSIM/PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/00000/004973E8-26BA-E611-93E0-A0000420FE80.root  --fileout file:step3.root > step3.log  2>&1 

cmsDriver.py step4  --filetype DQM --conditions auto:run2_mc --mc  --scenario pp -s HARVESTING:@miniAODValidation+@miniAODDQM --era Run2_2016,run2_miniAOD_80XLegacy -n -1 --filein file:step3_inDQM.root --fileout file:step4.root  > step4.log  2>&1 

```

for data:
```
cmsDriver.py step3  --conditions auto:run2_data --data --scenario pp --process PAT --era Run2_2016,run2_miniAOD_80XLegacy --eventcontent MINIAOD,DQM --runUnscheduled  -s PAT,DQM:@miniAODDQM --datatier MINIAOD,DQMIO  -n 3000 --filein /store/data/Run2016E/MET/AOD/18Apr2017-v1/120001/A21C3008-A548-E711-A90D-FA163E26AC84.root  --fileout file:step3.root > step3.log  2>&1 

cmsDriver.py step4  --filetype DQM --conditions auto:run2_data --data --scenario pp  -s HARVESTING:@miniAODDQM --era Run2_2016,run2_miniAOD_80XLegacy -n -1 --filein file:step3_inDQM.root --fileout file:step4.root  > step4.log  2>&1 
```

Here are a couple of plots from the MET PD (instructions above):
- some things are essentially the same (with recognizeable changes [simple , e.g. p4 kinematics pf packedCandidates is the same)]:
![all_8_0_28_patch1-orig-patvs9_2_3_patch1-sign917-pat_met18apr2017c_patpackedcandidates_packedpfcandidates__pat_obj_packeddxy_](https://user-images.githubusercontent.com/4676718/27243425-b3b4eee0-5296-11e7-90d1-2b9b22e63de8.png)

- Some things differ more (and I don't obviously recognize the difference
E.g. in slimmedJets (maybe cleaning is not the same? it's the same ak4PFJetsCHS on input from AOD directly)
![all_8_0_28_patch1-orig-patvs9_2_3_patch1-sign917-pat_met18apr2017c_log10patjets_slimmedjets__pat_obj_et](https://user-images.githubusercontent.com/4676718/27243499-0d36b67e-5297-11e7-885b-5ccddfc21705.png)
)
![all_8_0_28_patch1-orig-patvs9_2_3_patch1-sign917-pat_met18apr2017c_log10patjets_slimmedjets__pat_obj_energy](https://user-images.githubusercontent.com/4676718/27243484-f6f1034c-5296-11e7-8a51-5e29ec33370a.png)
Note that ak4PFJets 

@mverzett @kmcdermo @arizzi @gpetruc 

@fabozzi please take a look to possibly set up a matrix workflow to have this regularly tested.
