### PR TITLE
Add include for iostream to EgHLTDebugFuncs.h

### DIFF
--- a/DQMOffline/Trigger/interface/EgHLTDebugFuncs.h
+++ b/DQMOffline/Trigger/interface/EgHLTDebugFuncs.h
@@ -16,6 +16,9 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Event.h"
+
+#include <iostream>
+
 namespace egHLT {
   namespace debug {
     


### PR DESCRIPTION
We use std::cout in this header, so we also need to include
iostream to make this file compile on its own.