### PR TITLE
Fix includes/fwd decls in Fireworks/Core

### DIFF
--- a/Fireworks/Core/interface/FWDetailViewBase.h
+++ b/Fireworks/Core/interface/FWDetailViewBase.h
@@ -21,7 +21,10 @@
 
 #include "Fireworks/Core/interface/FWSimpleProxyHelper.h"
 
+#include "Rtypes.h"
+
 class TEveWindow;
+class TEveWindowSlot;
 class FWModelId;
 class FWEventItem;
 

--- a/Fireworks/Core/interface/FWDetailViewCanvas.h
+++ b/Fireworks/Core/interface/FWDetailViewCanvas.h
@@ -3,6 +3,7 @@
 
 class TCanvas;
 class TGCompositeFrame;
+class TEveWindowSlot;
 
 #include "Fireworks/Core/interface/FWDetailView.h"
 

--- a/Fireworks/Core/interface/FWDetailViewManager.h
+++ b/Fireworks/Core/interface/FWDetailViewManager.h
@@ -19,6 +19,7 @@
 //
 #include <map>
 #include <string>
+#include <vector>
 
 class FWColorManager;
 class TEveCompositeFrameInMainFrame;

--- a/Fireworks/Core/interface/FWEveViewManager.h
+++ b/Fireworks/Core/interface/FWEveViewManager.h
@@ -31,6 +31,7 @@
 // forward declarations
 class TEveCompund;
 class TEveScene;
+class TEveElement;
 class TEveWindowSlot;
 class FWViewBase;
 class FWEveView;

--- a/Fireworks/Core/interface/FWInteractionList.h
+++ b/Fireworks/Core/interface/FWInteractionList.h
@@ -22,6 +22,7 @@
 
 // user include files
 #include <set>
+#include <vector>
 
 // forward declarations
 class TEveElement;

--- a/Fireworks/Core/interface/FWModelExpressionSelector.h
+++ b/Fireworks/Core/interface/FWModelExpressionSelector.h
@@ -22,6 +22,7 @@
 #include <string>
 
 // user include files
+#include <Rtypes.h>
 
 // forward declarations
 class FWEventItem;

--- a/Fireworks/Core/interface/FWViewBase.h
+++ b/Fireworks/Core/interface/FWViewBase.h
@@ -26,6 +26,8 @@
 #include "Fireworks/Core/interface/FWConfigurableParameterizable.h"
 #include "Fireworks/Core/interface/FWViewType.h"
 
+#include "Rtypes.h"
+
 // forward declarations
 class TGFrame;
 class FWViewContextMenuHandlerBase;


### PR DESCRIPTION
We have to forward declare TEveWindowSlot/TEveElement because
we reference pointers to those types in the respective headers.

We have to include Rtypes.h to get Color_t in FWDetailViewBase.h
and FWModelExpressionSelector.h. In FWViewBase.h we have to
include Rtypes.h for Int_t.

In FWDetailViewManager.h/FWInteractionList.h we have to
include <vector> because we use std::vector there.