### PR TITLE
Fix ODR problems and includes in Selections.h

### DIFF
--- a/PhysicsTools/UtilAlgos/interface/Selections.h
+++ b/PhysicsTools/UtilAlgos/interface/Selections.h
@@ -1,6 +1,7 @@
 #ifndef Selections_H
 #define Selections_H
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CommonTools/UtilAlgos/interface/EventSelector.h"
 #include <cstdlib>
 #include <iomanip>
@@ -130,14 +131,14 @@ class FilterOR : public Filter{
 
 
 //forward declaration for friendship
-class Selections;
+class FilterSelections;
 
-class Selection : public Filter {
+class FilterSelection : public Filter {
  public:
   typedef std::vector<SFilter>::iterator iterator;
-  friend class Selections;
+  friend class FilterSelections;
 
-  Selection(std::string name, const edm::ParameterSet& iConfig) :
+  FilterSelection(std::string name, const edm::ParameterSet& iConfig) :
     name_(name),
     ntuplize_(iConfig.getParameter<bool>("ntuplize")),
     makeContentPlots_(iConfig.getParameter<bool>("makeContentPlots")),
@@ -308,11 +309,11 @@ class Selection : public Filter {
   std::string detailledPrintoutCategory_;
 };
 
-class Selections {
+class FilterSelections {
  public:
-  typedef std::vector<Selection>::iterator iterator;
+  typedef std::vector<FilterSelection>::iterator iterator;
 
-  Selections(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) :
+  FilterSelections(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) :
     filtersPSet_(iConfig.getParameter<edm::ParameterSet>("filters")),
     selectionPSet_(iConfig.getParameter<edm::ParameterSet>("selections"))
   {
@@ -333,7 +334,7 @@ class Selections {
     for (unsigned int iS=0;iS!=nS;iS++){
       edm::ParameterSet pset=selectionPSet_.getParameter<edm::ParameterSet>(selectionNames[iS]);
       // JR-2014 : the filters are not expanded here
-      selections_.push_back(Selection(selectionNames[iS],pset));
+      selections_.push_back(FilterSelection(selectionNames[iS],pset));
       //      selections_.insert(std::make_pair(selectionNames[iS],Selection(selectionNames[iS],pset)));
       //keep track of list of filters for this selection for further dependency resolution
       selectionFilters[selectionNames[iS]]=pset.getParameter<std::vector<std::string> >("filterOrder");
@@ -382,12 +383,12 @@ class Selections {
 
     //finally, configure the Selections
     //loop the selections instanciated
-    //    for (std::map<std::string, Selection>::iterator sIt=selections_.begin();sIt!=selections_.end();++sIt)
+    //    for (std::map<std::string, FilterSelection>::iterator sIt=selections_.begin();sIt!=selections_.end();++sIt)
     //      const std::string & sName=sIt->first;
-    //Selection & selection =sIt->second;
-    for (std::vector<Selection>::iterator sIt=selections_.begin();sIt!=selections_.end();++sIt){
+    //FilterSelection & selection =sIt->second;
+    for (std::vector<FilterSelection>::iterator sIt=selections_.begin();sIt!=selections_.end();++sIt){
       const std::string & sName=sIt->name();
-      Selection & selection =*sIt;
+      FilterSelection & selection =*sIt;
 
       //parse the vector of filterNames
       std::vector<std::string> & listOfFilters=selectionFilters[sName];
@@ -404,7 +405,7 @@ class Selections {
 	    // JR-2014 include the selection here, directly !
 	    bool replaceBySelection=false;
 	    //find an existing selection that match that name
-	    for ( std::vector<Selection>::iterator sit=selections_.begin(); sit!= selections_.end() ; ++sit){
+	    for ( std::vector<FilterSelection>::iterator sit=selections_.begin(); sit!= selections_.end() ; ++sit){
 	      if (fOsName == sit->name_){
 		selection.filters_.push_back( SFilter(& (*sit), inverted));
 		replaceBySelection=true;
@@ -431,14 +432,14 @@ class Selections {
   iterator end() { return selections_.end();}
 
   //print each selection
-  void print(){ for (std::vector<Selection>::iterator sIt=selections_.begin();sIt!=selections_.end();++sIt) sIt->print();}
+  void print(){ for (std::vector<FilterSelection>::iterator sIt=selections_.begin();sIt!=selections_.end();++sIt) sIt->print();}
 
  private:
   edm::ParameterSet filtersPSet_;
   std::map<std::string, Filter*> filters_; // the global collection of available filters to pick from
 
   edm::ParameterSet selectionPSet_;
-  std::vector<Selection> selections_;
+  std::vector<FilterSelection> selections_;
 };
 
 

--- a/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
+++ b/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
@@ -52,7 +52,7 @@ class ConfigurableAnalysis : public edm::EDFilter {
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
       virtual void endJob() override ;
 
-  Selections * selections_;
+  FilterSelections * selections_;
   Plotter * plotter_;
   NTupler * ntupler_;
 
@@ -85,7 +85,7 @@ ConfigurableAnalysis::ConfigurableAnalysis(const edm::ParameterSet& iConfig) :
   edm::Service<VariableHelperService>()->init(moduleLabel,iConfig.getParameter<edm::ParameterSet>("Variables"), consumesCollector());
 
   //list of selections
-  selections_ = new Selections(iConfig.getParameter<edm::ParameterSet>("Selections"), consumesCollector());
+  selections_ = new FilterSelections(iConfig.getParameter<edm::ParameterSet>("Selections"), consumesCollector());
 
   //plotting device
   edm::ParameterSet plotPset = iConfig.getParameter<edm::ParameterSet>("Plotter");
@@ -134,7 +134,7 @@ bool ConfigurableAnalysis::filter(edm::Event& iEvent, const edm::EventSetup& iSe
   bool filledOnce=false;
 
   // loop the requested selections
-  for (Selections::iterator selection=selections_->begin(); selection!=selections_->end();++selection){
+  for (FilterSelections::iterator selection=selections_->begin(); selection!=selections_->end();++selection){
     //was this flow of filter actually asked for
     bool skip=true;
     unsigned int iFlow=0;
@@ -158,7 +158,7 @@ bool ConfigurableAnalysis::filter(edm::Event& iEvent, const edm::EventSetup& iSe
       plotter_->fill(fullContent,iEvent);
 
     //loop the filters to make cumulative and allButOne job
-    for (Selection::iterator filterIt=selection->begin(); filterIt!=selection->end();++filterIt){
+    for (FilterSelection::iterator filterIt=selection->begin(); filterIt!=selection->end();++filterIt){
       SFilter & filter = (*filterIt);
       //      bool lastCut=((filterIt+1)==selection->end());
 


### PR DESCRIPTION
We include MessageLogger.h because we use edm::LogVerbatim in this
header and this way it can compile on its own.

We renamed Selection to FilterSelection because we already have
a Selection class in CommonTools/Utils/interface/Selection.h,
which is breaking the One Definition Rule and breaks the C++
modules builds (and can also break the normal CMSSW builds).