### PR TITLE
Adding Cluster charge and size per layer

### DIFF
--- a/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
+++ b/DQM/SiPixelPhase1Clusters/python/SiPixelPhase1Clusters_cfi.py
@@ -20,7 +20,7 @@ SiPixelPhase1ClustersCharge = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersSize = DefaultHistoDigiCluster.clone(
   name = "size",
   title = "Total Cluster Size",
-  range_min = 0, range_max = 50, range_nbins = 50,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "size[pixels]",
   specs = VPSet(
     StandardSpecification2DProfile,
@@ -34,7 +34,7 @@ SiPixelPhase1ClustersSize = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersSizeX = DefaultHistoDigiCluster.clone(
   name = "sizeX",
   title = "Cluster Size in X",
-  range_min = 0, range_max = 50, range_nbins = 50,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "size[pixels]",
   specs = VPSet(
     #StandardSpecification2DProfile,
@@ -48,7 +48,7 @@ SiPixelPhase1ClustersSizeX = DefaultHistoDigiCluster.clone(
 SiPixelPhase1ClustersSizeY = DefaultHistoDigiCluster.clone(
   name = "sizeY",
   title = "Cluster Size in Y",
-  range_min = 0, range_max = 50, range_nbins = 50,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "size[pixels]",
   specs = VPSet(
     #StandardSpecification2DProfile,
@@ -101,6 +101,7 @@ SiPixelPhase1ClustersEventrate = DefaultHistoDigiCluster.clone(
   title = "Number of Events with clusters",
   ylabel = "#Events",
   dimensions = 0,
+  enabled=False,
   specs = VPSet(
     Specification().groupBy("Lumisection")
                    .groupBy("", "EXTEND_X").save(),

--- a/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
+++ b/DQM/SiPixelPhase1Digis/python/SiPixelPhase1Digis_cfi.py
@@ -70,7 +70,8 @@ SiPixelPhase1DigisNdigisPerFED = DefaultHisto.clone( #to be removed?
     Specification().groupBy("FED/Event")
                    .reduce("COUNT")
                    .groupBy("FED")
-                   .groupBy("", "EXTEND_Y")
+                   .reduce("MEAN")
+                   .groupBy("", "EXTEND_X")
                    .save()
   )
 )
@@ -108,7 +109,9 @@ SiPixelPhase1DigisEvents = DefaultHistoDigiCluster.clone(
   ylabel = "#Events",
   dimensions = 0,
   specs = VPSet(
+
     Specification().groupBy("Lumisection")
+                   .reduce("MEAN")
                    .groupBy("", "EXTEND_X").save(),
     Specification().groupBy("BX")
                    .groupBy("", "EXTEND_X").save()
@@ -152,16 +155,21 @@ SiPixelPhase1DigisOccupancy = DefaultHistoReadout.clone(
   specs = VPSet(
     Specification(PerReadout).groupBy("PXBarrel/FED/Channel")
                              .groupBy("PXBarrel/FED", "EXTEND_X").save(),
-    Specification(PerReadout).groupBy("PXBarrel/FED/Channel/RocInLink")
-                             .groupBy("PXBarrel/FED/Channel", "EXTEND_Y")
-                             .groupBy("PXBarrel/FED", "EXTEND_X").save(),
+
+    #Specification(PerReadout).groupBy("PXBarrel/FED/Channel/RocInLink") #Deactivating 2D maps giving redundant information
+    #                         .groupBy("PXBarrel/FED/Channel", "EXTEND_Y")
+    #                         .groupBy("PXBarrel/FED", "EXTEND_X").save(),
+
     Specification(PerReadout).groupBy("PXForward/FED/Channel")
                              .groupBy("PXForward/FED", "EXTEND_X").save(),
-    Specification(PerReadout).groupBy("PXForward/FED/Channel/RocInLink")
-                             .groupBy("PXForward/FED/Channel", "EXTEND_Y")
-                             .groupBy("PXForward/FED", "EXTEND_X").save(),
+
+    #Specification(PerReadout).groupBy("PXForward/FED/Channel/RocInLink")
+    #                         .groupBy("PXForward/FED/Channel", "EXTEND_Y")
+    #                         .groupBy("PXForward/FED", "EXTEND_X").save(),
+
     Specification(PerReadout).groupBy("PXBarrel/FED")
                              .groupBy("PXBarrel", "EXTEND_X").save(),
+
     Specification(PerReadout).groupBy("PXForward/FED")
                              .groupBy("PXForward", "EXTEND_X").save(),
 

--- a/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
+++ b/DQM/SiPixelPhase1TrackClusters/python/SiPixelPhase1TrackClusters_cfi.py
@@ -12,31 +12,61 @@ SiPixelPhase1TrackClustersOnTrackCharge = DefaultHistoTrack.clone(
     Specification().groupBy("PXBarrel/PXLayer").saveAll(),
     Specification().groupBy("PXForward/PXDisk").saveAll(),
     StandardSpecification2DProfile,#what is below is only for the timing client
+
     Specification(OverlayCurvesForTiming).groupBy("PXBarrel/OnlineBlock")
          .groupBy("PXBarrel", "EXTEND_Y")
          .save(),
     Specification(OverlayCurvesForTiming).groupBy("PXForward/OnlineBlock")
           .groupBy("PXForward", "EXTEND_Y")
           .save(),
+    
+    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification().groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
+    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save(),
+
+    
     Specification(OverlayCurvesForTiming).groupBy("PXForward/PXDisk/OnlineBlock") # per-layer with history for online
-          .groupBy("PXForward/PXDisk", "EXTEND_Y")
-          .save(),
+                   .groupBy("PXForward/PXDisk", "EXTEND_Y")
+                   .save(),
     Specification(OverlayCurvesForTiming).groupBy("PXBarrel/PXLayer/OnlineBlock") # per-layer with history for online
-                                 .groupBy("PXBarrel/PXLayer", "EXTEND_Y")
-                                 .save()
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_Y")
+                   .save()
   )
 )
 
 SiPixelPhase1TrackClustersOnTrackSize = DefaultHistoTrack.clone(
   name = "size",
   title = "Total Cluster Size (OnTrack)",
-  range_min = 0, range_max = 50, range_nbins = 50,
+  range_min = 0, range_max = 30, range_nbins = 30,
   xlabel = "size[pixels]",
 
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").saveAll(),
     Specification().groupBy("PXForward/PXDisk").saveAll(),
-    StandardSpecification2DProfile
+    StandardSpecification2DProfile,
+
+    Specification().groupBy("PXBarrel/PXLayer/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer", "EXTEND_X")
+                   .save(),
+
+    Specification().groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk", "EXTEND_X")
+                   .save(),
+
+    Specification(PerLayer1D).groupBy("PXBarrel/Shell/PXLayer").save(),
+    Specification(PerLayer1D).groupBy("PXForward/HalfCylinder/PXRing/PXDisk").save()
+
   )
 )
 
@@ -64,6 +94,7 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
                              .reduce("COUNT")    
                              .groupBy("PXBarrel/PXLayer")
                              .save(nbins=100, xmin=0, xmax=20000),
+
     Specification().groupBy("PXForward/PXDisk/Event")
                              .reduce("COUNT")    
                              .groupBy("PXForward/PXDisk/")
@@ -73,14 +104,33 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
                    .reduce("COUNT")
                    .groupBy("PXBarrel")
                    .save(nbins=150, xmin=0, xmax=30000),
+
     Specification().groupBy("PXForward/Event")
                    .reduce("COUNT")
                    .groupBy("PXForward")
                    .save(nbins=150, xmin=0, xmax=30000),
+
     Specification().groupBy("PXAll/Event")
                    .reduce("COUNT")
                    .groupBy("PXAll")
                    .save(nbins=150, xmin=0, xmax=30000),
+
+    Specification().groupBy("BX")
+                   .groupBy("", "EXTEND_X").save(),
+
+    Specification().groupBy("PXBarrel/PXLayer/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXBarrel/PXLayer/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXBarrel/PXLayer","EXTEND_X")
+                   .save(),
+
+    Specification().groupBy("PXForward/PXDisk/Event")
+                   .reduce("COUNT")
+                   .groupBy("PXForward/PXDisk/Lumisection")
+                   .reduce("MEAN")
+                   .groupBy("PXForward/PXDisk","EXTEND_X")
+                   .save(),
 
     #below is for timing client
     Specification(OverlayCurvesForTiming).groupBy("DetId/Event")
@@ -88,11 +138,13 @@ SiPixelPhase1TrackClustersOnTrackNClusters = DefaultHistoTrack.clone(
                     .groupBy("PXForward/OnlineBlock")
                     .groupBy("PXForward", "EXTEND_Y")
                     .save(),
+
     Specification(OverlayCurvesForTiming).groupBy("DetId/Event")
                     .reduce("COUNT")
                     .groupBy("PXBarrel/OnlineBlock")
                     .groupBy("PXBarrel", "EXTEND_Y")
                     .save()
+   
   )
 )
 


### PR DESCRIPTION
This PR adds plots of cluster charge and size for on-track and inclusive clusters (important for the commissioning of the pixel detector)

It also disable about 100 2D plots giving a quite redundant information

The final count of bins added/deleted is quite even