### PR TITLE
Fix includes to HLTDiMuonGlbTrkFilter.h

### DIFF
--- a/HLTrigger/Muon/interface/HLTDiMuonGlbTrkFilter.h
+++ b/HLTrigger/Muon/interface/HLTDiMuonGlbTrkFilter.h
@@ -3,6 +3,7 @@
 // author D.Kovalskyi
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 namespace edm {


### PR DESCRIPTION
We use reco::MuonCollection in this header, so we also need to
include MuonFwd.h to make this file compile on its file.