### PR TITLE
update conditions for unit test

### DIFF
--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -69,7 +69,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
 
 if allFromGT:
      print ">>>>>>>>>> testPVValidation_cfg.py: msg%-i: All is taken from GT"
@@ -82,7 +82,7 @@ else:
                                              connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
                                              timetype = cms.string("runnumber"),
                                              toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
-                                                                        tag = cms.string('TrackerAlignment_2015StartupPessimisticScenario_mc')
+                                                                        tag = cms.string('TrackerAlignment_Upgrade2017_design_v4')
                                                                         )
                                                                )
                                              )


### PR DESCRIPTION
After https://github.com/cms-sw/cmssw/commit/175981a474887112d3760aac99116047be3e00fb the list of files picked up by the unit test via:

```python
from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpGENSIMRECO
```
points to a phase-I MC sample, hence breaking the unit test: [example of log file](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc530/CMSSW_9_3_X_2017-07-02-0000/unitTestLogs/Alignment/OfflineValidation).
This commit restores the previous behavior.