### PR TITLE
PCL new workflow for High Perf Beamspot, 2017B relval,  2017B HPBS relval

### DIFF
--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotManager.h"
+#include "RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h"
 
 // #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -37,6 +38,8 @@ class AlcaBeamSpotHarvester : public edm::EDAnalyzer {
   std::string 	      outputrecordName_;
   double      	      sigmaZValue_;
   double              sigmaZCut_;
+  bool                dumpTxt_;
+  std::string 	      outTxtFileName_;
   // Member Variables
   AlcaBeamSpotManager theAlcaBeamSpotManager_;
 

--- a/Calibration/TkAlCaRecoProducers/plugins/PCLMetadataWriter.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/PCLMetadataWriter.cc
@@ -17,6 +17,7 @@
 #include "CondFormats/DataRecord/interface/DropBoxMetadataRcd.h"
 #include "CondFormats/Common/interface/DropBoxMetadata.h"
 
+#include <iostream>
 
 using namespace std;
 using namespace edm;
@@ -30,8 +31,11 @@ PCLMetadataWriter::PCLMetadataWriter(const edm::ParameterSet& pSet){
   for(vector<ParameterSet>::const_iterator recordPset = recordsToMap.begin();
       recordPset != recordsToMap.end();
       ++recordPset) {
-    
+
+    // record is the key which identifies one set of metadata in DropBoxMetadataRcd
+    // (not necessarily a record in the strict framework sense)
     string record = (*recordPset).getUntrackedParameter<string>("record");
+
     map<string, string> jrInfo;
     if(!readFromDB) {
       vector<string> paramKeys = (*recordPset).getParameterNames();
@@ -85,6 +89,7 @@ void PCLMetadataWriter::endRun(const edm::Run& run, const edm::EventSetup& eSetu
 	  ++recordAndMap) {
 
 	string record = (*recordAndMap).first;
+
 	// this is the map of metadata that we write in the JR
 	map<string, string> jrInfo = (*recordAndMap).second;
 	if(readFromDB) {
@@ -92,11 +97,14 @@ void PCLMetadataWriter::endRun(const edm::Run& run, const edm::EventSetup& eSetu
 	    jrInfo = metadata->getRecordParameters(record).getParameterMap();
 	  }
 	}
-	jrInfo["inputtag"] = poolDbService->tag(record);
 	
+	// name of the the input tag in the metadata for the condUploader metadata
+	// needs to be the same as the tag written out by the harvesting step
+	jrInfo["inputtag"] = poolDbService->tag(record);
 	
 	// actually write in the job report
 	jr->reportAnalysisFile(filename, jrInfo);
+
       }
     }
   }

--- a/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotHarvester_cfi.py
@@ -7,7 +7,9 @@ alcaBeamSpotHarvester = cms.EDAnalyzer("AlcaBeamSpotHarvester",
 	BeamSpotLabel      = cms.untracked.string("alcaBeamSpot"),
 	outputRecordName   = cms.untracked.string("BeamSpotObjectsRcd"),
 	SigmaZValue        = cms.untracked.double(-1),
-	SigmaZCut        = cms.untracked.double(1) 
+	SigmaZCut        = cms.untracked.double(1), 
+	DumpTxt            = cms.untracked.bool(False),
+	TxtFileName        = cms.untracked.string("HPBSFit"),
     )
 )
 

--- a/Calibration/TkAlCaRecoProducers/python/PCLHPbeamspot_custom.py
+++ b/Calibration/TkAlCaRecoProducers/python/PCLHPbeamspot_custom.py
@@ -1,0 +1,44 @@
+"""
+_Utils_
+
+Tools to customise the PCL workflow which computes beamspot from a dedicated express-like stream
+
+"""
+
+def customise_HPbeamspot(process):
+
+    # write to sqlite the HP tag and use the HP medatata for uploading it  to the dropbox
+    # ByLumi
+    if ( hasattr(process,'PoolDBOutputService')   and
+         hasattr(process,'pclMetadataWriter')     and
+         hasattr(process,'ALCAHARVESTBeamSpotByLumi')  ):
+        for onePset in process.PoolDBOutputService.toPut:
+            if onePset.record == 'BeamSpotObjectsRcdByLumi':
+                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
+                onePset.tag    = 'BeamSpotObjectHP_ByLumi'
+        for onePset in process.pclMetadataWriter.recordsToMap:
+            if onePset.record == 'BeamSpotObjectsRcdByLumi':
+                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
+        if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
+            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
+            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.DumpTxt = True
+    # ByRun
+    if ( hasattr(process,'PoolDBOutputService')   and
+         hasattr(process,'pclMetadataWriter')     and
+         hasattr(process,'ALCAHARVESTBeamSpotByRun')  ):
+        for onePset in process.PoolDBOutputService.toPut:
+            if onePset.record == 'BeamSpotObjectsRcdByRun':
+                onePset.record = 'BeamSpotObjectsRcdHPByRun'
+                onePset.tag    = 'BeamSpotObjectHP_ByRun'
+        for onePset in process.pclMetadataWriter.recordsToMap:
+            if onePset.record == 'BeamSpotObjectsRcdByRun':
+                onePset.record = 'BeamSpotObjectsRcdHPByRun'
+        if process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByRun':
+            process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByRun'
+
+    # ALCARECOTkAlMinBiasTkAlDQM is part of the ALCARECO sequence we want and needs caloJets
+    # which are not available when running tracking only reco => remove it from the sequence
+    if hasattr(process,'ALCARECOTkAlMinBiasDQM') and 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames() :
+        process.ALCARECOTkAlMinBiasDQM.remove(process.ALCARECOTkAlMinBiasTkAlDQM)
+
+    return process

--- a/Configuration/DataProcessing/python/Impl/hcalnzs.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzs.py
@@ -16,6 +16,7 @@ class hcalnzs(pp):
         pp.__init__(self)
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
+        self.addEI=True
     """
     _hcalnzs_
 

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2016.py
@@ -17,6 +17,7 @@ class hcalnzsEra_Run2_2016(hcalnzs):
         hcalnzs.__init__(self)
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
+        self.addEI=True
         self.eras = Run2_2016
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2017.py
@@ -17,6 +17,7 @@ class hcalnzsEra_Run2_2017(hcalnzs):
         hcalnzs.__init__(self)
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
+        self.addEI=True
         self.eras = Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]

--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_25ns.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_25ns.py
@@ -17,6 +17,7 @@ class hcalnzsEra_Run2_25ns(hcalnzs):
         hcalnzs.__init__(self)
         self.recoSeq=':reconstruction_HcalNZS'
         self.cbSc='pp'
+        self.addEI=True
         self.eras = Run2_25ns
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -18,6 +18,7 @@ class pp(Reco):
         Reco.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True
         self.promptCustoms= [ 'Configuration/DataProcessing/RecoTLR.customisePrompt' ]
         self.expressCustoms=[ ]
         self.alcaHarvCustoms=[]

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -52,7 +52,6 @@ class pp(Reco):
 
         return process
 
-
     def expressProcessing(self, globalTag, **args):
         """
         _expressProcessing_

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -20,6 +20,7 @@ class pp(Reco):
         self.cbSc='pp'
         self.promptCustoms= [ 'Configuration/DataProcessing/RecoTLR.customisePrompt' ]
         self.expressCustoms=[ ]
+        self.alcaHarvCustoms=[]
         self.expressModifiers = modifyExpress
         self.visCustoms=[ ]
         self.visModifiers = modifyExpress
@@ -97,6 +98,12 @@ class pp(Reco):
 
         """
 
+        if not 'customs' in args:
+            args['customs']=[ ]
+
+        for c in self.alcaHarvCustoms:
+            args['customs'].append(c)
+
 
         if not 'skims' in args and not 'alcapromptdataset' in args:
             args['skims']=['BeamSpotByRun',
@@ -104,4 +111,3 @@ class pp(Reco):
                            'SiStripQuality']
             
         return Reco.alcaHarvesting(self, globalTag, datasetName, **args)
-

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016.py
@@ -20,6 +20,7 @@ class ppEra_Run2_2016(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True
         self.eras=Run2_2016
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016_pA.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016_pA.py
@@ -20,6 +20,7 @@ class ppEra_Run2_2016_pA(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True 
         self.eras=Run2_2016_pA
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016_trackingLowPU.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2016_trackingLowPU.py
@@ -20,6 +20,7 @@ class ppEra_Run2_2016_trackingLowPU(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True
         self.eras=Run2_2016_trackingLowPU
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017.py
@@ -20,6 +20,7 @@ class ppEra_Run2_2017(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingLowPU.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingLowPU.py
@@ -20,6 +20,7 @@ class ppEra_Run2_2017_trackingLowPU(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True
         self.eras=Run2_2017_trackingLowPU
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -18,12 +18,13 @@ from Configuration.DataProcessing.Impl.pp import pp
 class ppEra_Run2_2017_trackingOnly(pp):
     def __init__(self):
         pp.__init__(self)
-        # tracking only RECO is sufficient, to run high performance BS at PCL; some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
+        # tracking only RECO is sufficient, to run high performance BS at PCL;
+        # some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
         self.recoSeq=':reconstruction_trackingOnly'
         self.cbSc=self.__class__.__name__
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
-        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
 
     def expressProcessing(self, globalTag, **args):

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -17,7 +17,7 @@ from   Configuration.DataProcessing.Impl.pp import pp
 
 class ppEra_Run2_2017_trackingOnly(trackingOnly):
     def __init__(self):
-        pp.__init__(self)
+        trackingOnly.__init__(self)
         # tracking only RECO is sufficient, to run high performance BS at PCL;
         # some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
         self.recoSeq=':reconstruction_trackingOnly'

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+_ppEra_Run2_2017_trackingOnly
+
+Scenario supporting proton collisions and tracking only reconstruction for HP beamspot
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run2_2017_trackingOnly(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run2_2017
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+    """
+    _ppEra_Run2_2017_trackingOnly
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2, 2017 high performance beamspot
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -18,12 +18,29 @@ from Configuration.DataProcessing.Impl.pp import pp
 class ppEra_Run2_2017_trackingOnly(pp):
     def __init__(self):
         pp.__init__(self)
-        self.recoSeq=''
+        self.recoSeq=':reconstruction_trackingOnly'
         self.cbSc='pp'
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+
+    def expressProcessing(self, globalTag, **args):
+
+        # TkAlMinBias run but hidden to Tier0, in order not to persist it
+        if not args.has_key('skims') :
+            args['skims'] = 'TkAlMinBias'
+        else :
+            if not 'TkAlMinBias' in args['skims'] :
+                args['skims'].append('TkAlMinBias')
+
+        # reco sequence is limited to tracking => DQM accordingly
+        if not args.has_key('dqmSeq') :
+            args['dqmSeq'] = 'DQMOfflineTracking'
+
+
+        pp.expressProcessing(self, globalTag, **args)
+
     """
     _ppEra_Run2_2017_trackingOnly
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -18,13 +18,12 @@ from Configuration.DataProcessing.Impl.pp import pp
 class ppEra_Run2_2017_trackingOnly(pp):
     def __init__(self):
         pp.__init__(self)
-        self.recoSeq=''
-        # revert temporarily to full RECO sequence, because ALCARECOTkAlMinBiasTkAlDQM needs jets
-        #self.recoSeq=':reconstruction_trackingOnly'
+        # tracking only RECO is sufficient, to run high performance BS at PCL; some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
+        self.recoSeq=':reconstruction_trackingOnly'
         self.cbSc='pp'
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
-        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_trackingOnly' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
 
     def expressProcessing(self, globalTag, **args):

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -44,6 +44,17 @@ class ppEra_Run2_2017_trackingOnly(pp):
 
         return process
 
+    def alcaHarvesting(self, globalTag, datasetName, **args):
+
+        theCustom = 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly'
+        if not args.has_key('customs') :
+            args['customs']=[theCustom]
+        else :
+            if not theCustom in args['customs'] :
+                args['customs'].append('TkAlMinBias')
+
+        return pp.alcaHarvesting(self, globalTag, datasetName, **args)
+
     """
     _ppEra_Run2_2017_trackingOnly
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -21,7 +21,8 @@ class ppEra_Run2_2017_trackingOnly(trackingOnly):
         # tracking only RECO is sufficient, to run high performance BS at PCL;
         # some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
         self.recoSeq=':reconstruction_trackingOnly'
-        self.cbSc=self.__class__.__name__
+        self.cbSc='pp'
+        self.addEI=False
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -18,7 +18,9 @@ from Configuration.DataProcessing.Impl.pp import pp
 class ppEra_Run2_2017_trackingOnly(pp):
     def __init__(self):
         pp.__init__(self)
-        self.recoSeq=':reconstruction_trackingOnly'
+        self.recoSeq=''
+        # revert temporarily to full RECO sequence, because ALCARECOTkAlMinBiasTkAlDQM needs jets
+        #self.recoSeq=':reconstruction_trackingOnly'
         self.cbSc='pp'
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -29,17 +29,19 @@ class ppEra_Run2_2017_trackingOnly(pp):
 
         # TkAlMinBias run but hidden to Tier0, in order not to persist it
         if not args.has_key('skims') :
-            args['skims'] = 'TkAlMinBias'
+            args['skims']=['TkAlMinBias']
         else :
             if not 'TkAlMinBias' in args['skims'] :
                 args['skims'].append('TkAlMinBias')
 
         # reco sequence is limited to tracking => DQM accordingly
         if not args.has_key('dqmSeq') :
-            args['dqmSeq'] = 'DQMOfflineTracking'
+            args['dqmSeq'] = ['DQMOfflineTracking']
 
 
-        pp.expressProcessing(self, globalTag, **args)
+        process = pp.expressProcessing(self, globalTag, **args)
+
+        return process
 
     """
     _ppEra_Run2_2017_trackingOnly

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -20,10 +20,10 @@ class ppEra_Run2_2017_trackingOnly(pp):
         pp.__init__(self)
         # tracking only RECO is sufficient, to run high performance BS at PCL; some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
         self.recoSeq=':reconstruction_trackingOnly'
-        self.cbSc='pp'
+        self.cbSc=self.__class__.__name__
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
-        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_trackingOnly' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
 
     def expressProcessing(self, globalTag, **args):

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_2017_trackingOnly.py
@@ -9,13 +9,13 @@ Scenario supporting proton collisions and tracking only reconstruction for HP be
 import os
 import sys
 
-from Configuration.DataProcessing.Reco import Reco
+from   Configuration.DataProcessing.Impl.trackingOnly import trackingOnly
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
+from   Configuration.Eras.Era_Run2_2017_cff import Run2_2017
 
-from Configuration.DataProcessing.Impl.pp import pp
+from   Configuration.DataProcessing.Impl.pp import pp
 
-class ppEra_Run2_2017_trackingOnly(pp):
+class ppEra_Run2_2017_trackingOnly(trackingOnly):
     def __init__(self):
         pp.__init__(self)
         # tracking only RECO is sufficient, to run high performance BS at PCL;
@@ -25,36 +25,8 @@ class ppEra_Run2_2017_trackingOnly(pp):
         self.eras=Run2_2017
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly' ]
+        self.alcaHarvCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017' ]
-
-    def expressProcessing(self, globalTag, **args):
-
-        # TkAlMinBias run but hidden to Tier0, in order not to persist it
-        if not args.has_key('skims') :
-            args['skims']=['TkAlMinBias']
-        else :
-            if not 'TkAlMinBias' in args['skims'] :
-                args['skims'].append('TkAlMinBias')
-
-        # reco sequence is limited to tracking => DQM accordingly
-        if not args.has_key('dqmSeq') :
-            args['dqmSeq'] = ['DQMOfflineTracking']
-
-
-        process = pp.expressProcessing(self, globalTag, **args)
-
-        return process
-
-    def alcaHarvesting(self, globalTag, datasetName, **args):
-
-        theCustom = 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly'
-        if not args.has_key('customs') :
-            args['customs']=[theCustom]
-        else :
-            if not theCustom in args['customs'] :
-                args['customs'].append('TkAlMinBias')
-
-        return pp.alcaHarvesting(self, globalTag, datasetName, **args)
 
     """
     _ppEra_Run2_2017_trackingOnly

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_25ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_25ns.py
@@ -20,6 +20,7 @@ class ppEra_Run2_25ns(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True
         self.eras=Run2_25ns
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns' ]

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run2_50ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run2_50ns.py
@@ -20,6 +20,7 @@ class ppEra_Run2_50ns(pp):
         pp.__init__(self)
         self.recoSeq=''
         self.cbSc='pp'
+        self.addEI=True
         self.eras=Run2_50ns
     """
     _ppEra_Run2_50ns_

--- a/Configuration/DataProcessing/python/Impl/trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnly.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+_trackingOnly_
+
+Scenario supporting proton collisions and tracking only reconstruction for HP beamspot
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class trackingOnly(pp):
+    def __init__(self):
+        pp.__init__(self)
+        # tracking only RECO is sufficient, to run high performance BS at PCL;
+        # some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
+        self.recoSeq=':reconstruction_trackingOnly'
+    """
+    _trackingOnly_
+
+    Implement configuration building for data processing for proton
+    collision data taking
+
+    """
+
+    def expressProcessing(self, globalTag, **args):
+
+        # TkAlMinBias run but hidden to Tier0, in order not to persist it
+        if not args.has_key('skims') :
+            args['skims']=['TkAlMinBias']
+        else :
+            if not 'TkAlMinBias' in args['skims'] :
+                args['skims'].append('TkAlMinBias')
+
+        # reco sequence is limited to tracking => DQM accordingly
+        if not args.has_key('dqmSeq') :
+            args['dqmSeq'] = ['DQMOfflineTracking']
+
+        process = pp.expressProcessing(self, globalTag, **args)
+
+        return process
+
+    def alcaHarvesting(self, globalTag, datasetName, **args):
+
+# SEND THIS INTO THE 2017-only GUY
+#         theCustom = 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly'
+#        if not args.has_key('customs') :
+#            args['customs']=[theCustom]
+#        else :
+#            if not theCustom in args['customs'] :
+#                args['customs'].append('TkAlMinBias') # THIS MUST HAVE BEEN WRONGGGG !
+
+        return pp.alcaHarvesting(self, globalTag, datasetName, **args)
+
+    """
+    _ppEra_Run2_2017_trackingOnly
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2, 2017 high performance beamspot
+
+    """

--- a/Configuration/DataProcessing/python/Impl/trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnly.py
@@ -17,6 +17,9 @@ class trackingOnly(pp):
         # tracking only RECO is sufficient, to run high performance BS at PCL;
         # some dedicated customization are required, though: customisePostEra_Run2_2017_trackingOnly
         self.recoSeq=':reconstruction_trackingOnly'
+        self.cbSc='pp'
+        # don't run EI, because only tracking is done
+        self.addEI=False
     """
     _trackingOnly_
 

--- a/Configuration/DataProcessing/python/Impl/trackingOnly.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnly.py
@@ -45,18 +45,6 @@ class trackingOnly(pp):
 
         return process
 
-    def alcaHarvesting(self, globalTag, datasetName, **args):
-
-# SEND THIS INTO THE 2017-only GUY
-#         theCustom = 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly'
-#        if not args.has_key('customs') :
-#            args['customs']=[theCustom]
-#        else :
-#            if not theCustom in args['customs'] :
-#                args['customs'].append('TkAlMinBias') # THIS MUST HAVE BEEN WRONGGGG !
-
-        return pp.alcaHarvesting(self, globalTag, datasetName, **args)
-
     """
     _ppEra_Run2_2017_trackingOnly
 

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -80,7 +80,6 @@ class Reco(Scenario):
 
         options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+PhysicsSkimStep+miniAODStep+',DQM'+dqmStep+',ENDJOB'
 
-
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
         

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -18,6 +18,7 @@ class Reco(Scenario):
     def __init__(self):
         Scenario.__init__(self)
         self.recoSeq=''
+        self.addEI=False
         self.cbSc=self.__class__.__name__
         self.promptModifiers = cms.ModifierChain()
         self.expressModifiers = cms.ModifierChain()
@@ -75,7 +76,7 @@ class Reco(Scenario):
             options.customisation_file=args['customs']
 
         eiStep=''
-        if self.cbSc == 'pp':
+        if self.addEI:
             eiStep=',EI'
 
         options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+PhysicsSkimStep+miniAODStep+',DQM'+dqmStep+',ENDJOB'
@@ -117,7 +118,7 @@ class Reco(Scenario):
         options.scenario = self.cbSc
 
         eiStep=''
-        if self.cbSc == 'pp':
+        if self.addEI:
             eiStep=',EI'
 
         options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+',DQM'+dqmStep+',ENDJOB'
@@ -160,7 +161,7 @@ class Reco(Scenario):
             options.step +='FILTER:'+args['preFilter']+','
 
         eiStep=''
-        if self.cbSc == 'pp':
+        if self.addEI:
             eiStep=',EI'
 
         options.step += 'RAW2DIGI,L1Reco,RECO'+eiStep+',ENDJOB'

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,recoSeq,gtNameAndConnect
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
@@ -52,7 +52,6 @@ class Reco(Scenario):
         if ("PhysicsSkims" in args) :
             PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
         dqmStep = dqmSeq(args,'')
-        recoStep= recoSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
         options.scenario = self.cbSc
@@ -122,7 +121,7 @@ class Reco(Scenario):
         if self.cbSc == 'pp':
             eiStep=',EI'
 
-        options.step = 'RAW2DIGI,L1Reco,RECO'+recoStep+eiStep+step+',DQM'+dqmStep+',ENDJOB'
+        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+',DQM'+dqmStep+',ENDJOB'
 
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,recoSeq,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
@@ -51,7 +51,8 @@ class Reco(Scenario):
         PhysicsSkimStep = ''
         if ("PhysicsSkims" in args) :
             PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
-        dqmStep= dqmSeq(args,'')
+        dqmStep = dqmSeq(args,'')
+        recoStep= recoSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
         options.scenario = self.cbSc
@@ -121,7 +122,8 @@ class Reco(Scenario):
         if self.cbSc == 'pp':
             eiStep=',EI'
 
-        options.step = 'RAW2DIGI,L1Reco,RECO'+eiStep+step+',DQM'+dqmStep+',ENDJOB'
+        options.step = 'RAW2DIGI,L1Reco,RECO'+recoStep+eiStep+step+',DQM'+dqmStep+',ENDJOB'
+
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
 

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -47,10 +47,17 @@ def customisePostEra_Run2_2017(process):
     _hcalCustoms25ns(process)
     return process
 
+def customisePostEra_Run2_2017_express_trackingOnly(process):
+    customisePostEra_Run2_2017(process)
+    from Configuration.DataProcessing.Utils import customise_HPbeamspot
+    customise_HPbeamspot(process)
+    return process
+
 def customisePostEra_Run2_2017_harvesting_trackingOnly(process):
     from Configuration.DataProcessing.Utils import customise_HPbeamspot
     customise_HPbeamspot(process)
     return process
+
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -49,12 +49,12 @@ def customisePostEra_Run2_2017(process):
 
 def customisePostEra_Run2_2017_express_trackingOnly(process):
     customisePostEra_Run2_2017(process)
-    from Configuration.DataProcessing.Utils import customise_HPbeamspot
+    from Calibration.TkAlCaRecoProducers.PCLHPbeamspot_custom import customise_HPbeamspot
     customise_HPbeamspot(process)
     return process
 
 def customisePostEra_Run2_2017_harvesting_trackingOnly(process):
-    from Configuration.DataProcessing.Utils import customise_HPbeamspot
+    from Calibration.TkAlCaRecoProducers.PCLHPbeamspot_custom import customise_HPbeamspot
     customise_HPbeamspot(process)
     return process
 

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -47,17 +47,6 @@ def customisePostEra_Run2_2017(process):
     _hcalCustoms25ns(process)
     return process
 
-def customisePostEra_Run2_2017_trackingOnly(process):
-    customisePostEra_Run2_2017(process)
-    if hasattr(process,'pathALCARECOTkAlMinBias'):
-        print "process does have pathALCARECOTkAlMinBias"
-        process.pathALCARECOTkAlMinBias.remove(process.ALCARECOTkAlMinBiasDQM)
-    if hasattr(process,'schedule'):
-        print "process does have schedule"
-        process.schedule.remove(process.eventinterpretaion_step)
-    return process
-
-
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -52,35 +52,6 @@ def customisePostEra_Run2_2017_harvesting_trackingOnly(process):
     customise_HPbeamspot(process)
     return process
 
-#    # write to sqlite the HP tag and use the HP medatata for upload to the dropbox
-#    if ( hasattr(process,'PoolDBOutputService')   and 
-#         hasattr(process,'pclMetadataWriter')     and 
-#         hasattr(process,'ALCAHARVESTBeamSpotByLumi')  ):
-#        for onePset in process.PoolDBOutputService.toPut:
-#            if onePset.record == 'BeamSpotObjectsRcdByLumi':
-#                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
-#                onePset.tag    = 'BeamSpotObjectHP_ByLumi'
-#        for onePset in process.pclMetadataWriter.recordsToMap:
-#            if onePset.record == 'BeamSpotObjectsRcdByLumi':
-#                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
-#        if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
-#            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
-#
-#    if ( hasattr(process,'PoolDBOutputService')   and 
-#         hasattr(process,'pclMetadataWriter')     and 
-#         hasattr(process,'ALCAHARVESTBeamSpotByRun')  ):
-#        for onePset in process.PoolDBOutputService.toPut:
-#            if onePset.record == 'BeamSpotObjectsRcdByRun':
-#                onePset.record = 'BeamSpotObjectsRcdHPByRun'
-#                onePset.tag    = 'BeamSpotObjectHP_ByRun'
-#        for onePset in process.pclMetadataWriter.recordsToMap:
-#            if onePset.record == 'BeamSpotObjectsRcdByRun':
-#                onePset.record = 'BeamSpotObjectsRcdHPByRun'
-#        if process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByRun':
-#            process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByRun'
-#
-#    return process
-
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -48,7 +48,38 @@ def customisePostEra_Run2_2017(process):
     return process
 
 def customisePostEra_Run2_2017_harvesting_trackingOnly(process):
+    from Configuration.DataProcessing.Utils import customise_HPbeamspot
+    customise_HPbeamspot(process)
     return process
+
+#    # write to sqlite the HP tag and use the HP medatata for upload to the dropbox
+#    if ( hasattr(process,'PoolDBOutputService')   and 
+#         hasattr(process,'pclMetadataWriter')     and 
+#         hasattr(process,'ALCAHARVESTBeamSpotByLumi')  ):
+#        for onePset in process.PoolDBOutputService.toPut:
+#            if onePset.record == 'BeamSpotObjectsRcdByLumi':
+#                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
+#                onePset.tag    = 'BeamSpotObjectHP_ByLumi'
+#        for onePset in process.pclMetadataWriter.recordsToMap:
+#            if onePset.record == 'BeamSpotObjectsRcdByLumi':
+#                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
+#        if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
+#            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
+#
+#    if ( hasattr(process,'PoolDBOutputService')   and 
+#         hasattr(process,'pclMetadataWriter')     and 
+#         hasattr(process,'ALCAHARVESTBeamSpotByRun')  ):
+#        for onePset in process.PoolDBOutputService.toPut:
+#            if onePset.record == 'BeamSpotObjectsRcdByRun':
+#                onePset.record = 'BeamSpotObjectsRcdHPByRun'
+#                onePset.tag    = 'BeamSpotObjectHP_ByRun'
+#        for onePset in process.pclMetadataWriter.recordsToMap:
+#            if onePset.record == 'BeamSpotObjectsRcdByRun':
+#                onePset.record = 'BeamSpotObjectsRcdHPByRun'
+#        if process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByRun':
+#            process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByRun'
+#
+#    return process
 
 ##############################################################################
 def customisePPData(process):
@@ -185,4 +216,3 @@ def customiseRun2CommonHI(process):
     # process = customiseSimL1EmulatorForPostLS1_Additional_HI(process)
 
     return process
-

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -47,6 +47,9 @@ def customisePostEra_Run2_2017(process):
     _hcalCustoms25ns(process)
     return process
 
+def customisePostEra_Run2_2017_harvesting_trackingOnly(process):
+    return process
+
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -47,6 +47,16 @@ def customisePostEra_Run2_2017(process):
     _hcalCustoms25ns(process)
     return process
 
+def customisePostEra_Run2_2017_trackingOnly(process):
+    customisePostEra_Run2_2017(process)
+    if hasattr(process,'pathALCARECOTkAlMinBias'):
+        print "process does have pathALCARECOTkAlMinBias"
+        process.pathALCARECOTkAlMinBias.remove(process.ALCARECOTkAlMinBiasDQM)
+    if hasattr(process,'schedule'):
+        print "process does have schedule"
+        process.schedule.remove(process.eventinterpretaion_step)
+    return process
+
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -49,13 +49,13 @@ def customisePostEra_Run2_2017(process):
 
 def customisePostEra_Run2_2017_express_trackingOnly(process):
     customisePostEra_Run2_2017(process)
-    from Calibration.TkAlCaRecoProducers.PCLHPbeamspot_custom import customise_HPbeamspot
-    customise_HPbeamspot(process)
+    from Calibration.TkAlCaRecoProducers.PCLHPbeamspot_custom import customise_HPbeamspot as _customise_HPbeamspot
+    _customise_HPbeamspot(process)
     return process
 
 def customisePostEra_Run2_2017_harvesting_trackingOnly(process):
-    from Calibration.TkAlCaRecoProducers.PCLHPbeamspot_custom import customise_HPbeamspot
-    customise_HPbeamspot(process)
+    from Calibration.TkAlCaRecoProducers.PCLHPbeamspot_custom import customise_HPbeamspot as _customise_HPbeamspot
+    _customise_HPbeamspot(process)
     return process
 
 

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -141,6 +141,7 @@ def gtNameAndConnect(globalTag, args):
     return globalTag +',frontier://PromptProd/CMS_CONDITIONS'
 
 def customise_HPbeamspot(process):
+
     # write to sqlite the HP tag and use the HP medatata for uploading it  to the dropbox
     # ByLumi
     if ( hasattr(process,'PoolDBOutputService')   and
@@ -155,7 +156,6 @@ def customise_HPbeamspot(process):
                 onePset.record = 'BeamSpotObjectsRcdHPByLumi'
         if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
             process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
-
     # ByRun
     if ( hasattr(process,'PoolDBOutputService')   and
          hasattr(process,'pclMetadataWriter')     and
@@ -169,3 +169,18 @@ def customise_HPbeamspot(process):
                 onePset.record = 'BeamSpotObjectsRcdHPByRun'
         if process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByRun':
             process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByRun'
+
+    # ALCARECOTkAlMinBiasTkAlDQM is part of the ALCARECO sequence we want and needs caloJets
+    # which are not available when running tracking only reco => remove it from the sequence
+    print "BEF *****"
+    print hasattr(process,'ALCARECOTkAlMinBiasDQM')
+    print process.ALCARECOTkAlMinBiasDQM.moduleNames()
+    print 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames()
+    print "####"
+    if hasattr(process,'ALCARECOTkAlMinBiasDQM') and 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames() :
+        process.ALCARECOTkAlMinBiasDQM.remove(process.ALCARECOTkAlMinBiasTkAlDQM)
+    print "AFT *****"
+    print hasattr(process,'ALCARECOTkAlMinBiasDQM')
+    print process.ALCARECOTkAlMinBiasDQM.moduleNames()
+    print 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames()
+    print "####"

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -172,15 +172,5 @@ def customise_HPbeamspot(process):
 
     # ALCARECOTkAlMinBiasTkAlDQM is part of the ALCARECO sequence we want and needs caloJets
     # which are not available when running tracking only reco => remove it from the sequence
-    print "BEF *****"
-    print hasattr(process,'ALCARECOTkAlMinBiasDQM')
-    print process.ALCARECOTkAlMinBiasDQM.moduleNames()
-    print 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames()
-    print "####"
     if hasattr(process,'ALCARECOTkAlMinBiasDQM') and 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames() :
         process.ALCARECOTkAlMinBiasDQM.remove(process.ALCARECOTkAlMinBiasTkAlDQM)
-    print "AFT *****"
-    print hasattr(process,'ALCARECOTkAlMinBiasDQM')
-    print process.ALCARECOTkAlMinBiasDQM.moduleNames()
-    print 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames()
-    print "####"

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -134,12 +134,6 @@ def dqmSeq(args,default):
     else:
         return default
 
-def recoSeq(args,default):
-    if 'recoSeq' in args and len(args['recoSeq'])!=0:
-        return ':'+('+'.join(args['recoSeq']))
-    else:
-        return default
-
 def gtNameAndConnect(globalTag, args):
     if 'globalTagConnect' in args and args['globalTagConnect'] != '':
         return globalTag + ','+args['globalTagConnect']        

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -139,3 +139,33 @@ def gtNameAndConnect(globalTag, args):
         return globalTag + ','+args['globalTagConnect']        
     # we override here the default in the release which uses the FrontierProd servlet not suited for Tier0 activity
     return globalTag +',frontier://PromptProd/CMS_CONDITIONS'
+
+def customise_HPbeamspot(process):
+    # write to sqlite the HP tag and use the HP medatata for upload to the dropbox
+    if ( hasattr(process,'PoolDBOutputService')   and 
+         hasattr(process,'pclMetadataWriter')     and 
+         hasattr(process,'ALCAHARVESTBeamSpotByLumi')  ):
+        for onePset in process.PoolDBOutputService.toPut:
+            if onePset.record == 'BeamSpotObjectsRcdByLumi':
+                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
+                onePset.tag    = 'BeamSpotObjectHP_ByLumi'
+        for onePset in process.pclMetadataWriter.recordsToMap:
+            if onePset.record == 'BeamSpotObjectsRcdByLumi':
+                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
+        if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
+            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
+
+    if ( hasattr(process,'PoolDBOutputService')   and 
+         hasattr(process,'pclMetadataWriter')     and 
+         hasattr(process,'ALCAHARVESTBeamSpotByRun')  ):
+        for onePset in process.PoolDBOutputService.toPut:
+            if onePset.record == 'BeamSpotObjectsRcdByRun':
+                onePset.record = 'BeamSpotObjectsRcdHPByRun'
+                onePset.tag    = 'BeamSpotObjectHP_ByRun'
+        for onePset in process.pclMetadataWriter.recordsToMap:
+            if onePset.record == 'BeamSpotObjectsRcdByRun':
+                onePset.record = 'BeamSpotObjectsRcdHPByRun'
+        if process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByRun':
+            process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByRun'
+
+#    return process

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -156,6 +156,7 @@ def customise_HPbeamspot(process):
                 onePset.record = 'BeamSpotObjectsRcdHPByLumi'
         if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
             process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
+            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.DumpTxt = True
     # ByRun
     if ( hasattr(process,'PoolDBOutputService')   and
          hasattr(process,'pclMetadataWriter')     and

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -139,39 +139,3 @@ def gtNameAndConnect(globalTag, args):
         return globalTag + ','+args['globalTagConnect']        
     # we override here the default in the release which uses the FrontierProd servlet not suited for Tier0 activity
     return globalTag +',frontier://PromptProd/CMS_CONDITIONS'
-
-def customise_HPbeamspot(process):
-
-    # write to sqlite the HP tag and use the HP medatata for uploading it  to the dropbox
-    # ByLumi
-    if ( hasattr(process,'PoolDBOutputService')   and
-         hasattr(process,'pclMetadataWriter')     and
-         hasattr(process,'ALCAHARVESTBeamSpotByLumi')  ):
-        for onePset in process.PoolDBOutputService.toPut:
-            if onePset.record == 'BeamSpotObjectsRcdByLumi':
-                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
-                onePset.tag    = 'BeamSpotObjectHP_ByLumi'
-        for onePset in process.pclMetadataWriter.recordsToMap:
-            if onePset.record == 'BeamSpotObjectsRcdByLumi':
-                onePset.record = 'BeamSpotObjectsRcdHPByLumi'
-        if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
-            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
-            process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.DumpTxt = True
-    # ByRun
-    if ( hasattr(process,'PoolDBOutputService')   and
-         hasattr(process,'pclMetadataWriter')     and
-         hasattr(process,'ALCAHARVESTBeamSpotByRun')  ):
-        for onePset in process.PoolDBOutputService.toPut:
-            if onePset.record == 'BeamSpotObjectsRcdByRun':
-                onePset.record = 'BeamSpotObjectsRcdHPByRun'
-                onePset.tag    = 'BeamSpotObjectHP_ByRun'
-        for onePset in process.pclMetadataWriter.recordsToMap:
-            if onePset.record == 'BeamSpotObjectsRcdByRun':
-                onePset.record = 'BeamSpotObjectsRcdHPByRun'
-        if process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByRun':
-            process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByRun'
-
-    # ALCARECOTkAlMinBiasTkAlDQM is part of the ALCARECO sequence we want and needs caloJets
-    # which are not available when running tracking only reco => remove it from the sequence
-    if hasattr(process,'ALCARECOTkAlMinBiasDQM') and 'ALCARECOTkAlMinBiasTkAlDQM' in process.ALCARECOTkAlMinBiasDQM.moduleNames() :
-        process.ALCARECOTkAlMinBiasDQM.remove(process.ALCARECOTkAlMinBiasTkAlDQM)

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -133,7 +133,13 @@ def dqmSeq(args,default):
         return ':'+('+'.join(args['dqmSeq']))
     else:
         return default
-            
+
+def recoSeq(args,default):
+    if 'recoSeq' in args and len(args['recoSeq'])!=0:
+        return ':'+('+'.join(args['recoSeq']))
+    else:
+        return default
+
 def gtNameAndConnect(globalTag, args):
     if 'globalTagConnect' in args and args['globalTagConnect'] != '':
         return globalTag + ','+args['globalTagConnect']        

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -141,9 +141,10 @@ def gtNameAndConnect(globalTag, args):
     return globalTag +',frontier://PromptProd/CMS_CONDITIONS'
 
 def customise_HPbeamspot(process):
-    # write to sqlite the HP tag and use the HP medatata for upload to the dropbox
-    if ( hasattr(process,'PoolDBOutputService')   and 
-         hasattr(process,'pclMetadataWriter')     and 
+    # write to sqlite the HP tag and use the HP medatata for uploading it  to the dropbox
+    # ByLumi
+    if ( hasattr(process,'PoolDBOutputService')   and
+         hasattr(process,'pclMetadataWriter')     and
          hasattr(process,'ALCAHARVESTBeamSpotByLumi')  ):
         for onePset in process.PoolDBOutputService.toPut:
             if onePset.record == 'BeamSpotObjectsRcdByLumi':
@@ -155,8 +156,9 @@ def customise_HPbeamspot(process):
         if process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByLumi':
             process.ALCAHARVESTBeamSpotByLumi.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByLumi'
 
-    if ( hasattr(process,'PoolDBOutputService')   and 
-         hasattr(process,'pclMetadataWriter')     and 
+    # ByRun
+    if ( hasattr(process,'PoolDBOutputService')   and
+         hasattr(process,'pclMetadataWriter')     and
          hasattr(process,'ALCAHARVESTBeamSpotByRun')  ):
         for onePset in process.PoolDBOutputService.toPut:
             if onePset.record == 'BeamSpotObjectsRcdByRun':
@@ -167,5 +169,3 @@ def customise_HPbeamspot(process):
                 onePset.record = 'BeamSpotObjectsRcdHPByRun'
         if process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName == 'BeamSpotObjectsRcdByRun':
             process.ALCAHARVESTBeamSpotByRun.AlcaBeamSpotHarvesterParameters.outputRecordName = 'BeamSpotObjectsRcdHPByRun'
-
-#    return process

--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -103,7 +103,22 @@ class RunAlcaHarvesting:
 
 if __name__ == '__main__':
     valid = ["scenario=", "global-tag=", "lfn=", "dataset=","workflows=","alcapromptdataset="]
-    usage = """RunAlcaHarvesting.py <options>"""
+    usage = \
+    usage = """
+    RunAlcaHarvesting.py <options>
+
+
+    Where options are:
+    --scenario=ScenarioName
+    --global-tag=GlobalTag
+    --lfn=/store/input/lfn
+    --dataset=/A/B/C
+    --workflows=theWFs
+    --alcapromptdataset=theAPdataset
+
+    """
+
+
     try:
         opts, args = getopt.getopt(sys.argv[1:], "", valid)
     except getopt.GetoptError as ex:

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -53,3 +53,7 @@ done
 runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals "
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaTestEnable --lfn=/store/whatever --global-tag GLOBALTAG --skims PromptCalibProdEcalPedestals"
 runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=EcalPedestals"
+
+runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario ppEra_Run2_2017_trackingOnly --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias"
+runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario ppEra_Run2_2017_trackingOnly --lfn /store/whatever --global-tag GLOBALTAG --skims TkAlMinBias"
+runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario ppEra_Run2_2017_trackingOnly --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG"

--- a/Configuration/PyReleaseValidation/python/relval_production.py
+++ b/Configuration/PyReleaseValidation/python/relval_production.py
@@ -18,6 +18,7 @@ workflows[1004] = [ '',['RunHI2011','TIER0EXPHI','ALCAEXPHI','ALCAHARVD1HI','ALC
 
 workflows[1010] =  ['',['TestEnableEcalHCAL2016H','TIER0EXPTE', 'ALCAEXPTE', 'ALCAHARVDTE']]
 workflows[1020] =  ['',['AlCaLumiPixels2016H','TIER0PROMPTLP']]
+workflows[1030] =  ['',['RunHLTPhy2017B','TIER0EXPHPBS','ALCASPLITHPBS','ALCAHARVDHPBS']]
 
 
 

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -220,6 +220,9 @@ workflows[136.777] = ['',['RunSinglePh2016H','HLTDR2_2016','RECODR2_2016reHLT_sk
 workflows[136.778] = ['',['RunZeroBias2016H','HLTDR2_2016','RECODR2_2016reHLT_Prompt','HARVESTDR2']]
 workflows[136.779] = ['',['RunMuOnia2016H','HLTDR2_2016','RECODR2_2016reHLT_skimMuOnia_Prompt','HARVESTDR2']]
 
+### run 2017B ###
+workflows[136.780] = ['',['RunHLTPhy2017B','HLTDR2_2017','RECODR2_2017reHLT_Prompt','HARVEST2017']]
+
 ### fastsim ###
 workflows[5.1] = ['TTbar', ['TTbarFS','HARVESTFS']]
 workflows[5.2] = ['SingleMuPt10', ['SingleMuPt10FS','HARVESTFS']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -268,6 +268,11 @@ steps['RunSinglePh2016H']={'INPUT':InputInfo(dataSet='/SinglePhoton/Run2016H-v1/
 steps['RunZeroBias2016H']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2016H-v1/RAW',label='zb2016H',events=100000,location='STD', ls=Run2016H)}
 steps['RunMuOnia2016H']={'INPUT':InputInfo(dataSet='/MuOnia/Run2016H-v1/RAW',label='muOnia2016H',events=100000,location='STD', ls=Run2016H)}
 
+#### run2 2017B ####
+Run2017B={297113: [[1, 45]]} # replace with line below once Phedex transfer will be done
+#Run2017B={297227: [[1, 45]]}
+steps['RunHLTPhy2017B']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2017B-v1/RAW',label='hltPhy2017B',events=100000,location='STD', ls=Run2017B)}
+
 
 # Highstat HLTPhysics
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])
@@ -1174,10 +1179,15 @@ menuR2_2016 = autoHLT[hltKey2016]
 steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 steps['HLTDR2newL1repack_2016']=merge( [ {'-s':'L1REPACK:FullSimTP,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 
+hltKey2017='relval2016' # replace this with 'frozen2017' after PR 19308 is merged
+menuR2_2017 = autoHLT[hltKey2017]
+steps['HLTDR2_2017']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2017,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2017'},steps['HLTD'] ] )
+
 # use --era
 steps['RECODR2_50ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_50ns',},dataReco])
 steps['RECODR2_25ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_25ns','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns'},dataReco])
 steps['RECODR2_2016']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_2016','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2016'},dataReco])
+steps['RECODR2_2017']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_2017','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017'},dataReco])
 
 steps['RECODR2AlCaEle']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--customise':'Configuration/DataProcessing/RecoTLR.customisePromptRun2',},dataRecoAlCaCalo])
 
@@ -1340,6 +1350,7 @@ steps['RECODreHLTAlCaCalo']=merge([{'--hltProcess':'reHLT','--conditions':'auto:
 steps['RECODR2_25nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_25ns']])
 steps['RECODR2_50nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_50ns']])
 steps['RECODR2_2016reHLT']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2_2016']])
+steps['RECODR2_2017reHLT']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2_2017']])
 steps['RECODR2newL1repack_2016reHLT']=merge([{'-s':'L1REPACK:FullSimTP,RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@miniAODDQM','--hltProcess':'reHLT'},steps['RECODR2_2016']])
 steps['RECODR2reHLTAlCaEle']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2AlCaEle']])
 steps['RECODR2reHLTAlCaTkCosmics']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval','-s':'RAW2DIGI,L1Reco,RECO,SKIM:EXONoBPTXSkim,EI,PAT,ALCA:TkAlCosmicsInCollisions,DQM:@standardDQM+@miniAODDQM'},steps['RECODR2_2016']])
@@ -1372,6 +1383,7 @@ steps['RECODR2_2016reHLT_skimSinglePh_Prompt']=merge([{'--conditions':'auto:run2
 steps['RECODR2_2016reHLT_skimMuOnia_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimMuOnia']])
 steps['RECODR2_2016reHLT_Prompt_Lumi']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@miniAODDQM+@lumi'},steps['RECODR2_2016reHLT_Prompt']])
 
+steps['RECODR2_2017reHLT_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2017reHLT']])
 
 steps['RECO']=merge([step3Defaults])
 
@@ -1606,6 +1618,7 @@ steps['HARVESTDR1']={'-s':'HARVESTING:@standardDQMFakeHLT+@miniAODDQM',
 steps['HARVESTDreHLT'] = merge([ {'--conditions':'auto:run1_data_%s'%menu}, steps['HARVESTD'] ])
 steps['HARVESTDR1reHLT'] = merge([ {'--conditions':'auto:run1_data_%s'%menu}, steps['HARVESTDR1'] ])
 steps['HARVESTDR2'] = merge([ {'--conditions':'auto:run2_data_relval'}, steps['HARVESTD'] ])
+steps['HARVEST2017'] = merge([ {'--conditions':'auto:run2_data_relval','--era':'Run2_2017','--conditions':'auto:run2_data_promptlike',}, steps['HARVESTD'] ])
 
 steps['HARVESTDDQM']=merge([{'-s':'HARVESTING:@common+@muon+@hcal+@jetmet+@ecal'},steps['HARVESTD']])
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -269,8 +269,7 @@ steps['RunZeroBias2016H']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2016H-v1/RAW'
 steps['RunMuOnia2016H']={'INPUT':InputInfo(dataSet='/MuOnia/Run2016H-v1/RAW',label='muOnia2016H',events=100000,location='STD', ls=Run2016H)}
 
 #### run2 2017B ####
-Run2017B={297292: [[1, 45]]} # replace with line below once Phedex transfer will be done
-#Run2017B={297227: [[1, 45]]}
+Run2017B={297227: [[1, 45]]}
 steps['RunHLTPhy2017B']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2017B-v1/RAW',label='hltPhy2017B',events=100000,location='STD', ls=Run2017B)}
 
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1178,8 +1178,7 @@ menuR2_2016 = autoHLT[hltKey2016]
 steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 steps['HLTDR2newL1repack_2016']=merge( [ {'-s':'L1REPACK:FullSimTP,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 
-hltKey2017='relval2016' # replace this with 'frozen2017' after PR 19308 is merged
-menuR2_2017 = autoHLT[hltKey2017]
+hltKey2017='relval2017'
 steps['HLTDR2_2017']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2017,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2017'},steps['HLTD'] ] )
 
 # use --era

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -269,7 +269,7 @@ steps['RunZeroBias2016H']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2016H-v1/RAW'
 steps['RunMuOnia2016H']={'INPUT':InputInfo(dataSet='/MuOnia/Run2016H-v1/RAW',label='muOnia2016H',events=100000,location='STD', ls=Run2016H)}
 
 #### run2 2017B ####
-Run2017B={297113: [[1, 45]]} # replace with line below once Phedex transfer will be done
+Run2017B={297292: [[1, 45]]} # replace with line below once Phedex transfer will be done
 #Run2017B={297227: [[1, 45]]}
 steps['RunHLTPhy2017B']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2017B-v1/RAW',label='hltPhy2017B',events=100000,location='STD', ls=Run2017B)}
 
@@ -1244,6 +1244,7 @@ steps['TIER0EXPTE']={'-s': 'ALCAPRODUCER:EcalTestPulsesRaw',
                      '--scenario': 'pp',
                      #'--customise':'Configuration/DataProcessing/RecoTLR.customiseExpress',
                      }
+
 steps['TIER0PROMPTLP']={'-s': 'ALCA:AlCaPCCZeroBias+AlCaPCCRandom',
                         '--conditions': 'auto:run2_data',
                         '--datatier':'ALCARECO',
@@ -1252,6 +1253,36 @@ steps['TIER0PROMPTLP']={'-s': 'ALCA:AlCaPCCZeroBias+AlCaPCCRandom',
                         '--scenario': 'pp',
                         # '--customise':'Configuration/DataProcessing/RecoTLR.customiseExpress',
                         }
+
+steps['TIER0EXPHPBS']={'-s':'RAW2DIGI,L1Reco,RECO:reconstruction_trackingOnly,ALCAPRODUCER:TkAlMinBias,DQM:DQMOfflineTracking,ENDJOB',
+                          '--process':'RECO',
+                          '--scenario': 'pp',
+                          '--era':'Run2_2017',
+                          '--conditions':'auto:run2_data_promptlike',
+                          '--data': '',
+                          '--datatier':'ALCARECO,DQMIO',
+                          '--eventcontent':'ALCARECO,DQM',
+                          '--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_express_trackingOnly',
+                          }
+
+steps['ALCASPLITHPBS']={'-s':'ALCAOUTPUT:TkAlMinBias,ALCA:PromptCalibProd',
+                        '--scenario':'pp',
+                        '--data':'',
+                        '--era':'Run2_2017',
+                        '--datatier':'ALCARECO',
+                        '--eventcontent':'ALCARECO',
+                        '--conditions':'auto:run2_data_promptlike',
+                        '--triggerResultsProcess':'RECO',
+                        }
+
+steps['ALCAHARVDHPBS']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProd']),
+                        #'--conditions':'auto:run2_data_promptlike',
+                        '--conditions':'92X_dataRun2_Express_v2_snapshotted', # to replaced with line above once run2_data_promptlike will contain DropBoxMetadata
+                        '--scenario':'pp',
+                        '--data':'',
+                        '--era':'Run2_2017',
+                        '--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2017_harvesting_trackingOnly',
+                        '--filein':'file:PromptCalibProd.root'}
 
 
 steps['RECOCOSD']=merge([{'--scenario':'cosmics',

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
@@ -1,0 +1,60 @@
+#ifndef RecoVertex_BeamSpotProducer_BeamSpotWrite2Txt_h
+#define RecoVertex_BeamSpotProducer_BeamSpotWrite2Txt_h
+
+#include <fstream>
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+namespace beamspot {
+
+  struct BeamSpotContainer {
+      reco::BeamSpot beamspot          ;
+      int            run               ;
+      char           beginTimeOfFit[32];
+      char           endTimeOfFit  [32];
+      int            beginLumiOfFit    ;
+      int            endLumiOfFit      ;
+      std::time_t    reftime[2]        ;
+  };
+  
+  void dumpBeamSpotTxt(std::string & fileName, bool append, beamspot::BeamSpotContainer bsContainer){
+    std::ofstream outFile;
+  
+    if (!append)
+      outFile.open(fileName.c_str());
+    else
+      outFile.open(fileName.c_str(), std::ios::app);
+  
+    outFile << "Runnumber "            << bsContainer.run                                                 << std::endl;
+    outFile << "BeginTimeOfFit "       << bsContainer.beginTimeOfFit << " "   << bsContainer.reftime[0]   << std::endl;
+    outFile << "EndTimeOfFit "         << bsContainer.endTimeOfFit   << " "   << bsContainer.reftime[1]   << std::endl;
+    outFile << "LumiRange "            << bsContainer.beginLumiOfFit << " - " << bsContainer.endLumiOfFit << std::endl;
+    outFile << "Type "                 << bsContainer.beamspot.type()                                     << std::endl;
+    outFile << "X0 "                   << bsContainer.beamspot.x0()                                       << std::endl;
+    outFile << "Y0 "                   << bsContainer.beamspot.y0()                                       << std::endl;
+    outFile << "Z0 "                   << bsContainer.beamspot.z0()                                       << std::endl;
+    outFile << "sigmaZ0 "              << bsContainer.beamspot.sigmaZ()                                   << std::endl;
+    outFile << "dxdz "                 << bsContainer.beamspot.dxdz()                                     << std::endl;
+    outFile << "dydz "                 << bsContainer.beamspot.dydz()                                     << std::endl;
+    outFile << "BeamWidthX "           << bsContainer.beamspot.BeamWidthX()                               << std::endl;
+    outFile << "BeamWidthY "           << bsContainer.beamspot.BeamWidthY()                               << std::endl;
+    for (int i = 0; i<6; ++i) {
+      outFile << "Cov("<<i<<",j) ";
+      for (int j=0; j<7; ++j) {
+        outFile << bsContainer.beamspot.covariance(i,j) << " ";
+      }
+        outFile << std::endl;
+      }
+    // Uncertainties on sigmaX and sigmaY are set to be equal. Legacy from a distant past
+    outFile << "Cov(6,j) 0 0 0 0 0 0 " << bsContainer.beamspot.covariance(6,6)                            << std::endl;
+    outFile << "EmittanceX "           << bsContainer.beamspot.emittanceX()                               << std::endl;
+    outFile << "EmittanceY "           << bsContainer.beamspot.emittanceY()                               << std::endl;
+    outFile << "BetaStar "             << bsContainer.beamspot.betaStar()                                 << std::endl;
+  
+    outFile.close();
+  }
+
+} // end namespace beamspot
+
+
+#endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
@@ -16,8 +16,9 @@ namespace beamspot {
       int            endLumiOfFit      ;
       std::time_t    reftime[2]        ;
   };
-  
-  void dumpBeamSpotTxt(std::string & fileName, bool append, beamspot::BeamSpotContainer bsContainer){
+ 
+  void dumpBeamSpotTxt(std::string const& fileName, bool append, BeamSpotContainer const& bsContainer){
+
     std::ofstream outFile;
   
     if (!append)

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -24,6 +24,10 @@ ________________________________________________________________**/
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+
+// HOOK RM
+#include "RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h"
+
 // Update the string representations of the time
 void BeamFitter::updateBTime() {
   char ts[] = "yyyy.mn.dd hh:mm:ss zzz ";
@@ -672,6 +676,20 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     }
   }//if bx results needed
   else {
+  
+    beamspot::BeamSpotContainer currentBS;
+    
+    currentBS.beamspot       = fbeamspot      ;
+    currentBS.run            = frun           ;
+    std::copy(fbeginTimeOfFit, fbeginTimeOfFit+32, currentBS.beginTimeOfFit);
+    std::copy(fendTimeOfFit  , fendTimeOfFit  +32, currentBS.endTimeOfFit  );
+    currentBS.beginLumiOfFit = fbeginLumiOfFit;
+    currentBS.endLumiOfFit   = fendLumiOfFit  ;
+    std::copy(freftime, freftime+2, currentBS.reftime);
+          
+    beamspot::dumpBeamSpotTxt(fileName, append, currentBS);
+        
+    /*
     outFile << "Runnumber " << frun << std::endl;
     outFile << "BeginTimeOfFit " << fbeginTimeOfFit << " " << freftime[0] << std::endl;
     outFile << "EndTimeOfFit " << fendTimeOfFit << " " << freftime[1] << std::endl;
@@ -708,6 +726,8 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     outFile << "EmittanceX " << fbeamspot.emittanceX() << std::endl;
     outFile << "EmittanceY " << fbeamspot.emittanceY() << std::endl;
     outFile << "BetaStar " << fbeamspot.betaStar() << std::endl;
+    //*/
+
 
     //write here Pv info for DIP only: This added only if append is false, which happen for DIP only :)
   if(!append){

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -10,23 +10,20 @@
 
 ________________________________________________________________**/
 
-#include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/Common/interface/View.h"
 
+#include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
+#include "RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h"
+
+#include "DataFormats/Common/interface/View.h"
 #include "DataFormats/TrackReco/interface/HitPattern.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-
-// HOOK RM
-#include "RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h"
 
 // Update the string representations of the time
 void BeamFitter::updateBTime() {

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -689,46 +689,6 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
           
     beamspot::dumpBeamSpotTxt(fileName, append, currentBS);
         
-    /*
-    outFile << "Runnumber " << frun << std::endl;
-    outFile << "BeginTimeOfFit " << fbeginTimeOfFit << " " << freftime[0] << std::endl;
-    outFile << "EndTimeOfFit " << fendTimeOfFit << " " << freftime[1] << std::endl;
-    outFile << "LumiRange " << fbeginLumiOfFit << " - " << fendLumiOfFit << std::endl;
-    outFile << "Type " << fbeamspot.type() << std::endl;
-    outFile << "X0 " << fbeamspot.x0() << std::endl;
-    outFile << "Y0 " << fbeamspot.y0() << std::endl;
-    outFile << "Z0 " << fbeamspot.z0() << std::endl;
-    outFile << "sigmaZ0 " << fbeamspot.sigmaZ() << std::endl;
-    outFile << "dxdz " << fbeamspot.dxdz() << std::endl;
-    outFile << "dydz " << fbeamspot.dydz() << std::endl;
-    //  if (inputBeamWidth_ > 0 ) {
-    //    outFile << "BeamWidthX " << inputBeamWidth_ << std::endl;
-    //    outFile << "BeamWidthY " << inputBeamWidth_ << std::endl;
-    //  } else {
-    outFile << "BeamWidthX " << fbeamspot.BeamWidthX() << std::endl;
-    outFile << "BeamWidthY " << fbeamspot.BeamWidthY() << std::endl;
-    //  }
-
-    for (int i = 0; i<6; ++i) {
-      outFile << "Cov("<<i<<",j) ";
-      for (int j=0; j<7; ++j) {
-	outFile << fbeamspot.covariance(i,j) << " ";
-      }
-      outFile << std::endl;
-    }
-
-    // beam width error
-    //if (inputBeamWidth_ > 0 ) {
-    //  outFile << "Cov(6,j) 0 0 0 0 0 0 " << "1e-4" << std::endl;
-    //} else {
-    outFile << "Cov(6,j) 0 0 0 0 0 0 " << fbeamspot.covariance(6,6) << std::endl;
-    //}
-    outFile << "EmittanceX " << fbeamspot.emittanceX() << std::endl;
-    outFile << "EmittanceY " << fbeamspot.emittanceY() << std::endl;
-    outFile << "BetaStar " << fbeamspot.betaStar() << std::endl;
-    //*/
-
-
     //write here Pv info for DIP only: This added only if append is false, which happen for DIP only :)
   if(!append){
     outFile << "events "<< (int)ForDIPPV_[0] << std::endl;


### PR DESCRIPTION
+ a new Tier0 scenario  `ppEra_Run2_2017_trackingOnly` is added 
  which executes tracking only RECO and performs by-lumi-section and by-run
  high performance beamspot measurement (HPBS), loading the resulting AlCa payloads to dedicated tags
  . intended to consume the new dedicated stream (80 Hz of JetHT-like events) which will allow accurate measurements also of the transverse width of luminous region 
  . for an initial validation stage, this new PCL workflow can/will operate in parallel to the existing beamspot measurement which consumes the EXPRESS

+ 2017B standard data processing relval consuming RAW from run 297227
  .  @fabozzi : this is the configuration we agreed upon a few days back

+ 2017B production-like relval which emulates the HPBS workflow

Credits to @cerminar
@arunhep you'll want to follow this. We'll need to update prompt-like GT for these 2 wf's to be accurate

The bot tests will only marginally probe these developments. I report below the sequence of testing commands



```

export SCRAM_ARCH=slc6_amd64_gcc530
cmsrel CMSSW_9_2_X_2017-06-25-1100
cd CMSSW_9_2_X_2017-06-25-1100/src ; cmsenv
git cms-addpkg Calibration/TkAlCaRecoProducers
git cms-addpkg Configuration/DataProcessing
git cms-addpkg Configuration/PyReleaseValidation
git fetch https://github.com/cms-sw/cmssw.git master:master
git checkout master
git fetch https://github.com/franzoni/cmssw.git  HPBeamspot_Scenarios_from-CMSSW_9_2_2_rebased:HPBeamspot_Scenarios_from-CMSSW_9_2_2_rebased
git checkout HPBeamspot_Scenarios_from-CMSSW_9_2_2_rebased
scramv1 build -j 8

voms-proxy-init -voms cms

+ the relval workflows:
  processing 2017B HLTPhysics data (standard L1+HTL, RECO+DQM, HARV) and
  emulating the HPBS workflowlow

runTheMatrix.py  --command='-n 1'   -l 1030.0,136.78  >& relval-test.1.log &


+ the Tier0-like commands using the newly introducd scenario ppEra_Run2_2017_trackingOnly

cmsenv;   python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunExpressProcessing.py \
--scenario=ppEra_Run2_2017_trackingOnly --global-tag 92X_dataRun2_Express_v2  \
--lfn '/store/data/Run2017B/HLTPhysics/RAW/v1/000/297/227/00000/7A7E24B7-2257-E711-A5CD-02163E0145EE.root'  \
--alcarecos=TkAlMinBias

cmsRun -e RunExpressProcessingCfg.py >&  RunExpressProcessingCfg.1.log &


python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunAlcaSkimming.py \
--scenario ppEra_Run2_2017_trackingOnly \
--lfn=file:output.root \
--global-tag 92X_dataRun2_Express_v2 \
--skims TkAlMinBias


cmsRun -e RunAlcaSkimmingCfg.py >& RunAlcaSkimmingCfg.1.log &


python $CMSSW_BASE/src/Configuration/DataProcessing/test/RunAlcaHarvesting.py \
--scenario ppEra_Run2_2017_trackingOnly \
--lfn file:TkAlMinBias.root \
--dataset /A/B/C \
--global-tag 92X_dataRun2_Express_v2

cmsRun -j FrameworkJobReport.xml RunAlcaHarvestingCfg.py >& RunAlcaHarvestingCfg.1.log &
```
 