### PR TITLE
Use std::shared_ptr in FastMonitoringThread.h

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -146,7 +146,7 @@ namespace evf{
 
     void start(void (FastMonitoringService::*fp)(),FastMonitoringService *cp){
       assert(!m_thread);
-      m_thread = boost::shared_ptr<std::thread>(new std::thread(fp,cp));
+      m_thread = std::shared_ptr<std::thread>(new std::thread(fp,cp));
     }
     void stop(){
       assert(m_thread);
@@ -157,7 +157,7 @@ namespace evf{
   private:
 
     std::atomic<bool> m_stoprequest;
-    boost::shared_ptr<std::thread> m_thread;
+    std::shared_ptr<std::thread> m_thread;
     MonitorData m_data;
     std::mutex monlock_;
 


### PR DESCRIPTION
We don't include boost/shared_ptr in this header, so this header
doesn't compile on its own right now. Instead of include the
boost header, let's just move to std::shared_ptr instead as this
is anyway just a private member variable.