### PR TITLE
Fixing the statistics for MultiRunHarvesting

### DIFF
--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -1339,6 +1339,8 @@ void SiStripGainFromCalibTree::qualityMonitor() {
         double        NEntries     = APV->NEntries;
         double        PreviousGain = APV->PreviousGain;
 
+        if (SubDet<3) continue;  // avoid to loop over Pixel det id
+
         if (Gain!=1.) {
             std::vector<MonitorElement*> charge_histos = APVGain::FetchMonitor(newCharge, DetId, tTopo_);
             TH2S *chvsidx = (Charge_Vs_Index[elepos])->getTH2S();
@@ -1357,22 +1359,21 @@ void SiStripGainFromCalibTree::qualityMonitor() {
 
 
         if (FitMPV<0.) {  // No fit of MPV
-            if(SubDet>=3) NoMPV->Fill(z,R);
+            NoMPV->Fill(z,R);
 
         } else {          // Fit of MPV
-            if ( SubDet>=3 ) {  // remove input from Pixel detector id.
-                if(FitMPV>0.) Gains->Fill(Gain);
+            if(FitMPV>0.) Gains->Fill(Gain);
 
-                MPVs->Fill(FitMPV);
-                if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
-                if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
+            MPVs->Fill(FitMPV);
+            if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
+            if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
 
-                MPVError->Fill(FitMPVErr);
-                MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
-                MPVErrorVsEta->Fill(Eta,FitMPVErr);
-                MPVErrorVsPhi->Fill(Phi,FitMPVErr);
-                MPVErrorVsN->Fill(NEntries,FitMPVErr);
-            }
+            MPVError->Fill(FitMPVErr);
+            MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
+            MPVErrorVsEta->Fill(Eta,FitMPVErr);
+            MPVErrorVsPhi->Fill(Phi,FitMPVErr);
+            MPVErrorVsN->Fill(NEntries,FitMPVErr);
+
             if(SubDet==3) {
                 MPV_Vs_EtaTIB->Fill(Eta,FitMPV);
                 MPV_Vs_PhiTIB->Fill(Phi,FitMPV);

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -1360,18 +1360,19 @@ void SiStripGainFromCalibTree::qualityMonitor() {
             if(SubDet>=3) NoMPV->Fill(z,R);
 
         } else {          // Fit of MPV
-            if(FitMPV>0.) Gains->Fill(Gain);
+            if ( SubDet>=3 ) {  // remove input from Pixel detector id.
+                if(FitMPV>0.) Gains->Fill(Gain);
 
-            MPVs->Fill(FitMPV);
-            if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
-            if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
+                MPVs->Fill(FitMPV);
+                if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
+                if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
 
-            MPVError->Fill(FitMPVErr);
-            MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
-            MPVErrorVsEta->Fill(Eta,FitMPVErr);
-            MPVErrorVsPhi->Fill(Phi,FitMPVErr);
-            MPVErrorVsN->Fill(NEntries,FitMPVErr);
-
+                MPVError->Fill(FitMPVErr);
+                MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
+                MPVErrorVsEta->Fill(Eta,FitMPVErr);
+                MPVErrorVsPhi->Fill(Phi,FitMPVErr);
+                MPVErrorVsN->Fill(NEntries,FitMPVErr);
+            }
             if(SubDet==3) {
                 MPV_Vs_EtaTIB->Fill(Eta,FitMPV);
                 MPV_Vs_PhiTIB->Fill(Phi,FitMPV);

--- a/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLHarvester_cfi.py
+++ b/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLHarvester_cfi.py
@@ -9,6 +9,6 @@ SiStripGainsPCLHarvester = DQMEDHarvester(
     calibrationMode     = cms.untracked.string('StdBunch'),
     minNrEntries        = cms.untracked.double(25),
     GoodFracForTagProd  = cms.untracked.double(0.98),
-    NClustersForTagProd = cms.untracked.double(1E8),
+    NClustersForTagProd = cms.untracked.double(8E8),
     ChargeHisto         = cms.untracked.vstring('TIB','TIB_layer_1','TOB','TOB_layer_1','TIDminus','TIDplus','TECminus','TECplus')
     )

--- a/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
+++ b/CalibTracker/SiStripChannelGain/python/computeGain_cff.py
@@ -31,7 +31,7 @@ SiStripCalib = cms.EDAnalyzer(
     saveSummary         = cms.untracked.bool(False),
 
     GoodFracForTagProd  = cms.untracked.double(0.98),
-    NClustersForTagProd = cms.untracked.double(1E8),
+    NClustersForTagProd = cms.untracked.double(8E8),
     
 
     SinceAppendMode         = cms.bool(True),

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -265,18 +265,19 @@ SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_, const 
        if(SubDet>=3) NoMPV->Fill(z,R);
 
     } else {          // Fit of MPV
-       if(FitMPV>0.) Gains->Fill(Gain);
+       if ( SubDet>=3 ) {  // remove input from Pixel detector id.
+         if(FitMPV>0.) Gains->Fill(Gain);
  
-       MPVs->Fill(FitMPV);
-       if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
-       if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
+         MPVs->Fill(FitMPV);
+         if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
+         if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
 
-       MPVError->Fill(FitMPVErr);
-       MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
-       MPVErrorVsEta->Fill(Eta,FitMPVErr);
-       MPVErrorVsPhi->Fill(Phi,FitMPVErr);
-       MPVErrorVsN->Fill(NEntries,FitMPVErr);
-
+         MPVError->Fill(FitMPVErr);
+         MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
+         MPVErrorVsEta->Fill(Eta,FitMPVErr);
+         MPVErrorVsPhi->Fill(Phi,FitMPVErr);
+         MPVErrorVsN->Fill(NEntries,FitMPVErr);
+       }
        if(SubDet==3) {
          MPV_Vs_EtaTIB->Fill(Eta,FitMPV);
          MPV_Vs_PhiTIB->Fill(Phi,FitMPV);

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -243,6 +243,7 @@ SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_, const 
     double        NEntries     = APV->NEntries;
     double        PreviousGain = APV->PreviousGain;
 
+    if (SubDet<3) continue;  // avoid to loop over Pixel det id
 
     if (Gain!=1.) {
       std::vector<MonitorElement*> charge_histos = APVGain::FetchMonitor(new_charge_histos, DetId, tTopo_);
@@ -262,22 +263,21 @@ SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_, const 
     
 
     if (FitMPV<0.) {  // No fit of MPV
-       if(SubDet>=3) NoMPV->Fill(z,R);
+       NoMPV->Fill(z,R);
 
     } else {          // Fit of MPV
-       if ( SubDet>=3 ) {  // remove input from Pixel detector id.
-         if(FitMPV>0.) Gains->Fill(Gain);
+       if(FitMPV>0.) Gains->Fill(Gain);
  
-         MPVs->Fill(FitMPV);
-         if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
-         if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
+       MPVs->Fill(FitMPV);
+       if(Thickness<0.04) MPVs320->Fill(Phi,FitMPV);
+       if(Thickness>0.04) MPVs500->Fill(Phi,FitMPV);
 
-         MPVError->Fill(FitMPVErr);
-         MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
-         MPVErrorVsEta->Fill(Eta,FitMPVErr);
-         MPVErrorVsPhi->Fill(Phi,FitMPVErr);
-         MPVErrorVsN->Fill(NEntries,FitMPVErr);
-       }
+       MPVError->Fill(FitMPVErr);
+       MPVErrorVsMPV->Fill(FitMPV,FitMPVErr);
+       MPVErrorVsEta->Fill(Eta,FitMPVErr);
+       MPVErrorVsPhi->Fill(Phi,FitMPVErr);
+       MPVErrorVsN->Fill(NEntries,FitMPVErr);
+
        if(SubDet==3) {
          MPV_Vs_EtaTIB->Fill(Eta,FitMPV);
          MPV_Vs_PhiTIB->Fill(Phi,FitMPV);


### PR DESCRIPTION
Greetings,

the main purpose of this pull request is to raise the threshold on the total amount of clusters that have to be collected before fitting the APV cluster charge thus producing the gain payload. The change consists of a setting of a parameter in two python filles. 

Since the cluster statistics affects the precision of the gain payload, it is important to have this PR merged in the main branch and to have it delivered at Tier0 asap. indeed it impacts the gain computation in  the MRH framework. The framework that uses the calibration ntuple is not affected by this one, because - in this case - the input statistic is handled manually.

In addition to the statistic fix, the fill of some monitoring histogram has been protected against the inclusion of statistics from the Pixel detector. This change concerns the inclusion of an if statement into two .cc files.


