### PR TITLE
Fix includes ElectronEffectiveArea.h

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
@@ -8,6 +8,8 @@
 // Authors: S.Xie, E. DiMarco
 //--------------------------------------------------------------------------------------------------
 
+#include <Rtypes.h>
+#include <cmath>
 
 /// --> NOTE if you want to use this class as standalone without the CMSSW part 
 ///  you need to uncomment the below line and compile normally with scramv1 b 


### PR DESCRIPTION
We use double_t in this header, so we also need to include Rtypes.h.
We also `fabs` in this header, so we need to include cmath to make
this file compile on its own.