### PR TITLE
Modification of Pixel Pair Step in HI Tracking

### DIFF
--- a/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
@@ -40,7 +40,11 @@ hiPixelPairSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerPairs_cfi.PixelLay
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('hiPixelPairClusters')
         )
-            )
+)
+from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+trackingPhase1.toModify(hiPixelPairSeedLayers,
+	layerList = cms.vstring('BPix1+BPix4','BPix1+FPix1_pos','BPix1+FPix1_neg')  #only use first and fourth barrel layers or first barrel and first forward layer around area where BPIX2+3 are inactive
+)
 
 # SEEDS
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
@@ -67,6 +71,47 @@ hiPixelPairSeeds.SeedComparitorPSet = cms.PSet(
     ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
     ClusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache")
     )
+
+#rectangular tracking region around area missing BPIX2/3 in Phase 1
+from RecoTracker.TkTrackingRegions.pointSeededTrackingRegion_cfi import pointSeededTrackingRegion as _pointSeededTrackingRegion
+hiPixelPairStepTrackingRegionPhase1 = _pointSeededTrackingRegion.clone(
+    RegionPSet = dict(
+        ptMin = 0.9,
+        originRadius = 0.005,
+        mode = "VerticesSigma",
+        nSigmaZVertex = 4.0,
+        vertexCollection = "hiSelectedPixelVertex",
+        beamSpot = "offlineBeamSpot",
+        whereToUseMeasurementTracker = "Never",
+        deltaEta = 1.8,
+        deltaPhi = 0.5,
+        points = dict(
+            eta = [0.0],
+            phi = [3.0],
+        )
+    )
+)
+
+from RecoTracker.TkHitPairs.hitPairEDProducer_cfi import hitPairEDProducer as _hitPairEDProducer
+hiPixelPairStepHitDoubletsPhase1 = _hitPairEDProducer.clone(
+    seedingLayers = "hiPixelPairSeedLayers",
+    trackingRegions = "hiPixelPairStepTrackingRegionPhase1",
+    clusterCheck = "",
+    produceSeedingHitSets = cms.bool(True), 
+)
+
+from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsEDProducer
+hiPixelPairStepSeedsPhase1 = _seedCreatorFromRegionConsecutiveHitsEDProducer.clone(
+    seedingHitSets = "hiPixelPairStepHitDoubletsPhase1",
+    SeedComparitorPSet = dict(
+        ComponentName = 'PixelClusterShapeSeedComparitor',
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(False),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter'),
+        ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache'),
+    )
+)
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
@@ -105,6 +150,9 @@ hiPixelPairTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTr
     onlyPixelHitsForSeedCleaner = cms.bool(True),
 
     )
+trackingPhase1.toModify(hiPixelPairTrackCandidates,
+    src = cms.InputTag('hiPixelPairStepSeedsPhase1')
+)
 
 
 # TRACK FITTING
@@ -168,10 +216,12 @@ trackingPhase1.toModify(hiPixelPairStepSelector, trackSelectors= cms.VPSet(
 
 
 # Final sequence
-
 hiPixelPairStep = cms.Sequence(hiPixelPairClusters*
                                hiPixelPairSeedLayers*
                                hiPixelPairSeeds*
                                hiPixelPairTrackCandidates*
                                hiPixelPairGlobalPrimTracks*
                                hiPixelPairStepSelector)
+hiPixelPairStep_Phase1 = hiPixelPairStep.copy()
+hiPixelPairStep_Phase1.replace(hiPixelPairSeeds,hiPixelPairStepTrackingRegionPhase1*hiPixelPairStepHitDoubletsPhase1*hiPixelPairStepSeedsPhase1)
+trackingPhase1.toReplaceWith(hiPixelPairStep, hiPixelPairStep_Phase1)


### PR DESCRIPTION
After the inclusion of additional quadruplet iterations for Phase 1 tracking in PR #18646, we have decided to mostly remove the pixel pair step from the phase 1 HI tracking workflow (similar to what was done for pp tracking). Studies here show that this iteration is only recovering 1-2% efficiency, while also contributing ~1% fake rate.  A small tracking region for pixel layers 1 and 4, and forward pixel disk 1 has been kept to cover a gap in acceptance of BPIX2 and 3 (very similar to this pp PR: #19051). 

Timing studies show an overall decrease in tracking time in 0-10% events from ~109 s to ~99 s, and from 10.3 to 9.7s in inclusive events.

Testing can be done using the HI Phase 1 relval proposed in PR #19089.
@mandrenguyen