### PR TITLE
cleanup uninitialized reads or conditions and leaks

### DIFF
--- a/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
+++ b/DQM/SiPixelPhase1Common/interface/GeometryInterface.h
@@ -46,8 +46,8 @@ class GeometryInterface {
     // in this order the struct should fit 2 64bit words and is cheap to copy.
     const edm::Event* sourceEvent;
     DetId sourceModule;
-    int16_t col;
-    int16_t row;
+    int16_t col = 0;
+    int16_t row = 0;
   };
 
   // This has to be fast, _should_ not malloc.

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -34,6 +34,7 @@ SiStripMonitorTrack::SiStripMonitorTrack(const edm::ParameterSet& conf):
   Mod_On_        = conf.getParameter<bool>("Mod_On");
   Trend_On_      = conf.getParameter<bool>("Trend_On");
   TkHistoMap_On_ = conf.getParameter<bool>("TkHistoMap_On");
+  clchCMoriginTkHmap_On_ = conf.getParameter<bool>("clchCMoriginTkHmap_On");
 
   TrackProducer_ = conf_.getParameter<std::string>("TrackProducer");
   TrackLabel_    = conf_.getParameter<std::string>("TrackLabel");

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaPhotonConversionProducer.cc
@@ -169,7 +169,7 @@ void OniaPhotonConversionProducer::produce(edm::Event& event, const edm::EventSe
      int flags = 0;
      if (flag1 && flag2 && flag3 && flag4){
         flags = PackFlags(*conv,flagTkVtxCompatibility,flagCompatibleInnerHits,flagHighpurity,pizero_rejected,large_pizero_window);
-        pat::CompositeCandidate *pat_conv = makePhotonCandidate(*conv);
+        std::unique_ptr<pat::CompositeCandidate> pat_conv(makePhotonCandidate(*conv));
         pat_conv->addUserInt("flags",flags);
         patoutCollection->push_back(*pat_conv);
      }

--- a/PhysicsTools/MVAComputer/interface/MVAComputer.icc
+++ b/PhysicsTools/MVAComputer/interface/MVAComputer.icc
@@ -72,7 +72,7 @@ double MVAComputer::eval(Iterator_t first, Iterator_t last) const
 
 	// allocate value array and fill input variables
 	double *values = __TMP_ALLOC(max - size + 1, double);
-	values[0] = 0.0;
+	std::fill_n(values, max - size + 1, 0.0);
 	for(Iterator_t cur = first; cur < last; ++cur) {
 		int id = getVariableId(cur->getName());
 		if(id<0) continue;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducer.cc
@@ -59,10 +59,12 @@ void EcalUncalibRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions&
 
     std::unique_ptr<edm::ParameterDescriptionCases<std::string>> s;
     {
-      s = (itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_)->getAlgoDescription(), true));
+      std::unique_ptr<EcalUncalibRecHitWorkerBaseClass> tmw(EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_));
+      s = (itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", tmw->getAlgoDescription(), true));      
     }
     for (++itInfos; itInfos != infos.end(); ++itInfos) {
-      s = (std::move(s) or itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_)->getAlgoDescription(), true));
+      std::unique_ptr<EcalUncalibRecHitWorkerBaseClass> tmw(EcalUncalibRecHitFillDescriptionWorkerFactory::get()->create(itInfos->name_));
+      s = (std::move(s) or itInfos->name_ >> edm::ParameterDescription<edm::ParameterSetDescription>("algoPSet", tmw->getAlgoDescription(), true));
     }
     desc.ifValue(edm::ParameterDescription<std::string>("algo", "EcalUncalibRecHitWorkerMultiFit", true), std::move(s));
     

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -170,16 +170,16 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
       const reco::Track* trk = &(*trackref);
       // pointer to old track:
-      reco::Track* newTrk = new reco::Track(*trk);
+      std::unique_ptr<reco::Track> newTrk(new reco::Track(*trk));
 
       newTrk->setExtra( reco::TrackExtraRef( rTrackExtras, idx++ ) );
       PropagationDirection seedDir = trk->seedDirection();
       // new copy of track Extras
-      reco::TrackExtra * newExtra = new reco::TrackExtra( trk->outerPosition(), trk->outerMomentum(), 
-                                        trk->outerOk(), trk->innerPosition(), 
-                                        trk->innerMomentum(), trk->innerOk(),
-                                        trk->outerStateCovariance(), trk->outerDetId(),
-                                        trk->innerStateCovariance(), trk->innerDetId() , seedDir ) ;
+      std::unique_ptr<reco::TrackExtra> newExtra(new reco::TrackExtra( trk->outerPosition(), trk->outerMomentum(), 
+								       trk->outerOk(), trk->innerPosition(), 
+								       trk->innerMomentum(), trk->innerOk(),
+								       trk->outerStateCovariance(), trk->outerDetId(),
+								       trk->innerStateCovariance(), trk->innerDetId() , seedDir )) ;
 
       // new copy of the silicon hits; add hit refs to Extra and hits to hit collection
       

--- a/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
+++ b/Validation/EcalDigis/src/EcalSelectiveReadoutValidation.cc
@@ -266,6 +266,7 @@ void EcalSelectiveReadoutValidation::analyzeEE(const edm::Event& event,
 					       const edm::EventSetup& es){
   bool eventError = false;
   nEeZsErrors_ = 0;
+  nEeZsErrorsType1_ = 0;
 
   for(int iZ0=0; iZ0<nEndcaps; ++iZ0){
     for(int iX0=0; iX0<nEeX; ++iX0){
@@ -544,6 +545,7 @@ EcalSelectiveReadoutValidation::analyzeEB(const edm::Event& event,
 
   bool eventError = false;
   nEbZsErrors_ = 0;
+  nEbZsErrorsType1_ = 0;
   vector<pair<int,int> > xtalEtaPhi;
 
   xtalEtaPhi.reserve(nEbPhi*nEbEta);


### PR DESCRIPTION
these were collected from the valgrind report for "step3" run with a 2017 workflow with PU (10211).

The change in DQM/SiPixelPhase1Common/interface/GeometryInterface.h actually didn't fix anything, but it still looks useful.

Local short matrix run shows no differences.