### PR TITLE
Fix includes in SiStripMonitorHLT.h

### DIFF
--- a/DQM/SiStripMonitorCluster/interface/SiStripMonitorHLT.h
+++ b/DQM/SiStripMonitorCluster/interface/SiStripMonitorHLT.h
@@ -19,6 +19,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 
 class DQMStore;
 


### PR DESCRIPTION
We need to include SiStripCluster.h in this header because we
reference SiStripCluster, otherwise this file won't compile
on its own.