### PR TITLE
 CTPPS: fixes for 2017 diamond data taking operations (backport to 9_2_X)

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -73,6 +73,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 
     bool excludeMultipleHits_;
     double minimumStripAngleForTomography_;
+    double maximumStripAngleForTomography_;
     int centralOOT_;
     unsigned int verbosity_;
 
@@ -93,9 +94,9 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-      MonitorElement* activity_per_fedbx = NULL;
-      MonitorElement* activity_per_fedbx_plus1 = NULL;
-      MonitorElement* activity_per_fedbx_minus1 = NULL;
+//       MonitorElement* activity_per_fedbx = NULL;
+//       MonitorElement* activity_per_fedbx_plus1 = NULL;
+//       MonitorElement* activity_per_fedbx_minus1 = NULL;
 
       MonitorElement* hitDistribution2d = NULL;
       MonitorElement* hitDistribution2dOOT = NULL;
@@ -106,9 +107,12 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* trackDistribution = NULL;
       MonitorElement* trackDistributionOOT = NULL;
 
-      MonitorElement* stripTomographyAllFar = NULL, *stripTomographyAllNear = NULL;
-      MonitorElement* stripTomographyAllFar_plus1 = NULL, *stripTomographyAllNear_plus1 = NULL;
-      MonitorElement* stripTomographyAllFar_minus1 = NULL, *stripTomographyAllNear_minus1 = NULL;
+      MonitorElement* stripTomographyAllFar = NULL;
+      MonitorElement* stripTomographyAllFar_plus1 = NULL;
+      MonitorElement* stripTomographyAllFar_minus1 = NULL;
+//       MonitorElement* stripTomographyAllNear = NULL;
+//       MonitorElement* stripTomographyAllNear_plus1 = NULL;
+//       MonitorElement* stripTomographyAllNear_minus1 = NULL;
 
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
@@ -136,10 +140,10 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* digiProfileCumulativePerPlane = NULL;
       MonitorElement* hitProfile = NULL;
       MonitorElement* hit_multiplicity = NULL;
-      MonitorElement* threshold_voltage = NULL;
+//       MonitorElement* threshold_voltage = NULL;
 
       MonitorElement* stripTomography_far = NULL;
-      MonitorElement* stripTomography_near = NULL;
+//       MonitorElement* stripTomography_near = NULL;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -153,18 +157,18 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-      MonitorElement* activity_per_fedbx = NULL;
-      MonitorElement* activity_per_fedbx_plus1 = NULL;
-      MonitorElement* activity_per_fedbx_minus1 = NULL;
+//       MonitorElement* activity_per_fedbx = NULL;
+//       MonitorElement* activity_per_fedbx_plus1 = NULL;
+//       MonitorElement* activity_per_fedbx_minus1 = NULL;
       
       MonitorElement* HPTDCErrorFlags = NULL;
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* TimeOverThresholdCumulativePerChannel = NULL;
       MonitorElement* LeadingTrailingCorrelationPerChannel = NULL;
       MonitorElement* leadingWithoutTrailing = NULL;
-      MonitorElement* efficiency = NULL;
+//       MonitorElement* efficiency = NULL;
       MonitorElement* stripTomography_far = NULL;
-      MonitorElement* stripTomography_near = NULL;
+//       MonitorElement* stripTomography_near = NULL;
       MonitorElement* hit_rate = NULL;
       MonitorElement* ECCheckPerChannel = NULL;
       unsigned long hitsCounterPerLumisection;
@@ -224,9 +228,9 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
 
   hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
@@ -238,13 +242,13 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
   stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
 
   stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
 
   stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-  stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );  
+//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );  
 
   leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 300, -100, 200 );
   leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 300, -100, 200 );
@@ -267,9 +271,9 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
   ibooker.setCurrentFolder( path+"/clock/" );
   clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 1000, 0, 100 );
-  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 1000, 0, 100 );
+  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 100, 0, 100 );
+  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 5000, 0, 100 );
+  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 100, 0, 100 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -286,10 +290,10 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-  threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
+//   threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
 
   stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
-  stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
+//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -311,9 +315,9 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
+//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   
   
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
@@ -329,7 +333,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
 
   stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
-  stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
+//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
   
   hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 1000, 0, 100 );
 }
@@ -345,6 +349,7 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource( const edm::ParameterSet& ps ) :
   tokenFEDInfo_     ( consumes< std::vector<TotemFEDInfo> >                ( ps.getParameter<edm::InputTag>( "tagFEDInfo" ) ) ),
   excludeMultipleHits_           ( ps.getParameter<bool>( "excludeMultipleHits" ) ),
   minimumStripAngleForTomography_( ps.getParameter<double>( "minimumStripAngleForTomography" ) ),
+  maximumStripAngleForTomography_( ps.getParameter<double>( "maximumStripAngleForTomography" ) ),
   centralOOT_( ps.getParameter<int>( "centralOOT" ) ),
   verbosity_                     ( ps.getUntrackedParameter<unsigned int>( "verbosity", 0 ) ),
   EC_difference_56_( -500 ), EC_difference_45_( -500 )
@@ -455,7 +460,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 //           }
 //         }
 //   
-//   if (event.bunchCrossing() > 100) return;
+  if (event.bunchCrossing() > 100) return;
   
   
   //------------------------------
@@ -669,22 +674,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             break;
         }      
         
-        // FED BX monitoring (for MINIDAQ)
-        for ( const auto& fit : *fedInfo ) {
-          if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-            switch ( rechit.getOOTIndex() - centralOOT_ ) {
-              case -1: 
-                potPlots_[detId_pot].activity_per_fedbx_minus1->Fill( fit.getBX() );
-                break;
-              case 0: 
-                potPlots_[detId_pot].activity_per_fedbx->Fill( fit.getBX() );
-                break;
-              case 1: 
-                potPlots_[detId_pot].activity_per_fedbx_plus1->Fill( fit.getBX() );
-                break;
-            }
-          }
-        }
+//         // FED BX monitoring (for MINIDAQ)
+//         for ( const auto& fit : *fedInfo ) {
+//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
+//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
+//               case -1: 
+//                 potPlots_[detId_pot].activity_per_fedbx_minus1->Fill( fit.getBX() );
+//                 break;
+//               case 0: 
+//                 potPlots_[detId_pot].activity_per_fedbx->Fill( fit.getBX() );
+//                 break;
+//               case 1: 
+//                 potPlots_[detId_pot].activity_per_fedbx_plus1->Fill( fit.getBX() );
+//                 break;
+//             }
+//           }
+//         }
       } // End if (complete hits)
     }
   }
@@ -742,7 +747,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         for ( const auto& striplt : ds ) {
           if ( !striplt.isValid() ) continue;
           if ( stripId.arm() != detId_pot.arm() ) continue;
-          if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_) continue; 
+          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             switch ( rechit.getOOTIndex() - centralOOT_ ) {
               case -1: {
@@ -756,19 +762,19 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
               } break;
             }
           }
-          else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-            switch ( rechit.getOOTIndex() - centralOOT_ ) {
-              case -1: {
-                potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-              case 0: {
-                potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-              case 1: {
-                potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
-              } break;
-            }
-          }
+//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
+//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
+//               case -1: {
+//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//               } break;
+//               case 0: {
+//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//               } break;
+//               case 1: {
+//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//               } break;
+//             }
+//           }
         }
       }
     }
@@ -813,7 +819,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( planePlots_.find( detId_plane ) == planePlots_.end() ) continue;
 
-      planePlots_[detId_plane].threshold_voltage->Fill( detId.channel(), digi.getThresholdVoltage() );
+//       planePlots_[detId_plane].threshold_voltage->Fill( detId.channel(), digi.getThresholdVoltage() );
 
       if ( digi.getLeadingEdge() != 0 ) {
         planePlots_[detId_plane].digiProfileCumulativePerPlane->Fill( detId.channel() );
@@ -862,13 +868,14 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         for ( const auto& striplt : ds ) {
           if (! striplt.isValid()) continue;
           if ( stripId.arm() != detId_plane.arm() ) continue;
-          if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_ ) continue;
+          if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+          if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
           }
-          else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
-          }
+//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
+//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
+//           }
         }
       }
     }
@@ -911,14 +918,14 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 4 );
       }
             
-      // FED BX monitoring (for MINIDAQ)
-      for ( const auto& fit : *fedInfo ) {
-        if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-          if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
-            channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-          }
-        }
-      }
+//       // FED BX monitoring (for MINIDAQ)
+//       for ( const auto& fit : *fedInfo ) {
+//         if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
+//           if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
+//             channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
+//           }
+//         }
+//       }
     }
   }
   
@@ -949,22 +956,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             channelPlots_[detId].activity_per_bx_plus1->Fill( event.bunchCrossing() );
           } break;
         }
-        // FED BX monitoring (for MINIDAQ)
-        for ( const auto& fit : *fedInfo ) {
-          if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-            switch ( rechit.getOOTIndex() - centralOOT_ ) {
-              case -1: {
-                channelPlots_[detId].activity_per_fedbx_minus1->Fill( fit.getBX() );
-              } break;
-              case 0: {
-                channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-              } break;
-              case 1: {
-                channelPlots_[detId].activity_per_fedbx_plus1->Fill( fit.getBX() );
-              } break;
-            }
-          }
-        }
+//         // FED BX monitoring (for MINIDAQ)
+//         for ( const auto& fit : *fedInfo ) {
+//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
+//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
+//               case -1: {
+//                 channelPlots_[detId].activity_per_fedbx_minus1->Fill( fit.getBX() );
+//               } break;
+//               case 0: {
+//                 channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
+//               } break;
+//               case 1: {
+//                 channelPlots_[detId].activity_per_fedbx_plus1->Fill( fit.getBX() );
+//               } break;
+//             }
+//           }
+//         }
       }
     }
     
@@ -982,13 +989,14 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             CTPPSDetId stripId(ds.detId());
             if ( !striplt.isValid() ) continue;
             if ( stripId.arm() != detId.arm() ) continue;
-            if ( striplt.getTx() > minimumStripAngleForTomography_ || striplt.getTy() > minimumStripAngleForTomography_ ) continue;
+            if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
+            if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
               channelPlots_[detId].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
             }
-            else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
-            }
+//             else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
+//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
+//             }
           }
         }
       }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -39,7 +39,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
   public:
     CTPPSDiamondDQMSource( const edm::ParameterSet& );
     virtual ~CTPPSDiamondDQMSource();
-  
+
   protected:
     void dqmBeginRun( const edm::Run&, const edm::EventSetup& ) override;
     void bookHistograms( DQMStore::IBooker&, const edm::Run&, const edm::EventSetup& ) override;
@@ -87,16 +87,13 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     };
 
     GlobalPlots globalPlot_;
-    
+
     /// plots related to one Diamond detector package
     struct PotPlots
     {
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-//       MonitorElement* activity_per_fedbx = NULL;
-//       MonitorElement* activity_per_fedbx_plus1 = NULL;
-//       MonitorElement* activity_per_fedbx_minus1 = NULL;
 
       MonitorElement* hitDistribution2d = NULL;
       MonitorElement* hitDistribution2dOOT = NULL;
@@ -110,9 +107,6 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* stripTomographyAllFar = NULL;
       MonitorElement* stripTomographyAllFar_plus1 = NULL;
       MonitorElement* stripTomographyAllFar_minus1 = NULL;
-//       MonitorElement* stripTomographyAllNear = NULL;
-//       MonitorElement* stripTomographyAllNear_plus1 = NULL;
-//       MonitorElement* stripTomographyAllNear_minus1 = NULL;
 
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* timeOverThresholdCumulativePot = NULL, *leadingTrailingCorrelationPot = NULL;
@@ -140,10 +134,8 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* digiProfileCumulativePerPlane = NULL;
       MonitorElement* hitProfile = NULL;
       MonitorElement* hit_multiplicity = NULL;
-//       MonitorElement* threshold_voltage = NULL;
 
       MonitorElement* stripTomography_far = NULL;
-//       MonitorElement* stripTomography_near = NULL;
 
       PlanePlots() {}
       PlanePlots( DQMStore::IBooker& ibooker, unsigned int id );
@@ -157,18 +149,13 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
       MonitorElement* activity_per_bx = NULL;
       MonitorElement* activity_per_bx_plus1 = NULL;
       MonitorElement* activity_per_bx_minus1 = NULL;
-//       MonitorElement* activity_per_fedbx = NULL;
-//       MonitorElement* activity_per_fedbx_plus1 = NULL;
-//       MonitorElement* activity_per_fedbx_minus1 = NULL;
-      
+
       MonitorElement* HPTDCErrorFlags = NULL;
       MonitorElement* leadingEdgeCumulative_both = NULL, *leadingEdgeCumulative_le = NULL;
       MonitorElement* TimeOverThresholdCumulativePerChannel = NULL;
       MonitorElement* LeadingTrailingCorrelationPerChannel = NULL;
       MonitorElement* leadingWithoutTrailing = NULL;
-//       MonitorElement* efficiency = NULL;
       MonitorElement* stripTomography_far = NULL;
-//       MonitorElement* stripTomography_near = NULL;
       MonitorElement* hit_rate = NULL;
       MonitorElement* ECCheckPerChannel = NULL;
       unsigned long hitsCounterPerLumisection;
@@ -228,9 +215,6 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
 
   hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
@@ -242,13 +226,8 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
   stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-
   stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-
   stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
-//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 ); 
 
   leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
   leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
@@ -290,10 +269,7 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
-//   threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
-
   stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
-//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -315,11 +291,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   activity_per_bx = ibooker.book1D( "activity per BX", title+" activity per BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx = ibooker.book1D( "activity per FED BX", title+" activity per FED BX;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_plus1 = ibooker.book1D( "activity per FED BX OOT +1", title+" activity per FED BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-//   activity_per_fedbx_minus1 = ibooker.book1D( "activity per FED BX OOT -1", title+" activity per FED BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
-  
-  
+
   HPTDCErrorFlags = ibooker.book1D( "hptdc_Errors", title+" HPTDC Errors", 16, -0.5, 16.5 );
   for ( unsigned short error_index=1; error_index<16; ++error_index )
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
@@ -333,8 +305,7 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
 
   stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
-//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
-  
+
   hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 10, 0, 100 );
 }
 
@@ -350,7 +321,7 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource( const edm::ParameterSet& ps ) :
   excludeMultipleHits_           ( ps.getParameter<bool>( "excludeMultipleHits" ) ),
   minimumStripAngleForTomography_( ps.getParameter<double>( "minimumStripAngleForTomography" ) ),
   maximumStripAngleForTomography_( ps.getParameter<double>( "maximumStripAngleForTomography" ) ),
-  centralOOT_( ps.getParameter<int>( "centralOOT" ) ),
+  centralOOT_                    ( ps.getParameter<int>( "centralOOT" ) ),
   verbosity_                     ( ps.getUntrackedParameter<unsigned int>( "verbosity", 0 ) ),
   EC_difference_56_( -500 ), EC_difference_45_( -500 )
 {}
@@ -373,7 +344,7 @@ CTPPSDiamondDQMSource::bookHistograms( DQMStore::IBooker& ibooker, const edm::Ru
 {
   ibooker.cd();
   ibooker.setCurrentFolder( "CTPPS" );
-  
+
   globalPlot_= GlobalPlots( ibooker );
 
   for ( unsigned short arm = 0; arm < CTPPS_NUM_OF_ARMS; ++arm ) {
@@ -450,13 +421,13 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   // RP Plots
   //------------------------------  
 
-//   if (event.bunchCrossing() > 100) return;
-  
-  
+  //   if (event.bunchCrossing() > 100) return;
+
+
   //------------------------------
   // Correlation Plots
   //------------------------------
-  
+
   for ( const auto& ds1 : *stripTracks ) {
     for ( const auto& tr1 : ds1 ) {
       if ( ! tr1.isValid() )  continue;
@@ -566,20 +537,22 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_56_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_56_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_56_ != 1 && EC_difference_56_ != -500 && EC_difference_56_ < 128 && EC_difference_56_ > -128 )
-            if (verbosity_) edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
-                                                                      << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
-                                                                      << "\twith ID: " << std::dec << detId
-                                                                      << "\tdiff: " <<  EC_difference_56_;
+            if (verbosity_)
+              edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_56 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
+                << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
+                << "\twith ID: " << std::dec << detId
+                << "\tdiff: " <<  EC_difference_56_;
         }
         else if ( detId.arm() == 0 && optorx.getFEDId()== CTPPS_FED_ID_45 ) {
           potPlots_[detId_pot].ECCheck->Fill((int)((optorx.getLV1()& 0xFF)-status.getEC()) & 0xFF);
           if ( ( static_cast<int>( ( optorx.getLV1() & 0xFF )-status.getEC() ) != EC_difference_45_ ) && ( static_cast<uint8_t>( ( optorx.getLV1() & 0xFF )-status.getEC() ) < 128 ) )
             EC_difference_45_ = static_cast<int>( optorx.getLV1() & 0xFF )-( static_cast<unsigned int>( status.getEC() ) & 0xFF );
           if ( EC_difference_45_ != 1 && EC_difference_45_ != -500 && EC_difference_45_ < 128 && EC_difference_45_ > -128 )
-            if (verbosity_) edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
-                                                                      << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
-                                                                      << "\twith ID: " << std::dec << detId
-                                                                      << "\tdiff: " <<  EC_difference_45_;
+            if (verbosity_)
+              edm::LogProblem("CTPPSDiamondDQMSource")  << "FED " << CTPPS_FED_ID_45 << ": ECError at EV: 0x"<< std::hex << optorx.getLV1()
+                << "\t\tVFAT EC: 0x"<< static_cast<unsigned int>( status.getEC() )
+                << "\twith ID: " << std::dec << detId
+                << "\tdiff: " <<  EC_difference_45_;
         }
       }
     }
@@ -602,7 +575,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
 
       float UFSDShift = 0.0;
       if ( rechit.getYWidth() < 3 ) UFSDShift = 0.5;  // Display trick for UFSD that have 2 pixels with same X
-        
+
       if ( rechit.getToT() != 0 && rechit.getOOTIndex() == centralOOT_ ) {
         TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
         TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
@@ -612,7 +585,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           hitHistoTmp->Fill( detId.plane(), hitHistoTmpYAxis->GetBinCenter(startBin+i) + UFSDShift );
         }
       }
-      
+
       if ( rechit.getToT() != 0 ) {
         // Both
         potPlots_[detId_pot].leadingEdgeCumulative_both->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
@@ -640,7 +613,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         else {
           // Only leading
           potPlots_[detId_pot].leadingEdgeCumulative_le->Fill( rechit.getT() + 25*rechit.getOOTIndex() );
-          
+
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
@@ -650,7 +623,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           }
         }
       }
-      
+
       if ( rechit.getToT() != 0 ) {
         switch ( rechit.getOOTIndex() - centralOOT_ ) {
           case -1:
@@ -663,31 +636,15 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             potPlots_[detId_pot].activity_per_bx_plus1->Fill( event.bunchCrossing() );
             break;
         }      
-        
-//         // FED BX monitoring (for MINIDAQ)
-//         for ( const auto& fit : *fedInfo ) {
-//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
-//               case -1: 
-//                 potPlots_[detId_pot].activity_per_fedbx_minus1->Fill( fit.getBX() );
-//                 break;
-//               case 0: 
-//                 potPlots_[detId_pot].activity_per_fedbx->Fill( fit.getBX() );
-//                 break;
-//               case 1: 
-//                 potPlots_[detId_pot].activity_per_fedbx_plus1->Fill( fit.getBX() );
-//                 break;
-//             }
-//           }
-//         }
+
       } // End if (complete hits)
     }
   }
-  
+
   for ( const auto& plt : potPlots_ ) {
     plt.second.activePlanes->Fill( planes[plt.first].size() );
   }
-  
+
   // Using CTPPSDiamondLocalTrack
   for ( const auto& tracks : *diamondLocalTracks ) {
     CTPPSDiamondDetId detId_pot( tracks.detId() );
@@ -707,7 +664,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       for ( int i=0; i<numOfBins; ++i) {
         trackHistoOOTTmp->Fill( track.getOOTIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
       }
-      
+
       if ( track.getOOTIndex() == centralOOT_ ) {
         TH1F *trackHistoInTimeTmp = potPlots_[detId_pot].trackDistribution->getTH1F();
         int startBin = trackHistoInTimeTmp->FindBin( track.getX0() - track.getX0Sigma() );
@@ -718,7 +675,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       }
     }
   }
-  
+
   // Tomography of diamonds using strips
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_pot( rechits.detId() );
@@ -752,19 +709,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
               } break;
             }
           }
-//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
-//               case -1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-//               } break;
-//               case 0: {
-//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-//               } break;
-//               case 1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
-//               } break;
-//             }
-//           }
         }
       }
     }
@@ -809,8 +753,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( detId.channel() == CHANNEL_OF_VFAT_CLOCK ) continue;
       if ( planePlots_.find( detId_plane ) == planePlots_.end() ) continue;
 
-//       planePlots_[detId_plane].threshold_voltage->Fill( detId.channel(), digi.getThresholdVoltage() );
-
       if ( digi.getLeadingEdge() != 0 ) {
         planePlots_[detId_plane].digiProfileCumulativePerPlane->Fill( detId.channel() );
         if ( channelsPerPlane.find(detId_plane) != channelsPerPlane.end() ) channelsPerPlane[detId_plane]++;
@@ -822,7 +764,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   for ( const auto& plt : channelsPerPlane ) {
     planePlots_[plt.first].hit_multiplicity->Fill( plt.second );
   }
-  
+
   // Using CTPPSDiamondRecHit
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId_plane( rechits.detId() );
@@ -852,7 +794,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( rechit.getToT() == 0 ) continue;
       if ( !stripTracks.isValid() ) continue;
       if (planePlots_.find(detId_plane) == planePlots_.end()) continue;
-      
+
       for ( const auto& ds : *stripTracks ) {
         const CTPPSDetId stripId(ds.detId());
         for ( const auto& striplt : ds ) {
@@ -863,9 +805,6 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
           }
-//           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
-//           }
         }
       }
     }
@@ -907,18 +846,9 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         else if ( digi.getLeadingEdge() == 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 3 );
         else if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) channelPlots_[detId].leadingWithoutTrailing->Fill( 4 );
       }
-            
-//       // FED BX monitoring (for MINIDAQ)
-//       for ( const auto& fit : *fedInfo ) {
-//         if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//           if ( digi.getLeadingEdge() != 0 && digi.getTrailingEdge() != 0 ) {
-//             channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-//           }
-//         }
-//       }
     }
   }
-  
+
   // Using CTPPSDiamondRecHit
   for ( const auto& rechits : *diamondRecHits ) {
     CTPPSDiamondDetId detId( rechits.detId() );
@@ -933,7 +863,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         channelPlots_[detId].LeadingTrailingCorrelationPerChannel->Fill( rechit.getT() + 25*rechit.getOOTIndex(), rechit.getT() + 25*rechit.getOOTIndex() + rechit.getToT() );
         ++(channelPlots_[detId].hitsCounterPerLumisection);
       }
-    
+
       if ( rechit.getToT() != 0 ) {
         switch ( rechit.getOOTIndex() - centralOOT_ ) {
           case -1: {
@@ -946,27 +876,11 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             channelPlots_[detId].activity_per_bx_plus1->Fill( event.bunchCrossing() );
           } break;
         }
-//         // FED BX monitoring (for MINIDAQ)
-//         for ( const auto& fit : *fedInfo ) {
-//           if ( ( detId.arm() == 1 && fit.getFEDId() == CTPPS_FED_ID_56 ) || ( detId.arm() == 0 && fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//             switch ( rechit.getOOTIndex() - centralOOT_ ) {
-//               case -1: {
-//                 channelPlots_[detId].activity_per_fedbx_minus1->Fill( fit.getBX() );
-//               } break;
-//               case 0: {
-//                 channelPlots_[detId].activity_per_fedbx->Fill( fit.getBX() );
-//               } break;
-//               case 1: {
-//                 channelPlots_[detId].activity_per_fedbx_plus1->Fill( fit.getBX() );
-//               } break;
-//             }
-//           }
-//         }
       }
     }
-    
+
   }
-  
+
   // Tomography of diamonds using strips
   for ( const auto& rechits : *diamondRecHits ) {
     const CTPPSDiamondDetId detId( rechits.detId() );
@@ -984,15 +898,11 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
               channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
             }
-//             else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
-//             }
           }
         }
       }
     }
   }
-  
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -632,10 +632,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           case 0:
             potPlots_[detId_pot].activity_per_bx->Fill( event.bunchCrossing() );
             break;
-          case 1: 
+          case 1:
             potPlots_[detId_pot].activity_per_bx_plus1->Fill( event.bunchCrossing() );
             break;
-        }      
+        }
 
       } // End if (complete hits)
     }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -54,6 +54,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
     static const double SEC_PER_LUMI_SECTION;                   // Number of seconds per lumisection: used to compute hit rates in Hz
     static const int CHANNEL_OF_VFAT_CLOCK;                     // Channel ID of the VFAT that contains clock data
     static const double DISPLAY_RESOLUTION_FOR_HITS_MM;         // Bin width of histograms showing hits and tracks (in mm)
+    static const double INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
     static const double HPTDC_BIN_WIDTH_NS;                        // ns per HPTDC bin
     static const int CTPPS_NUM_OF_ARMS;
     static const int CTPPS_DIAMOND_STATION_ID;
@@ -175,6 +176,7 @@ class CTPPSDiamondDQMSource : public DQMEDAnalyzer
 const double    CTPPSDiamondDQMSource::SEC_PER_LUMI_SECTION = 23.31;
 const int       CTPPSDiamondDQMSource::CHANNEL_OF_VFAT_CLOCK = 30;
 const double    CTPPSDiamondDQMSource::DISPLAY_RESOLUTION_FOR_HITS_MM = 0.1;
+const double    CTPPSDiamondDQMSource::INV_DISPLAY_RESOLUTION_FOR_HITS_MM = 1./DISPLAY_RESOLUTION_FOR_HITS_MM;
 const double    CTPPSDiamondDQMSource::HPTDC_BIN_WIDTH_NS = 25./1024;
 const int       CTPPSDiamondDQMSource::CTPPS_NUM_OF_ARMS = 2;
 const int       CTPPSDiamondDQMSource::CTPPS_DIAMOND_STATION_ID = 1;
@@ -218,14 +220,14 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   activity_per_bx_plus1 = ibooker.book1D( "activity per BX OOT +1", title+" activity per BX OOT +1;Event.BX", 4002, -1.5, 4000. + 0.5 );
   activity_per_bx_minus1 = ibooker.book1D( "activity per BX OOT -1", title+" activity per BX OOT -1;Event.BX", 4002, -1.5, 4000. + 0.5 );
 
-  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  hitDistribution2dOOT_te= ibooker.book2D( "hits with OOT in planes (te only)", title+" hits with OOT in planes (te only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2d = ibooker.book2D( "hits in planes", title+" hits in planes;plane number;x (mm)", 10, -0.5, 4.5, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT= ibooker.book2D( "hits with OOT in planes", title+" hits with OOT in planes;plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT_le= ibooker.book2D( "hits with OOT in planes (le only)", title+" hits with OOT in planes (le only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitDistribution2dOOT_te= ibooker.book2D( "hits with OOT in planes (te only)", title+" hits with OOT in planes (te only);plane number + 0.1 OOT;x (mm)", 41, -0.1, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   activePlanes = ibooker.book1D( "active planes", title+" active planes;number of active planes", 6, -0.5, 5.5 );
 
-  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
-  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
   stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
   stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
@@ -268,7 +270,7 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
   CTPPSDiamondDetId( id ).planeName( title, CTPPSDiamondDetId::nFull );
 
   digiProfileCumulativePerPlane = ibooker.book1D( "digi profile", title+" digi profile; ch number", 12, -0.5, 11.5 );
-  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
+  hitProfile = ibooker.book1D( "hit profile", title+" hit profile;x (mm)", 19.*INV_DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   hit_multiplicity = ibooker.book1D( "channels per plane", title+" channels per plane; ch per plane", 13, -0.5, 12.5 );
 
   stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
@@ -593,7 +595,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         TH2F *hitHistoTmp = potPlots_[detId_pot].hitDistribution2d->getTH2F();
         TAxis *hitHistoTmpYAxis = hitHistoTmp->GetYaxis();
         int startBin = hitHistoTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-        int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoTmp->Fill( detId.plane(), hitHistoTmpYAxis->GetBinCenter(startBin+i) + UFSDShift );
         }
@@ -607,7 +609,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT->getTH2F();
         TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
         int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-        int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
         }
@@ -618,7 +620,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_te->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-          int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
           }
@@ -630,7 +632,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           TH2F *hitHistoOOTTmp = potPlots_[detId_pot].hitDistribution2dOOT_le->getTH2F();
           TAxis *hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
           int startBin = hitHistoOOTTmpYAxis->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-          int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoOOTTmp->Fill( detId.plane() + 0.1 * rechit.getOOTIndex(), hitHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
           }
@@ -673,7 +675,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       TH2F *trackHistoOOTTmp = potPlots_[detId_pot].trackDistributionOOT->getTH2F();
       TAxis *trackHistoOOTTmpYAxis = trackHistoOOTTmp->GetYaxis();
       int startBin = trackHistoOOTTmpYAxis->FindBin( track.getX0() - track.getX0Sigma() );
-      int numOfBins = 2*track.getX0Sigma()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+      int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
       for ( int i=0; i<numOfBins; ++i) {
         trackHistoOOTTmp->Fill( track.getOOTIndex(), trackHistoOOTTmpYAxis->GetBinCenter(startBin+i) );
       }
@@ -681,7 +683,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
       if ( centralOOT_ != -999 && track.getOOTIndex() == centralOOT_ ) {
         TH1F *trackHistoInTimeTmp = potPlots_[detId_pot].trackDistribution->getTH1F();
         int startBin = trackHistoInTimeTmp->FindBin( track.getX0() - track.getX0Sigma() );
-        int numOfBins = 2*track.getX0Sigma()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+        int numOfBins = 2*track.getX0Sigma()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for ( int i=0; i<numOfBins; ++i) {
           trackHistoInTimeTmp->Fill( trackHistoInTimeTmp->GetBinCenter(startBin+i) );
         }
@@ -789,7 +791,7 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
         if ( centralOOT_ != -999 && rechit.getOOTIndex() == centralOOT_ ) {
           TH1F *hitHistoTmp = planePlots_[detId_plane].hitProfile->getTH1F();
           int startBin = hitHistoTmp->FindBin( rechit.getX() - 0.5*rechit.getXWidth() );
-          int numOfBins = rechit.getXWidth()/DISPLAY_RESOLUTION_FOR_HITS_MM;
+          int numOfBins = rechit.getXWidth()*INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
           for ( int i=0; i<numOfBins; ++i) {
             hitHistoTmp->Fill( hitHistoTmp->GetBinCenter(startBin+i) );
           }

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -241,18 +241,18 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
   trackDistribution = ibooker.book1D( "tracks", title+" tracks;x (mm)", 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
   trackDistributionOOT = ibooker.book2D( "tracks with OOT", title+" tracks with OOT;plane number;x (mm)", 9, -0.5, 4, 19./DISPLAY_RESOLUTION_FOR_HITS_MM, -1, 18 );
 
-  stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+  stripTomographyAllFar = ibooker.book2D( "tomography all far", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+//   stripTomographyAllNear = ibooker.book2D( "tomography all near", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
 
-  stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
+  stripTomographyAllFar_plus1 = ibooker.book2D( "tomography all far OOT +1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+//   stripTomographyAllNear_plus1 = ibooker.book2D( "tomography all near OOT +1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
 
-  stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );
-//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 50*plane(mm);y (mm)", 200, 0, 200, 100, -50, 50 );  
+  stripTomographyAllFar_minus1 = ibooker.book2D( "tomography all far OOT -1", title+" tomography with strips far (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 );
+//   stripTomographyAllNear_minus1 = ibooker.book2D( "tomography all near OOT -1", title+" tomography with strips near (all planes);x + 25*plane(mm);y (mm)", 100, 0, 100, 24, -2, 10 ); 
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 300, -100, 200 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 300, -100, 200 );
-  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -50, 50 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge (le and te); leading edge (ns)", 125, 0, 125 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge (le only); leading edge (ns)", 125, 0, 125 );
+  timeOverThresholdCumulativePot = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
   leadingTrailingCorrelationPot = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
 
   leadingWithoutTrailingCumulativePot = ibooker.book1D( "leading edges without trailing", title+" leading edges without trailing;leading edges without trailing", 4, 0.5, 4.5 );
@@ -270,10 +270,10 @@ CTPPSDiamondDQMSource::PotPlots::PotPlots( DQMStore::IBooker& ibooker, unsigned 
 
 
   ibooker.setCurrentFolder( path+"/clock/" );
-  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 1000, 0, 100 );
-  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 100, 0, 100 );
-  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 5000, 0, 100 );
-  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 100, 0, 100 );
+  clock_Digi1_le = ibooker.book1D( "clock1 leading edge", title+" clock1;leading edge (ns)", 125, 0, 125 );
+  clock_Digi1_te = ibooker.book1D( "clock1 trailing edge", title+" clock1;trailing edge (ns)", 125, 0, 125 );
+  clock_Digi3_le = ibooker.book1D( "clock3 leading edge", title+" clock3;leading edge (ns)", 1000, 0, 125 );
+  clock_Digi3_te = ibooker.book1D( "clock3 trailing edge", title+" clock3;trailing edge (ns)", 125, 0, 125 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -292,8 +292,8 @@ CTPPSDiamondDQMSource::PlanePlots::PlanePlots( DQMStore::IBooker& ibooker, unsig
 
 //   threshold_voltage = ibooker.book2D( "threshold I2C", title+" threshold I2C; channel; value", 12, -0.5, 11.5, 512, 0, 512 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
-//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 50 OOT (mm);y (mm)", 50, 0, 50, 150, -50, 100 );
+  stripTomography_far = ibooker.book2D( "tomography far", title+" tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+//   stripTomography_near = ibooker.book2D( "tomography near", title+" tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -325,17 +325,17 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots( DQMStore::IBooker& ibooker, u
     HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( error_index, HPTDCErrorFlags::getHPTDCErrorName( error_index-1 ).c_str() );
   HPTDCErrorFlags->getTH1F()->GetXaxis()->SetBinLabel( 16, "MH" );
 
-  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 300, -100, 200 );
-  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 300, -100, 200 );
-  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 200, -100, 100 );
+  leadingEdgeCumulative_both = ibooker.book1D( "leading edge (le and te)", title+" leading edge; leading edge (ns)", 100, 0, 200 );
+  leadingEdgeCumulative_le = ibooker.book1D( "leading edge (le only)", title+" leading edge; leading edge (ns)", 200, 0, 200 );
+  TimeOverThresholdCumulativePerChannel = ibooker.book1D( "time over threshold", title+" time over threshold;time over threshold (ns)", 100, -100, 100 );
   LeadingTrailingCorrelationPerChannel = ibooker.book2D( "leading trailing correlation", title+" leading trailing correlation;leading edge (ns);trailing edge (ns)", 100, 0, 100, 100, 0, 100 );
 
   ECCheckPerChannel = ibooker.book1D("optorxEC(8bit) - vfatEC vs optorxEC", title+" EC Error;optorxEC-vfatEC", 512, -256, 256 );
 
-  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
-//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 50 OOT (mm);y (mm)", 200, -50, 150, 150, -50, 100 );
+  stripTomography_far = ibooker.book2D( "tomography far", "tomography with strips far;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
+//   stripTomography_near = ibooker.book2D( "tomography near", "tomography with strips near;x + 25 OOT (mm);y (mm)", 150, -50, 100, 24, -2, 10 );
   
-  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 1000, 0, 100 );
+  hit_rate = ibooker.book1D( "hit rate", title+"hit rate;rate (Hz)", 10, 0, 100 );
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -449,18 +449,8 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
   //------------------------------
   // RP Plots
   //------------------------------  
-  
-    // FED BX monitoring (for MINIDAQ)
-//       for ( const auto& fit : *fedInfo ) {
-// //         std::cout<<"FED BX pre "<< fit.getBX()  <<std::endl;
-//         if ( ( fit.getFEDId() == CTPPS_FED_ID_56 ) || ( fit.getFEDId() == CTPPS_FED_ID_45 ) ) {
-//           if ( (int) fit.getBX() > 100 ) return;
-// //           if ( (int) fit.getBX() > 990 and (int) fit.getBX() < 1100 ) return;
-// //           if ( (int) fit.getBX() < 775 or (int) fit.getBX() > 815 ) return;
-//           }
-//         }
-//   
-  if (event.bunchCrossing() > 100) return;
+
+//   if (event.bunchCrossing() > 100) return;
   
   
   //------------------------------
@@ -752,26 +742,26 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
             switch ( rechit.getOOTIndex() - centralOOT_ ) {
               case -1: {
-                potPlots_[detId_pot].stripTomographyAllFar_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
               case 0: {
-                potPlots_[detId_pot].stripTomographyAllFar->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
               case 1: {
-                potPlots_[detId_pot].stripTomographyAllFar_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+                potPlots_[detId_pot].stripTomographyAllFar_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
               } break;
             }
           }
 //           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
 //             switch ( rechit.getOOTIndex() - centralOOT_ ) {
 //               case -1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//                 potPlots_[detId_pot].stripTomographyAllNear_minus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
 //               } break;
 //               case 0: {
-//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//                 potPlots_[detId_pot].stripTomographyAllNear->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
 //               } break;
 //               case 1: {
-//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 50*detId.plane(), striplt.getY0() );
+//                 potPlots_[detId_pot].stripTomographyAllNear_plus1->Fill( striplt.getX0() + 25*detId.plane(), striplt.getY0() );
 //               } break;
 //             }
 //           }
@@ -871,10 +861,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
           if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
           if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
           if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
+            planePlots_[detId_plane].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
           }
 //           else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*(rechit.getOOTIndex() - centralOOT_ +1) );
+//             planePlots_[detId_plane].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
 //           }
         }
       }
@@ -992,10 +982,10 @@ CTPPSDiamondDQMSource::analyze( const edm::Event& event, const edm::EventSetup& 
             if ( striplt.getTx() > maximumStripAngleForTomography_ || striplt.getTy() > maximumStripAngleForTomography_) continue;
             if ( striplt.getTx() < minimumStripAngleForTomography_ || striplt.getTy() < minimumStripAngleForTomography_) continue;
             if ( stripId.rp() == CTPPS_FAR_RP_ID ) {
-              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
+              channelPlots_[detId].stripTomography_far->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
             }
 //             else if ( stripId.rp() == CTPPS_NEAR_RP_ID ) {
-//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0(), striplt.getY0() + 50*( rechit.getOOTIndex() - centralOOT_ +1 ) );
+//               channelPlots_[detId].stripTomography_near->Fill( striplt.getX0() + 25*(rechit.getOOTIndex() - centralOOT_ +1), striplt.getY0() );
 //             }
           }
         }

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -9,7 +9,8 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
     
     excludeMultipleHits = cms.bool(True),
-    minimumStripAngleForTomography = cms.double(1e-3),
+    minimumStripAngleForTomography = cms.double(1),
+    centralOOT = cms.int32(2),
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -16,7 +16,7 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
         # 2016, after TS2
         cms.PSet(
             validityRange = cms.EventRange("1:min - 292520:max"),
-            centralOOT = cms.int32(-1),
+            centralOOT = cms.int32(-999), # no cut on OOT index
         ),
         # 2017
         cms.PSet(

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -9,8 +9,9 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
     
     excludeMultipleHits = cms.bool(True),
-    minimumStripAngleForTomography = cms.double(1),
-    centralOOT = cms.int32(2),
+    minimumStripAngleForTomography = cms.double(0),
+    maximumStripAngleForTomography = cms.double(1),
+    centralOOT = cms.int32(3),
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -11,7 +11,19 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     excludeMultipleHits = cms.bool(True),
     minimumStripAngleForTomography = cms.double(0),
     maximumStripAngleForTomography = cms.double(1),
-    centralOOT = cms.int32(3),
+
+    offsetsOOT = cms.VPSet(
+        # 2016, after TS2
+        cms.PSet(
+            validityRange = cms.EventRange("1:min - 292520:max"),
+            centralOOT = cms.int32(-1),
+        ),
+        # 2017
+        cms.PSet(
+            validityRange = cms.EventRange("292521:min - 999999999:max"),
+            centralOOT = cms.int32(3),
+        ),
+    ),
   
     verbosity = cms.untracked.uint32(10),
 )

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -12,11 +12,11 @@ ctppsDiamondDQMSource = cms.EDAnalyzer("CTPPSDiamondDQMSource",
     minimumStripAngleForTomography = cms.double(0),
     maximumStripAngleForTomography = cms.double(1),
 
-    offsetsOOT = cms.VPSet(
+    offsetsOOT = cms.VPSet( # cut on the OOT bin for physics hits
         # 2016, after TS2
         cms.PSet(
             validityRange = cms.EventRange("1:min - 292520:max"),
-            centralOOT = cms.int32(-999), # no cut on OOT index
+            centralOOT = cms.int32(1),
         ),
         # 2017
         cms.PSet(

--- a/DQM/CTPPS/test/diamond_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_cfg.py
@@ -26,7 +26,8 @@ process.dqmSaver.tag = "CTPPS"
 process.source = cms.Source("NewEventStreamFileReader",
   fileNames = cms.untracked.vstring(
     #'file:/afs/cern.ch/user/j/jkaspar/public/run273062_ls0001-2_stream.root'
-    '/store/t0streamer/Data/Physics/000/294/737/run294737_ls0011_streamPhysics_StorageManager.dat',
+    #'/store/t0streamer/Data/Physics/000/294/737/run294737_ls0011_streamPhysics_StorageManager.dat',
+    '/store/t0streamer/Minidaq/A/000/295/626/run295626_ls0001_streamA_StorageManager.dat',
   )
 )
 

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -39,7 +39,7 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const e
       const int time_slice = ( t-t_shift_ ) / 1024;
 
       int tot = 0;
-      if ( i==0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
+      if ( t!=0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
                                               ( t0 * ts_to_ns_ ),

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -18,10 +18,9 @@ CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm( const 
 void
 CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const edm::DetSetVector<CTPPSDiamondDigi>& input, edm::DetSetVector<CTPPSDiamondRecHit>& output )
 {
-  for ( edm::DetSetVector<CTPPSDiamondDigi>::const_iterator vec = input.begin(); vec != input.end(); ++vec )
-  {
+  for ( edm::DetSetVector<CTPPSDiamondDigi>::const_iterator vec = input.begin(); vec != input.end(); ++vec ) {
     const CTPPSDiamondDetId detid( vec->detId() );
-    
+
     if ( detid.channel() > 20 ) continue;              // VFAT-like information, to be ignored by CTPPSDiamondRecHitProducer
 
     const DetGeomDesc* det = geom->GetDetector( detid );
@@ -32,16 +31,15 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const e
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );
 
-    for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi )
-    {
+    for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi ) {
       if ( digi->getLeadingEdge()==0 and digi->getTrailingEdge()==0 ) { continue; }
-      
+
       const int t = digi->getLeadingEdge();
       const int t0 = ( t-t_shift_ ) % 1024;
       const int time_slice = ( t-t_shift_ ) / 1024;
-                
+
       int tot = 0;
-      if (t!=0 and digi->getTrailingEdge()!=0) tot = ( (int) digi->getTrailingEdge() ) -t;
+      if ( i==0 && digi->getTrailingEdge()!=0 ) tot = ( (int) digi->getTrailingEdge() ) - t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
                                               ( t0 * ts_to_ns_ ),

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -34,15 +34,18 @@ CTPPSDiamondRecHitProducerAlgorithm::build( const TotemRPGeometry* geom, const e
 
     for ( edm::DetSet<CTPPSDiamondDigi>::const_iterator digi = vec->begin(); digi != vec->end(); ++digi )
     {
+      if ( digi->getLeadingEdge()==0 and digi->getTrailingEdge()==0 ) { continue; }
+      
       const int t = digi->getLeadingEdge();
-      if ( t==0 ) { continue; }
-
-      const int t0 = ( t-t_shift_ ) % 1024,
-                time_slice = ( t-t_shift_ ) / 1024;
+      const int t0 = ( t-t_shift_ ) % 1024;
+      const int time_slice = ( t-t_shift_ ) / 1024;
+                
+      int tot = 0;
+      if (t!=0 and digi->getTrailingEdge()!=0) tot = ( (int) digi->getTrailingEdge() ) -t;
 
       rec_hits.push_back( CTPPSDiamondRecHit( x_pos, x_width, y_pos, y_width, // spatial information
                                               ( t0 * ts_to_ns_ ),
-                                              ( digi->getTrailingEdge()-t0 ) * ts_to_ns_,
+                                              ( tot * ts_to_ns_),
                                               time_slice,
                                               digi->getHPTDCErrorFlags(),
                                               digi->getMultipleHit() ) );


### PR DESCRIPTION
Backport of #19185

This PR introduces a set of useful fixes for 2017 data-taking with CTPPS diamond detector, namely:
* a bug fix in the rechits time-over-threshold computation (removed the extra time-slice subtraction)
* lighter DQM source (reduced number of output histograms, coarser binnings)

Needed for data-taking (i.e. asap)