### PR TITLE
Fix includes of ElectronSelector.h/UniqueElectrons.h

### DIFF
--- a/ElectroWeakAnalysis/ZEE/interface/ElectronSelector.h
+++ b/ElectroWeakAnalysis/ZEE/interface/ElectronSelector.h
@@ -1,3 +1,7 @@
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+#include <vector>
+
 std::vector<reco::GsfElectronRef> electronSelector(const std::vector<reco::GsfElectronRef>& electrons,
 							const edm::Handle<trigger::TriggerEvent>& pHLT, const int filterId,
 							 const std::vector<double>& Cuts )

--- a/ElectroWeakAnalysis/ZEE/interface/UniqueElectrons.h
+++ b/ElectroWeakAnalysis/ZEE/interface/UniqueElectrons.h
@@ -1,3 +1,7 @@
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+#include <vector>
+
 std::vector<reco::GsfElectronRef> uniqueElectronFinder(edm::Handle<reco::GsfElectronCollection>& pElectrons)
 {
 	const reco::GsfElectronCollection *electrons = pElectrons.product();


### PR DESCRIPTION
We use `std::vector<reco::GsfElectronRef>` in these headers, so we
also need to have includes for vector and GsfElectronFwd.h which
provide the definitions of those classes, as those file otherwise
won't compile on their own.
