### PR TITLE
Add missing includes to SiPixelHitEfficiencySource.h

### DIFF
--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -39,7 +39,9 @@
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
 class SiPixelHitEfficiencySource : public DQMEDAnalyzer {
   public:


### PR DESCRIPTION
We need to include VertexFwd.h in this header for reco::VertexCollection
and MeasurementTrackerEvent.h for MeasurementTrackerEvent, otherwise
this header doesn't compile on its own.