### PR TITLE
add module label to module name printout in fatal signal handler

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -430,6 +430,8 @@ namespace {
           strlcpy(buff, "\nModule: ", moduleBufferSize);
           if (edm::CurrentModuleOnThread::getCurrentModuleOnThread() != nullptr) {
             strlcat(buff, edm::CurrentModuleOnThread::getCurrentModuleOnThread()->moduleDescription()->moduleName().c_str(), moduleBufferSize);
+            strlcat(buff, ":", moduleBufferSize);
+            strlcat(buff, edm::CurrentModuleOnThread::getCurrentModuleOnThread()->moduleDescription()->moduleLabel().c_str(), moduleBufferSize);
           } else {
             strlcat(buff, "none", moduleBufferSize);
           }
@@ -531,6 +533,8 @@ namespace {
         char buff[moduleBufferSize] = "\nModule: ";
         if (edm::CurrentModuleOnThread::getCurrentModuleOnThread() != nullptr) {
           strlcat(buff, edm::CurrentModuleOnThread::getCurrentModuleOnThread()->moduleDescription()->moduleName().c_str(), moduleBufferSize);
+          strlcat(buff, ":", moduleBufferSize);
+          strlcat(buff, edm::CurrentModuleOnThread::getCurrentModuleOnThread()->moduleDescription()->moduleLabel().c_str(), moduleBufferSize);
         } else {
           strlcat(buff, "none", moduleBufferSize);
         }


### PR DESCRIPTION
Add moduleLabel to the module name printout in the fatal signal handler, in order to disambiguate cases where multiple instances of a module have been created.