### PR TITLE
Adding Cross Trigger Support to E/gamma TnP DQM

### DIFF
--- a/DQMOffline/Trigger/interface/FunctionDefs.h
+++ b/DQMOffline/Trigger/interface/FunctionDefs.h
@@ -32,6 +32,7 @@
 #include <functional>
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
 
 namespace hltdqm {
   //here we define needed functions that otherwise dont exist
@@ -69,7 +70,13 @@ namespace hltdqm {
     else if(varName=="hOverE") varFunc = &reco::GsfElectron::hcalOverEcal;
     return varFunc;
   }
-  
+  template<>
+  std::function<float(const reco::Photon&)> getUnaryFuncExtraFloat<reco::Photon>(const std::string& varName){
+    std::function<float(const reco::Photon&)> varFunc;
+    if(varName=="scEta") varFunc = scEtaFunc<reco::Photon>;
+    else if(varName=="hOverE") varFunc = &reco::Photon::hadTowOverEm;
+    return varFunc;
+  }
   
 }
 

--- a/DQMOffline/Trigger/interface/HLTDQMFilterTnPEffHists.h
+++ b/DQMOffline/Trigger/interface/HLTDQMFilterTnPEffHists.h
@@ -24,7 +24,7 @@
 
 #include <string>
 
-template <typename ObjType>
+template <typename TagType,typename ProbeType=TagType>
 class HLTDQMFilterTnPEffHists  {
 public:
   HLTDQMFilterTnPEffHists(const edm::ParameterSet& config,
@@ -35,18 +35,18 @@ public:
     hltProcess_(hltProcess){}
 
   static edm::ParameterSetDescription makePSetDescription(){
-    edm::ParameterSetDescription desc = HLTDQMFilterEffHists<ObjType>::makePSetDescription();
+    edm::ParameterSetDescription desc = HLTDQMFilterEffHists<ProbeType>::makePSetDescription();
     desc.add<std::string>("tagExtraFilter","");
     return desc;
   }
   static edm::ParameterSetDescription makePSetDescriptionHistConfigs(){
-    return HLTDQMFilterEffHists<ObjType>::makePSetDescriptionHistConfigs();
+    return HLTDQMFilterEffHists<ProbeType>::makePSetDescriptionHistConfigs();
   }
 
   void bookHists(DQMStore::IBooker& iBooker,const std::vector<edm::ParameterSet>& histConfigs){
     histColl_.bookHists(iBooker,histConfigs);
   }
-  void fillHists(const ObjType& tag,const ObjType& probe,
+  void fillHists(const TagType& tag,const ProbeType& probe,
 		 const edm::Event& event,const edm::EventSetup& setup,
 		 const trigger::TriggerEvent& trigEvt){
     if(tagExtraFilter_.empty() || hltdqm::passTrig(tag.eta(),tag.phi(),trigEvt,tagExtraFilter_,hltProcess_)){
@@ -54,7 +54,8 @@ public:
     } 
   }
 private:
-  HLTDQMFilterEffHists<ObjType> histColl_;
+  //these hists take the probe as input hence they are of ProbeType
+  HLTDQMFilterEffHists<ProbeType> histColl_;
   std::string tagExtraFilter_;
   //really wondering whether to put an accessor to HLTDQMFilterEffHists for this
   //feels ineligant though so I made another copy here

--- a/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
@@ -26,7 +26,7 @@
 #include <string>
 
 
-template <typename ObjType,typename ObjCollType> 
+template <typename TagType,typename TagCollType,typename ProbeType=TagType,typename ProbeCollType=TagCollType> 
 class HLTTagAndProbeOfflineSource : public DQMEDAnalyzer {
  public:
   explicit HLTTagAndProbeOfflineSource(const edm::ParameterSet&);
@@ -41,43 +41,43 @@ class HLTTagAndProbeOfflineSource : public DQMEDAnalyzer {
   virtual void dqmBeginRun(edm::Run const& run, edm::EventSetup const& c) override{}
 
 private:
-  std::vector<HLTDQMTagAndProbeEff<ObjType,ObjCollType> > tagAndProbeEffs_;
+  std::vector<HLTDQMTagAndProbeEff<TagType,TagCollType,ProbeType,ProbeCollType> > tagAndProbeEffs_;
 
 };
 
-template <typename ObjType,typename ObjCollType> 
-HLTTagAndProbeOfflineSource<ObjType,ObjCollType>::
+template <typename TagType,typename TagCollType,typename ProbeType,typename ProbeCollType> 
+HLTTagAndProbeOfflineSource<TagType,TagCollType,ProbeType,ProbeCollType>::
 HLTTagAndProbeOfflineSource(const edm::ParameterSet& config)
 {
   auto histCollConfigs =  config.getParameter<std::vector<edm::ParameterSet> >("tagAndProbeCollections");
   for(auto& histCollConfig : histCollConfigs){
-    tagAndProbeEffs_.emplace_back(HLTDQMTagAndProbeEff<ObjType,ObjCollType>(histCollConfig,consumesCollector()));
+    tagAndProbeEffs_.emplace_back(HLTDQMTagAndProbeEff<TagType,TagCollType,ProbeType,ProbeCollType>(histCollConfig,consumesCollector()));
   }
 }
 
 
-template <typename ObjType,typename ObjCollType> 
-void HLTTagAndProbeOfflineSource<ObjType,ObjCollType>::
+template <typename TagType,typename TagCollType,typename ProbeType,typename ProbeCollType> 
+void HLTTagAndProbeOfflineSource<TagType,TagCollType,ProbeType,ProbeCollType>::
 fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("objs", edm::InputTag(""));
   desc.addVPSet("tagAndProbeCollections",
-		HLTDQMTagAndProbeEff<ObjType,ObjCollType>::makePSetDescription(),
+		HLTDQMTagAndProbeEff<TagType,TagCollType,ProbeType,ProbeCollType>::makePSetDescription(),
 		std::vector<edm::ParameterSet>());
   descriptions.add("hltTagAndProbeOfflineSource", desc);
   
 }
 
-template <typename ObjType,typename ObjCollType> 
-void HLTTagAndProbeOfflineSource<ObjType,ObjCollType>::
+template <typename TagType,typename TagCollType,typename ProbeType,typename ProbeCollType> 
+void HLTTagAndProbeOfflineSource<TagType,TagCollType,ProbeType,ProbeCollType>::
 bookHistograms(DQMStore::IBooker& iBooker,const edm::Run& run,const edm::EventSetup& setup)
 {
   for(auto& tpEff : tagAndProbeEffs_) tpEff.bookHists(iBooker);
 }
 
-template <typename ObjType,typename ObjCollType> 
-void HLTTagAndProbeOfflineSource<ObjType,ObjCollType>::
+template <typename TagType,typename TagCollType,typename ProbeType,typename ProbeCollType> 
+void HLTTagAndProbeOfflineSource<TagType,TagCollType,ProbeType,ProbeCollType>::
 analyze(const edm::Event& event,const edm::EventSetup& setup)
 {
   for(auto& tpEff : tagAndProbeEffs_) tpEff.fill(event,setup);
@@ -86,5 +86,18 @@ analyze(const edm::Event& event,const edm::EventSetup& setup)
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h" 
+#include "DataFormats/MuonReco/interface/MuonFwd.h" 
 using HLTEleTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::GsfElectron,reco::GsfElectronCollection>;
+using HLTPhoTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::Photon,reco::PhotonCollection>;
+using HLTElePhoTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::GsfElectron,reco::GsfElectronCollection,reco::Photon,reco::PhotonCollection>;
+using HLTMuEleTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::Muon,reco::MuonCollection,reco::GsfElectron,reco::GsfElectronCollection>;
+using HLTMuTagAndProbeOfflineSource = HLTTagAndProbeOfflineSource<reco::Muon,reco::MuonCollection>;
 DEFINE_FWK_MODULE(HLTEleTagAndProbeOfflineSource);
+DEFINE_FWK_MODULE(HLTPhoTagAndProbeOfflineSource);
+DEFINE_FWK_MODULE(HLTElePhoTagAndProbeOfflineSource);
+DEFINE_FWK_MODULE(HLTMuEleTagAndProbeOfflineSource);
+DEFINE_FWK_MODULE(HLTMuTagAndProbeOfflineSource);
+

--- a/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_Client_cff.py
@@ -6,20 +6,32 @@ def makeEGEffHistDef(baseName,filterName):
     return ["{0}_{1}_vsEt_eff '{1} Efficiency vs E_{{T}};E_{{T}} [GeV];Efficiency' {0}_{1}_vsEt_pass {0}_{1}_vsEt_tot".format(baseName,filterName),
             "{0}_{1}_EBvsEt_eff '{1} Barrel Efficiency vs E_{{T}};E_{{T}} [GeV];Efficiency' {0}_{1}_EBvsEt_pass {0}_{1}_EBvsEt_tot".format(baseName,filterName),
             "{0}_{1}_EEvsEt_eff '{1} Endcap Efficiency vs E_{{T}};E_{{T}} [GeV];Efficiency' {0}_{1}_EEvsEt_pass {0}_{1}_EEvsEt_tot".format(baseName,filterName),
+            "{0}_{1}_vsEt_eff '{1} Efficiency vs E_{{T}};E_{{T}} [GeV];Efficiency' {0}_{1}_vsEt_pass {0}_{1}_vsEt_tot".format(baseName,filterName),
             "{0}_{1}_vsSCEta_eff '{1} Efficiency vs SC #eta;#eta_{{SC}};Efficiency' {0}_{1}_vsSCEta_pass {0}_{1}_vsSCEta_tot".format(baseName,filterName),
             "{0}_{1}_EBvsPhi_eff '{1} Barrel Efficiency vs #phi [rad];#phi [rad];Efficiency' {0}_{1}_EBvsPhi_pass {0}_{1}_EBvsPhi_tot".format(baseName,filterName),
-            "{0}_{1}_EEvsPhi_eff '{1} Endcap Efficiency vs #phi;#phi [rad];Efficiency' {0}_{1}_EEvsPhi_pass {0}_{1}_EEvsPhi_tot".format(baseName,filterName),            
+            "{0}_{1}_EEvsPhi_eff '{1} Endcap Efficiency vs #phi;#phi [rad];Efficiency' {0}_{1}_EEvsPhi_pass {0}_{1}_EEvsPhi_tot".format(baseName,filterName), 
+            "{0}_{1}_vsPhi_eff '{1} Efficiency vs #phi;#phi [rad];Efficiency' {0}_{1}_vsPhi_pass {0}_{1}_vsPhi_tot".format(baseName,filterName),            
             "{0}_{1}_vsSCEtaPhi_eff '{1} Efficiency vs SC #eta/#phi;#eta_{{SC}};#phi [rad];' {0}_{1}_vsSCEtaPhi_pass {0}_{1}_vsSCEtaPhi_tot".format(baseName,filterName)]
             
 def makeAllEGEffHistDefs():
     baseNames=["eleWPTightTag","eleWPTightTag-HEP17","eleWPTightTag-HEM17"]
-    filterNames=["hltEle33CaloIdLMWPMS2Filter","hltDiEle33CaloIdLMWPMS2UnseededFilter","hltEG300erFilter","hltEG70HEFilter","hltDiEG70HEUnseededFilter","hltEG85HEFilter","hltDiEG85HEUnseededFilter","hltEG30EIso15HE30EcalIsoLastFilter","hltEG18EIso15HE30EcalIsoUnseededFilter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter","hltEle27WPTightGsfTrackIsoFilter","hltEle32noerWPTightGsfTrackIsoFilter","hltEle35noerWPTightGsfTrackIsoFilter","hltEle38noerWPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightGsfTrackIsoFilter","hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEG33L1EG26HEFilter","hltEG50HEFilter","hltEG75HEFilter","hltEG90HEFilter","hltEG120HEFilter","hltEG150HEFilter","hltEG175HEFilter","hltEG200HEFilter","hltSingleCaloJet500","hltSingleCaloJet550"]
-
+    filterNames=["hltEle33CaloIdLMWPMS2Filter","hltDiEle33CaloIdLMWPMS2UnseededFilter","hltEG300erFilter","hltEG70HEFilter","hltDiEG70HEUnseededFilter","hltEG85HEFilter","hltDiEG85HEUnseededFilter","hltEG30EIso15HE30EcalIsoLastFilter","hltEG18EIso15HE30EcalIsoUnseededFilter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter","hltEle23Ele12CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter","hltEle27WPTightGsfTrackIsoFilter","hltEle32noerWPTightGsfTrackIsoFilter","hltEle35noerWPTightGsfTrackIsoFilter","hltEle38noerWPTightGsfTrackIsoFilter","hltEle27L1DoubleEGWPTightGsfTrackIsoFilter","hltEle32L1DoubleEGWPTightGsfTrackIsoFilter","hltEG33L1EG26HEFilter","hltEG50HEFilter","hltEG75HEFilter","hltEG90HEFilter","hltEG120HEFilter","hltEG150HEFilter","hltEG175HEFilter","hltEG200HEFilter","hltSingleCaloJet500","hltSingleCaloJet550","hltEle28HighEtaSC20TrackIsoFilter","hltEle50CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle115CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle135CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle145CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle200CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle250CaloIdVTGsfTrkIdTGsfDphiFilter","hltEle300CaloIdVTGsfTrkIdTGsfDphiFilter"
+                 ]
+    
 
     histDefs=[]
     for baseName in baseNames:
         for filterName in filterNames:
             histDefs.extend(makeEGEffHistDef(baseName,filterName))
+
+    baseNames=["eleWPTightTagPhoProbe","eleWPTightTagPhoProbe-HEM17","eleWPTightTagPhoProbe-HEP17"]
+    filterNames=["hltEle28HighEtaSC20Mass55Filter","hltEle28HighEtaSC20HcalIsoFilterUnseeded"]
+
+    for baseName in baseNames:
+        for filterName in filterNames:
+            histDefs.extend(makeEGEffHistDef(baseName,filterName))
+    
+#    print histDefs
     return histDefs
 
 

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource
+from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,photonIDValueMapProducer,photonMVAValueMapProducer,egmPhotonIDsForDQM
 
 egammaMonitorHLT = cms.Sequence(
     egmGsfElectronIDsForDQM*
-    egHLTDQMOfflineTnPSource
+    egHLTDQMOfflineTnPSource*
+    egmPhotonIDSequenceForDQM*
+    egHLTElePhoDQMOfflineTnPSource
 )

--- a/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/EgammaMonitoring_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,photonIDValueMapProducer,photonMVAValueMapProducer,egmPhotonIDsForDQM
+from DQMOffline.Trigger.HLTEGTnPMonitor_cfi import egmGsfElectronIDsForDQM,egHLTDQMOfflineTnPSource,egmPhotonIDSequenceForDQM,egHLTElePhoDQMOfflineTnPSource,photonIDValueMapProducer,egmPhotonIDsForDQM
 
 egammaMonitorHLT = cms.Sequence(
     egmGsfElectronIDsForDQM*

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -18,6 +18,19 @@ ecalEndcapEtaCut=cms.PSet(
     rangeVar=cms.string("scEta"),
     allowedRanges=cms.vstring("-2.5:-1.556","1.556:2.5")
     )
+ecalEndcapHighEtaCut=cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("-3.0:-2.5","2.5:3.0")
+    )
+ecalEndcapPosHighEtaCut= cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("2.5:3.0"),
+    )
+ecalEndcapNegHighEtaCut= cms.PSet(
+    rangeVar=cms.string("scEta"),
+    allowedRanges=cms.vstring("-3.0:-2.5"),
+    )
+
 ecalBarrelAndEndcapEtaCut = cms.PSet(
     rangeVar=cms.string("scEta"),
     allowedRanges=cms.vstring("-1.4442:1.4442","-2.5:-1.556","1.556:2.5"),
@@ -26,6 +39,7 @@ hcalPosEtaCut= cms.PSet(
     rangeVar=cms.string("scEta"),
     allowedRanges=cms.vstring("1.3:1.4442","1.556:2.5"),
     )
+
 hcalNegEtaCut= cms.PSet(
     rangeVar=cms.string("scEta"),
     allowedRanges=cms.vstring("-2.5:-1.556","-1.4442:-1.3"),
@@ -83,17 +97,18 @@ tagAndProbeConfigEle27WPTightHEM17 = tagAndProbeConfigEle27WPTight.clone(
 
 tagAndProbeElePhoConfigEle27WPTight = tagAndProbeConfigEle27WPTight.clone(
     probeColl=cms.InputTag("gedPhotons"),
-    probeVIDCuts=cms.InputTag(""),
+    probeVIDCuts=cms.InputTag("cutBasedPhotonID-Spring16-V2p2-loose"),
+    probeRangeCuts = cms.VPSet(),
     minTagProbeDR=cms.double(0.1)
 )
 tagAndProbeElePhoConfigEle27WPTightHEP17 = tagAndProbeElePhoConfigEle27WPTight.clone(
      probeRangeCuts = cms.VPSet(
-        hcalPosEtaCut,
+        ecalEndcapPosHighEtaCut,
         hcalPhi17Cut,
 ))
 tagAndProbeElePhoConfigEle27WPTightHEM17 = tagAndProbeElePhoConfigEle27WPTight.clone(
      probeRangeCuts = cms.VPSet(
-        hcalNegEtaCut,
+        ecalEndcapPosHighEtaCut,
         hcalPhi17Cut,
 ))
 
@@ -140,6 +155,39 @@ egammaStdHistConfigs = cms.VPSet(
         nameSuffex=cms.string("_vsSCEtaPhi"), 
         rangeCuts=cms.VPSet(),
         xBinLowEdges=scEtaBinsStd,
+        yBinLowEdges=phiBinsStd,
+        ),
+    
+    )
+egammaHighEtaHistConfigs = cms.VPSet(
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("et"),
+        nameSuffex=cms.string("_vsEt"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=etBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("scEta"),
+        nameSuffex=cms.string("_vsSCEta"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=cms.vdouble(-3.0,-2.9,-2.8,-2.7,-2.6,-2.5,2.5,2.6,2.7,2.8,2.9,3.0),
+        ),
+    cms.PSet(
+        histType=cms.string("1D"),
+        vsVar=cms.string("phi"),
+        nameSuffex=cms.string("_vsPhi"),
+        rangeCuts=cms.VPSet(),
+        binLowEdges=phiBinsStd,
+        ),
+    cms.PSet(
+        histType=cms.string("2D"),
+        xVar=cms.string("scEta"),
+        yVar=cms.string("phi"),
+        nameSuffex=cms.string("_vsSCEtaPhi"), 
+        rangeCuts=cms.VPSet(),
+        xBinLowEdges=cms.vdouble(-3.0,-2.9,-2.8,-2.7,-2.6,-2.5,2.5,2.6,2.7,2.8,2.9,3.0),
         yBinLowEdges=phiBinsStd,
         ),
     
@@ -336,10 +384,84 @@ egammaStdFiltersToMonitor= cms.VPSet(
         histTitle = cms.string(""),
         tagExtraFilter = cms.string(""),
         ),
-   
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele28_HighEta_SC20_Mass55"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("32:99999")),),
+        filterName = cms.string("hltEle28HighEtaSC20TrackIsoFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("55:99999")),),
+        filterName = cms.string("hltEle50CaloIdVTGsfTrkIdTGsfDphiFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""), 
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele115_CaloIdVT_GsfTrkIdT"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("120:99999")),),
+        filterName = cms.string("hltEle115CaloIdVTGsfTrkIdTGsfDphiFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele135_CaloIdVT_GsfTrkIdT"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("140:99999")),),
+        filterName = cms.string("hltEle135CaloIdVTGsfTrkIdTGsfDphiFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele145_CaloIdVT_GsfTrkIdT"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("150:99999")),),
+        filterName = cms.string("hltEle145CaloIdVTGsfTrkIdTGsfDphiFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele200_CaloIdVT_GsfTrkIdT"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("210:99999")),),
+        filterName = cms.string("hltEle200CaloIdVTGsfTrkIdTGsfDphiFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele250_CaloIdVT_GsfTrkIdT"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("260:99999")),),
+        filterName = cms.string("hltEle250CaloIdVTGsfTrkIdTGsfDphiFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele300_CaloIdVT_GsfTrkIdT"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("310:99999")),),
+        filterName = cms.string("hltEle300CaloIdVTGsfTrkIdTGsfDphiFilter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string(""),
+        ),
      )
   
- 
+egammaPhoFiltersToMonitor= cms.VPSet(
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele28_HighEta_SC20_Mass55"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("22:99999")),
+                              ecalEndcapHighEtaCut
+                              ),
+        filterName = cms.string("hltEle28HighEtaSC20Mass55Filter"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEle28HighEtaSC20TrackIsoFilter"),
+        ), 
+    cms.PSet(
+        folderName = cms.string("HLT/EGTagAndProbeEffs/HLT_Ele28_HighEta_SC20_Mass55"),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("22:99999")),
+                              ecalEndcapHighEtaCut
+                              ),
+        filterName = cms.string("hltEle28HighEtaSC20HcalIsoFilterUnseeded"),
+        histTitle = cms.string(""),
+        tagExtraFilter = cms.string("hltEle28HighEtaSC20TrackIsoFilter"),
+        ),
+) 
 
 egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
                                           tagAndProbeCollections = cms.VPSet(
@@ -368,26 +490,27 @@ egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
 egHLTElePhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
                                                 tagAndProbeCollections = cms.VPSet(
         cms.PSet( 
-            tagAndProbeConfigEle27WPTight.clone(probeColl=cms.InputTag("gedPhotons"),
-            histConfigs = egammaStdHistConfigs,
-            baseHistName = cms.string("eleWPTightTag_"),
-            filterConfigs = egammaStdFiltersToMonitor,
+            tagAndProbeElePhoConfigEle27WPTight,
+            histConfigs = egammaHighEtaHistConfigs,
+            baseHistName = cms.string("eleWPTightTagPhoProbe_"),
+            filterConfigs = egammaPhoFiltersToMonitor,
         ),
         cms.PSet(
-            tagAndProbeConfigEle27WPTightHEM17,
-            histConfigs = egammaStdHistConfigs,
-            baseHistName = cms.string("eleWPTightTag-HEM17_"),
-            filterConfigs = egammaStdFiltersToMonitor,
+            tagAndProbeElePhoConfigEle27WPTightHEM17,
+            histConfigs = egammaHighEtaHistConfigs,
+            baseHistName = cms.string("eleWPTightTagPhoProbe-HEM17_"),
+            filterConfigs = egammaPhoFiltersToMonitor,
         ),
         cms.PSet(
-            tagAndProbeConfigEle27WPTightHEP17,
-            histConfigs = egammaStdHistConfigs,
-            baseHistName = cms.string("eleWPTightTag-HEP17_"),
-            filterConfigs = egammaStdFiltersToMonitor,
+            tagAndProbeElePhoConfigEle27WPTightHEP17,
+            histConfigs = egammaHighEtaHistConfigs,
+            baseHistName = cms.string("eleWPTightTagPhoProbe-HEP17_"),
+            filterConfigs = egammaPhoFiltersToMonitor,
         ),
            
         )
-           
+                                                )
+
 from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import egmGsfElectronIDs
 
 egmGsfElectronIDsForDQM = egmGsfElectronIDs.clone()
@@ -403,3 +526,24 @@ for id_module_name in my_id_modules:
         item = getattr(idmod,name)
         if hasattr(item,'idName') and hasattr(item,'cutFlow'):
             setupVIDSelection(egmGsfElectronIDsForDQM,item)
+
+
+from RecoEgamma.PhotonIdentification.PhotonIDValueMapProducer_cfi import photonIDValueMapProducer
+from RecoEgamma.PhotonIdentification.PhotonMVAValueMapProducer_cfi import photonMVAValueMapProducer
+from RecoEgamma.PhotonIdentification.egmPhotonIDs_cfi import egmPhotonIDs
+egmPhotonIDsForDQM = egmPhotonIDs.clone()
+egmPhotonIDsForDQM.physicsObjectsIDs = cms.VPSet()
+egmPhotonIDsForDQM.physicsObjectSrc == cms.InputTag('gedPhotons')
+#note: be careful here to when selecting new ids that the vid tools dont do extra setup for them
+#for example the HEEP cuts need an extra producer which vid tools automatically handles
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import setupVIDSelection
+my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff']
+for id_module_name in my_id_modules: 
+    idmod= __import__(id_module_name, globals(), locals(), ['idName','cutFlow'])
+    for name in dir(idmod):
+        item = getattr(idmod,name)
+        if hasattr(item,'idName') and hasattr(item,'cutFlow'):
+            setupVIDSelection(egmPhotonIDsForDQM,item)
+egmPhotonIDSequenceForDQM = cms.Sequence(photonIDValueMapProducer*
+                                         photonMVAValueMapProducer*
+                                         egmPhotonIDsForDQM)

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -38,7 +38,8 @@ hcalPhi17Cut = cms.PSet(
 
 tagAndProbeConfigEle27WPTight = cms.PSet(
     trigEvent = cms.InputTag("hltTriggerSummaryAOD","","HLT"),
-    objColl = cms.InputTag("gedGsfElectrons"),
+    tagColl = cms.InputTag("gedGsfElectrons"),
+    probeColl = cms.InputTag("gedGsfElectrons"),
     tagVIDCuts = cms.InputTag("egmGsfElectronIDsForDQM:cutBasedElectronID-Summer16-80X-V1-tight"),
     probeVIDCuts = cms.InputTag("egmGsfElectronIDsForDQM:cutBasedElectronID-Summer16-80X-V1-tight"),
     sampleTrigRequirements = cms.PSet(
@@ -60,6 +61,7 @@ tagAndProbeConfigEle27WPTight = cms.PSet(
     probeFilters = cms.vstring(),
     probeFiltersORed = cms.bool(False),
     probeRangeCuts = cms.VPSet(ecalBarrelAndEndcapEtaCut),
+    minTagProbeDR = cms.double(0),
     minMass = cms.double(70.0),
     maxMass = cms.double(110.0),
     requireOpSign = cms.bool(False),
@@ -78,7 +80,22 @@ tagAndProbeConfigEle27WPTightHEM17 = tagAndProbeConfigEle27WPTight.clone(
         hcalNegEtaCut,
         hcalPhi17Cut,
 ))
-    
+
+tagAndProbeElePhoConfigEle27WPTight = tagAndProbeConfigEle27WPTight.clone(
+    probeColl=cms.InputTag("gedPhotons"),
+    probeVIDCuts=cms.InputTag(""),
+    minTagProbeDR=cms.double(0.1)
+)
+tagAndProbeElePhoConfigEle27WPTightHEP17 = tagAndProbeElePhoConfigEle27WPTight.clone(
+     probeRangeCuts = cms.VPSet(
+        hcalPosEtaCut,
+        hcalPhi17Cut,
+))
+tagAndProbeElePhoConfigEle27WPTightHEM17 = tagAndProbeElePhoConfigEle27WPTight.clone(
+     probeRangeCuts = cms.VPSet(
+        hcalNegEtaCut,
+        hcalPhi17Cut,
+))
 
 egammaStdHistConfigs = cms.VPSet(
     cms.PSet(
@@ -348,6 +365,29 @@ egHLTDQMOfflineTnPSource = cms.EDAnalyzer("HLTEleTagAndProbeOfflineSource",
         )
                                          )
 
+egHLTElePhoDQMOfflineTnPSource = cms.EDAnalyzer("HLTElePhoTagAndProbeOfflineSource",
+                                                tagAndProbeCollections = cms.VPSet(
+        cms.PSet( 
+            tagAndProbeConfigEle27WPTight.clone(probeColl=cms.InputTag("gedPhotons"),
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("eleWPTightTag_"),
+            filterConfigs = egammaStdFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeConfigEle27WPTightHEM17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("eleWPTightTag-HEM17_"),
+            filterConfigs = egammaStdFiltersToMonitor,
+        ),
+        cms.PSet(
+            tagAndProbeConfigEle27WPTightHEP17,
+            histConfigs = egammaStdHistConfigs,
+            baseHistName = cms.string("eleWPTightTag-HEP17_"),
+            filterConfigs = egammaStdFiltersToMonitor,
+        ),
+           
+        )
+           
 from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import egmGsfElectronIDs
 
 egmGsfElectronIDsForDQM = egmGsfElectronIDs.clone()

--- a/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTEGTnPMonitor_cfi.py
@@ -529,7 +529,6 @@ for id_module_name in my_id_modules:
 
 
 from RecoEgamma.PhotonIdentification.PhotonIDValueMapProducer_cfi import photonIDValueMapProducer
-from RecoEgamma.PhotonIdentification.PhotonMVAValueMapProducer_cfi import photonMVAValueMapProducer
 from RecoEgamma.PhotonIdentification.egmPhotonIDs_cfi import egmPhotonIDs
 egmPhotonIDsForDQM = egmPhotonIDs.clone()
 egmPhotonIDsForDQM.physicsObjectsIDs = cms.VPSet()
@@ -545,5 +544,4 @@ for id_module_name in my_id_modules:
         if hasattr(item,'idName') and hasattr(item,'cutFlow'):
             setupVIDSelection(egmPhotonIDsForDQM,item)
 egmPhotonIDSequenceForDQM = cms.Sequence(photonIDValueMapProducer*
-                                         photonMVAValueMapProducer*
                                          egmPhotonIDsForDQM)


### PR DESCRIPTION
Dear All,

This PR adds cross trigger support to the E/gamma TnP DQM which is used by HLT_Ele28_HighEta_SC20_Mass55  . It also extends the monitoring to the following paths:

HLT_Ele28_HighEta_SC20_Mass55 (both legs)
HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165 (electron leg)
HLT_Ele115_CaloIdVT_GsfTrkIdT
HLT_Ele135_CaloIdVT_GsfTrkIdT
HLT_Ele145_CaloIdVT_GsfTrkIdT
HLT_Ele200_CaloIdVT_GsfTrkIdT
HLT_Ele250_CaloIdVT_GsfTrkIdT
HLT_Ele300_CaloIdVT_GsfTrkIdT