### PR TITLE
[92X] Adding the DQMEventInfo module in SiStripGains and SiPixelAli PCL sequences

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/AlcaSiPixelAliHarvester_cff.py
@@ -51,8 +51,11 @@ SiPixelAliPedeAlignmentProducer.algoConfig.pedeSteerer.options = cms.vstring(
 SiPixelAliPedeAlignmentProducer.algoConfig.minNumHits = 10
 SiPixelAliPedeAlignmentProducer.saveToDB = True
 
-
+dqmEnvSiPixelAli = cms.EDAnalyzer("DQMEventInfo",
+                                  subSystemFolder = cms.untracked.string('AlCaReco'),  
+                                  )
 
 ALCAHARVESTSiPixelAli = cms.Sequence(SiPixelAliMilleFileExtractor*
                                      SiPixelAliPedeAlignmentProducer*
-                                     SiPixelAliDQMModule)
+                                     SiPixelAliDQMModule*
+                                     dqmEnvSiPixelAli)

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsAAGHarvester_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsAAGHarvester_cff.py
@@ -7,8 +7,10 @@ EDMtoMEConvertSiStripGainsAAG = EDMtoMEConverter.clone()
 EDMtoMEConvertSiStripGainsAAG.lumiInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAAG","MEtoEDMConverterLumi")
 EDMtoMEConvertSiStripGainsAAG.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGainsAAG","MEtoEDMConverterRun")
 
-
 DQMStore = cms.Service("DQMStore")
 
-ALCAHARVESTSiStripGainsAAG = cms.Sequence( EDMtoMEConvertSiStripGainsAAG +
-                                                     alcaSiStripGainsAAGHarvester)
+dqmEnvSiStripGainsAAG = cms.EDAnalyzer("DQMEventInfo",
+                                       subSystemFolder = cms.untracked.string('AlCaReco'),  
+                                       )
+
+ALCAHARVESTSiStripGainsAAG = cms.Sequence( EDMtoMEConvertSiStripGainsAAG + alcaSiStripGainsAAGHarvester + dqmEnvSiStripGainsAAG )

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripGainsHarvester_cff.py
@@ -9,4 +9,8 @@ EDMtoMEConvertSiStripGains.runInputTag = cms.InputTag("MEtoEDMConvertSiStripGain
 
 DQMStore = cms.Service("DQMStore")
 
-ALCAHARVESTSiStripGains = cms.Sequence( EDMtoMEConvertSiStripGains + alcaSiStripGainsHarvester)
+dqmEnvSiStripGains = cms.EDAnalyzer("DQMEventInfo",
+                                    subSystemFolder = cms.untracked.string('AlCaReco'),  
+                                    )
+
+ALCAHARVESTSiStripGains = cms.Sequence( EDMtoMEConvertSiStripGains + alcaSiStripGainsHarvester + dqmEnvSiStripGains )


### PR DESCRIPTION
Greetings, 
this PR aims to provide to the harvested `ALCAPROMPT` files for the SiStripGains and SiPixelAli Prompt Calibration Loop flavours, the necessary input histograms to show the run/ LS / start time info to be displayed in the DQM GUI header, as it is done for the standard DQM.
Special thanks to @threus for guidance in solving the issue.

@franzoni @arunhep, there are probably other flavours of the PCL applications that might benefit from the same update. I've done it only for the ones I am most familiar with. Also the changes fall in the AlCa area, but it would be wise to assign dqm category as reviewers as well.

The changes have been tested via `runTheMatrix.py -l 1001.0` and the output harvested files have been uploaded to a local development GUI.
I am attaching here the results of the test:

   * `SiStripGainsAAG`:

![screenshot 2017-06-20 18 36 57](https://user-images.githubusercontent.com/5082376/27344926-567db09a-55e8-11e7-895b-c27f6ca3990c.png)

   * `SiStripGains`: 

![screenshot 2017-06-20 18 37 20](https://user-images.githubusercontent.com/5082376/27344932-597f7c6a-55e8-11e7-8928-a0ffc4be3211.png)

   * `SiPixelAli`:

![screenshot 2017-06-20 18 37 40](https://user-images.githubusercontent.com/5082376/27344938-5cccf0f0-55e8-11e7-861d-c9c0500ada10.png)
