### PR TITLE
DropBox Metadata: fix SiStripApvGain and add SiStripApvGainRcdAAG_multirun

### DIFF
--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -50,11 +50,13 @@ SiStripApvGainRcd_prod_str = encodeJsonInString("SiStripApvGainRcd_prod.json")
 SiStripApvGainRcd_multirun_prod_str = encodeJsonInString("SiStripApvGainRcd_multirun_prod.json") 
 SiStripApvGainRcdAfterAbortGap_prod_str = encodeJsonInString("SiStripApvGainRcdAfterAbortGap_prod.json") # can be removed, once 92x deployed
 SiStripApvGainRcdAAG_prod_str = encodeJsonInString("SiStripApvGainRcdAAG_prod.json") # will take over
+SiStripApvGainRcdAAG_multirun_prod_str = encodeJsonInString("SiStripApvGainRcdAAG_multirun_prod.json")
 
 SiStripApvGainRcd_prep_str = encodeJsonInString("SiStripApvGainRcd_prep.json")
 SiStripApvGainRcd_multirun_prep_str = encodeJsonInString("SiStripApvGainRcd_multirun_prep.json")
 SiStripApvGainRcdAfterAbortGap_prep_str = encodeJsonInString("SiStripApvGainRcdAfterAbortGap_prep.json") # can be removed, once 92x deployed
 SiStripApvGainRcdAAG_prep_str = encodeJsonInString("SiStripApvGainRcdAAG_prep.json") # will take over
+SiStripApvGainRcdAAG_multirun_prep_str = encodeJsonInString("SiStripApvGainRcdAAG_multirun_prep.json")
 
 #SiPixelAli
 SiPixelAliRcd_prod_str = encodeJsonInString("SiPixelAliRcd_prod.json")
@@ -124,7 +126,9 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                Source              = cms.untracked.string("AlcaHarvesting"),
                                                                FileClass           = cms.untracked.string("ALCA"),
                                                                prodMetaData        = cms.untracked.string(SiStripApvGainRcdAAG_prod_str),
+                                                               prodMetaDataMultiRun = cms.untracked.string(SiStripApvGainRcdAAG_multirun_prod_str),
                                                                prepMetaData        = cms.untracked.string(SiStripApvGainRcdAAG_prep_str),
+                                                               prepMetaDataMultiRun = cms.untracked.string(SiStripApvGainRcdAAG_multirun_prep_str)
                                                                ),
                                                       cms.PSet(record              = cms.untracked.string('EcalPedestalsRcd'),
                                                                Source              = cms.untracked.string("AlcaHarvesting"),
@@ -146,7 +150,7 @@ process.p = cms.Path(process.mywriter)
 if process.mywriter.write:
 
     from CondCore.CondDB.CondDB_cfi import CondDB
-    CondDB.connect = "sqlite_file:DropBoxMetadata_addHPbyRun.db"
+    CondDB.connect = "sqlite_file:DropBoxMetadata_addHPbyRun_addAAGmulti.db"
 
     process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                               CondDB,

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prep.json
@@ -1,0 +1,10 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripApvGain_PCL_multirun_v0_prompt": {},
+        "SiStripApvGain_PCL_multirun_v0_hlt": {}
+    }, 
+    "inputTag": "SiStripApvGain_pcl", 
+    "since": null, 
+    "userText": "PCL MultiRun Upload for SiStrip Gains calib. (prep)"
+}

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prep.json
@@ -1,10 +1,9 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGain_PCL_multirun_v0_prompt": {},
-        "SiStripApvGain_PCL_multirun_v0_hlt": {}
+        "SiStripApvGainAfterAbortGap_PCL_multirun_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGain_pcl", 
     "since": null, 
-    "userText": "PCL MultiRun Upload for SiStrip Gains calib. (prep)"
+    "userText": "PCL MultiRun Upload for SiStrip Gains calib. AAG (prep)"
 }

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prod.json
@@ -1,0 +1,10 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripApvGain_PCL_multirun_v0_prompt": {},
+        "SiStripApvGain_PCL_multirun_v0_hlt": {}
+    }, 
+    "inputTag": "SiStripApvGain_pcl", 
+    "since": null, 
+    "userText": "PCL MultiRun Upload for SiStrip Gains calib. (prod)"
+}

--- a/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcdAAG_multirun_prod.json
@@ -1,10 +1,9 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGain_PCL_multirun_v0_prompt": {},
-        "SiStripApvGain_PCL_multirun_v0_hlt": {}
+        "SiStripApvGainAfterAbortGap_PCL_multirun_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGain_pcl", 
     "since": null, 
-    "userText": "PCL MultiRun Upload for SiStrip Gains calib. (prod)"
+    "userText": "PCL MultiRun Upload for SiStrip Gains calib. AAG (prod)"
 }

--- a/CondFormats/Common/test/SiStripApvGainRcd_prep.json
+++ b/CondFormats/Common/test/SiStripApvGainRcd_prep.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGain_PCL_multirun_v0_hlt": {}, 
-        "SiStripApvGain_PCL_multirun_v0_prompt": {}
+        "SiStripApvGain_PCL_v0_hlt": {}, 
+        "SiStripApvGain_PCL_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGain_pcl", 
     "since": null, 

--- a/CondFormats/Common/test/SiStripApvGainRcd_prod.json
+++ b/CondFormats/Common/test/SiStripApvGainRcd_prod.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiStripApvGain_PCL_multirun_v0_hlt": {}, 
-        "SiStripApvGain_PCL_multirun_v0_prompt": {}
+        "SiStripApvGain_PCL_v0_hlt": {}, 
+        "SiStripApvGain_PCL_v0_prompt": {}
     }, 
     "inputTag": "SiStripApvGain_pcl", 
     "since": null, 


### PR DESCRIPTION
+ the tags SiStripApvGain now writes in the correct tags (was: multirun). Thanks @mmusich 
+ SiStripApvGainRcdAAG multirun: key added (we already had  SiStripApvGainRcd_multirun)

These changes don't affect any of the standard sequences.
More info about DropBox Metadata in : https://twiki.cern.ch/twiki/bin/viewauth/CMS/AlCaDBPCL#Drop_box_metadata_management 