### PR TITLE
Fix includes TwoObjectCalculator.h

### DIFF
--- a/PhysicsTools/UtilAlgos/interface/TwoObjectCalculator.h
+++ b/PhysicsTools/UtilAlgos/interface/TwoObjectCalculator.h
@@ -1,6 +1,9 @@
 #ifndef CommonTools_UtilAlgos_TwoObjectCalculator_H
 #define CommonTools_UtilAlgos_TwoObjectCalculator_H
 
+#include <string>
+#include <cmath>
+
 struct CosDphiCalculator {
   template <typename LHS, typename RHS > double operator()( const LHS & lhs, const RHS & rhs){
     double cdphi = cos(lhs.phi()-rhs.phi());


### PR DESCRIPTION
We use std::string and std::cos in this header, so we also need to
include string/cmath to make this file compile on its own.