### PR TITLE
Add include for cmath to MakeRegionalCand.h

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/MakeRegionalCand.h
+++ b/L1Trigger/L1TMuonEndCap/interface/MakeRegionalCand.h
@@ -9,6 +9,8 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
 
+#include <cmath>
+
 int GMT_eta_from_theta[128] = {239, 235, 233, 230, 227, 224, 222, 219, 217, 214, 212, 210, 207, 205, 203, 201,
 			       199, 197, 195, 193, 191, 189, 187, 186, 184, 182, 180, 179, 177, 176, 174, 172,
 			       171, 169, 168, 166, 165, 164, 162, 161, 160, 158, 157, 156, 154, 153, 152, 151,


### PR DESCRIPTION
We use `floor` in this file, so we also need to include cmath as
otherwise this header won't compile on its own.