### PR TITLE
Update dimuon L3 filter, for 2017 online muon reconstruction. 92X Version

### DIFF
--- a/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
@@ -12,11 +12,18 @@
  */
 
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
 namespace edm {
    class ConfigurationDescriptions;
@@ -32,13 +39,18 @@ class HLTMuonDimuonL3Filter : public HLTFilter {
 
    private:
       static bool triggeredByLevel2(reco::TrackRef const & track, std::vector<reco::RecoChargedCandidateRef> const & vcands);
-
-      edm::InputTag                    beamspotTag_ ;
-      edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;
-      edm::InputTag                                          candTag_;   // input tag identifying product contains muons
-      edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_; // token identifying product contains muons
-      edm::InputTag                                          previousCandTag_;   // input tag identifying product contains muons passing the previous level
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_; // tokenidentifying product contains muons passing the previous level
+      bool applyMuonSelection(const reco::RecoChargedCandidateRef&, const reco::BeamSpot&) const;
+      bool applyDiMuonSelection(const reco::RecoChargedCandidateRef&, const reco::RecoChargedCandidateRef&, const reco::BeamSpot&, const edm::ESHandle<MagneticField>&) const;
+      const edm::InputTag                    beamspotTag_ ;
+      const edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;
+      const edm::InputTag                                          candTag_;   		// input tag identifying product contains muons
+      const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_;		// token identifying product contains muons
+      const edm::InputTag                                          previousCandTag_;	// input tag identifying product contains muons passing the previous level
+      const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;	// tokenidentifying product contains muons passing the previous level
+      const edm::InputTag                                          l1CandTag_;		// input tag identifying product contains muons passing the L1 level
+      const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> l1CandToken_;	// token identifying product contains muons passing the L1 level
+      const edm::InputTag                                          recoMuTag_;		// input tag identifying reco muons
+      const edm::EDGetTokenT<reco::MuonCollection>                 recoMuToken_;	// token identifying product contains reco muons
       bool   previousCandIsL2_;
       bool   fast_Accept_;      // flag to save time: stop processing after identification of the first valid pair
       int    min_N_;            // minimum number of muons to fire the trigger
@@ -64,6 +76,9 @@ class HLTMuonDimuonL3Filter : public HLTFilter {
       bool cutCowboys_;             ///< if true, reject muon-track pairs that bend towards each other
       const edm::InputTag theL3LinksLabel;					//Needed to iterL3
       const edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;	//Needed to iterL3
+      const double L1MatchingdR_;
+      const bool matchPreviousCand_;
+      const double MuMass2_;
 };
 
 #endif //HLTMuonDimuonFilter_h

--- a/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
@@ -17,12 +17,10 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 namespace edm {

--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -236,7 +236,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	  }
         } //MTL loop
 
-        if ( !( l1CandTag_ == edm::InputTag("")) && check_l1match && matchPreviousCand_){
+        if (not l1CandTag_.label().empty() and check_l1match and matchPreviousCand_){
             iEvent.getByToken(l1CandToken_,level1Cands);
             level1Cands->getObjects(trigger::TriggerL1Mu,vl1cands);
             const unsigned int nL1Muons(vl1cands.size());
@@ -456,17 +456,17 @@ bool HLTMuonDimuonL3Filter::triggeredByLevel2(TrackRef const & staTrack,vector<R
 
 bool HLTMuonDimuonL3Filter::applyMuonSelection(const RecoChargedCandidateRef& cand, const BeamSpot& beamSpot) const{
 	// eta cut
-	if (fabs(cand->eta())>max_Eta_) return false;
+	if (std::abs(cand->eta())>max_Eta_) return false;
 	
 	// cut on number of hits
 	TrackRef tk = cand->track();
 	if (tk->numberOfValidHits()<min_Nhits_) return false;
 	
 	//dr cut
-	if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) >max_Dr_) return false;
+	if (std::abs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) >max_Dr_) return false;
 	
 	//dz cut
-	if (fabs((cand->vz()-beamSpot.z0()) - ((cand->vx()-beamSpot.x0())*cand->px()+(cand->vy()-beamSpot.y0())*cand->py())/cand->pt() * cand->pz()/cand->pt())>max_Dz_) return false;
+	if (std::abs((cand->vz()-beamSpot.z0()) - ((cand->vx()-beamSpot.x0())*cand->px()+(cand->vy()-beamSpot.y0())*cand->py())/cand->pt() * cand->pz()/cand->pt())>max_Dz_) return false;
 
 	return true;
 }
@@ -478,7 +478,7 @@ bool HLTMuonDimuonL3Filter::applyDiMuonSelection(const RecoChargedCandidateRef& 
 	else if (chargeOpt_>0 and (cand1->charge()*cand2->charge()<0)) return false;
 	
 	// Acoplanarity
-	double acop = fabs(cand1->phi()-cand2->phi());
+	double acop = std::abs(cand1->phi()-cand2->phi());
 	if (acop>M_PI) acop = 2*M_PI - acop;
 	acop = M_PI - acop;
 	LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 acop= " << acop;
@@ -486,7 +486,7 @@ bool HLTMuonDimuonL3Filter::applyDiMuonSelection(const RecoChargedCandidateRef& 
 	if (acop>max_Acop_) return false;
 	
 	// Pt balance
-	double ptbalance = fabs(cand1->pt()-cand2->pt());
+	double ptbalance = std::abs(cand1->pt()-cand2->pt());
 	if (ptbalance<min_PtBalance_) return false;
 	if (ptbalance>max_PtBalance_) return false;
 	
@@ -527,7 +527,7 @@ bool HLTMuonDimuonL3Filter::applyDiMuonSelection(const RecoChargedCandidateRef& 
 	if (!proceed) return false;
 	
 	// Delta Z between the two muons
-	//double DeltaZMuMu = fabs(tk2->dz(beamSpot.position())-tk1->dz(beamSpot.position()));
+	//double DeltaZMuMu = std::abs(tk2->dz(beamSpot.position())-tk1->dz(beamSpot.position()));
 	//if ( DeltaZMuMu > max_DzMuMu_) return false;
 	
 	// DCA between the two muons
@@ -545,7 +545,7 @@ bool HLTMuonDimuonL3Filter::applyDiMuonSelection(const RecoChargedCandidateRef& 
 	}
 	
 	// Max dimuon |rapidity|
-	double rapidity = fabs(p.Rapidity());
+	double rapidity = std::abs(p.Rapidity());
 	if ( rapidity > max_YPair_) return false;
 	
 	// if cutting on cowboys reject muons that bend towards each other

--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -6,33 +6,18 @@
  *
  */
 
-
-#include "DataFormats/Common/interface/Handle.h"
-
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "DataFormats/HLTReco/interface/TriggerRefsCollections.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
-#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-
 #include "TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-
-#include "DataFormats/Math/interface/deltaR.h"
 
 using namespace edm;
 using namespace std;
@@ -49,6 +34,10 @@ HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig) :
    candToken_         (consumes<reco::RecoChargedCandidateCollection>(candTag_)),
    previousCandTag_   (iConfig.getParameter<InputTag > ("PreviousCandTag")),
    previousCandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
+   l1CandTag_   (iConfig.getParameter<InputTag > ("L1CandTag")),
+   l1CandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(l1CandTag_)),
+   recoMuTag_   (iConfig.getParameter<InputTag > ("inputMuonCollection")),
+   recoMuToken_ (consumes<reco::MuonCollection>(recoMuTag_)),   
    previousCandIsL2_(iConfig.getParameter<bool> ("PreviousCandIsL2")),
    fast_Accept_ (iConfig.getParameter<bool> ("FastAccept")),
    min_N_       (iConfig.getParameter<int> ("MinN")),
@@ -73,7 +62,10 @@ HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig) :
    max_YPair_   (iConfig.getParameter<double>("MaxRapidityPair")),
    cutCowboys_(iConfig.getParameter<bool>("CutCowboys")),
    theL3LinksLabel (iConfig.getParameter<InputTag>("InputLinks")),
-   linkToken_ (consumes<reco::MuonTrackLinksCollection>(theL3LinksLabel))
+   linkToken_ (consumes<reco::MuonTrackLinksCollection>(theL3LinksLabel)),
+   L1MatchingdR_ (iConfig.getParameter<double> ("L1MatchingdR")),
+   matchPreviousCand_ (iConfig.getParameter<bool>("MatchToPreviousCand") ),
+   MuMass2_(0.106*0.106)
 {
 
    LogDebug("HLTMuonDimuonL3Filter")
@@ -105,6 +97,8 @@ HLTMuonDimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<edm::InputTag>("CandTag",edm::InputTag("hltL3MuonCandidates"));
   //  desc.add<edm::InputTag>("PreviousCandTag",edm::InputTag("hltDiMuonL2PreFiltered0"));
   desc.add<edm::InputTag>("PreviousCandTag",edm::InputTag(""));
+  desc.add<edm::InputTag>("L1CandTag",edm::InputTag(""));
+  desc.add<edm::InputTag>("inputMuonCollection",edm::InputTag(""));
   desc.add<bool>("PreviousCandIsL2",true);
   desc.add<bool>("FastAccept",false);
   desc.add<int>("MinN",1);
@@ -136,6 +130,8 @@ HLTMuonDimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<double>("MaxRapidityPair",999999.0);
   desc.add<bool>("CutCowboys",false);
   desc.add<edm::InputTag>("InputLinks",edm::InputTag(""));
+  desc.add<double>("L1MatchingdR",0.3);
+  desc.add<bool>("MatchToPreviousCand", true);
   descriptions.add("hltMuonDimuonL3Filter",desc);
 }
 
@@ -155,16 +151,30 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
    if (min_InvMass_.size() != max_PtMin_.size()) {cout << "ERROR!!! Vector sizes don't match!" << endl; return false;}
    if (min_InvMass_.size() != max_InvMass_.size()) {cout << "ERROR!!! Vector sizes don't match!" << endl; return false;}
 
-   double const MuMass = 0.106;
-   double const MuMass2 = MuMass*MuMass;
    // All HLT filters must create and fill an HLT filter object,
    // recording any reconstructed physics objects satisfying (or not)
    // this HLT filter, and place it in the Event.
 
-   // get hold of trks
+   // Read RecoChargedCandidates from L3MuonCandidateProducer:
    Handle<RecoChargedCandidateCollection> mucands;
-   if (saveTags()) filterproduct.addCollectionTag(candTag_);
+   if (saveTags()) filterproduct.addCollectionTag(candTag_);	//?
    iEvent.getByToken(candToken_,mucands);
+
+   // Read L2 triggered objects:
+   Handle<TriggerFilterObjectWithRefs> previousLevelCands;
+   iEvent.getByToken(previousCandToken_,previousLevelCands);
+   vector<RecoChargedCandidateRef> vl2cands;
+   previousLevelCands->getObjects(TriggerMuon,vl2cands);
+
+   // Read BeamSpot information:
+   Handle<BeamSpot> recoBeamSpotHandle;
+   iEvent.getByToken(beamspotToken_,recoBeamSpotHandle);
+   const BeamSpot& beamSpot = *recoBeamSpotHandle;
+
+   // sort them by L2Track
+   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > L2toL3s;
+   // map the L3 cands matched to a L1 to their position in the recoMuon collection
+   std::map<unsigned int, RecoChargedCandidateRef > MuonToL3s;
 
    // Test to see if we can use L3MuonTrajectorySeeds:
    if (mucands->empty()) return false;
@@ -175,9 +185,6 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	   auto a = dynamic_cast<const L3MuonTrajectorySeed*>(tk->seedRef().get());
 	   useL3MTS = a != nullptr;
    }
-
-   // sort them by L2Track
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > L2toL3s;
 
    // If we can use L3MuonTrajectory seeds run the older code:
    if (useL3MTS){
@@ -199,55 +206,63 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
      edm::Handle<reco::MuonTrackLinksCollection> links;
      iEvent.getByToken(linkToken_, links);
 
+     edm::Handle<trigger::TriggerFilterObjectWithRefs> level1Cands;
+     std::vector<l1t::MuonRef> vl1cands;
+     std::vector<l1t::MuonRef>::iterator vl1cands_begin;
+     std::vector<l1t::MuonRef>::iterator vl1cands_end;
+
+     bool check_l1match = true;
+
      // Loop over RecoChargedCandidates:
      for(unsigned int i(0); i < mucands->size(); ++i){
 	RecoChargedCandidateRef cand(mucands,i);
+        TrackRef tk = cand->track(); // is inner track
+	check_l1match = true;
+        int nlink = 0;
 	for(auto const & link : *links){
-	  TrackRef tk = cand->track();
+	  nlink++;
 
 	  // Using the same method that was used to create the links between L3 and L2
 	  // ToDo: there should be a better way than dR,dPt matching
-	  const reco::Track& globalTrack = *link.globalTrack();
-	  float dR2 = deltaR2(tk->eta(),tk->phi(),globalTrack.eta(),globalTrack.phi());
-	  float dPt = std::abs(tk->pt() - globalTrack.pt())/tk->pt();
-          const TrackRef staTrack = link.standAloneTrack();
-	  if (dR2 < 0.02*0.02 and dPt < 0.001 and previousCandIsL2_) {
+	  const reco::Track& trackerTrack = *link.trackerTrack();
+
+	  float dR2 = deltaR2(tk->eta(),tk->phi(),trackerTrack.eta(),trackerTrack.phi());
+	  float dPt = std::abs(tk->pt() - trackerTrack.pt())/tk->pt();
+
+	  if (matchPreviousCand_ and dR2 < 0.02*0.02 and dPt < 0.001) {
+	      const TrackRef staTrack = link.standAloneTrack();
 	      L2toL3s[staTrack].push_back(RecoChargedCandidateRef(cand));
-	  }
-	  else if (not previousCandIsL2_){
-	      L2toL3s[tk].push_back(RecoChargedCandidateRef(cand));
+	      check_l1match = false;
 	  }
         } //MTL loop
+
+        if ( !( l1CandTag_ == edm::InputTag("")) && check_l1match && matchPreviousCand_){
+            iEvent.getByToken(l1CandToken_,level1Cands);
+            level1Cands->getObjects(trigger::TriggerL1Mu,vl1cands);
+            const unsigned int nL1Muons(vl1cands.size());
+	    for (unsigned int il1=0; il1!=nL1Muons; ++il1) {
+                if (deltaR(cand->eta(), cand->phi(), vl1cands[il1]->eta(), vl1cands[il1]->phi()) < L1MatchingdR_) { //was muon, non cand
+  	          MuonToL3s[i] = RecoChargedCandidateRef(cand);
+                }
+	    }
+        }
      } //RCC loop
    } //end of using normal TrajectorySeeds
-
-
-   Handle<TriggerFilterObjectWithRefs> previousLevelCands;
-   iEvent.getByToken(previousCandToken_,previousLevelCands);
-   BeamSpot beamSpot;
-   Handle<BeamSpot> recoBeamSpotHandle;
-   iEvent.getByToken(beamspotToken_,recoBeamSpotHandle);
-   beamSpot = *recoBeamSpotHandle;
 
    // Needed for DCA calculation
    ESHandle<MagneticField> bFieldHandle;
    iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
 
-   // needed to compare to L2
-   vector<RecoChargedCandidateRef> vl2cands;
-   previousLevelCands->getObjects(TriggerMuon,vl2cands);
-
    // look at all mucands,  check cuts and add to filter object
    int n = 0;
-   double e1,e2;
-   Particle::LorentzVector p,p1,p2;
 
+   // look at all mucands,  check cuts and add to filter object
    auto L2toL3s_it1 = L2toL3s.begin();
    auto L2toL3s_end = L2toL3s.end();
    bool atLeastOnePair=false;
    for (; L2toL3s_it1!=L2toL3s_end; ++L2toL3s_it1){
 
-     if (!triggeredByLevel2(L2toL3s_it1->first,vl2cands)) continue;
+     if (matchPreviousCand_ and (!triggeredByLevel2(L2toL3s_it1->first,vl2cands))) continue;
 
      //loop over the L3Tk reconstructed for this L2.
      unsigned int iTk1=0;
@@ -256,30 +271,19 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
        bool thisL3Index1isDone=false;
        RecoChargedCandidateRef & cand1=L2toL3s_it1->second[iTk1];
        TrackRef tk1 = cand1->get<TrackRef>();
-       // eta cut
-       LogDebug("HLTMuonDimuonL3Filter") << " 1st muon in loop: q*pt= "
-					 << tk1->charge()*tk1->pt() << " (" << cand1->charge()*cand1->pt()<< ") " << ", eta= " << tk1->eta() << " (" << cand1->eta() << ") " << ", hits= " << tk1->numberOfValidHits();
 
-       if (fabs(cand1->eta())>max_Eta_) continue;
+       LogDebug("HLTMuonDimuonL3Filter") << " 1st muon in loop: q*pt= " << tk1->charge()*tk1->pt() 
+		<< " (" << cand1->charge()*cand1->pt()<< ") " << ", eta= " << tk1->eta() 
+		<< " (" << cand1->eta() << ") " << ", hits= " << tk1->numberOfValidHits();
 
-       // cut on number of hits
-       if (tk1->numberOfValidHits()<min_Nhits_) continue;
-
-       //dr cut
-       //      if (fabs(tk1->d0())>max_Dr_) continue;
-       if (fabs( (- (cand1->vx()-beamSpot.x0()) * cand1->py() + (cand1->vy()-beamSpot.y0()) * cand1->px() ) / cand1->pt() ) >max_Dr_) continue;
-
-       //dz cut
-       if (fabs((cand1->vz()-beamSpot.z0()) - ((cand1->vx()-beamSpot.x0())*cand1->px()+(cand1->vy()-beamSpot.y0())*cand1->py())/cand1->pt() * cand1->pz()/cand1->pt())>max_Dz_) continue;
+       // Run muon selection on first muon:
+       if (!applyMuonSelection(cand1, beamSpot)) continue;
 
        // Pt threshold cut
-       double pt1 = cand1->pt();
-       //       double err1 = tk1->error(0);
-       //       double abspar1 = fabs(tk1->parameter(0));
-       double ptLx1 = pt1;
        // Don't convert to 90% efficiency threshold
-       LogDebug("HLTMuonDimuonL3Filter") << " ... 1st muon in loop, pt1= "
-					 << pt1 << ", ptLx1= " << ptLx1;
+       LogDebug("HLTMuonDimuonL3Filter") << " ... 1st muon in loop, pt1= " << cand1->pt();
+
+       // Loop on 2nd muon cand
        auto L2toL3s_it2 = L2toL3s_it1;
        L2toL3s_it2++;
        for (; L2toL3s_it2!=L2toL3s_end; ++L2toL3s_it2){
@@ -292,109 +296,24 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	      RecoChargedCandidateRef & cand2=L2toL3s_it2->second[iTk2];
 	      TrackRef tk2 = cand2->get<TrackRef>();
 	
-	      // eta cut
-	      LogDebug("HLTMuonDimuonL3Filter") << " 2nd muon in loop: q*pt= " << tk2->charge()*tk2->pt() << " (" << cand2->charge()*cand2->pt() << ") " << ", eta= " << tk2->eta() << " (" << cand2->eta() << ") " << ", hits= " << tk2->numberOfValidHits() << ", d0= " << tk2->d0() ;
-	      if (fabs(cand2->eta())>max_Eta_) continue;
-	
-	      // cut on number of hits
-	      if (tk2->numberOfValidHits()<min_Nhits_) continue;
-	
-	      //dr cut
-	      // if (fabs(tk2->d0())>max_Dr_) continue;
-	      if (fabs( (- (cand2->vx()-beamSpot.x0()) * cand2->py() + (cand2->vy()-beamSpot.y0()) * cand2->px() ) / cand2->pt() ) >max_Dr_) continue;
+	      LogDebug("HLTMuonDimuonL3Filter") << " 2nd muon in loop: q*pt= " << tk2->charge()*tk2->pt()
+		<< " (" << cand2->charge()*cand2->pt() << ") " << ", eta= " << tk2->eta() 
+		<< " (" << cand2->eta() << ") " << ", hits= " << tk2->numberOfValidHits() << ", d0= " << tk2->d0() ;
 
-	      //dz cut
-	      if (fabs((cand2->vz()-beamSpot.z0()) - ((cand2->vx()-beamSpot.x0())*cand2->px()+(cand2->vy()-beamSpot.y0())*cand2->py())/cand2->pt() * cand2->pz()/cand2->pt())>max_Dz_) continue;	
+              // Run muon selection on second muon:
+              if (!applyMuonSelection(cand2, beamSpot)) continue;
 
 	      // Pt threshold cut
-	      double pt2 = cand2->pt();
-        //	      double err2 = tk2->error(0);
-        //	      double abspar2 = fabs(tk2->parameter(0));
-	      double ptLx2 = pt2;
 	      // Don't convert to 90% efficiency threshold
-	      LogDebug("HLTMuonDimuonL3Filter") << " ... 2nd muon in loop, pt2= "
-						<< pt2 << ", ptLx2= " << ptLx2;
+	      LogDebug("HLTMuonDimuonL3Filter") << " ... 2nd muon in loop, pt2= " << cand2->pt();
+
+              // Run dimuon selection:
+              if (!applyDiMuonSelection(cand1, cand2, beamSpot, bFieldHandle)) continue;
 	
-	      if (chargeOpt_<0) {
-		if (cand1->charge()*cand2->charge()>0) continue;
-	      } else if (chargeOpt_>0) {
-		if (cand1->charge()*cand2->charge()<0) continue;
-	      }
-	
-	      // Acoplanarity
-	      double acop = fabs(cand1->phi()-cand2->phi());
-	      if (acop>M_PI) acop = 2*M_PI - acop;
-	      acop = M_PI - acop;
-	      LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 acop= " << acop;
-	      if (acop<min_Acop_) continue;
-	      if (acop>max_Acop_) continue;
-
-	      // Pt balance
-	      double ptbalance = fabs(cand1->pt()-cand2->pt());
-	      if (ptbalance<min_PtBalance_) continue;
-	      if (ptbalance>max_PtBalance_) continue;
-
-	      // Combined dimuon system
-	      e1 = sqrt(cand1->momentum().Mag2()+MuMass2);
-	      e2 = sqrt(cand2->momentum().Mag2()+MuMass2);
-	      p1 = Particle::LorentzVector(cand1->px(),cand1->py(),cand1->pz(),e1);
-	      p2 = Particle::LorentzVector(cand2->px(),cand2->py(),cand2->pz(),e2);
-	      p = p1+p2;
-	
-	      double pt12 = p.pt();
-	      LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 pt12= " << pt12;
-	
-	      double invmass = abs(p.mass());
-	      // if (invmass>0) invmass = sqrt(invmass); else invmass = 0;
-	      LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 invmass= " << invmass;
-	      bool proceed=false;
-	      for (unsigned int iv=0 ; iv<min_InvMass_.size(); iv++) {
-		if (invmass<min_InvMass_[iv]) continue;
-		if (invmass>max_InvMass_[iv]) continue;
-		if (ptLx1>ptLx2) {
-		  if (ptLx1<min_PtMax_[iv]) continue;
-		  if (ptLx2<min_PtMin_[iv]) continue;
-		  if (ptLx2>max_PtMin_[iv]) continue;
-		} else {
-		  if (ptLx2<min_PtMax_[iv]) continue;
-		  if (ptLx1<min_PtMin_[iv]) continue;
-		  if (ptLx1>max_PtMin_[iv]) continue;
-		}
-		if (pt12<min_PtPair_[iv]) continue;
-		if (pt12>max_PtPair_[iv]) continue;
-		proceed=true;
-	      }
-	      if (!proceed) continue;
-
-              // Delta Z between the two muons
-              //double DeltaZMuMu = fabs(tk2->dz(beamSpot.position())-tk1->dz(beamSpot.position()));
-              //if ( DeltaZMuMu > max_DzMuMu_) continue;
-
-	      // DCA between the two muons
-	      TransientTrack mu1TT(*tk1, &(*bFieldHandle));
-	      TransientTrack mu2TT(*tk2, &(*bFieldHandle));
-	      TrajectoryStateClosestToPoint mu1TS = mu1TT.impactPointTSCP();
-	      TrajectoryStateClosestToPoint mu2TS = mu2TT.impactPointTSCP();
-	      if (mu1TS.isValid() && mu2TS.isValid()) {
-		ClosestApproachInRPhi cApp;
-		cApp.calculate(mu1TS.theState(), mu2TS.theState());
-		if (!cApp.status()
-		    || cApp.distance() > max_DCAMuMu_) continue;
-	      }
-
-              // Max dimuon |rapidity|
-              double rapidity = fabs(p.Rapidity());
-              if ( rapidity > max_YPair_) continue;
-
-	      ///
-	      // if cutting on cowboys reject muons that bend towards each other
-	      if(cutCowboys_ && (cand1->charge()*deltaPhi(cand1->phi(), cand2->phi()) > 0.)) continue;
-
 	      // Add this pair
 	      n++;
 	      LogDebug("HLTMuonDimuonL3Filter") << " Track1 passing filter: pt= " << cand1->pt() << ", eta: " << cand1->eta();
 	      LogDebug("HLTMuonDimuonL3Filter") << " Track2 passing filter: pt= " << cand2->pt() << ", eta: " << cand2->eta();
-	      LogDebug("HLTMuonDimuonL3Filter") << " Invmass= " << invmass;
 
 	      bool i1done = false;
 	      bool i2done = false;
@@ -403,20 +322,12 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	      for (auto & i : vref) {
 		RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
 		TrackRef tktmp = candref->get<TrackRef>();
-		if (tktmp==tk1) {
-		  i1done = true;
-		} else if (tktmp==tk2) {
-		  i2done = true;
-		}
+		if (tktmp==tk1) i1done = true;
+		else if (tktmp==tk2) i2done = true;	//why is this an elif?
 		if (i1done && i2done) break;
 	      }
-	
-	      if (!i1done) {
-		filterproduct.addObject(TriggerMuon,cand1);
-	      }
-	      if (!i2done) {
-		filterproduct.addObject(TriggerMuon,cand2);
-	      }
+	      if (!i1done) filterproduct.addObject(TriggerMuon,cand1);
+	      if (!i2done) filterproduct.addObject(TriggerMuon,cand2);
 	
 	      //break anyway since a L3 track pair has been found matching the criteria
 	      thisL3Index1isDone=true;
@@ -436,6 +347,59 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
      if (atLeastOnePair && fast_Accept_) break;
    }//loop on the first L2
 
+
+   // now loop on 1st L3 from L1
+   edm::Handle<reco::MuonCollection> recomuons;
+   iEvent.getByToken(recoMuToken_,recomuons);
+
+   auto MuonToL3s_it1  = MuonToL3s.begin();
+   auto MuonToL3s_end = MuonToL3s.end();
+   for (; MuonToL3s_it1!=MuonToL3s_end; ++MuonToL3s_it1){
+     bool thisL3Index1isDone=false;
+     const RecoChargedCandidateRef& cand1=MuonToL3s_it1->second;
+     if (!applyMuonSelection(cand1, beamSpot)) continue;
+     TrackRef tk1 = cand1->get<TrackRef>();
+
+     // Loop on 2nd L3 from L1
+     auto MuonToL3s_it2 = MuonToL3s_it1;
+     for (; MuonToL3s_it2!=MuonToL3s_end; ++MuonToL3s_it2){
+       const RecoChargedCandidateRef& cand2=MuonToL3s_it2->second;
+       if (!applyMuonSelection(cand2, beamSpot)) continue;
+       TrackRef tk2 = cand2->get<TrackRef>();
+
+       // Run dimuon selection:
+       if (!applyDiMuonSelection(cand1, cand2, beamSpot, bFieldHandle)) continue;
+
+       n++;
+       LogDebug("HLTMuonDimuonL3Filter") << " L3FromL1 Track1 passing filter: pt= " << cand1->pt() << ", eta: " << cand1->eta();
+       LogDebug("HLTMuonDimuonL3Filter") << " L3FromL1 Track2 passing filter: pt= " << cand2->pt() << ", eta: " << cand2->eta();
+
+       bool i1done = false;
+       bool i2done = false;
+       vector<RecoChargedCandidateRef> vref;
+       filterproduct.getObjects(TriggerMuon,vref);
+       for (auto & i : vref) {
+         RecoChargedCandidateRef candref =  RecoChargedCandidateRef(i);
+         TrackRef tktmp = candref->get<TrackRef>();
+         if (tktmp==tk1) i1done = true;
+         else if (tktmp==tk2) i2done = true;	//why is this an elif?
+         if (i1done && i2done) break;
+       }
+       if (!i1done) filterproduct.addObject(TriggerMuon,cand1);
+       if (!i2done) filterproduct.addObject(TriggerMuon,cand2);
+       
+       //break anyway since a L3 track pair has been found matching the criteria
+       thisL3Index1isDone=true;
+       atLeastOnePair=true;
+       break;
+       if (atLeastOnePair && fast_Accept_) break;
+     } //loop on 2nd muon
+     //break the loop if fast accept
+     if (atLeastOnePair && fast_Accept_) break;
+     if (thisL3Index1isDone) break;
+   } //loop on 1st muon
+
+
    // filter decision
    const bool accept (n >= min_N_);
 
@@ -445,9 +409,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 }
 
 
-bool
-HLTMuonDimuonL3Filter::triggeredByLevel2(TrackRef const & staTrack,vector<RecoChargedCandidateRef> const & vcands)
-{
+bool HLTMuonDimuonL3Filter::triggeredByLevel2(TrackRef const & staTrack,vector<RecoChargedCandidateRef> const & vcands){
   bool ok=false;
   for (auto const & vcand : vcands) {
     if ( vcand->get<TrackRef>() == staTrack ) {
@@ -457,4 +419,103 @@ HLTMuonDimuonL3Filter::triggeredByLevel2(TrackRef const & staTrack,vector<RecoCh
     }
   }
   return ok;
+}
+
+bool HLTMuonDimuonL3Filter::applyMuonSelection(const RecoChargedCandidateRef& cand, const BeamSpot& beamSpot) const{
+	// eta cut
+	if (fabs(cand->eta())>max_Eta_) return false;
+	
+	// cut on number of hits
+	TrackRef tk = cand->track();
+	if (tk->numberOfValidHits()<min_Nhits_) return false;
+	
+	//dr cut
+	if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) >max_Dr_) return false;
+	
+	//dz cut
+	if (fabs((cand->vz()-beamSpot.z0()) - ((cand->vx()-beamSpot.x0())*cand->px()+(cand->vy()-beamSpot.y0())*cand->py())/cand->pt() * cand->pz()/cand->pt())>max_Dz_) return false;
+
+	return true;
+}
+
+
+bool HLTMuonDimuonL3Filter::applyDiMuonSelection(const RecoChargedCandidateRef& cand1, const RecoChargedCandidateRef& cand2, const BeamSpot& beamSpot, const ESHandle<MagneticField>& bFieldHandle) const{
+	// Opposite Charge
+	if (chargeOpt_<0 and (cand1->charge()*cand2->charge()>0)) return false;
+	else if (chargeOpt_>0 and (cand1->charge()*cand2->charge()<0)) return false;
+	
+	// Acoplanarity
+	double acop = fabs(cand1->phi()-cand2->phi());
+	if (acop>M_PI) acop = 2*M_PI - acop;
+	acop = M_PI - acop;
+	LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 acop= " << acop;
+	if (acop<min_Acop_) return false;
+	if (acop>max_Acop_) return false;
+	
+	// Pt balance
+	double ptbalance = fabs(cand1->pt()-cand2->pt());
+	if (ptbalance<min_PtBalance_) return false;
+	if (ptbalance>max_PtBalance_) return false;
+	
+	// Combined dimuon syste
+	double e1,e2;
+        Particle::LorentzVector p,p1,p2;
+	e1 = sqrt(cand1->momentum().Mag2()+MuMass2_);
+	e2 = sqrt(cand2->momentum().Mag2()+MuMass2_);
+	p1 = Particle::LorentzVector(cand1->px(),cand1->py(),cand1->pz(),e1);
+	p2 = Particle::LorentzVector(cand2->px(),cand2->py(),cand2->pz(),e2);
+	p = p1+p2;
+	
+	double pt12 = p.pt();
+	LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 pt12= " << pt12;
+	
+	double ptLx1 = cand1->pt();
+	double ptLx2 = cand2->pt();
+	double invmass = abs(p.mass());
+	// if (invmass>0) invmass = sqrt(invmass); else invmass = 0;
+	LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 invmass= " << invmass;
+	bool proceed=false;
+	for (unsigned int iv=0 ; iv<min_InvMass_.size(); iv++) {
+	  if (invmass<min_InvMass_[iv]) return false;
+	  if (invmass>max_InvMass_[iv]) return false;
+	  if (ptLx1>ptLx2) {
+	    if (ptLx1<min_PtMax_[iv]) return false;
+	    if (ptLx2<min_PtMin_[iv]) return false;
+	    if (ptLx2>max_PtMin_[iv]) return false;
+	  } else {
+	    if (ptLx2<min_PtMax_[iv]) return false;
+	    if (ptLx1<min_PtMin_[iv]) return false;
+	    if (ptLx1>max_PtMin_[iv]) return false;
+	  }
+	  if (pt12<min_PtPair_[iv]) return false;
+	  if (pt12>max_PtPair_[iv]) return false;
+	  proceed=true;
+	}
+	if (!proceed) return false;
+	
+	// Delta Z between the two muons
+	//double DeltaZMuMu = fabs(tk2->dz(beamSpot.position())-tk1->dz(beamSpot.position()));
+	//if ( DeltaZMuMu > max_DzMuMu_) return false;
+	
+	// DCA between the two muons
+	TrackRef tk1 = cand1->track();
+	TrackRef tk2 = cand2->track();
+	TransientTrack mu1TT(*tk1, &(*bFieldHandle));
+	TransientTrack mu2TT(*tk2, &(*bFieldHandle));
+	TrajectoryStateClosestToPoint mu1TS = mu1TT.impactPointTSCP();
+	TrajectoryStateClosestToPoint mu2TS = mu2TT.impactPointTSCP();
+	if (mu1TS.isValid() && mu2TS.isValid()) {
+	  ClosestApproachInRPhi cApp;
+	  cApp.calculate(mu1TS.theState(), mu2TS.theState());
+	  if (!cApp.status()
+	      || cApp.distance() > max_DCAMuMu_) return false;
+	}
+	
+	// Max dimuon |rapidity|
+	double rapidity = fabs(p.Rapidity());
+	if ( rapidity > max_YPair_) return false;
+	
+	// if cutting on cowboys reject muons that bend towards each other
+	if(cutCowboys_ && (cand1->charge()*deltaPhi(cand1->phi(), cand2->phi()) > 0.)) return false;
+	return true;
 }

--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -18,6 +18,8 @@
 #include "TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 using namespace edm;
 using namespace std;
@@ -218,13 +220,12 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	RecoChargedCandidateRef cand(mucands,i);
         TrackRef tk = cand->track(); // is inner track
 	check_l1match = true;
-        int nlink = 0;
 	for(auto const & link : *links){
-	  nlink++;
 
 	  // Using the same method that was used to create the links between L3 and L2
 	  // ToDo: there should be a better way than dR,dPt matching
 	  const reco::Track& trackerTrack = *link.trackerTrack();
+          if (tk->pt()==0 or trackerTrack.pt()==0) continue;
 
 	  float dR2 = deltaR2(tk->eta(),tk->phi(),trackerTrack.eta(),trackerTrack.phi());
 	  float dPt = std::abs(tk->pt() - trackerTrack.pt())/tk->pt();
@@ -523,6 +524,7 @@ bool HLTMuonDimuonL3Filter::applyDiMuonSelection(const RecoChargedCandidateRef& 
 	  if (pt12<min_PtPair_[iv]) return false;
 	  if (pt12>max_PtPair_[iv]) return false;
 	  proceed=true;
+          break;
 	}
 	if (!proceed) return false;
 	


### PR DESCRIPTION
This is a 92X backport of PR #19466 
Updating the dimuon L3 filter to:
- handle muons reconstructed by the full (L3FromL2 + L3FromL1) iterL3 sequence, and perform the matching with the candidate from the previous step
- introduce the possibility of disabling the matching of the L3 to the previous candidate (L2 or L1)