### PR TITLE
Add include to Fraction.h to SimplifyNumerical.h

### DIFF
--- a/PhysicsTools/Utilities/interface/SimplifyNumerical.h
+++ b/PhysicsTools/Utilities/interface/SimplifyNumerical.h
@@ -1,5 +1,6 @@
 #ifndef PhysicsTools_Utilities_SimplifyNumerical_h
 #define PhysicsTools_Utilities_SimplifyNumerical_h
+#include "PhysicsTools/Utilities/interface/Fraction.h"
 #include "PhysicsTools/Utilities/interface/Numerical.h"
 #include "PhysicsTools/Utilities/interface/Operations.h"
 


### PR DESCRIPTION
We access the Fraction class in the struct NumPower, so we also
need to include the Fraction.h header to make sure this file
compiles on its own.