### PR TITLE
Add fstream include to DEcompare.h

### DIFF
--- a/L1Trigger/HardwareValidation/interface/DEcompare.h
+++ b/L1Trigger/HardwareValidation/interface/DEcompare.h
@@ -9,6 +9,8 @@
 
 /*\note specialization free*/
 
+#include <fstream>
+
 #include "L1Trigger/HardwareValidation/interface/DEtrait.h"
 #include "L1Trigger/HardwareValidation/interface/DEutils.h"
 


### PR DESCRIPTION
We use std::ofstream in this header, so we also need to include
fstream to provide this class as otherwise this header won't
compile.