### PR TITLE
Add CSC and DT segments in miniAOD for highpt muons and enable muon match slimmer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -184,7 +184,7 @@ pat::PATMuonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
                     smatch.dXdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.dXdZErr);
                     smatch.dYdZErr = MiniFloatConverter::reduceMantissaToNbitsRounding<12>(smatch.dYdZErr);
                     if( saveSegments_ ) {
-                      dtSegmentsRefs.insert(smatch.dtSegmentRef);
+		      if(smatch.dtSegmentRef.isNonnull()) dtSegmentsRefs.insert(smatch.dtSegmentRef);
         //               std::cout << smatch.dtSegmentRef->first << std::endl;
                     }
                 }
@@ -199,7 +199,7 @@ pat::PATMuonSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
          dtMap[seg]=outDTSegments->size();
          outDTSegmentsTmp.push_back(*seg);
       }
-      outDTSegments->put(0,outDTSegmentsTmp.begin(),outDTSegmentsTmp.end());
+      outDTSegments->put(DTChamberId(),outDTSegmentsTmp.begin(),outDTSegmentsTmp.end());
       auto dtHandle = iEvent.put(std::move(outDTSegments));
       for( auto & mu : *out) {
         if(mu.isMatchesValid()) {

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
@@ -12,6 +12,7 @@ slimmedMuons = cms.EDProducer("PATMuonSlimmer",
     slimKinkVars = cms.string("1"),
     slimCaloMETCorr = cms.string("1"),
     slimMatches = cms.string("0"),
+    saveSegments = cms.bool(True),
     modifyMuons = cms.bool(True),
     modifierConfig = cms.PSet( modifications = cms.VPSet() )
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
@@ -12,6 +12,7 @@ slimmedMuons = cms.EDProducer("PATMuonSlimmer",
     slimKinkVars = cms.string("1"),
     slimCaloMETCorr = cms.string("1"),
     slimMatches = cms.string("1"),
+    segmentsMuonSelection = cms.string("pt > 50"), #segments are needed for EXO analysis looking at TOF and for very high pt from e.g. Z' 
     saveSegments = cms.bool(True),
     modifyMuons = cms.bool(True),
     modifierConfig = cms.PSet( modifications = cms.VPSet() )

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
@@ -11,7 +11,7 @@ slimmedMuons = cms.EDProducer("PATMuonSlimmer",
     slimCaloVars = cms.string("1"),
     slimKinkVars = cms.string("1"),
     slimCaloMETCorr = cms.string("1"),
-    slimMatches = cms.string("0"),
+    slimMatches = cms.string("1"),
     saveSegments = cms.bool(True),
     modifyMuons = cms.bool(True),
     modifierConfig = cms.PSet( modifications = cms.VPSet() )


### PR DESCRIPTION
This PR adds DT and CSC segments in miniaod with relinking of the refs in muon matches to the new collection.
The current default is that segments are stored for muons with pt>50 (as the target is exo analyses at high pt).

In addition this PR enables minimal slimming of the muonmatches, this should be cross checked by the muon POG / experts to see if the IDs are stable against this change.

@gpetruc 