### PR TITLE
Remove Legacy Files

### DIFF
--- a/Alignment/APEEstimation/plugins/ApeEstimator.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimator.cc
@@ -67,7 +67,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/RadialStripTopology.h"
 //added by Ajay 6Nov 2014

--- a/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
+++ b/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
@@ -12,9 +12,6 @@
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 #include "CLHEP/Vector/RotationInterfaces.h" 
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-
 #include "Alignment/CommonAlignment/interface/AlignableBeamSpot.h"
 
 #include "FWCore/Utilities/interface/Exception.h"

--- a/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
+++ b/Alignment/CommonAlignment/src/AlignableBeamSpot.cc
@@ -13,7 +13,7 @@
 #include "CLHEP/Vector/RotationInterfaces.h" 
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Alignment/CommonAlignment/interface/AlignableBeamSpot.h"
 

--- a/Alignment/CommonAlignment/src/AlignableDet.cc
+++ b/Alignment/CommonAlignment/src/AlignableDet.cc
@@ -4,7 +4,6 @@
 #include "CLHEP/Vector/RotationInterfaces.h" 
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Alignment/CommonAlignment/interface/AlignableDet.h"
 

--- a/Alignment/CommonAlignment/src/AlignableDet.cc
+++ b/Alignment/CommonAlignment/src/AlignableDet.cc
@@ -4,7 +4,7 @@
 #include "CLHEP/Vector/RotationInterfaces.h" 
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Alignment/CommonAlignment/interface/AlignableDet.h"
 

--- a/Alignment/CommonAlignment/src/AlignableDetUnit.cc
+++ b/Alignment/CommonAlignment/src/AlignableDetUnit.cc
@@ -1,6 +1,6 @@
 #include "Alignment/CommonAlignment/interface/AlignableDetUnit.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"

--- a/Alignment/CommonAlignment/src/AlignableExtras.cc
+++ b/Alignment/CommonAlignment/src/AlignableExtras.cc
@@ -10,10 +10,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-// Geometry
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-
 // Alignment
 #include "Alignment/CommonAlignment/interface/AlignableBeamSpot.h"
 

--- a/Alignment/CommonAlignment/src/AlignableExtras.cc
+++ b/Alignment/CommonAlignment/src/AlignableExtras.cc
@@ -12,7 +12,7 @@
 
 // Geometry
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 // Alignment
 #include "Alignment/CommonAlignment/interface/AlignableBeamSpot.h"

--- a/Alignment/HIPAlignmentAlgorithm/interface/LhcTrackAnalyzer.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/LhcTrackAnalyzer.h
@@ -37,7 +37,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 

--- a/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
+++ b/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
@@ -27,7 +27,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include <Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h>
 #include <Geometry/Records/interface/TrackerDigiGeometryRecord.h>
 #include <MagneticField/Engine/interface/MagneticField.h>

--- a/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.cc
+++ b/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.cc
@@ -14,7 +14,7 @@
 #include "FWCore/Utilities/interface/EDMException.h" 
 #include "FWCore/MessageLogger/interface/MessageLogger.h" 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
 #include "DataFormats/DetId/interface/DetId.h" 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h" 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -54,7 +54,7 @@
 #include "DataFormats/Alignment/interface/TkFittedLasBeam.h"
 #include "Alignment/LaserAlignment/interface/TsosVectorCollection.h"
 
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include <Geometry/CommonDetUnit/interface/GeomDetType.h>
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
@@ -16,7 +16,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include <Geometry/CommonDetUnit/interface/GeomDetType.h>
 
 #include "Alignment/CommonAlignment/interface/Alignable.h"

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteerer.cc
@@ -31,7 +31,7 @@
 #include "Alignment/CommonAlignment/interface/AlignableExtras.h"
 // GF doubts the need of these includes from include checker campaign:
 #include <FWCore/Framework/interface/EventSetup.h> 
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h> 
+#include <Geometry/CommonDetUnit/interface/GeomDet.h> 
 #include <Geometry/CommonDetUnit/interface/GeomDetType.h> 
 #include <DataFormats/GeometrySurface/interface/LocalError.h> 
 #include <Geometry/DTGeometry/interface/DTLayer.h> 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
@@ -31,7 +31,7 @@
 #include "Alignment/CommonAlignment/interface/AlignableExtras.h"
 // GF doubts the need of these includes from include checker campaign:
 #include <FWCore/Framework/interface/EventSetup.h>
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include <Geometry/CommonDetUnit/interface/GeomDetType.h>
 #include <DataFormats/GeometrySurface/interface/LocalError.h>
 #include <Geometry/DTGeometry/interface/DTLayer.h>

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -40,7 +40,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
@@ -62,7 +62,6 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 // To access kinks and bows 
-#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
 

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
@@ -63,7 +63,7 @@
 
 // To access kinks and bows 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
 
 #include "CLHEP/Matrix/SymMatrix.h"

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -59,7 +59,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"

--- a/Alignment/OfflineValidation/src/TrackerValidationVariables.cc
+++ b/Alignment/OfflineValidation/src/TrackerValidationVariables.cc
@@ -10,7 +10,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/RadialStripTopology.h"
 

--- a/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
@@ -51,7 +51,6 @@
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 

--- a/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
@@ -51,7 +51,7 @@
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -5,7 +5,7 @@
 
 // geometry
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 
 // alignment

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -5,7 +5,6 @@
 
 // geometry
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 
 // alignment

--- a/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
+++ b/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
@@ -8,7 +8,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 
 using namespace reco;

--- a/CalibFormats/SiStripObjects/test/plugins/testSiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/test/plugins/testSiStripHashedDetId.cc
@@ -7,7 +7,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
@@ -11,7 +11,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 

--- a/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
+++ b/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
@@ -39,7 +39,7 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
@@ -14,7 +14,7 @@
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -50,7 +50,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
@@ -9,7 +9,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -16,7 +16,7 @@
 
 #include "CondFormats/RunInfo/interface/RunInfo.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -12,7 +12,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainRandomCalculator.cc
@@ -11,7 +11,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 

--- a/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowGainCalibration.h
@@ -27,7 +27,7 @@
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 

--- a/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDetInfoFileWriter.cc
@@ -11,7 +11,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -28,7 +28,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "CalibTracker/SiStripHitEfficiency/interface/TrajectoryAtInvalidHit.h"

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -29,7 +29,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"

--- a/CalibTracker/SiStripHitEfficiency/src/TrajectoryAtInvalidHit.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/TrajectoryAtInvalidHit.cc
@@ -2,7 +2,7 @@
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
@@ -19,7 +19,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.cc
@@ -11,7 +11,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"

--- a/Calibration/HcalCalibAlgos/plugins/ValidIsoTrkCalib.cc
+++ b/Calibration/HcalCalibAlgos/plugins/ValidIsoTrkCalib.cc
@@ -44,7 +44,7 @@ https://twiki.cern.ch/twiki/bin/view/CMS/ValidIsoTrkCalib
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "CondFormats/HcalObjects/interface/HcalRespCorrs.h"
 #include "CondFormats/DataRecord/interface/HcalRespCorrsRcd.h"
 

--- a/CondTools/SiPixel/test/SiPixelPerformanceSummaryBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelPerformanceSummaryBuilder.cc
@@ -6,7 +6,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripDetVOffFakeBuilder.cc
@@ -10,7 +10,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 

--- a/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
@@ -55,7 +55,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include <Geometry/CommonTopologies/interface/Topology.h>
 #include <Geometry/CommonTopologies/interface/StripTopology.h>
 #include <Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h>

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -30,7 +30,7 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -50,7 +50,7 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
@@ -35,7 +35,7 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/DQM/SiStripCommissioningDbClients/src/FineDelayHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/FineDelayHistosUsingDb.cc
@@ -8,7 +8,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include <Geometry/CommonTopologies/interface/Topology.h>
 #include <CondFormats/DataRecord/interface/SiStripFedCablingRcd.h>
 #include <CondFormats/SiStripObjects/interface/SiStripFedCabling.h>

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
@@ -63,7 +63,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include <Geometry/CommonTopologies/interface/Topology.h>
 #include <Geometry/CommonTopologies/interface/StripTopology.h>
 

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.cc
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.cc
@@ -9,7 +9,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/CommonTopologies/interface/Topology.h"

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -4,7 +4,7 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 /*  a Hit composed by a "single" measurement

--- a/DataFormats/TrackingRecHit/src/TrackingRecHit.cc
+++ b/DataFormats/TrackingRecHit/src/TrackingRecHit.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include <string>

--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
@@ -34,7 +34,7 @@
 #include "FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/GenericTransientTrackingRecHit.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"

--- a/FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h
+++ b/FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h
@@ -2,7 +2,7 @@
 
 #define FastSimulation_Tracking_TrajectorySeedHitCandidate_H_
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -6,7 +6,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 

--- a/FastSimulation/TrackingRecHitProducer/plugins/FastTrackerRecHitMatcher.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/FastTrackerRecHitMatcher.cc
@@ -18,7 +18,7 @@
 // geometry stuff
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"

--- a/FastSimulation/TrackingRecHitProducer/plugins/PixelBarrelTemplateSmearerPlugin.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/PixelBarrelTemplateSmearerPlugin.cc
@@ -6,7 +6,7 @@
 
 // Geometry
 //#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"

--- a/FastSimulation/TrackingRecHitProducer/plugins/PixelForwardTemplateSmearerPlugin.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/PixelForwardTemplateSmearerPlugin.cc
@@ -18,7 +18,7 @@
 
 // Geometry
 //#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"

--- a/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
@@ -15,7 +15,7 @@
 #include "FastSimulation/TrackingRecHitProducer/interface/TrackingRecHitProduct.h"
 
 // Geometry
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"

--- a/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
+++ b/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
@@ -13,7 +13,7 @@
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include "FastSimulation/TrajectoryManager/interface/InsideBoundsMeasurementEstimator.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/GeomPropagators/interface/HelixArbitraryPlaneCrossing.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 //#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/Geometry/CSCGeometry/interface/CSCLayer.h
+++ b/Geometry/CSCGeometry/interface/CSCLayer.h
@@ -11,7 +11,7 @@
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include <Geometry/CommonDetUnit/interface/GeomDetType.h>
 #include <Geometry/CSCGeometry/interface/CSCLayerGeometry.h>
 #include <Geometry/CSCGeometry/interface/CSCChamber.h>

--- a/Geometry/CSCGeometry/src/CSCGeometry.cc
+++ b/Geometry/CSCGeometry/src/CSCGeometry.cc
@@ -1,7 +1,7 @@
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCChamber.h"
 #include "Geometry/CSCGeometry/interface/CSCChamberSpecs.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
 

--- a/Geometry/CommonDetUnit/interface/DetPositioner.h
+++ b/Geometry/CommonDetUnit/interface/DetPositioner.h
@@ -2,7 +2,7 @@
 #define DetPositioner_H
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 /* A base class for classes which modify the positions/orientations of GeomDets.
  * The derived classes can call the methods moveGeomDet, rotateGeomDet, setGeomDetPosition,

--- a/Geometry/CommonDetUnit/interface/GeomDetUnit.h
+++ b/Geometry/CommonDetUnit/interface/GeomDetUnit.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/Geometry/CommonDetUnit/src/GeomDet.cc
+++ b/Geometry/CommonDetUnit/src/GeomDet.cc
@@ -37,7 +37,7 @@ bool GeomDet::setAlignmentPositionError (const AlignmentPositionError& ape)
   return ape.valid();
 }
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "FWCore/Utilities/interface/Exception.h"
 

--- a/Geometry/DTGeometry/interface/DTLayer.h
+++ b/Geometry/DTGeometry/interface/DTLayer.h
@@ -13,7 +13,7 @@
  */
 
 /* Base Class Headers */
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 /* Collaborating Class Declarations */
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"

--- a/Geometry/DTGeometry/src/DTGeometry.cc
+++ b/Geometry/DTGeometry/src/DTGeometry.cc
@@ -4,7 +4,7 @@
  */
 
 #include <Geometry/DTGeometry/interface/DTGeometry.h>
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 
 #include <algorithm>
 #include <iostream>

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -10,7 +10,7 @@
 #include <FWCore/Framework/interface/EventSetup.h>
 #include <FWCore/Framework/interface/ESHandle.h>
 
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 
 #include <Geometry/DTGeometry/interface/DTGeometry.h>
 #include <Geometry/Records/interface/MuonGeometryRecord.h>

--- a/Geometry/GEMGeometry/interface/GEMEtaPartition.h
+++ b/Geometry/GEMGeometry/interface/GEMEtaPartition.h
@@ -1,7 +1,7 @@
 #ifndef Geometry_GEMGeometry_GEMEtaPartition_H
 #define Geometry_GEMGeometry_GEMEtaPartition_H
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"

--- a/Geometry/GEMGeometry/interface/ME0EtaPartition.h
+++ b/Geometry/GEMGeometry/interface/ME0EtaPartition.h
@@ -1,7 +1,7 @@
 #ifndef Geometry_GEMGeometry_ME0EtaPartition_H
 #define Geometry_GEMGeometry_ME0EtaPartition_H
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -4,7 +4,7 @@
  */
 
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 GEMGeometry::GEMGeometry(){}
 

--- a/Geometry/GEMGeometry/src/ME0Geometry.cc
+++ b/Geometry/GEMGeometry/src/ME0Geometry.cc
@@ -4,7 +4,7 @@
  */
 
 #include "Geometry/GEMGeometry/interface/ME0Geometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 ME0Geometry::ME0Geometry(){}
 ME0Geometry::~ME0Geometry(){}  

--- a/Geometry/RPCGeometry/interface/RPCRoll.h
+++ b/Geometry/RPCGeometry/interface/RPCRoll.h
@@ -1,7 +1,7 @@
 #ifndef Geometry_RPCSimAlgo_RPCRoll_H
 #define Geometry_RPCSimAlgo_RPCRoll_H
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"

--- a/Geometry/RPCGeometry/src/RPCGeometry.cc
+++ b/Geometry/RPCGeometry/src/RPCGeometry.cc
@@ -4,7 +4,7 @@
  */
 
 #include <Geometry/RPCGeometry/interface/RPCGeometry.h>
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 RPCGeometry::RPCGeometry(){}

--- a/Geometry/TrackerGeometryBuilder/interface/GeomDetLess.h
+++ b/Geometry/TrackerGeometryBuilder/interface/GeomDetLess.h
@@ -1,1 +1,0 @@
-#error "Include has been moved to Geometry/CommonDetUnit package!"

--- a/Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h
+++ b/Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h
@@ -1,1 +1,0 @@
-#error "Include has been moved to Geometry/CommonDetUnit package!"

--- a/Geometry/TrackerGeometryBuilder/interface/PlaneBuilderForGluedDet.h
+++ b/Geometry/TrackerGeometryBuilder/interface/PlaneBuilderForGluedDet.h
@@ -5,7 +5,7 @@
 #include "DataFormats/GeometrySurface/interface/ReferenceCounted.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include <utility>
 #include <vector>
 

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -1,7 +1,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PlaneBuilderForGluedDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StackGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -2,7 +2,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/Geometry/TrackingGeometryAligner/interface/GeometryAligner.h
+++ b/Geometry/TrackingGeometryAligner/interface/GeometryAligner.h
@@ -19,7 +19,6 @@
 #include "CondFormats/Alignment/interface/AlignmentSurfaceDeformations.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
 #include "DataFormats/GeometrySurface/interface/Surface.h"

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
@@ -65,7 +65,7 @@
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
@@ -65,7 +65,7 @@
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronAlgo.h
@@ -36,7 +36,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronSeedGenerator.h
@@ -22,7 +22,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/RecoEgamma/EgammaPhotonProducers/interface/ConversionProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ConversionProducer.h
@@ -27,7 +27,7 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"
 #include "DataFormats/GeometrySurface/interface/SimpleCylinderBounds.h"

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
@@ -26,7 +26,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackMerger.cc
@@ -27,7 +27,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 

--- a/RecoEgamma/Examples/plugins/SiStripElectronAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/SiStripElectronAnalyzer.cc
@@ -41,7 +41,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h
@@ -4,7 +4,7 @@
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
@@ -4,7 +4,7 @@
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
@@ -4,7 +4,7 @@
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h
@@ -4,7 +4,7 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 

--- a/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEGeometric.h
+++ b/RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPEGeometric.h
@@ -2,7 +2,7 @@
 #define RecoLocalTracker_Phase2TrackerRecHits_Phase2StripCPEGeometric_H
 
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2TrackerRecHits.cc
@@ -10,7 +10,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"

--- a/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidation.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidation.cc
@@ -15,7 +15,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"

--- a/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizer.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/plugins/Phase2TrackerClusterizer.cc
@@ -14,7 +14,7 @@
 #endif
 #include "Phase2TrackerClusterizerSequentialAlgorithm.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"

--- a/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc
@@ -15,7 +15,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"

--- a/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
@@ -38,7 +38,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 // For L1

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
@@ -38,7 +38,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //#include "Geometry/TrackerTopology/interface/RectangularPixelTopology.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
@@ -39,7 +39,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //#include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 // For L1

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
@@ -42,7 +42,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //#include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 // For L1

--- a/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
@@ -57,7 +57,7 @@
 //#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 

--- a/RecoLocalTracker/SiPixelRecHits/test/ReadPixelRecHit.cc
+++ b/RecoLocalTracker/SiPixelRecHits/test/ReadPixelRecHit.cc
@@ -19,7 +19,7 @@
 //#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -6,7 +6,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
 #include "DataFormats/DetId/interface/DetId.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"

--- a/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
@@ -31,7 +31,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
 #include "RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h"

--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemoverNew.cc
@@ -29,7 +29,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
 //

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemover.cc
@@ -31,7 +31,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
 //

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
@@ -29,7 +29,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
 //

--- a/RecoMET/METAlgorithms/interface/EcalHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/EcalHaloAlgo.h
@@ -8,7 +8,7 @@
 */
 #include "DataFormats/METReco/interface/EcalHaloData.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonTrackMatcher.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonTrackMatcher.cc
@@ -39,7 +39,7 @@
 #include "DataFormats/GeometrySurface/interface/TangentPlane.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 using namespace std;
 using namespace reco;

--- a/RecoMuon/MuonIdentification/test/RPCMuonAnalyzer.cc
+++ b/RecoMuon/MuonIdentification/test/RPCMuonAnalyzer.cc
@@ -11,7 +11,7 @@
 
 //#include "DataFormats/TrackReco/interface/Track.h"
 //#include "Geometry/Records/interface/MuonGeometryRecord.h"
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.cc
@@ -6,7 +6,7 @@
 
 #include "RecoMuon/MuonSeedGenerator/src/RPCSeedOverlapper.h"
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
-#include <Geometry/CommonDetUnit/interface/GeomDetUnit.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
 
 using namespace std;
 using namespace edm;

--- a/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHit.cc
+++ b/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHit.cc
@@ -3,7 +3,7 @@
  */
 
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
@@ -10,7 +10,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterData.h"
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
@@ -8,7 +8,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
@@ -18,7 +18,7 @@
 #include "CommonTools/Statistics/interface/LinearFit.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/test/ClusterShapeExtractor.cc
@@ -20,7 +20,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
 

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByConformalMappingAndLine.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByConformalMappingAndLine.cc
@@ -15,7 +15,6 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByConformalMappingAndLine.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByConformalMappingAndLine.cc
@@ -18,7 +18,7 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
 #include "ConformalMappingFit.h"

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -17,7 +17,7 @@
 #include "CommonTools/Statistics/interface/LinearFit.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/RecoTracker/DeDx/interface/DeDxTools.h
+++ b/RecoTracker/DeDx/interface/DeDxTools.h
@@ -27,7 +27,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram3D.h"

--- a/RecoTracker/DebugTools/interface/CkfDebugger.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugger.h
@@ -8,7 +8,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 

--- a/RecoTracker/DebugTools/interface/TSOSFromSimHitFactory.h
+++ b/RecoTracker/DebugTools/interface/TSOSFromSimHitFactory.h
@@ -4,7 +4,7 @@
 #include "RecoTracker/DebugTools/interface/FTSFromSimHitFactory.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 class SimHit;
 class MagneticField;

--- a/RecoTracker/DebugTools/src/FTSFromSimHitFactory.cc
+++ b/RecoTracker/DebugTools/src/FTSFromSimHitFactory.cc
@@ -1,6 +1,6 @@
 #include "RecoTracker/DebugTools/interface/FTSFromSimHitFactory.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
 #include <algorithm>
 

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
@@ -22,7 +22,7 @@
 // added by me
 
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometrySurface/interface/Surface.h"
 #include "DataFormats/GeometrySurface/interface/GloballyPositioned.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"

--- a/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
@@ -89,7 +89,7 @@ class SimpleTrackListMerger : public edm::stream::EDProducer<> {
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -127,7 +127,7 @@ class dso_hidden TrackListMerger : public edm::stream::EDProducer<>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -128,7 +128,6 @@ class dso_hidden TrackListMerger : public edm::stream::EDProducer<>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
@@ -5,7 +5,6 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StackGeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
@@ -5,7 +5,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StackGeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
@@ -35,7 +35,7 @@
 //Geometry
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"

--- a/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.h
+++ b/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.h
@@ -4,7 +4,7 @@
 #include "BoundDiskSector.h"
 #include "DiskSectorBounds.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <utility>
 #include <vector>

--- a/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.h
+++ b/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.h
@@ -4,7 +4,6 @@
 #include "BoundDiskSector.h"
 #include "DiskSectorBounds.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <utility>
 #include <vector>

--- a/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.h
+++ b/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.h
@@ -4,7 +4,7 @@
 #include "BoundDiskSector.h"
 #include "DiskSectorBounds.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <utility>
 #include <vector>

--- a/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.h
+++ b/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.h
@@ -4,7 +4,6 @@
 #include "BoundDiskSector.h"
 #include "DiskSectorBounds.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <utility>
 #include <vector>

--- a/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
+++ b/RecoTracker/TkDetLayers/src/GeometricSearchTrackerBuilder.cc
@@ -12,7 +12,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "DataFormats/Common/interface/Trie.h"

--- a/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
+++ b/RecoTracker/TkDetLayers/test/TkDetLayersAnalyzer.cc
@@ -28,7 +28,7 @@
 
 // for trie
 #include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/Common/interface/Trie.h"
 
 // for the test

--- a/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.cc
+++ b/RecoTracker/TkMSParametrization/src/MSLayersKeeperX0DetLayer.cc
@@ -4,7 +4,7 @@
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "DataFormats/GeometrySurface/interface/BoundSurface.h"
 #include "DataFormats/GeometrySurface/interface/MediumProperties.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include <vector>
 

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
@@ -4,7 +4,7 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
@@ -2,7 +2,7 @@
 #define RECOTRACKER_TRANSIENTRACKINGRECHIT_TSiStripRecHit2DLocalPos_H
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #endif

--- a/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
@@ -7,7 +7,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
 

--- a/RecoVertex/V0Producer/test/V0Analyzer.cc
+++ b/RecoVertex/V0Producer/test/V0Analyzer.cc
@@ -55,7 +55,6 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/RecoVertex/V0Producer/test/V0Analyzer.cc
+++ b/RecoVertex/V0Producer/test/V0Analyzer.cc
@@ -55,7 +55,7 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
+++ b/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
@@ -45,7 +45,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyBuilder.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 // For ROOT
 #include <TROOT.h>

--- a/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.h
+++ b/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.h
@@ -20,7 +20,7 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 

--- a/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
+++ b/SUSYBSMAnalysis/HSCP/plugins/HSCPTreeBuilder.cc
@@ -33,7 +33,7 @@
 #include <MagneticField/Engine/interface/MagneticField.h>
 #include <MagneticField/Records/interface/IdealMagneticFieldRecord.h>
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.h
@@ -30,7 +30,7 @@
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "CondFormats/DataRecord/interface/SiPixelDynamicInefficiencyRcd.h"

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripMCDigiWorker.h
@@ -36,7 +36,7 @@
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/SiStripFedZeroSuppression.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -1,6 +1,6 @@
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -1,6 +1,6 @@
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
@@ -1,6 +1,6 @@
 #include "SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -47,7 +47,7 @@
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.cc
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerMonitorDigi.cc
@@ -27,7 +27,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 

--- a/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.cc
+++ b/SimTracker/SiPhase2Digitizer/test/Phase2TrackerValidateDigi.cc
@@ -25,7 +25,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"

--- a/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
+++ b/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
@@ -38,7 +38,7 @@
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -42,7 +42,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
@@ -36,7 +36,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 // my includes
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
 

--- a/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
@@ -33,7 +33,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 // my includes
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
@@ -36,7 +36,7 @@ New det-id.
 #include "FWCore/Framework/interface/ESHandle.h"
 
 // my includes
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTestForward.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTestForward.cc
@@ -32,7 +32,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 // my includes
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.h
@@ -25,7 +25,7 @@
 #include "SimTracker/SiStripDigitizer/interface/SiGaussianTailNoiseAdder.h"
 #include "SiHitDigitizer.h"
 #include "DigiSimLinkPileUpSignals.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"

--- a/SimTracker/SiStripDigitizer/plugins/SiHitDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiHitDigitizer.h
@@ -4,7 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SiChargeCollectionDrifter.h"

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
@@ -27,7 +27,7 @@
 #include "SimTracker/SiStripDigitizer/interface/SiGaussianTailNoiseAdder.h"
 #include "SiHitDigitizer.h"
 #include "SimTracker/SiStripDigitizer/interface/SiPileUpSignals.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
@@ -18,7 +18,7 @@
 #include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 //##---new stuff
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
@@ -42,7 +42,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.h
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.h
@@ -21,7 +21,7 @@
 //--- for SimHit
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"

--- a/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/test/SteppingHelixPropagatorAnalyzer.cc
@@ -49,7 +49,7 @@
 //#include "Geometry/RPCGeometry/interface/RPCRoll.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/TrackingTools/KalmanUpdators/src/Chi2Strip1DEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2Strip1DEstimator.cc
@@ -1,7 +1,7 @@
 #include "TrackingTools/KalmanUpdators/interface/Chi2Strip1DEstimator.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 using namespace std;
 

--- a/TrackingTools/KalmanUpdators/src/Chi2Switching1DEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/Chi2Switching1DEstimator.cc
@@ -1,6 +1,6 @@
 #include "TrackingTools/KalmanUpdators/interface/Chi2Switching1DEstimator.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 using namespace std;
 

--- a/TrackingTools/KalmanUpdators/src/KFSwitching1DUpdator.cc
+++ b/TrackingTools/KalmanUpdators/src/KFSwitching1DUpdator.cc
@@ -1,7 +1,7 @@
 #include "TrackingTools/KalmanUpdators/interface/KFSwitching1DUpdator.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 TrajectoryStateOnSurface
 KFSwitching1DUpdator::update(const TSOS& aTsos, const TrackingRecHit& aHit) const {

--- a/TrackingTools/KalmanUpdators/src/Strip1DMeasurementTransformator.cc
+++ b/TrackingTools/KalmanUpdators/src/Strip1DMeasurementTransformator.cc
@@ -1,5 +1,5 @@
 #include "TrackingTools/KalmanUpdators/interface/Strip1DMeasurementTransformator.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 // #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
 #include "Geometry/CommonTopologies/interface/RadialStripTopology.h"

--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 

--- a/TrackingTools/TrackAssociator/src/TrackDetectorAssociator.cc
+++ b/TrackingTools/TrackAssociator/src/TrackDetectorAssociator.cc
@@ -62,7 +62,7 @@
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/TrackingTools/TrackAssociator/test/CaloMatchingExample.cc
+++ b/TrackingTools/TrackAssociator/test/CaloMatchingExample.cc
@@ -63,7 +63,7 @@
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/TrackingTools/TrackAssociator/test/TestTrackAssociator.cc
+++ b/TrackingTools/TrackAssociator/test/TestTrackAssociator.cc
@@ -65,7 +65,7 @@
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
@@ -20,7 +20,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 //DQM services

--- a/Validation/GlobalHits/interface/GlobalHitsHistogrammer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsHistogrammer.h
@@ -18,7 +18,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //#include "DataFormats/DetId/interface/DetId.h"
 
 //DQM services

--- a/Validation/GlobalHits/interface/GlobalHitsProdHist.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProdHist.h
@@ -21,7 +21,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 //DQM services

--- a/Validation/GlobalHits/interface/GlobalHitsProducer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsProducer.h
@@ -22,7 +22,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 // tracker info

--- a/Validation/GlobalHits/interface/GlobalHitsTester.h
+++ b/Validation/GlobalHits/interface/GlobalHitsTester.h
@@ -19,7 +19,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+//#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //#include "DataFormats/DetId/interface/DetId.h"
 #include "TRandom.h"
 #include "TRandom3.h"

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
@@ -124,7 +124,7 @@
 // general info 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 
 #include <iostream>
 #include <stdlib.h>

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
@@ -129,7 +129,7 @@
 // general info 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 
 // helper files
 //#include <CLHEP/Vector/LorentzVector.h>

--- a/Validation/MuonHits/src/MuonSimHitsValidAnalyzer.h
+++ b/Validation/MuonHits/src/MuonSimHitsValidAnalyzer.h
@@ -12,7 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include "DataFormats/DetId/interface/DetId.h"
 

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -18,7 +18,6 @@
 //
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -20,7 +20,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //
 #include "DataFormats/Math/interface/deltaR.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"

--- a/Validation/RecoEgamma/plugins/TkConvValidator.cc
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.cc
@@ -23,7 +23,6 @@
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //
@@ -43,7 +42,6 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 
 //

--- a/Validation/RecoEgamma/plugins/TkConvValidator.cc
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.cc
@@ -25,7 +25,7 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 //
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"

--- a/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
@@ -54,7 +54,7 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
@@ -55,7 +55,7 @@
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
@@ -38,7 +38,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyBuilder.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 
 #include <TTree.h>

--- a/Validation/RecoVertex/interface/V0Validator.h
+++ b/Validation/RecoVertex/interface/V0Validator.h
@@ -57,7 +57,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/Validation/RecoVertex/interface/V0Validator.h
+++ b/Validation/RecoVertex/interface/V0Validator.h
@@ -57,7 +57,6 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -15,11 +15,11 @@
 
 // tracker info
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 // data in edm::event

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -15,7 +15,6 @@
 
 // tracker info
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"

--- a/Validation/TrackerHits/src/TrackerHitProducer.cc
+++ b/Validation/TrackerHits/src/TrackerHitProducer.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 // tracker info
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -26,7 +26,7 @@
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -32,7 +32,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"


### PR DESCRIPTION
* GeomDetUnit is a type alias of GeomDet and the header file of the first includes the latter
* Remove other include files which define error since the classes themselves have been moved
* Remove double includes
