### PR TITLE
Fix includes of FastTimerService.h

### DIFF
--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -28,6 +28,7 @@
 #include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"


### PR DESCRIPTION
We use ConfigurationDescriptions as a parameter for `fillDescriptions`,
so we also need to include the header that provides this class.