### PR TITLE
OnlineDQM : Tune L1T Muon Mismatch Ratio QTs

### DIFF
--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
@@ -4,32 +4,32 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="uGMTDE_MismatchRatioMax0p05">
+  <QTEST name="uGMTDE_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio">
-      <TestName activate="true">uGMTDE_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTDE_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- Intermediate Muons QTest -->
 
-  <QTEST name="InterMuonsDE_MismatchRatioMax0p05">
+  <QTEST name="InterMuonsDE_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2uGMT/intermediate_muons/*/data_vs_emulator_comparison/mismatchRatio">
-      <TestName activate="true">InterMuonsDE_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">InterMuonsDE_MismatchRatioMax0</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -373,62 +373,62 @@
 
   <!-- uGMT Output vs uGT Input -->
 
-  <QTEST name="uGMTvsuGT_MismatchRatioMax0p05">
+  <QTEST name="uGMTvsuGT_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio">
-      <TestName activate="true">uGMTvsuGT_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTvsuGT_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- BMTF Output vs uGMT Input -->
 
-  <QTEST name="BMTFvsuGMT_MismatchRatioMax0p05">
+  <QTEST name="BMTFvsuGMT_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio">
-      <TestName activate="true">BMTFvsuGMT_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">BMTFvsuGMT_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- EMTF Output vs uGMT Input -->
 
-  <QTEST name="EMTFvsuGMT_MismatchRatioMax0p05">
+  <QTEST name="EMTFvsuGMT_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
 
   <LINK name="*/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio">
-      <TestName activate="true">EMTFvsuGMT_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">EMTFvsuGMT_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- uGMT Muon Copy vs uGMT Muon -->
 
-  <QTEST name="uGMTCopies_MismatchRatioMax0p05">
+  <QTEST name="uGMTCopies_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/uGMTMuonCopies/*/mismatchRatio">
-      <TestName activate="true">uGMTCopies_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTCopies_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- Bad Zero Suppression Rates -->

--- a/DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h
@@ -32,6 +32,7 @@ class L1TStage2RatioClient: public DQMEDHarvester
     std::string ratioTitle_;
     std::string yAxisTitle_;
     bool binomialErr_;
+    std::vector<int> ignoreBin_;
 
     MonitorElement* ratioME_;
 };

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
@@ -129,32 +129,32 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/BMTF/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -258,42 +258,42 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTvsuGT_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTvsuGT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("BMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("BMTFvsuGMT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/GMTMuonCopy1/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -9,7 +9,8 @@ l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between OMTF muons and OMTF emulator muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
+    binomialErr = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(1)
 )
 
 # sequences

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -56,6 +56,7 @@ l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir
 l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF')
+l1tStage2BmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(1)
 
 l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
 l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput')

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -27,30 +27,35 @@ l1tStage2uGMTEmulImdMuBMTFCompRatioClient.monitorDir = cms.untracked.string(ugmt
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'BMTF')
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF-')
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF+')
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF-')
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF+')
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 # sequences
 l1tStage2uGMTEmulatorClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
@@ -7,7 +7,8 @@ L1TStage2RatioClient::L1TStage2RatioClient(const edm::ParameterSet& ps):
   ratioName_(ps.getUntrackedParameter<std::string>("ratioName")),
   ratioTitle_(ps.getUntrackedParameter<std::string>("ratioTitle")),
   yAxisTitle_(ps.getUntrackedParameter<std::string>("yAxisTitle")),
-  binomialErr_(ps.getUntrackedParameter<bool>("binomialErr"))
+  binomialErr_(ps.getUntrackedParameter<bool>("binomialErr")),
+  ignoreBin_(ps.getUntrackedParameter<std::vector<int>>("ignoreBin"))
 {
 }
 
@@ -23,6 +24,7 @@ void L1TStage2RatioClient::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.addUntracked<std::string>("ratioTitle", "ratio")->setComment("Ratio plot title.");
   desc.addUntracked<std::string>("yAxisTitle", "")->setComment("Title of y axis.");
   desc.addUntracked<bool>("binomialErr", "true")->setComment("Compute binomial errors.");
+  desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore. Will set their ratio to 0.");
   descriptions.add("l1TStage2RatioClient", desc);
 }
 
@@ -71,6 +73,14 @@ void L1TStage2RatioClient::processHistograms(DQMStore::IGetter& igetter)
     }
      
     hRatio->Divide(hNum, hDen, 1, 1, errOption.c_str());
+
+    // Set the ratio to 0 for those bins that need to be ignored
+    for (const int & bin : ignoreBin_) {
+      if (bin > 0 && bin <= hRatio->GetNbinsX()) {
+        hRatio->SetBinContent(bin, 0.0);
+        hRatio->GetXaxis()->SetBinLabel(bin, "Ignored");
+      }
+    }
 
     delete hDen;
   }


### PR DESCRIPTION
Description:

This PR includes the following changes:

- Set the maximum mismatch ratio to zero for some of the L1T Muon QT tests (uGMT Muon Copies, uGMT Intermediate Muons, uGMT Data vs Emulator, and OMTF Data vs Emulator)

- Modifies the L1TStage2RatioClient to include the option to ignore bins when making the mistmatch ratio plots.