### PR TITLE
[92x] EcalPedestal PCL workflow: fixes and improvements

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalTestPulsesRaw_Output_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalTestPulsesRaw_Output_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+import copy
+
+# AlCaReco for Bad Component Identification
+OutALCARECOEcalTestPulsesRaw_noDrop = cms.PSet(
+    SelectEvents=cms.untracked.PSet(
+        SelectEvents=cms.vstring('pathALCARECOEcalTestPulsesRaw')
+    ),
+    outputCommands=cms.untracked.vstring(
+        'keep  FEDRawDataCollection_hltEcalCalibrationRaw_*_HLT',
+        'keep  edmTriggerResults_*_*_HLT')
+)
+
+OutALCARECOEcalTestPulsesRaw = copy.deepcopy(OutALCARECOEcalTestPulsesRaw_noDrop)
+OutALCARECOEcalTestPulsesRaw.outputCommands.insert(0, "drop *")

--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalTestPulsesRaw_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalTestPulsesRaw_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOEcalTestPulsesRawHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    # choose logical OR between Triggerbits
+    andOr=True,
+    HLTPaths=['HLT_*'],
+    # tolerate triggers stated above, but not available
+    throw=False
+    )
+
+seqALCARECOEcalTestPulsesRaw = cms.Sequence(ALCARECOEcalTestPulsesRawHLT)

--- a/Calibration/EcalCalibAlgos/python/ALCARECOPromptCalibProdEcalPedestals_cff.py
+++ b/Calibration/EcalCalibAlgos/python/ALCARECOPromptCalibProdEcalPedestals_cff.py
@@ -2,6 +2,13 @@ import FWCore.ParameterSet.Config as cms
 import copy
 from EventFilter.EcalRawToDigi.EcalUnpackerData_cfi import ecalEBunpacker
 from Calibration.EcalCalibAlgos.ecalPedestalPCLworker_cfi import ecalpedestalPCL
+from HLTrigger.HLTfilters.hltHighLevel_cfi import *
+
+ALCARECOEcalTestPulsesRaw = copy.deepcopy(hltHighLevel)
+ALCARECOEcalTestPulsesRaw.HLTPaths = ['pathALCARECOEcalTestPulsesRaw']
+# dont throw on unknown path names
+ALCARECOEcalTestPulsesRaw.throw = True
+ALCARECOEcalTestPulsesRaw.TriggerResultsTag = cms.InputTag("TriggerResults", "", "RECO")
 
 ALCARECOEcalPedestalsDigis = ecalEBunpacker.clone()
 ALCARECOEcalPedestalsDigis.InputLabel = cms.InputTag('hltEcalCalibrationRaw')
@@ -23,6 +30,7 @@ MEtoEDMConvertEcalPedestals = cms.EDProducer("MEtoEDMConverter",
                                              )
 
 # The actual sequence
-seqALCARECOPromptCalibProdEcalPedestals = cms.Sequence(ALCARECOEcalPedestalsDigis *
+seqALCARECOPromptCalibProdEcalPedestals = cms.Sequence(ALCARECOEcalTestPulsesRaw *
+                                                       ALCARECOEcalPedestalsDigis *
                                                        ALCARECOEcalPedestals *
                                                        MEtoEDMConvertEcalPedestals)

--- a/Calibration/EcalCalibAlgos/python/AlcaEcalPedestalsHarvester_cff.py
+++ b/Calibration/EcalCalibAlgos/python/AlcaEcalPedestalsHarvester_cff.py
@@ -9,4 +9,8 @@ EDMtoMEConvertEcalPedestals.runInputTag = cms.InputTag("MEtoEDMConvertEcalPedest
 
 DQMStore = cms.Service("DQMStore")
 
-ALCAHARVESTEcalPedestals = cms.Sequence(EDMtoMEConvertEcalPedestals + ECALpedestalPCLHarvester)
+DQMInfoEcalPedestals = cms.EDAnalyzer("DQMEventInfo",
+                                      subSystemFolder=cms.untracked.string('AlCaReco'),
+                                      )
+
+ALCAHARVESTEcalPedestals = cms.Sequence(EDMtoMEConvertEcalPedestals + DQMInfoEcalPedestals + ECALpedestalPCLHarvester)

--- a/Configuration/DataProcessing/python/Impl/AlCaTestEnable.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaTestEnable.py
@@ -34,7 +34,18 @@ class AlCaTestEnable(AlCa):
         options.scenario = "pp"
         options.step = stepALCAPRODUCER(skims)
 
-        dictIO(options,args)
+        if 'outputs' in args:
+            # the RAW data-tier needs a special treatment since the event-content as defined in release is not good enough
+            outputs_Raw = [x for x in args['outputs'] if x['dataTier'] == 'RAW']
+            outputs_noRaw = [x for x in args['outputs'] if x['dataTier'] != 'RAW']
+            print args['outputs']
+            print outputs_noRaw
+            print outputs_Raw
+            if len(outputs_Raw) == 1:
+                print 'RAW data-tier requested'
+            options.outputDefinition = outputs_noRaw.__str__()
+
+        # dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
 
         options.filein = 'tobeoverwritten.xyz'
@@ -50,6 +61,35 @@ class AlCaTestEnable(AlCa):
         cb.prepare()
 
         addMonitoring(process)
+
+        for output in outputs_Raw:
+            print output
+            moduleLabel = output['moduleLabel']
+            selectEvents = output.get('selectEvents', None)
+            maxSize = output.get('maxSize', None)
+
+            outputModule = cms.OutputModule(
+                "PoolOutputModule",
+                fileName = cms.untracked.string("%s.root" % moduleLabel)
+                )
+
+            outputModule.dataset = cms.untracked.PSet(dataTier = cms.untracked.string("RAW"))
+
+            if maxSize != None:
+                outputModule.maxSize = cms.untracked.int32(maxSize)
+
+            if selectEvents != None:
+                outputModule.SelectEvents = cms.untracked.PSet(
+                    SelectEvents = cms.vstring(selectEvents)
+                    )
+            outputModule.outputCommands = cms.untracked.vstring('drop *',
+                                                                'keep  *_*_*_HLT')
+
+            setattr(process, moduleLabel, outputModule)
+	        # outputModule=getattr(self.process,theModuleLabel)
+            setattr(process, moduleLabel+'_step', cms.EndPath(outputModule))
+            path = getattr(process, moduleLabel+'_step')
+            process.schedule.append(path)
 
         return process
 

--- a/Configuration/DataProcessing/python/Impl/AlCaTestEnable.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaTestEnable.py
@@ -27,7 +27,14 @@ class AlCaTestEnable(AlCa):
         Proton collision data taking express processing
 
         """
-        skims = args['skims']
+        skims = []
+        if 'skims' in args:
+            skims = args['skims']
+            if 'EcalTestPulsesRaw' not in args['skims']:
+                skims.append('EcalTestPulsesRaw')
+            pclWkflws = [x for x in skims if "PromptCalibProd" in x]
+            for wfl in pclWkflws:
+                skims.remove(wfl)
 
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
@@ -38,9 +45,6 @@ class AlCaTestEnable(AlCa):
             # the RAW data-tier needs a special treatment since the event-content as defined in release is not good enough
             outputs_Raw = [x for x in args['outputs'] if x['dataTier'] == 'RAW']
             outputs_noRaw = [x for x in args['outputs'] if x['dataTier'] != 'RAW']
-            print args['outputs']
-            print outputs_noRaw
-            print outputs_Raw
             if len(outputs_Raw) == 1:
                 print 'RAW data-tier requested'
             options.outputDefinition = outputs_noRaw.__str__()

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -68,6 +68,7 @@ from Calibration.EcalAlCaRecoProducers.ALCARECOEcalCalEtaCalib_Output_cff import
 # ECAL ES alignment
 from Calibration.EcalAlCaRecoProducers.ALCARECOEcalESAlign_Output_cff import *
 from Calibration.EcalAlCaRecoProducers.ALCARECOEcalTrg_Output_cff import *
+from Calibration.EcalAlCaRecoProducers.ALCARECOEcalTestPulsesRaw_Output_cff import *
 
 ###############################################################
 # HCAL Calibration

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1157,7 +1157,7 @@ steps['TIER0EXPHI']={      '--conditions':'auto:run1_data',
           '--repacked':'',
           '-n':'10'
                           }
-steps['TIER0EXPTE']={'-s': 'ALCAPRODUCER:PromptCalibProdEcalPedestals',
+steps['TIER0EXPTE']={'-s': 'ALCAPRODUCER:EcalTestPulsesRaw',
                      '--conditions': 'auto:run2_data',
                      '--datatier':'ALCARECO',
                      '--eventcontent':'ALCARECO',
@@ -1405,7 +1405,7 @@ steps['ALCAEXP']={'-s':'ALCAOUTPUT:SiStripCalZeroBias+TkAlMinBias+DtCalib+Hotlin
                   '--triggerResultsProcess': 'RECO'}
 steps['ALCAEXPHI']=merge([{'-s':'ALCA:PromptCalibProd+PromptCalibProdSiStrip+PromptCalibProdSiStripGains+PromptCalibProdSiStripGainsAAG',
                   '--scenario':'HeavyIons'},steps['ALCAEXP']])
-steps['ALCAEXPTE']={'-s':'ALCAOUTPUT:PromptCalibProdEcalPedestals',
+steps['ALCAEXPTE']={'-s':'ALCA:PromptCalibProdEcalPedestals',
                     '--conditions':'auto:run2_data',
                     '--datatier':'ALCARECO',
                     '--eventcontent':'ALCARECO',

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -62,6 +62,8 @@ from Calibration.EcalAlCaRecoProducers.ALCARECOEcalUncalIsolElectron_cff import 
 from Calibration.EcalAlCaRecoProducers.ALCARECOEcalESAlign_cff import *
 # -- alcareco for trigger studies
 from Calibration.EcalAlCaRecoProducers.ALCARECOEcalTrg_cff import *
+# -- alcareco which selects RAW from test enables
+from Calibration.EcalAlCaRecoProducers.ALCARECOEcalTestPulsesRaw_cff import *
 
 ###############################################################
 # HCAL Calibration
@@ -168,6 +170,7 @@ pathALCARECOEcalCalWElectron     = cms.Path(seqALCARECOEcalCalWElectron)
 pathALCARECOEcalUncalZElectron   = cms.Path(seqALCARECOEcalUncalZElectron)
 pathALCARECOEcalUncalZSCElectron = cms.Path(seqALCARECOEcalUncalZSCElectron)
 pathALCARECOEcalUncalWElectron   = cms.Path(seqALCARECOEcalUncalWElectron)
+pathALCARECOEcalTestPulsesRaw    = cms.Path(seqALCARECOEcalTestPulsesRaw)
 
 #### Not meant to be used for central production
 #pathALCARECOEcalRecalElectron = cms.Path(seqALCARECOEcalRecalElectron)
@@ -451,6 +454,15 @@ ALCARECOStreamEcalTrg = cms.FilteredStream(
     paths = pathALCARECOEcalTrg,
     content=  OutALCARECOEcalTrg.outputCommands,
     selectEvents = OutALCARECOEcalTrg.SelectEvents,
+    dataTier = cms.untracked.string('ALCARECO')
+)
+
+ALCARECOStreamEcalTestPulsesRaw = cms.FilteredStream(
+    responsible = 'Stefano Argiro',
+    name = 'EcalTestPulsesRaw',
+    paths = pathALCARECOEcalTestPulsesRaw,
+    content=  OutALCARECOEcalTestPulsesRaw.outputCommands,
+    selectEvents = OutALCARECOEcalTestPulsesRaw.SelectEvents,
     dataTier = cms.untracked.string('ALCARECO')
 )
 


### PR DESCRIPTION
This PR addresses some issues of this new PCL workflow. It would be useful to have this integrated to complete tests @ tier0

 - fix RAW output module in TestEnable AlcaRAW scenario
 - fix ALCAPROMPT data-tier in alcaskimming
 - add the needed metadata for the GUI to the DQM file produced by the workflow
 - decouple RAW production from actual PCL processing (should be safer for the RAW)
 - change the relval workflow 1010 accordingly