### PR TITLE
Add iostream include to LumiReweightingStandalone.h

### DIFF
--- a/PhysicsTools/Utilities/interface/LumiReweightingStandAlone.h
+++ b/PhysicsTools/Utilities/interface/LumiReweightingStandAlone.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <cmath>
 #include <algorithm>
+#include <iostream>
 
 namespace reweight {
 


### PR DESCRIPTION
We use std::cout in this file, so we also need to include iostream
to make this header compile on its own.