### PR TITLE
Fwd declare EventSetup to DQM/SiPixelMonitorTrack headers.

### DIFF
--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
@@ -25,6 +25,8 @@
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
+namespace edm { class EventSetup; }
+
 class SiPixelHitEfficiencyModule { 
   public:
     SiPixelHitEfficiencyModule();

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -23,6 +23,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 
+namespace edm { class EventSetup; }
 
 class SiPixelTrackResidualModule { 
   public:


### PR DESCRIPTION
Both SiPixelHitEfficiencyModule.h and
SiPixelTrackResidualModule.h reference edm::EventSetup in the
constructor, so we also need to forward declare this class
to make this header compile on its own.