### PR TITLE
Fix includes HLTMuonDimuonL3Filter.h

### DIFF
--- a/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
@@ -12,9 +12,11 @@
  */
 
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 namespace edm {
    class ConfigurationDescriptions;


### PR DESCRIPTION
We have to include MuonFwd.h for MuonTrackLinksCollection
and BeamSpot.h because we reference Beamspot, otherwise
this header doesn't compile on its own.