### PR TITLE
Add include for signal.h to DQMNet.h

### DIFF
--- a/DQMServices/Core/interface/DQMNet.h
+++ b/DQMServices/Core/interface/DQMNet.h
@@ -9,6 +9,7 @@
 # include "classlib/utils/Time.h"
 # include <pthread.h>
 # include <stdint.h>
+# include <signal.h>
 # include <iostream>
 # include <vector>
 # include <string>


### PR DESCRIPTION
We use sig_atomic_t in this header, so we also need to include
signal.h to make this header compile on its own.