### PR TITLE
import METSignificanceParams_Data when needed

### DIFF
--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -555,6 +555,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if postfix=="NoHF":
                 getattr(process, "pat"+metType+"Met"+postfix).computeMETSignificance = cms.bool(False)
             if self._parameters["runOnData"].value:
+                from RecoMET.METProducers.METSignificanceParams_cfi import METSignificanceParams_Data
                 getattr(process, "pat"+metType+"Met"+postfix).parameters = METSignificanceParams_Data
             if self._parameters["Puppi"].value:
                 getattr(process, "pat"+metType+"Met"+postfix).srcPFCands = cms.InputTag('puppiForMET')


### PR DESCRIPTION
This PR backports a fix from 09d06f1 in #16140 that is not in the 80X branch. This is needed to use the MET tool on data.

attn: @mmarionncern @zdemirag 