### PR TITLE
Fix includes in SiStripMonitorRawData.h

### DIFF
--- a/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
+++ b/DQM/SiStripMonitorPedestals/interface/SiStripMonitorRawData.h
@@ -32,6 +32,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
+
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
 #include "boost/cstdint.hpp"


### PR DESCRIPTION
Because we have in this file `edm::DetSetVector<SiStripRawDigi>`, we
need to include DetSetVector.h and SiStripRawDigi.h.