### PR TITLE
Fix includes in SigmaPtDiff.h

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/interface/SigmaPtDiff.h
+++ b/MuonAnalysis/MomentumScaleCalibration/interface/SigmaPtDiff.h
@@ -1,6 +1,9 @@
 #ifndef SigmaPtDiff_h
 #define SigmaPtDiff_h
 
+#include <vector>
+#include <cmath>
+
 class SigmaPt
 {
  public:


### PR DESCRIPTION
We use std::vector and `fabs` in this file, so we also need to
include the corresponding headers to make this header compile
on its own.