### PR TITLE
Add include for unistd.h in FFFNamingSchema.h

### DIFF
--- a/EventFilter/Utilities/interface/FFFNamingSchema.h
+++ b/EventFilter/Utilities/interface/FFFNamingSchema.h
@@ -3,6 +3,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <unistd.h>
 
 namespace fffnaming {
 


### PR DESCRIPTION
We call getpid() in this header, so we also need to include the
unistd.h header whcih provides getpid() to make this file compile
on its own.