### PR TITLE
making EgammaHLTPixelMatchVarProducer thread safe

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTPixelMatchVarProducer.cc
@@ -1,7 +1,7 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -100,14 +100,14 @@ private:
 };
 
 
-class EgammaHLTPixelMatchVarProducer : public edm::global::EDProducer<> {
+class EgammaHLTPixelMatchVarProducer : public edm::stream::EDProducer<> {
 public:
 
   explicit EgammaHLTPixelMatchVarProducer(const edm::ParameterSet&);
   ~EgammaHLTPixelMatchVarProducer();
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   std::array<float,4> calS2(const reco::ElectronSeed& seed,int charge)const;
 
 private: 
@@ -203,7 +203,7 @@ void EgammaHLTPixelMatchVarProducer::fillDescriptions(edm::ConfigurationDescript
   descriptions.add(("hltEgammaHLTPixelMatchVarProducer"), desc);  
 }
 
-void EgammaHLTPixelMatchVarProducer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void EgammaHLTPixelMatchVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
   
   // Get the HLT filtered objects
   edm::Handle<reco::RecoEcalCandidateCollection> recoEcalCandHandle;


### PR DESCRIPTION
Dear All,

Unfortunately for some reason I cant explain, I made EgammaHLTPixelMatchVarProducer a global module when creating it. And unfortunately it uses a TF1 which is not thread safe. My apologies for this and thank you @slava77  for the spot.

Here is the fix. I also compared the variable it produces as a global module and as a stream module.  I ran the standard HLT setup with 4 cores on a machine with 12 cores to ensure it was actually multithreading (400% CPU usage was observed). The results are here:
https://sharper.web.cern.ch/sharper/cms/heep/2017/Jun22nd/pmS2PreAndPostFix.png
indicating the effect is thankfully very small (no difference observed in 100K Z->ee events) However it is extremely serious hence this quick simple patch while I continue to work on https://github.com/cms-sw/cmssw/pull/19263

It would have been sooner but been swamped with p5 operations today. 
