### PR TITLE
Fix includes in DEutils.h

### DIFF
--- a/L1Trigger/HardwareValidation/interface/DEutils.h
+++ b/L1Trigger/HardwareValidation/interface/DEutils.h
@@ -8,6 +8,9 @@
  *\date 07.04
  */
 
+#include <iomanip>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/HardwareValidation/interface/DEtrait.h"
 
 template <typename T> 


### PR DESCRIPTION
We need to include MessageLogger.h here because we use edm::LogError.
We also need to include iomanip for the definition of std::setw that
we use in this file, as otherwise it won't compile on its own.