### PR TITLE
Assert if formula is missing in PF calib 

### DIFF
--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -1,4 +1,5 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 const int PerformancePayloadFromTFormula::InvalidPos=-1;
 
@@ -28,8 +29,10 @@ float PerformancePayloadFromTFormula::getResult(PerformanceResult::ResultType r 
   //
   // which formula to use?
   //
-  assert(! isInPayload(r,p));
-
+  if ( ! isInPayload(r,p) ) {
+    edm::LogError("PerformancePayloadFromTFormula") <<"Missing formula in conditions. Maybe code/conditions are inconsistent" << std::endl;
+    assert(false);
+  }
   // nice, what to do here???
   const boost::shared_ptr<TFormula>& formula = compiledFormulas_[resultPos(r)];
   //

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -28,7 +28,7 @@ float PerformancePayloadFromTFormula::getResult(PerformanceResult::ResultType r 
   //
   // which formula to use?
   //
-  if (! isInPayload(r,p)) return PerformancePayload::InvalidResult;
+  assert(! isInPayload(r,p));
 
   // nice, what to do here???
   const boost::shared_ptr<TFormula>& formula = compiledFormulas_[resultPos(r)];


### PR DESCRIPTION
instead of returning a dummy value with no errors.