### PR TITLE
Add track selection MVA plots to tracking DQM (92X)

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -34,6 +34,9 @@ class DQMStore;
 class TrackBuildingAnalyzer 
 {
     public:
+        using MVACollection = std::vector<float>;
+        using QualityMaskCollection = std::vector<unsigned char>;
+
         TrackBuildingAnalyzer(const edm::ParameterSet&);
         ~TrackBuildingAnalyzer();
         void initHisto(DQMStore::IBooker & ibooker, const edm::ParameterSet&);
@@ -54,6 +57,11 @@ class TrackBuildingAnalyzer
             const reco::BeamSpot& bs, 
             const edm::ESHandle<MagneticField>& theMF,
             const edm::ESHandle<TransientTrackingRecHitBuilder>& theTTRHBuilder
+        );
+        void analyze
+        (
+            const std::vector<const MVACollection *>& mvaCollections,
+            const std::vector<const QualityMaskCollection *>& qualityMaskCollections
         );
 
     private:
@@ -92,6 +100,9 @@ class TrackBuildingAnalyzer
 	MonitorElement* stoppingSource;
 	MonitorElement* stoppingSourceVSeta;
 	MonitorElement* stoppingSourceVSphi;
+
+	std::vector<MonitorElement *> trackMVAs;
+	std::vector<MonitorElement *> trackMVAsHP;
 	
         std::string histname;  //for naming the histograms according to algorithm used
 
@@ -112,5 +123,6 @@ class TrackBuildingAnalyzer
 	bool doProfPHI;
 	bool doProfETA;
 	bool doStopSource;
+	bool doMVAPlots;
 };
 #endif

--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -60,6 +60,7 @@ class TrackBuildingAnalyzer
         );
         void analyze
         (
+            const edm::View<reco::Track>& trackCollection,
             const std::vector<const MVACollection *>& mvaCollections,
             const std::vector<const QualityMaskCollection *>& qualityMaskCollections
         );
@@ -103,6 +104,10 @@ class TrackBuildingAnalyzer
 
 	std::vector<MonitorElement *> trackMVAs;
 	std::vector<MonitorElement *> trackMVAsHP;
+	std::vector<MonitorElement *> trackMVAsVsPtProfile;
+	std::vector<MonitorElement *> trackMVAsHPVsPtProfile;
+	std::vector<MonitorElement *> trackMVAsVsEtaProfile;
+	std::vector<MonitorElement *> trackMVAsHPVsEtaProfile;
 	
         std::string histname;  //for naming the histograms according to algorithm used
 

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -99,6 +99,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
 
 	std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection> > > mvaQualityTokens_;
+	edm::EDGetTokenT<edm::View<reco::Track> > mvaTrackToken_;
 
 	std::string Quality_;
 	std::string AlgoName_;

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -51,6 +51,9 @@ class GenericTriggerEventFlag;
 class TrackingMonitor : public DQMEDAnalyzer 
 {
     public:
+        using MVACollection = std::vector<float>;
+        using QualityMaskCollection = std::vector<unsigned char>;
+
         explicit TrackingMonitor(const edm::ParameterSet&);
         ~TrackingMonitor();
         virtual void beginJob(void);
@@ -94,6 +97,8 @@ class TrackingMonitor : public DQMEDAnalyzer
 	edm::InputTag pixelClusterInputTag_;
 	edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersToken_;
 	edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
+
+	std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection> > > mvaQualityTokens_;
 
 	std::string Quality_;
 	std::string AlgoName_;
@@ -181,6 +186,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	bool doGeneralPropertiesPlots_;
 	bool doHitPropertiesPlots_;
 	bool doTkCandPlots;
+	bool doMVAPlots;
 	bool doSeedNumberPlot;
 	bool doSeedLumiAnalysis_;
 	bool doSeedVsClusterPlot;

--- a/DQM/TrackingMonitor/python/MonitorTrackSTAMuons_cfi.py
+++ b/DQM/TrackingMonitor/python/MonitorTrackSTAMuons_cfi.py
@@ -12,10 +12,8 @@ MonitorTrackSTAMuons.beamSpot      = cms.InputTag("offlineBeamSpot")
 MonitorTrackSTAMuons.ClusterLabels = cms.vstring('Tot')
 
 # output parameters
-MonitorTrackSTAMuons.OutputMEsInRootFile = cms.bool(False)
 MonitorTrackSTAMuons.AlgoName            = cms.string('sta')
 MonitorTrackSTAMuons.Quality             = cms.string('')
-MonitorTrackSTAMuons.OutputFileName      = cms.string('monitortrackparameters_stamuons.root')
 MonitorTrackSTAMuons.FolderName          = cms.string('Muons/standAloneMuonsUpdatedAtVtx')
 MonitorTrackSTAMuons.BSFolderName        = cms.string('Muons/standAloneMuonsUpdatedAtVtx/BeamSpotParameters')
 

--- a/DQM/TrackingMonitor/python/TrackingMonitorAllTrackingSequences_cff.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitorAllTrackingSequences_cff.py
@@ -6,8 +6,6 @@ import FWCore.ParameterSet.Config as cms
 from DQM.TrackingMonitor.TrackingMonitor_cfi import *
 
 # properties
-TrackMon.OutputMEsInRootFile    = cms.bool(False)
-TrackMon.OutputFileName         = cms.string('TrackingMonitorAllSequences.root')
 TrackMon.MeasurementState       = cms.string('ImpactPoint')
 
 # which plots to do

--- a/DQM/TrackingMonitor/python/TrackingMonitorSeed_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitorSeed_cfi.py
@@ -4,8 +4,6 @@ import DQM.TrackingMonitor.TrackingMonitor_cfi
 
 TrackMonSeed = DQM.TrackingMonitor.TrackingMonitor_cfi.TrackMon.clone()
 
-TrackMonSeed.OutputMEsInRootFile        = cms.bool(False)
-TrackMonSeed.OutputFileName             = cms.string('TrackingMonitorSeedMultiplicity.root')
 TrackMonSeed.MeasurementState           = cms.string('ImpactPoint')
 TrackMonSeed.FolderName                 = cms.string('Tracking/TrackParameters')
 TrackMonSeed.BSFolderName               = cms.string('Tracking/TrackParameters/BeamSpotParameters')

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -32,10 +32,8 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     pvLabels = cms.vstring(),
                           
     # output parameters
-    OutputMEsInRootFile = cms.bool(False),
     AlgoName            = cms.string('GenTk'),
     Quality             = cms.string(''),
-    OutputFileName      = cms.string('MonitorTrack.root'),
     FolderName          = cms.string('Tracking/GlobalParameters'),
     BSFolderName        = cms.string('Tracking/ParametersVsBeamSpot'),
     PVFolderName        = cms.string('Tracking/PrimaryVertices'),

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -11,6 +11,7 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     TrackProducer    = cms.InputTag("generalTracks"),
     SeedProducer     = cms.InputTag("initialStepSeeds"),
     TCProducer       = cms.InputTag("initialStepTrackCandidates"),
+    MVAProducers     = cms.vstring("initialStepClassifier1", "initialStepClassifier2"),
     ClusterLabels    = cms.vstring('Tot'), # to decide which Seeds-Clusters correlation plots to have default is Total other options 'Strip', 'Pix'
     beamSpot         = cms.InputTag("offlineBeamSpot"),
     primaryVertex    = cms.InputTag('offlinePrimaryVertices'),
@@ -89,6 +90,7 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     doPlotsVsLUMI                       = cms.bool(False),
     doPlotsVsBX                         = cms.bool(False),
     doHIPlots                           = cms.bool(False),                              
+    doMVAPlots                          = cms.bool(False),
     qualityString = cms.string("highPurity"),                      
     #which seed plots to do
     doSeedNumberHisto = cms.bool(False),
@@ -360,6 +362,11 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     TCDzBin = cms.int32(100),
     TCDzMax = cms.double(400.0),
     TCDzMin = cms.double(-400.0),                                                
+
+    # Track selection MVA
+    MVABin  = cms.int32(100),
+    MVAMin  = cms.double(-1),
+    MVAMax  = cms.double(1),
 
 #######################################
 ## needed for tracksVScluster and seedVScluster

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -12,6 +12,7 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     SeedProducer     = cms.InputTag("initialStepSeeds"),
     TCProducer       = cms.InputTag("initialStepTrackCandidates"),
     MVAProducers     = cms.vstring("initialStepClassifier1", "initialStepClassifier2"),
+    TrackProducerForMVA = cms.InputTag("initialStepTracks"),
     ClusterLabels    = cms.vstring('Tot'), # to decide which Seeds-Clusters correlation plots to have default is Total other options 'Strip', 'Pix'
     beamSpot         = cms.InputTag("offlineBeamSpot"),
     primaryVertex    = cms.InputTag('offlinePrimaryVertices'),

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -333,6 +333,8 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::Pa
 
         if(i == 1) {
           trackMVAsHP.push_back(nullptr);
+          trackMVAsHPVsPtProfile.push_back(nullptr);
+          trackMVAsHPVsEtaProfile.push_back(nullptr);
         }
         else {
           pfix = " (not loose-selected)";
@@ -341,12 +343,32 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker & ibooker, const edm::Pa
           trackMVAsHP.push_back(ibooker.book1D(histname+CatagoryName, histname+CatagoryName+pfix2, MVABin, MVAMin, MVAMax));
           trackMVAsHP.back()->setAxisTitle("Track selection MVA"+num, 1);
           trackMVAsHP.back()->setAxisTitle("Number of tracks", 2);
+
+          histname = "TrackMVA"+num+"HPVsPtProfile_"+tcProducer.label() + "_";
+          trackMVAsHPVsPtProfile.push_back(ibooker.bookProfile(histname+CatagoryName, histname+CatagoryName+pfix2, TrackPtBin, TrackPtMin, TrackPtMax, MVABin, MVAMin, MVAMax));
+          trackMVAsHPVsPtProfile.back()->setAxisTitle("Track p_{T} (GeV/c)", 1);
+          trackMVAsHPVsPtProfile.back()->setAxisTitle("Track selection MVA"+num, 2);
+
+          histname = "TrackMVA"+num+"HPVsEtaProfile_"+tcProducer.label() + "_";
+          trackMVAsHPVsEtaProfile.push_back(ibooker.bookProfile(histname+CatagoryName, histname+CatagoryName+pfix2, EtaBin, EtaMin, EtaMax, MVABin, MVAMin, MVAMax));
+          trackMVAsHPVsEtaProfile.back()->setAxisTitle("Track #eta", 1);
+          trackMVAsHPVsEtaProfile.back()->setAxisTitle("Track selection MVA"+num, 2);
         }
 
         histname = "TrackMVA"+num+"_"+tcProducer.label() + "_";
         trackMVAs.push_back(ibooker.book1D(histname+CatagoryName, histname+CatagoryName+pfix, MVABin, MVAMin, MVAMax));
         trackMVAs.back()->setAxisTitle("Track selection MVA"+num, 1);
         trackMVAs.back()->setAxisTitle("Number of tracks", 2);
+
+        histname = "TrackMVA"+num+"VsPtProfile_"+tcProducer.label() + "_";
+        trackMVAsVsPtProfile.push_back(ibooker.bookProfile(histname+CatagoryName, histname+CatagoryName+pfix, TrackPtBin, TrackPtMin, TrackPtMax, MVABin, MVAMin, MVAMax));
+        trackMVAsVsPtProfile.back()->setAxisTitle("Track p_{T} (GeV/c)", 1);
+        trackMVAsVsPtProfile.back()->setAxisTitle("Track selection MVA"+num, 2);
+
+        histname = "TrackMVA"+num+"VsEtaProfile_"+tcProducer.label() + "_";
+        trackMVAsVsEtaProfile.push_back(ibooker.bookProfile(histname+CatagoryName, histname+CatagoryName+pfix, EtaBin, EtaMin, EtaMax, MVABin, MVAMin, MVAMax));
+        trackMVAsVsEtaProfile.back()->setAxisTitle("Track #eta", 1);
+        trackMVAsVsEtaProfile.back()->setAxisTitle("Track selection MVA"+num, 2);
       }
     }
   }
@@ -479,24 +501,25 @@ namespace {
     return mask & 1<<qual;
   }
 }
-void TrackBuildingAnalyzer::analyze(const std::vector<const MVACollection *>& mvaCollections,
+void TrackBuildingAnalyzer::analyze(const edm::View<reco::Track>& trackCollection,
+                                    const std::vector<const MVACollection *>& mvaCollections,
                                     const std::vector<const QualityMaskCollection *>& qualityMaskCollections) {
   if(!(doAllTCPlots || doMVAPlots))
     return;
-  if(mvaCollections.empty() || qualityMaskCollections.empty())
+  if(trackCollection.empty())
     return;
 
-  const auto ntracks = mvaCollections[0]->size();
+  const auto ntracks = trackCollection.size();
   const auto nmva = mvaCollections.size();
   for(const auto mva: mvaCollections) {
     if(mva->size() != ntracks) {
-      edm::LogError("LogicError") << "TrackBuildingAnalyzer: Incompatible size of MVACollection, " << mva->size() << " differs from the size of the first collection " << ntracks;
+      edm::LogError("LogicError") << "TrackBuildingAnalyzer: Incompatible size of MVACollection, " << mva->size() << " differs from the size of the track collection " << ntracks;
       return;
     }
   }
   for(const auto qual: qualityMaskCollections) {
     if(qual->size() != ntracks) {
-      edm::LogError("LogicError") << "TrackBuildingAnalyzer: Incompatible size of QualityMaskCollection, " << qual->size() << " differs from the size of the first MVACollection " << ntracks;
+      edm::LogError("LogicError") << "TrackBuildingAnalyzer: Incompatible size of QualityMaskCollection, " << qual->size() << " differs from the size of the track collection " << ntracks;
       return;
     }
   }
@@ -507,13 +530,21 @@ void TrackBuildingAnalyzer::analyze(const std::vector<const MVACollection *>& mv
     // not selected by MVA1 etc
     bool selectedLoose = false;
     bool selectedHP = false;
+
+    const auto pt = trackCollection[iTrack].pt();
+    const auto eta = trackCollection[iTrack].eta();
+
     for(size_t iMVA=0; iMVA<nmva; ++iMVA) {
       const auto mva = (*(mvaCollections[iMVA]))[iTrack];
       if(!selectedLoose) {
         trackMVAs[iMVA]->Fill(mva);
+        trackMVAsVsPtProfile[iMVA]->Fill(pt, mva);
+        trackMVAsVsEtaProfile[iMVA]->Fill(eta, mva);
       }
       if(iMVA >= 1 && !selectedHP) {
         trackMVAsHP[iMVA]->Fill(mva);
+        trackMVAsHPVsPtProfile[iMVA]->Fill(pt, mva);
+        trackMVAsHPVsEtaProfile[iMVA]->Fill(eta, mva);
       }
 
       const auto qual = (*(qualityMaskCollections)[iMVA])[iTrack];

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -127,6 +127,7 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
                                                 return std::make_tuple(consumes<MVACollection>(edm::InputTag(tag, "MVAValues")),
                                                                        consumes<QualityMaskCollection>(edm::InputTag(tag, "QualityMasks")));
                                               });
+    mvaTrackToken_ = consumes<edm::View<reco::Track> >(iConfig.getParameter<edm::InputTag>("TrackProducerForMVA"));
   }
 
   edm::InputTag stripClusterInputTag_ = iConfig.getParameter<edm::InputTag>("stripCluster");
@@ -868,6 +869,9 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	  std::vector<const MVACollection *> mvaCollections;
 	  std::vector<const QualityMaskCollection *> qualityMaskCollections;
 
+	  edm::Handle<edm::View<reco::Track> > htracks;
+	  iEvent.getByToken(mvaTrackToken_, htracks);
+
 	  edm::Handle<MVACollection> hmva;
 	  edm::Handle<QualityMaskCollection> hqual;
 	  for(const auto& tokenTpl: mvaQualityTokens_) {
@@ -877,7 +881,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	    mvaCollections.push_back(hmva.product());
 	    qualityMaskCollections.push_back(hqual.product());
 	  }
-	  theTrackBuildingAnalyzer->analyze(mvaCollections, qualityMaskCollections);
+	  theTrackBuildingAnalyzer->analyze(*htracks, mvaCollections, qualityMaskCollections);
 	}
       }
       

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -13,6 +13,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/transform.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h"
 #include "DQM/TrackingMonitor/interface/TrackAnalyzer.h"
@@ -118,6 +119,15 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   trackToken_          = consumes<edm::View<reco::Track> >(trackProducer);
   trackCandidateToken_ = consumes<TrackCandidateCollection>(tcProducer); 
   seedToken_           = consumes<edm::View<TrajectorySeed> >(seedProducer);
+
+  doMVAPlots = iConfig.getParameter<bool>("doMVAPlots");
+  if(doMVAPlots) {
+    mvaQualityTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<std::string> >("MVAProducers"),
+                                              [&](const std::string& tag) {
+                                                return std::make_tuple(consumes<MVACollection>(edm::InputTag(tag, "MVAValues")),
+                                                                       consumes<QualityMaskCollection>(edm::InputTag(tag, "QualityMasks")));
+                                              });
+  }
 
   edm::InputTag stripClusterInputTag_ = iConfig.getParameter<edm::InputTag>("stripCluster");
   edm::InputTag pixelClusterInputTag_ = iConfig.getParameter<edm::InputTag>("pixelCluster");
@@ -851,6 +861,23 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	  }
 	} else {
 	  edm::LogWarning("TrackingMonitor") << "No Track Candidates in the event.  Not filling associated histograms";
+	}
+
+	if(doMVAPlots) {
+	  // Get MVA and quality mask collections
+	  std::vector<const MVACollection *> mvaCollections;
+	  std::vector<const QualityMaskCollection *> qualityMaskCollections;
+
+	  edm::Handle<MVACollection> hmva;
+	  edm::Handle<QualityMaskCollection> hqual;
+	  for(const auto& tokenTpl: mvaQualityTokens_) {
+	    iEvent.getByToken(std::get<0>(tokenTpl), hmva);
+	    iEvent.getByToken(std::get<1>(tokenTpl), hqual);
+
+	    mvaCollections.push_back(hmva.product());
+	    qualityMaskCollections.push_back(hqual.product());
+	  }
+	  theTrackBuildingAnalyzer->analyze(mvaCollections, qualityMaskCollections);
 	}
       }
       

--- a/DQM/TrackingMonitor/test/TrackingMonitor_StandAlone_cfg.py
+++ b/DQM/TrackingMonitor/test/TrackingMonitor_StandAlone_cfg.py
@@ -76,8 +76,6 @@ process.TrackMon.beamSpot               = cms.InputTag("offlineBeamSpot")
 
 # properties
 process.TrackMon.AlgoName               = cms.string('GenTk')
-process.TrackMon.OutputFileName 	= cms.string('TrackingMonitor.root')
-process.TrackMon.OutputMEsInRootFile 	= cms.bool(True)
 
 process.TrackMon.FolderName             = cms.string('Track/GlobalParameters')
 process.TrackMon.BSFolderName           = cms.string('Track/BeamSpotParameters')

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
+import RecoTracker.IterativeTracking.iterativeTkUtils as _utils
 
 ### load which are the tracks collection 2 be monitored
 from DQM.TrackingMonitorSource.TrackCollections2monitor_cff import *
@@ -310,8 +311,13 @@ for tracks in selectedTracks :
     TrackingDQMSourceTier0 += cms.ignore(locals()[label])
 # seeding monitoring
 for _eraName, _postfix, _era in _cfg.allEras():
+    mvaSel = _utils.getMVASelectors(_postfix)
     _seq = cms.Sequence()
     for step in locals()["selectedIterTrackingStep"+_postfix]:
+        if step in mvaSel:
+            locals()["TrackSeedMon"+step].doMVAPlots = True
+            locals()["TrackSeedMon"+step].MVAProducers = mvaSel[step]
+
         _seq += locals()["TrackSeedMon"+step]
     if _eraName == "":
         locals()["TrackSeedMonSequence"] = _seq

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -316,7 +316,8 @@ for _eraName, _postfix, _era in _cfg.allEras():
     for step in locals()["selectedIterTrackingStep"+_postfix]:
         if step in mvaSel:
             locals()["TrackSeedMon"+step].doMVAPlots = True
-            locals()["TrackSeedMon"+step].MVAProducers = mvaSel[step]
+            locals()["TrackSeedMon"+step].TrackProducerForMVA = mvaSel[step][0]
+            locals()["TrackSeedMon"+step].MVAProducers = mvaSel[step][1]
 
         _seq += locals()["TrackSeedMon"+step]
     if _eraName == "":

--- a/RecoTracker/IterativeTracking/python/iterativeTkUtils.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkUtils.py
@@ -1,0 +1,32 @@
+# This file provides additional helpers for getting information of
+# iterations in automated way.
+import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
+import RecoTracker.IterativeTracking.iterativeTk_cff as _iterativeTk_cff
+
+def getMVASelectors(postfix):
+    # assume naming convention that the iteration name (when first
+    # letter in lower case) is the selector name
+
+    ret = {}
+
+    for iterName, seqName in _cfg.iterationAlgos(postfix, includeSequenceName=True):
+        if hasattr(_iterativeTk_cff, iterName):
+            mod = getattr(_iterativeTk_cff, iterName)
+            seq = getattr(_iterativeTk_cff, seqName)
+
+            # Ignore iteration if the MVA selector module is not in the sequence
+            try:
+                seq.index(mod)
+            except:
+                continue
+
+            typeName = mod._TypedParameterizable__type
+            classifiers = []
+            if typeName == "ClassifierMerger":
+                classifiers = mod.inputClassifiers.value()
+            elif "TrackMVAClassifier" in typeName:
+                classifiers = [iterName]
+            if len(classifiers) > 0:
+                ret[iterName] = classifiers
+
+    return ret

--- a/RecoTracker/IterativeTracking/python/iterativeTkUtils.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkUtils.py
@@ -27,6 +27,6 @@ def getMVASelectors(postfix):
             elif "TrackMVAClassifier" in typeName:
                 classifiers = [iterName]
             if len(classifiers) > 0:
-                ret[iterName] = classifiers
+                ret[iterName] = (iterName+"Tracks", classifiers)
 
     return ret

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -214,8 +214,8 @@ def _getMVASelectors(postfix):
     mvaSel = _utils.getMVASelectors(postfix)
 
     pset = cms.untracked.PSet()
-    for iteration, classifiers in mvaSel.iteritems():
-        setattr(pset, iteration+"Tracks", cms.untracked.vstring(classifiers))
+    for iteration, (trackProducer, classifiers) in mvaSel.iteritems():
+        setattr(pset, trackProducer, cms.untracked.vstring(classifiers))
     return pset
 for _eraName, _postfix, _era in _relevantEras:
     locals()["_mvaSelectors"+_postfix] = _getMVASelectors(_postfix)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -19,6 +19,7 @@ from SimGeneral.TrackingAnalysis.trackingParticleNumberOfLayersProducer_cff impo
 from CommonTools.RecoAlgos.recoChargedRefCandidateToTrackRefProducer_cfi import recoChargedRefCandidateToTrackRefProducer as _recoChargedRefCandidateToTrackRefProducer
 
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
+import RecoTracker.IterativeTracking.iterativeTkUtils as _utils
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 ### First define the stuff for the standard validation sequence
@@ -210,31 +211,11 @@ for _eraName, _postfix, _era in _relevantEras:
 
 # MVA selectors
 def _getMVASelectors(postfix):
-    import RecoTracker.IterativeTracking.iterativeTk_cff as _iterativeTk_cff
+    mvaSel = _utils.getMVASelectors(postfix)
 
-    # assume naming convention that the iteration name (when first
-    # letter in lower case) is the selector name
     pset = cms.untracked.PSet()
-    for iterName, seqName in _cfg.iterationAlgos(postfix, includeSequenceName=True):
-        if hasattr(_iterativeTk_cff, iterName):
-            mod = getattr(_iterativeTk_cff, iterName)
-            seq = getattr(_iterativeTk_cff, seqName)
-
-            # Ignore iteration if the MVA selector module is not in the sequence
-            try:
-                seq.index(mod)
-            except:
-                continue
-
-            typeName = mod._TypedParameterizable__type
-            classifiers = []
-            if typeName == "ClassifierMerger":
-                classifiers = mod.inputClassifiers.value()
-            elif "TrackMVAClassifier" in typeName:
-                classifiers = [iterName]
-            if len(classifiers) > 0:
-                setattr(pset, iterName+"Tracks", cms.untracked.vstring(classifiers))
-
+    for iteration, classifiers in mvaSel.iteritems():
+        setattr(pset, iteration+"Tracks", cms.untracked.vstring(classifiers))
     return pset
 for _eraName, _postfix, _era in _relevantEras:
     locals()["_mvaSelectors"+_postfix] = _getMVASelectors(_postfix)


### PR DESCRIPTION
Backport of #19481. Original description:

> This PR adds distributions and profiles vs. pT and eta of the track selection MVA output for each tracking iteration with an MVA track selection. For the cases where an iteration makes use of multiple MVA selectors (as in phase0), a similar logic is used as in MultiTrackValidator, i.e.
> - For the first MVA there is one histogram called "MVA1"
> - For the second MVA there are two histograms
>   * "MVA2" for tracks not selected as loose by the first MVA
>   * "MVA2HP" for tracks not selected as highPurity by the first MVA
> - Same for third MVA (and possibly onwards)
> 
> I also removed two obsolete configuration parameters (OutputMEsInRootFile and OutputFileName) to not hit the 255 parameter limit (and needing to modify the entire TrackingMonitor_cfi).
> 
> Tested in CMSSW_9_2_3. Expecting new histograms in phase0 and phase1, and no changes in phase2.
> 

@rovere @VinInn @mtosi @hajohajo