### PR TITLE
Fix includes in Matcher.h

### DIFF
--- a/DQMOffline/PFTau/interface/Matchers.h
+++ b/DQMOffline/PFTau/interface/Matchers.h
@@ -5,6 +5,7 @@
 
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include <vector>


### PR DESCRIPTION
We use edm::ParameterSet in this header, so we also need to include
the corresponding header to make this file include on its own.