### PR TITLE
Add include for EventSetup to PhotonFixCMS.h

### DIFF
--- a/HiggsAnalysis/HiggsToGammaGamma/interface/PhotonFixCMS.h
+++ b/HiggsAnalysis/HiggsToGammaGamma/interface/PhotonFixCMS.h
@@ -44,7 +44,7 @@
 #include <string>
 #include "../interface/PhotonFix.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
-
+#include "FWCore/Framework/interface/EventSetup.h"
 
 class PhotonFixCMS {
  public:


### PR DESCRIPTION
We use EventSetup in this header, so we also need to include
the reelvant header to make this file compile on its own.