### PR TITLE
Skim on NoBPTX primary dataset for EXO

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1342,7 +1342,7 @@ steps['RECODR2_50nsreHLT']=merge([{'--hltProcess':'reHLT'},steps['RECODR2_50ns']
 steps['RECODR2_2016reHLT']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2_2016']])
 steps['RECODR2newL1repack_2016reHLT']=merge([{'-s':'L1REPACK:FullSimTP,RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@miniAODDQM','--hltProcess':'reHLT'},steps['RECODR2_2016']])
 steps['RECODR2reHLTAlCaEle']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval'},steps['RECODR2AlCaEle']])
-steps['RECODR2reHLTAlCaTkCosmics']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval','-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,ALCA:TkAlCosmicsInCollisions,DQM:@standardDQM+@miniAODDQM'},steps['RECODR2_2016']])
+steps['RECODR2reHLTAlCaTkCosmics']=merge([{'--hltProcess':'reHLT','--conditions':'auto:run2_data_relval','-s':'RAW2DIGI,L1Reco,RECO,SKIM:EXONoBPTXSkim,EI,PAT,ALCA:TkAlCosmicsInCollisions,DQM:@standardDQM+@miniAODDQM'},steps['RECODR2_2016']])
 
 
 steps['RECODR2_2016reHLT_skimSingleMu']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:ZMu+MuTau,EI,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign,DQM:@standardDQM+@miniAODDQM'},steps['RECODR2_2016reHLT']])

--- a/Configuration/Skimming/python/PDWG_EXONoBPTXSkim_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXONoBPTXSkim_cff.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+# Pick branches you want to keep
+EXONoBPTXSkim_EventContent = cms.PSet(
+     outputCommands = cms.untracked.vstring(
+                     'drop *',
+                     'keep *_BeamHaloSummary_*_*',
+                     'keep recoCaloJets_ak4CaloJets_*_*',
+                     'keep *_hcalnoise_*_*',
+                     'keep *_towerMaker_*_*',
+                     'keep *_hbhereco_*_*',
+                     'keep *_hfreco_*_*',
+                     'keep *_hfprereco_*_*',
+                     'keep *_cscSegments_*_*',
+                     'keep *_dt4DSegments_*_*',
+                     'keep *_rpcRecHits_*_*',
+                     'keep recoMuons_muons_*_*',
+                     'keep *_muons_dt_*',
+                     'keep *_muons_csc_*',
+                     'keep *_muons_combined_*',
+                     'keep recoMuons_muonsFromCosmics1Leg_*_*',
+                     'keep recoMuons_muonsFromCosmics_*_*',
+                     'keep recoTracks_displacedStandAloneMuons_*_*',
+                     'keep recoTracks_generalTracks_*_*',
+                     'keep recoVertexs_offlinePrimaryVertices_*_*',
+                     'keep *_TriggerResults_*_*',
+     )
+)

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -89,6 +89,19 @@ SKIMStreamBPHSkim = cms.FilteredStream(
 
 #####################
 
+from Configuration.Skimming.PDWG_EXONoBPTXSkim_cff import *
+EXONoBPTXSkimPath = cms.Path()
+SKIMStreamEXONoBPTXSkim = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'EXONoBPTXSkim',
+    paths = (EXONoBPTXSkimPath),
+    content = EXONoBPTXSkim_EventContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('USER')
+    )
+
+#####################
+
 from Configuration.Skimming.PDWG_DiJetAODSkim_cff import *
 diJetAveSkimPath = cms.Path(DiJetAveSkim_Trigger)
 SKIMStreamDiJet = cms.FilteredStream(

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -15,7 +15,7 @@ autoSkim = {
  'DoubleMuonLowMass' : 'BPHSkim+LogError+LogErrorMonitor',
  'MuOnia' : 'BPHSkim+LogError+LogErrorMonitor',
  'Charmonium' : 'BPHSkim+LogError+LogErrorMonitor',
- 'NoBPTX' : 'LogError+LogErrorMonitor',
+ 'NoBPTX' : 'EXONoBPTXSkim+LogError+LogErrorMonitor',
  'HcalHPDNoise' : 'LogError+LogErrorMonitor',
  'HcalNZS' : 'LogError+LogErrorMonitor',
  'HLTPhysics' : 'LogError+LogErrorMonitor',


### PR DESCRIPTION
This PR creates a skim on the the NoBPTX dataset for EXO-16-004, EXO-17-004, and HCal DPG noise studies. No event selection criteria are applied, but the event content is greatly reduced from RECO. Furthermore, this skim need only be applied to the NoBPTX dataset, which is already quite small.
The approval talk in the PPD meeting is here: https://indico.cern.ch/event/651440/contributions/2651033/attachments/1489030/2313761/NoBPTXExoSkim_PPDMeeting_6July2017.pdf