### PR TITLE
Fix includes in CandMapTrait.h

### DIFF
--- a/PhysicsTools/CandUtils/interface/CandMapTrait.h
+++ b/PhysicsTools/CandUtils/interface/CandMapTrait.h
@@ -1,5 +1,9 @@
 #ifndef PhysicsTools_CandUtils_CandMapTrait_h
 #define PhysicsTools_CandUtils_CandMapTrait_h
+
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
 /* \class reco::helper::CandMapTrait<T>
  *
  * \author Luca Lista, INFN 


### PR DESCRIPTION
We use CandidateView and AssociationMap in this header, so we
also need to use the relevant includes to make this file compile
on its own.