### PR TITLE
Add include to Parameter.h to rootFunction.h

### DIFF
--- a/PhysicsTools/Utilities/interface/rootFunction.h
+++ b/PhysicsTools/Utilities/interface/rootFunction.h
@@ -1,6 +1,7 @@
 #ifndef PhysicsTools_Utilities_rootFunction_h
 #define PhysicsTools_Utilities_rootFunction_h
 #include "PhysicsTools/Utilities/interface/RootFunctionHelper.h"
+#include "PhysicsTools/Utilities/interface/Parameter.h"
 
 namespace root {
   template<unsigned int args, typename Tag, typename F>


### PR DESCRIPTION
We use funct::Parameter in this header, so we also need to include
the corresponding header Parameter.h to make sure this file compiles
on its own.