### PR TITLE
Include TrackFwd.h in TkAlCaRecoMonitor.h

### DIFF
--- a/DQMOffline/Alignment/interface/TkAlCaRecoMonitor.h
+++ b/DQMOffline/Alignment/interface/TkAlCaRecoMonitor.h
@@ -24,7 +24,7 @@ Monitoring special quantities related to Tracker Alignment AlCaReco Production.
 
 //DataFormats
 #include <DataFormats/JetReco/interface/CaloJet.h>
-
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 class TrackerGeometry;
 class DQMStore;


### PR DESCRIPTION
We use reco::TrackCollection in this header, so we also need to
include TrackFwd.h so that this file compiles on its own.