### PR TITLE
Add missing includes to somedefinitions.h

### DIFF
--- a/DQM/RCTMonitor/interface/somedefinitions.h
+++ b/DQM/RCTMonitor/interface/somedefinitions.h
@@ -1,3 +1,7 @@
+#include "DQM/RCTMonitor/interface/RCTMonitor.h"
+
+#include <cmath>
+
 // Define statics for bins etc.
 const unsigned int RCTMonitor::ETABINS = 22;    const float RCTMonitor::ETAMIN = -0.5;       const float RCTMonitor::ETAMAX = 21.5;
 const unsigned int RCTMonitor::METPHIBINS = 72; const float RCTMonitor::METPHIMIN = -0.5;    const float RCTMonitor::METPHIMAX = 71.5;


### PR DESCRIPTION
We add an include for RCTMonitor because we use it everywhere
in this header.

We also include cmath for M_PI that we reference in line 12.