### PR TITLE
Configuration to produce ME0 pseudo stubs for Phase-2

### DIFF
--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -192,7 +192,7 @@ phase2_muon.toModify(
     simMuonME0PseudoReDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(7654321),
         engineName = cms.untracked.string('HepJamesRandom')),
-    simMuonME0PseudoReDigis192 = cms.PSet(
+    simMuonME0PseudoReDigisCoarse = cms.PSet(
         initialSeed = cms.untracked.uint32(2234567),
         engineName = cms.untracked.string('HepJamesRandom')),
 )

--- a/IOMC/RandomEngine/python/IOMC_cff.py
+++ b/IOMC/RandomEngine/python/IOMC_cff.py
@@ -177,7 +177,8 @@ run3_GEM.toModify(
     RandomNumberGeneratorService, 
     simMuonGEMDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(1234567),
-        engineName = cms.untracked.string('HepJamesRandom')) )
+        engineName = cms.untracked.string('HepJamesRandom'))
+)
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(
@@ -190,7 +191,10 @@ phase2_muon.toModify(
         engineName = cms.untracked.string('HepJamesRandom')),
     simMuonME0PseudoReDigis = cms.PSet(
         initialSeed = cms.untracked.uint32(7654321),
-        engineName = cms.untracked.string('HepJamesRandom'))
+        engineName = cms.untracked.string('HepJamesRandom')),
+    simMuonME0PseudoReDigis192 = cms.PSet(
+        initialSeed = cms.untracked.uint32(2234567),
+        engineName = cms.untracked.string('HepJamesRandom')),
 )
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -123,3 +123,13 @@ def _appendHGCalDigis(obj):
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(L1TriggerFEVTDEBUG, func=_appendHGCalDigis)
+
+# adding ME0 pseudo trigger stubs
+def _appendME0PseudoStubs(obj):
+    l1ME0PseudoStubs = [
+        'keep *_me0TriggerPseudoDigis__*',
+        ]
+    obj.outputCommands += l1ME0PseudoStubs
+
+from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+phase2_muon.toModify(L1TriggerFEVTDEBUG, func=_appendME0PseudoStubs)

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -127,8 +127,8 @@ phase2_hgcal.toModify(L1TriggerFEVTDEBUG, func=_appendHGCalDigis)
 # adding ME0 pseudo trigger stubs
 def _appendME0PseudoStubs(obj):
     l1ME0PseudoStubs = [
-        'keep *_simMuonME0PseudoReDigis192__*',
-        'keep *_me0RecHits192__*',
+        'keep *_simMuonME0PseudoReDigisCoarse__*',
+        'keep *_me0RecHitsCoarse__*',
         'keep *_me0TriggerPseudoDigis__*',
         ]
     obj.outputCommands += l1ME0PseudoStubs

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -127,6 +127,8 @@ phase2_hgcal.toModify(L1TriggerFEVTDEBUG, func=_appendHGCalDigis)
 # adding ME0 pseudo trigger stubs
 def _appendME0PseudoStubs(obj):
     l1ME0PseudoStubs = [
+        'keep *_simMuonME0PseudoReDigis192__*',
+        'keep *_me0RecHits192__*',
         'keep *_me0TriggerPseudoDigis__*',
         ]
     obj.outputCommands += l1ME0PseudoStubs

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -77,3 +77,10 @@ if stage2L1Trigger.isChosen():
 #
 #
     SimL1TMuon = cms.Sequence(SimL1TMuonCommon + simTwinMuxDigis + simBmtfDigis + simEmtfDigis + simOmtfDigis + simGmtCaloSumDigis + simGmtStage2Digis)
+
+    from L1Trigger.ME0Trigger.me0TriggerPseudoDigis_cff import *
+    _phase2_SimL1TMuon = SimL1TMuon.copy()
+    _phase2_SimL1TMuon += me0TriggerPseudoDigiSequence
+
+    from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
+    phase2_muon.toReplaceWith( SimL1TMuon, _phase2_SimL1TMuon )

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -9,17 +9,17 @@ from SimMuon.GEMDigitizer.muonME0PseudoReDigis_cfi import *
 from RecoLocalMuon.GEMRecHit.me0RecHits_cfi import *
 from RecoLocalMuon.GEMSegment.me0Segments_cfi import *
 
-simMuonME0PseudoReDigis192 = simMuonME0PseudoReDigis.clone(
+simMuonME0PseudoReDigisCoarse = simMuonME0PseudoReDigis.clone(
     numberOfStrips = cms.uint32(192)
 )
-me0RecHits192 = me0RecHits.clone(
-    me0DigiLabel = cms.InputTag("simMuonME0PseudoReDigis192")
+me0RecHitsCoarse = me0RecHits.clone(
+    me0DigiLabel = cms.InputTag("simMuonME0PseudoReDigisCoarse")
 )
 me0TriggerPseudoDigis = me0Segments.clone(
-    me0RecHitLabel = cms.InputTag("me0RecHits192")
+    me0RecHitLabel = cms.InputTag("me0RecHitsCoarse")
 )
 me0TriggerPseudoDigiSequence = cms.Sequence(
-    simMuonME0PseudoReDigis192 *
-    me0RecHits192 *
+    simMuonME0PseudoReDigisCoarse *
+    me0RecHitsCoarse *
     me0TriggerPseudoDigis
 )

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+## configuration to build fast L1 ME0 trigger stubs
+## pseudo pads are created from pseudo digis with 192 strips instead of 384
+## the rechits are a necessary intermediate step before the pseudo pads are used
+## as input to build pseudo stubs
+
+from SimMuon.GEMDigitizer.muonME0PseudoReDigis_cfi import *
+from RecoLocalMuon.GEMRecHit.me0RecHits_cfi import *
+from RecoLocalMuon.GEMSegment.me0Segments_cfi import *
+
+simMuonME0PseudoReDigis192 = simMuonME0PseudoReDigis.clone(
+    numberOfStrips = cms.uint32(192)
+)
+me0RecHits192 = me0RecHits.clone(
+    me0DigiLabel = cms.InputTag("simMuonME0PseudoReDigis192")
+)
+me0TriggerPseudoDigis = me0Segments.clone(
+    me0RecHitLabel = cms.InputTag("me0RecHits192")
+)
+me0TriggerPseudoDigiSequence = cms.Sequence(
+    simMuonME0PseudoReDigis192 *
+    me0RecHits192 *
+    me0TriggerPseudoDigis
+)

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -10,6 +10,7 @@ from RecoLocalMuon.GEMRecHit.me0RecHits_cfi import *
 from RecoLocalMuon.GEMSegment.me0Segments_cfi import *
 
 simMuonME0PseudoReDigisCoarse = simMuonME0PseudoReDigis.clone(
+    usePads = cms.bool(True)
 )
 me0RecHitsCoarse = me0RecHits.clone(
     me0DigiLabel = cms.InputTag("simMuonME0PseudoReDigisCoarse")

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -10,12 +10,11 @@ from RecoLocalMuon.GEMRecHit.me0RecHits_cfi import *
 from RecoLocalMuon.GEMSegment.me0Segments_cfi import *
 
 simMuonME0PseudoReDigisCoarse = simMuonME0PseudoReDigis.clone(
-    numberOfStrips = cms.uint32(192)
 )
 me0RecHitsCoarse = me0RecHits.clone(
     me0DigiLabel = cms.InputTag("simMuonME0PseudoReDigisCoarse")
 )
-nStrips = 192
+nStrips = simMuonME0PseudoReDigisCoarse.numberOfStrips
 me0TriggerPseudoDigis = me0Segments.clone(
     me0RecHitLabel = cms.InputTag("me0RecHitsCoarse")
 )

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -22,7 +22,7 @@ me0TriggerPseudoDigis = me0Segments.clone(
 ## 1.2 is to make the matching window safely the two nearest strips
 ## 0.35 is the size of an ME0 chamber in radians
 ## nStrips is divided by 2 since we use 2-strip trigger pads
-nStrips = simMuonME0PseudoReDigisCoarse.numberOfStrips/2
+nStrips = simMuonME0PseudoReDigisCoarse.numberOfStrips.value()/2
 maxPhi = 1.2*0.35/nStrips
 me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiAdditional = cms.double(maxPhi)
 me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiSeeds = cms.double(maxPhi)

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -15,9 +15,13 @@ simMuonME0PseudoReDigisCoarse = simMuonME0PseudoReDigis.clone(
 me0RecHitsCoarse = me0RecHits.clone(
     me0DigiLabel = cms.InputTag("simMuonME0PseudoReDigisCoarse")
 )
+nStrips = 192
 me0TriggerPseudoDigis = me0Segments.clone(
     me0RecHitLabel = cms.InputTag("me0RecHitsCoarse")
 )
+me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiAdditional = cms.double(1.2*0.35/nStrips)
+me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiSeeds = cms.double(1.2*0.35/nStrips)
+
 me0TriggerPseudoDigiSequence = cms.Sequence(
     simMuonME0PseudoReDigisCoarse *
     me0RecHitsCoarse *

--- a/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
+++ b/L1Trigger/ME0Trigger/python/me0TriggerPseudoDigis_cff.py
@@ -15,12 +15,17 @@ simMuonME0PseudoReDigisCoarse = simMuonME0PseudoReDigis.clone(
 me0RecHitsCoarse = me0RecHits.clone(
     me0DigiLabel = cms.InputTag("simMuonME0PseudoReDigisCoarse")
 )
-nStrips = simMuonME0PseudoReDigisCoarse.numberOfStrips
+
 me0TriggerPseudoDigis = me0Segments.clone(
     me0RecHitLabel = cms.InputTag("me0RecHitsCoarse")
 )
-me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiAdditional = cms.double(1.2*0.35/nStrips)
-me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiSeeds = cms.double(1.2*0.35/nStrips)
+## 1.2 is to make the matching window safely the two nearest strips
+## 0.35 is the size of an ME0 chamber in radians
+## nStrips is divided by 2 since we use 2-strip trigger pads
+nStrips = simMuonME0PseudoReDigisCoarse.numberOfStrips/2
+maxPhi = 1.2*0.35/nStrips
+me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiAdditional = cms.double(maxPhi)
+me0TriggerPseudoDigis.algo_psets[1].algo_pset.maxPhiSeeds = cms.double(maxPhi)
 
 me0TriggerPseudoDigiSequence = cms.Sequence(
     simMuonME0PseudoReDigisCoarse *

--- a/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
@@ -81,6 +81,7 @@ private:
   //paramters
   const float bxWidth;              // ns
   bool         useCusGeoFor1PartGeo      ; //Use custom strips and partitions for digitization for single partition geometry
+  bool         usePadsForDefaultGeo      ; //Use trigger pads for digitization for built in partition geometry
   unsigned int numberOfStrips     ; // Custom number of strips per partition
   unsigned int numberOfPartitions; // Custom number of partitions per chamber
   double       neutronAcceptance ; // fraction of neutron events to keep in event (>= 1 means no filtering)

--- a/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
+++ b/SimMuon/GEMDigitizer/interface/ME0ReDigiProducer.h
@@ -81,7 +81,7 @@ private:
   //paramters
   const float bxWidth;              // ns
   bool         useCusGeoFor1PartGeo      ; //Use custom strips and partitions for digitization for single partition geometry
-  bool         usePadsForDefaultGeo      ; //Use trigger pads for digitization for built in partition geometry
+  bool         usePads                   ; //sets strip granularity to x2 coarser
   unsigned int numberOfStrips     ; // Custom number of strips per partition
   unsigned int numberOfPartitions; // Custom number of partitions per chamber
   double       neutronAcceptance ; // fraction of neutron events to keep in event (>= 1 means no filtering)

--- a/SimMuon/GEMDigitizer/python/muonME0PseudoReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0PseudoReDigis_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 simMuonME0PseudoReDigis = cms.EDProducer("ME0ReDigiProducer",
     inputCollection    =cms.string('simMuonME0PseudoDigis'),
     useCusGeoFor1PartGeo =cms.bool(True),   #Use custom strips and partitions for digitization for single partition geometry
-    usePadsForDefaultGeo =cms.bool(False),   #Use trigger pads for digitization for built in partition geometry
+    usePads             =cms.bool(False),   #sets strip granularity to x2 coarser
     numberOfStrips     =cms.uint32(384), # If use custom: number of strips per partition                                             
     numberOfPartitions =cms.uint32(8),   # If use custom:  number of partitions per chamber                                           
     neutronAcceptance  =cms.double(2.0),   # fraction of neutron events to keep in event (>= 1 means no filtering)      

--- a/SimMuon/GEMDigitizer/python/muonME0PseudoReDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonME0PseudoReDigis_cfi.py
@@ -4,6 +4,7 @@ import FWCore.ParameterSet.Config as cms
 simMuonME0PseudoReDigis = cms.EDProducer("ME0ReDigiProducer",
     inputCollection    =cms.string('simMuonME0PseudoDigis'),
     useCusGeoFor1PartGeo =cms.bool(True),   #Use custom strips and partitions for digitization for single partition geometry
+    usePadsForDefaultGeo =cms.bool(False),   #Use trigger pads for digitization for built in partition geometry
     numberOfStrips     =cms.uint32(384), # If use custom: number of strips per partition                                             
     numberOfPartitions =cms.uint32(8),   # If use custom:  number of partitions per chamber                                           
     neutronAcceptance  =cms.double(2.0),   # fraction of neutron events to keep in event (>= 1 means no filtering)      

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -136,6 +136,7 @@ TrapezoidalStripTopology * ME0ReDigiProducer::TemporaryGeometry::buildTopo(const
 ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps) :
 		bxWidth            (25.0),
 		useCusGeoFor1PartGeo(ps.getParameter<bool>("useCusGeoFor1PartGeo")),
+		usePadsForDefaultGeo(ps.getParameter<bool>("usePadsForDefaultGeo")),
 		numberOfStrips      (ps.getParameter<unsigned int>("numberOfStrips")),
 		numberOfPartitions (ps.getParameter<unsigned int>("numberOfPartitions")),
 		neutronAcceptance  (ps.getParameter<double>("neutronAcceptance")),
@@ -160,6 +161,7 @@ ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps) :
 	useBuiltinGeo = true;
 
 	if(useCusGeoFor1PartGeo){
+          	numberOfStrips = numberOfStrips/2;
 		if(numberOfStrips == 0)
 			throw cms::Exception("Setup") << "ME0ReDigiProducer::ME0PreRecoDigiProducer() - Must have at least one strip if using custom geometry.";
 		if(numberOfPartitions == 0)
@@ -397,14 +399,18 @@ void ME0ReDigiProducer::getStripProperties(const ME0EtaPartition* etaPart, const
 	//convert to relative to partition
 	tof -= tofs[etaPart->id().layer()-1][etaPart->id().roll() -1];
 
+	const TrapezoidalStripTopology * origTopo = (const TrapezoidalStripTopology*)(&etaPart->specificTopology());
+	TrapezoidalStripTopology padTopo(origTopo->nstrips()/2,origTopo->pitch()*2,origTopo->stripLength(),origTopo->radius());
+	const auto & topo = usePadsForDefaultGeo ?  padTopo : etaPart->specificTopology();
+
 	//find channel
 	const LocalPoint partLocalPoint(inDigi->x(), inDigi->y(),0.);
-	strip = etaPart->specificTopology().channel(partLocalPoint);
+	strip = topo.channel(partLocalPoint);
 	const float stripF = float(strip)+0.5;
 
 	//get digitized location
-	digiLocalPoint = etaPart->specificTopology().localPosition(stripF);
-	digiLocalError = etaPart->specificTopology().localError(stripF, 1./sqrt(12.));
+	digiLocalPoint = topo.localPosition(stripF);
+	digiLocalError = topo.localError(stripF, 1./sqrt(12.));
 }
 
 unsigned int ME0ReDigiProducer::fillDigiMap(ChamberDigiMap& chDigiMap, unsigned int bx, unsigned int part, unsigned int strip, unsigned int currentIDX) const {

--- a/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/src/ME0ReDigiProducer.cc
@@ -136,7 +136,7 @@ TrapezoidalStripTopology * ME0ReDigiProducer::TemporaryGeometry::buildTopo(const
 ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps) :
 		bxWidth            (25.0),
 		useCusGeoFor1PartGeo(ps.getParameter<bool>("useCusGeoFor1PartGeo")),
-		usePadsForDefaultGeo(ps.getParameter<bool>("usePadsForDefaultGeo")),
+		usePads(ps.getParameter<bool>("usePads")),
 		numberOfStrips      (ps.getParameter<unsigned int>("numberOfStrips")),
 		numberOfPartitions (ps.getParameter<unsigned int>("numberOfPartitions")),
 		neutronAcceptance  (ps.getParameter<double>("neutronAcceptance")),
@@ -161,7 +161,8 @@ ME0ReDigiProducer::ME0ReDigiProducer(const edm::ParameterSet& ps) :
 	useBuiltinGeo = true;
 
 	if(useCusGeoFor1PartGeo){
-          	numberOfStrips = numberOfStrips/2;
+	        if (usePads)
+		        numberOfStrips = numberOfStrips/2;
 		if(numberOfStrips == 0)
 			throw cms::Exception("Setup") << "ME0ReDigiProducer::ME0PreRecoDigiProducer() - Must have at least one strip if using custom geometry.";
 		if(numberOfPartitions == 0)
@@ -401,7 +402,7 @@ void ME0ReDigiProducer::getStripProperties(const ME0EtaPartition* etaPart, const
 
 	const TrapezoidalStripTopology * origTopo = (const TrapezoidalStripTopology*)(&etaPart->specificTopology());
 	TrapezoidalStripTopology padTopo(origTopo->nstrips()/2,origTopo->pitch()*2,origTopo->stripLength(),origTopo->radius());
-	const auto & topo = usePadsForDefaultGeo ?  padTopo : etaPart->specificTopology();
+	const auto & topo = usePads ?  padTopo : etaPart->specificTopology();
 
 	//find channel
 	const LocalPoint partLocalPoint(inDigi->x(), inDigi->y(),0.);


### PR DESCRIPTION
In PRs https://github.com/cms-sw/cmssw/pull/18229, https://github.com/cms-sw/cmssw/pull/18660 and https://github.com/cms-sw/cmssw/pull/19254 I have been putting various objects and producers in place to build a realistic L1 ME0 trigger stub producer. It could take a while before we have something that works, since the `ME0Motherboard` will likely be as complicated as the `CSCCathodeLCTProcessor` class.

In the mean time we have been running L1 simulations for the muon upgrade TDR on prompt muon and displaced muon triggers with so-called ME0 pseudo stubs. These are not actual `ME0TriggerDigi` objects, but rather `ME0Segments` produced from pseudo digis with a 2x coarser resolution than what is used in the offline. This is a reasonable emulation a future ME0 trigger. In this PR I put in place configuration fragments in order to produce such pseudo stubs. It is placed in the `ME0Trigger` package for now. 

@kpedro88 @tahuang1991 @nickmccoll 