### PR TITLE
Forward declare ClusterSHape in ElectronSelector.h

### DIFF
--- a/PhysicsTools/PatUtils/interface/ElectronSelector.h
+++ b/PhysicsTools/PatUtils/interface/ElectronSelector.h
@@ -25,6 +25,10 @@
 
 #include "PhysicsTools/PatUtils/interface/ParticleCode.h"
 
+namespace reco {
+  class ClusterShape;
+}
+
 namespace pat {
 
   /// Structure defining the electron selection


### PR DESCRIPTION
We use a pointer to this type in this header, but we don't include
the relevant headers, so this file fails to compile on its own.
As we don't need the definition here, we just forward declare it.