### PR TITLE
Add header guards to IPTagPlotter_cc.h

### DIFF
--- a/DQMOffline/RecoB/interface/IPTagPlotter_cc.h
+++ b/DQMOffline/RecoB/interface/IPTagPlotter_cc.h
@@ -1,3 +1,6 @@
+#ifndef IPTagPlotter_cc_H
+#define IPTagPlotter_cc_H
+
 #include <cstddef>
 #include <string>
 
@@ -972,3 +975,5 @@ reco::TrackBase::TrackQuality IPTagPlotter<Container, Base>::highestTrackQual(co
 
   return reco::TrackBase::undefQuality;
 }
+
+#endif


### PR DESCRIPTION
This file looks like a normal header but it doesn't have header
guards, so let's add some.