### PR TITLE
Add header guards and includes to ParserFunctions.h

### DIFF
--- a/DQMServices/ClientConfig/interface/ParserFunctions.h
+++ b/DQMServices/ClientConfig/interface/ParserFunctions.h
@@ -1,3 +1,9 @@
+#ifndef ParserFunctions_H
+#define ParserFunctions_H
+
+#include <string>
+#include "xercesc/util/XMLString.hpp"
+
 namespace qtxml{
 	inline std::string _toString(const XMLCh *toTranscode){
 		std::string tmp(xercesc::XMLString::transcode(toTranscode));
@@ -10,3 +16,5 @@ namespace qtxml{
 	}
 
 }
+
+#endif


### PR DESCRIPTION
This file looks like a normal header but it doesn't have header
guards, so let's add some.

We also add a include for String and XMLString.hpp because this file
references std::string/XMLCh and we want it to compile on its own.