### PR TITLE
Update online beamspot to quadruplet-only and rescale track uncertainties (92X)

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -340,7 +340,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
         process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
         process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
         process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
+        process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 6
         process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
         process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
         process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -132,7 +132,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
     process.pixelVertices.TkFilterParameters.minPt = cms.double(0.9)
     process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
+    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 6
     process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
     process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
     process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -14,28 +14,17 @@ class TrackerTopology;
 
 class PixelFitterByHelixProjections final : public PixelFitterBase {
 public:
-  explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field, const edm::ParameterSet&);
+  explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field,
+                                         bool scaleErrorsForPhaseI, float scaleFactor);
   virtual ~PixelFitterByHelixProjections() {}
   virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
                                            const TrackingRegion& region) const override;
 
 private:
-  /* these are just static and local moved to local namespace in cc .... 
-   *
-  int charge(const std::vector<GlobalPoint> & points) const;
-  float cotTheta(const GlobalPoint& pinner, const GlobalPoint& pouter) const;
-  float phi(float xC, float yC, int charge) const;
-  float pt(float curvature) const;
-  float zip(float d0, float phi_p, float curv, 
-    const GlobalPoint& pinner, const GlobalPoint& pouter) const;
-  double errZip2(float apt, float eta) const;
-  double errTip2(float apt, float eta) const;
-  */
-private:
   const edm::EventSetup *theES;
   const MagneticField *theField;
-  bool thescaleErrorsForPhaseIQuadruplets;
-  float thescaleFactor;
+  const bool thescaleErrorsForPhaseI;
+  const float thescaleFactor;
   TrackerTopology const * theTopo=nullptr;
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -10,11 +10,11 @@
 
 #include <vector>
 
-
+class TrackerTopology;
 
 class PixelFitterByHelixProjections final : public PixelFitterBase {
 public:
-  explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field);
+  explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field, const edm::ParameterSet&);
   virtual ~PixelFitterByHelixProjections() {}
   virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
                                            const TrackingRegion& region) const override;
@@ -34,5 +34,8 @@ private:
 private:
   const edm::EventSetup *theES;
   const MagneticField *theField;
+  bool thescaleErrorsForPhaseIQuadruplets;
+  float thescaleFactor;
+  TrackerTopology const * theTopo=nullptr;
 };
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -15,7 +15,7 @@ class TrackerTopology;
 class PixelFitterByHelixProjections final : public PixelFitterBase {
 public:
   explicit PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field,
-                                         bool scaleErrorsForPhaseI, float scaleFactor);
+                                         bool scaleErrorsForBPix1, float scaleFactor);
   virtual ~PixelFitterByHelixProjections() {}
   virtual std::unique_ptr<reco::Track> run(const std::vector<const TrackingRecHit *>& hits,
                                            const TrackingRegion& region) const override;
@@ -23,7 +23,7 @@ public:
 private:
   const edm::EventSetup *theES;
   const MagneticField *theField;
-  const bool thescaleErrorsForPhaseI;
+  const bool thescaleErrorsForBPix1;
   const float thescaleFactor;
   TrackerTopology const * theTopo=nullptr;
 };

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
@@ -19,7 +19,7 @@
 class PixelFitterByHelixProjectionsProducer: public edm::global::EDProducer<> {
 public:
   explicit PixelFitterByHelixProjectionsProducer(const edm::ParameterSet& iConfig)
-    : thescaleErrorsForPhaseI(iConfig.getParameter<bool>("scaleErrorsForPhaseI"))
+    : thescaleErrorsForBPix1(iConfig.getParameter<bool>("scaleErrorsForBPix1"))
     , thescaleFactor(iConfig.getParameter<double>("scaleFactor"))  {
     produces<PixelFitter>();
   }
@@ -27,14 +27,14 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<bool>("scaleErrorsForPhaseI", false);
-    desc.add<double>("scaleFactor", 0.65);
+    desc.add<bool>("scaleErrorsForBPix1", false);
+    desc.add<double>("scaleFactor", 0.65)->setComment("The default value was derived for phase1 pixel");
     descriptions.add("pixelFitterByHelixProjectionsDefault", desc);
   }
 
 private:
   virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
-  const bool thescaleErrorsForPhaseI;
+  const bool thescaleErrorsForBPix1;
   const float thescaleFactor;
 };
 
@@ -43,7 +43,7 @@ void PixelFitterByHelixProjectionsProducer::produce(edm::StreamID, edm::Event& i
   edm::ESHandle<MagneticField> fieldESH;
   iSetup.get<IdealMagneticFieldRecord>().get(fieldESH);
 
-  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product(), thescaleErrorsForPhaseI, thescaleFactor);
+  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product(), thescaleErrorsForBPix1, thescaleFactor);
   auto prod = std::make_unique<PixelFitter>(std::move(impl));
   iEvent.put(std::move(prod));
 }

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
@@ -18,18 +18,22 @@
 
 class PixelFitterByHelixProjectionsProducer: public edm::global::EDProducer<> {
 public:
-  explicit PixelFitterByHelixProjectionsProducer(const edm::ParameterSet& iConfig) {
+  explicit PixelFitterByHelixProjectionsProducer(const edm::ParameterSet& iConfig)
+    : iConfig_(&iConfig) {
     produces<PixelFitter>();
   }
   ~PixelFitterByHelixProjectionsProducer() {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    descriptions.add("pixelFitterByHelixProjections", desc);
+    desc.add<bool>("scaleErrorsForPhaseIQuadruplets", false);
+    desc.add<double>("scaleFactor", 0.65);
+    descriptions.add("pixelFitterByHelixProjectionsDefault", desc);
   }
 
 private:
   virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+  const edm::ParameterSet * iConfig_=nullptr;
 };
 
 
@@ -37,7 +41,7 @@ void PixelFitterByHelixProjectionsProducer::produce(edm::StreamID, edm::Event& i
   edm::ESHandle<MagneticField> fieldESH;
   iSetup.get<IdealMagneticFieldRecord>().get(fieldESH);
 
-  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product());
+  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product(), *iConfig_);
   auto prod = std::make_unique<PixelFitter>(std::move(impl));
   iEvent.put(std::move(prod));
 }

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelFitterByHelixProjectionsProducer.cc
@@ -19,21 +19,23 @@
 class PixelFitterByHelixProjectionsProducer: public edm::global::EDProducer<> {
 public:
   explicit PixelFitterByHelixProjectionsProducer(const edm::ParameterSet& iConfig)
-    : iConfig_(&iConfig) {
+    : thescaleErrorsForPhaseI(iConfig.getParameter<bool>("scaleErrorsForPhaseI"))
+    , thescaleFactor(iConfig.getParameter<double>("scaleFactor"))  {
     produces<PixelFitter>();
   }
   ~PixelFitterByHelixProjectionsProducer() {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<bool>("scaleErrorsForPhaseIQuadruplets", false);
+    desc.add<bool>("scaleErrorsForPhaseI", false);
     desc.add<double>("scaleFactor", 0.65);
     descriptions.add("pixelFitterByHelixProjectionsDefault", desc);
   }
 
 private:
   virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
-  const edm::ParameterSet * iConfig_=nullptr;
+  const bool thescaleErrorsForPhaseI;
+  const float thescaleFactor;
 };
 
 
@@ -41,7 +43,7 @@ void PixelFitterByHelixProjectionsProducer::produce(edm::StreamID, edm::Event& i
   edm::ESHandle<MagneticField> fieldESH;
   iSetup.get<IdealMagneticFieldRecord>().get(fieldESH);
 
-  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product(), *iConfig_);
+  auto impl = std::make_unique<PixelFitterByHelixProjections>(&iSetup, fieldESH.product(), thescaleErrorsForPhaseI, thescaleFactor);
   auto prod = std::make_unique<PixelFitter>(std::move(impl));
   iEvent.put(std::move(prod));
 }

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
@@ -49,7 +49,7 @@ pixelTracksQuadHitQuadruplets = initialStepHitQuadruplets.clone(
     SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
 )
 
-pixelTracksQuad = _pixelTracks.clone(
+pixelTracks = _pixelTracks.clone(
     SeedingHitSets = "pixelTracksQuadHitQuadruplets"
 )
 
@@ -57,7 +57,7 @@ pixelTracksQuadSequence = cms.Sequence(
     pixelTracksQuadSeedLayers +
     pixelTracksQuadHitDoublets +
     pixelTracksQuadHitQuadruplets +
-    pixelTracksQuad
+    pixelTracks
 )
 
 # Pixel Triplets Tracking
@@ -99,36 +99,36 @@ pixelTracksTripletSequence = cms.Sequence(
 
 
 
-pixelTracks = cms.EDProducer( "TrackListMerger",
-                              ShareFrac = cms.double( 0.19 ),
-                              writeOnlyTrkQuals = cms.bool( False ),
-                              MinPT = cms.double( 0.05 ),
-                              allowFirstHitShare = cms.bool( True ),
-                              copyExtras = cms.untracked.bool( True ),
-                              Epsilon = cms.double( -0.001 ),
-                              selectedTrackQuals = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
-                              indivShareFrac = cms.vdouble( 1.0, 1.0 ),
-                              MaxNormalizedChisq = cms.double( 1000.0 ),
-                              copyMVA = cms.bool( False ),
-                              FoundHitBonus = cms.double( 5.0 ),
-                              setsToMerge = cms.VPSet(
-                                  cms.PSet(  pQual = cms.bool( False ),
-                                             tLists = cms.vint32( 0, 1 )
-                                  )
-                              ),
-                              MinFound = cms.int32( 3 ),
-                              hasSelector = cms.vint32( 0, 0 ),
-                              TrackProducers = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
-                              LostHitPenalty = cms.double( 20.0 ),
-                              newQuality = cms.string( "confirmed" ),
-                              trackAlgoPriorityOrder = cms.string("trackAlgoPriorityOrder")
+pixelTracks_full = cms.EDProducer( "TrackListMerger",
+                                   ShareFrac = cms.double( 0.19 ),
+                                   writeOnlyTrkQuals = cms.bool( False ),
+                                   MinPT = cms.double( 0.05 ),
+                                   allowFirstHitShare = cms.bool( True ),
+                                   copyExtras = cms.untracked.bool( True ),
+                                   Epsilon = cms.double( -0.001 ),
+                                   selectedTrackQuals = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
+                                   indivShareFrac = cms.vdouble( 1.0, 1.0 ),
+                                   MaxNormalizedChisq = cms.double( 1000.0 ),
+                                   copyMVA = cms.bool( False ),
+                                   FoundHitBonus = cms.double( 5.0 ),
+                                   setsToMerge = cms.VPSet(
+                                       cms.PSet(  pQual = cms.bool( False ),
+                                                  tLists = cms.vint32( 0, 1 )
+                                       )
+                                   ),
+                                   MinFound = cms.int32( 3 ),
+                                   hasSelector = cms.vint32( 0, 0 ),
+                                   TrackProducers = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
+                                   LostHitPenalty = cms.double( 20.0 ),
+                                   newQuality = cms.string( "confirmed" ),
+                                   trackAlgoPriorityOrder = cms.string("trackAlgoPriorityOrder")
 )
 
 pixelTracksSequence = cms.Sequence(
     pixelTracksTrackingRegions +
     pixelFitterByHelixProjections +
     pixelTrackFilterByKinematics +
-    pixelTracksQuadSequence +
-    pixelTracksTripletSequence +
-    pixelTracks
+    pixelTracksQuadSequence
+#    pixelTracksTripletSequence +
+#    pixelTracks
 )

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_2017_cff.py
@@ -23,112 +23,39 @@ import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cf
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 
 # SEEDING LAYERS
-import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
-import RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff
 from RecoTracker.IterativeTracking.InitialStep_cff import initialStepSeedLayers, initialStepHitDoublets, initialStepHitQuadruplets
-from RecoTracker.IterativeTracking.HighPtTripletStep_cff import highPtTripletStepClusters, highPtTripletStepSeedLayers, highPtTripletStepHitDoublets, highPtTripletStepHitTriplets
 
 # TrackingRegion
 pixelTracksTrackingRegions = _globalTrackingRegion.clone()
 
 
 # Pixel Quadruplets Tracking
-pixelTracksQuadSeedLayers = initialStepSeedLayers.clone(
+pixelTracksSeedLayers = initialStepSeedLayers.clone(
     BPix = dict(HitProducer = "siPixelRecHitsPreSplitting"),
     FPix = dict(HitProducer = "siPixelRecHitsPreSplitting")
 )
 
-pixelTracksQuadHitDoublets = initialStepHitDoublets.clone(
+pixelTracksHitDoublets = initialStepHitDoublets.clone(
     clusterCheck = "",
-    seedingLayers = "pixelTracksQuadSeedLayers",
+    seedingLayers = "pixelTracksSeedLayers",
     trackingRegions = "pixelTracksTrackingRegions"
 )
 
-pixelTracksQuadHitQuadruplets = initialStepHitQuadruplets.clone(
-    doublets = "pixelTracksQuadHitDoublets",
+pixelTracksHitQuadruplets = initialStepHitQuadruplets.clone(
+    doublets = "pixelTracksHitDoublets",
     SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
 )
 
 pixelTracks = _pixelTracks.clone(
-    SeedingHitSets = "pixelTracksQuadHitQuadruplets"
-)
-
-pixelTracksQuadSequence = cms.Sequence(
-    pixelTracksQuadSeedLayers +
-    pixelTracksQuadHitDoublets +
-    pixelTracksQuadHitQuadruplets +
-    pixelTracks
-)
-
-# Pixel Triplets Tracking
-pixelTracksTripletSeedLayers = highPtTripletStepSeedLayers.clone(
-    BPix = dict(skipClusters = cms.InputTag('pixelTracksTripletClusters'), HitProducer = "siPixelRecHitsPreSplitting"),
-    FPix = dict(skipClusters = cms.InputTag('pixelTracksTripletClusters'), HitProducer = "siPixelRecHitsPreSplitting")
-)
-
-pixelTracksTripletClusters = highPtTripletStepClusters.clone(
-    trackClassifier = cms.InputTag( '','QualityMasks' ),
-    maxChi2 = cms.double( 3000.0 ),
-    trajectories = cms.InputTag( "pixelTracksQuad" ),
-    oldClusterRemovalInfo = cms.InputTag( "" ),
-    pixelClusters = cms.InputTag( "siPixelClustersPreSplitting" ),
-)
-
-pixelTracksTripletHitDoublets = highPtTripletStepHitDoublets.clone(
-    clusterCheck = "",
-    seedingLayers = "pixelTracksTripletSeedLayers",
-    trackingRegions = "pixelTracksTrackingRegions"
-)
-
-pixelTracksTripletHitTriplets = highPtTripletStepHitTriplets.clone(
-    doublets = "pixelTracksTripletHitDoublets",
-    SeedComparitorPSet = dict(clusterShapeCacheSrc = 'siPixelClusterShapeCachePreSplitting')
-)
-
-pixelTracksTriplet = _pixelTracks.clone(
-    SeedingHitSets = "pixelTracksTripletHitTriplets"
-)
-
-pixelTracksTripletSequence = cms.Sequence(
-    pixelTracksTripletClusters +
-    pixelTracksTripletSeedLayers +
-    pixelTracksTripletHitDoublets +
-    pixelTracksTripletHitTriplets +
-    pixelTracksTriplet
-)
-
-
-
-pixelTracks_full = cms.EDProducer( "TrackListMerger",
-                                   ShareFrac = cms.double( 0.19 ),
-                                   writeOnlyTrkQuals = cms.bool( False ),
-                                   MinPT = cms.double( 0.05 ),
-                                   allowFirstHitShare = cms.bool( True ),
-                                   copyExtras = cms.untracked.bool( True ),
-                                   Epsilon = cms.double( -0.001 ),
-                                   selectedTrackQuals = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
-                                   indivShareFrac = cms.vdouble( 1.0, 1.0 ),
-                                   MaxNormalizedChisq = cms.double( 1000.0 ),
-                                   copyMVA = cms.bool( False ),
-                                   FoundHitBonus = cms.double( 5.0 ),
-                                   setsToMerge = cms.VPSet(
-                                       cms.PSet(  pQual = cms.bool( False ),
-                                                  tLists = cms.vint32( 0, 1 )
-                                       )
-                                   ),
-                                   MinFound = cms.int32( 3 ),
-                                   hasSelector = cms.vint32( 0, 0 ),
-                                   TrackProducers = cms.VInputTag( 'pixelTracksTriplet','pixelTracksQuad' ),
-                                   LostHitPenalty = cms.double( 20.0 ),
-                                   newQuality = cms.string( "confirmed" ),
-                                   trackAlgoPriorityOrder = cms.string("trackAlgoPriorityOrder")
+    SeedingHitSets = "pixelTracksHitQuadruplets"
 )
 
 pixelTracksSequence = cms.Sequence(
     pixelTracksTrackingRegions +
     pixelFitterByHelixProjections +
     pixelTrackFilterByKinematics +
-    pixelTracksQuadSequence
-#    pixelTracksTripletSequence +
-#    pixelTracks
+    pixelTracksSeedLayers +
+    pixelTracksHitDoublets +
+    pixelTracksHitQuadruplets +
+    pixelTracks
 )

--- a/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+
+from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjectionsDefault_cfi import pixelFitterByHelixProjectionsDefault
+
+pixelFitterByHelixProjections = pixelFitterByHelixProjectionsDefault.clone()
+
+phase1Pixel.toModify( pixelFitterByHelixProjections, scaleErrorsForPhaseIQuadruplets = cms.bool(True))

--- a/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
@@ -5,4 +5,4 @@ from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjectionsDefault_c
 
 pixelFitterByHelixProjections = pixelFitterByHelixProjectionsDefault.clone()
 
-phase1Pixel.toModify( pixelFitterByHelixProjections, scaleErrorsForPhaseI = True)
+phase1Pixel.toModify( pixelFitterByHelixProjections, scaleErrorsForBPix1 = True)

--- a/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/pixelFitterByHelixProjections_cfi.py
@@ -5,4 +5,4 @@ from RecoPixelVertexing.PixelTrackFitting.pixelFitterByHelixProjectionsDefault_c
 
 pixelFitterByHelixProjections = pixelFitterByHelixProjectionsDefault.clone()
 
-phase1Pixel.toModify( pixelFitterByHelixProjections, scaleErrorsForPhaseIQuadruplets = cms.bool(True))
+phase1Pixel.toModify( pixelFitterByHelixProjections, scaleErrorsForPhaseI = True)

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -95,10 +95,11 @@ namespace {
   
 PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSetup *es,
 							     const MagneticField *field,
-							     const edm::ParameterSet& iConfig):
-  theES(es), theField(field) {
-  thescaleErrorsForPhaseIQuadruplets = iConfig.getParameter<bool>("scaleErrorsForPhaseIQuadruplets");
-  thescaleFactor = (float)iConfig.getParameter<double>("scaleFactor");
+                                                             bool scaleErrorsForPhaseI,
+                                                             float scaleFactor):
+  theES(es), theField(field),
+  thescaleErrorsForPhaseI(scaleErrorsForPhaseI), thescaleFactor(scaleFactor)
+{
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopo;
   es->get<TrackerTopologyRcd>().get(tTopo);
@@ -159,7 +160,7 @@ std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
   // that the pulls of the pixelVertices derived from the pixelTracks
   // have the correct mean and sigma.
   float errFactor = 1.;
-  if ( thescaleErrorsForPhaseIQuadruplets
+  if ( thescaleErrorsForPhaseI
        && (hits[0]->geographicalId().subdetId() == PixelSubdetector::PixelBarrel) &&
        (theTopo->pxbLayer(hits[0]->geographicalId()) == 1))
 	errFactor = thescaleFactor;

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -95,10 +95,10 @@ namespace {
   
 PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSetup *es,
 							     const MagneticField *field,
-                                                             bool scaleErrorsForPhaseI,
+                                                             bool scaleErrorsForBPix1,
                                                              float scaleFactor):
   theES(es), theField(field),
-  thescaleErrorsForPhaseI(scaleErrorsForPhaseI), thescaleFactor(scaleFactor)
+  thescaleErrorsForBPix1(scaleErrorsForBPix1), thescaleFactor(scaleFactor)
 {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopo;
@@ -160,7 +160,7 @@ std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
   // that the pulls of the pixelVertices derived from the pixelTracks
   // have the correct mean and sigma.
   float errFactor = 1.;
-  if ( thescaleErrorsForPhaseI
+  if ( thescaleErrorsForBPix1
        && (hits[0]->geographicalId().subdetId() == PixelSubdetector::PixelBarrel) &&
        (theTopo->pxbLayer(hits[0]->geographicalId()) == 1))
 	errFactor = thescaleFactor;

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -30,6 +30,9 @@
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackErrorParam.h"
 #include "DataFormats/GeometryVector/interface/Pi.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 #include "CommonTools/Utils/interface/DynArray.h"
 
 using namespace std;
@@ -90,8 +93,17 @@ namespace {
   }
 }
   
-PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSetup *es, const MagneticField *field):
-  theES(es), theField(field) {}
+PixelFitterByHelixProjections::PixelFitterByHelixProjections(const edm::EventSetup *es,
+							     const MagneticField *field,
+							     const edm::ParameterSet& iConfig):
+  theES(es), theField(field) {
+  thescaleErrorsForPhaseIQuadruplets = iConfig.getParameter<bool>("scaleErrorsForPhaseIQuadruplets");
+  thescaleFactor = (float)iConfig.getParameter<double>("scaleFactor");
+  //Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopo;
+  es->get<TrackerTopologyRcd>().get(tTopo);
+  theTopo = tTopo.product();
+}
 
 std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
     const std::vector<const TrackingRecHit * > & hits,
@@ -141,12 +153,23 @@ std::unique_ptr<reco::Track> PixelFitterByHelixProjections::run(
   float valEta = std::asinh(valCotTheta);
   float valZip = zip(valTip, valPhi, curvature, points[0],points[1]);
 
+  // Rescale down the error to take into accont the fact that the
+  // inner pixel barrel layer for PhaseI is closer to the interaction
+  // point. The effective scale factor has been derived by checking
+  // that the pulls of the pixelVertices derived from the pixelTracks
+  // have the correct mean and sigma.
+  float errFactor = 1.;
+  if ( thescaleErrorsForPhaseIQuadruplets
+       && (hits[0]->geographicalId().subdetId() == PixelSubdetector::PixelBarrel) &&
+       (theTopo->pxbLayer(hits[0]->geographicalId()) == 1))
+	errFactor = thescaleFactor;
+
   PixelTrackErrorParam param(valEta, valPt);
-  float errValPt  = param.errPt();
-  float errValCot = param.errCot();
-  float errValTip = param.errTip();
-  float errValPhi = param.errPhi();
-  float errValZip = param.errZip();
+  float errValPt  = errFactor*param.errPt();
+  float errValCot = errFactor*param.errCot();
+  float errValTip = errFactor*param.errTip();
+  float errValPhi = errFactor*param.errPhi();
+  float errValZip = errFactor*param.errZip();
 
 
   float chi2 = 0;


### PR DESCRIPTION
Backport of #19267. Original description:

> This PR makes the following updates to the online beamspot applications making them more robust:
> 
> rescale pixel track parameter uncertainties to match better the reality
> the uncertainties come from phase0 parametrization, so a difference wrt. phase1 is expected
> @rovere tuned the scale factor such that the pulls of pixel vertex position coordinates were correct
> do pixel tracks only from quadruplets
> triplets produce too many fakes that introduce small biases in the beamspot position
> enlargen the tracking region in Z from +- 3 cm to +- 6 cm
> Tested in CMSSW_9_2_X_2017-06-09-1100. Should have no impact on runTheMatrix workflows.
> 
> @rovere @VinInn @mtosi @JanFSchulte @dinardo @sikler