### PR TITLE
Initial implementation of PathStatus and EndPathStatus products

### DIFF
--- a/DataFormats/Common/interface/EndPathStatus.h
+++ b/DataFormats/Common/interface/EndPathStatus.h
@@ -1,0 +1,11 @@
+#ifndef DataFormats_Common_EndPathStatus_h
+#define DataFormats_Common_EndPathStatus_h
+
+namespace edm
+{
+  class EndPathStatus {
+  public:
+    EndPathStatus() {}
+  };
+}
+#endif

--- a/DataFormats/Common/interface/PathStatus.h
+++ b/DataFormats/Common/interface/PathStatus.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_Common_PathStatus_h
+#define DataFormats_Common_PathStatus_h
+
+#include "DataFormats/Common/interface/HLTPathStatus.h"
+
+namespace edm {
+  using PathStatus = HLTPathStatus;
+}
+#endif

--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/CopyPolicy.h"
+#include "DataFormats/Common/interface/EndPathStatus.h"
 #include "DataFormats/Common/interface/HLTGlobalStatus.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"
 #include "DataFormats/Common/interface/OwnVector.h"

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -115,7 +115,11 @@
  <class name="edm::HLTPathStatus" ClassVersion="10">
   <version ClassVersion="10" checksum="1011460161"/>
  </class>
- <class name="edm::Wrapper<edm::HLTPathStatus>" splitLevel="0"/>
+ <class name="edm::Wrapper<edm::HLTPathStatus>"  persistent="false" splitLevel="0"/>
+ <class name="edm::EndPathStatus" ClassVersion="10">
+  <version ClassVersion="10" checksum="2166507936"/>
+ </class>
+ <class name="edm::Wrapper<edm::EndPathStatus>"  persistent="false" splitLevel="0"/>
  <class name="std::vector<edm::HLTPathStatus>"/>
  <class name="edm::Wrapper<std::vector<edm::HLTPathStatus> >" splitLevel="0"/>
  <class name="edm::HLTGlobalStatus" ClassVersion="10">

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -116,8 +116,8 @@
   <version ClassVersion="10" checksum="1011460161"/>
  </class>
  <class name="edm::Wrapper<edm::HLTPathStatus>"  persistent="false" splitLevel="0"/>
- <class name="edm::EndPathStatus" ClassVersion="10">
-  <version ClassVersion="10" checksum="2166507936"/>
+ <class name="edm::EndPathStatus" ClassVersion="3">
+  <version ClassVersion="3" checksum="2166507936"/>
  </class>
  <class name="edm::Wrapper<edm::EndPathStatus>"  persistent="false" splitLevel="0"/>
  <class name="std::vector<edm::HLTPathStatus>"/>

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -137,7 +137,7 @@ namespace edm {
       std::shared_ptr<ProductResolverIndexHelper>& runProductLookup() {return get_underlying_safe(runProductLookup_);}
 
       bool frozen_;
-      // Is at least one (run), (lumi), (event) product produced this process?
+      // Is at least one (run), (lumi), (event) persistent product produced this process?
       boost::array<bool, NumBranchTypes> productProduced_;
       bool anyProductProduced_;
 

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -122,10 +122,10 @@ namespace edm {
       << "' contains an underscore ('_'), which is illegal in the name of a product.\n";
     }
 
-    if(moduleLabel_.find(underscore) != std::string::npos) {
-      throw cms::Exception("IllegalCharacter") << "Module label '" << moduleLabel()
-      << "' contains an underscore ('_'), which is illegal in a module label.\n";
-    }
+    // Module labels of non-persistent products are allowed to contain
+    // underscores. For module labels of persistent products, the module
+    // label is checked for underscores in the function initFromDictionary
+    // after we determine whether the product is persistent or not.
 
     if(productInstanceName_.find(underscore) != std::string::npos) {
       throw cms::Exception("IllegalCharacter") << "Product instance name '" << productInstanceName()
@@ -200,7 +200,18 @@ namespace edm {
       // Set transient if persistent == "false".
       setTransient(true);
       return;
+    } else {
+      // Module labels of persistent products cannot contain underscores,
+      // but for non-persistent products it is allowed because path names
+      // are used as module labels for path status products and there
+      // are many path names that include underscores.
+      char const underscore('_');
+      if(moduleLabel_.find(underscore) != std::string::npos) {
+        throw cms::Exception("IllegalCharacter") << "Module label '" << moduleLabel()
+        << "' contains an underscore ('_'), which is illegal in a module label.\n";
+      }
     }
+
     if (wp && wp->HasKey("splitLevel")) {
       setSplitLevel(strtol(wp->GetPropertyAsString("splitLevel"), 0, 0));
       if (splitLevel() < 0) {

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -297,7 +297,7 @@ namespace edm {
 
       checkForDuplicateProcessName(desc, processName);
 
-      if(desc.produced()) {
+      if(desc.produced() && !desc.transient()) {
         setProductProduced(desc.branchType());
       }
 

--- a/FWCore/Concurrency/bin/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/bin/edmStreamStallGrapher.py
@@ -233,7 +233,7 @@ def findStalledModules(processingSteps, numStreams):
                     waitTime = time - streamTime[s]
         if trans == kFinished:
             if n != kSourceDelayedRead and n!=kSourceFindEvent:
-                del modulesOnStream[n]
+                modulesOnStream.pop(n, None)
             streamTime[s] = time
         if waitTime is not None:
             if waitTime > kStallThreshold:
@@ -263,7 +263,7 @@ def createAsciiImage(processingSteps, numStreams, maxNameSize):
                     waitTime = time-streamTime[s]
         if trans == kFinished:
             if n != kSourceDelayedRead and n!=kSourceFindEvent:
-                del modulesActiveOnStream[n]
+                modulesActiveOnStream.pop(n, None)
             if n != kSourceFindEvent:
                 streamState[s] -=1
             streamTime[s] = time

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -80,6 +80,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>
@@ -109,6 +110,8 @@ namespace edm {
   class ThinnedAssociationsHelper;
   class SubProcessParentageHelper;
   class TriggerResultInserter;
+  class PathStatusInserter;
+  class EndPathStatusInserter;
   class WaitingTaskHolder;
 
   
@@ -121,7 +124,7 @@ namespace edm {
     typedef std::vector<Worker*> Workers;
 
     Schedule(ParameterSet& proc_pset,
-             service::TriggerNamesService& tns,
+             service::TriggerNamesService const& tns,
              ProductRegistry& pregistry,
              BranchIDListHelper& branchIDListHelper,
              ThinnedAssociationsHelper& thinnedAssociationsHelper,
@@ -289,6 +292,8 @@ namespace edm {
     std::shared_ptr<ModuleRegistry>& moduleRegistry() {return get_underlying_safe(moduleRegistry_);}
 
     edm::propagate_const<std::shared_ptr<TriggerResultInserter>> resultsInserter_;
+    std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>> pathStatusInserters_;
+    std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>> endPathStatusInserters_;
     edm::propagate_const<std::shared_ptr<ModuleRegistry>> moduleRegistry_;
     std::vector<edm::propagate_const<std::shared_ptr<StreamSchedule>>> streamSchedules_;
     //In the future, we will have one GlobalSchedule per simultaneous transition
@@ -299,7 +304,9 @@ namespace edm {
 
     edm::propagate_const<std::unique_ptr<SystemTimeKeeper>> summaryTimeKeeper_;
 
-    bool                           wantSummary_;
+    std::vector<std::string> const* pathNames_;
+    std::vector<std::string> const* endPathNames_;
+    bool wantSummary_;
 
     volatile bool           endpathsAreActive_;
   };

--- a/FWCore/Framework/src/EndPathStatusInserter.cc
+++ b/FWCore/Framework/src/EndPathStatusInserter.cc
@@ -1,0 +1,20 @@
+
+#include "FWCore/Framework/src/EndPathStatusInserter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/Common/interface/EndPathStatus.h"
+
+#include <memory>
+
+namespace edm
+{
+  EndPathStatusInserter::EndPathStatusInserter(unsigned int) {
+    produces<EndPathStatus>();
+  }
+
+  void
+  EndPathStatusInserter::produce(StreamID, edm::Event& event, edm::EventSetup const&) const
+  {
+    event.put(std::make_unique<EndPathStatus>());
+  }
+}

--- a/FWCore/Framework/src/EndPathStatusInserter.h
+++ b/FWCore/Framework/src/EndPathStatusInserter.h
@@ -1,0 +1,20 @@
+#ifndef FWCore_Framework_EndPathStatusInserter_h
+#define FWCore_Framework_EndPathStatusInserter_h
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+namespace edm {
+
+  class Event;
+  class EventSetup;
+  class StreamID;
+
+  class EndPathStatusInserter : public global::EDProducer<> {
+  public:
+
+    EndPathStatusInserter(unsigned int numberOfStreams);
+
+    void produce(StreamID, Event&, EventSetup const&) const override final;
+  };
+}
+#endif

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -69,6 +69,8 @@ namespace edm {
   class PreallocationConfiguration;
   class ModuleRegistry;
   class TriggerResultInserter;
+  class PathStatusInserter;
+  class EndPathStatusInserter;
   
   class GlobalSchedule {
   public:
@@ -78,6 +80,8 @@ namespace edm {
     typedef std::vector<Worker*> Workers;
 
     GlobalSchedule(std::shared_ptr<TriggerResultInserter> inserter,
+                   std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+                   std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
                    std::shared_ptr<ModuleRegistry> modReg,
                    std::vector<std::string> const& modulesToUse,
                    ParameterSet& proc_pset,
@@ -164,7 +168,8 @@ namespace edm {
     WorkerManager                         workerManager_;
     std::shared_ptr<ActivityRegistry>     actReg_; // We do not use propagate_const because the registry itself is mutable.
     edm::propagate_const<WorkerPtr>       results_inserter_;
-
+    std::vector<edm::propagate_const<WorkerPtr>> pathStatusInserterWorkers_;
+    std::vector<edm::propagate_const<WorkerPtr>> endPathStatusInserterWorkers_;
 
     ProcessContext const*                 processContext_;
   };

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -294,10 +294,14 @@ namespace edm {
       if (pathStatusInserter_) { // pathStatusInserter is null for EndPaths
         pathStatusInserter_->setPathStatus(streamID, status);
       }
-      pathStatusInserterWorker_->runStatusInserter<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+      std::exception_ptr jException =
+        pathStatusInserterWorker_->runModuleDirectly<OccurrenceTraits<EventPrincipal,
+                                                                      BranchActionStreamBegin>>(
           iEP, iES, streamID, ParentContext(iContext), iContext
-      );
-
+        );
+      if(jException && not iException) {
+        iException = jException;
+      }
       actReg_->postPathEventSignal_(*iContext, pathContext_, status);
     } catch(...) {
       if(not iException) {

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -1,7 +1,10 @@
 
 #include "FWCore/Framework/src/Path.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
+#include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/src/EarlyDeleteHelper.h"
+#include "FWCore/Framework/src/PathStatusInserter.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -28,7 +31,9 @@ namespace edm {
     act_table_(&actions),
     workers_(workers),
     pathContext_(path_name, streamContext, bitpos, pathType),
-    stopProcessingEvent_(stopProcessingEvent){
+    stopProcessingEvent_(stopProcessingEvent),
+    pathStatusInserter_(nullptr),
+    pathStatusInserterWorker_(nullptr) {
 
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
@@ -48,7 +53,9 @@ namespace edm {
     workers_(r.workers_),
     earlyDeleteHelpers_(r.earlyDeleteHelpers_),
     pathContext_(r.pathContext_),
-    stopProcessingEvent_(r.stopProcessingEvent_){
+    stopProcessingEvent_(r.stopProcessingEvent_),
+    pathStatusInserter_(r.pathStatusInserter_),
+    pathStatusInserterWorker_(r.pathStatusInserterWorker_) {
 
     for (auto& workerInPath : workers_) {
       workerInPath.setPathContext(&pathContext_);
@@ -185,6 +192,13 @@ namespace edm {
   }
 
   void
+  Path::setPathStatusInserter(PathStatusInserter* pathStatusInserter,
+                              Worker* pathStatusInserterWorker) {
+    pathStatusInserter_ = pathStatusInserter;
+    pathStatusInserterWorker_ = pathStatusInserterWorker;
+  }
+
+  void
   Path::handleEarlyFinish(EventPrincipal const& iEvent) {
     for(auto helper: earlyDeleteHelpers_) {
       helper->pathFinished(iEvent);
@@ -206,7 +220,7 @@ namespace edm {
     state_ = hlt::Ready;
     
     if(workers_.empty()) {
-      finished(-1, true, std::exception_ptr(), iStreamContext);
+      finished(-1, true, std::exception_ptr(), iStreamContext, iEP, iES, iStreamID);
       return;
     }
     
@@ -261,11 +275,14 @@ namespace edm {
       }
       handleEarlyFinish(iEP);
     }
-    finished(iModuleIndex, shouldContinue, finalException, iContext);
+    finished(iModuleIndex, shouldContinue, finalException, iContext, iEP, iES, iID);
   }
   
   void
-  Path::finished(int iModuleIndex, bool iSucceeded, std::exception_ptr iException, StreamContext const* iContext) {
+  Path::finished(int iModuleIndex, bool iSucceeded, std::exception_ptr iException, StreamContext const* iContext,
+                 EventPrincipal const& iEP,
+                 EventSetup const& iES,
+                 StreamID const& streamID) {
     
     if(not iException) {
       updateCounters(iSucceeded, true);
@@ -273,6 +290,14 @@ namespace edm {
     }
     try {
       HLTPathStatus status(state_, iModuleIndex);
+
+      if (pathStatusInserter_) { // pathStatusInserter is null for EndPaths
+        pathStatusInserter_->setPathStatus(streamID, status);
+      }
+      pathStatusInserterWorker_->runStatusInserter<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+          iEP, iES, streamID, ParentContext(iContext), iContext
+      );
+
       actReg_->postPathEventSignal_(*iContext, pathContext_, status);
     } catch(...) {
       if(not iException) {

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -31,7 +31,9 @@
 
 namespace edm {
   class EventPrincipal;
+  class EventSetup;
   class ModuleDescription;
+  class PathStatusInserter;
   class RunPrincipal;
   class LuminosityBlockPrincipal;
   class EarlyDeleteHelper;
@@ -92,6 +94,9 @@ namespace edm {
     
     void setEarlyDeleteHelpers(std::map<const Worker*,EarlyDeleteHelper*> const&);
 
+    void setPathStatusInserter(PathStatusInserter* pathStatusInserter,
+                               Worker* pathStatusInserterWorker);
+
   private:
 
     // If you define this be careful about the pointer in the
@@ -117,8 +122,9 @@ namespace edm {
     WaitingTaskList waitingTasks_;
     std::atomic<bool>* stopProcessingEvent_;
 
+    PathStatusInserter* pathStatusInserter_;
+    Worker* pathStatusInserterWorker_;
 
-    
     // Helper functions
     // nwrwue = numWorkersRunWithoutUnhandledException (really!)
     bool handleWorkerFailure(cms::Exception & e,
@@ -139,8 +145,11 @@ namespace edm {
     void updateCounters(bool succeed, bool isEvent);
     
     void finished(int iModuleIndex, bool iSucceeded, std::exception_ptr,
-                  StreamContext const*);
-    
+                  StreamContext const*,
+                  EventPrincipal const& iEP,
+                  EventSetup const& iES,
+                  StreamID const& streamID);
+
     void handleEarlyFinish(EventPrincipal const&);
     void handleEarlyFinish(RunPrincipal const&) {}
     void handleEarlyFinish(LuminosityBlockPrincipal const&) {}

--- a/FWCore/Framework/src/PathStatusInserter.cc
+++ b/FWCore/Framework/src/PathStatusInserter.cc
@@ -1,0 +1,27 @@
+
+#include "FWCore/Framework/src/PathStatusInserter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <memory>
+
+namespace edm
+{
+  PathStatusInserter::PathStatusInserter(unsigned int numberOfStreams) :
+    hltPathStatus_(numberOfStreams)
+  {
+    produces<HLTPathStatus>();
+  }
+
+  void
+  PathStatusInserter::setPathStatus(StreamID const& streamID,
+                                    HLTPathStatus const& hltPathStatus) {
+    hltPathStatus_[streamID.value()] = hltPathStatus;
+  }
+
+  void
+  PathStatusInserter::produce(StreamID streamID, edm::Event& event, edm::EventSetup const&) const
+  {
+    event.put(std::make_unique<HLTPathStatus>(hltPathStatus_[streamID.value()]));
+  }
+}

--- a/FWCore/Framework/src/PathStatusInserter.h
+++ b/FWCore/Framework/src/PathStatusInserter.h
@@ -1,0 +1,28 @@
+#ifndef FWCore_Framework_PathStatusInserter_h
+#define FWCore_Framework_PathStatusInserter_h
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "DataFormats/Common/interface/HLTPathStatus.h"
+#include <vector>
+
+namespace edm {
+
+  class Event;
+  class EventSetup;
+  class StreamID;
+
+  class PathStatusInserter : public global::EDProducer<> {
+  public:
+
+    PathStatusInserter(unsigned int numberOfStreams);
+
+    void setPathStatus(StreamID const&, HLTPathStatus const&);
+
+    void produce(StreamID, Event&, EventSetup const&) const override final;
+
+  private:
+
+    std::vector<HLTPathStatus> hltPathStatus_;
+  };
+}
+#endif

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -142,7 +142,7 @@ namespace edm {
     //Need to lookup ids to names quickly
     std::unordered_map<unsigned int, std::string> moduleIndexToNames;
 
-    std::map<std::string, unsigned int> pathStatusInserterModuleLabelToModuleID;
+    std::unordered_map<std::string, unsigned int> pathStatusInserterModuleLabelToModuleID;
 
     //for testing, state that TriggerResults is at the end of all paths
     const std::string kTriggerResults("TriggerResults");

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -141,9 +141,13 @@ namespace edm {
     using namespace edm::graph;
     //Need to lookup ids to names quickly
     std::unordered_map<unsigned int, std::string> moduleIndexToNames;
-    
+
+    std::map<std::string, unsigned int> pathStatusInserterModuleLabelToModuleID;
+
     //for testing, state that TriggerResults is at the end of all paths
     const std::string kTriggerResults("TriggerResults");
+    const std::string kPathStatusInserter("PathStatusInserter");
+    const std::string kEndPathStatusInserter("EndPathStatusInserter");
     unsigned int kTriggerResultsIndex = kInvalidIndex;
     unsigned int largestIndex = 0;
     unsigned int kPathToTriggerResultsDependencyLastIndex = kInvalidIndex;
@@ -155,6 +159,9 @@ namespace edm {
       }
       if(description->id() > largestIndex) {
         largestIndex = description->id();
+      }
+      if(description->moduleName() == kPathStatusInserter || description->moduleName() == kEndPathStatusInserter) {
+        pathStatusInserterModuleLabelToModuleID[description->moduleLabel()] = description->id();
       }
     }
     kPathToTriggerResultsDependencyLastIndex = largestIndex ;
@@ -254,18 +261,24 @@ namespace edm {
         }
         //Have TriggerResults depend on the end of all paths 
         // Have all EndPaths depend on TriggerResults
+        auto labelToID = pathStatusInserterModuleLabelToModuleID.find(pathNames[pathIndex]);
+        if(labelToID == pathStatusInserterModuleLabelToModuleID.end()) {
+          // should never happen
+          throw Exception(errors::LogicError)
+            << "PathsAndConsumesOfModules::moduleDescription:checkForModuleDependencyCorrectness Could not find PathStatusInserter\n";
+        }
+        unsigned int pathStatusInserterModuleID = labelToID->second;
         if( pathIndex < kFirstEndPathIndex) {
           if( (lastModuleIndex  != kInvalidIndex) ) {
-            ++kPathToTriggerResultsDependencyLastIndex;
-            edgeToPathMap[std::make_pair(kPathToTriggerResultsDependencyLastIndex,lastModuleIndex)].push_back(pathIndex);
-            moduleIndexToNames.insert(std::make_pair(kPathToTriggerResultsDependencyLastIndex,
+            edgeToPathMap[std::make_pair(pathStatusInserterModuleID, lastModuleIndex)].push_back(pathIndex);
+            moduleIndexToNames.insert(std::make_pair(pathStatusInserterModuleID,
                                                      kPathEnded));
             if (kTriggerResultsIndex != kInvalidIndex) {
-              edgeToPathMap[std::make_pair(kTriggerResultsIndex, kPathToTriggerResultsDependencyLastIndex)].push_back(kDataDependencyIndex);
+              edgeToPathMap[std::make_pair(kTriggerResultsIndex, pathStatusInserterModuleID)].push_back(kDataDependencyIndex);
             }
             //Need to make dependency for finished process
-            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, kPathToTriggerResultsDependencyLastIndex)].push_back(kDataDependencyIndex);
-            pathOrder.push_back(kPathToTriggerResultsDependencyLastIndex);
+            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, pathStatusInserterModuleID)].push_back(kDataDependencyIndex);
+            pathOrder.push_back(pathStatusInserterModuleID);
           }
         } else {
           if( (not moduleDescriptions->empty()) ) {
@@ -279,11 +292,11 @@ namespace edm {
             }
             //Need to make dependency for finished process
             ++kPathToTriggerResultsDependencyLastIndex;
-            edgeToPathMap[std::make_pair(kPathToTriggerResultsDependencyLastIndex,lastModuleIndex)].push_back(pathIndex);
-            moduleIndexToNames.insert(std::make_pair(kPathToTriggerResultsDependencyLastIndex,
+            edgeToPathMap[std::make_pair(pathStatusInserterModuleID, lastModuleIndex)].push_back(pathIndex);
+            moduleIndexToNames.insert(std::make_pair(pathStatusInserterModuleID,
                                                      kPathEnded));
-            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, kPathToTriggerResultsDependencyLastIndex)].push_back(kDataDependencyIndex);
-            pathOrder.push_back(kPathToTriggerResultsDependencyLastIndex);
+            edgeToPathMap[std::make_pair(kFinishedProcessingIndex, pathStatusInserterModuleID)].push_back(kDataDependencyIndex);
+            pathOrder.push_back(pathStatusInserterModuleID);
           }
         }
       }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Principal.h"
 
+#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
@@ -370,9 +371,29 @@ namespace edm {
       std::vector<std::string> const& lookupProcessNames = productLookup_->lookupProcessNames();
       lookupProcessOrder_.assign(lookupProcessNames.size(), 0);
       unsigned int k = 0;
-      for (auto iter = processHistoryPtr_->rbegin(),
-                iEnd = processHistoryPtr_->rend();
-           iter != iEnd; ++iter) {
+
+      // We loop over processes in reverse order of the ProcessHistory.
+      // If any entries in the product lookup tables are associated with
+      // the process we add it to the vector of processes in the order
+      // the lookup should be performed. There is one exception though,
+      // We start with the current process even if it is not in the ProcessHistory.
+      // The current process might be needed but not be in the process
+      // history if all the products produced in the current process are
+      // transient.
+      auto nameIter = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), processConfiguration_->processName());
+      if (nameIter != lookupProcessNames.end()) {
+        lookupProcessOrder_.at(k) = nameIter - lookupProcessNames.begin();
+        ++k;
+      }
+
+      // We just looked for the current process so skip it if
+      // it is in the ProcessHistory.
+      auto iter = processHistoryPtr_->rbegin();
+      if (iter->processName() == processConfiguration_->processName()) {
+        ++iter;
+      }
+
+      for (auto iEnd = processHistoryPtr_->rend(); iter != iEnd; ++iter) {
         auto nameIter = std::find(lookupProcessNames.begin(), lookupProcessNames.end(), iter->processName());
         if (nameIter == lookupProcessNames.end()) {
           continue;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -17,10 +17,13 @@
 #include "FWCore/Framework/src/ModuleHolder.h"
 #include "FWCore/Framework/src/ModuleRegistry.h"
 #include "FWCore/Framework/src/TriggerResultInserter.h"
+#include "FWCore/Framework/src/PathStatusInserter.h"
+#include "FWCore/Framework/src/EndPathStatusInserter.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
@@ -41,6 +44,9 @@
 #include <sstream>
 
 namespace edm {
+
+  class Maker;
+
   namespace {
     using std::placeholders::_1;
 
@@ -95,6 +101,57 @@ namespace edm {
       return returnValue;
     }
 
+    template <typename T>
+    void
+    makePathStatusInserters(std::vector<edm::propagate_const<std::shared_ptr<T>>>& pathStatusInserters,
+                            std::vector<std::string> const& pathNames,
+                            PreallocationConfiguration const& iPrealloc,
+                            ProductRegistry& preg,
+                            std::shared_ptr<ActivityRegistry> areg,
+                            std::shared_ptr<ProcessConfiguration> processConfiguration,
+                            std::string const& moduleTypeName) {
+
+      ParameterSet pset;
+      pset.addParameter<std::string>("@module_type", moduleTypeName);
+      pset.addParameter<std::string>("@module_edm_type", "EDProducer");
+      pset.registerIt();
+
+      pathStatusInserters.reserve(pathNames.size());
+
+      for (auto const& pathName : pathNames) {
+
+        ModuleDescription md(pset.id(),
+                             moduleTypeName,
+                             pathName,
+                             processConfiguration.get(),
+                             ModuleDescription::getUniqueID());
+
+        areg->preModuleConstructionSignal_(md);
+        bool postCalled = false;
+
+        try {
+          maker::ModuleHolderT<T> holder(std::make_shared<T>(iPrealloc.numberOfStreams()),
+                                         static_cast<Maker const*>(nullptr));
+          holder.setModuleDescription(md);
+          holder.registerProductsAndCallbacks(&preg);
+          pathStatusInserters.emplace_back(holder.module());
+          postCalled = true;
+          // if exception then post will be called in the catch block
+          areg->postModuleConstructionSignal_(md);
+        }
+        catch (...) {
+          if(!postCalled) {
+            try {
+              areg->postModuleConstructionSignal_(md);
+            }
+            catch (...) {
+              // If post throws an exception ignore it because we are already handling another exception
+            }
+          }
+          throw;
+        }
+      }
+    }
 
     void
     checkAndInsertAlias(std::string const& friendlyClassName,
@@ -279,14 +336,18 @@ namespace edm {
 
       const unsigned int sizeBeforeOutputModules = labelsToBeDropped.size();
       for (auto const& modLabel: usedModuleLabels) {
-        edmType = proc_pset.getParameterSet(modLabel).getParameter<std::string>(moduleEdmType);
-        if (edmType == outputModule) {
-          outputModuleLabels.push_back(modLabel);
-          labelsToBeDropped.push_back(modLabel);
-        }
-        if(edmType == edAnalyzer) {
-          if(modulesOnPaths.end()==modulesOnPaths.find(modLabel)) {
+        // Do nothing for modules that do not have a ParameterSet. Modules of type
+        // PathStatusInserter and EndPathStatusInserter will not have a ParameterSet.
+        if (proc_pset.existsAs<ParameterSet>(modLabel)) {
+          edmType = proc_pset.getParameterSet(modLabel).getParameter<std::string>(moduleEdmType);
+          if (edmType == outputModule) {
+            outputModuleLabels.push_back(modLabel);
             labelsToBeDropped.push_back(modLabel);
+          }
+          if(edmType == edAnalyzer) {
+            if(modulesOnPaths.end()==modulesOnPaths.find(modLabel)) {
+              labelsToBeDropped.push_back(modLabel);
+            }
           }
         }
       }
@@ -370,7 +431,7 @@ namespace edm {
   // -----------------------------
 
   Schedule::Schedule(ParameterSet& proc_pset,
-                     service::TriggerNamesService& tns,
+                     service::TriggerNamesService const& tns,
                      ProductRegistry& preg,
                      BranchIDListHelper& branchIDListHelper,
                      ThinnedAssociationsHelper& thinnedAssociationsHelper,
@@ -386,14 +447,34 @@ namespace edm {
     moduleRegistry_(new ModuleRegistry()),
     all_output_communicators_(),
     preallocConfig_(prealloc),
+    pathNames_(&tns.getTrigPaths()),
+    endPathNames_(&tns.getEndPaths()),
     wantSummary_(tns.wantSummary()),
     endpathsAreActive_(true)
   {
+    makePathStatusInserters(pathStatusInserters_,
+                            *pathNames_,
+                            prealloc,
+                            preg,
+                            areg,
+                            processConfiguration,
+                            std::string("PathStatusInserter"));
+
+    makePathStatusInserters(endPathStatusInserters_,
+                            *endPathNames_,
+                            prealloc,
+                            preg,
+                            areg,
+                            processConfiguration,
+                            std::string("EndPathStatusInserter"));
+
     assert(0<prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());
     for(unsigned int i=0; i<prealloc.numberOfStreams();++i) {
       streamSchedules_.emplace_back(std::make_shared<StreamSchedule>(
         resultsInserter(),
+        pathStatusInserters_,
+        endPathStatusInserters_,
         moduleRegistry(),
         proc_pset,tns,prealloc,preg,
         branchIDListHelper,actions,
@@ -428,6 +509,8 @@ namespace edm {
     // propagate_const<T> has no reset() function
     globalSchedule_ = std::make_unique<GlobalSchedule>(
       resultsInserter(),
+      pathStatusInserters_,
+      endPathStatusInserters_,
       moduleRegistry(),
       modulesToUse,
       proc_pset, preg, prealloc,
@@ -957,7 +1040,7 @@ namespace edm {
                                       EventPrincipal& ep,
                                       EventSetup const& es) {
     assert(iStreamID<streamSchedules_.size());
-    streamSchedules_[iStreamID]->processOneEventAsync(std::move(iTask),ep,es);
+    streamSchedules_[iStreamID]->processOneEventAsync(std::move(iTask),ep,es,pathStatusInserters_);
   }
   
   void Schedule::preForkReleaseResources() {
@@ -1028,12 +1111,13 @@ namespace edm {
 
   void
   Schedule::triggerPaths(std::vector<std::string>& oLabelsToFill) const {
-    streamSchedules_[0]->triggerPaths(oLabelsToFill);
+    oLabelsToFill = *pathNames_;
+
   }
 
   void
   Schedule::endPaths(std::vector<std::string>& oLabelsToFill) const {
-    streamSchedules_[0]->endPaths(oLabelsToFill);
+    oLabelsToFill = *endPathNames_;
   }
 
   void

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -10,6 +10,8 @@
 #include "FWCore/Framework/src/Factory.h"
 #include "FWCore/Framework/src/OutputModuleCommunicator.h"
 #include "FWCore/Framework/src/TriggerResultInserter.h"
+#include "FWCore/Framework/src/PathStatusInserter.h"
+#include "FWCore/Framework/src/EndPathStatusInserter.h"
 #include "FWCore/Framework/src/WorkerInPath.h"
 #include "FWCore/Framework/src/ModuleHolder.h"
 #include "FWCore/Framework/src/WorkerT.h"
@@ -131,9 +133,11 @@ namespace edm {
   // -----------------------------
 
   StreamSchedule::StreamSchedule(std::shared_ptr<TriggerResultInserter> inserter,
+                                 std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+                                 std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
                                  std::shared_ptr<ModuleRegistry> modReg,
                                  ParameterSet& proc_pset,
-                                 service::TriggerNamesService& tns,
+                                 service::TriggerNamesService const& tns,
                                  PreallocationConfiguration const& prealloc,
                                  ProductRegistry& preg,
                                  BranchIDListHelper& branchIDListHelper,
@@ -145,9 +149,7 @@ namespace edm {
                                  ProcessContext const* processContext) :
     workerManager_(modReg,areg, actions),
     actReg_(areg),
-    trig_name_list_(tns.getTrigPaths()),
-    end_path_name_list_(tns.getEndPaths()),
-    results_(new HLTGlobalStatus(trig_name_list_.size())),
+    results_(new HLTGlobalStatus(tns.getTrigPaths().size())),
     results_inserter_(),
     trig_paths_(),
     end_paths_(),
@@ -161,12 +163,13 @@ namespace edm {
 
     ParameterSet const& opts = proc_pset.getUntrackedParameterSet("options", ParameterSet());
     bool hasPath = false;
+    std::vector<std::string> const& pathNames = tns.getTrigPaths();
+    std::vector<std::string> const& endPathNames = tns.getEndPaths();
 
     int trig_bitpos = 0;
-    trig_paths_.reserve(trig_name_list_.size());
-    vstring labelsOnTriggerPaths;
-      for (auto const& trig_name : trig_name_list_) {
-      fillTrigPath(proc_pset, preg, &prealloc, processConfiguration, trig_bitpos, trig_name, results(), &labelsOnTriggerPaths);
+    trig_paths_.reserve(pathNames.size());
+    for (auto const& trig_name : pathNames) {
+      fillTrigPath(proc_pset, preg, &prealloc, processConfiguration, trig_bitpos, trig_name, results(), endPathNames);
       ++trig_bitpos;
       hasPath = true;
     }
@@ -181,11 +184,13 @@ namespace edm {
 
     // fill normal endpaths
     int bitpos = 0;
-    end_paths_.reserve(end_path_name_list_.size());
-      for (auto const& end_path_name : end_path_name_list_) {
-      fillEndPath(proc_pset, preg, &prealloc, processConfiguration, bitpos, end_path_name);
+    end_paths_.reserve(endPathNames.size());
+    for (auto const& end_path_name : endPathNames) {
+      fillEndPath(proc_pset, preg, &prealloc, processConfiguration, bitpos, end_path_name, endPathNames);
       ++bitpos;
     }
+
+    makePathStatusInserters(pathStatusInserters, endPathStatusInserters, actions);
 
     //See if all modules were used
     std::set<std::string> usedWorkerLabels;
@@ -401,14 +406,12 @@ namespace edm {
                                    std::string const& pathName,
                                    bool ignoreFilters,
                                    PathWorkers& out,
-                                   vstring* labelsOnPaths) {
+                                   std::vector<std::string> const& endPathNames) {
     vstring modnames = proc_pset.getParameter<vstring>(pathName);
     PathWorkers tmpworkers;
 
     unsigned int placeInPath = 0;
     for (auto const& name : modnames) {
-
-      if (labelsOnPaths) labelsOnPaths->push_back(name);
 
       WorkerInPath::FilterAction filterAction = WorkerInPath::Normal;
       if (name[0] == '!')       filterAction = WorkerInPath::Veto;
@@ -421,7 +424,7 @@ namespace edm {
       ParameterSet* modpset = proc_pset.getPSetForUpdate(moduleLabel, isTracked);
       if (modpset == 0) {
         std::string pathType("endpath");
-        if (!search_all(end_path_name_list_, pathName)) {
+        if (!search_all(endPathNames, pathName)) {
           pathType = std::string("path");
         }
         throw Exception(errors::Configuration) <<
@@ -458,46 +461,39 @@ namespace edm {
                                     PreallocationConfiguration const* prealloc,
                                     std::shared_ptr<ProcessConfiguration const> processConfiguration,
                                     int bitpos, std::string const& name, TrigResPtr trptr,
-                                    vstring* labelsOnTriggerPaths) {
-    using std::placeholders::_1;
+                                    std::vector<std::string> const& endPathNames) {
     PathWorkers tmpworkers;
-    Workers holder;
-    fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, false, tmpworkers, labelsOnTriggerPaths);
-
-    for (PathWorkers::iterator wi(tmpworkers.begin()),
-          we(tmpworkers.end()); wi != we; ++wi) {
-      holder.push_back(wi->getWorker());
-    }
+    fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, false, tmpworkers, endPathNames);
 
     // an empty path will cause an extra bit that is not used
     if (!tmpworkers.empty()) {
       trig_paths_.emplace_back(bitpos, name, tmpworkers, trptr, actionTable(), actReg_, &streamContext_, &skippingEvent_, PathContext::PathType::kPath);
     } else {
       empty_trig_paths_.push_back(bitpos);
-      empty_trig_path_names_.push_back(name);
     }
-    for_all(holder, std::bind(&StreamSchedule::addToAllWorkers, this, _1));
+    for (WorkerInPath const& workerInPath : tmpworkers) {
+      addToAllWorkers(workerInPath.getWorker());
+    }
   }
 
   void StreamSchedule::fillEndPath(ParameterSet& proc_pset,
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,
                                    std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                                   int bitpos, std::string const& name) {
-    using std::placeholders::_1;
+                                   int bitpos, std::string const& name,
+                                   std::vector<std::string> const& endPathNames) {
     PathWorkers tmpworkers;
-    fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, true, tmpworkers, 0);
-    Workers holder;
-
-    for (PathWorkers::iterator wi(tmpworkers.begin()), we(tmpworkers.end()); wi != we; ++wi) {
-      holder.push_back(wi->getWorker());
-    }
+    fillWorkers(proc_pset, preg, prealloc, processConfiguration, name, true, tmpworkers, endPathNames);
 
     if (!tmpworkers.empty()) {
       //EndPaths are not supposed to stop if SkipEvent type exception happens
       end_paths_.emplace_back(bitpos, name, tmpworkers, TrigResPtr(), actionTable(), actReg_, &streamContext_, nullptr, PathContext::PathType::kEndPath);
+    } else {
+      empty_end_paths_.push_back(bitpos);
     }
-    for_all(holder, std::bind(&StreamSchedule::addToAllWorkers, this, _1));
+    for (WorkerInPath const& workerInPath : tmpworkers) {
+      addToAllWorkers(workerInPath.getWorker());
+    }
   }
 
   void StreamSchedule::beginStream() {
@@ -539,17 +535,35 @@ namespace edm {
   
   void StreamSchedule::processOneEventAsync(WaitingTaskHolder iTask,
                                             EventPrincipal& ep,
-                                            EventSetup const& es)
-  {
+                                            EventSetup const& es,
+                                            std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters) {
     this->resetAll();
-    for (int empty_trig_path : empty_trig_paths_) {
-      results_->at(empty_trig_path) = HLTPathStatus(hlt::Pass, 0);
-    }
-    
+
     using Traits = OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>;
     
     Traits::setStreamContext(streamContext_, ep);
     Traits::preScheduleSignal(actReg_.get(), &streamContext_);
+
+    try {
+      HLTPathStatus hltPathStatus(hlt::Pass, 0);
+      for (int empty_trig_path : empty_trig_paths_) {
+        results_->at(empty_trig_path) = hltPathStatus;
+        pathStatusInserters.at(empty_trig_path)->setPathStatus(streamID_, hltPathStatus);
+        pathStatusInserterWorkers_.at(empty_trig_path)->runStatusInserter<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+            ep, es, streamID_, ParentContext(&streamContext_), &streamContext_
+        );
+      }
+      for (int empty_end_path : empty_end_paths_) {
+        endPathStatusInserterWorkers_.at(empty_end_path)->runStatusInserter<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+            ep, es, streamID_, ParentContext(&streamContext_), &streamContext_
+        );
+      }
+    } catch(...) {
+      auto iException = std::current_exception();
+      iTask.doneWaiting(iException);
+      return;
+    }
+
     
     // This call takes care of the unscheduled processing.
     workerManager_.setupOnDemandSystem(ep,es);
@@ -701,16 +715,6 @@ namespace edm {
                    trig_paths_.end(),
                    std::back_inserter(oLabelsToFill),
                    std::bind(&Path::name, std::placeholders::_1));
-  }
-
-  void
-  StreamSchedule::triggerPaths(std::vector<std::string>& oLabelsToFill) const {
-    oLabelsToFill = trig_name_list_;
-  }
-
-  void
-  StreamSchedule::endPaths(std::vector<std::string>& oLabelsToFill) const {
-    oLabelsToFill = end_path_name_list_;
   }
 
   void
@@ -894,4 +898,60 @@ namespace edm {
     }
   }
 
+  void
+  StreamSchedule::makePathStatusInserters(
+      std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+      std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
+      ExceptionToActionTable const& actions) {
+
+    int bitpos = 0;
+    unsigned int indexEmpty = 0;
+    unsigned int indexOfPath = 0;
+    for(auto & pathStatusInserter : pathStatusInserters) {
+      std::shared_ptr<PathStatusInserter> inserterPtr = get_underlying(pathStatusInserter);
+      WorkerPtr workerPtr(new edm::WorkerT<PathStatusInserter::ModuleType>(inserterPtr,
+                                                                           inserterPtr->moduleDescription(),
+                                                                           &actions));
+      pathStatusInserterWorkers_.emplace_back(workerPtr);
+      workerPtr->setActivityRegistry(actReg_);
+      addToAllWorkers(workerPtr.get());
+
+      // A little complexity here because a C++ Path object is not
+      // instantiated and put into end_paths if there are no modules
+      // on the configured path.
+      if (indexEmpty < empty_trig_paths_.size() && bitpos == empty_trig_paths_.at(indexEmpty)) {
+        ++indexEmpty;
+      } else {
+        trig_paths_.at(indexOfPath).setPathStatusInserter(inserterPtr.get(),
+                                                          workerPtr.get());
+        ++indexOfPath;
+      }
+      ++bitpos;
+    }
+
+    bitpos = 0;
+    indexEmpty = 0;
+    indexOfPath = 0;
+    for(auto & endPathStatusInserter : endPathStatusInserters) {
+      std::shared_ptr<EndPathStatusInserter> inserterPtr = get_underlying(endPathStatusInserter);
+      WorkerPtr workerPtr(new edm::WorkerT<EndPathStatusInserter::ModuleType>(inserterPtr,
+                                                                              inserterPtr->moduleDescription(),
+                                                                              &actions));
+      endPathStatusInserterWorkers_.emplace_back(workerPtr);
+      workerPtr->setActivityRegistry(actReg_);
+      addToAllWorkers(workerPtr.get());
+
+      // A little complexity here because a C++ Path object is not
+      // instantiated and put into end_paths if there are no modules
+      // on the configured path.
+      if (indexEmpty < empty_end_paths_.size() && bitpos == empty_end_paths_.at(indexEmpty)) {
+        ++indexEmpty;
+      } else {
+        end_paths_.at(indexOfPath).setPathStatusInserter(nullptr,
+                                                         workerPtr.get());
+        ++indexOfPath;
+      }
+      ++bitpos;
+    }
+  }
 }

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -84,6 +84,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 #include <map>
 #include <memory>
@@ -99,12 +100,15 @@ namespace edm {
   class BranchIDListHelper;
   class EventSetup;
   class ExceptionCollector;
+  class ExceptionToActionTable;
   class OutputModuleCommunicator;
   class ProcessContext;
   class UnscheduledCallProducer;
   class WorkerInPath;
   class ModuleRegistry;
   class TriggerResultInserter;
+  class PathStatusInserter;
+  class EndPathStatusInserter;
   class PreallocationConfiguration;
   class WaitingTaskHolder;
 
@@ -155,9 +159,11 @@ namespace edm {
     typedef std::vector<WorkerInPath> PathWorkers;
 
     StreamSchedule(std::shared_ptr<TriggerResultInserter> inserter,
+                   std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+                   std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
                    std::shared_ptr<ModuleRegistry>,
                    ParameterSet& proc_pset,
-                   service::TriggerNamesService& tns,
+                   service::TriggerNamesService const& tns,
                    PreallocationConfiguration const& prealloc,
                    ProductRegistry& pregistry,
                    BranchIDListHelper& branchIDListHelper,
@@ -172,7 +178,8 @@ namespace edm {
 
     void processOneEventAsync(WaitingTaskHolder iTask,
                               EventPrincipal& ep,
-                              EventSetup const& es);
+                              EventSetup const& es,
+                              std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters);
 
     template <typename T>
     void processOneStream(typename T::MyPrincipal& principal,
@@ -200,14 +207,6 @@ namespace edm {
 
     ///adds to oLabelsToFill the labels for all paths in the process
     void availablePaths(std::vector<std::string>& oLabelsToFill) const;
-
-    ///adds to oLabelsToFill the labels for all trigger paths in the process
-    ///this is different from availablePaths because it includes the
-    ///empty paths so matches the entries in TriggerResults exactly.
-    void triggerPaths(std::vector<std::string>& oLabelsToFill) const;
-
-    ///adds to oLabelsToFill the labels for all end paths in the process
-    void endPaths(std::vector<std::string>& oLabelsToFill) const;
 
     ///adds to oLabelsToFill in execution order the labels of all modules in path iPathLabel
     void modulesInPath(std::string const& iPathLabel,
@@ -316,18 +315,19 @@ namespace edm {
                      PreallocationConfiguration const* prealloc,
                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
                      std::string const& name, bool ignoreFilters, PathWorkers& out,
-                     vstring* labelsOnPaths);
+                     std::vector<std::string> const& endPathNames);
     void fillTrigPath(ParameterSet& proc_pset,
                       ProductRegistry& preg,
                       PreallocationConfiguration const* prealloc,
                       std::shared_ptr<ProcessConfiguration const> processConfiguration,
                       int bitpos, std::string const& name, TrigResPtr,
-                      vstring* labelsOnTriggerPaths);
+                      std::vector<std::string> const& endPathNames);
     void fillEndPath(ParameterSet& proc_pset,
                      ProductRegistry& preg,
                      PreallocationConfiguration const* prealloc,
                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                     int bitpos, std::string const& name);
+                     int bitpos, std::string const& name,
+                     std::vector<std::string> const& endPathNames);
 
     void addToAllWorkers(Worker* w);
     
@@ -340,19 +340,24 @@ namespace edm {
     TrigResConstPtr results() const {return get_underlying_safe(results_);}
     TrigResPtr& results() {return get_underlying_safe(results_);}
 
+    void makePathStatusInserters(
+      std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
+      std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
+      ExceptionToActionTable const& actions);
+
     WorkerManager            workerManager_;
     std::shared_ptr<ActivityRegistry> actReg_; // We do not use propagate_const because the registry itself is mutable.
-
-    vstring                  trig_name_list_;
-    vstring                  end_path_name_list_;
 
     edm::propagate_const<TrigResPtr> results_;
 
     edm::propagate_const<WorkerPtr> results_inserter_;
+    std::vector<edm::propagate_const<WorkerPtr>> pathStatusInserterWorkers_;
+    std::vector<edm::propagate_const<WorkerPtr>> endPathStatusInserterWorkers_;
+
     TrigPaths                trig_paths_;
     TrigPaths                end_paths_;
     std::vector<int>         empty_trig_paths_;
-    vstring                  empty_trig_path_names_;
+    std::vector<int>         empty_end_paths_;
 
     //For each branch that has been marked for early deletion
     // keep track of how many modules are left that read this data but have

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -67,7 +67,7 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
-<library   file="stubs/TestGlobalProducers.cc,stubs/TestGlobalAnalyzers.cc,stubs/TestGlobalFilters.cc" name="TestGlobalModules">
+<library   file="stubs/TestGlobalProducers.cc,stubs/TestGlobalAnalyzers.cc,stubs/TestGlobalFilters.cc,stubs/TestGetPathStatus.cc" name="TestGlobalModules">
   <flags   EDM_PLUGIN="1"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -430,12 +430,12 @@ testeventprocessor::activityRegistryTest() {
   CPPUNIT_ASSERT(listener.postEndJob_ == 1);
   CPPUNIT_ASSERT(listener.preEventProcessing_ == 5);
   CPPUNIT_ASSERT(listener.postEventProcessing_ == 5);
-  CPPUNIT_ASSERT(listener.preModule_ == 10);
-  CPPUNIT_ASSERT(listener.postModule_ == 10);
+  CPPUNIT_ASSERT(listener.preModule_ == 15);
+  CPPUNIT_ASSERT(listener.postModule_ == 15);
 
   typedef std::vector<edm::ModuleDescription const*> ModuleDescs;
   ModuleDescs allModules = proc.getAllModuleDescriptions();
-  CPPUNIT_ASSERT(2 == allModules.size()); // TestMod & TriggerResults
+  CPPUNIT_ASSERT(3 == allModules.size()); // TestMod & TriggerResults
   //std::cout << "\nModuleDescriptions in testeventprocessor::activityRegistryTest()---\n";
   for (ModuleDescs::const_iterator i = allModules.begin(), e = allModules.end();
        i != e ;

--- a/FWCore/Framework/test/run_trigbit.sh
+++ b/FWCore/Framework/test/run_trigbit.sh
@@ -9,6 +9,7 @@ F3=${LOCAL_TEST_DIR}/testBitsMove_cfg.py
 F4=${LOCAL_TEST_DIR}/testBitsCount_cfg.py
 F5=${LOCAL_TEST_DIR}/testFilterIgnore_cfg.py
 F6=${LOCAL_TEST_DIR}/testFilterOnEndPath_cfg.py
+F7=${LOCAL_TEST_DIR}/testPathStatus_cfg.py
 
 (cmsRun $F1 ) || die "Failure using $F1" $?
 (cmsRun $F2 ) || die "Failure using $F2" $?
@@ -16,5 +17,6 @@ F6=${LOCAL_TEST_DIR}/testFilterOnEndPath_cfg.py
 (cmsRun $F4 ) || die "Failure using $F4" $?
 (cmsRun $F5 ) || die "Failure using $F5" $?
 (cmsRun $F6 ) || die "Failure using $F6" $?
+(cmsRun $F7 ) || die "Failure using $F7" $?
 
 

--- a/FWCore/Framework/test/stubs/TestFilterModule.cc
+++ b/FWCore/Framework/test/stubs/TestFilterModule.cc
@@ -42,7 +42,6 @@ namespace edmtest
   private:
     int    passed_;
     int    failed_;
-    bool   dump_;
     std::string name_;
     int    numbits_;
   };
@@ -99,7 +98,6 @@ namespace edmtest
   TestResultAnalyzer::TestResultAnalyzer(edm::ParameterSet const& ps):
     passed_(),
     failed_(),
-    dump_(ps.getUntrackedParameter<bool>("dump",false)),
     name_(ps.getUntrackedParameter<std::string>("name","DEFAULT")),
     numbits_(ps.getUntrackedParameter<int>("numbits",-1))
   {

--- a/FWCore/Framework/test/stubs/TestGetPathStatus.cc
+++ b/FWCore/Framework/test/stubs/TestGetPathStatus.cc
@@ -1,0 +1,68 @@
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/Common/interface/EndPathStatus.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/PathStatus.h"
+
+#include <iostream>
+
+namespace edm {
+  class EventSetup;
+  class StreamID;
+}
+
+namespace edmtest {
+
+  class TestGetPathStatus : public edm::global::EDAnalyzer<> {
+  public:
+
+    explicit TestGetPathStatus(edm::ParameterSet const& pset);
+    virtual ~TestGetPathStatus() {}
+
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+
+private:
+
+    std::vector<int> expectedStates_;
+    std::vector<unsigned int> expectedIndexes_;
+
+    edm::EDGetTokenT<edm::PathStatus> tokenPathStatus_;
+    edm::EDGetTokenT<edm::EndPathStatus> tokenEndPathStatus_;
+  };
+
+  TestGetPathStatus::TestGetPathStatus(edm::ParameterSet const& pset) :
+    expectedStates_(pset.getParameter<std::vector<int>>("expectedStates")),
+    expectedIndexes_(pset.getParameter<std::vector<unsigned int>>("expectedIndexes")),
+    tokenPathStatus_(consumes<edm::PathStatus>(pset.getParameter<edm::InputTag>("pathStatusTag"))),
+    tokenEndPathStatus_(consumes<edm::EndPathStatus>(pset.getParameter<edm::InputTag>("endPathStatusTag"))){
+  }
+
+  void
+  TestGetPathStatus::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const&) const {
+
+    edm::Handle<edm::PathStatus> hPathStatus;
+    event.getByToken(tokenPathStatus_, hPathStatus);
+    *hPathStatus;
+
+    unsigned int eventID = event.id().event();
+    if (eventID < expectedStates_.size() && expectedStates_[eventID] != static_cast<int>(hPathStatus->state())) {
+      std::cerr << "TestGetPathStatus::analyze unexpected path status state" << std::endl;
+      abort();
+    }
+    if (eventID < expectedIndexes_.size() &&
+        expectedIndexes_[eventID] != hPathStatus->index()) {
+      std::cerr << "TestGetPathStatus::analyze unexpected path status index " << std::endl;
+      abort();
+    }
+
+    edm::Handle<edm::EndPathStatus> hEndPathStatus;
+    event.getByToken(tokenEndPathStatus_, hEndPathStatus);
+    *hEndPathStatus;
+  }
+}
+using edmtest::TestGetPathStatus;
+DEFINE_FWK_MODULE(TestGetPathStatus);

--- a/FWCore/Framework/test/testPathStatus_cfg.py
+++ b/FWCore/Framework/test/testPathStatus_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(7)
+)
+
+# The TestGetPathStatus analyzer tests that the PathStatus
+# and EndPathStatus can be read from the event and that
+# the PathStatus product contains the correct values.
+
+process.a1 = cms.EDAnalyzer("TestGetPathStatus",
+    pathStatusTag = cms.InputTag("path1"),
+    endPathStatusTag = cms.InputTag("endpath2"),
+    # The index into these two vectors is the EventID.
+    # The EventID starts at 1 so the first element is ignored.
+    expectedStates = cms.vint32(0,2,2,2,2,2,1,2),
+    expectedIndexes = cms.vuint32(0,1,2,1,2,1,2,1)
+)
+
+# Same test with an empty path and empty endpath
+
+process.a2 = cms.EDAnalyzer("TestGetPathStatus",
+    pathStatusTag = cms.InputTag("path2"),
+    endPathStatusTag = cms.InputTag("endpath3"),
+    expectedStates = cms.vint32(0,1,1,1,1,1,1,1),
+    expectedIndexes = cms.vuint32(0,0,0,0,0,0,0,0)
+)
+
+process.f1 = cms.EDFilter("ModuloEventIDFilter",
+    modulo = cms.uint32(2),
+    offset = cms.uint32(0)
+)
+
+process.f2 = cms.EDFilter("ModuloEventIDFilter",
+    modulo = cms.uint32(3),
+    offset = cms.uint32(0)
+)
+
+process.prod1 = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testPathStatus.root')
+)
+
+process.path1 = cms.Path(process.prod1 * process.f1 * process.f2)
+process.path2 = cms.Path()
+
+process.endpath1 = cms.EndPath(process.a1 * process.a2)
+process.endpath2 = cms.EndPath(process.out)
+process.endpath3 = cms.EndPath()

--- a/FWCore/Framework/test/test_no_concurrent_module_cfg.py
+++ b/FWCore/Framework/test/test_no_concurrent_module_cfg.py
@@ -31,5 +31,5 @@ process.t = cms.Task(process.i1, process.i2)
 process.p = cms.Path(process.c1+process.c2, process.t)
 
 process.add_(cms.Service("ConcurrentModuleTimer",
-                         modulesToExclude = cms.untracked.vstring("TriggerResults"),
+                         modulesToExclude = cms.untracked.vstring("TriggerResults", "p"),
                          excludeSource = cms.untracked.bool(True)))

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -2,40 +2,46 @@
 ++ finished: constructing source: EmptySource
 ++++ starting: constructing module with label 'TriggerResults' id = 1
 ++++ finished: constructing module with label 'TriggerResults' id = 1
-++++ starting: constructing module with label 'get' id = 2
-++++ finished: constructing module with label 'get' id = 2
-++++ starting: constructing module with label 'one' id = 3
+++++ starting: constructing module with label 'p' id = 2
+++++ finished: constructing module with label 'p' id = 2
+++++ starting: constructing module with label 'get' id = 3
+++++ finished: constructing module with label 'get' id = 3
+++++ starting: constructing module with label 'one' id = 4
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ finished: constructing module with label 'one' id = 3
+++++ finished: constructing module with label 'one' id = 4
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ starting: constructing module with label 'result1' id = 4
-++++ finished: constructing module with label 'result1' id = 4
-++++ starting: constructing module with label 'result2' id = 5
-++++ finished: constructing module with label 'result2' id = 5
-++++ starting: constructing module with label 'result4' id = 6
-++++ finished: constructing module with label 'result4' id = 6
+++++ starting: constructing module with label 'result1' id = 5
+++++ finished: constructing module with label 'result1' id = 5
+++++ starting: constructing module with label 'result2' id = 6
+++++ finished: constructing module with label 'result2' id = 6
+++++ starting: constructing module with label 'result4' id = 7
+++++ finished: constructing module with label 'result4' id = 7
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
-++++ starting: begin job for module with label 'one' id = 3
+++++ starting: begin job for module with label 'one' id = 4
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ finished: begin job for module with label 'one' id = 3
+++++ finished: begin job for module with label 'one' id = 4
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ starting: begin job for module with label 'result1' id = 4
-++++ finished: begin job for module with label 'result1' id = 4
-++++ starting: begin job for module with label 'result2' id = 5
-++++ finished: begin job for module with label 'result2' id = 5
-++++ starting: begin job for module with label 'result4' id = 6
-++++ finished: begin job for module with label 'result4' id = 6
-++++ starting: begin job for module with label 'get' id = 2
-++++ finished: begin job for module with label 'get' id = 2
+++++ starting: begin job for module with label 'result1' id = 5
+++++ finished: begin job for module with label 'result1' id = 5
+++++ starting: begin job for module with label 'result2' id = 6
+++++ finished: begin job for module with label 'result2' id = 6
+++++ starting: begin job for module with label 'result4' id = 7
+++++ finished: begin job for module with label 'result4' id = 7
+++++ starting: begin job for module with label 'get' id = 3
+++++ finished: begin job for module with label 'get' id = 3
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
+++++ starting: begin job for module with label 'p' id = 2
+++++ finished: begin job for module with label 'p' id = 2
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'get' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'get' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 3
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'one' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -47,7 +53,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ finished: begin stream for module: stream = 0 label = 'one' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -59,16 +65,16 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ starting: begin stream for module: stream = 0 label = 'result1' id = 4
-++++ finished: begin stream for module: stream = 0 label = 'result1' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'result2' id = 5
-++++ finished: begin stream for module: stream = 0 label = 'result2' id = 5
-++++ starting: begin stream for module: stream = 0 label = 'result4' id = 6
-++++ finished: begin stream for module: stream = 0 label = 'result4' id = 6
+++++ starting: begin stream for module: stream = 0 label = 'result1' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'result1' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'result2' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'result2' id = 6
+++++ starting: begin stream for module: stream = 0 label = 'result4' id = 7
+++++ finished: begin stream for module: stream = 0 label = 'result4' id = 7
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
-++++++ starting: global begin run for module: label = 'one' id = 3
+++++++ starting: global begin run for module: label = 'one' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -80,7 +86,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global begin run for module: label = 'one' id = 3
+++++++ finished: global begin run for module: label = 'one' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -92,25 +98,27 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global begin run for module: label = 'result1' id = 4
-++++++ finished: global begin run for module: label = 'result1' id = 4
-++++++ starting: global begin run for module: label = 'result2' id = 5
-++++++ finished: global begin run for module: label = 'result2' id = 5
-++++++ starting: global begin run for module: label = 'result4' id = 6
-++++++ finished: global begin run for module: label = 'result4' id = 6
-++++++ starting: global begin run for module: label = 'get' id = 2
-++++++ finished: global begin run for module: label = 'get' id = 2
+++++++ starting: global begin run for module: label = 'result1' id = 5
+++++++ finished: global begin run for module: label = 'result1' id = 5
+++++++ starting: global begin run for module: label = 'result2' id = 6
+++++++ finished: global begin run for module: label = 'result2' id = 6
+++++++ starting: global begin run for module: label = 'result4' id = 7
+++++++ finished: global begin run for module: label = 'result4' id = 7
+++++++ starting: global begin run for module: label = 'get' id = 3
+++++++ finished: global begin run for module: label = 'get' id = 3
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin run for module: label = 'p' id = 2
+++++++ finished: global begin run for module: label = 'p' id = 2
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
-++++++ starting: begin run for module: stream = 0 label = 'result4' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'result4' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'result2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'result2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'result1' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'result1' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'result4' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'result4' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'result2' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'result2' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'result1' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'result1' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -122,7 +130,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -134,13 +142,13 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global begin lumi for module: label = 'one' id = 3
+++++++ starting: global begin lumi for module: label = 'one' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -152,7 +160,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global begin lumi for module: label = 'one' id = 3
+++++++ finished: global begin lumi for module: label = 'one' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -164,25 +172,27 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global begin lumi for module: label = 'result1' id = 4
-++++++ finished: global begin lumi for module: label = 'result1' id = 4
-++++++ starting: global begin lumi for module: label = 'result2' id = 5
-++++++ finished: global begin lumi for module: label = 'result2' id = 5
-++++++ starting: global begin lumi for module: label = 'result4' id = 6
-++++++ finished: global begin lumi for module: label = 'result4' id = 6
-++++++ starting: global begin lumi for module: label = 'get' id = 2
-++++++ finished: global begin lumi for module: label = 'get' id = 2
+++++++ starting: global begin lumi for module: label = 'result1' id = 5
+++++++ finished: global begin lumi for module: label = 'result1' id = 5
+++++++ starting: global begin lumi for module: label = 'result2' id = 6
+++++++ finished: global begin lumi for module: label = 'result2' id = 6
+++++++ starting: global begin lumi for module: label = 'result4' id = 7
+++++++ finished: global begin lumi for module: label = 'result4' id = 7
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p' id = 2
+++++++ finished: global begin lumi for module: label = 'p' id = 2
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
-++++++ starting: begin lumi for module: stream = 0 label = 'result4' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'result4' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'result2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'result2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'result1' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'result1' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'result4' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'result4' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'result2' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'result2' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'result1' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'result1' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -194,7 +204,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -206,18 +216,18 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
 ++++++ starting: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 2
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -239,7 +249,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -261,7 +271,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -283,7 +293,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -305,18 +315,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 2
+++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -327,11 +339,11 @@ ModuleCallingContext state = Running
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
 ++++++ starting: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 2
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -353,7 +365,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -375,7 +387,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -397,7 +409,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -419,18 +431,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 2
+++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -441,11 +455,11 @@ ModuleCallingContext state = Running
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++++ starting: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 2
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -467,7 +481,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -489,7 +503,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -511,7 +525,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -533,18 +547,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 4
-++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 6
-++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 2
+++++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 5
+++++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -552,13 +568,13 @@ ModuleCallingContext state = Running
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'result4' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'result4' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'result2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'result2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'result1' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'result1' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'one' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'result4' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'result4' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'result2' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'result2' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'result1' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'result1' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -570,7 +586,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -582,11 +598,11 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global end lumi for module: label = 'one' id = 3
+++++++ starting: global end lumi for module: label = 'one' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -598,7 +614,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global end lumi for module: label = 'one' id = 3
+++++++ finished: global end lumi for module: label = 'one' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -610,25 +626,27 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global end lumi for module: label = 'result1' id = 4
-++++++ finished: global end lumi for module: label = 'result1' id = 4
-++++++ starting: global end lumi for module: label = 'result2' id = 5
-++++++ finished: global end lumi for module: label = 'result2' id = 5
-++++++ starting: global end lumi for module: label = 'result4' id = 6
-++++++ finished: global end lumi for module: label = 'result4' id = 6
-++++++ starting: global end lumi for module: label = 'get' id = 2
-++++++ finished: global end lumi for module: label = 'get' id = 2
+++++++ starting: global end lumi for module: label = 'result1' id = 5
+++++++ finished: global end lumi for module: label = 'result1' id = 5
+++++++ starting: global end lumi for module: label = 'result2' id = 6
+++++++ finished: global end lumi for module: label = 'result2' id = 6
+++++++ starting: global end lumi for module: label = 'result4' id = 7
+++++++ finished: global end lumi for module: label = 'result4' id = 7
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p' id = 2
+++++++ finished: global end lumi for module: label = 'p' id = 2
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'result4' id = 6
-++++++ finished: end run for module: stream = 0 label = 'result4' id = 6
-++++++ starting: end run for module: stream = 0 label = 'result2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'result2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'result1' id = 4
-++++++ finished: end run for module: stream = 0 label = 'result1' id = 4
-++++++ starting: end run for module: stream = 0 label = 'one' id = 3
+++++++ starting: end run for module: stream = 0 label = 'result4' id = 7
+++++++ finished: end run for module: stream = 0 label = 'result4' id = 7
+++++++ starting: end run for module: stream = 0 label = 'result2' id = 6
+++++++ finished: end run for module: stream = 0 label = 'result2' id = 6
+++++++ starting: end run for module: stream = 0 label = 'result1' id = 5
+++++++ finished: end run for module: stream = 0 label = 'result1' id = 5
+++++++ starting: end run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -640,7 +658,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: end run for module: stream = 0 label = 'one' id = 3
+++++++ finished: end run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -652,11 +670,11 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end run for module: stream = 0 label = 'get' id = 2
-++++++ finished: end run for module: stream = 0 label = 'get' id = 2
+++++++ starting: end run for module: stream = 0 label = 'get' id = 3
+++++++ finished: end run for module: stream = 0 label = 'get' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
-++++++ starting: global end run for module: label = 'one' id = 3
+++++++ starting: global end run for module: label = 'one' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -668,7 +686,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global end run for module: label = 'one' id = 3
+++++++ finished: global end run for module: label = 'one' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -680,22 +698,26 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global end run for module: label = 'result1' id = 4
-++++++ finished: global end run for module: label = 'result1' id = 4
-++++++ starting: global end run for module: label = 'result2' id = 5
-++++++ finished: global end run for module: label = 'result2' id = 5
-++++++ starting: global end run for module: label = 'result4' id = 6
-++++++ finished: global end run for module: label = 'result4' id = 6
-++++++ starting: global end run for module: label = 'get' id = 2
-++++++ finished: global end run for module: label = 'get' id = 2
+++++++ starting: global end run for module: label = 'result1' id = 5
+++++++ finished: global end run for module: label = 'result1' id = 5
+++++++ starting: global end run for module: label = 'result2' id = 6
+++++++ finished: global end run for module: label = 'result2' id = 6
+++++++ starting: global end run for module: label = 'result4' id = 7
+++++++ finished: global end run for module: label = 'result4' id = 7
+++++++ starting: global end run for module: label = 'get' id = 3
+++++++ finished: global end run for module: label = 'get' id = 3
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 1
+++++++ starting: global end run for module: label = 'p' id = 2
+++++++ finished: global end run for module: label = 'p' id = 2
 ++++ finished: global end run 1 : time = 1000030
-++++ starting: end stream for module: stream = 0 label = 'get' id = 2
-++++ finished: end stream for module: stream = 0 label = 'get' id = 2
+++++ starting: end stream for module: stream = 0 label = 'get' id = 3
+++++ finished: end stream for module: stream = 0 label = 'get' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'one' id = 3
+++++ starting: end stream for module: stream = 0 label = 'p' id = 2
+++++ finished: end stream for module: stream = 0 label = 'p' id = 2
+++++ starting: end stream for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -707,7 +729,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ finished: end stream for module: stream = 0 label = 'one' id = 3
+++++ finished: end stream for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -719,24 +741,26 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ starting: end stream for module: stream = 0 label = 'result1' id = 4
-++++ finished: end stream for module: stream = 0 label = 'result1' id = 4
-++++ starting: end stream for module: stream = 0 label = 'result2' id = 5
-++++ finished: end stream for module: stream = 0 label = 'result2' id = 5
-++++ starting: end stream for module: stream = 0 label = 'result4' id = 6
-++++ finished: end stream for module: stream = 0 label = 'result4' id = 6
-++++ starting: end job for module with label 'one' id = 3
+++++ starting: end stream for module: stream = 0 label = 'result1' id = 5
+++++ finished: end stream for module: stream = 0 label = 'result1' id = 5
+++++ starting: end stream for module: stream = 0 label = 'result2' id = 6
+++++ finished: end stream for module: stream = 0 label = 'result2' id = 6
+++++ starting: end stream for module: stream = 0 label = 'result4' id = 7
+++++ finished: end stream for module: stream = 0 label = 'result4' id = 7
+++++ starting: end job for module with label 'one' id = 4
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ finished: end job for module with label 'one' id = 3
+++++ finished: end job for module with label 'one' id = 4
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ starting: end job for module with label 'result1' id = 4
-++++ finished: end job for module with label 'result1' id = 4
-++++ starting: end job for module with label 'result2' id = 5
-++++ finished: end job for module with label 'result2' id = 5
-++++ starting: end job for module with label 'result4' id = 6
-++++ finished: end job for module with label 'result4' id = 6
-++++ starting: end job for module with label 'get' id = 2
-++++ finished: end job for module with label 'get' id = 2
+++++ starting: end job for module with label 'result1' id = 5
+++++ finished: end job for module with label 'result1' id = 5
+++++ starting: end job for module with label 'result2' id = 6
+++++ finished: end job for module with label 'result2' id = 6
+++++ starting: end job for module with label 'result4' id = 7
+++++ finished: end job for module with label 'result4' id = 7
+++++ starting: end job for module with label 'get' id = 3
+++++ finished: end job for module with label 'get' id = 3
 ++++ starting: end job for module with label 'TriggerResults' id = 1
 ++++ finished: end job for module with label 'TriggerResults' id = 1
+++++ starting: end job for module with label 'p' id = 2
+++++ finished: end job for module with label 'p' id = 2
 ++ finished: end job

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -2,105 +2,117 @@
 ++ finished: constructing source: EmptySource
 ++++ starting: constructing module with label 'TriggerResults' id = 1
 ++++ finished: constructing module with label 'TriggerResults' id = 1
-++++ starting: constructing module with label 'one' id = 2
-++++ finished: constructing module with label 'one' id = 2
-++++ starting: constructing module with label 'getOne' id = 3
-++++ finished: constructing module with label 'getOne' id = 3
-++++ starting: constructing module with label 'two' id = 4
-++++ finished: constructing module with label 'two' id = 4
-++++ starting: constructing module with label 'getTwo' id = 5
-++++ finished: constructing module with label 'getTwo' id = 5
+++++ starting: constructing module with label 'p' id = 2
+++++ finished: constructing module with label 'p' id = 2
+++++ starting: constructing module with label 'one' id = 3
+++++ finished: constructing module with label 'one' id = 3
+++++ starting: constructing module with label 'getOne' id = 4
+++++ finished: constructing module with label 'getOne' id = 4
+++++ starting: constructing module with label 'two' id = 5
+++++ finished: constructing module with label 'two' id = 5
+++++ starting: constructing module with label 'getTwo' id = 6
+++++ finished: constructing module with label 'getTwo' id = 6
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
-++++ starting: begin job for module with label 'one' id = 2
-++++ finished: begin job for module with label 'one' id = 2
-++++ starting: begin job for module with label 'getOne' id = 3
-++++ finished: begin job for module with label 'getOne' id = 3
-++++ starting: begin job for module with label 'two' id = 4
-++++ finished: begin job for module with label 'two' id = 4
-++++ starting: begin job for module with label 'getTwo' id = 5
-++++ finished: begin job for module with label 'getTwo' id = 5
+++++ starting: begin job for module with label 'one' id = 3
+++++ finished: begin job for module with label 'one' id = 3
+++++ starting: begin job for module with label 'getOne' id = 4
+++++ finished: begin job for module with label 'getOne' id = 4
+++++ starting: begin job for module with label 'two' id = 5
+++++ finished: begin job for module with label 'two' id = 5
+++++ starting: begin job for module with label 'getTwo' id = 6
+++++ finished: begin job for module with label 'getTwo' id = 6
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
+++++ starting: begin job for module with label 'p' id = 2
+++++ finished: begin job for module with label 'p' id = 2
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'one' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'one' id = 2
-++++ starting: begin stream for module: stream = 0 label = 'getOne' id = 3
-++++ finished: begin stream for module: stream = 0 label = 'getOne' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'two' id = 4
-++++ finished: begin stream for module: stream = 0 label = 'two' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'getTwo' id = 5
-++++ finished: begin stream for module: stream = 0 label = 'getTwo' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'one' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'one' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'getOne' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'getOne' id = 4
+++++ starting: begin stream for module: stream = 0 label = 'two' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'two' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'getTwo' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'getTwo' id = 6
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
-++++++ starting: global begin run for module: label = 'one' id = 2
-++++++ finished: global begin run for module: label = 'one' id = 2
-++++++ starting: global begin run for module: label = 'getOne' id = 3
-++++++ finished: global begin run for module: label = 'getOne' id = 3
-++++++ starting: global begin run for module: label = 'two' id = 4
-++++++ finished: global begin run for module: label = 'two' id = 4
-++++++ starting: global begin run for module: label = 'getTwo' id = 5
-++++++ finished: global begin run for module: label = 'getTwo' id = 5
+++++++ starting: global begin run for module: label = 'one' id = 3
+++++++ finished: global begin run for module: label = 'one' id = 3
+++++++ starting: global begin run for module: label = 'getOne' id = 4
+++++++ finished: global begin run for module: label = 'getOne' id = 4
+++++++ starting: global begin run for module: label = 'two' id = 5
+++++++ finished: global begin run for module: label = 'two' id = 5
+++++++ starting: global begin run for module: label = 'getTwo' id = 6
+++++++ finished: global begin run for module: label = 'getTwo' id = 6
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin run for module: label = 'p' id = 2
+++++++ finished: global begin run for module: label = 'p' id = 2
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
-++++++ starting: begin run for module: stream = 0 label = 'two' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'two' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'getOne' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'getOne' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'getTwo' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'getTwo' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'one' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'one' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'getOne' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'getOne' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'getTwo' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'getTwo' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global begin lumi for module: label = 'one' id = 2
-++++++ finished: global begin lumi for module: label = 'one' id = 2
-++++++ starting: global begin lumi for module: label = 'getOne' id = 3
-++++++ finished: global begin lumi for module: label = 'getOne' id = 3
-++++++ starting: global begin lumi for module: label = 'two' id = 4
-++++++ finished: global begin lumi for module: label = 'two' id = 4
-++++++ starting: global begin lumi for module: label = 'getTwo' id = 5
-++++++ finished: global begin lumi for module: label = 'getTwo' id = 5
+++++++ starting: global begin lumi for module: label = 'one' id = 3
+++++++ finished: global begin lumi for module: label = 'one' id = 3
+++++++ starting: global begin lumi for module: label = 'getOne' id = 4
+++++++ finished: global begin lumi for module: label = 'getOne' id = 4
+++++++ starting: global begin lumi for module: label = 'two' id = 5
+++++++ finished: global begin lumi for module: label = 'two' id = 5
+++++++ starting: global begin lumi for module: label = 'getTwo' id = 6
+++++++ finished: global begin lumi for module: label = 'getTwo' id = 6
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p' id = 2
+++++++ finished: global begin lumi for module: label = 'p' id = 2
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
-++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'two' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'getOne' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'getOne' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'getTwo' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'getTwo' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'two' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'getOne' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'getOne' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'getTwo' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'getTwo' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
 ++++++ starting: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'one' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'one' id = 2
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'two' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'two' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'two' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -111,22 +123,24 @@
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
 ++++++ starting: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'one' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'one' id = 2
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'two' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'two' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'two' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -137,22 +151,24 @@
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++++ starting: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'one' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'one' id = 2
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'two' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'two' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'getOne' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'two' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'two' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'getTwo' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -160,67 +176,75 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'two' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'two' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'getOne' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'getOne' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'getTwo' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'getTwo' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'one' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'one' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'two' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'two' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'getOne' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'getOne' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'getTwo' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'getTwo' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'one' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global end lumi for module: label = 'one' id = 2
-++++++ finished: global end lumi for module: label = 'one' id = 2
-++++++ starting: global end lumi for module: label = 'getOne' id = 3
-++++++ finished: global end lumi for module: label = 'getOne' id = 3
-++++++ starting: global end lumi for module: label = 'two' id = 4
-++++++ finished: global end lumi for module: label = 'two' id = 4
-++++++ starting: global end lumi for module: label = 'getTwo' id = 5
-++++++ finished: global end lumi for module: label = 'getTwo' id = 5
+++++++ starting: global end lumi for module: label = 'one' id = 3
+++++++ finished: global end lumi for module: label = 'one' id = 3
+++++++ starting: global end lumi for module: label = 'getOne' id = 4
+++++++ finished: global end lumi for module: label = 'getOne' id = 4
+++++++ starting: global end lumi for module: label = 'two' id = 5
+++++++ finished: global end lumi for module: label = 'two' id = 5
+++++++ starting: global end lumi for module: label = 'getTwo' id = 6
+++++++ finished: global end lumi for module: label = 'getTwo' id = 6
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p' id = 2
+++++++ finished: global end lumi for module: label = 'p' id = 2
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'two' id = 4
-++++++ finished: end run for module: stream = 0 label = 'two' id = 4
-++++++ starting: end run for module: stream = 0 label = 'getOne' id = 3
-++++++ finished: end run for module: stream = 0 label = 'getOne' id = 3
-++++++ starting: end run for module: stream = 0 label = 'getTwo' id = 5
-++++++ finished: end run for module: stream = 0 label = 'getTwo' id = 5
-++++++ starting: end run for module: stream = 0 label = 'one' id = 2
-++++++ finished: end run for module: stream = 0 label = 'one' id = 2
+++++++ starting: end run for module: stream = 0 label = 'two' id = 5
+++++++ finished: end run for module: stream = 0 label = 'two' id = 5
+++++++ starting: end run for module: stream = 0 label = 'getOne' id = 4
+++++++ finished: end run for module: stream = 0 label = 'getOne' id = 4
+++++++ starting: end run for module: stream = 0 label = 'getTwo' id = 6
+++++++ finished: end run for module: stream = 0 label = 'getTwo' id = 6
+++++++ starting: end run for module: stream = 0 label = 'one' id = 3
+++++++ finished: end run for module: stream = 0 label = 'one' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
-++++++ starting: global end run for module: label = 'one' id = 2
-++++++ finished: global end run for module: label = 'one' id = 2
-++++++ starting: global end run for module: label = 'getOne' id = 3
-++++++ finished: global end run for module: label = 'getOne' id = 3
-++++++ starting: global end run for module: label = 'two' id = 4
-++++++ finished: global end run for module: label = 'two' id = 4
-++++++ starting: global end run for module: label = 'getTwo' id = 5
-++++++ finished: global end run for module: label = 'getTwo' id = 5
+++++++ starting: global end run for module: label = 'one' id = 3
+++++++ finished: global end run for module: label = 'one' id = 3
+++++++ starting: global end run for module: label = 'getOne' id = 4
+++++++ finished: global end run for module: label = 'getOne' id = 4
+++++++ starting: global end run for module: label = 'two' id = 5
+++++++ finished: global end run for module: label = 'two' id = 5
+++++++ starting: global end run for module: label = 'getTwo' id = 6
+++++++ finished: global end run for module: label = 'getTwo' id = 6
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 1
+++++++ starting: global end run for module: label = 'p' id = 2
+++++++ finished: global end run for module: label = 'p' id = 2
 ++++ finished: global end run 1 : time = 1000030
-++++ starting: end stream for module: stream = 0 label = 'one' id = 2
-++++ finished: end stream for module: stream = 0 label = 'one' id = 2
-++++ starting: end stream for module: stream = 0 label = 'getOne' id = 3
-++++ finished: end stream for module: stream = 0 label = 'getOne' id = 3
-++++ starting: end stream for module: stream = 0 label = 'two' id = 4
-++++ finished: end stream for module: stream = 0 label = 'two' id = 4
-++++ starting: end stream for module: stream = 0 label = 'getTwo' id = 5
-++++ finished: end stream for module: stream = 0 label = 'getTwo' id = 5
+++++ starting: end stream for module: stream = 0 label = 'one' id = 3
+++++ finished: end stream for module: stream = 0 label = 'one' id = 3
+++++ starting: end stream for module: stream = 0 label = 'getOne' id = 4
+++++ finished: end stream for module: stream = 0 label = 'getOne' id = 4
+++++ starting: end stream for module: stream = 0 label = 'two' id = 5
+++++ finished: end stream for module: stream = 0 label = 'two' id = 5
+++++ starting: end stream for module: stream = 0 label = 'getTwo' id = 6
+++++ finished: end stream for module: stream = 0 label = 'getTwo' id = 6
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end job for module with label 'one' id = 2
-++++ finished: end job for module with label 'one' id = 2
-++++ starting: end job for module with label 'getOne' id = 3
-++++ finished: end job for module with label 'getOne' id = 3
-++++ starting: end job for module with label 'two' id = 4
-++++ finished: end job for module with label 'two' id = 4
-++++ starting: end job for module with label 'getTwo' id = 5
-++++ finished: end job for module with label 'getTwo' id = 5
+++++ starting: end stream for module: stream = 0 label = 'p' id = 2
+++++ finished: end stream for module: stream = 0 label = 'p' id = 2
+++++ starting: end job for module with label 'one' id = 3
+++++ finished: end job for module with label 'one' id = 3
+++++ starting: end job for module with label 'getOne' id = 4
+++++ finished: end job for module with label 'getOne' id = 4
+++++ starting: end job for module with label 'two' id = 5
+++++ finished: end job for module with label 'two' id = 5
+++++ starting: end job for module with label 'getTwo' id = 6
+++++ finished: end job for module with label 'getTwo' id = 6
 ++++ starting: end job for module with label 'TriggerResults' id = 1
 ++++ finished: end job for module with label 'TriggerResults' id = 1
+++++ starting: end job for module with label 'p' id = 2
+++++ finished: end job for module with label 'p' id = 2
 ++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
@@ -53,6 +53,11 @@ All modules and modules in the current process whose products they consume:
     IntProducer/'testStreamingProducer'
     IntVectorProducer/'intVectorProducer'
   TriggerResultInserter/'TriggerResults'
+  PathStatusInserter/'p'
+  PathStatusInserter/'p2'
+  PathStatusInserter/'p11'
+  EndPathStatusInserter/'e'
+  EndPathStatusInserter/'p1ep2'
 All modules (listed by class and label) and all their consumed products.
 Consumed products are listed by type, label, instance, process.
 For products not in the event, 'run' or 'lumi' is added to indicate the TTree they are from.
@@ -91,6 +96,11 @@ For products only read from previous processes, 'skip current process' is added
     edmtest::IntProduct 'testStreamingProducer' '' 'PROD1'
     std::vector<int> 'intVectorProducer' '' 'PROD1'
   TriggerResultInserter/'TriggerResults'
+  PathStatusInserter/'p'
+  PathStatusInserter/'p2'
+  PathStatusInserter/'p11'
+  EndPathStatusInserter/'e'
+  EndPathStatusInserter/'p1ep2'
 
 Process name = COPY
 paths:
@@ -126,6 +136,9 @@ All modules and modules in the current process whose products they consume:
   ConsumingIntProducer/'testManyConsumingProducer' consumes products from these modules:
     TriggerResultInserter/'TriggerResults'
   TriggerResultInserter/'TriggerResults'
+  PathStatusInserter/'p3'
+  EndPathStatusInserter/'ep1'
+  EndPathStatusInserter/'ep2'
 All modules (listed by class and label) and all their consumed products.
 Consumed products are listed by type, label, instance, process.
 For products not in the event, 'run' or 'lumi' is added to indicate the TTree they are from.
@@ -160,6 +173,9 @@ For products only read from previous processes, 'skip current process' is added
     edm::TriggerResults 'TriggerResults' '' ''
     edm::TriggerResults '' '' ''
   TriggerResultInserter/'TriggerResults'
+  PathStatusInserter/'p3'
+  EndPathStatusInserter/'ep1'
+  EndPathStatusInserter/'ep2'
 
 TestFindProduct sum = 12
 TestFindProduct sum = 300

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -4,61 +4,73 @@ Module type=IntSource, Module label=source, Parameter Set ID=031810a3ee2992e7936
 Module type=IntSource, Module label=source, Parameter Set ID=031810a3ee2992e7936b85708f83a8b2
 ++++ starting: constructing module with label 'TriggerResults' id = 1
 ++++ finished: constructing module with label 'TriggerResults' id = 1
-++++ starting: constructing module with label 'intProducer' id = 2
-++++ finished: constructing module with label 'intProducer' id = 2
-++++ starting: constructing module with label 'a1' id = 3
-++++ finished: constructing module with label 'a1' id = 3
-++++ starting: constructing module with label 'a2' id = 4
-++++ finished: constructing module with label 'a2' id = 4
-++++ starting: constructing module with label 'a3' id = 5
-++++ finished: constructing module with label 'a3' id = 5
-++++ starting: constructing module with label 'out' id = 6
-++++ finished: constructing module with label 'out' id = 6
-++++ starting: constructing module with label 'intProducerA' id = 7
+++++ starting: constructing module with label 'p' id = 2
+++++ finished: constructing module with label 'p' id = 2
+++++ starting: constructing module with label 'e' id = 3
+++++ finished: constructing module with label 'e' id = 3
+++++ starting: constructing module with label 'intProducer' id = 4
+++++ finished: constructing module with label 'intProducer' id = 4
+++++ starting: constructing module with label 'a1' id = 5
+++++ finished: constructing module with label 'a1' id = 5
+++++ starting: constructing module with label 'a2' id = 6
+++++ finished: constructing module with label 'a2' id = 6
+++++ starting: constructing module with label 'a3' id = 7
+++++ finished: constructing module with label 'a3' id = 7
+++++ starting: constructing module with label 'out' id = 8
+++++ finished: constructing module with label 'out' id = 8
+++++ starting: constructing module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ finished: constructing module with label 'intProducerA' id = 7
+++++ finished: constructing module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ starting: constructing module with label 'intProducerU' id = 8
-++++ finished: constructing module with label 'intProducerU' id = 8
-++++ starting: constructing module with label 'intVectorProducer' id = 9
-++++ finished: constructing module with label 'intVectorProducer' id = 9
+++++ starting: constructing module with label 'intProducerU' id = 10
+++++ finished: constructing module with label 'intProducerU' id = 10
+++++ starting: constructing module with label 'intVectorProducer' id = 11
+++++ finished: constructing module with label 'intVectorProducer' id = 11
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
-++++ starting: begin job for module with label 'intProducerA' id = 7
+++++ starting: begin job for module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ finished: begin job for module with label 'intProducerA' id = 7
+++++ finished: begin job for module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ starting: begin job for module with label 'intProducerU' id = 8
-++++ finished: begin job for module with label 'intProducerU' id = 8
-++++ starting: begin job for module with label 'intVectorProducer' id = 9
-++++ finished: begin job for module with label 'intVectorProducer' id = 9
-++++ starting: begin job for module with label 'intProducer' id = 2
-++++ finished: begin job for module with label 'intProducer' id = 2
-++++ starting: begin job for module with label 'a1' id = 3
-++++ finished: begin job for module with label 'a1' id = 3
-++++ starting: begin job for module with label 'a2' id = 4
-++++ finished: begin job for module with label 'a2' id = 4
-++++ starting: begin job for module with label 'a3' id = 5
-++++ finished: begin job for module with label 'a3' id = 5
-++++ starting: begin job for module with label 'out' id = 6
-++++ finished: begin job for module with label 'out' id = 6
+++++ starting: begin job for module with label 'intProducerU' id = 10
+++++ finished: begin job for module with label 'intProducerU' id = 10
+++++ starting: begin job for module with label 'intVectorProducer' id = 11
+++++ finished: begin job for module with label 'intVectorProducer' id = 11
+++++ starting: begin job for module with label 'intProducer' id = 4
+++++ finished: begin job for module with label 'intProducer' id = 4
+++++ starting: begin job for module with label 'a1' id = 5
+++++ finished: begin job for module with label 'a1' id = 5
+++++ starting: begin job for module with label 'a2' id = 6
+++++ finished: begin job for module with label 'a2' id = 6
+++++ starting: begin job for module with label 'a3' id = 7
+++++ finished: begin job for module with label 'a3' id = 7
+++++ starting: begin job for module with label 'out' id = 8
+++++ finished: begin job for module with label 'out' id = 8
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
+++++ starting: begin job for module with label 'p' id = 2
+++++ finished: begin job for module with label 'p' id = 2
+++++ starting: begin job for module with label 'e' id = 3
+++++ finished: begin job for module with label 'e' id = 3
 ++ starting: begin job
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 2
-++++ starting: begin stream for module: stream = 0 label = 'a1' id = 3
-++++ finished: begin stream for module: stream = 0 label = 'a1' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'a2' id = 4
-++++ finished: begin stream for module: stream = 0 label = 'a2' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'a3' id = 5
-++++ finished: begin stream for module: stream = 0 label = 'a3' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 4
+++++ starting: begin stream for module: stream = 0 label = 'a1' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'a1' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'a2' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'a2' id = 6
+++++ starting: begin stream for module: stream = 0 label = 'a3' id = 7
+++++ finished: begin stream for module: stream = 0 label = 'a3' id = 7
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'out' id = 6
-++++ finished: begin stream for module: stream = 0 label = 'out' id = 6
-++++ starting: begin stream for module: stream = 0 label = 'intProducerA' id = 7
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 8
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 8
+++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'e' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'e' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -70,7 +82,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++ finished: begin stream for module: stream = 0 label = 'intProducerA' id = 7
+++++ finished: begin stream for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -82,10 +94,10 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 8
-++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 8
-++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 9
-++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 9
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 10
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 10
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 11
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 11
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -94,7 +106,7 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global begin run for module: label = 'intProducerA' id = 7
+++++++ starting: global begin run for module: label = 'intProducerA' id = 9
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -106,7 +118,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: global begin run for module: label = 'intProducerA' id = 7
+++++++ finished: global begin run for module: label = 'intProducerA' id = 9
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -118,22 +130,26 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global begin run for module: label = 'intProducerU' id = 8
-++++++ finished: global begin run for module: label = 'intProducerU' id = 8
-++++++ starting: global begin run for module: label = 'intVectorProducer' id = 9
-++++++ finished: global begin run for module: label = 'intVectorProducer' id = 9
-++++++ starting: global begin run for module: label = 'intProducer' id = 2
-++++++ finished: global begin run for module: label = 'intProducer' id = 2
-++++++ starting: global begin run for module: label = 'a1' id = 3
-++++++ finished: global begin run for module: label = 'a1' id = 3
-++++++ starting: global begin run for module: label = 'a2' id = 4
-++++++ finished: global begin run for module: label = 'a2' id = 4
-++++++ starting: global begin run for module: label = 'a3' id = 5
-++++++ finished: global begin run for module: label = 'a3' id = 5
-++++++ starting: global begin run for module: label = 'out' id = 6
-++++++ finished: global begin run for module: label = 'out' id = 6
+++++++ starting: global begin run for module: label = 'intProducerU' id = 10
+++++++ finished: global begin run for module: label = 'intProducerU' id = 10
+++++++ starting: global begin run for module: label = 'intVectorProducer' id = 11
+++++++ finished: global begin run for module: label = 'intVectorProducer' id = 11
+++++++ starting: global begin run for module: label = 'intProducer' id = 4
+++++++ finished: global begin run for module: label = 'intProducer' id = 4
+++++++ starting: global begin run for module: label = 'a1' id = 5
+++++++ finished: global begin run for module: label = 'a1' id = 5
+++++++ starting: global begin run for module: label = 'a2' id = 6
+++++++ finished: global begin run for module: label = 'a2' id = 6
+++++++ starting: global begin run for module: label = 'a3' id = 7
+++++++ finished: global begin run for module: label = 'a3' id = 7
+++++++ starting: global begin run for module: label = 'out' id = 8
+++++++ finished: global begin run for module: label = 'out' id = 8
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin run for module: label = 'p' id = 2
+++++++ finished: global begin run for module: label = 'p' id = 2
+++++++ starting: global begin run for module: label = 'e' id = 3
+++++++ finished: global begin run for module: label = 'e' id = 3
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -160,9 +176,9 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -174,7 +190,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -186,18 +202,18 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: begin run for module: stream = 0 label = 'a1' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'a1' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'a2' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'a2' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'a3' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'a3' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 2
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'a1' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'a1' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'a2' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'a2' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'a3' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'a3' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 8
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -226,7 +242,7 @@ GlobalContext: transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global begin lumi for module: label = 'intProducerA' id = 7
+++++++ starting: global begin lumi for module: label = 'intProducerA' id = 9
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -238,7 +254,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: global begin lumi for module: label = 'intProducerA' id = 7
+++++++ finished: global begin lumi for module: label = 'intProducerA' id = 9
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -250,22 +266,26 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global begin lumi for module: label = 'intProducerU' id = 8
-++++++ finished: global begin lumi for module: label = 'intProducerU' id = 8
-++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 9
-++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 9
-++++++ starting: global begin lumi for module: label = 'intProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'intProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'a1' id = 3
-++++++ finished: global begin lumi for module: label = 'a1' id = 3
-++++++ starting: global begin lumi for module: label = 'a2' id = 4
-++++++ finished: global begin lumi for module: label = 'a2' id = 4
-++++++ starting: global begin lumi for module: label = 'a3' id = 5
-++++++ finished: global begin lumi for module: label = 'a3' id = 5
-++++++ starting: global begin lumi for module: label = 'out' id = 6
-++++++ finished: global begin lumi for module: label = 'out' id = 6
+++++++ starting: global begin lumi for module: label = 'intProducerU' id = 10
+++++++ finished: global begin lumi for module: label = 'intProducerU' id = 10
+++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 11
+++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 11
+++++++ starting: global begin lumi for module: label = 'intProducer' id = 4
+++++++ finished: global begin lumi for module: label = 'intProducer' id = 4
+++++++ starting: global begin lumi for module: label = 'a1' id = 5
+++++++ finished: global begin lumi for module: label = 'a1' id = 5
+++++++ starting: global begin lumi for module: label = 'a2' id = 6
+++++++ finished: global begin lumi for module: label = 'a2' id = 6
+++++++ starting: global begin lumi for module: label = 'a3' id = 7
+++++++ finished: global begin lumi for module: label = 'a3' id = 7
+++++++ starting: global begin lumi for module: label = 'out' id = 8
+++++++ finished: global begin lumi for module: label = 'out' id = 8
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p' id = 2
+++++++ finished: global begin lumi for module: label = 'p' id = 2
+++++++ starting: global begin lumi for module: label = 'e' id = 3
+++++++ finished: global begin lumi for module: label = 'e' id = 3
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -292,9 +312,9 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -306,7 +326,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -318,18 +338,18 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: begin lumi for module: stream = 0 label = 'a1' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'a1' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'a2' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'a2' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'a3' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'a3' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 2
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'a1' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'a1' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'a2' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'a2' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'a3' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'a3' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 8
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -369,16 +389,16 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 4
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -394,7 +414,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -410,7 +430,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -426,7 +446,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -442,13 +462,15 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -475,18 +497,20 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 6
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -537,16 +561,16 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 4
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -562,7 +586,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -578,7 +602,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -594,7 +618,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -610,13 +634,15 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -643,18 +669,20 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 6
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -705,16 +733,16 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 4
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -730,7 +758,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -746,7 +774,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -762,7 +790,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -778,13 +806,15 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -811,18 +841,20 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 6
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 8
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -860,9 +892,9 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -874,7 +906,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -886,18 +918,18 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: end lumi for module: stream = 0 label = 'a1' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'a1' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'a2' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'a2' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'a3' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'a3' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 2
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'a1' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'a1' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'a2' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'a2' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'a3' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'a3' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 8
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -924,7 +956,7 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global end lumi for module: label = 'intProducerA' id = 7
+++++++ starting: global end lumi for module: label = 'intProducerA' id = 9
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -936,7 +968,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: global end lumi for module: label = 'intProducerA' id = 7
+++++++ finished: global end lumi for module: label = 'intProducerA' id = 9
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -948,22 +980,26 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global end lumi for module: label = 'intProducerU' id = 8
-++++++ finished: global end lumi for module: label = 'intProducerU' id = 8
-++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 9
-++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 9
-++++++ starting: global end lumi for module: label = 'intProducer' id = 2
-++++++ finished: global end lumi for module: label = 'intProducer' id = 2
-++++++ starting: global end lumi for module: label = 'a1' id = 3
-++++++ finished: global end lumi for module: label = 'a1' id = 3
-++++++ starting: global end lumi for module: label = 'a2' id = 4
-++++++ finished: global end lumi for module: label = 'a2' id = 4
-++++++ starting: global end lumi for module: label = 'a3' id = 5
-++++++ finished: global end lumi for module: label = 'a3' id = 5
-++++++ starting: global end lumi for module: label = 'out' id = 6
-++++++ finished: global end lumi for module: label = 'out' id = 6
+++++++ starting: global end lumi for module: label = 'intProducerU' id = 10
+++++++ finished: global end lumi for module: label = 'intProducerU' id = 10
+++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 11
+++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 11
+++++++ starting: global end lumi for module: label = 'intProducer' id = 4
+++++++ finished: global end lumi for module: label = 'intProducer' id = 4
+++++++ starting: global end lumi for module: label = 'a1' id = 5
+++++++ finished: global end lumi for module: label = 'a1' id = 5
+++++++ starting: global end lumi for module: label = 'a2' id = 6
+++++++ finished: global end lumi for module: label = 'a2' id = 6
+++++++ starting: global end lumi for module: label = 'a3' id = 7
+++++++ finished: global end lumi for module: label = 'a3' id = 7
+++++++ starting: global end lumi for module: label = 'out' id = 8
+++++++ finished: global end lumi for module: label = 'out' id = 8
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p' id = 2
+++++++ finished: global end lumi for module: label = 'p' id = 2
+++++++ starting: global end lumi for module: label = 'e' id = 3
+++++++ finished: global end lumi for module: label = 'e' id = 3
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -990,9 +1026,9 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 8
-++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 7
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 10
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 10
+++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1004,7 +1040,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 7
+++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1016,18 +1052,18 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: end run for module: stream = 0 label = 'a1' id = 3
-++++++ finished: end run for module: stream = 0 label = 'a1' id = 3
-++++++ starting: end run for module: stream = 0 label = 'a2' id = 4
-++++++ finished: end run for module: stream = 0 label = 'a2' id = 4
-++++++ starting: end run for module: stream = 0 label = 'a3' id = 5
-++++++ finished: end run for module: stream = 0 label = 'a3' id = 5
-++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 9
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 2
-++++++ starting: end run for module: stream = 0 label = 'out' id = 6
-++++++ finished: end run for module: stream = 0 label = 'out' id = 6
+++++++ starting: end run for module: stream = 0 label = 'a1' id = 5
+++++++ finished: end run for module: stream = 0 label = 'a1' id = 5
+++++++ starting: end run for module: stream = 0 label = 'a2' id = 6
+++++++ finished: end run for module: stream = 0 label = 'a2' id = 6
+++++++ starting: end run for module: stream = 0 label = 'a3' id = 7
+++++++ finished: end run for module: stream = 0 label = 'a3' id = 7
+++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 11
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: end run for module: stream = 0 label = 'out' id = 8
+++++++ finished: end run for module: stream = 0 label = 'out' id = 8
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -1054,7 +1090,7 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global end run for module: label = 'intProducerA' id = 7
+++++++ starting: global end run for module: label = 'intProducerA' id = 9
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1066,7 +1102,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ finished: global end run for module: label = 'intProducerA' id = 7
+++++++ finished: global end run for module: label = 'intProducerA' id = 9
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1078,22 +1114,26 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++++ starting: global end run for module: label = 'intProducerU' id = 8
-++++++ finished: global end run for module: label = 'intProducerU' id = 8
-++++++ starting: global end run for module: label = 'intVectorProducer' id = 9
-++++++ finished: global end run for module: label = 'intVectorProducer' id = 9
-++++++ starting: global end run for module: label = 'intProducer' id = 2
-++++++ finished: global end run for module: label = 'intProducer' id = 2
-++++++ starting: global end run for module: label = 'a1' id = 3
-++++++ finished: global end run for module: label = 'a1' id = 3
-++++++ starting: global end run for module: label = 'a2' id = 4
-++++++ finished: global end run for module: label = 'a2' id = 4
-++++++ starting: global end run for module: label = 'a3' id = 5
-++++++ finished: global end run for module: label = 'a3' id = 5
-++++++ starting: global end run for module: label = 'out' id = 6
-++++++ finished: global end run for module: label = 'out' id = 6
+++++++ starting: global end run for module: label = 'intProducerU' id = 10
+++++++ finished: global end run for module: label = 'intProducerU' id = 10
+++++++ starting: global end run for module: label = 'intVectorProducer' id = 11
+++++++ finished: global end run for module: label = 'intVectorProducer' id = 11
+++++++ starting: global end run for module: label = 'intProducer' id = 4
+++++++ finished: global end run for module: label = 'intProducer' id = 4
+++++++ starting: global end run for module: label = 'a1' id = 5
+++++++ finished: global end run for module: label = 'a1' id = 5
+++++++ starting: global end run for module: label = 'a2' id = 6
+++++++ finished: global end run for module: label = 'a2' id = 6
+++++++ starting: global end run for module: label = 'a3' id = 7
+++++++ finished: global end run for module: label = 'a3' id = 7
+++++++ starting: global end run for module: label = 'out' id = 8
+++++++ finished: global end run for module: label = 'out' id = 8
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 1
+++++++ starting: global end run for module: label = 'p' id = 2
+++++++ finished: global end run for module: label = 'p' id = 2
+++++++ starting: global end run for module: label = 'e' id = 3
+++++++ finished: global end run for module: label = 'e' id = 3
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
@@ -1114,19 +1154,23 @@ GlobalContext: transition = EndRun
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 2
-++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 2
-++++ starting: end stream for module: stream = 0 label = 'a1' id = 3
-++++ finished: end stream for module: stream = 0 label = 'a1' id = 3
-++++ starting: end stream for module: stream = 0 label = 'a2' id = 4
-++++ finished: end stream for module: stream = 0 label = 'a2' id = 4
-++++ starting: end stream for module: stream = 0 label = 'a3' id = 5
-++++ finished: end stream for module: stream = 0 label = 'a3' id = 5
+++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4
+++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 4
+++++ starting: end stream for module: stream = 0 label = 'a1' id = 5
+++++ finished: end stream for module: stream = 0 label = 'a1' id = 5
+++++ starting: end stream for module: stream = 0 label = 'a2' id = 6
+++++ finished: end stream for module: stream = 0 label = 'a2' id = 6
+++++ starting: end stream for module: stream = 0 label = 'a3' id = 7
+++++ finished: end stream for module: stream = 0 label = 'a3' id = 7
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'out' id = 6
-++++ finished: end stream for module: stream = 0 label = 'out' id = 6
-++++ starting: end stream for module: stream = 0 label = 'intProducerA' id = 7
+++++ starting: end stream for module: stream = 0 label = 'out' id = 8
+++++ finished: end stream for module: stream = 0 label = 'out' id = 8
+++++ starting: end stream for module: stream = 0 label = 'p' id = 2
+++++ finished: end stream for module: stream = 0 label = 'p' id = 2
+++++ starting: end stream for module: stream = 0 label = 'e' id = 3
+++++ finished: end stream for module: stream = 0 label = 'e' id = 3
+++++ starting: end stream for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1138,7 +1182,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++ finished: end stream for module: stream = 0 label = 'intProducerA' id = 7
+++++ finished: end stream for module: stream = 0 label = 'intProducerA' id = 9
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1150,31 +1194,35 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 4fe4a2816617359f330df85fe06ebaf1
 
-++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 8
-++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 8
-++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 9
-++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 9
-++++ starting: end job for module with label 'intProducerA' id = 7
+++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 10
+++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 10
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 11
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 11
+++++ starting: end job for module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ finished: end job for module with label 'intProducerA' id = 7
+++++ finished: end job for module with label 'intProducerA' id = 9
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ starting: end job for module with label 'intProducerU' id = 8
-++++ finished: end job for module with label 'intProducerU' id = 8
-++++ starting: end job for module with label 'intVectorProducer' id = 9
-++++ finished: end job for module with label 'intVectorProducer' id = 9
-++++ starting: end job for module with label 'intProducer' id = 2
-++++ finished: end job for module with label 'intProducer' id = 2
-++++ starting: end job for module with label 'a1' id = 3
+++++ starting: end job for module with label 'intProducerU' id = 10
+++++ finished: end job for module with label 'intProducerU' id = 10
+++++ starting: end job for module with label 'intVectorProducer' id = 11
+++++ finished: end job for module with label 'intVectorProducer' id = 11
+++++ starting: end job for module with label 'intProducer' id = 4
+++++ finished: end job for module with label 'intProducer' id = 4
+++++ starting: end job for module with label 'a1' id = 5
 TestFindProduct sum = 12
-++++ finished: end job for module with label 'a1' id = 3
-++++ starting: end job for module with label 'a2' id = 4
+++++ finished: end job for module with label 'a1' id = 5
+++++ starting: end job for module with label 'a2' id = 6
 TestFindProduct sum = 300
-++++ finished: end job for module with label 'a2' id = 4
-++++ starting: end job for module with label 'a3' id = 5
+++++ finished: end job for module with label 'a2' id = 6
+++++ starting: end job for module with label 'a3' id = 7
 TestFindProduct sum = 300
-++++ finished: end job for module with label 'a3' id = 5
-++++ starting: end job for module with label 'out' id = 6
-++++ finished: end job for module with label 'out' id = 6
+++++ finished: end job for module with label 'a3' id = 7
+++++ starting: end job for module with label 'out' id = 8
+++++ finished: end job for module with label 'out' id = 8
 ++++ starting: end job for module with label 'TriggerResults' id = 1
 ++++ finished: end job for module with label 'TriggerResults' id = 1
+++++ starting: end job for module with label 'p' id = 2
+++++ finished: end job for module with label 'p' id = 2
+++++ starting: end job for module with label 'e' id = 3
+++++ finished: end job for module with label 'e' id = 3
 ++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -6,32 +6,40 @@ Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4f
 Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4ff4f335f14507fa
 ++++ starting: constructing module with label 'TriggerResults' id = 1
 ++++ finished: constructing module with label 'TriggerResults' id = 1
-++++ starting: constructing module with label 'intProducer' id = 2
+++++ starting: constructing module with label 'p' id = 2
+++++ finished: constructing module with label 'p' id = 2
+++++ starting: constructing module with label 'e' id = 3
+++++ finished: constructing module with label 'e' id = 3
+++++ starting: constructing module with label 'intProducer' id = 4
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ finished: constructing module with label 'intProducer' id = 2
+++++ finished: constructing module with label 'intProducer' id = 4
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ starting: constructing module with label 'out' id = 3
-++++ finished: constructing module with label 'out' id = 3
-++++ starting: constructing module with label 'intProducerU' id = 4
-++++ finished: constructing module with label 'intProducerU' id = 4
-++++ starting: constructing module with label 'intVectorProducer' id = 5
-++++ finished: constructing module with label 'intVectorProducer' id = 5
+++++ starting: constructing module with label 'out' id = 5
+++++ finished: constructing module with label 'out' id = 5
+++++ starting: constructing module with label 'intProducerU' id = 6
+++++ finished: constructing module with label 'intProducerU' id = 6
+++++ starting: constructing module with label 'intVectorProducer' id = 7
+++++ finished: constructing module with label 'intVectorProducer' id = 7
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
-++++ starting: begin job for module with label 'intProducerU' id = 4
-++++ finished: begin job for module with label 'intProducerU' id = 4
-++++ starting: begin job for module with label 'intVectorProducer' id = 5
-++++ finished: begin job for module with label 'intVectorProducer' id = 5
-++++ starting: begin job for module with label 'intProducer' id = 2
+++++ starting: begin job for module with label 'intProducerU' id = 6
+++++ finished: begin job for module with label 'intProducerU' id = 6
+++++ starting: begin job for module with label 'intVectorProducer' id = 7
+++++ finished: begin job for module with label 'intVectorProducer' id = 7
+++++ starting: begin job for module with label 'intProducer' id = 4
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ finished: begin job for module with label 'intProducer' id = 2
+++++ finished: begin job for module with label 'intProducer' id = 4
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ starting: begin job for module with label 'out' id = 3
-++++ finished: begin job for module with label 'out' id = 3
+++++ starting: begin job for module with label 'out' id = 5
+++++ finished: begin job for module with label 'out' id = 5
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
+++++ starting: begin job for module with label 'p' id = 2
+++++ finished: begin job for module with label 'p' id = 2
+++++ starting: begin job for module with label 'e' id = 3
+++++ finished: begin job for module with label 'e' id = 3
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -43,7 +51,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -57,12 +65,16 @@ ModuleCallingContext state = Running
 
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'out' id = 3
-++++ finished: begin stream for module: stream = 0 label = 'out' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 4
-++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 5
-++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'e' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'e' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 6
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 7
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 7
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -71,11 +83,11 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global begin run for module: label = 'intProducerU' id = 4
-++++++ finished: global begin run for module: label = 'intProducerU' id = 4
-++++++ starting: global begin run for module: label = 'intVectorProducer' id = 5
-++++++ finished: global begin run for module: label = 'intVectorProducer' id = 5
-++++++ starting: global begin run for module: label = 'intProducer' id = 2
+++++++ starting: global begin run for module: label = 'intProducerU' id = 6
+++++++ finished: global begin run for module: label = 'intProducerU' id = 6
+++++++ starting: global begin run for module: label = 'intVectorProducer' id = 7
+++++++ finished: global begin run for module: label = 'intVectorProducer' id = 7
+++++++ starting: global begin run for module: label = 'intProducer' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -87,7 +99,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: global begin run for module: label = 'intProducer' id = 2
+++++++ finished: global begin run for module: label = 'intProducer' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -99,10 +111,14 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global begin run for module: label = 'out' id = 3
-++++++ finished: global begin run for module: label = 'out' id = 3
+++++++ starting: global begin run for module: label = 'out' id = 5
+++++++ finished: global begin run for module: label = 'out' id = 5
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin run for module: label = 'p' id = 2
+++++++ finished: global begin run for module: label = 'p' id = 2
+++++++ starting: global begin run for module: label = 'e' id = 3
+++++++ finished: global begin run for module: label = 'e' id = 3
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -115,11 +131,11 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -131,7 +147,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -143,8 +159,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -159,11 +175,11 @@ GlobalContext: transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global begin lumi for module: label = 'intProducerU' id = 4
-++++++ finished: global begin lumi for module: label = 'intProducerU' id = 4
-++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 5
-++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 5
-++++++ starting: global begin lumi for module: label = 'intProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'intProducerU' id = 6
+++++++ finished: global begin lumi for module: label = 'intProducerU' id = 6
+++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 7
+++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 7
+++++++ starting: global begin lumi for module: label = 'intProducer' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -175,7 +191,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: global begin lumi for module: label = 'intProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'intProducer' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -187,10 +203,14 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global begin lumi for module: label = 'out' id = 3
-++++++ finished: global begin lumi for module: label = 'out' id = 3
+++++++ starting: global begin lumi for module: label = 'out' id = 5
+++++++ finished: global begin lumi for module: label = 'out' id = 5
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p' id = 2
+++++++ finished: global begin lumi for module: label = 'p' id = 2
+++++++ starting: global begin lumi for module: label = 'e' id = 3
+++++++ finished: global begin lumi for module: label = 'e' id = 3
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -203,11 +223,11 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -219,7 +239,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -231,8 +251,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -258,7 +278,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -272,7 +292,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -286,7 +306,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -300,7 +320,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -314,6 +334,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -340,32 +362,34 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 3
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -402,7 +426,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -416,7 +440,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -430,7 +454,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -444,7 +468,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -458,6 +482,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -484,32 +510,34 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 3
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -546,7 +574,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -560,7 +588,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -574,7 +602,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -588,7 +616,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -602,6 +630,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -628,32 +658,34 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 3
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 3
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 6
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -677,11 +709,11 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -693,7 +725,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -705,8 +737,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -719,11 +751,11 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global end lumi for module: label = 'intProducerU' id = 4
-++++++ finished: global end lumi for module: label = 'intProducerU' id = 4
-++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 5
-++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 5
-++++++ starting: global end lumi for module: label = 'intProducer' id = 2
+++++++ starting: global end lumi for module: label = 'intProducerU' id = 6
+++++++ finished: global end lumi for module: label = 'intProducerU' id = 6
+++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 7
+++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 7
+++++++ starting: global end lumi for module: label = 'intProducer' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -735,7 +767,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: global end lumi for module: label = 'intProducer' id = 2
+++++++ finished: global end lumi for module: label = 'intProducer' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -747,10 +779,14 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global end lumi for module: label = 'out' id = 3
-++++++ finished: global end lumi for module: label = 'out' id = 3
+++++++ starting: global end lumi for module: label = 'out' id = 5
+++++++ finished: global end lumi for module: label = 'out' id = 5
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p' id = 2
+++++++ finished: global end lumi for module: label = 'p' id = 2
+++++++ starting: global end lumi for module: label = 'e' id = 3
+++++++ finished: global end lumi for module: label = 'e' id = 3
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -763,11 +799,11 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 5
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 4
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 4
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 7
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 6
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 6
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -779,7 +815,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -791,8 +827,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: end run for module: stream = 0 label = 'out' id = 3
-++++++ finished: end run for module: stream = 0 label = 'out' id = 3
+++++++ starting: end run for module: stream = 0 label = 'out' id = 5
+++++++ finished: end run for module: stream = 0 label = 'out' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -805,11 +841,11 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global end run for module: label = 'intProducerU' id = 4
-++++++ finished: global end run for module: label = 'intProducerU' id = 4
-++++++ starting: global end run for module: label = 'intVectorProducer' id = 5
-++++++ finished: global end run for module: label = 'intVectorProducer' id = 5
-++++++ starting: global end run for module: label = 'intProducer' id = 2
+++++++ starting: global end run for module: label = 'intProducerU' id = 6
+++++++ finished: global end run for module: label = 'intProducerU' id = 6
+++++++ starting: global end run for module: label = 'intVectorProducer' id = 7
+++++++ finished: global end run for module: label = 'intVectorProducer' id = 7
+++++++ starting: global end run for module: label = 'intProducer' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -821,7 +857,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ finished: global end run for module: label = 'intProducer' id = 2
+++++++ finished: global end run for module: label = 'intProducer' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -833,10 +869,14 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++ starting: global end run for module: label = 'out' id = 3
-++++++ finished: global end run for module: label = 'out' id = 3
+++++++ starting: global end run for module: label = 'out' id = 5
+++++++ finished: global end run for module: label = 'out' id = 5
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 1
+++++++ starting: global end run for module: label = 'p' id = 2
+++++++ finished: global end run for module: label = 'p' id = 2
+++++++ starting: global end run for module: label = 'e' id = 3
+++++++ finished: global end run for module: label = 'e' id = 3
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
@@ -845,7 +885,7 @@ GlobalContext: transition = EndRun
 
 ++++ starting: close input file: lfn = file:testGetBy1.root usedFallBack = 0
 ++++ finished: close input file: lfn = file:testGetBy1.root usedFallBack = 0
-++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 2
+++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -857,7 +897,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 2
+++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -871,22 +911,30 @@ ModuleCallingContext state = Running
 
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'out' id = 3
-++++ finished: end stream for module: stream = 0 label = 'out' id = 3
-++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 4
-++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 4
-++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 5
-++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 5
-++++ starting: end job for module with label 'intProducerU' id = 4
-++++ finished: end job for module with label 'intProducerU' id = 4
-++++ starting: end job for module with label 'intVectorProducer' id = 5
-++++ finished: end job for module with label 'intVectorProducer' id = 5
-++++ starting: end job for module with label 'intProducer' id = 2
+++++ starting: end stream for module: stream = 0 label = 'out' id = 5
+++++ finished: end stream for module: stream = 0 label = 'out' id = 5
+++++ starting: end stream for module: stream = 0 label = 'p' id = 2
+++++ finished: end stream for module: stream = 0 label = 'p' id = 2
+++++ starting: end stream for module: stream = 0 label = 'e' id = 3
+++++ finished: end stream for module: stream = 0 label = 'e' id = 3
+++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 6
+++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 6
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 7
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 7
+++++ starting: end job for module with label 'intProducerU' id = 6
+++++ finished: end job for module with label 'intProducerU' id = 6
+++++ starting: end job for module with label 'intVectorProducer' id = 7
+++++ finished: end job for module with label 'intVectorProducer' id = 7
+++++ starting: end job for module with label 'intProducer' id = 4
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ finished: end job for module with label 'intProducer' id = 2
+++++ finished: end job for module with label 'intProducer' id = 4
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ starting: end job for module with label 'out' id = 3
-++++ finished: end job for module with label 'out' id = 3
+++++ starting: end job for module with label 'out' id = 5
+++++ finished: end job for module with label 'out' id = 5
 ++++ starting: end job for module with label 'TriggerResults' id = 1
 ++++ finished: end job for module with label 'TriggerResults' id = 1
+++++ starting: end job for module with label 'p' id = 2
+++++ finished: end job for module with label 'p' id = 2
+++++ starting: end job for module with label 'e' id = 3
+++++ finished: end job for module with label 'e' id = 3
 ++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -2,38 +2,38 @@
 ++ finished: constructing source: EmptySource
 ++++ starting: constructing module with label 'TriggerResults' id = 1
 ++++ finished: constructing module with label 'TriggerResults' id = 1
-++++ starting: constructing module with label 'thingWithMergeProducer' id = 2
-++++ finished: constructing module with label 'thingWithMergeProducer' id = 2
-++++ starting: constructing module with label 'get' id = 3
-++++ finished: constructing module with label 'get' id = 3
-++++ starting: constructing module with label 'putInt' id = 4
-++++ finished: constructing module with label 'putInt' id = 4
-++++ starting: constructing module with label 'putInt2' id = 5
-++++ finished: constructing module with label 'putInt2' id = 5
-++++ starting: constructing module with label 'putInt3' id = 6
-++++ finished: constructing module with label 'putInt3' id = 6
-++++ starting: constructing module with label 'getInt' id = 7
-++++ finished: constructing module with label 'getInt' id = 7
-++++ starting: constructing module with label 'noPut' id = 8
-++++ finished: constructing module with label 'noPut' id = 8
-++++ starting: constructing module with label 'TriggerResults' id = 9
-++++ finished: constructing module with label 'TriggerResults' id = 9
-++++ starting: constructing module with label 'thingWithMergeProducer' id = 10
-++++ finished: constructing module with label 'thingWithMergeProducer' id = 10
-++++ starting: constructing module with label 'test' id = 11
-++++ finished: constructing module with label 'test' id = 11
-++++ starting: constructing module with label 'testmerge' id = 12
-++++ finished: constructing module with label 'testmerge' id = 12
-++++ starting: constructing module with label 'get' id = 13
-++++ finished: constructing module with label 'get' id = 13
-++++ starting: constructing module with label 'getInt' id = 14
-++++ finished: constructing module with label 'getInt' id = 14
-++++ starting: constructing module with label 'dependsOnNoPut' id = 15
-++++ finished: constructing module with label 'dependsOnNoPut' id = 15
-++++ starting: constructing module with label 'out' id = 16
-++++ finished: constructing module with label 'out' id = 16
-++++ starting: constructing module with label 'TriggerResults' id = 17
-++++ finished: constructing module with label 'TriggerResults' id = 17
+++++ starting: constructing module with label 'p1' id = 2
+++++ finished: constructing module with label 'p1' id = 2
+++++ starting: constructing module with label 'path1' id = 3
+++++ finished: constructing module with label 'path1' id = 3
+++++ starting: constructing module with label 'path2' id = 4
+++++ finished: constructing module with label 'path2' id = 4
+++++ starting: constructing module with label 'thingWithMergeProducer' id = 5
+++++ finished: constructing module with label 'thingWithMergeProducer' id = 5
+++++ starting: constructing module with label 'get' id = 6
+++++ finished: constructing module with label 'get' id = 6
+++++ starting: constructing module with label 'putInt' id = 7
+++++ finished: constructing module with label 'putInt' id = 7
+++++ starting: constructing module with label 'putInt2' id = 8
+++++ finished: constructing module with label 'putInt2' id = 8
+++++ starting: constructing module with label 'putInt3' id = 9
+++++ finished: constructing module with label 'putInt3' id = 9
+++++ starting: constructing module with label 'getInt' id = 10
+++++ finished: constructing module with label 'getInt' id = 10
+++++ starting: constructing module with label 'noPut' id = 11
+++++ finished: constructing module with label 'noPut' id = 11
+++++ starting: constructing module with label 'TriggerResults' id = 12
+++++ finished: constructing module with label 'TriggerResults' id = 12
+++++ starting: constructing module with label 'path1' id = 13
+++++ finished: constructing module with label 'path1' id = 13
+++++ starting: constructing module with label 'path2' id = 14
+++++ finished: constructing module with label 'path2' id = 14
+++++ starting: constructing module with label 'path3' id = 15
+++++ finished: constructing module with label 'path3' id = 15
+++++ starting: constructing module with label 'path4' id = 16
+++++ finished: constructing module with label 'path4' id = 16
+++++ starting: constructing module with label 'endPath1' id = 17
+++++ finished: constructing module with label 'endPath1' id = 17
 ++++ starting: constructing module with label 'thingWithMergeProducer' id = 18
 ++++ finished: constructing module with label 'thingWithMergeProducer' id = 18
 ++++ starting: constructing module with label 'test' id = 19
@@ -48,44 +48,59 @@
 ++++ finished: constructing module with label 'dependsOnNoPut' id = 23
 ++++ starting: constructing module with label 'out' id = 24
 ++++ finished: constructing module with label 'out' id = 24
+++++ starting: constructing module with label 'TriggerResults' id = 25
+++++ finished: constructing module with label 'TriggerResults' id = 25
+++++ starting: constructing module with label 'path1' id = 26
+++++ finished: constructing module with label 'path1' id = 26
+++++ starting: constructing module with label 'path2' id = 27
+++++ finished: constructing module with label 'path2' id = 27
+++++ starting: constructing module with label 'path3' id = 28
+++++ finished: constructing module with label 'path3' id = 28
+++++ starting: constructing module with label 'path4' id = 29
+++++ finished: constructing module with label 'path4' id = 29
+++++ starting: constructing module with label 'endPath1' id = 30
+++++ finished: constructing module with label 'endPath1' id = 30
+++++ starting: constructing module with label 'thingWithMergeProducer' id = 31
+++++ finished: constructing module with label 'thingWithMergeProducer' id = 31
+++++ starting: constructing module with label 'test' id = 32
+++++ finished: constructing module with label 'test' id = 32
+++++ starting: constructing module with label 'testmerge' id = 33
+++++ finished: constructing module with label 'testmerge' id = 33
+++++ starting: constructing module with label 'get' id = 34
+++++ finished: constructing module with label 'get' id = 34
+++++ starting: constructing module with label 'getInt' id = 35
+++++ finished: constructing module with label 'getInt' id = 35
+++++ starting: constructing module with label 'dependsOnNoPut' id = 36
+++++ finished: constructing module with label 'dependsOnNoPut' id = 36
+++++ starting: constructing module with label 'out' id = 37
+++++ finished: constructing module with label 'out' id = 37
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
 ++ starting: begin job
 ++ starting: begin job
-++++ starting: begin job for module with label 'thingWithMergeProducer' id = 2
-++++ finished: begin job for module with label 'thingWithMergeProducer' id = 2
-++++ starting: begin job for module with label 'get' id = 3
-++++ finished: begin job for module with label 'get' id = 3
-++++ starting: begin job for module with label 'putInt' id = 4
-++++ finished: begin job for module with label 'putInt' id = 4
-++++ starting: begin job for module with label 'putInt2' id = 5
-++++ finished: begin job for module with label 'putInt2' id = 5
-++++ starting: begin job for module with label 'putInt3' id = 6
-++++ finished: begin job for module with label 'putInt3' id = 6
-++++ starting: begin job for module with label 'getInt' id = 7
-++++ finished: begin job for module with label 'getInt' id = 7
-++++ starting: begin job for module with label 'noPut' id = 8
-++++ finished: begin job for module with label 'noPut' id = 8
+++++ starting: begin job for module with label 'thingWithMergeProducer' id = 5
+++++ finished: begin job for module with label 'thingWithMergeProducer' id = 5
+++++ starting: begin job for module with label 'get' id = 6
+++++ finished: begin job for module with label 'get' id = 6
+++++ starting: begin job for module with label 'putInt' id = 7
+++++ finished: begin job for module with label 'putInt' id = 7
+++++ starting: begin job for module with label 'putInt2' id = 8
+++++ finished: begin job for module with label 'putInt2' id = 8
+++++ starting: begin job for module with label 'putInt3' id = 9
+++++ finished: begin job for module with label 'putInt3' id = 9
+++++ starting: begin job for module with label 'getInt' id = 10
+++++ finished: begin job for module with label 'getInt' id = 10
+++++ starting: begin job for module with label 'noPut' id = 11
+++++ finished: begin job for module with label 'noPut' id = 11
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
+++++ starting: begin job for module with label 'p1' id = 2
+++++ finished: begin job for module with label 'p1' id = 2
+++++ starting: begin job for module with label 'path1' id = 3
+++++ finished: begin job for module with label 'path1' id = 3
+++++ starting: begin job for module with label 'path2' id = 4
+++++ finished: begin job for module with label 'path2' id = 4
 ++ starting: begin job
-++ starting: begin job
-++++ starting: begin job for module with label 'thingWithMergeProducer' id = 10
-++++ finished: begin job for module with label 'thingWithMergeProducer' id = 10
-++++ starting: begin job for module with label 'test' id = 11
-++++ finished: begin job for module with label 'test' id = 11
-++++ starting: begin job for module with label 'testmerge' id = 12
-++++ finished: begin job for module with label 'testmerge' id = 12
-++++ starting: begin job for module with label 'get' id = 13
-++++ finished: begin job for module with label 'get' id = 13
-++++ starting: begin job for module with label 'getInt' id = 14
-++++ finished: begin job for module with label 'getInt' id = 14
-++++ starting: begin job for module with label 'dependsOnNoPut' id = 15
-++++ finished: begin job for module with label 'dependsOnNoPut' id = 15
-++++ starting: begin job for module with label 'out' id = 16
-++++ finished: begin job for module with label 'out' id = 16
-++++ starting: begin job for module with label 'TriggerResults' id = 9
-++++ finished: begin job for module with label 'TriggerResults' id = 9
 ++ starting: begin job
 ++++ starting: begin job for module with label 'thingWithMergeProducer' id = 18
 ++++ finished: begin job for module with label 'thingWithMergeProducer' id = 18
@@ -101,41 +116,68 @@
 ++++ finished: begin job for module with label 'dependsOnNoPut' id = 23
 ++++ starting: begin job for module with label 'out' id = 24
 ++++ finished: begin job for module with label 'out' id = 24
-++++ starting: begin job for module with label 'TriggerResults' id = 17
-++++ finished: begin job for module with label 'TriggerResults' id = 17
+++++ starting: begin job for module with label 'TriggerResults' id = 12
+++++ finished: begin job for module with label 'TriggerResults' id = 12
+++++ starting: begin job for module with label 'path1' id = 13
+++++ finished: begin job for module with label 'path1' id = 13
+++++ starting: begin job for module with label 'path2' id = 14
+++++ finished: begin job for module with label 'path2' id = 14
+++++ starting: begin job for module with label 'path3' id = 15
+++++ finished: begin job for module with label 'path3' id = 15
+++++ starting: begin job for module with label 'path4' id = 16
+++++ finished: begin job for module with label 'path4' id = 16
+++++ starting: begin job for module with label 'endPath1' id = 17
+++++ finished: begin job for module with label 'endPath1' id = 17
+++ starting: begin job
+++++ starting: begin job for module with label 'thingWithMergeProducer' id = 31
+++++ finished: begin job for module with label 'thingWithMergeProducer' id = 31
+++++ starting: begin job for module with label 'test' id = 32
+++++ finished: begin job for module with label 'test' id = 32
+++++ starting: begin job for module with label 'testmerge' id = 33
+++++ finished: begin job for module with label 'testmerge' id = 33
+++++ starting: begin job for module with label 'get' id = 34
+++++ finished: begin job for module with label 'get' id = 34
+++++ starting: begin job for module with label 'getInt' id = 35
+++++ finished: begin job for module with label 'getInt' id = 35
+++++ starting: begin job for module with label 'dependsOnNoPut' id = 36
+++++ finished: begin job for module with label 'dependsOnNoPut' id = 36
+++++ starting: begin job for module with label 'out' id = 37
+++++ finished: begin job for module with label 'out' id = 37
+++++ starting: begin job for module with label 'TriggerResults' id = 25
+++++ finished: begin job for module with label 'TriggerResults' id = 25
+++++ starting: begin job for module with label 'path1' id = 26
+++++ finished: begin job for module with label 'path1' id = 26
+++++ starting: begin job for module with label 'path2' id = 27
+++++ finished: begin job for module with label 'path2' id = 27
+++++ starting: begin job for module with label 'path3' id = 28
+++++ finished: begin job for module with label 'path3' id = 28
+++++ starting: begin job for module with label 'path4' id = 29
+++++ finished: begin job for module with label 'path4' id = 29
+++++ starting: begin job for module with label 'endPath1' id = 30
+++++ finished: begin job for module with label 'endPath1' id = 30
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++ starting: begin stream for module: stream = 0 label = 'get' id = 3
-++++ finished: begin stream for module: stream = 0 label = 'get' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'putInt' id = 4
-++++ finished: begin stream for module: stream = 0 label = 'putInt' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'putInt2' id = 5
-++++ finished: begin stream for module: stream = 0 label = 'putInt2' id = 5
-++++ starting: begin stream for module: stream = 0 label = 'putInt3' id = 6
-++++ finished: begin stream for module: stream = 0 label = 'putInt3' id = 6
-++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 7
-++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 7
-++++ starting: begin stream for module: stream = 0 label = 'noPut' id = 8
-++++ finished: begin stream for module: stream = 0 label = 'noPut' id = 8
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 6
+++++ starting: begin stream for module: stream = 0 label = 'putInt' id = 7
+++++ finished: begin stream for module: stream = 0 label = 'putInt' id = 7
+++++ starting: begin stream for module: stream = 0 label = 'putInt2' id = 8
+++++ finished: begin stream for module: stream = 0 label = 'putInt2' id = 8
+++++ starting: begin stream for module: stream = 0 label = 'putInt3' id = 9
+++++ finished: begin stream for module: stream = 0 label = 'putInt3' id = 9
+++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 10
+++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 10
+++++ starting: begin stream for module: stream = 0 label = 'noPut' id = 11
+++++ finished: begin stream for module: stream = 0 label = 'noPut' id = 11
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++ starting: begin stream for module: stream = 0 label = 'test' id = 11
-++++ finished: begin stream for module: stream = 0 label = 'test' id = 11
-++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 12
-++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 12
-++++ starting: begin stream for module: stream = 0 label = 'get' id = 13
-++++ finished: begin stream for module: stream = 0 label = 'get' id = 13
-++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 14
-++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 14
-++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 9
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 9
-++++ starting: begin stream for module: stream = 0 label = 'out' id = 16
-++++ finished: begin stream for module: stream = 0 label = 'out' id = 16
+++++ starting: begin stream for module: stream = 0 label = 'p1' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'p1' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'path1' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'path1' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'path2' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'path2' id = 4
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++ starting: begin stream for module: stream = 0 label = 'test' id = 19
@@ -148,10 +190,46 @@
 ++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 22
 ++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 17
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 17
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 12
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 12
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 24
+++++ starting: begin stream for module: stream = 0 label = 'path1' id = 13
+++++ finished: begin stream for module: stream = 0 label = 'path1' id = 13
+++++ starting: begin stream for module: stream = 0 label = 'path2' id = 14
+++++ finished: begin stream for module: stream = 0 label = 'path2' id = 14
+++++ starting: begin stream for module: stream = 0 label = 'path3' id = 15
+++++ finished: begin stream for module: stream = 0 label = 'path3' id = 15
+++++ starting: begin stream for module: stream = 0 label = 'path4' id = 16
+++++ finished: begin stream for module: stream = 0 label = 'path4' id = 16
+++++ starting: begin stream for module: stream = 0 label = 'endPath1' id = 17
+++++ finished: begin stream for module: stream = 0 label = 'endPath1' id = 17
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: begin stream for module: stream = 0 label = 'test' id = 32
+++++ finished: begin stream for module: stream = 0 label = 'test' id = 32
+++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 33
+++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 33
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 34
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 34
+++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 35
+++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 35
+++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 25
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 25
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 37
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 37
+++++ starting: begin stream for module: stream = 0 label = 'path1' id = 26
+++++ finished: begin stream for module: stream = 0 label = 'path1' id = 26
+++++ starting: begin stream for module: stream = 0 label = 'path2' id = 27
+++++ finished: begin stream for module: stream = 0 label = 'path2' id = 27
+++++ starting: begin stream for module: stream = 0 label = 'path3' id = 28
+++++ finished: begin stream for module: stream = 0 label = 'path3' id = 28
+++++ starting: begin stream for module: stream = 0 label = 'path4' id = 29
+++++ finished: begin stream for module: stream = 0 label = 'path4' id = 29
+++++ starting: begin stream for module: stream = 0 label = 'endPath1' id = 30
+++++ finished: begin stream for module: stream = 0 label = 'endPath1' id = 30
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -159,27 +237,60 @@
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin run for module: label = 'get' id = 3
-++++++ finished: global begin run for module: label = 'get' id = 3
-++++++ starting: global begin run for module: label = 'putInt' id = 4
-++++++ finished: global begin run for module: label = 'putInt' id = 4
-++++++ starting: global begin run for module: label = 'putInt2' id = 5
-++++++ finished: global begin run for module: label = 'putInt2' id = 5
-++++++ starting: global begin run for module: label = 'putInt3' id = 6
-++++++ finished: global begin run for module: label = 'putInt3' id = 6
-++++++ starting: global begin run for module: label = 'getInt' id = 7
-++++++ finished: global begin run for module: label = 'getInt' id = 7
-++++++ starting: global begin run for module: label = 'noPut' id = 8
-++++++ finished: global begin run for module: label = 'noPut' id = 8
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin run for module: label = 'get' id = 6
+++++++ finished: global begin run for module: label = 'get' id = 6
+++++++ starting: global begin run for module: label = 'putInt' id = 7
+++++++ finished: global begin run for module: label = 'putInt' id = 7
+++++++ starting: global begin run for module: label = 'putInt2' id = 8
+++++++ finished: global begin run for module: label = 'putInt2' id = 8
+++++++ starting: global begin run for module: label = 'putInt3' id = 9
+++++++ finished: global begin run for module: label = 'putInt3' id = 9
+++++++ starting: global begin run for module: label = 'getInt' id = 10
+++++++ finished: global begin run for module: label = 'getInt' id = 10
+++++++ starting: global begin run for module: label = 'noPut' id = 11
+++++++ finished: global begin run for module: label = 'noPut' id = 11
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin run for module: label = 'p1' id = 2
+++++++ finished: global begin run for module: label = 'p1' id = 2
+++++++ starting: global begin run for module: label = 'path1' id = 3
+++++++ finished: global begin run for module: label = 'path1' id = 3
+++++++ starting: global begin run for module: label = 'path2' id = 4
+++++++ finished: global begin run for module: label = 'path2' id = 4
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin run for module: label = 'test' id = 32
+++++++ finished: global begin run for module: label = 'test' id = 32
+++++++ starting: global begin run for module: label = 'testmerge' id = 33
+++++++ finished: global begin run for module: label = 'testmerge' id = 33
+++++++ starting: global begin run for module: label = 'get' id = 34
+++++++ finished: global begin run for module: label = 'get' id = 34
+++++++ starting: global begin run for module: label = 'getInt' id = 35
+++++++ finished: global begin run for module: label = 'getInt' id = 35
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin run for module: label = 'out' id = 37
+++++++ finished: global begin run for module: label = 'out' id = 37
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin run for module: label = 'path1' id = 26
+++++++ finished: global begin run for module: label = 'path1' id = 26
+++++++ starting: global begin run for module: label = 'path2' id = 27
+++++++ finished: global begin run for module: label = 'path2' id = 27
+++++++ starting: global begin run for module: label = 'path3' id = 28
+++++++ finished: global begin run for module: label = 'path3' id = 28
+++++++ starting: global begin run for module: label = 'path4' id = 29
+++++++ finished: global begin run for module: label = 'path4' id = 29
+++++++ starting: global begin run for module: label = 'endPath1' id = 30
+++++++ finished: global begin run for module: label = 'endPath1' id = 30
+++++ finished: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin run for module: label = 'test' id = 19
@@ -194,47 +305,56 @@
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin run for module: label = 'out' id = 24
 ++++++ finished: global begin run for module: label = 'out' id = 24
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
-++++ finished: global begin run 1 : time = 1
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin run for module: label = 'test' id = 11
-++++++ finished: global begin run for module: label = 'test' id = 11
-++++++ starting: global begin run for module: label = 'testmerge' id = 12
-++++++ finished: global begin run for module: label = 'testmerge' id = 12
-++++++ starting: global begin run for module: label = 'get' id = 13
-++++++ finished: global begin run for module: label = 'get' id = 13
-++++++ starting: global begin run for module: label = 'getInt' id = 14
-++++++ finished: global begin run for module: label = 'getInt' id = 14
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin run for module: label = 'out' id = 16
-++++++ finished: global begin run for module: label = 'out' id = 16
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin run for module: label = 'path1' id = 13
+++++++ finished: global begin run for module: label = 'path1' id = 13
+++++++ starting: global begin run for module: label = 'path2' id = 14
+++++++ finished: global begin run for module: label = 'path2' id = 14
+++++++ starting: global begin run for module: label = 'path3' id = 15
+++++++ finished: global begin run for module: label = 'path3' id = 15
+++++++ starting: global begin run for module: label = 'path4' id = 16
+++++++ finished: global begin run for module: label = 'path4' id = 16
+++++++ starting: global begin run for module: label = 'endPath1' id = 17
+++++++ finished: global begin run for module: label = 'endPath1' id = 17
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -252,22 +372,6 @@
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 1 time = 1
-++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
-++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
@@ -275,27 +379,60 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -310,47 +447,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -368,22 +514,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
@@ -392,38 +522,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -434,90 +570,110 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: source event
@@ -528,38 +684,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -570,6 +732,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -577,53 +748,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -632,6 +761,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -640,20 +771,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: source event
@@ -664,38 +846,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -706,6 +894,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -713,53 +910,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -768,6 +923,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -776,20 +933,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: source event
@@ -800,38 +1008,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -842,6 +1056,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -849,53 +1072,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -904,6 +1085,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -912,20 +1095,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 20000001
@@ -933,22 +1167,38 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -966,63 +1216,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++ finished: global end lumi: run = 1 lumi = 1 time = 1
-++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1039,8 +1261,46 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1049,27 +1309,60 @@
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -1084,47 +1377,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1142,22 +1444,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
@@ -1166,38 +1452,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -1208,90 +1500,110 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: source event
@@ -1302,38 +1614,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -1344,6 +1662,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -1351,53 +1678,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -1406,6 +1691,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -1414,20 +1701,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: source event
@@ -1438,38 +1776,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -1480,6 +1824,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -1487,53 +1840,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -1542,6 +1853,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -1550,20 +1863,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: source event
@@ -1574,38 +1938,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -1616,6 +1986,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -1623,53 +2002,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -1678,6 +2015,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -1686,20 +2025,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 40000001
@@ -1707,22 +2097,38 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1740,63 +2146,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
-++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -1813,8 +2191,46 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1823,27 +2239,60 @@
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -1858,47 +2307,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -1916,22 +2374,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
@@ -1940,38 +2382,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -1982,6 +2430,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -1989,53 +2446,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -2044,6 +2459,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -2052,20 +2469,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: source event
@@ -2076,38 +2544,44 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -2118,6 +2592,15 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -2125,53 +2608,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -2180,6 +2621,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -2188,20 +2631,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
@@ -2209,22 +2703,38 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2242,63 +2752,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
-++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -2315,30 +2797,84 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end run for module: stream = 0 label = 'get' id = 3
-++++++ finished: end run for module: stream = 0 label = 'get' id = 3
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end run for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'get' id = 6
+++++++ finished: end run for module: stream = 0 label = 'get' id = 6
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
+++++ finished: end run: stream = 0 run = 1 time = 0
+++++ starting: end run: stream = 0 run = 1 time = 0
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end run for module: stream = 0 label = 'get' id = 34
+++++++ finished: end run for module: stream = 0 label = 'get' id = 34
+++++++ starting: end run for module: stream = 0 label = 'test' id = 32
+++++++ finished: end run for module: stream = 0 label = 'test' id = 32
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end run for module: stream = 0 label = 'out' id = 37
+++++++ finished: end run for module: stream = 0 label = 'out' id = 37
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2356,48 +2892,65 @@
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 1 time = 0
-++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end run for module: stream = 0 label = 'get' id = 13
-++++++ finished: end run for module: stream = 0 label = 'get' id = 13
-++++++ starting: end run for module: stream = 0 label = 'test' id = 11
-++++++ finished: end run for module: stream = 0 label = 'test' id = 11
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end run for module: stream = 0 label = 'out' id = 16
-++++++ finished: end run for module: stream = 0 label = 'out' id = 16
-++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: global end run 1 : time = 50000001
 ++++ finished: global end run 1 : time = 50000001
 ++++ starting: global end run 1 : time = 0
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end run for module: label = 'get' id = 3
-++++++ finished: global end run for module: label = 'get' id = 3
-++++++ starting: global end run for module: label = 'putInt' id = 4
-++++++ finished: global end run for module: label = 'putInt' id = 4
-++++++ starting: global end run for module: label = 'putInt2' id = 5
-++++++ finished: global end run for module: label = 'putInt2' id = 5
-++++++ starting: global end run for module: label = 'putInt3' id = 6
-++++++ finished: global end run for module: label = 'putInt3' id = 6
-++++++ starting: global end run for module: label = 'getInt' id = 7
-++++++ finished: global end run for module: label = 'getInt' id = 7
-++++++ starting: global end run for module: label = 'noPut' id = 8
-++++++ finished: global end run for module: label = 'noPut' id = 8
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end run for module: label = 'get' id = 6
+++++++ finished: global end run for module: label = 'get' id = 6
+++++++ starting: global end run for module: label = 'putInt' id = 7
+++++++ finished: global end run for module: label = 'putInt' id = 7
+++++++ starting: global end run for module: label = 'putInt2' id = 8
+++++++ finished: global end run for module: label = 'putInt2' id = 8
+++++++ starting: global end run for module: label = 'putInt3' id = 9
+++++++ finished: global end run for module: label = 'putInt3' id = 9
+++++++ starting: global end run for module: label = 'getInt' id = 10
+++++++ finished: global end run for module: label = 'getInt' id = 10
+++++++ starting: global end run for module: label = 'noPut' id = 11
+++++++ finished: global end run for module: label = 'noPut' id = 11
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 1
+++++++ starting: global end run for module: label = 'p1' id = 2
+++++++ finished: global end run for module: label = 'p1' id = 2
+++++++ starting: global end run for module: label = 'path1' id = 3
+++++++ finished: global end run for module: label = 'path1' id = 3
+++++++ starting: global end run for module: label = 'path2' id = 4
+++++++ finished: global end run for module: label = 'path2' id = 4
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end run for module: label = 'test' id = 32
+++++++ finished: global end run for module: label = 'test' id = 32
+++++++ starting: global end run for module: label = 'testmerge' id = 33
+++++++ finished: global end run for module: label = 'testmerge' id = 33
+++++++ starting: global end run for module: label = 'get' id = 34
+++++++ finished: global end run for module: label = 'get' id = 34
+++++++ starting: global end run for module: label = 'getInt' id = 35
+++++++ finished: global end run for module: label = 'getInt' id = 35
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end run for module: label = 'out' id = 37
+++++++ finished: global end run for module: label = 'out' id = 37
+++++++ starting: global end run for module: label = 'TriggerResults' id = 25
+++++++ finished: global end run for module: label = 'TriggerResults' id = 25
+++++++ starting: global end run for module: label = 'path1' id = 26
+++++++ finished: global end run for module: label = 'path1' id = 26
+++++++ starting: global end run for module: label = 'path2' id = 27
+++++++ finished: global end run for module: label = 'path2' id = 27
+++++++ starting: global end run for module: label = 'path3' id = 28
+++++++ finished: global end run for module: label = 'path3' id = 28
+++++++ starting: global end run for module: label = 'path4' id = 29
+++++++ finished: global end run for module: label = 'path4' id = 29
+++++++ starting: global end run for module: label = 'endPath1' id = 30
+++++++ finished: global end run for module: label = 'endPath1' id = 30
+++++ finished: global end run 1 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global end run for module: label = 'test' id = 19
@@ -2412,25 +2965,18 @@
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
-++++++ starting: global end run for module: label = 'TriggerResults' id = 17
-++++++ finished: global end run for module: label = 'TriggerResults' id = 17
-++++ finished: global end run 1 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end run for module: label = 'test' id = 11
-++++++ finished: global end run for module: label = 'test' id = 11
-++++++ starting: global end run for module: label = 'testmerge' id = 12
-++++++ finished: global end run for module: label = 'testmerge' id = 12
-++++++ starting: global end run for module: label = 'get' id = 13
-++++++ finished: global end run for module: label = 'get' id = 13
-++++++ starting: global end run for module: label = 'getInt' id = 14
-++++++ finished: global end run for module: label = 'getInt' id = 14
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end run for module: label = 'out' id = 16
-++++++ finished: global end run for module: label = 'out' id = 16
-++++++ starting: global end run for module: label = 'TriggerResults' id = 9
-++++++ finished: global end run for module: label = 'TriggerResults' id = 9
+++++++ starting: global end run for module: label = 'TriggerResults' id = 12
+++++++ finished: global end run for module: label = 'TriggerResults' id = 12
+++++++ starting: global end run for module: label = 'path1' id = 13
+++++++ finished: global end run for module: label = 'path1' id = 13
+++++++ starting: global end run for module: label = 'path2' id = 14
+++++++ finished: global end run for module: label = 'path2' id = 14
+++++++ starting: global end run for module: label = 'path3' id = 15
+++++++ finished: global end run for module: label = 'path3' id = 15
+++++++ starting: global end run for module: label = 'path4' id = 16
+++++++ finished: global end run for module: label = 'path4' id = 16
+++++++ starting: global end run for module: label = 'endPath1' id = 17
+++++++ finished: global end run for module: label = 'endPath1' id = 17
 ++++ finished: global end run 1 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -2439,27 +2985,60 @@
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin run for module: label = 'get' id = 3
-++++++ finished: global begin run for module: label = 'get' id = 3
-++++++ starting: global begin run for module: label = 'putInt' id = 4
-++++++ finished: global begin run for module: label = 'putInt' id = 4
-++++++ starting: global begin run for module: label = 'putInt2' id = 5
-++++++ finished: global begin run for module: label = 'putInt2' id = 5
-++++++ starting: global begin run for module: label = 'putInt3' id = 6
-++++++ finished: global begin run for module: label = 'putInt3' id = 6
-++++++ starting: global begin run for module: label = 'getInt' id = 7
-++++++ finished: global begin run for module: label = 'getInt' id = 7
-++++++ starting: global begin run for module: label = 'noPut' id = 8
-++++++ finished: global begin run for module: label = 'noPut' id = 8
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin run for module: label = 'get' id = 6
+++++++ finished: global begin run for module: label = 'get' id = 6
+++++++ starting: global begin run for module: label = 'putInt' id = 7
+++++++ finished: global begin run for module: label = 'putInt' id = 7
+++++++ starting: global begin run for module: label = 'putInt2' id = 8
+++++++ finished: global begin run for module: label = 'putInt2' id = 8
+++++++ starting: global begin run for module: label = 'putInt3' id = 9
+++++++ finished: global begin run for module: label = 'putInt3' id = 9
+++++++ starting: global begin run for module: label = 'getInt' id = 10
+++++++ finished: global begin run for module: label = 'getInt' id = 10
+++++++ starting: global begin run for module: label = 'noPut' id = 11
+++++++ finished: global begin run for module: label = 'noPut' id = 11
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin run for module: label = 'p1' id = 2
+++++++ finished: global begin run for module: label = 'p1' id = 2
+++++++ starting: global begin run for module: label = 'path1' id = 3
+++++++ finished: global begin run for module: label = 'path1' id = 3
+++++++ starting: global begin run for module: label = 'path2' id = 4
+++++++ finished: global begin run for module: label = 'path2' id = 4
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin run for module: label = 'test' id = 32
+++++++ finished: global begin run for module: label = 'test' id = 32
+++++++ starting: global begin run for module: label = 'testmerge' id = 33
+++++++ finished: global begin run for module: label = 'testmerge' id = 33
+++++++ starting: global begin run for module: label = 'get' id = 34
+++++++ finished: global begin run for module: label = 'get' id = 34
+++++++ starting: global begin run for module: label = 'getInt' id = 35
+++++++ finished: global begin run for module: label = 'getInt' id = 35
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin run for module: label = 'out' id = 37
+++++++ finished: global begin run for module: label = 'out' id = 37
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin run for module: label = 'path1' id = 26
+++++++ finished: global begin run for module: label = 'path1' id = 26
+++++++ starting: global begin run for module: label = 'path2' id = 27
+++++++ finished: global begin run for module: label = 'path2' id = 27
+++++++ starting: global begin run for module: label = 'path3' id = 28
+++++++ finished: global begin run for module: label = 'path3' id = 28
+++++++ starting: global begin run for module: label = 'path4' id = 29
+++++++ finished: global begin run for module: label = 'path4' id = 29
+++++++ starting: global begin run for module: label = 'endPath1' id = 30
+++++++ finished: global begin run for module: label = 'endPath1' id = 30
+++++ finished: global begin run 2 : time = 55000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin run for module: label = 'test' id = 19
@@ -2474,47 +3053,56 @@
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin run for module: label = 'out' id = 24
 ++++++ finished: global begin run for module: label = 'out' id = 24
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
-++++ finished: global begin run 2 : time = 55000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin run for module: label = 'test' id = 11
-++++++ finished: global begin run for module: label = 'test' id = 11
-++++++ starting: global begin run for module: label = 'testmerge' id = 12
-++++++ finished: global begin run for module: label = 'testmerge' id = 12
-++++++ starting: global begin run for module: label = 'get' id = 13
-++++++ finished: global begin run for module: label = 'get' id = 13
-++++++ starting: global begin run for module: label = 'getInt' id = 14
-++++++ finished: global begin run for module: label = 'getInt' id = 14
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin run for module: label = 'out' id = 16
-++++++ finished: global begin run for module: label = 'out' id = 16
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin run for module: label = 'path1' id = 13
+++++++ finished: global begin run for module: label = 'path1' id = 13
+++++++ starting: global begin run for module: label = 'path2' id = 14
+++++++ finished: global begin run for module: label = 'path2' id = 14
+++++++ starting: global begin run for module: label = 'path3' id = 15
+++++++ finished: global begin run for module: label = 'path3' id = 15
+++++++ starting: global begin run for module: label = 'path4' id = 16
+++++++ finished: global begin run for module: label = 'path4' id = 16
+++++++ starting: global begin run for module: label = 'endPath1' id = 17
+++++++ finished: global begin run for module: label = 'endPath1' id = 17
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2532,22 +3120,6 @@
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
-++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
-++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
@@ -2555,27 +3127,60 @@
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -2590,47 +3195,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -2648,22 +3262,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
@@ -2672,38 +3270,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -2714,90 +3318,110 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: source event
@@ -2808,38 +3432,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -2850,6 +3480,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -2857,53 +3496,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -2912,6 +3509,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -2920,20 +3519,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: source event
@@ -2944,38 +3594,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -2986,6 +3642,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -2993,53 +3658,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -3048,6 +3671,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -3056,20 +3681,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: source event
@@ -3080,38 +3756,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -3122,6 +3804,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -3129,53 +3820,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -3184,6 +3833,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -3192,20 +3843,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 70000001
@@ -3213,22 +3915,38 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -3246,63 +3964,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
-++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -3319,8 +4009,46 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -3329,27 +4057,60 @@
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -3364,47 +4125,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -3422,22 +4192,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
@@ -3446,38 +4200,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -3488,90 +4248,110 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: source event
@@ -3582,38 +4362,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -3624,6 +4410,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -3631,53 +4426,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -3686,6 +4439,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -3694,20 +4449,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: source event
@@ -3718,38 +4524,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -3760,6 +4572,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -3767,53 +4588,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -3822,6 +4601,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -3830,20 +4611,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: source event
@@ -3854,38 +4686,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -3896,6 +4734,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -3903,53 +4750,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -3958,6 +4763,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -3966,20 +4773,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 90000001
@@ -3987,22 +4845,38 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4020,63 +4894,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
-++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4093,8 +4939,46 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4103,27 +4987,60 @@
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -4138,47 +5055,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4196,22 +5122,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
@@ -4220,38 +5130,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -4262,6 +5178,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -4269,53 +5194,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -4324,6 +5207,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -4332,20 +5217,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: source event
@@ -4356,38 +5292,44 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -4398,6 +5340,15 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -4405,53 +5356,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -4460,6 +5369,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -4468,20 +5379,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
@@ -4489,22 +5451,38 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4522,63 +5500,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
-++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -4595,30 +5545,84 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end run for module: stream = 0 label = 'get' id = 3
-++++++ finished: end run for module: stream = 0 label = 'get' id = 3
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end run for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'get' id = 6
+++++++ finished: end run for module: stream = 0 label = 'get' id = 6
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
+++++ finished: end run: stream = 0 run = 2 time = 0
+++++ starting: end run: stream = 0 run = 2 time = 0
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end run for module: stream = 0 label = 'get' id = 34
+++++++ finished: end run for module: stream = 0 label = 'get' id = 34
+++++++ starting: end run for module: stream = 0 label = 'test' id = 32
+++++++ finished: end run for module: stream = 0 label = 'test' id = 32
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end run for module: stream = 0 label = 'out' id = 37
+++++++ finished: end run for module: stream = 0 label = 'out' id = 37
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4636,48 +5640,65 @@
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 2 time = 0
-++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end run for module: stream = 0 label = 'get' id = 13
-++++++ finished: end run for module: stream = 0 label = 'get' id = 13
-++++++ starting: end run for module: stream = 0 label = 'test' id = 11
-++++++ finished: end run for module: stream = 0 label = 'test' id = 11
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end run for module: stream = 0 label = 'out' id = 16
-++++++ finished: end run for module: stream = 0 label = 'out' id = 16
-++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: global end run 2 : time = 100000001
 ++++ finished: global end run 2 : time = 100000001
 ++++ starting: global end run 2 : time = 0
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end run for module: label = 'get' id = 3
-++++++ finished: global end run for module: label = 'get' id = 3
-++++++ starting: global end run for module: label = 'putInt' id = 4
-++++++ finished: global end run for module: label = 'putInt' id = 4
-++++++ starting: global end run for module: label = 'putInt2' id = 5
-++++++ finished: global end run for module: label = 'putInt2' id = 5
-++++++ starting: global end run for module: label = 'putInt3' id = 6
-++++++ finished: global end run for module: label = 'putInt3' id = 6
-++++++ starting: global end run for module: label = 'getInt' id = 7
-++++++ finished: global end run for module: label = 'getInt' id = 7
-++++++ starting: global end run for module: label = 'noPut' id = 8
-++++++ finished: global end run for module: label = 'noPut' id = 8
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end run for module: label = 'get' id = 6
+++++++ finished: global end run for module: label = 'get' id = 6
+++++++ starting: global end run for module: label = 'putInt' id = 7
+++++++ finished: global end run for module: label = 'putInt' id = 7
+++++++ starting: global end run for module: label = 'putInt2' id = 8
+++++++ finished: global end run for module: label = 'putInt2' id = 8
+++++++ starting: global end run for module: label = 'putInt3' id = 9
+++++++ finished: global end run for module: label = 'putInt3' id = 9
+++++++ starting: global end run for module: label = 'getInt' id = 10
+++++++ finished: global end run for module: label = 'getInt' id = 10
+++++++ starting: global end run for module: label = 'noPut' id = 11
+++++++ finished: global end run for module: label = 'noPut' id = 11
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 1
+++++++ starting: global end run for module: label = 'p1' id = 2
+++++++ finished: global end run for module: label = 'p1' id = 2
+++++++ starting: global end run for module: label = 'path1' id = 3
+++++++ finished: global end run for module: label = 'path1' id = 3
+++++++ starting: global end run for module: label = 'path2' id = 4
+++++++ finished: global end run for module: label = 'path2' id = 4
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end run for module: label = 'test' id = 32
+++++++ finished: global end run for module: label = 'test' id = 32
+++++++ starting: global end run for module: label = 'testmerge' id = 33
+++++++ finished: global end run for module: label = 'testmerge' id = 33
+++++++ starting: global end run for module: label = 'get' id = 34
+++++++ finished: global end run for module: label = 'get' id = 34
+++++++ starting: global end run for module: label = 'getInt' id = 35
+++++++ finished: global end run for module: label = 'getInt' id = 35
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end run for module: label = 'out' id = 37
+++++++ finished: global end run for module: label = 'out' id = 37
+++++++ starting: global end run for module: label = 'TriggerResults' id = 25
+++++++ finished: global end run for module: label = 'TriggerResults' id = 25
+++++++ starting: global end run for module: label = 'path1' id = 26
+++++++ finished: global end run for module: label = 'path1' id = 26
+++++++ starting: global end run for module: label = 'path2' id = 27
+++++++ finished: global end run for module: label = 'path2' id = 27
+++++++ starting: global end run for module: label = 'path3' id = 28
+++++++ finished: global end run for module: label = 'path3' id = 28
+++++++ starting: global end run for module: label = 'path4' id = 29
+++++++ finished: global end run for module: label = 'path4' id = 29
+++++++ starting: global end run for module: label = 'endPath1' id = 30
+++++++ finished: global end run for module: label = 'endPath1' id = 30
+++++ finished: global end run 2 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global end run for module: label = 'test' id = 19
@@ -4692,25 +5713,18 @@
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
-++++++ starting: global end run for module: label = 'TriggerResults' id = 17
-++++++ finished: global end run for module: label = 'TriggerResults' id = 17
-++++ finished: global end run 2 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end run for module: label = 'test' id = 11
-++++++ finished: global end run for module: label = 'test' id = 11
-++++++ starting: global end run for module: label = 'testmerge' id = 12
-++++++ finished: global end run for module: label = 'testmerge' id = 12
-++++++ starting: global end run for module: label = 'get' id = 13
-++++++ finished: global end run for module: label = 'get' id = 13
-++++++ starting: global end run for module: label = 'getInt' id = 14
-++++++ finished: global end run for module: label = 'getInt' id = 14
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end run for module: label = 'out' id = 16
-++++++ finished: global end run for module: label = 'out' id = 16
-++++++ starting: global end run for module: label = 'TriggerResults' id = 9
-++++++ finished: global end run for module: label = 'TriggerResults' id = 9
+++++++ starting: global end run for module: label = 'TriggerResults' id = 12
+++++++ finished: global end run for module: label = 'TriggerResults' id = 12
+++++++ starting: global end run for module: label = 'path1' id = 13
+++++++ finished: global end run for module: label = 'path1' id = 13
+++++++ starting: global end run for module: label = 'path2' id = 14
+++++++ finished: global end run for module: label = 'path2' id = 14
+++++++ starting: global end run for module: label = 'path3' id = 15
+++++++ finished: global end run for module: label = 'path3' id = 15
+++++++ starting: global end run for module: label = 'path4' id = 16
+++++++ finished: global end run for module: label = 'path4' id = 16
+++++++ starting: global end run for module: label = 'endPath1' id = 17
+++++++ finished: global end run for module: label = 'endPath1' id = 17
 ++++ finished: global end run 2 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -4719,27 +5733,60 @@
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin run for module: label = 'get' id = 3
-++++++ finished: global begin run for module: label = 'get' id = 3
-++++++ starting: global begin run for module: label = 'putInt' id = 4
-++++++ finished: global begin run for module: label = 'putInt' id = 4
-++++++ starting: global begin run for module: label = 'putInt2' id = 5
-++++++ finished: global begin run for module: label = 'putInt2' id = 5
-++++++ starting: global begin run for module: label = 'putInt3' id = 6
-++++++ finished: global begin run for module: label = 'putInt3' id = 6
-++++++ starting: global begin run for module: label = 'getInt' id = 7
-++++++ finished: global begin run for module: label = 'getInt' id = 7
-++++++ starting: global begin run for module: label = 'noPut' id = 8
-++++++ finished: global begin run for module: label = 'noPut' id = 8
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin run for module: label = 'get' id = 6
+++++++ finished: global begin run for module: label = 'get' id = 6
+++++++ starting: global begin run for module: label = 'putInt' id = 7
+++++++ finished: global begin run for module: label = 'putInt' id = 7
+++++++ starting: global begin run for module: label = 'putInt2' id = 8
+++++++ finished: global begin run for module: label = 'putInt2' id = 8
+++++++ starting: global begin run for module: label = 'putInt3' id = 9
+++++++ finished: global begin run for module: label = 'putInt3' id = 9
+++++++ starting: global begin run for module: label = 'getInt' id = 10
+++++++ finished: global begin run for module: label = 'getInt' id = 10
+++++++ starting: global begin run for module: label = 'noPut' id = 11
+++++++ finished: global begin run for module: label = 'noPut' id = 11
 ++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin run for module: label = 'p1' id = 2
+++++++ finished: global begin run for module: label = 'p1' id = 2
+++++++ starting: global begin run for module: label = 'path1' id = 3
+++++++ finished: global begin run for module: label = 'path1' id = 3
+++++++ starting: global begin run for module: label = 'path2' id = 4
+++++++ finished: global begin run for module: label = 'path2' id = 4
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin run for module: label = 'test' id = 32
+++++++ finished: global begin run for module: label = 'test' id = 32
+++++++ starting: global begin run for module: label = 'testmerge' id = 33
+++++++ finished: global begin run for module: label = 'testmerge' id = 33
+++++++ starting: global begin run for module: label = 'get' id = 34
+++++++ finished: global begin run for module: label = 'get' id = 34
+++++++ starting: global begin run for module: label = 'getInt' id = 35
+++++++ finished: global begin run for module: label = 'getInt' id = 35
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin run for module: label = 'out' id = 37
+++++++ finished: global begin run for module: label = 'out' id = 37
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin run for module: label = 'path1' id = 26
+++++++ finished: global begin run for module: label = 'path1' id = 26
+++++++ starting: global begin run for module: label = 'path2' id = 27
+++++++ finished: global begin run for module: label = 'path2' id = 27
+++++++ starting: global begin run for module: label = 'path3' id = 28
+++++++ finished: global begin run for module: label = 'path3' id = 28
+++++++ starting: global begin run for module: label = 'path4' id = 29
+++++++ finished: global begin run for module: label = 'path4' id = 29
+++++++ starting: global begin run for module: label = 'endPath1' id = 30
+++++++ finished: global begin run for module: label = 'endPath1' id = 30
+++++ finished: global begin run 3 : time = 105000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin run for module: label = 'test' id = 19
@@ -4754,47 +5801,56 @@
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin run for module: label = 'out' id = 24
 ++++++ finished: global begin run for module: label = 'out' id = 24
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 17
-++++ finished: global begin run 3 : time = 105000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin run for module: label = 'test' id = 11
-++++++ finished: global begin run for module: label = 'test' id = 11
-++++++ starting: global begin run for module: label = 'testmerge' id = 12
-++++++ finished: global begin run for module: label = 'testmerge' id = 12
-++++++ starting: global begin run for module: label = 'get' id = 13
-++++++ finished: global begin run for module: label = 'get' id = 13
-++++++ starting: global begin run for module: label = 'getInt' id = 14
-++++++ finished: global begin run for module: label = 'getInt' id = 14
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin run for module: label = 'out' id = 16
-++++++ finished: global begin run for module: label = 'out' id = 16
-++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin run for module: label = 'path1' id = 13
+++++++ finished: global begin run for module: label = 'path1' id = 13
+++++++ starting: global begin run for module: label = 'path2' id = 14
+++++++ finished: global begin run for module: label = 'path2' id = 14
+++++++ starting: global begin run for module: label = 'path3' id = 15
+++++++ finished: global begin run for module: label = 'path3' id = 15
+++++++ starting: global begin run for module: label = 'path4' id = 16
+++++++ finished: global begin run for module: label = 'path4' id = 16
+++++++ starting: global begin run for module: label = 'endPath1' id = 17
+++++++ finished: global begin run for module: label = 'endPath1' id = 17
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4812,22 +5868,6 @@
 ++++++ starting: begin run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin run for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
-++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
-++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
@@ -4835,27 +5875,60 @@
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -4870,47 +5943,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -4928,22 +6010,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
@@ -4952,38 +6018,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -4994,90 +6066,110 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: source event
@@ -5088,38 +6180,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -5130,6 +6228,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -5137,53 +6244,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -5192,6 +6257,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -5200,20 +6267,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: source event
@@ -5224,38 +6342,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -5266,6 +6390,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -5273,53 +6406,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -5328,6 +6419,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -5336,20 +6429,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: source event
@@ -5360,38 +6504,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -5402,6 +6552,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -5409,53 +6568,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -5464,6 +6581,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -5472,20 +6591,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
@@ -5493,22 +6663,38 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5526,63 +6712,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
-++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -5599,8 +6757,46 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -5609,27 +6805,60 @@
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -5644,47 +6873,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -5702,22 +6940,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
@@ -5726,38 +6948,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -5768,90 +6996,110 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: source event
@@ -5862,38 +7110,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -5904,6 +7158,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -5911,53 +7174,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -5966,6 +7187,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -5974,20 +7197,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: source event
@@ -5998,38 +7272,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -6040,6 +7320,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -6047,53 +7336,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -6102,6 +7349,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -6110,20 +7359,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: source event
@@ -6134,38 +7434,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -6176,6 +7482,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -6183,53 +7498,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -6238,6 +7511,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -6246,20 +7521,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
@@ -6267,22 +7593,38 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -6300,63 +7642,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
-++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6373,8 +7687,46 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -6383,27 +7735,60 @@
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
-++++++ starting: global begin lumi for module: label = 'putInt' id = 4
-++++++ finished: global begin lumi for module: label = 'putInt' id = 4
-++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
-++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
-++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
-++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
-++++++ starting: global begin lumi for module: label = 'getInt' id = 7
-++++++ finished: global begin lumi for module: label = 'getInt' id = 7
-++++++ starting: global begin lumi for module: label = 'noPut' id = 8
-++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
+++++++ starting: global begin lumi for module: label = 'putInt' id = 7
+++++++ finished: global begin lumi for module: label = 'putInt' id = 7
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 8
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 8
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 9
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 9
+++++++ starting: global begin lumi for module: label = 'getInt' id = 10
+++++++ finished: global begin lumi for module: label = 'getInt' id = 10
+++++++ starting: global begin lumi for module: label = 'noPut' id = 11
+++++++ finished: global begin lumi for module: label = 'noPut' id = 11
 ++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global begin lumi for module: label = 'p1' id = 2
+++++++ finished: global begin lumi for module: label = 'p1' id = 2
+++++++ starting: global begin lumi for module: label = 'path1' id = 3
+++++++ finished: global begin lumi for module: label = 'path1' id = 3
+++++++ starting: global begin lumi for module: label = 'path2' id = 4
+++++++ finished: global begin lumi for module: label = 'path2' id = 4
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global begin lumi for module: label = 'test' id = 32
+++++++ finished: global begin lumi for module: label = 'test' id = 32
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
+++++++ starting: global begin lumi for module: label = 'getInt' id = 35
+++++++ finished: global begin lumi for module: label = 'getInt' id = 35
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global begin lumi for module: label = 'out' id = 37
+++++++ finished: global begin lumi for module: label = 'out' id = 37
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global begin lumi for module: label = 'path1' id = 26
+++++++ finished: global begin lumi for module: label = 'path1' id = 26
+++++++ starting: global begin lumi for module: label = 'path2' id = 27
+++++++ finished: global begin lumi for module: label = 'path2' id = 27
+++++++ starting: global begin lumi for module: label = 'path3' id = 28
+++++++ finished: global begin lumi for module: label = 'path3' id = 28
+++++++ starting: global begin lumi for module: label = 'path4' id = 29
+++++++ finished: global begin lumi for module: label = 'path4' id = 29
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 30
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 30
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global begin lumi for module: label = 'test' id = 19
@@ -6418,47 +7803,56 @@
 ++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global begin lumi for module: label = 'out' id = 24
 ++++++ finished: global begin lumi for module: label = 'out' id = 24
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 17
-++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global begin lumi for module: label = 'test' id = 11
-++++++ finished: global begin lumi for module: label = 'test' id = 11
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
-++++++ starting: global begin lumi for module: label = 'get' id = 13
-++++++ finished: global begin lumi for module: label = 'get' id = 13
-++++++ starting: global begin lumi for module: label = 'getInt' id = 14
-++++++ finished: global begin lumi for module: label = 'getInt' id = 14
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global begin lumi for module: label = 'out' id = 16
-++++++ finished: global begin lumi for module: label = 'out' id = 16
-++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global begin lumi for module: label = 'path1' id = 13
+++++++ finished: global begin lumi for module: label = 'path1' id = 13
+++++++ starting: global begin lumi for module: label = 'path2' id = 14
+++++++ finished: global begin lumi for module: label = 'path2' id = 14
+++++++ starting: global begin lumi for module: label = 'path3' id = 15
+++++++ finished: global begin lumi for module: label = 'path3' id = 15
+++++++ starting: global begin lumi for module: label = 'path4' id = 16
+++++++ finished: global begin lumi for module: label = 'path4' id = 16
+++++++ starting: global begin lumi for module: label = 'endPath1' id = 17
+++++++ finished: global begin lumi for module: label = 'endPath1' id = 17
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -6476,22 +7870,6 @@
 ++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
@@ -6500,38 +7878,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -6542,6 +7926,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -6549,53 +7942,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -6604,6 +7955,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -6612,20 +7965,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: source event
@@ -6636,38 +8040,44 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 6
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'p1' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'p1' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 6
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 7
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 8
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 10
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 3
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
@@ -6678,6 +8088,15 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'path4' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++ starting: processing path 'path3' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
@@ -6685,53 +8104,11 @@
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++ starting: processing path 'path1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
-++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
-++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 16
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
-++++++ finished: processing path 'endPath1' : stream = 0
-++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
@@ -6740,6 +8117,8 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
 ++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
@@ -6748,20 +8127,71 @@
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
 ++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
 ++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++ finished: processing path 'path1' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++ finished: processing path 'path3' : stream = 0
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
+++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
@@ -6769,22 +8199,38 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 32
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 37
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 37
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -6802,63 +8248,35 @@
 ++++++ starting: end lumi for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end lumi for module: stream = 0 label = 'out' id = 24
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
-++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
-++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
-++++++ starting: global end lumi for module: label = 'putInt' id = 4
-++++++ finished: global end lumi for module: label = 'putInt' id = 4
-++++++ starting: global end lumi for module: label = 'putInt2' id = 5
-++++++ finished: global end lumi for module: label = 'putInt2' id = 5
-++++++ starting: global end lumi for module: label = 'putInt3' id = 6
-++++++ finished: global end lumi for module: label = 'putInt3' id = 6
-++++++ starting: global end lumi for module: label = 'getInt' id = 7
-++++++ finished: global end lumi for module: label = 'getInt' id = 7
-++++++ starting: global end lumi for module: label = 'noPut' id = 8
-++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
+++++++ starting: global end lumi for module: label = 'putInt' id = 7
+++++++ finished: global end lumi for module: label = 'putInt' id = 7
+++++++ starting: global end lumi for module: label = 'putInt2' id = 8
+++++++ finished: global end lumi for module: label = 'putInt2' id = 8
+++++++ starting: global end lumi for module: label = 'putInt3' id = 9
+++++++ finished: global end lumi for module: label = 'putInt3' id = 9
+++++++ starting: global end lumi for module: label = 'getInt' id = 10
+++++++ finished: global end lumi for module: label = 'getInt' id = 10
+++++++ starting: global end lumi for module: label = 'noPut' id = 11
+++++++ finished: global end lumi for module: label = 'noPut' id = 11
 ++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ starting: global end lumi for module: label = 'p1' id = 2
+++++++ finished: global end lumi for module: label = 'p1' id = 2
+++++++ starting: global end lumi for module: label = 'path1' id = 3
+++++++ finished: global end lumi for module: label = 'path1' id = 3
+++++++ starting: global end lumi for module: label = 'path2' id = 4
+++++++ finished: global end lumi for module: label = 'path2' id = 4
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
-++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end lumi for module: label = 'test' id = 11
-++++++ finished: global end lumi for module: label = 'test' id = 11
-++++++ starting: global end lumi for module: label = 'testmerge' id = 12
-++++++ finished: global end lumi for module: label = 'testmerge' id = 12
-++++++ starting: global end lumi for module: label = 'get' id = 13
-++++++ finished: global end lumi for module: label = 'get' id = 13
-++++++ starting: global end lumi for module: label = 'getInt' id = 14
-++++++ finished: global end lumi for module: label = 'getInt' id = 14
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end lumi for module: label = 'out' id = 16
-++++++ finished: global end lumi for module: label = 'out' id = 16
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
@@ -6875,30 +8293,84 @@
 ++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end lumi for module: label = 'out' id = 24
 ++++++ finished: global end lumi for module: label = 'out' id = 24
-++++++ starting: global end lumi for module: label = 'TriggerResults' id = 17
-++++++ finished: global end lumi for module: label = 'TriggerResults' id = 17
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 12
+++++++ starting: global end lumi for module: label = 'path1' id = 13
+++++++ finished: global end lumi for module: label = 'path1' id = 13
+++++++ starting: global end lumi for module: label = 'path2' id = 14
+++++++ finished: global end lumi for module: label = 'path2' id = 14
+++++++ starting: global end lumi for module: label = 'path3' id = 15
+++++++ finished: global end lumi for module: label = 'path3' id = 15
+++++++ starting: global end lumi for module: label = 'path4' id = 16
+++++++ finished: global end lumi for module: label = 'path4' id = 16
+++++++ starting: global end lumi for module: label = 'endPath1' id = 17
+++++++ finished: global end lumi for module: label = 'endPath1' id = 17
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end lumi for module: label = 'test' id = 32
+++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'testmerge' id = 33
+++++++ finished: global end lumi for module: label = 'testmerge' id = 33
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
+++++++ starting: global end lumi for module: label = 'getInt' id = 35
+++++++ finished: global end lumi for module: label = 'getInt' id = 35
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end lumi for module: label = 'out' id = 37
+++++++ finished: global end lumi for module: label = 'out' id = 37
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 25
+++++++ starting: global end lumi for module: label = 'path1' id = 26
+++++++ finished: global end lumi for module: label = 'path1' id = 26
+++++++ starting: global end lumi for module: label = 'path2' id = 27
+++++++ finished: global end lumi for module: label = 'path2' id = 27
+++++++ starting: global end lumi for module: label = 'path3' id = 28
+++++++ finished: global end lumi for module: label = 'path3' id = 28
+++++++ starting: global end lumi for module: label = 'path4' id = 29
+++++++ finished: global end lumi for module: label = 'path4' id = 29
+++++++ starting: global end lumi for module: label = 'endPath1' id = 30
+++++++ finished: global end lumi for module: label = 'endPath1' id = 30
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
-++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
-++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
-++++++ starting: end run for module: stream = 0 label = 'get' id = 3
-++++++ finished: end run for module: stream = 0 label = 'get' id = 3
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'noPut' id = 11
+++++++ finished: end run for module: stream = 0 label = 'noPut' id = 11
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 10
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 10
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'get' id = 6
+++++++ finished: end run for module: stream = 0 label = 'get' id = 6
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
+++++ finished: end run: stream = 0 run = 3 time = 0
+++++ starting: end run: stream = 0 run = 3 time = 0
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++ starting: end run for module: stream = 0 label = 'get' id = 34
+++++++ finished: end run for module: stream = 0 label = 'get' id = 34
+++++++ starting: end run for module: stream = 0 label = 'test' id = 32
+++++++ finished: end run for module: stream = 0 label = 'test' id = 32
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 33
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 33
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 35
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 35
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++ starting: end run for module: stream = 0 label = 'out' id = 37
+++++++ finished: end run for module: stream = 0 label = 'out' id = 37
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 23
@@ -6916,48 +8388,65 @@
 ++++++ starting: end run for module: stream = 0 label = 'out' id = 24
 ++++++ finished: end run for module: stream = 0 label = 'out' id = 24
 ++++ finished: end run: stream = 0 run = 3 time = 0
-++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++++ starting: end run for module: stream = 0 label = 'get' id = 13
-++++++ finished: end run for module: stream = 0 label = 'get' id = 13
-++++++ starting: end run for module: stream = 0 label = 'test' id = 11
-++++++ finished: end run for module: stream = 0 label = 'test' id = 11
-++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
-++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++++ starting: end run for module: stream = 0 label = 'out' id = 16
-++++++ finished: end run for module: stream = 0 label = 'out' id = 16
-++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: global end run 3 : time = 150000001
 ++++ finished: global end run 3 : time = 150000001
 ++++ starting: global end run 3 : time = 0
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 2
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 2
-++++++ starting: global end run for module: label = 'get' id = 3
-++++++ finished: global end run for module: label = 'get' id = 3
-++++++ starting: global end run for module: label = 'putInt' id = 4
-++++++ finished: global end run for module: label = 'putInt' id = 4
-++++++ starting: global end run for module: label = 'putInt2' id = 5
-++++++ finished: global end run for module: label = 'putInt2' id = 5
-++++++ starting: global end run for module: label = 'putInt3' id = 6
-++++++ finished: global end run for module: label = 'putInt3' id = 6
-++++++ starting: global end run for module: label = 'getInt' id = 7
-++++++ finished: global end run for module: label = 'getInt' id = 7
-++++++ starting: global end run for module: label = 'noPut' id = 8
-++++++ finished: global end run for module: label = 'noPut' id = 8
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end run for module: label = 'get' id = 6
+++++++ finished: global end run for module: label = 'get' id = 6
+++++++ starting: global end run for module: label = 'putInt' id = 7
+++++++ finished: global end run for module: label = 'putInt' id = 7
+++++++ starting: global end run for module: label = 'putInt2' id = 8
+++++++ finished: global end run for module: label = 'putInt2' id = 8
+++++++ starting: global end run for module: label = 'putInt3' id = 9
+++++++ finished: global end run for module: label = 'putInt3' id = 9
+++++++ starting: global end run for module: label = 'getInt' id = 10
+++++++ finished: global end run for module: label = 'getInt' id = 10
+++++++ starting: global end run for module: label = 'noPut' id = 11
+++++++ finished: global end run for module: label = 'noPut' id = 11
 ++++++ starting: global end run for module: label = 'TriggerResults' id = 1
 ++++++ finished: global end run for module: label = 'TriggerResults' id = 1
+++++++ starting: global end run for module: label = 'p1' id = 2
+++++++ finished: global end run for module: label = 'p1' id = 2
+++++++ starting: global end run for module: label = 'path1' id = 3
+++++++ finished: global end run for module: label = 'path1' id = 3
+++++++ starting: global end run for module: label = 'path2' id = 4
+++++++ finished: global end run for module: label = 'path2' id = 4
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 31
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 31
+++++++ starting: global end run for module: label = 'test' id = 32
+++++++ finished: global end run for module: label = 'test' id = 32
+++++++ starting: global end run for module: label = 'testmerge' id = 33
+++++++ finished: global end run for module: label = 'testmerge' id = 33
+++++++ starting: global end run for module: label = 'get' id = 34
+++++++ finished: global end run for module: label = 'get' id = 34
+++++++ starting: global end run for module: label = 'getInt' id = 35
+++++++ finished: global end run for module: label = 'getInt' id = 35
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++ starting: global end run for module: label = 'out' id = 37
+++++++ finished: global end run for module: label = 'out' id = 37
+++++++ starting: global end run for module: label = 'TriggerResults' id = 25
+++++++ finished: global end run for module: label = 'TriggerResults' id = 25
+++++++ starting: global end run for module: label = 'path1' id = 26
+++++++ finished: global end run for module: label = 'path1' id = 26
+++++++ starting: global end run for module: label = 'path2' id = 27
+++++++ finished: global end run for module: label = 'path2' id = 27
+++++++ starting: global end run for module: label = 'path3' id = 28
+++++++ finished: global end run for module: label = 'path3' id = 28
+++++++ starting: global end run for module: label = 'path4' id = 29
+++++++ finished: global end run for module: label = 'path4' id = 29
+++++++ starting: global end run for module: label = 'endPath1' id = 30
+++++++ finished: global end run for module: label = 'endPath1' id = 30
+++++ finished: global end run 3 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
 ++++++ starting: global end run for module: label = 'test' id = 19
@@ -6972,58 +8461,41 @@
 ++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
 ++++++ starting: global end run for module: label = 'out' id = 24
 ++++++ finished: global end run for module: label = 'out' id = 24
-++++++ starting: global end run for module: label = 'TriggerResults' id = 17
-++++++ finished: global end run for module: label = 'TriggerResults' id = 17
+++++++ starting: global end run for module: label = 'TriggerResults' id = 12
+++++++ finished: global end run for module: label = 'TriggerResults' id = 12
+++++++ starting: global end run for module: label = 'path1' id = 13
+++++++ finished: global end run for module: label = 'path1' id = 13
+++++++ starting: global end run for module: label = 'path2' id = 14
+++++++ finished: global end run for module: label = 'path2' id = 14
+++++++ starting: global end run for module: label = 'path3' id = 15
+++++++ finished: global end run for module: label = 'path3' id = 15
+++++++ starting: global end run for module: label = 'path4' id = 16
+++++++ finished: global end run for module: label = 'path4' id = 16
+++++++ starting: global end run for module: label = 'endPath1' id = 17
+++++++ finished: global end run for module: label = 'endPath1' id = 17
 ++++ finished: global end run 3 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 10
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 10
-++++++ starting: global end run for module: label = 'test' id = 11
-++++++ finished: global end run for module: label = 'test' id = 11
-++++++ starting: global end run for module: label = 'testmerge' id = 12
-++++++ finished: global end run for module: label = 'testmerge' id = 12
-++++++ starting: global end run for module: label = 'get' id = 13
-++++++ finished: global end run for module: label = 'get' id = 13
-++++++ starting: global end run for module: label = 'getInt' id = 14
-++++++ finished: global end run for module: label = 'getInt' id = 14
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 15
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 15
-++++++ starting: global end run for module: label = 'out' id = 16
-++++++ finished: global end run for module: label = 'out' id = 16
-++++++ starting: global end run for module: label = 'TriggerResults' id = 9
-++++++ finished: global end run for module: label = 'TriggerResults' id = 9
-++++ finished: global end run 3 : time = 0
-++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
-++++ starting: end stream for module: stream = 0 label = 'get' id = 3
-++++ finished: end stream for module: stream = 0 label = 'get' id = 3
-++++ starting: end stream for module: stream = 0 label = 'putInt' id = 4
-++++ finished: end stream for module: stream = 0 label = 'putInt' id = 4
-++++ starting: end stream for module: stream = 0 label = 'putInt2' id = 5
-++++ finished: end stream for module: stream = 0 label = 'putInt2' id = 5
-++++ starting: end stream for module: stream = 0 label = 'putInt3' id = 6
-++++ finished: end stream for module: stream = 0 label = 'putInt3' id = 6
-++++ starting: end stream for module: stream = 0 label = 'getInt' id = 7
-++++ finished: end stream for module: stream = 0 label = 'getInt' id = 7
-++++ starting: end stream for module: stream = 0 label = 'noPut' id = 8
-++++ finished: end stream for module: stream = 0 label = 'noPut' id = 8
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
+++++ starting: end stream for module: stream = 0 label = 'get' id = 6
+++++ finished: end stream for module: stream = 0 label = 'get' id = 6
+++++ starting: end stream for module: stream = 0 label = 'putInt' id = 7
+++++ finished: end stream for module: stream = 0 label = 'putInt' id = 7
+++++ starting: end stream for module: stream = 0 label = 'putInt2' id = 8
+++++ finished: end stream for module: stream = 0 label = 'putInt2' id = 8
+++++ starting: end stream for module: stream = 0 label = 'putInt3' id = 9
+++++ finished: end stream for module: stream = 0 label = 'putInt3' id = 9
+++++ starting: end stream for module: stream = 0 label = 'getInt' id = 10
+++++ finished: end stream for module: stream = 0 label = 'getInt' id = 10
+++++ starting: end stream for module: stream = 0 label = 'noPut' id = 11
+++++ finished: end stream for module: stream = 0 label = 'noPut' id = 11
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
-++++ starting: end stream for module: stream = 0 label = 'test' id = 11
-++++ finished: end stream for module: stream = 0 label = 'test' id = 11
-++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 12
-++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 12
-++++ starting: end stream for module: stream = 0 label = 'get' id = 13
-++++ finished: end stream for module: stream = 0 label = 'get' id = 13
-++++ starting: end stream for module: stream = 0 label = 'getInt' id = 14
-++++ finished: end stream for module: stream = 0 label = 'getInt' id = 14
-++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 9
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 9
-++++ starting: end stream for module: stream = 0 label = 'out' id = 16
-++++ finished: end stream for module: stream = 0 label = 'out' id = 16
+++++ starting: end stream for module: stream = 0 label = 'p1' id = 2
+++++ finished: end stream for module: stream = 0 label = 'p1' id = 2
+++++ starting: end stream for module: stream = 0 label = 'path1' id = 3
+++++ finished: end stream for module: stream = 0 label = 'path1' id = 3
+++++ starting: end stream for module: stream = 0 label = 'path2' id = 4
+++++ finished: end stream for module: stream = 0 label = 'path2' id = 4
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
 ++++ starting: end stream for module: stream = 0 label = 'test' id = 19
@@ -7036,42 +8508,68 @@
 ++++ finished: end stream for module: stream = 0 label = 'getInt' id = 22
 ++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
 ++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 17
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 17
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 12
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 12
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 24
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 24
-++++ starting: end job for module with label 'thingWithMergeProducer' id = 2
-++++ finished: end job for module with label 'thingWithMergeProducer' id = 2
-++++ starting: end job for module with label 'get' id = 3
-++++ finished: end job for module with label 'get' id = 3
-++++ starting: end job for module with label 'putInt' id = 4
-++++ finished: end job for module with label 'putInt' id = 4
-++++ starting: end job for module with label 'putInt2' id = 5
-++++ finished: end job for module with label 'putInt2' id = 5
-++++ starting: end job for module with label 'putInt3' id = 6
-++++ finished: end job for module with label 'putInt3' id = 6
-++++ starting: end job for module with label 'getInt' id = 7
-++++ finished: end job for module with label 'getInt' id = 7
-++++ starting: end job for module with label 'noPut' id = 8
-++++ finished: end job for module with label 'noPut' id = 8
+++++ starting: end stream for module: stream = 0 label = 'path1' id = 13
+++++ finished: end stream for module: stream = 0 label = 'path1' id = 13
+++++ starting: end stream for module: stream = 0 label = 'path2' id = 14
+++++ finished: end stream for module: stream = 0 label = 'path2' id = 14
+++++ starting: end stream for module: stream = 0 label = 'path3' id = 15
+++++ finished: end stream for module: stream = 0 label = 'path3' id = 15
+++++ starting: end stream for module: stream = 0 label = 'path4' id = 16
+++++ finished: end stream for module: stream = 0 label = 'path4' id = 16
+++++ starting: end stream for module: stream = 0 label = 'endPath1' id = 17
+++++ finished: end stream for module: stream = 0 label = 'endPath1' id = 17
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++ starting: end stream for module: stream = 0 label = 'test' id = 32
+++++ finished: end stream for module: stream = 0 label = 'test' id = 32
+++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 33
+++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 33
+++++ starting: end stream for module: stream = 0 label = 'get' id = 34
+++++ finished: end stream for module: stream = 0 label = 'get' id = 34
+++++ starting: end stream for module: stream = 0 label = 'getInt' id = 35
+++++ finished: end stream for module: stream = 0 label = 'getInt' id = 35
+++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 25
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 25
+++++ starting: end stream for module: stream = 0 label = 'out' id = 37
+++++ finished: end stream for module: stream = 0 label = 'out' id = 37
+++++ starting: end stream for module: stream = 0 label = 'path1' id = 26
+++++ finished: end stream for module: stream = 0 label = 'path1' id = 26
+++++ starting: end stream for module: stream = 0 label = 'path2' id = 27
+++++ finished: end stream for module: stream = 0 label = 'path2' id = 27
+++++ starting: end stream for module: stream = 0 label = 'path3' id = 28
+++++ finished: end stream for module: stream = 0 label = 'path3' id = 28
+++++ starting: end stream for module: stream = 0 label = 'path4' id = 29
+++++ finished: end stream for module: stream = 0 label = 'path4' id = 29
+++++ starting: end stream for module: stream = 0 label = 'endPath1' id = 30
+++++ finished: end stream for module: stream = 0 label = 'endPath1' id = 30
+++++ starting: end job for module with label 'thingWithMergeProducer' id = 5
+++++ finished: end job for module with label 'thingWithMergeProducer' id = 5
+++++ starting: end job for module with label 'get' id = 6
+++++ finished: end job for module with label 'get' id = 6
+++++ starting: end job for module with label 'putInt' id = 7
+++++ finished: end job for module with label 'putInt' id = 7
+++++ starting: end job for module with label 'putInt2' id = 8
+++++ finished: end job for module with label 'putInt2' id = 8
+++++ starting: end job for module with label 'putInt3' id = 9
+++++ finished: end job for module with label 'putInt3' id = 9
+++++ starting: end job for module with label 'getInt' id = 10
+++++ finished: end job for module with label 'getInt' id = 10
+++++ starting: end job for module with label 'noPut' id = 11
+++++ finished: end job for module with label 'noPut' id = 11
 ++++ starting: end job for module with label 'TriggerResults' id = 1
 ++++ finished: end job for module with label 'TriggerResults' id = 1
-++++ starting: end job for module with label 'thingWithMergeProducer' id = 10
-++++ finished: end job for module with label 'thingWithMergeProducer' id = 10
-++++ starting: end job for module with label 'test' id = 11
-++++ finished: end job for module with label 'test' id = 11
-++++ starting: end job for module with label 'testmerge' id = 12
-++++ finished: end job for module with label 'testmerge' id = 12
-++++ starting: end job for module with label 'get' id = 13
-++++ finished: end job for module with label 'get' id = 13
-++++ starting: end job for module with label 'getInt' id = 14
-++++ finished: end job for module with label 'getInt' id = 14
-++++ starting: end job for module with label 'dependsOnNoPut' id = 15
-++++ finished: end job for module with label 'dependsOnNoPut' id = 15
-++++ starting: end job for module with label 'out' id = 16
-++++ finished: end job for module with label 'out' id = 16
-++++ starting: end job for module with label 'TriggerResults' id = 9
-++++ finished: end job for module with label 'TriggerResults' id = 9
+++++ starting: end job for module with label 'p1' id = 2
+++++ finished: end job for module with label 'p1' id = 2
+++++ starting: end job for module with label 'path1' id = 3
+++++ finished: end job for module with label 'path1' id = 3
+++++ starting: end job for module with label 'path2' id = 4
+++++ finished: end job for module with label 'path2' id = 4
 ++++ starting: end job for module with label 'thingWithMergeProducer' id = 18
 ++++ finished: end job for module with label 'thingWithMergeProducer' id = 18
 ++++ starting: end job for module with label 'test' id = 19
@@ -7086,6 +8584,42 @@
 ++++ finished: end job for module with label 'dependsOnNoPut' id = 23
 ++++ starting: end job for module with label 'out' id = 24
 ++++ finished: end job for module with label 'out' id = 24
-++++ starting: end job for module with label 'TriggerResults' id = 17
-++++ finished: end job for module with label 'TriggerResults' id = 17
+++++ starting: end job for module with label 'TriggerResults' id = 12
+++++ finished: end job for module with label 'TriggerResults' id = 12
+++++ starting: end job for module with label 'path1' id = 13
+++++ finished: end job for module with label 'path1' id = 13
+++++ starting: end job for module with label 'path2' id = 14
+++++ finished: end job for module with label 'path2' id = 14
+++++ starting: end job for module with label 'path3' id = 15
+++++ finished: end job for module with label 'path3' id = 15
+++++ starting: end job for module with label 'path4' id = 16
+++++ finished: end job for module with label 'path4' id = 16
+++++ starting: end job for module with label 'endPath1' id = 17
+++++ finished: end job for module with label 'endPath1' id = 17
+++++ starting: end job for module with label 'thingWithMergeProducer' id = 31
+++++ finished: end job for module with label 'thingWithMergeProducer' id = 31
+++++ starting: end job for module with label 'test' id = 32
+++++ finished: end job for module with label 'test' id = 32
+++++ starting: end job for module with label 'testmerge' id = 33
+++++ finished: end job for module with label 'testmerge' id = 33
+++++ starting: end job for module with label 'get' id = 34
+++++ finished: end job for module with label 'get' id = 34
+++++ starting: end job for module with label 'getInt' id = 35
+++++ finished: end job for module with label 'getInt' id = 35
+++++ starting: end job for module with label 'dependsOnNoPut' id = 36
+++++ finished: end job for module with label 'dependsOnNoPut' id = 36
+++++ starting: end job for module with label 'out' id = 37
+++++ finished: end job for module with label 'out' id = 37
+++++ starting: end job for module with label 'TriggerResults' id = 25
+++++ finished: end job for module with label 'TriggerResults' id = 25
+++++ starting: end job for module with label 'path1' id = 26
+++++ finished: end job for module with label 'path1' id = 26
+++++ starting: end job for module with label 'path2' id = 27
+++++ finished: end job for module with label 'path2' id = 27
+++++ starting: end job for module with label 'path3' id = 28
+++++ finished: end job for module with label 'path3' id = 28
+++++ starting: end job for module with label 'path4' id = 29
+++++ finished: end job for module with label 'path4' id = 29
+++++ starting: end job for module with label 'endPath1' id = 30
+++++ finished: end job for module with label 'endPath1' id = 30
 ++ finished: end job

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -302,8 +302,12 @@ namespace edm {
      if(getData_) {
         callWhenNewProductsRegistered([this](edm::BranchDescription const& iBranch) {
            if(getModuleLabels_.empty()) {
-              this->consumes(edm::TypeToGet{iBranch.unwrappedTypeID(),PRODUCT_TYPE},
-                             edm::InputTag{iBranch.moduleLabel(),iBranch.productInstanceName(),iBranch.processName()});
+              const std::string kPathStatus("edm::PathStatus");
+              const std::string kEndPathStatus("edm::EndPathStatus");
+              if(iBranch.className() != kPathStatus && iBranch.className() != kEndPathStatus) {
+                 this->consumes(edm::TypeToGet{iBranch.unwrappedTypeID(),PRODUCT_TYPE},
+                                edm::InputTag{iBranch.moduleLabel(),iBranch.productInstanceName(),iBranch.processName()});
+              }
            } else {
               for (auto const& mod : this->getModuleLabels_) {
                  if (iBranch.moduleLabel() == mod) {
@@ -348,7 +352,11 @@ namespace edm {
      std::string startIndent = indentation_+verboseIndentation_;
      for(auto const& provenance : provenances) {
          std::string const& className = provenance->className();
-
+         const std::string kPathStatus("edm::PathStatus");
+         const std::string kEndPathStatus("edm::EndPathStatus");
+         if(className == kPathStatus || className == kEndPathStatus) {
+           continue;
+         }
          std::string const& friendlyName = provenance->friendlyClassName();
          //if(friendlyName.empty())  friendlyName = std::string("||");
 

--- a/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
@@ -3,10 +3,10 @@
 RandomNumberGeneratorService dump
 
     Contents of seedsAndNameMap (label moduleID engineType seeds)
-        t1  2  HepJamesRandom  81
-        t2  3  RanecuEngine  1  2
-        t3  4  TRandom3  83
-        t4  5  HepJamesRandom  84
+        t1  4  HepJamesRandom  81
+        t2  5  RanecuEngine  1  2
+        t3  6  TRandom3  83
+        t4  7  HepJamesRandom  84
         t5  4294967295  TRandom3  191
     nStreams_ = 3
     saveFileName_ = StashStateStream.data

--- a/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
@@ -3,10 +3,10 @@
 RandomNumberGeneratorService dump
 
     Contents of seedsAndNameMap (label moduleID engineType seeds)
-        t1  2  HepJamesRandom  81
-        t2  3  RanecuEngine  1  2
-        t3  4  TRandom3  83
-        t4  5  HepJamesRandom  84
+        t1  4  HepJamesRandom  81
+        t2  5  RanecuEngine  1  2
+        t3  6  TRandom3  83
+        t4  7  HepJamesRandom  84
         t5  4294967295  TRandom3  191
     nStreams_ = 1
     saveFileName_ = StashState1.data


### PR DESCRIPTION
The producers for these products are run automatically after
a Path or EndPath completes. They will be useful in a
multithreaded context as they allow creating a dependence
between a module and a path in a way similar to how
a consumes declaration creates a dependence between
two modules.