### PR TITLE
Fix the header guard of MicroStateService.h

### DIFF
--- a/EventFilter/Utilities/interface/MicroStateService.h
+++ b/EventFilter/Utilities/interface/MicroStateService.h
@@ -1,5 +1,5 @@
 #ifndef EvFMicroStateService_H
-#define EvFMicroStateServiceH 1
+#define EvFMicroStateService_H 1
 
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
The header guard is currently not working because the symbols don't
match.