### PR TITLE
Fix includes in SimplifyRatio.h

### DIFF
--- a/PhysicsTools/Utilities/interface/SimplifyRatio.h
+++ b/PhysicsTools/Utilities/interface/SimplifyRatio.h
@@ -7,8 +7,11 @@
 #include "PhysicsTools/Utilities/interface/Minus.h"
 #include "PhysicsTools/Utilities/interface/Fraction.h"
 #include "PhysicsTools/Utilities/interface/DecomposePower.h"
+#include "PhysicsTools/Utilities/interface/ParametricTrait.h"
 
 #include "PhysicsTools/Utilities/interface/Simplify_begin.h"
+
+#include <boost/mpl/if.hpp>
 
 namespace funct {
 


### PR DESCRIPTION
We use ::boost::mpl::if_ in this file, so we also need to include
boost/mpl/if.hpp to get the definition.

We also used Parametric in this file, so we further need to include
ParametricTrait.h to get the definition of this file to make sure
this header compiles on its own.