### PR TITLE
FWCore/Services: Timing service updated to report modules that exceed a time threshold.

### DIFF
--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -178,7 +178,8 @@ namespace edm {
       if( (not summary_only_) || (threshold_ > 0.) ) {
         iRegistry.watchPreModuleEvent(this, &Timing::preModule);
         iRegistry.watchPostModuleEvent(this, &Timing::postModule);
- 
+      } 
+      if(threshold_ > 0.) {
         iRegistry.watchPreSourceEvent(this, &Timing::preSourceEvent);
         iRegistry.watchPostSourceEvent(this, &Timing::postSourceEvent);
       

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -144,7 +144,7 @@ namespace edm {
       iRegistry.watchPreEvent(this, &Timing::preEvent);
       iRegistry.watchPostEvent(this, &Timing::postEvent);
 
-      if( (not summary_only_) || threshold_ ) {
+      if( (not summary_only_) || (threshold_ > 0.) ) {
         iRegistry.watchPreModuleEvent(this, &Timing::preModule);
         iRegistry.watchPostModuleEvent(this, &Timing::postModule);
       }
@@ -313,7 +313,7 @@ namespace edm {
       auto const & desc = *(iModule.moduleDescription());
       
       if( t > threshold_) {
-          LogPrint("TimeModule") << "ExcessiveTime> "
+          LogError("TimeModule") << "ExcessiveTime> "
           << eventID.event() << " "
           << eventID.run() << " "
           << desc.moduleLabel() << " "

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -321,12 +321,12 @@ namespace edm {
           << t << " secs exceeds excessive time threshold "<<threshold_ <<" secs.";
       }
       if ( not summary_only_) {
-      LogPrint("TimeModule") << "TimeModule> "
-      << eventID.event() << " "
-      << eventID.run() << " "
-      << desc.moduleLabel() << " "
-      << desc.moduleName() << " "
-      << t;
+          LogPrint("TimeModule") << "TimeModule> "
+          << eventID.event() << " "
+          << eventID.run() << " "
+          << desc.moduleLabel() << " "
+          << desc.moduleName() << " "
+          << t;
       }
     }
   }

--- a/Validation/Performance/python/TimeMemorySummary.py
+++ b/Validation/Performance/python/TimeMemorySummary.py
@@ -8,7 +8,7 @@ def customise(process):
     #Adding Timing service:
     process.Timing=cms.Service("Timing",
                                summaryOnly=cms.untracked.bool(True),
-                               excessiveTimeThreshold=cms.untracked.double(100))
+                               excessiveTimeThreshold=cms.untracked.double(600))
     
     #Add these 3 lines to put back the summary for timing information at the end of the logfile
     #(needed for TimeReport report)

--- a/Validation/Performance/python/TimeMemorySummary.py
+++ b/Validation/Performance/python/TimeMemorySummary.py
@@ -7,7 +7,8 @@ def customise(process):
                                           oncePerEventMode=cms.untracked.bool(False))
     #Adding Timing service:
     process.Timing=cms.Service("Timing",
-                               summaryOnly=cms.untracked.bool(True))
+                               summaryOnly=cms.untracked.bool(True),
+                               excessiveTimeThreshold=cms.untracked.double(100))
     
     #Add these 3 lines to put back the summary for timing information at the end of the logfile
     #(needed for TimeReport report)


### PR DESCRIPTION
This make the Timing service report module that exceed a time threshold. The default is set to 100 in Validation/Performance/python/TimeMemorySummary.py