### PR TITLE
Add include for EDMException to HistoPdf.h

### DIFF
--- a/PhysicsTools/Utilities/interface/HistoPdf.h
+++ b/PhysicsTools/Utilities/interface/HistoPdf.h
@@ -1,5 +1,8 @@
 #ifndef PhysicsTools_Utilities_HistoPdf_h
 #define PhysicsTools_Utilities_HistoPdf_h
+
+#include "FWCore/Utilities/interface/EDMException.h"
+
 #include <iostream>
 #include "TH1.h"
 


### PR DESCRIPTION
We use edm::Exception in this header, so we also need to include
the relevant header to make this file compile on its own.