### PR TITLE
Forward declare TrackerTopology in SiStripMonitorQuality.h

### DIFF
--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorQuality.h
@@ -42,6 +42,7 @@ class MonitorElement;
 class DQMStore;
 class SiStripDetCabling;
 class SiStripQuality;
+class TrackerTopology;
 
 class SiStripMonitorQuality : public DQMEDAnalyzer {
  public:


### PR DESCRIPTION
We use a pointer to getQualityME in the method `getQualityME`,
so we also need to forward declare TrackerTopology to make this
file compile on its own.