### PR TITLE
Add include for Ratio.h to SimplifyLogExp.h

### DIFF
--- a/PhysicsTools/Utilities/interface/SimplifyLogExp.h
+++ b/PhysicsTools/Utilities/interface/SimplifyLogExp.h
@@ -7,6 +7,7 @@
 #include "PhysicsTools/Utilities/interface/Product.h"
 #include "PhysicsTools/Utilities/interface/Sum.h"
 #include "PhysicsTools/Utilities/interface/Difference.h"
+#include "PhysicsTools/Utilities/interface/Ratio.h"
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
 


### PR DESCRIPTION
The RATIO_S macro in this header expands to RatioStruct, which
we first need to import by including Ratio.h to make this
file compile on its own.