### PR TITLE
Fix includes for SiPixelTrackResidualSource.h

### DIFF
--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -43,6 +43,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 


### PR DESCRIPTION
We have to include TransientTrackingRecHit.h because we use
TransientTrackingRecHit::ConstRecHitPointer in this header.
Without this, this header wouldn't compile on its own.