### PR TITLE
Remove tracker subdetector DetId in some Reco/Geometry ES products

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/PFCheckHitPattern.h
+++ b/RecoParticleFlow/PFTracking/interface/PFCheckHitPattern.h
@@ -48,8 +48,8 @@ class PFCheckHitPattern {
   /// on track.
 
   PFTrackHitFullInfo 
-    analyze(edm::ESHandle<TrackerGeometry>, const reco::TrackBaseRef track, 
-	    const TransientVertex& vert);
+    analyze(const TrackerTopology* tkerTopo, const TrackerGeometry* tkerGeom,
+            const reco::TrackBaseRef track, const TransientVertex& vert);
 
   /// Print hit pattern on track
   void print(const reco::TrackBaseRef track) const;
@@ -58,12 +58,12 @@ class PFCheckHitPattern {
 
 private:
   /// Create map indicating r/z values of all layers/disks.
-  void init (edm::ESHandle<TrackerGeometry>);
+  void init (const TrackerTopology*, const TrackerGeometry*);
 
   /// Return a pair<uint32, uint32> consisting of the numbers used by HitPattern to 
   /// identify subdetector and layer number respectively.
   typedef std::pair<uint32_t, uint32_t> DetInfo;
-  static DetInfo interpretDetId(DetId detId);
+  static DetInfo interpretDetId(DetId detId, const TrackerTopology*);
 
   /// Return a bool indicating if a given subdetector is in the barrel.
   static bool barrel(uint32_t subDet);

--- a/RecoParticleFlow/PFTracking/interface/PFCheckHitPattern.h
+++ b/RecoParticleFlow/PFTracking/interface/PFCheckHitPattern.h
@@ -60,10 +60,9 @@ private:
   /// Create map indicating r/z values of all layers/disks.
   void init (const TrackerTopology*, const TrackerGeometry*);
 
-  /// Return a pair<uint32, uint32> consisting of the numbers used by HitPattern to 
+  /// a pair<uint32, uint32> consisting of the numbers used by HitPattern to
   /// identify subdetector and layer number respectively.
   typedef std::pair<uint32_t, uint32_t> DetInfo;
-  static DetInfo interpretDetId(DetId detId, const TrackerTopology*);
 
   /// Return a bool indicating if a given subdetector is in the barrel.
   static bool barrel(uint32_t subDet);

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexFinder.h
@@ -75,10 +75,12 @@ class PFDisplacedVertexFinder {
   /// Sets parameters for track extrapolation and hits study
   void setEdmParameters( const MagneticField* magField,
 			 edm::ESHandle<GlobalTrackingGeometry> globTkGeomHandle,
-			 edm::ESHandle<TrackerGeometry> tkerGeomHandle){ 
+			 const TrackerTopology* tkerTopo,
+			 const TrackerGeometry* tkerGeom){
     magField_ = magField; 
     globTkGeomHandle_ = globTkGeomHandle;
-    tkerGeomHandle_ = tkerGeomHandle; 
+    tkerTopo_ = tkerTopo;
+    tkerGeom_ = tkerGeom;
   }
 
   void setTracksSelector(const edm::ParameterSet& ps){
@@ -181,7 +183,8 @@ class PFDisplacedVertexFinder {
   edm::ESHandle<GlobalTrackingGeometry> globTkGeomHandle_;
 
   /// doc? 
-  edm::ESHandle<TrackerGeometry> tkerGeomHandle_;
+  const TrackerTopology* tkerTopo_;
+  const TrackerGeometry* tkerGeom_;
 
   /// to be able to extrapolate tracks f
   const MagneticField* magField_;

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
@@ -117,6 +117,9 @@ PFDisplacedVertexProducer::produce(Event& iEvent,
   ESHandle<GlobalTrackingGeometry> globTkGeomHandle;
   iSetup.get<GlobalTrackingGeometryRecord>().get(globTkGeomHandle);
 
+  ESHandle<TrackerTopology> tkerTopoHandle;
+  iSetup.get<TrackerTopologyRcd>().get(tkerTopoHandle);
+
   ESHandle<TrackerGeometry> tkerGeomHandle;
   iSetup.get<TrackerDigiGeometryRecord>().get(tkerGeomHandle);
 
@@ -130,7 +133,7 @@ PFDisplacedVertexProducer::produce(Event& iEvent,
   iEvent.getByToken(inputTagBeamSpot_, beamSpotHandle);
 
   // Fill useful event information for the Finder
-  pfDisplacedVertexFinder_.setEdmParameters(theMagField, globTkGeomHandle, tkerGeomHandle); 
+  pfDisplacedVertexFinder_.setEdmParameters(theMagField, globTkGeomHandle, tkerTopoHandle.product(), tkerGeomHandle.product());
   pfDisplacedVertexFinder_.setPrimaryVertex(mainVertexHandle, beamSpotHandle);
   pfDisplacedVertexFinder_.setInput(vertexCandidates);
 

--- a/RecoParticleFlow/PFTracking/src/PFCheckHitPattern.cc
+++ b/RecoParticleFlow/PFTracking/src/PFCheckHitPattern.cc
@@ -8,21 +8,16 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 // To convert detId to subdet/layer number.
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 
 #include <map>
 
 using namespace reco;
 using namespace std;
 
-void PFCheckHitPattern::init(edm::ESHandle<TrackerGeometry> tkerGeomHandle_) {
+void PFCheckHitPattern::init(const TrackerTopology* tkerTopo, const TrackerGeometry* tkerGeom) {
 
   //
   // Note min/max radius (z) of each barrel layer (endcap disk).
@@ -31,13 +26,13 @@ void PFCheckHitPattern::init(edm::ESHandle<TrackerGeometry> tkerGeomHandle_) {
   geomInitDone_ = true;
 
   // Get Tracker geometry
-  const TrackingGeometry::DetContainer& dets = tkerGeomHandle_->dets();
+  const TrackingGeometry::DetContainer& dets = tkerGeom->dets();
 
   // Loop over all modules in the Tracker.
   for (unsigned int i = 0; i < dets.size(); i++) {    
 
     // Get subdet and layer of this module
-    DetInfo detInfo = this->interpretDetId(dets[i]->geographicalId());
+    DetInfo detInfo = this->interpretDetId(dets[i]->geographicalId(), tkerTopo);
     uint32_t subDet = detInfo.first;
 
     // Note r (or z) of module if barrel (or endcap).
@@ -72,24 +67,34 @@ void PFCheckHitPattern::init(edm::ESHandle<TrackerGeometry> tkerGeomHandle_) {
 #endif
 }
 
-PFCheckHitPattern::DetInfo PFCheckHitPattern::interpretDetId(DetId detId) {
+PFCheckHitPattern::DetInfo PFCheckHitPattern::interpretDetId(DetId detId, const TrackerTopology* tkerTopo) {
   // Convert detId to a pair<uint32, uint32> consisting of the numbers used by HitPattern 
   // to identify subdetector and layer number respectively.
-  if (detId.subdetId() == StripSubdetector::TIB) {
-    return DetInfo( detId.subdetId() , TIBDetId(detId).layer() );
-  } else if (detId.subdetId() == StripSubdetector::TOB) {
-    return DetInfo( detId.subdetId() , TOBDetId(detId).layer() );
-  } else if (detId.subdetId() == StripSubdetector::TID) {
-    return DetInfo( detId.subdetId() , TIDDetId(detId).wheel() );
-  } else if (detId.subdetId() == StripSubdetector::TEC) {
-    return DetInfo( detId.subdetId() , TECDetId(detId).wheel() );
-  } else if (detId.subdetId() == PixelSubdetector::PixelBarrel) {
-    return DetInfo( detId.subdetId() , PXBDetId(detId).layer() );
-  } else if (detId.subdetId() == PixelSubdetector::PixelEndcap) {
-    return DetInfo( detId.subdetId() , PXFDetId(detId).disk() );
-  } else {
-    throw cms::Exception("RecoParticleFlow", "Found DetId that is not in Tracker");
-  }   
+  const auto subdetId = detId.subdetId();
+  uint32_t second{};
+  switch (subdetId) {
+    case StripSubdetector::TIB:
+      second = tkerTopo->tibLayer(detId);
+      break;
+    case StripSubdetector::TOB:
+      second = tkerTopo->tobLayer(detId);
+      break;
+    case StripSubdetector::TID:
+      second = tkerTopo->tidWheel(detId);
+      break;
+    case StripSubdetector::TEC:
+      second = tkerTopo->tecWheel(detId);
+      break;
+    case PixelSubdetector::PixelBarrel:
+      second = tkerTopo->pxbLayer(detId);
+      break;
+    case PixelSubdetector::PixelEndcap:
+      second = tkerTopo->pxfDisk(detId);
+      break;
+    default:
+      throw cms::Exception("RecoParticleFlow", "Found DetId that is not in Tracker");
+  }
+  return DetInfo(subdetId, second);
 }
 
 bool PFCheckHitPattern::barrel(uint32_t subDet) {
@@ -100,7 +105,7 @@ bool PFCheckHitPattern::barrel(uint32_t subDet) {
 
 
 pair< PFCheckHitPattern::PFTrackHitInfo, PFCheckHitPattern::PFTrackHitInfo> 
-PFCheckHitPattern::analyze(edm::ESHandle<TrackerGeometry> tkerGeomHandle_, 
+PFCheckHitPattern::analyze(const TrackerTopology* tkerTopo, const TrackerGeometry* tkerGeom,
 			   const TrackBaseRef track, const TransientVertex& vert) 
 {
 
@@ -110,7 +115,7 @@ PFCheckHitPattern::analyze(edm::ESHandle<TrackerGeometry> tkerGeomHandle_,
   // on track.
 
   // Initialise geometry info if not yet done.
-  if (!geomInitDone_) this->init(tkerGeomHandle_);
+  if (!geomInitDone_) this->init(tkerTopo, tkerGeom);
 
   // Get hit patterns of this track
   const reco::HitPattern& hp = track.get()->hitPattern();

--- a/RecoParticleFlow/PFTracking/src/PFCheckHitPattern.cc
+++ b/RecoParticleFlow/PFTracking/src/PFCheckHitPattern.cc
@@ -32,7 +32,8 @@ void PFCheckHitPattern::init(const TrackerTopology* tkerTopo, const TrackerGeome
   for (unsigned int i = 0; i < dets.size(); i++) {    
 
     // Get subdet and layer of this module
-    DetInfo detInfo = this->interpretDetId(dets[i]->geographicalId(), tkerTopo);
+    auto detId = dets[i]->geographicalId();
+    auto detInfo = DetInfo(detId.subdetId(), tkerTopo->layer(detId));
     uint32_t subDet = detInfo.first;
 
     // Note r (or z) of module if barrel (or endcap).
@@ -65,36 +66,6 @@ void PFCheckHitPattern::init(const TrackerTopology* tkerTopo, const TrackerGeome
     pair<double, double> rangeRZ = d->second;
   }
 #endif
-}
-
-PFCheckHitPattern::DetInfo PFCheckHitPattern::interpretDetId(DetId detId, const TrackerTopology* tkerTopo) {
-  // Convert detId to a pair<uint32, uint32> consisting of the numbers used by HitPattern 
-  // to identify subdetector and layer number respectively.
-  const auto subdetId = detId.subdetId();
-  uint32_t second{};
-  switch (subdetId) {
-    case StripSubdetector::TIB:
-      second = tkerTopo->tibLayer(detId);
-      break;
-    case StripSubdetector::TOB:
-      second = tkerTopo->tobLayer(detId);
-      break;
-    case StripSubdetector::TID:
-      second = tkerTopo->tidWheel(detId);
-      break;
-    case StripSubdetector::TEC:
-      second = tkerTopo->tecWheel(detId);
-      break;
-    case PixelSubdetector::PixelBarrel:
-      second = tkerTopo->pxbLayer(detId);
-      break;
-    case PixelSubdetector::PixelEndcap:
-      second = tkerTopo->pxfDisk(detId);
-      break;
-    default:
-      throw cms::Exception("RecoParticleFlow", "Found DetId that is not in Tracker");
-  }
-  return DetInfo(subdetId, second);
 }
 
 bool PFCheckHitPattern::barrel(uint32_t subDet) {

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexFinder.cc
@@ -418,7 +418,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
 
     if (theVertexAdaptiveRaw.trackWeight(transTracksRaw[i]) > minAdaptWeight_){
 
-      PFTrackHitFullInfo pattern = hitPattern_.analyze(tkerGeomHandle_, transTracksRefRaw[i], theVertexAdaptiveRaw);
+      PFTrackHitFullInfo pattern = hitPattern_.analyze(tkerTopo_, tkerGeom_, transTracksRefRaw[i], theVertexAdaptiveRaw);
 
       PFDisplacedVertex::VertexTrackType vertexTrackType = getVertexTrackType(pattern);
 
@@ -535,7 +535,7 @@ PFDisplacedVertexFinder::fitVertexFromSeed(const PFDisplacedVertexSeed& displace
   
   for(unsigned i = 0; i < transTracks.size();i++) {
     
-    PFTrackHitFullInfo pattern = hitPattern_.analyze(tkerGeomHandle_, transTracksRef[i], theRecoVertex);
+    PFTrackHitFullInfo pattern = hitPattern_.analyze(tkerTopo_, tkerGeom_, transTracksRef[i], theRecoVertex);
 
     PFDisplacedVertex::VertexTrackType vertexTrackType = getVertexTrackType(pattern);
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -58,7 +58,6 @@ std::shared_ptr<MeasurementTracker>
 MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 { 
 
-
   // ========= SiPixelQuality related tasks =============
   const SiPixelQuality    *ptr_pixelQuality = 0;
   const SiPixelFedCabling *ptr_pixelCabling = 0;
@@ -125,6 +124,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   edm::ESHandle<PixelClusterParameterEstimator> pixelCPE;
   edm::ESHandle<StripClusterParameterEstimator> stripCPE;
   edm::ESHandle<SiStripRecHitMatcher>           hitMatcher;
+  edm::ESHandle<TrackerTopology>                trackerTopology;
   edm::ESHandle<TrackerGeometry>                trackerGeom;
   edm::ESHandle<GeometricSearchTracker>         geometricSearchTracker;
   edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > phase2TrackerCPE;
@@ -132,6 +132,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   iRecord.getRecord<TkPixelCPERecord>().get(pixelCPEName,pixelCPE);
   iRecord.getRecord<TkStripCPERecord>().get(stripCPEName,stripCPE);
   iRecord.getRecord<TkStripCPERecord>().get(matcherName,hitMatcher);
+  iRecord.getRecord<TrackerTopologyRcd>().get(trackerTopology);
   iRecord.getRecord<TrackerDigiGeometryRecord>().get(trackerGeom);
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
 
@@ -141,6 +142,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 							          pixelCPE.product(),
 							          stripCPE.product(),
 							          hitMatcher.product(),
+							          trackerTopology.product(),
 							          trackerGeom.product(),
 							          geometricSearchTracker.product(),
 							          ptr_stripQuality,
@@ -156,6 +158,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
 							          pixelCPE.product(),
 							          stripCPE.product(),
 							          hitMatcher.product(),
+							          trackerTopology.product(),
 							          trackerGeom.product(),
 							          geometricSearchTracker.product(),
 							          ptr_stripQuality,

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
@@ -81,6 +81,7 @@ MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet&         
 				       const PixelClusterParameterEstimator* pixelCPE,
 				       const StripClusterParameterEstimator* stripCPE,
 				       const SiStripRecHitMatcher*  hitMatcher,
+				       const TrackerTopology*  trackerTopology,
 				       const TrackerGeometry*  trackerGeom,
 				       const GeometricSearchTracker* geometricSearchTracker,
                                        const SiStripQuality *stripQuality,
@@ -98,7 +99,7 @@ MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet&         
   thePxDetConditions(pixelCPE),
   thePhase2DetConditions(phase2OTCPE)
 {
-  this->initialize();
+  this->initialize(trackerTopology);
   this->initializeStripStatus(stripQuality, stripQualityFlags, stripQualityDebugFlags);
   this->initializePixelStatus(pixelQuality, pixelCabling, pixelQualityFlags, pixelQualityDebugFlags);
 }
@@ -108,7 +109,7 @@ MeasurementTrackerImpl::~MeasurementTrackerImpl()
 }
 
 
-void MeasurementTrackerImpl::initialize()
+void MeasurementTrackerImpl::initialize(const TrackerTopology* trackerTopology)
 { 
 
   bool subIsPixel = false;
@@ -158,7 +159,7 @@ void MeasurementTrackerImpl::initialize()
   // now the glued dets
   sortTKD(theGluedDets);
   for (unsigned int i=0; i!=theGluedDets.size(); ++i)
-    initGluedDet(theGluedDets[i]);
+    initGluedDet(theGluedDets[i], trackerTopology);
 
   // then the pixels
   sortTKD(thePixelDets);
@@ -310,7 +311,7 @@ void MeasurementTrackerImpl::addStackDet( const StackGeomDet* gd)
   theStackDets.push_back(TkStackMeasurementDet( gd, thePxDetConditions.pixelCPE() ));
 }
 
-void MeasurementTrackerImpl::initGluedDet( TkGluedMeasurementDet & det)
+void MeasurementTrackerImpl::initGluedDet( TkGluedMeasurementDet & det, const TrackerTopology* trackerTopology)
 {
   const GluedGeomDet& gd = det.specificGeomDet();
   const MeasurementDet* monoDet = findDet( gd.monoDet()->geographicalId());
@@ -319,7 +320,7 @@ void MeasurementTrackerImpl::initGluedDet( TkGluedMeasurementDet & det)
     edm::LogError("MeasurementDet") << "MeasurementTracker ERROR: GluedDet components not found as MeasurementDets ";
     throw MeasurementDetException("MeasurementTracker ERROR: GluedDet components not found as MeasurementDets");
   }
-  det.init(monoDet,stereoDet);
+  det.init(monoDet, stereoDet, trackerTopology);
   theDetMap[gd.geographicalId()] = &det;
 }
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
@@ -52,6 +52,7 @@ public:
 		     const PixelClusterParameterEstimator* pixelCPE,
 		     const StripClusterParameterEstimator* stripCPE,
 		     const SiStripRecHitMatcher*  hitMatcher,
+		     const TrackerTopology*  trackerTopology,
 		     const TrackerGeometry*  trackerGeom,
 		     const GeometricSearchTracker* geometricSearchTracker,
                      const SiStripQuality *stripQuality,
@@ -126,7 +127,7 @@ public:
 
   const SiPixelFedCabling*              thePixelCabling;
 
-  void initialize();
+  void initialize(const TrackerTopology* trackerTopology);
   void initStMeasurementConditionSet(std::vector<TkStripMeasurementDet> & stripDets);
   void initPxMeasurementConditionSet(std::vector<TkPixelMeasurementDet> & pixelDets);
   void initPhase2OTMeasurementConditionSet(std::vector<TkPhase2OTMeasurementDet> & phase2Dets);
@@ -138,7 +139,7 @@ public:
   void addGluedDet( const GluedGeomDet* gd);
   void addStackDet( const StackGeomDet* gd);
 
-  void initGluedDet( TkGluedMeasurementDet & det);
+  void initGluedDet( TkGluedMeasurementDet & det, const TrackerTopology* trackerTopology);
   void initStackDet( TkStackMeasurementDet & det);
 
   void addDets( const TrackingGeometry::DetContainer& dets, bool subIsPixel, bool subIsOT);

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -9,14 +9,13 @@
 #include "RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h"
 #include "RecHitPropagator.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/InvalidTransientRecHit.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include <memory>
 
 #include <typeinfo>
-
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
 
 
 namespace {
@@ -74,13 +73,16 @@ TkGluedMeasurementDet::TkGluedMeasurementDet( const GluedGeomDet* gdet,
                                               const StripClusterParameterEstimator* cpe) :
   MeasurementDet(gdet), 
   theMatcher(matcher),  theCPE(cpe),
-  theMonoDet(nullptr), theStereoDet(nullptr)
+  theMonoDet(nullptr), theStereoDet(nullptr),
+  theTopology(nullptr)
 {}
 
 void TkGluedMeasurementDet::init(const MeasurementDet* monoDet,
-				 const MeasurementDet* stereoDet) {
+				 const MeasurementDet* stereoDet,
+                                 const TrackerTopology* tTopo) {
   theMonoDet = dynamic_cast<const TkStripMeasurementDet *>(monoDet);
   theStereoDet = dynamic_cast<const TkStripMeasurementDet *>(stereoDet);
+  theTopology = tTopo;
   
   if ((theMonoDet == 0) || (theStereoDet == 0)) {
     throw MeasurementDetException("TkGluedMeasurementDet ERROR: Trying to glue a det which is not a TkStripMeasurementDet");
@@ -134,7 +136,7 @@ bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateO
    if (result.size()>oldSize) return true;
    
    auto id = geomDet().geographicalId().subdetId()-3;
-   auto l = TOBDetId(geomDet().geographicalId()).layer();
+   auto l = theTopology->tobLayer(geomDet().geographicalId());
    bool killHIP = (1==l) && (2==id); //TOB1
    killHIP &= stateOnThisDet.globalMomentum().perp2()>est.minPt2ForHitRecoveryInGluedDet();
    if (killHIP) {

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
@@ -21,7 +21,8 @@ public:
 
   TkGluedMeasurementDet( const GluedGeomDet* gdet,const SiStripRecHitMatcher* matcher, const StripClusterParameterEstimator* cpe);
   void init(const MeasurementDet* monoDet,
-	    const MeasurementDet* stereoDet);
+	    const MeasurementDet* stereoDet,
+	    const TrackerTopology* tTopo);
 
   virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const;
 
@@ -55,6 +56,7 @@ private:
   const StripClusterParameterEstimator* theCPE;
   const TkStripMeasurementDet*       theMonoDet;
   const TkStripMeasurementDet*       theStereoDet;
+  const TrackerTopology*             theTopology;
 
 
   template<typename Collector>

--- a/RecoTracker/SiTrackerMRHTools/interface/SimpleDAFHitCollector.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/SimpleDAFHitCollector.h
@@ -16,11 +16,12 @@ class StripRecHit1D;
 
 class SimpleDAFHitCollector :public MultiRecHitCollector {
 	public:
-	explicit SimpleDAFHitCollector(const MeasurementTracker* measurementTracker,
+	explicit SimpleDAFHitCollector(const TrackerTopology* trackerTopology,
+                                 const MeasurementTracker* measurementTracker,
 				 const SiTrackerMultiRecHitUpdator* updator,
 			         const MeasurementEstimator* est,
 				 const Propagator* propagator, bool debug
-				 ):MultiRecHitCollector(measurementTracker), theUpdator(updator), theEstimator(est), thePropagator(propagator), debug_(debug){
+				 ):MultiRecHitCollector(measurementTracker), theTopology(trackerTopology), theUpdator(updator), theEstimator(est), thePropagator(propagator), debug_(debug){
     theHitCloner = static_cast<TkTransientTrackingRecHitBuilder const *>(theUpdator->getBuilder())->cloner();
 }
 			
@@ -76,6 +77,7 @@ class SimpleDAFHitCollector :public MultiRecHitCollector {
         }
 
 	private:
+	const TrackerTopology* theTopology;
 	const SiTrackerMultiRecHitUpdator* theUpdator;
 	const MeasurementEstimator* theEstimator;
 	//this actually is not used in the fastMeasurement method 	

--- a/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.cc
+++ b/RecoTracker/SiTrackerMRHTools/plugins/MultiRecHitCollectorESProducer.cc
@@ -50,6 +50,8 @@ MultiRecHitCollectorESProducer::produce(const MultiRecHitRecord& iRecord){
   iRecord.getRecord<CkfComponentsRecord>().getRecord<TrackingComponentsRecord>().get(estimatorName, estimatorhandle);
   ESHandle<MeasurementTracker> measurementhandle;
   iRecord.getRecord<CkfComponentsRecord>().get(measurementTrackerName, measurementhandle);
+  ESHandle<TrackerTopology> trackerTopologyHandle;
+  iRecord.getRecord<CkfComponentsRecord>().getRecord<TrackerTopologyRcd>().get(trackerTopologyHandle);
  
   if (mode == "Grouped"){
 	std::string propagatorOppositeName = conf_.getParameter<std::string>("propagatorOpposite");  
@@ -62,7 +64,8 @@ MultiRecHitCollectorESProducer::produce(const MultiRecHitRecord& iRecord){
 							 propagatorOppositehandle.product(), debug);
   } 
   else {
-	collector_ = std::make_shared<SimpleDAFHitCollector>(measurementhandle.product(),
+	collector_ = std::make_shared<SimpleDAFHitCollector>(trackerTopologyHandle.product(),
+                                                             measurementhandle.product(),
                                                              mrhuhandle.product(),
                                                              estimatorhandle.product(),
                                                              propagatorhandle.product(), debug);

--- a/RecoTracker/SiTrackerMRHTools/src/SiTrackerMultiRecHitUpdator.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/SiTrackerMultiRecHitUpdator.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "DataFormats/Math/interface/invertPosDefMatrix.h"
 #include "DataFormats/Math/interface/ProjectMatrix.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "RecoTracker/SiTrackerMRHTools/interface/GenericProjectedRecHit2D.h"
 #include "RecoTracker/SiTrackerMRHTools/interface/SiTrackerMultiRecHitUpdator.h"
@@ -10,9 +11,6 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
@@ -15,12 +15,6 @@
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TOBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIDDetId.h"
-#include "DataFormats/SiStripDetId/interface/TECDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
 #endif
 
 
@@ -173,20 +167,22 @@ void SimpleDAFHitCollector::Debug( const std::vector<TrajectoryMeasurement> TM )
       DetId hitId = itrajmeas->recHit()->geographicalId();
 
       if(hitId.det() == DetId::Tracker) {
-        if (hitId.subdetId() == StripSubdetector::TIB )
-          LogTrace("MultiRecHitCollector") << "  I am TIB " << TIBDetId(hitId).layer();
-        else if (hitId.subdetId() == StripSubdetector::TOB )
-          LogTrace("MultiRecHitCollector") << "  I am TOB " << TOBDetId(hitId).layer();
-        else if (hitId.subdetId() == StripSubdetector::TEC )
-          LogTrace("MultiRecHitCollector") << "  I am TEC " << TECDetId(hitId).wheel();
-        else if (hitId.subdetId() == StripSubdetector::TID )
-          LogTrace("MultiRecHitCollector") << "  I am TID " << TIDDetId(hitId).wheel();
-        else if (hitId.subdetId() == (int) PixelSubdetector::PixelBarrel )
-          LogTrace("MultiRecHitCollector") << "  I am PixBar " << PXBDetId(hitId).layer();
-        else if (hitId.subdetId() == (int) PixelSubdetector::PixelEndcap )
-          LogTrace("MultiRecHitCollector") << "  I am PixFwd " << PXFDetId(hitId).disk();
-        else
-          LogTrace("MultiRecHitCollector") << "  UNKNOWN TRACKER HIT TYPE ";
+        switch (hitId.subdetid()) {
+          case StripSubdetector::TIB:
+            LogTrace("MultiRecHitCollector") << "  I am TIB " << theTopology->tibLayer(hitId); break;
+          case StripSubdetector::TOB:
+            LogTrace("MultiRecHitCollector") << "  I am TOB " << theTopology->tobLayer(hitId); break;
+          case StripSubdetector::TEC:
+            LogTrace("MultiRecHitCollector") << "  I am TEC " << theTopology->tecWheel(hitId); break;
+          case StripSubdetector::TID:
+            LogTrace("MultiRecHitCollector") << "  I am TID " << theTopology->tidWheel(hitId); break;
+          case PixelSubdetector::PixelBarrel:
+            LogTrace("MultiRecHitCollector") << "  I am PixBar " << theTopology->pxbLayer(hitId); break;
+          case PixelSubdetector::PixelEndcap:
+            LogTrace("MultiRecHitCollector") << "  I am PixFwd " << theTopology->pxfDisk(hitId); break;
+          default:
+            LogTrace("MultiRecHitCollector") << "  UNKNOWN TRACKER HIT TYPE "; break;
+        }
       }
       else if(hitId.det() == DetId::Muon) {
         if(hitId.subdetId() == MuonSubdetId::DT) 


### PR DESCRIPTION
Purely technical change, no differences expected (part of the TIBDetId/TOBDetId/TIDDetId/TECDetID/PXBDetId/PXFDetId deprecation)

- PFCheckHitPattern in RecoParticleFlow/PFTracking
- SimpleDAFHitCollector in RecoTracker/SiTrackerMRHTools
- TkGluedMeasurementDet in RecoTracker/MeasurementDet

cc @OlivierBondu @alesaggio @vidalm