### PR TITLE
make RU CSC segment algorithm reproducible by enforcing constness

### DIFF
--- a/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegAlgoRU.cc
@@ -18,7 +18,7 @@
 #include <string>
 
 CSCSegAlgoRU::CSCSegAlgoRU(const edm::ParameterSet& ps)
-  : CSCSegmentAlgorithm(ps), myName("CSCSegAlgoRU"), sfit_(nullptr) {
+  : CSCSegmentAlgorithm(ps), myName("CSCSegAlgoRU"){
   doCollisions = ps.getParameter<bool>("doCollisions");
   chi2_str_ = ps.getParameter<double>("chi2_str");
   chi2Norm_2D_ = ps.getParameter<double>("chi2Norm_2D_");
@@ -52,12 +52,7 @@ CSCSegAlgoRU::CSCSegAlgoRU(const edm::ParameterSet& ps)
   }
 }
 
-std::vector<CSCSegment> CSCSegAlgoRU::run(const CSCChamber* aChamber, const ChamberHitContainer& rechits){
-  theChamber = aChamber;
-  return buildSegments(rechits);
-}
-
-std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& urechits) {
+std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const CSCChamber* aChamber, const ChamberHitContainer& urechits) const {
   ChamberHitContainer rechits = urechits;
   LayerIndex layerIndex(rechits.size());
   int recHits_per_layer[6] = {0,0,0,0,0,0};
@@ -70,8 +65,8 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& u
     recHits_per_layer[rechits[i]->cscDetId().layer()-1]++;//count rh per chamber
     layerIndex[i] = rechits[i]->cscDetId().layer();
   }
-  double z1 = theChamber->layer(1)->position().z();
-  double z6 = theChamber->layer(6)->position().z();
+  double z1 = aChamber->layer(1)->position().z();
+  double z6 = aChamber->layer(6)->position().z();
   if (std::abs(z1) > std::abs(z6)){
     reverse(layerIndex.begin(), layerIndex.end());
     reverse(rechits.begin(), rechits.end());
@@ -95,22 +90,32 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& u
   BoolContainer used(rechits.size(), false);
   BoolContainer used3p(rechits.size(), false);
   // This is going to point to fits to hits, and its content will be used to create a CSCSegment
-  sfit_ = 0;
+  AlgoState aState;
+  aState.aChamber = aChamber;
+  aState.doCollisions = doCollisions;
+  aState.dRMax = dRMax;
+  aState.dPhiMax = dPhiMax;
+  aState.dRIntMax = dRIntMax;
+  aState.dPhiIntMax = dPhiIntMax;
+  aState.chi2Norm_2D_ = chi2Norm_2D_;
+  aState.chi2_str_ = chi2_str_;
+  aState.chi2Max = chi2Max;
+
   // Define buffer for segments we build
   std::vector<CSCSegment> segments;
   ChamberHitContainerCIt ib = rechits.begin();
   ChamberHitContainerCIt ie = rechits.end();
   // Possibly allow 3 passes, second widening scale factor for cuts, third for segments from displaced vertices
-  windowScale = 1.; // scale factor for cuts
+  aState.windowScale = 1.; // scale factor for cuts
   bool search_disp = false;
-  strip_iadd = 1;
-  chi2D_iadd = 1;
+  aState.strip_iadd = 1;
+  aState.chi2D_iadd = 1;
   int npass = (wideSeg > 1.)? 3 : 2;
   for (int ipass = 0; ipass < npass; ++ipass) {
-    if(windowScale >1.){
+    if(aState.windowScale >1.){
       iadd = 1;
-      strip_iadd = 2;
-      chi2D_iadd = 2;
+      aState.strip_iadd = 2;
+      aState.chi2D_iadd = 2;
     }
     int used_rh = 0;
     for (ChamberHitContainerCIt i1 = ib; i1 != ie; ++i1) {
@@ -118,16 +123,16 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& u
     }
 
     //change the tresholds if it's time to look for displaced mu segments
-    if(doCollisions && search_disp && int(rechits.size()-used_rh)>2){//check if there are enough recHits left to build a segment from displaced vertices
-      doCollisions = false;
-      windowScale = 1.; // scale factor for cuts
-      dRMax = 2.0;
-      dPhiMax = 2*dPhiMax;
-      dRIntMax = 2*dRIntMax;
-      dPhiIntMax = 2*dPhiIntMax;
-      chi2Norm_2D_ = 5*chi2Norm_2D_;
-      chi2_str_ = 100;
-      chi2Max = 2*chi2Max;
+    if(aState.doCollisions && search_disp && int(rechits.size()-used_rh)>2){//check if there are enough recHits left to build a segment from displaced vertices
+      aState.doCollisions = false;
+      aState.windowScale = 1.; // scale factor for cuts
+      aState.dRMax = 2.0;
+      aState.dPhiMax = 2*aState.dPhiMax;
+      aState.dRIntMax = 2*aState.dRIntMax;
+      aState.dPhiIntMax = 2*aState.dPhiIntMax;
+      aState.chi2Norm_2D_ = 5*aState.chi2Norm_2D_;
+      aState.chi2_str_ = 100;
+      aState.chi2Max = 2*aState.chi2Max;
     }else{
       search_disp = false;//make sure the flag is off
     }
@@ -153,36 +158,36 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& u
 	  int layer2 = layerIndex[i2-ib];
 	  if((abs(layer2 - layer1) + 1) < int(n_seg_min)) break;//decrease n_seg_min
 	  const CSCRecHit2D* h2 = *i2;
-	  if (areHitsCloseInR(h1, h2) && areHitsCloseInGlobalPhi(h1, h2)) {
-	    proto_segment.clear();
-	    if (!addHit(h1, layer1))continue;
-	    if (!addHit(h2, layer2))continue;
+	  if (areHitsCloseInR(aState, h1, h2) && areHitsCloseInGlobalPhi(aState, h1, h2)) {
+	    aState.proto_segment.clear();
+	    if (!addHit(aState, h1, layer1))continue;
+	    if (!addHit(aState, h2, layer2))continue;
 	    // Can only add hits if already have a segment
-	    if ( sfit_ )tryAddingHitsToSegment(rechits, used, layerIndex, i1, i2);
-	    segok = isSegmentGood(rechits);
+	    if ( aState.sfit )tryAddingHitsToSegment(aState, rechits, used, layerIndex, i1, i2);
+	    segok = isSegmentGood(aState, rechits);
 	    if (segok) {
-	      if(proto_segment.size() > n_seg_min){
-		baseline(n_seg_min);
-		updateParameters();
+	      if(aState.proto_segment.size() > n_seg_min){
+		baseline(aState, n_seg_min);
+		updateParameters(aState);
 	      }
-	      if(sfit_->chi2() > chi2Norm_2D_*chi2D_iadd || proto_segment.size() < n_seg_min) proto_segment.clear();
-	      if (!proto_segment.empty()) {
-		updateParameters();
+	      if(aState.sfit->chi2() > aState.chi2Norm_2D_*aState.chi2D_iadd || aState.proto_segment.size() < n_seg_min) aState.proto_segment.clear();
+	      if (!aState.proto_segment.empty()) {
+		updateParameters(aState);
 		//add same-size overcrossed protosegments to the collection
 		if(first_proto_segment){
-		  flagHitsAsUsed(rechits, common_used_it[0]);
-		  min_chi[0] = sfit_->chi2();
-		  best_proto_segment[0] = proto_segment;
+		  flagHitsAsUsed(aState, rechits, common_used_it[0]);
+		  min_chi[0] = aState.sfit->chi2();
+		  best_proto_segment[0] = aState.proto_segment;
 		  first_proto_segment = false;
 		}else{ //for the rest of found proto_segments
 		  common_it++;
-		  flagHitsAsUsed(rechits, common_used_it[common_it]);
-		  min_chi[common_it] = sfit_->chi2();
-		  best_proto_segment[common_it] = proto_segment;
+		  flagHitsAsUsed(aState, rechits, common_used_it[common_it]);
+		  min_chi[common_it] = aState.sfit->chi2();
+		  best_proto_segment[common_it] = aState.proto_segment;
 		  ChamberHitContainerCIt hi, iu, ik;
 		  int iter = common_it;
 		  for(iu = ib; iu != ie; ++iu) {
-		    for(hi = proto_segment.begin(); hi != proto_segment.end(); ++hi) {
+		    for(hi = aState.proto_segment.begin(); hi != aState.proto_segment.end(); ++hi) {
 		      if(*hi == *iu) {
 			int merge_nr = -1;
 			for(int k = 0; k < iter+1; k++){
@@ -224,38 +229,38 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& u
 
       //add the reconstructed segments
       for(int j = 0;j < common_it+1; j++){
-	proto_segment = best_proto_segment[j];
+	aState.proto_segment = best_proto_segment[j];
 	best_proto_segment[j].clear();
 	//SKIP empty proto-segments
-	if(proto_segment.size() == 0) continue;
-	updateParameters();
+	if(aState.proto_segment.size() == 0) continue;
+	updateParameters(aState);
 	// Create an actual CSCSegment - retrieve all info from the fit
-	CSCSegment temp(sfit_->hits(), sfit_->intercept(),
-			sfit_->localdir(), sfit_->covarianceMatrix(), sfit_->chi2());
-	sfit_ = 0;
+	CSCSegment temp(aState.sfit->hits(), aState.sfit->intercept(),
+			aState.sfit->localdir(), aState.sfit->covarianceMatrix(), aState.sfit->chi2());
+	aState.sfit = 0;
 	segments.push_back(temp);
 	//if the segment has 3 hits flag them as used in a particular way
-	if(proto_segment.size() == 3){
-	  flagHitsAsUsed(rechits, used3p);
+	if(aState.proto_segment.size() == 3){
+	  flagHitsAsUsed(aState, rechits, used3p);
 	}
 	else{
-	  flagHitsAsUsed(rechits, used);
+	  flagHitsAsUsed(aState, rechits, used);
 	}
-	proto_segment.clear();
+	aState.proto_segment.clear();
       }
     }//for n_seg_min
 
     if(search_disp){
       //reset params and flags for the next chamber
       search_disp = false;
-      doCollisions = true;
-      dRMax = 2.0;
-      dPhiMax = dPhiMax/2;
-      dRIntMax = dRIntMax/2;
-      dPhiIntMax = dPhiIntMax/2;
-      chi2Norm_2D_ = chi2Norm_2D_/5;
-      chi2_str_ = 100;
-      chi2Max = chi2Max/2;
+      aState.doCollisions = true;
+      aState.dRMax = 2.0;
+      aState.dPhiMax = aState.dPhiMax/2;
+      aState.dRIntMax = aState.dRIntMax/2;
+      aState.dPhiIntMax = aState.dPhiIntMax/2;
+      aState.chi2Norm_2D_ = aState.chi2Norm_2D_/5;
+      aState.chi2_str_ = 100;
+      aState.chi2Max = aState.chi2Max/2;
     }
 
     std::vector<CSCSegment>::iterator it =segments.begin();
@@ -267,14 +272,14 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& u
       }
       ++it;
     }
-    if (good_segs && doCollisions) { // only change window if not enough good segments were found (bool can be changed to int if a >0 number of good segs is required)
+    if (good_segs && aState.doCollisions) { // only change window if not enough good segments were found (bool can be changed to int if a >0 number of good segs is required)
       search_disp = true;
       continue;//proceed to search the segs from displaced vertices
     }
 
     // Increase cut windows by factor of wideSeg only for collisions
-    if(!doCollisions && !search_disp) break;
-    windowScale = wideSeg;
+    if(!aState.doCollisions && !search_disp) break;
+    aState.windowScale = wideSeg;
   } // ipass
 
   //get rid of enchansed 3p segments
@@ -319,9 +324,9 @@ std::vector<CSCSegment> CSCSegAlgoRU::buildSegments(const ChamberHitContainer& u
   return segments;
 }//build segments
 
-void CSCSegAlgoRU::tryAddingHitsToSegment(const ChamberHitContainer& rechits,
+void CSCSegAlgoRU::tryAddingHitsToSegment(AlgoState& aState, const ChamberHitContainer& rechits,
 					  const BoolContainer& used, const LayerIndex& layerIndex,
-					  const ChamberHitContainerCIt i1, const ChamberHitContainerCIt i2) {
+					  const ChamberHitContainerCIt i1, const ChamberHitContainerCIt i2) const {
   // Iterate over the layers with hits in the chamber
   // Skip the layers containing the segment endpoints
   // Test each hit on the other layers to see if it is near the segment
@@ -335,24 +340,24 @@ void CSCSegAlgoRU::tryAddingHitsToSegment(const ChamberHitContainer& rechits,
   ChamberHitContainerCIt ie = rechits.end();
   for (ChamberHitContainerCIt i = ib; i != ie; ++i) {
     int layer = layerIndex[i-ib];
-    if (hasHitOnLayer(layer) && proto_segment.size() <= 2)continue;  
+    if (hasHitOnLayer(aState, layer) && aState.proto_segment.size() <= 2)continue;  
     if (layerIndex[i-ib] == layerIndex[i1-ib] || layerIndex[i-ib] == layerIndex[i2-ib] || used[i-ib])continue;
     
     const CSCRecHit2D* h = *i;
-    if (isHitNearSegment(h)) {
+    if (isHitNearSegment(aState, h)) {
       // Don't consider alternate hits on layers holding the two starting points
-      if (hasHitOnLayer(layer)) {
-	if (proto_segment.size() <= 2)continue;
-	compareProtoSegment(h, layer);
+      if (hasHitOnLayer(aState, layer)) {
+	if (aState.proto_segment.size() <= 2)continue;
+	compareProtoSegment(aState, h, layer);
       }
       else{
-	increaseProtoSegment(h, layer, chi2D_iadd);
+	increaseProtoSegment(aState, h, layer, aState.chi2D_iadd);
       }
     } // h & seg close
   } // i
 }
 
-bool CSCSegAlgoRU::areHitsCloseInR(const CSCRecHit2D* h1, const CSCRecHit2D* h2) const {
+bool CSCSegAlgoRU::areHitsCloseInR(const AlgoState& aState, const CSCRecHit2D* h1, const CSCRecHit2D* h2) const {
   float maxWG_width[10] = {0, 0, 4.1, 5.69, 2.49, 5.06, 2.49, 5.06, 1.87, 5.06};
   CSCDetId id = h1->cscDetId();
   int iStn = id.iChamberType()-1;
@@ -372,19 +377,19 @@ bool CSCSegAlgoRU::areHitsCloseInR(const CSCRecHit2D* h1, const CSCRecHit2D* h2)
       maxWG_width[1] = 10.75;
     }
   }
-  const CSCLayer* l1 = theChamber->layer(h1->cscDetId().layer());
+  const CSCLayer* l1 = aState.aChamber->layer(h1->cscDetId().layer());
   GlobalPoint gp1 = l1->toGlobal(h1->localPosition());
-  const CSCLayer* l2 = theChamber->layer(h2->cscDetId().layer());
+  const CSCLayer* l2 = aState.aChamber->layer(h2->cscDetId().layer());
   GlobalPoint gp2 = l2->toGlobal(h2->localPosition());
   //find z to understand the direction
   float h1z = gp1.z();
   float h2z = gp2.z();
   //switch off the IP check for non collisions case
-  if (!doCollisions){
+  if (!aState.doCollisions){
     h1z = 1;
     h2z = 1;
   }
-  if (gp2.perp() > ((gp1.perp() - dRMax*maxWG_width[iStn])*h2z)/h1z && gp2.perp() < ((gp1.perp() + dRMax*maxWG_width[iStn])*h2z)/h1z){
+  if (gp2.perp() > ((gp1.perp() - aState.dRMax*maxWG_width[iStn])*h2z)/h1z && gp2.perp() < ((gp1.perp() + aState.dRMax*maxWG_width[iStn])*h2z)/h1z){
     return true;
   }
   else{
@@ -392,11 +397,11 @@ bool CSCSegAlgoRU::areHitsCloseInR(const CSCRecHit2D* h1, const CSCRecHit2D* h2)
   }
 }
 
-bool CSCSegAlgoRU::areHitsCloseInGlobalPhi(const CSCRecHit2D* h1, const CSCRecHit2D* h2) const {
+bool CSCSegAlgoRU::areHitsCloseInGlobalPhi(const AlgoState& aState, const CSCRecHit2D* h1, const CSCRecHit2D* h2) const {
   float strip_width[10] = {0.003878509, 0.002958185, 0.002327105, 0.00152552, 0.00465421, 0.002327105, 0.00465421, 0.002327105, 0.00465421, 0.002327105};//in rad
-  const CSCLayer* l1 = theChamber->layer(h1->cscDetId().layer());
+  const CSCLayer* l1 = aState.aChamber->layer(h1->cscDetId().layer());
   GlobalPoint gp1 = l1->toGlobal(h1->localPosition());
-  const CSCLayer* l2 = theChamber->layer(h2->cscDetId().layer());
+  const CSCLayer* l2 = aState.aChamber->layer(h2->cscDetId().layer());
   GlobalPoint gp2 = l2->toGlobal(h2->localPosition());
   float err_stpos_h1 = h1->errorWithinStrip();
   float err_stpos_h2 = h2->errorWithinStrip();
@@ -405,28 +410,28 @@ bool CSCSegAlgoRU::areHitsCloseInGlobalPhi(const CSCRecHit2D* h1, const CSCRecHi
   float dphi_incr = 0;
   if(err_stpos_h1>0.25*strip_width[iStn] || err_stpos_h2>0.25*strip_width[iStn])dphi_incr = 0.5*strip_width[iStn];
   float dphi12 = deltaPhi(gp1.barePhi(),gp2.barePhi());
-  return (fabs(dphi12) < (dPhiMax*strip_iadd+dphi_incr))? true:false; // +v
+  return (fabs(dphi12) < (aState.dPhiMax*aState.strip_iadd+dphi_incr))? true:false; // +v
 }
 
-bool CSCSegAlgoRU::isHitNearSegment(const CSCRecHit2D* h) const {
+bool CSCSegAlgoRU::isHitNearSegment(const AlgoState& aState, const CSCRecHit2D* h) const {
   // Is hit near segment?
   // Requires deltaphi and deltaR within ranges specified in parameter set.
   // Note that to make intuitive cuts on delta(phi) one must work in
   // phi range (-pi, +pi] not [0, 2pi)
   float strip_width[10] = {0.003878509, 0.002958185, 0.002327105, 0.00152552, 0.00465421, 0.002327105, 0.00465421, 0.002327105, 0.00465421, 0.002327105};//in rad
-  const CSCLayer* l1 = theChamber->layer((*(proto_segment.begin()))->cscDetId().layer());
-  GlobalPoint gp1 = l1->toGlobal((*(proto_segment.begin()))->localPosition());
-  const CSCLayer* l2 = theChamber->layer((*(proto_segment.begin()+1))->cscDetId().layer());
-  GlobalPoint gp2 = l2->toGlobal((*(proto_segment.begin()+1))->localPosition());
-  float err_stpos_h1 = (*(proto_segment.begin()))->errorWithinStrip();
-  float err_stpos_h2 = (*(proto_segment.begin()+1))->errorWithinStrip();
-  const CSCLayer* l = theChamber->layer(h->cscDetId().layer());
+  const CSCLayer* l1 = aState.aChamber->layer((*(aState.proto_segment.begin()))->cscDetId().layer());
+  GlobalPoint gp1 = l1->toGlobal((*(aState.proto_segment.begin()))->localPosition());
+  const CSCLayer* l2 = aState.aChamber->layer((*(aState.proto_segment.begin()+1))->cscDetId().layer());
+  GlobalPoint gp2 = l2->toGlobal((*(aState.proto_segment.begin()+1))->localPosition());
+  float err_stpos_h1 = (*(aState.proto_segment.begin()))->errorWithinStrip();
+  float err_stpos_h2 = (*(aState.proto_segment.begin()+1))->errorWithinStrip();
+  const CSCLayer* l = aState.aChamber->layer(h->cscDetId().layer());
   GlobalPoint hp = l->toGlobal(h->localPosition());
   float err_stpos_h = h->errorWithinStrip();
   float hphi = hp.phi(); // in (-pi, +pi]
   if (hphi < 0.)
     hphi += 2.*M_PI; // into range [0, 2pi)
-  float sphi = phiAtZ(hp.z()); // in [0, 2*pi)
+  float sphi = phiAtZ(aState, hp.z()); // in [0, 2*pi)
   float phidif = sphi-hphi;
   if (phidif < 0.)
     phidif += 2.*M_PI; // into range [0, 2pi)
@@ -448,11 +453,11 @@ bool CSCSegAlgoRU::isHitNearSegment(const CSCRecHit2D* h) const {
   }else{
     if(centr_str) pos_str = 1.3;
   }
-  r_glob((*(proto_segment.begin()))->cscDetId().layer()-1) = gp1.perp();
-  r_glob((*(proto_segment.begin()+1))->cscDetId().layer()-1) = gp2.perp();
+  r_glob((*(aState.proto_segment.begin()))->cscDetId().layer()-1) = gp1.perp();
+  r_glob((*(aState.proto_segment.begin()+1))->cscDetId().layer()-1) = gp2.perp();
   float R = hp.perp();
   int layer = h->cscDetId().layer();
-  float r_interpolated = fit_r_phi(r_glob,layer);
+  float r_interpolated = fit_r_phi(aState, r_glob,layer);
   float dr = fabs(r_interpolated - R);
   float maxWG_width[10] = {0, 0, 4.1, 5.69, 2.49, 5.06, 2.49, 5.06, 1.87, 5.06};
   //find maxWG_width for ME11 (tilt = 29deg)
@@ -471,15 +476,15 @@ bool CSCSegAlgoRU::isHitNearSegment(const CSCRecHit2D* h) const {
       maxWG_width[1] = 10.75;
     }
   }
-  return (fabs(phidif) < dPhiIntMax*strip_iadd*pos_str+dphi_incr && fabs(dr) < dRIntMax*maxWG_width[iStn])? true:false;
+  return (fabs(phidif) < aState.dPhiIntMax*aState.strip_iadd*pos_str+dphi_incr && fabs(dr) < aState.dRIntMax*maxWG_width[iStn])? true:false;
 }
 
-float CSCSegAlgoRU::phiAtZ(float z) const {
-  if ( !sfit_ ) return 0.;
+float CSCSegAlgoRU::phiAtZ(const AlgoState& aState, float z) const {
+  if ( !aState.sfit ) return 0.;
   // Returns a phi in [ 0, 2*pi )
-  const CSCLayer* l1 = theChamber->layer((*(proto_segment.begin()))->cscDetId().layer());
-  GlobalPoint gp = l1->toGlobal(sfit_->intercept());
-  GlobalVector gv = l1->toGlobal(sfit_->localdir());
+  const CSCLayer* l1 = aState.aChamber->layer((*(aState.proto_segment.begin()))->cscDetId().layer());
+  GlobalPoint gp = l1->toGlobal(aState.sfit->intercept());
+  GlobalVector gv = l1->toGlobal(aState.sfit->localdir());
   float x = gp.x() + (gv.x()/gv.z())*(z - gp.z());
   float y = gp.y() + (gv.y()/gv.z())*(z - gp.z());
   float phi = atan2(y, x);
@@ -487,25 +492,25 @@ float CSCSegAlgoRU::phiAtZ(float z) const {
   return phi ;
 }
 
-bool CSCSegAlgoRU::isSegmentGood(const ChamberHitContainer& rechitsInChamber) const {
+bool CSCSegAlgoRU::isSegmentGood(const AlgoState& aState,  const ChamberHitContainer& rechitsInChamber) const {
   // If the chamber has 20 hits or fewer, require at least 3 hits on segment
   // If the chamber has >20 hits require at least 4 hits
   //@@ THESE VALUES SHOULD BECOME PARAMETERS?
   bool ok = false;
   unsigned int iadd = ( rechitsInChamber.size() > 20)? 1 : 0;
-  if (windowScale > 1.)
+  if (aState.windowScale > 1.)
     iadd = 1;
-  if (proto_segment.size() >= 3+iadd)
+  if (aState.proto_segment.size() >= 3+iadd)
     ok = true;
   return ok;
 }
 
-void CSCSegAlgoRU::flagHitsAsUsed(const ChamberHitContainer& rechitsInChamber,
+void CSCSegAlgoRU::flagHitsAsUsed(const AlgoState& aState, const ChamberHitContainer& rechitsInChamber,
 				  BoolContainer& used ) const {
   // Flag hits on segment as used
   ChamberHitContainerCIt ib = rechitsInChamber.begin();
   ChamberHitContainerCIt hi, iu;
-  for(hi = proto_segment.begin(); hi != proto_segment.end(); ++hi) {
+  for(hi = aState.proto_segment.begin(); hi != aState.proto_segment.end(); ++hi) {
     for(iu = ib; iu != rechitsInChamber.end(); ++iu) {
       if(*hi == *iu)
 	used[iu-ib] = true;
@@ -513,28 +518,28 @@ void CSCSegAlgoRU::flagHitsAsUsed(const ChamberHitContainer& rechitsInChamber,
   }
 }
 
-bool CSCSegAlgoRU::addHit(const CSCRecHit2D* aHit, int layer) {
+bool CSCSegAlgoRU::addHit(AlgoState& aState, const CSCRecHit2D* aHit, int layer) const {
   // Return true if hit was added successfully
   // (and then parameters are updated).
   // Return false if there is already a hit on the same layer, or insert failed.
   ChamberHitContainer::const_iterator it;
-  for(it = proto_segment.begin(); it != proto_segment.end(); it++)
+  for(it = aState.proto_segment.begin(); it != aState.proto_segment.end(); it++)
     if (((*it)->cscDetId().layer() == layer) && (aHit != (*it)))
       return false;
-  proto_segment.push_back(aHit);
+  aState.proto_segment.push_back(aHit);
   // make a fit
-  updateParameters();
+  updateParameters(aState);
   return true;
 }
 
-void CSCSegAlgoRU::updateParameters() {
+void CSCSegAlgoRU::updateParameters(AlgoState& aState) const {
   // Delete input CSCSegFit, create a new one and make the fit
-  // delete sfit_;
-  sfit_.reset(new CSCSegFit( theChamber, proto_segment ));
-  sfit_->fit();
+  // delete sfit;
+  aState.sfit.reset(new CSCSegFit( aState.aChamber, aState.proto_segment ));
+  aState.sfit->fit();
 }
 
-float CSCSegAlgoRU::fit_r_phi(SVector6 points, int layer) const{
+float CSCSegAlgoRU::fit_r_phi(const AlgoState& aState, const SVector6& points, int layer) const{
   //find R or Phi on the given layer using the given points for the interpolation
   float Sx = 0;
   float Sy = 0;
@@ -553,20 +558,20 @@ float CSCSegAlgoRU::fit_r_phi(SVector6 points, int layer) const{
   return (intercept + slope*layer);
 }
 
-void CSCSegAlgoRU::baseline(int n_seg_min){
-  int nhits = proto_segment.size();
+void CSCSegAlgoRU::baseline(AlgoState& aState, int n_seg_min) const {
+  int nhits = aState.proto_segment.size();
   ChamberHitContainer::const_iterator iRH_worst;
   //initialise vectors for strip position and error within strip
   SVector6 sp;
   SVector6 se;
-  unsigned int init_size = proto_segment.size();
+  unsigned int init_size = aState.proto_segment.size();
   ChamberHitContainer buffer;
   buffer.clear();
   buffer.reserve(init_size);
   while (buffer.size()< init_size){
     ChamberHitContainer::iterator min;
     int min_layer = 10;
-    for(ChamberHitContainer::iterator k = proto_segment.begin(); k != proto_segment.end(); k++){
+    for(ChamberHitContainer::iterator k = aState.proto_segment.begin(); k != aState.proto_segment.end(); k++){
       const CSCRecHit2D* iRHk = *k;
       CSCDetId idRHk = iRHk->cscDetId();
       int kLayer = idRHk.layer();
@@ -576,15 +581,15 @@ void CSCSegAlgoRU::baseline(int n_seg_min){
       }
     }
     buffer.push_back(*min);
-    proto_segment.erase(min);
+    aState.proto_segment.erase(min);
   }//while
 
-  proto_segment.clear();
+  aState.proto_segment.clear();
   for (ChamberHitContainer::const_iterator cand = buffer.begin(); cand != buffer.end(); cand++) {
-    proto_segment.push_back(*cand);
+    aState.proto_segment.push_back(*cand);
   }
 
-  for(ChamberHitContainer::const_iterator iRH = proto_segment.begin(); iRH != proto_segment.end(); iRH++){
+  for(ChamberHitContainer::const_iterator iRH = aState.proto_segment.begin(); iRH != aState.proto_segment.end(); iRH++){
     const CSCRecHit2D* iRHp = *iRH;
     CSCDetId idRH = iRHp->cscDetId();
     int kRing = idRH.ring();
@@ -603,7 +608,7 @@ void CSCSegAlgoRU::baseline(int n_seg_min){
     }
   }
   float chi2_str;
-  fitX(sp, se, -1, -1, chi2_str);
+  fitX(aState, sp, se, -1, -1, chi2_str);
 
   //-----------------------------------------------------
   // Optimal point rejection method
@@ -615,20 +620,20 @@ void CSCSegAlgoRU::baseline(int n_seg_min){
   int bad_layer = -1;
   ChamberHitContainer::const_iterator rh_to_be_deleted_1;
   ChamberHitContainer::const_iterator rh_to_be_deleted_2;
-  if ( (chi2_str) > chi2_str_*chi2D_iadd){///(nhits-2)
-    for (ChamberHitContainer::const_iterator i1 = proto_segment.begin(); i1 != proto_segment.end();++i1) {
+  if ( (chi2_str) > aState.chi2_str_*aState.chi2D_iadd){///(nhits-2)
+    for (ChamberHitContainer::const_iterator i1 = aState.proto_segment.begin(); i1 != aState.proto_segment.end();++i1) {
       ++i1b;
       const CSCRecHit2D* i1_1 = *i1;
       CSCDetId idRH1 = i1_1->cscDetId();
       int z1 = idRH1.layer();
       i2b = i1b;
-      for (ChamberHitContainer::const_iterator i2 = i1+1; i2 != proto_segment.end(); ++i2) {
+      for (ChamberHitContainer::const_iterator i2 = i1+1; i2 != aState.proto_segment.end(); ++i2) {
 	++i2b;
 	const CSCRecHit2D* i2_1 = *i2;
 	CSCDetId idRH2 = i2_1->cscDetId();
 	int z2 = idRH2.layer();
 	int irej = 0;
-	for ( ChamberHitContainer::const_iterator ir = proto_segment.begin(); ir != proto_segment.end(); ++ir) {
+	for ( ChamberHitContainer::const_iterator ir = aState.proto_segment.begin(); ir != aState.proto_segment.end(); ++ir) {
 	  ++irej;
 	  if (ir == i1 || ir == i2) continue;
 	  float dsum = 0;
@@ -636,7 +641,7 @@ void CSCSegAlgoRU::baseline(int n_seg_min){
 	  const CSCRecHit2D* ir_1 = *ir;
 	  CSCDetId idRH = ir_1->cscDetId();
 	  int worst_layer = idRH.layer();
-	  for (ChamberHitContainer::const_iterator i = proto_segment.begin(); i != proto_segment.end(); ++i) {
+	  for (ChamberHitContainer::const_iterator i = aState.proto_segment.begin(); i != aState.proto_segment.end(); ++i) {
 	    ++hit_nr;
 	    const CSCRecHit2D* i_1 = *i;
 	    if (i == i1 || i == i2 || i == ir) continue;
@@ -656,37 +661,37 @@ void CSCSegAlgoRU::baseline(int n_seg_min){
 	}//ir
       }//i2
     }//i1
-    fitX(sp, se, bad_layer, -1, chi2_str);
+    fitX(aState, sp, se, bad_layer, -1, chi2_str);
   }//if chi2prob<1.0e-4
 
   //find worst from n-1 hits
   int iworst2 = -1;
   int bad_layer2 = -1;
-  if (iworst > -1 && (nhits-1) > n_seg_min && (chi2_str) > chi2_str_*chi2D_iadd){///(nhits-3)
+  if (iworst > -1 && (nhits-1) > n_seg_min && (chi2_str) > aState.chi2_str_*aState.chi2D_iadd){///(nhits-3)
     iworst = -1;
     float minSum = 1000;
     int i1b = 0;
     int i2b = 0;
-    for (ChamberHitContainer::const_iterator i1 = proto_segment.begin(); i1 != proto_segment.end();++i1) {
+    for (ChamberHitContainer::const_iterator i1 = aState.proto_segment.begin(); i1 != aState.proto_segment.end();++i1) {
       ++i1b;
       const CSCRecHit2D* i1_1 = *i1;
       CSCDetId idRH1 = i1_1->cscDetId();
       int z1 = idRH1.layer();
       i2b = i1b;
-      for ( ChamberHitContainer::const_iterator i2 = i1+1; i2 != proto_segment.end(); ++i2) {
+      for ( ChamberHitContainer::const_iterator i2 = i1+1; i2 != aState.proto_segment.end(); ++i2) {
 	++i2b;
 	const CSCRecHit2D* i2_1 = *i2;
 	CSCDetId idRH2 = i2_1->cscDetId();
 	int z2 = idRH2.layer();
 	int irej = 0;
-	for ( ChamberHitContainer::const_iterator ir = proto_segment.begin(); ir != proto_segment.end(); ++ir) {
+	for ( ChamberHitContainer::const_iterator ir = aState.proto_segment.begin(); ir != aState.proto_segment.end(); ++ir) {
 	  ++irej;
 	  int irej2 = 0;
 	  if (ir == i1 || ir == i2 ) continue;
 	  const CSCRecHit2D* ir_1 = *ir;
 	  CSCDetId idRH = ir_1->cscDetId();
 	  int worst_layer = idRH.layer();
-	  for ( ChamberHitContainer::const_iterator ir2 = proto_segment.begin(); ir2 != proto_segment.end(); ++ir2) {
+	  for ( ChamberHitContainer::const_iterator ir2 = aState.proto_segment.begin(); ir2 != aState.proto_segment.end(); ++ir2) {
 	    ++irej2;
 	    if (ir2 == i1 || ir2 == i2 || ir2 ==ir ) continue;
 	    float dsum = 0;
@@ -694,7 +699,7 @@ void CSCSegAlgoRU::baseline(int n_seg_min){
 	    const CSCRecHit2D* ir2_1 = *ir2;
 	    CSCDetId idRH = ir2_1->cscDetId();
 	    int worst_layer2 = idRH.layer();
-	    for ( ChamberHitContainer::const_iterator i = proto_segment.begin(); i != proto_segment.end(); ++i) {
+	    for ( ChamberHitContainer::const_iterator i = aState.proto_segment.begin(); i != aState.proto_segment.end(); ++i) {
 	      ++hit_nr;
 	      const CSCRecHit2D* i_1 = *i;
 	      if (i == i1 || i == i2 || i == ir|| i == ir2 ) continue;
@@ -718,21 +723,21 @@ void CSCSegAlgoRU::baseline(int n_seg_min){
 	}//ir
       }//i2
     }//i1
-    fitX(sp, se, bad_layer ,bad_layer2, chi2_str);
+    fitX(aState, sp, se, bad_layer ,bad_layer2, chi2_str);
   }//if prob(n-1)<e-4
 
   //----------------------------------
   //erase bad_hits
   //----------------------------------
-  if( iworst2-1 >= 0 && iworst2 <= int(proto_segment.size()) ) {
-    proto_segment.erase( rh_to_be_deleted_2);
+  if( iworst2-1 >= 0 && iworst2 <= int(aState.proto_segment.size()) ) {
+    aState.proto_segment.erase( rh_to_be_deleted_2);
   }
-  if( iworst-1 >= 0 && iworst <= int(proto_segment.size()) ){
-    proto_segment.erase(rh_to_be_deleted_1);
+  if( iworst-1 >= 0 && iworst <= int(aState.proto_segment.size()) ){
+    aState.proto_segment.erase(rh_to_be_deleted_1);
   }
 }
 
-float CSCSegAlgoRU::fitX(SVector6 points, SVector6 errors, int ir, int ir2, float &chi2_str){
+float CSCSegAlgoRU::fitX(const AlgoState& aState, SVector6 points, SVector6 errors, int ir, int ir2, float &chi2_str) const {
   float S = 0;
   float Sx = 0;
   float Sy = 0;
@@ -763,55 +768,55 @@ float CSCSegAlgoRU::fitX(SVector6 points, SVector6 errors, int ir, int ir2, floa
   return (intercept + slope*0);
 }
 
-bool CSCSegAlgoRU::hasHitOnLayer(int layer) const {
+bool CSCSegAlgoRU::hasHitOnLayer(const AlgoState& aState, int layer) const {
   // Is there is already a hit on this layer?
   ChamberHitContainerCIt it;
-  for(it = proto_segment.begin(); it != proto_segment.end(); it++)
+  for(it = aState.proto_segment.begin(); it != aState.proto_segment.end(); it++)
     if ((*it)->cscDetId().layer() == layer)
       return true;
   return false;
 }
 
-bool CSCSegAlgoRU::replaceHit(const CSCRecHit2D* h, int layer) {
+bool CSCSegAlgoRU::replaceHit(AlgoState& aState, const CSCRecHit2D* h, int layer) const {
   // replace a hit from a layer
   ChamberHitContainer::const_iterator it;
-  for (it = proto_segment.begin(); it != proto_segment.end();) {
+  for (it = aState.proto_segment.begin(); it != aState.proto_segment.end();) {
     if ((*it)->cscDetId().layer() == layer)
-      it = proto_segment.erase(it);
+      it = aState.proto_segment.erase(it);
     else
       ++it;
   }
-  return addHit(h, layer);
+  return addHit(aState, h, layer);
 }
 
-void CSCSegAlgoRU::compareProtoSegment(const CSCRecHit2D* h, int layer) {
+void CSCSegAlgoRU::compareProtoSegment(AlgoState& aState, const CSCRecHit2D* h, int layer) const {
   // Copy the input CSCSegFit
   std::unique_ptr<CSCSegFit> oldfit;
-  oldfit.reset(new CSCSegFit( theChamber, proto_segment ));
+  oldfit.reset(new CSCSegFit( aState.aChamber, aState.proto_segment ));
   oldfit->fit();
-  ChamberHitContainer oldproto = proto_segment;
+  ChamberHitContainer oldproto = aState.proto_segment;
   
   // May create a new fit
-  bool ok = replaceHit(h, layer);
-  if ( (sfit_->chi2() >= oldfit->chi2() ) || !ok ) {
+  bool ok = replaceHit(aState, h, layer);
+  if ( (aState.sfit->chi2() >= oldfit->chi2() ) || !ok ) {
     // keep original fit
-    proto_segment = oldproto;
-    sfit_ = std::move(oldfit); // reset to the original input fit
+    aState.proto_segment = oldproto;
+    aState.sfit = std::move(oldfit); // reset to the original input fit
   }
 }
 
-void CSCSegAlgoRU::increaseProtoSegment(const CSCRecHit2D* h, int layer, int chi2_factor) {
+void CSCSegAlgoRU::increaseProtoSegment(AlgoState& aState, const CSCRecHit2D* h, int layer, int chi2_factor) const {
   // Creates a new fit
   std::unique_ptr<CSCSegFit> oldfit;
-  ChamberHitContainer oldproto = proto_segment;
-  oldfit.reset(new CSCSegFit( theChamber, proto_segment ));
+  ChamberHitContainer oldproto = aState.proto_segment;
+  oldfit.reset(new CSCSegFit( aState.aChamber, aState.proto_segment ));
   oldfit->fit();
 
-  bool ok = addHit(h, layer);
+  bool ok = addHit(aState, h, layer);
   //@@ TEST ON ndof<=0 IS JUST TO ACCEPT nhits=2 CASE??
-  if ( !ok || ( (sfit_->ndof() > 0) && (sfit_->chi2()/sfit_->ndof() >= chi2Max)) ) {
+  if ( !ok || ( (aState.sfit->ndof() > 0) && (aState.sfit->chi2()/aState.sfit->ndof() >= aState.chi2Max)) ) {
     // reset to original fit
-    proto_segment = oldproto;
-    sfit_ = std::move(oldfit);
+    aState.proto_segment = oldproto;
+    aState.sfit = std::move(oldfit);
   }
 }


### PR DESCRIPTION
make method buildSegments const and move all varying data members to an AlgoState percolated through all methods. 

This is a somewhat mindless method to make each call independent and resolve the problem with reproducibility running the algorithm in multithreaded mode or otherwise reordered events.
With this solution the reproducibility is effectively enforced by the compiler.

The code is called chamber-by chamber. Clearly, there was a changing memory between calls to build a segment in different chambers. After the constness is enforced, the order of calls between chambers or between events shouldn't matter.

Changes, compared to the baseline (black CMSSW_9_2_3_patch1) in wf 27411 (10 muons per event)
in one thread:
![all_sign935-mt1vsorig_tenmuextendede2023d17wf27411p0c_cscdetidcscsegmentsownedrangemap_cscsegments__reco_obj_collection__data__degreesoffreedom](https://user-images.githubusercontent.com/4676718/27506679-b63a2d60-5872-11e7-94aa-fc0254132199.png)

Baseline CMSSW_9_2_3_patch1 comparison between single-thread run (black) and multi-thread (red, using 8 threads)
![all_orig-mt8vsorig_tenmuextendede2023d17wf27411p0c_cscdetidcscsegmentsownedrangemap_cscsegments__reco_obj_collection__data__localposition_x](https://user-images.githubusercontent.com/4676718/27506701-4240604a-5873-11e7-9bc0-98d5889e05d7.png)
in this test the events are still somewhat in order and on the same events there should be no differences. This explains much smaller size of changes in the multithread-single thread.

After the fix there are no differences in the cscSegments distributions in comparison between MT1 and MT8 runs.
