### PR TITLE
ForOnlineDQM : Tune L1T Muon Mismatch Ratio QTs - Backport CMSSW_9_2_3

### DIFF
--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml
@@ -1,0 +1,20 @@
+<TESTSCONFIGURATION>
+
+  <!-- BMTF Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="BMTFDE_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2BMTF/mismatchRatio">
+      <TestName activate="true">BMTFDE_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml
@@ -1,0 +1,48 @@
+<TESTSCONFIGURATION>
+
+  <!-- BMTF HW pT -->
+
+  <QTEST name="BMTF_hwPtRange">
+    <TYPE>ContentsXRange</TYPE> 
+    <PARAM name="xmin">6</PARAM>
+    <PARAM name="xmax">511</PARAM>
+    <PARAM name="error">0.98</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  <QTEST name="BMTF_hwPtSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2BMTF/bmtf_hwPt">
+      <TestName activate="true">BMTF_hwPtRange</TestName>
+      <TestName activate="true">BMTF_hwPtSpectrum</TestName>
+  </LINK>
+
+  <!-- BMTF WEDGE vs BX -->
+
+  <QTEST name="BMTF_WedgeBXSpectrum">
+    <TYPE>Comp2Ref2DChi2</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+    <PARAM name="minEntries">60</PARAM>
+  </QTEST>
+
+  <QTEST name="BMTF_WedgeBXNoisyWedge">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">10</PARAM>
+    <PARAM name="neighbours">1</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2BMTF/bmtf_wedge_bx">
+      <TestName activate="true">BMTF_WedgeBXSpectrum</TestName>
+      <TestName activate="true">BMTF_WedgeBXNoisyWedge</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml
@@ -1,0 +1,20 @@
+<TESTSCONFIGURATION>
+
+  <!-- EMTF Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="EMTFDE_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2EMTF/mismatchRatio">
+      <TestName activate="true">EMTFDE_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml
@@ -1,0 +1,48 @@
+<TESTSCONFIGURATION>
+
+  <!-- EMTF Hit Occupancy -->
+
+  <QTEST name="EMTF_HitOccupancyDeadChamber">
+    <TYPE>DeadChannel</TYPE>	
+    <PARAM name="threshold">0</PARAM>
+    <PARAM name="error">0.60</PARAM>
+    <PARAM name="warning">0.80</PARAM>
+  </QTEST>
+
+  <QTEST name="EMTF_HitOccupancyNoisyChamber">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">20</PARAM>
+    <PARAM name="neighbours">9</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2EMTF/emtfHitOccupancy">
+      <TestName activate="true">EMTF_HitOccupancyDeadChamber</TestName>
+      <TestName activate="true">EMTF_HitOccupancyNoisyChamber</TestName>
+  </LINK>
+
+  <!-- EMTF Track BX -->
+
+  <QTEST name="EMTF_TrackBXSpectrum">
+    <TYPE>Comp2Ref2DChi2</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+    <PARAM name="minEntries">96</PARAM>
+  </QTEST>
+
+  <QTEST name="EMTF_TrackBXNoisyTrack">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">10</PARAM>
+    <PARAM name="neighbours">1</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2EMTF/emtfTrackBX">
+      <TestName activate="true">EMTF_TrackBXSpectrum</TestName>
+      <TestName activate="true">EMTF_TrackBXNoisyTrack</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml
@@ -1,0 +1,20 @@
+<TESTSCONFIGURATION>
+
+  <!-- OMTF Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="OMTFDE_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2OMTF/mismatchRatio">
+      <TestName activate="true">OMTFDE_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2OMTFQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2OMTFQualityTests.xml
@@ -1,0 +1,6 @@
+<TESTSCONFIGURATION>
+
+  <!-- Placeholder for OMTF Quality Tests -->
+
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
@@ -1,0 +1,35 @@
+<TESTSCONFIGURATION>
+
+  <!-- uGMT Data vs Emulator -->
+
+  <!-- Mismatch Summary QTest -->
+
+  <QTEST name="uGMTDE_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio">
+      <TestName activate="true">uGMTDE_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- Intermediate Muons QTest -->
+
+  <QTEST name="InterMuonsDE_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="L1TEMU/L1TdeStage2uGMT/intermediate_muons/*/data_vs_emulator_comparison/mismatchRatio">
+      <TestName activate="true">InterMuonsDE_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml
@@ -4,32 +4,32 @@
 
   <!-- Mismatch Summary QTest -->
 
-  <QTEST name="uGMTDE_MismatchRatioMax0p05">
+  <QTEST name="uGMTDE_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio">
-      <TestName activate="true">uGMTDE_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTDE_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- Intermediate Muons QTest -->
 
-  <QTEST name="InterMuonsDE_MismatchRatioMax0p05">
+  <QTEST name="InterMuonsDE_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="L1TEMU/L1TdeStage2uGMT/intermediate_muons/*/data_vs_emulator_comparison/mismatchRatio">
-      <TestName activate="true">InterMuonsDE_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">InterMuonsDE_MismatchRatioMax0</TestName>
   </LINK>
 
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -373,62 +373,62 @@
 
   <!-- uGMT Output vs uGT Input -->
 
-  <QTEST name="uGMTvsuGT_MismatchRatioMax0p05">
+  <QTEST name="uGMTvsuGT_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio">
-      <TestName activate="true">uGMTvsuGT_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTvsuGT_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- BMTF Output vs uGMT Input -->
 
-  <QTEST name="BMTFvsuGMT_MismatchRatioMax0p05">
+  <QTEST name="BMTFvsuGMT_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio">
-      <TestName activate="true">BMTFvsuGMT_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">BMTFvsuGMT_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- EMTF Output vs uGMT Input -->
 
-  <QTEST name="EMTFvsuGMT_MismatchRatioMax0p05">
+  <QTEST name="EMTFvsuGMT_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
 
   <LINK name="*/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio">
-      <TestName activate="true">EMTFvsuGMT_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">EMTFvsuGMT_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- uGMT Muon Copy vs uGMT Muon -->
 
-  <QTEST name="uGMTCopies_MismatchRatioMax0p05">
+  <QTEST name="uGMTCopies_MismatchRatioMax0">
     <TYPE>ContentsYRange</TYPE>	
     <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
     <PARAM name="error">0.95</PARAM>
     <PARAM name="warning">0.99</PARAM>
     <PARAM name="useEmptyBins">1</PARAM>
   </QTEST>
   
   <LINK name="*/L1TStage2uGMT/uGMTMuonCopies/*/mismatchRatio">
-      <TestName activate="true">uGMTCopies_MismatchRatioMax0p05</TestName>
+      <TestName activate="true">uGMTCopies_MismatchRatioMax0</TestName>
   </LINK>
 
   <!-- Bad Zero Suppression Rates -->

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -1,0 +1,449 @@
+<TESTSCONFIGURATION>
+
+  <!-- uGMT Muon Quality Tests -->
+
+  <!-- uGMT Muon BX -->
+
+  <QTEST name="uGMT_MuonBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_MuonBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
+    <PARAM name="error">0.4</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="minEntries">20</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonBX">
+      <TestName activate="true">uGMT_MuonBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_MuonBXMeanAtBX0</TestName>
+  </LINK>
+
+  <!-- uGMT Muon Eta -->
+
+  <QTEST name="uGMT_MuonEtaSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_MuonEtaMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">200</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonEta">
+      <TestName activate="true">uGMT_MuonEtaSpectrum</TestName>
+      <TestName activate="true">uGMT_MuonEtaMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT Muon pT -->
+
+  <QTEST name="uGMT_MuonPtRange">
+    <TYPE>ContentsXRange</TYPE> 
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">256</PARAM>
+    <PARAM name="error">0.98</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_MuonPtSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonPt">
+      <TestName activate="true">uGMT_MuonPtRange</TestName>
+      <TestName activate="true">uGMT_MuonPtSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT Muon Phi-Eta -->
+
+  <QTEST name="uGMT_MuonPhivsEtaSpectrum">
+    <TYPE>Comp2Ref2DChi2</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.01</PARAM>
+    <PARAM name="warning">0.30</PARAM>
+    <PARAM name="minEntries">3100</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonPhivsEta">
+      <TestName activate="true">uGMT_MuonPhivsEtaSpectrum</TestName>
+  </LINK>
+
+
+  <!-- uGMT BMTF Quality Tests -->
+
+  <!-- uGMT BMTF BX -->
+
+  <QTEST name="uGMT_BMTFBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+  <TestName activate="true">uGMTBMTFBXPeakAtBX0</TestName>
+
+  <QTEST name="uGMT_BMTFBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.15</PARAM>
+    <PARAM name="xmax">0.15</PARAM>
+    <PARAM name="error">0.4</PARAM>
+    <PARAM name="warning">0.5</PARAM>
+    <PARAM name="minEntries">10</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFBX">
+      <TestName activate="true">uGMT_BMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_BMTFBXMeanAtBX0</TestName>
+  </LINK>
+
+
+  <!-- uGMT BMTF Global HW Phi -->
+
+  <QTEST name="uGMT_BMTFhwPhiSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFglbhwPhi">
+      <TestName activate="true">uGMT_BMTFhwPhiSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT BMTF HW Eta -->
+
+  <QTEST name="uGMT_BMTFhwEtaSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_BMTFhwEtaMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-5.0</PARAM>
+    <PARAM name="xmax">5.0</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">200</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFhwEta">
+      <TestName activate="true">uGMT_BMTFhwEtaSpectrum</TestName>
+      <TestName activate="true">uGMT_BMTFhwEtaMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT BMTF HW Sign -->
+
+  <QTEST name="uGMT_BMTFhwSignUniform">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">0.3</PARAM>
+    <PARAM name="neighbours">2</PARAM>
+    <PARAM name="error">0.996</PARAM>
+    <PARAM name="warning">0.999</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtBMTFhwSign">
+      <TestName activate="true">uGMT_BMTFhwSignUniform</TestName>
+  </LINK>
+
+
+  <!-- uGMT OMTF Quality Tests -->
+
+  <!-- uGMT OMTF BX -->
+
+  <QTEST name="uGMT_OMTFBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_OMTFBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.05</PARAM>
+    <PARAM name="xmax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">20</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFBX">
+      <TestName activate="true">uGMT_OMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_OMTFBXMeanAtBX0</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF Global HW Phi Negative Side -->
+
+  <QTEST name="uGMT_OMTFhwPhiNegSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFglbhwPhiNeg">
+      <TestName activate="true">uGMT_OMTFhwPhiNegSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF Global HW Phi Positive Side -->
+
+  <QTEST name="uGMT_OMTFhwPhiPosSpectrum" activate="true">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFglbhwPhiPos">
+      <TestName activate="true">uGMT_OMTFhwPhiPosSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF HW Eta -->
+
+  <QTEST name="uGMT_OMTFhwEtaSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_OMTFhwEtaMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-5.0</PARAM>
+    <PARAM name="xmax">5.0</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">200</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwEta">
+      <TestName activate="true">uGMT_OMTFhwEtaSpectrum</TestName>
+      <TestName activate="true">uGMT_OMTFhwEtaMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF HW pT -->
+
+  <QTEST name="uGMT_OMTFhwPtRange">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">511</PARAM>
+    <PARAM name="error">0.98</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_OMTFhwPtSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.70</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwPt">
+      <TestName activate="true">uGMT_OMTFhwPtRange</TestName>
+      <TestName activate="true">uGMT_OMTFhwPtSpectrum</TestName>
+  </LINK>
+
+  <!-- uGMT OMTF HW Sign -->
+
+  <QTEST name="uGMT_OMTFhwSignUniform">
+    <TYPE>NoisyChannel</TYPE>	
+    <PARAM name="tolerance">0.3</PARAM>
+    <PARAM name="neighbours">2</PARAM>
+    <PARAM name="error">0.96</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtOMTFhwSign">
+      <TestName activate="true">uGMT_OMTFhwSignUniform</TestName>
+  </LINK>
+
+
+  <!-- uGMT EMTF Quality Tests -->
+
+  <!-- uGMT EMTF BX -->
+
+  <QTEST name="uGMT_EMTFBXPeakAtBX0">
+    <TYPE>ContentsXRange</TYPE>	
+    <PARAM name="xmin">0</PARAM>
+    <PARAM name="xmax">0</PARAM>
+    <PARAM name="error">0.30</PARAM>
+    <PARAM name="warning">0.60</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_EMTFBXMeanAtBX0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.05</PARAM>
+    <PARAM name="xmax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">20</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/*/ugmtEMTFBX">
+      <TestName activate="true">uGMT_EMTFBXPeakAtBX0</TestName>
+      <TestName activate="true">uGMT_EMTFBXMeanAtBX0</TestName>
+  </LINK>
+
+  <!-- uGMT EMTF Muon Phi -->
+
+  <QTEST name="uGMT_EMTFMuonPhiSpectrum">
+    <TYPE>Comp2RefKolmogorov</TYPE>	
+    <PARAM name="testparam">0</PARAM>
+    <PARAM name="error">0.10</PARAM>
+    <PARAM name="warning">0.50</PARAM>
+  </QTEST>
+
+  <QTEST name="uGMT_EMTFMuonPhiMeanAt0">
+    <TYPE>MeanWithinExpected</TYPE>
+    <PARAM name="mean">0.0</PARAM>
+    <PARAM name="useRMS">0</PARAM>
+    <PARAM name="useSigma">0</PARAM>
+    <PARAM name="useRange">1</PARAM>
+    <PARAM name="xmin">-0.2</PARAM>
+    <PARAM name="xmax">0.2</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="minEntries">128</PARAM>
+  </QTEST>
+
+  
+  <LINK name="*/L1TStage2uGMT/ugmtMuonPhiEmtf">
+      <TestName activate="true">uGMT_EMTFMuonPhiSpectrum</TestName>
+      <TestName activate="true">uGMT_EMTFMuonPhiMeanAt0</TestName>
+  </LINK>
+
+  <!-- uGMT Mismatch Summary QTest -->
+
+  <!-- uGMT Output vs uGT Input -->
+
+  <QTEST name="uGMTvsuGT_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio">
+      <TestName activate="true">uGMTvsuGT_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- BMTF Output vs uGMT Input -->
+
+  <QTEST name="BMTFvsuGMT_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio">
+      <TestName activate="true">BMTFvsuGMT_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- EMTF Output vs uGMT Input -->
+
+  <QTEST name="EMTFvsuGMT_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+
+  <LINK name="*/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio">
+      <TestName activate="true">EMTFvsuGMT_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- uGMT Muon Copy vs uGMT Muon -->
+
+  <QTEST name="uGMTCopies_MismatchRatioMax0p05">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.05</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/uGMTMuonCopies/*/mismatchRatio">
+      <TestName activate="true">uGMTCopies_MismatchRatioMax0p05</TestName>
+  </LINK>
+
+  <!-- Bad Zero Suppression Rates -->
+
+  <QTEST name="zeroSupp_MismatchRatioMax0">
+    <TYPE>ContentsYRange</TYPE>	
+    <PARAM name="ymin">0.00</PARAM>
+    <PARAM name="ymax">0.00</PARAM>
+    <PARAM name="error">0.95</PARAM>
+    <PARAM name="warning">0.99</PARAM>
+    <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  
+  <LINK name="*/L1TStage2uGMT/zeroSuppression/*/mismatchRatio">
+      <TestName activate="true">zeroSupp_MismatchRatioMax0</TestName>
+  </LINK>
+
+</TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TStage2RatioClient.h
@@ -32,6 +32,7 @@ class L1TStage2RatioClient: public DQMEDHarvester
     std::string ratioTitle_;
     std::string yAxisTitle_;
     bool binomialErr_;
+    std::vector<int> ignoreBin_;
 
     MonitorElement* ratioME_;
 };

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 BMTF Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2BMTFDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2BMTFDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2BMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2BMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2BMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2BMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 BMTF 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2BMTFQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2BMTFQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 EMTF Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2EMTFDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2EMTFDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2EMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2EMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2EMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2EMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2EMTFQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EMTFQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 EMTF 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2EMTFQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2EMTFQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
@@ -129,32 +129,32 @@ l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/BMTF/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorEventInfoClient_cfi.py
@@ -1,0 +1,196 @@
+# L1 Emulator Trigger Event Info client cfi
+#
+#   The cfi can be used, with appropriate settings, for both L1T and L1TEMU.
+#   Default version in cfi: L1T event client
+#
+#   authors previous versions - see CVS
+#
+#   V.M. Ghete 2010-10-22 revised version of L1T DQM and L1TEMU DQM
+#   A.G. Stahl 2017-06-02 first implementation for L1TEMU Stage2 DQM
+
+
+
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+l1tStage2EmulatorEventInfoClient = DQMEDHarvester("L1TEventInfoClient",
+    monitorDir = cms.untracked.string("L1TEMU"),
+
+    # decide when to run and update the results of the quality tests
+    # retrieval of quality test results must be consistent with the event / LS / Run execution
+    #
+    runInEventLoop=cms.untracked.bool(False),
+    runInEndLumi=cms.untracked.bool(True),
+    runInEndRun=cms.untracked.bool(True),
+    runInEndJob=cms.untracked.bool(False),
+
+    #
+    # for each L1 system, give:
+    #     - SystemLabel:  system label
+    #     - HwValLabel:   system label as used in hardware validation package
+    #                     (the package producing the ErrorFlag histogram)
+    #     - SystemDisable:   system disabled: if 1, all quality tests for the system
+    #                     are disabled in the summary plot
+    #     - for each quality test:
+    #         - QualityTestName: name of quality test
+    #         - QualityTestHist: histogram (full path)
+    #         - QualityTestSummaryEnabled: 0 if disabled, 1 if enabled in summary plot
+    #
+    # the position in the parameter set gives, in reverse order, the position in the reportSummaryMap
+    # in the emulator column (left column)
+    L1Systems = cms.VPSet(
+                    cms.PSet(
+                        SystemLabel = cms.string("ECAL_TPG"),
+                        HwValLabel = cms.string("ETP"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("HCAL_TPG"),
+                        HwValLabel = cms.string("HTP"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("Calo Layer1"),
+                        HwValLabel = cms.string("Stage2CaloLayer1"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("Calo Layer2"),
+                        HwValLabel = cms.string("Stage2CaloLayer2"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("BMTF"),
+                        HwValLabel = cms.string("Stage2BMTF"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTFDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2BMTF/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("OMTF"),
+                        HwValLabel = cms.string("Stage2OMTF"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("OMTFDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2OMTF/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("EMTF"),
+                        HwValLabel = cms.string("Stage2EMTF"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTFDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2EMTF/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("uGMT"),
+                        HwValLabel = cms.string("Stage2uGMT"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/BMTF/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/OMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_pos/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("InterMuonsDE_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1TEMU/L1TdeStage2uGMT/intermediate_muons/EMTF_neg/data_vs_emulator_comparison/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            )
+                        ),
+                    cms.PSet(
+                        SystemLabel = cms.string("uGT"),
+                        HwValLabel = cms.string("Stage2uGT"),
+                        SystemDisable  = cms.uint32(0),
+                        QualityTests = cms.VPSet(
+                            cms.PSet(
+                                QualityTestName = cms.string(""),
+                                QualityTestHist = cms.string(""),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            )
+                        ),
+                    ),
+
+    #
+    # for each L1 trigger object, give:
+    #     - ObjectLabel:  object label as used in enum L1GtObject
+    #     - ObjectDisable: emulator mask: if 1, the system is masked in the summary plot
+    #
+    # the position in the parameter set gives, in reverse order, the position in the reportSummaryMap
+    # in the trigger object column (right column)
+    L1Objects = cms.VPSet(),
+    #
+    # fast over-mask a system: if the name of the system is in the list, the system will be masked
+    # (the default mask value is given in L1Systems VPSet)
+    #
+    DisableL1Systems = cms.vstring(),
+    #
+    # fast over-mask an object: if the name of the object is in the list, the object will be masked
+    # (the default mask value is given in L1Objects VPSet)
+    #
+    DisableL1Objects =  cms.vstring()
+
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorMonitorClient_cff.py
@@ -14,8 +14,7 @@ import FWCore.ParameterSet.Config as cms
 #                       
 
 # DQM quality tests 
-# TODO: emulator QT
-#from DQM.L1TMonitorClient.L1TStage2EmulatorQualityTests_cff import *
+from DQM.L1TMonitorClient.L1TStage2EmulatorQualityTests_cff import *
 
 # Calo trigger layer2 client
 from DQM.L1TMonitorClient.L1TStage2CaloLayer2DEClient_cfi import *
@@ -33,8 +32,7 @@ from DQM.L1TMonitorClient.L1TStage2OMTFEmulatorClient_cff import *
 from DQM.L1TMonitorClient.L1TStage2EMTFEmulatorClient_cff import *
 
 # L1 emulator event info DQM client 
-# TODO: emulator summaryMap
-#from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
+from DQM.L1TMonitorClient.L1TStage2EmulatorEventInfoClient_cfi import *
 
 
 #
@@ -48,11 +46,11 @@ l1TStage2EmulatorClients = cms.Sequence(
                       + l1tStage2BMTFEmulatorClient
                       + l1tStage2OMTFEmulatorClient
                       + l1tStage2EMTFEmulatorClient
-                        # l1tStage2EmulatorEventInfoClient 
+                      + l1tStage2EmulatorEventInfoClient 
                         )
 
 l1tStage2EmulatorMonitorClient = cms.Sequence(
-                        # l1TStage2EmulatorQualityTests +
+                        l1TStage2EmulatorQualityTests +
                         l1TStage2EmulatorClients
                         )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2EmulatorQualityTests_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EmulatorQualityTests_cff.py
@@ -1,0 +1,32 @@
+# Quality tests for L1 Emulator DQM (L1T)
+
+import FWCore.ParameterSet.Config as cms
+
+# L1 systems quality tests
+
+# Stage 2 L1 Emulator Quality tests
+from DQM.L1TMonitorClient.L1TStage2uGMTDEQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2BMTFDEQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2OMTFDEQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2EMTFDEQualityTests_cfi import *
+
+# L1 objects quality tests
+
+# sequence for L1 systems
+l1TEmulatorSystemQualityTests = cms.Sequence(
+                                  l1TStage2uGMTDEQualityTests +
+                                  l1TStage2BMTFDEQualityTests +
+                                  l1TStage2OMTFDEQualityTests +
+                                  l1TStage2EMTFDEQualityTests
+                                  )
+
+# sequence for L1 objects
+l1TEmulatorObjectQualityTests = cms.Sequence(
+                                  )
+
+
+# general sequence
+l1TStage2EmulatorQualityTests = cms.Sequence(
+                                              l1TEmulatorSystemQualityTests + 
+                                              l1TEmulatorObjectQualityTests
+                                              )

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -258,42 +258,42 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTvsuGT_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTvsuGT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("BMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("BMTFvsuGMT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/GMTMuonCopy1/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             cms.PSet(
-                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0"),
                                 QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/mismatchRatio"),
                                 QualityTestSummaryEnabled = cms.uint32(1)
                                 ),

--- a/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2EventInfoClient_cfi.py
@@ -107,8 +107,23 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
+                                QualityTestName = cms.string("BMTF_hwPtRange"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_hwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTF_hwPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_hwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTF_WedgeBXNoisyWedge"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTF_WedgeBXSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2BMTF/bmtf_wedge_bx"),
                                 QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             )
@@ -131,8 +146,23 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
+                                QualityTestName = cms.string("EMTF_HitOccupancyDeadChambe"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfHitOccupancy"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTF_HitOccupancyNoisyChamber"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfHitOccupancy"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTF_TrackBXNoisyTrack"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfTrackBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTF_TrackBXSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2EMTF/emtfTrackBX"),
                                 QualityTestSummaryEnabled = cms.uint32(0)
                                 ),
                             )
@@ -143,9 +173,139 @@ l1tStage2EventInfoClient = DQMEDHarvester("L1TEventInfoClient",
                         SystemDisable  = cms.uint32(0),
                         QualityTests = cms.VPSet(
                             cms.PSet(
-                                QualityTestName = cms.string(""),
-                                QualityTestHist = cms.string(""),
+                                QualityTestName = cms.string("uGMT_MuonBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonEtaMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonEta"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonPtRange"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPt"),
                                 QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_MuonPhivsEtaSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhivsEta"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFhwPhiSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFglbhwPhi"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFhwEtaMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFhwEta"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_BMTFhwSignUniform"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFInput/ugmtBMTFhwSign"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwPhiPosSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiPos"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwEtaMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwEta"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwPtRange"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwPtSpectrum"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"),
+                                QualityTestSummaryEnabled = cms.uint32(0)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_OMTFhwSignUniform"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/OMTFInput/ugmtOMTFhwSign"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_EMTFBXMeanAtBX0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFInput/ugmtEMTFBX"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMT_EMTFMuonPhiMeanAt0"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/ugmtMuonPhiEmtf"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTvsuGT_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMToutput_vs_uGTinput/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("BMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/BMTFoutput_vs_uGMTinput/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("EMTFvsuGMT_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/GMTMuonCopy1/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("uGMTCopies_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
+                                ),
+                            cms.PSet(
+                                QualityTestName = cms.string("zeroSupp_MismatchRatioMax0p05"),
+                                QualityTestHist = cms.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts/mismatchRatio"),
+                                QualityTestSummaryEnabled = cms.uint32(1)
                                 ),
                             )
                         ),

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 OMTF Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2OMTFDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2OMTFDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -9,7 +9,8 @@ l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between OMTF muons and OMTF emulator muons'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
+    binomialErr = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(1)
 )
 
 # sequences

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFEmulatorClient_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # RegionalMuonCands
-l1tStage2OMTFEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2OMTFEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string('L1TEMU/L1TdeStage2OMTF'),
     inputNum = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryNum'),
     inputDen = cms.untracked.string('L1TEMU/L1TdeStage2OMTF/errorSummaryDen'),

--- a/DQM/L1TMonitorClient/python/L1TStage2OMTFQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2OMTFQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 OMTF 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2OMTFQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2OMTFQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2QualityTests_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2QualityTests_cff.py
@@ -6,12 +6,18 @@ import FWCore.ParameterSet.Config as cms
 
 # Stage 2 L1 Trigger Quality tests
 from DQM.L1TMonitorClient.L1TStage2CaloLayer1QualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2uGMTQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2BMTFQualityTests_cfi import *
+from DQM.L1TMonitorClient.L1TStage2EMTFQualityTests_cfi import *
 
 # L1 objects quality tests
 
 # sequence for L1 systems
 l1TriggerSystemQualityTests = cms.Sequence(
-                                l1TStage2CaloLayer1QualityTests
+                                l1TStage2CaloLayer1QualityTests +
+                                l1TStage2uGMTQualityTests +
+                                l1TStage2BMTFQualityTests +
+                                l1TStage2EMTFQualityTests
                                 )
 
 # sequence for L1 objects

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -56,6 +56,7 @@ l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir
 l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr)
 l1tStage2BmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF')
+l1tStage2BmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(1)
 
 l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTOutVsuGTInRatioClient.clone()
 l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput')

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # directory path shortening
 ugmtDqmDir = 'L1T/L1TStage2uGMT'
@@ -9,7 +10,7 @@ errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
 
 # Muons
-l1tStage2uGMTOutVsuGTInRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2uGMTOutVsuGTInRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput'),
     inputNum = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistNumStr),
     inputDen = cms.untracked.string(ugmtDqmDir+'/uGMToutput_vs_uGTinput/'+errHistDenStr),

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTDEQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTDEQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 uGMT Data vs Emulator 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2uGMTDEQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2uGMTDEQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 # directories
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
@@ -9,7 +10,7 @@ errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
 
 # Muons
-l1tStage2uGMTEmulatorCompRatioClient = cms.EDAnalyzer("L1TStage2RatioClient",
+l1tStage2uGMTEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtEmuDEDqmDir),
     inputNum = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistNumStr),
     inputDen = cms.untracked.string(ugmtEmuDEDqmDir+'/'+errHistDenStr),

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -27,30 +27,35 @@ l1tStage2uGMTEmulImdMuBMTFCompRatioClient.monitorDir = cms.untracked.string(ugmt
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'BMTF')
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF-')
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF+')
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF-')
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF+')
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(7, 8, 12, 13)
 
 # sequences
 l1tStage2uGMTEmulatorClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTQualityTests_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTQualityTests_cfi.py
@@ -1,0 +1,15 @@
+# quality tests for L1T Stage2 uGMT 
+ 
+import FWCore.ParameterSet.Config as cms
+
+l1TStage2uGMTQualityTests = cms.EDAnalyzer("QualityTester",
+    qtList=cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml'),
+    QualityTestPrescaler=cms.untracked.int32(1),
+    getQualityTestsFromFile=cms.untracked.bool(True),
+    testInEventloop=cms.untracked.bool(False),
+    qtestOnEndLumi=cms.untracked.bool(True),
+    qtestOnEndRun=cms.untracked.bool(True),
+    qtestOnEndJob=cms.untracked.bool(False),
+    reportThreshold=cms.untracked.string(""),
+    verboseQT=cms.untracked.bool(True)
+)

--- a/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TStage2RatioClient.cc
@@ -7,7 +7,8 @@ L1TStage2RatioClient::L1TStage2RatioClient(const edm::ParameterSet& ps):
   ratioName_(ps.getUntrackedParameter<std::string>("ratioName")),
   ratioTitle_(ps.getUntrackedParameter<std::string>("ratioTitle")),
   yAxisTitle_(ps.getUntrackedParameter<std::string>("yAxisTitle")),
-  binomialErr_(ps.getUntrackedParameter<bool>("binomialErr"))
+  binomialErr_(ps.getUntrackedParameter<bool>("binomialErr")),
+  ignoreBin_(ps.getUntrackedParameter<std::vector<int>>("ignoreBin"))
 {
 }
 
@@ -23,6 +24,7 @@ void L1TStage2RatioClient::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.addUntracked<std::string>("ratioTitle", "ratio")->setComment("Ratio plot title.");
   desc.addUntracked<std::string>("yAxisTitle", "")->setComment("Title of y axis.");
   desc.addUntracked<bool>("binomialErr", "true")->setComment("Compute binomial errors.");
+  desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore. Will set their ratio to 0.");
   descriptions.add("l1TStage2RatioClient", desc);
 }
 
@@ -71,6 +73,14 @@ void L1TStage2RatioClient::processHistograms(DQMStore::IGetter& igetter)
     }
      
     hRatio->Divide(hNum, hDen, 1, 1, errOption.c_str());
+
+    // Set the ratio to 0 for those bins that need to be ignored
+    for (const int & bin : ignoreBin_) {
+      if (bin > 0 && bin <= hRatio->GetNbinsX()) {
+        hRatio->SetBinContent(bin, 0.0);
+        hRatio->GetXaxis()->SetBinLabel(bin, "Ignored");
+      }
+    }
 
     delete hDen;
   }


### PR DESCRIPTION
This is a backport of https://github.com/cms-sw/cmssw/pull/19311 to CMSSW_9_2_3 for DQM integration. 


