### PR TITLE
narrow scope of TDirectory::TContext local

### DIFF
--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -18,15 +18,17 @@ namespace edm {
   InputFile::InputFile(char const* fileName, char const* msg, InputType inputType) :
     file_(), fileName_(fileName), reportToken_(0), inputType_(inputType) {
 
-    // ROOT's context management implicitly assumes that a file is opened and
-    // closed on the same thread.  To avoid the problem, we declare a local
-    // TContext object; when it goes out of scope, its destructor unregisters
-    // the context, guaranteeing the context is unregistered in the same thread
-    // it was registered in.  Fixes issue #15524.
-    TDirectory::TContext contextEraser;
-
     logFileAction(msg, fileName);
-    file_ = std::unique_ptr<TFile>(TFile::Open(fileName)); // propagate_const<T> has no reset() function
+    {
+      // ROOT's context management implicitly assumes that a file is opened and
+      // closed on the same thread.  To avoid the problem, we declare a local
+      // TContext object; when it goes out of scope, its destructor unregisters
+      // the context, guaranteeing the context is unregistered in the same thread
+      // it was registered in.  Fixes issue #15524.
+      TDirectory::TContext contextEraser;
+
+      file_ = std::unique_ptr<TFile>(TFile::Open(fileName)); // propagate_const<T> has no reset() function
+    }
     std::exception_ptr e = edm::threadLocalException::getException();
     if(e != std::exception_ptr()) {
       edm::threadLocalException::setException(std::exception_ptr());


### PR DESCRIPTION
Narrow the scope of the TDirectory::TContext local, which cleans up the TFile context, so that the scope only contains the call to TFile::Open.  This excludes from the scope exception handling and MessageLogger calls that might open windows for race conditions.  May help with issue #17971 