### PR TITLE
Add include to memory to GMTInternalMuonFwd.h

### DIFF
--- a/L1Trigger/L1TMuon/interface/GMTInternalMuonFwd.h
+++ b/L1Trigger/L1TMuon/interface/GMTInternalMuonFwd.h
@@ -3,6 +3,8 @@
 
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 
+#include <memory>
+
 namespace l1t {
   class GMTInternalMuon;
   typedef std::vector<GMTInternalMuon> GMTInternalMuonCollection;


### PR DESCRIPTION
We use std::shared_ptr in this file, so we also need to include
memory to make sure this file compiles on its own.