### PR TITLE
Add include for algorithm to DebugDigisPrintout.h

### DIFF
--- a/EventFilter/RPCRawToDigi/interface/DebugDigisPrintout.h
+++ b/EventFilter/RPCRawToDigi/interface/DebugDigisPrintout.h
@@ -1,6 +1,7 @@
 #ifndef EventFilter_RPCRawToDigi_debugDigisPrintout_h
 #define EventFilter_RPCRawToDigi_debugDigisPrintout_h
 
+#include <algorithm>
 #include <string>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
We use std::find in this header, so we also need to include
the algorithm header to make this file compile on its own.