### PR TITLE
Add include to CandDecaySelector.h to ObjectSelector.h

### DIFF
--- a/CommonTools/CandAlgos/interface/CandDecaySelector.h
+++ b/CommonTools/CandAlgos/interface/CandDecaySelector.h
@@ -7,6 +7,7 @@
  */
 #include "DataFormats/Candidate/interface/CompositeRefCandidate.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
 
 namespace helper {
   class CandDecayStoreManager {

--- a/CommonTools/UtilAlgos/interface/ObjectSelector.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelector.h
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "CommonTools/CandAlgos/interface/CandDecaySelector.h"
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "CommonTools/UtilAlgos/interface/NonNullNumberSelector.h"
 #include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
@@ -61,7 +62,7 @@ private:
   bool filter(edm::Event& evt, const edm::EventSetup& es) {
     Init::init(selector_, evt, es);
     using namespace std;
-    edm::Handle<typename Selector::collection> source;
+    edm::Handle<OutputCollection> source;
     evt.getByToken(srcToken_, source);
     StoreManager manager(source);
     selector_.select(source, evt, es);


### PR DESCRIPTION
There is specialization for StoreManagerTrait in CandDecaySelector.h
that is sometimes selected in some headers that use ObjectSelector.h
(ObjectShallowCloneSelector.h and SingleObjectShallowCloneSelector.h
to be precise).

Previously clang/gcc wasn't aware of this specialization because it wasn't
directly included from those headers, but with C++ modules clang sees
the non-included specialization and requests us to include CandDecaySelector.h.