### PR TITLE
Actually include DQMStore.h in TrackBuildingAnalyzer.h

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -19,6 +19,7 @@ Monitoring source for general quantities related to tracks.
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
@@ -27,9 +28,6 @@ Monitoring source for general quantities related to tracks.
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-
-
-class DQMStore;
 
 class TrackBuildingAnalyzer 
 {


### PR DESCRIPTION
We use DQMStore::IBooker in this header, so just forward declaring
DQMStore isn't enough to make this header compile on its own,
we actually need the include here.