### PR TITLE
Add include for Vertex.h to MuonVPlusJetsIDSelectionFunctor.h

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/MuonVPlusJetsIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/MuonVPlusJetsIDSelectionFunctor.h
@@ -6,6 +6,7 @@
 #endif
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "PhysicsTools/SelectorUtils/interface/Selector.h"


### PR DESCRIPTION
We use reco::Vertex in the MuonVPlusJetsIDSelectionFunctor constructor
so we also need to include the relevant header.