### PR TITLE
Update HcalSeverityLevelComputer to be able to use both phase0 and phase1 flags (for HLT)

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -44,7 +44,9 @@ def customisePostEra_Run2_2016(process):
     return process
 
 def customisePostEra_Run2_2017(process):
-    _hcalCustoms25ns(process)
+    import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
+    HcalRemoveAddSevLevel.AddFlag(process.hcalRecAlgos,"HBHEFlatNoise",8)
+    HcalRemoveAddSevLevel.RemoveFlag(process.hcalRecAlgos,"HFDigiTime")
     return process
 
 

--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -18,7 +18,7 @@ for qTest in particleFlowRecHitHF.producers[0].qualityTests:
              
 
 import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11)
+HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11,verbose=False)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)
 HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHENegativeNoise",12)
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h
@@ -57,8 +57,7 @@ class HcalSeverityLevelComputer
   HcalSeverityDefinition* DropChannel_;
  
   bool getChStBit(HcalSeverityDefinition& mydef, const std::string& mybit);
-  //bool getRecHitFlag(HcalSeverityDefinition& mydef, const std::string& mybit);
-  bool getRecHitFlag(HcalSeverityDefinition& mydef, const std::string& mybit, int phase_); // FIXME: Jae
+  bool getRecHitFlag(HcalSeverityDefinition& mydef, const std::string& mybit, int phase_);
   void setBit (const unsigned bitnumber, uint32_t& where);
   void setAllRHMasks(const unsigned bitnumber, HcalSeverityDefinition& mydef);
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h
@@ -57,7 +57,8 @@ class HcalSeverityLevelComputer
   HcalSeverityDefinition* DropChannel_;
  
   bool getChStBit(HcalSeverityDefinition& mydef, const std::string& mybit);
-  bool getRecHitFlag(HcalSeverityDefinition& mydef, const std::string& mybit);
+  //bool getRecHitFlag(HcalSeverityDefinition& mydef, const std::string& mybit);
+  bool getRecHitFlag(HcalSeverityDefinition& mydef, const std::string& mybit, int phase_); // FIXME: Jae
   void setBit (const unsigned bitnumber, uint32_t& where);
   void setAllRHMasks(const unsigned bitnumber, HcalSeverityDefinition& mydef);
 

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
@@ -97,10 +97,17 @@ HcalRecAlgoESProducer::produce(const HcalSeverityLevelComputerRcd& iRecord)
 }
 
 void HcalRecAlgoESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc;
-  desc.setAllowAnything();
-  desc.add<uint32_t>("phase",0);
-  descriptions.add("hcalRecAlgos",desc);
+    edm::ParameterSetDescription desc;
+    desc.add<uint32_t>("phase",0);
+    desc.add<std::vector<std::string>>("RecoveredRecHitBits");
+    desc.add<std::vector<std::string>>("DropChannelStatusBits");
+    descriptions.add("hcalRecAlgos",desc);
+
+    edm::ParameterSetDescription desc_sevlvl;
+    desc_sevlvl.add<uint32_t>("Level");
+    desc_sevlvl.add<std::vector<std::string>>("RecHitFlags");
+    desc_sevlvl.add<std::vector<std::string>>("ChannelStatus");
+    desc_sevlvl.addVPSet("SeverityLevels",desc_sevlvl);
 }
 
 //define this as a plug-in

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
@@ -30,7 +30,8 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 
-
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 //
 // class decleration
@@ -97,17 +98,141 @@ HcalRecAlgoESProducer::produce(const HcalSeverityLevelComputerRcd& iRecord)
 }
 
 void HcalRecAlgoESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-    edm::ParameterSetDescription desc;
-    desc.add<uint32_t>("phase",0);
-    desc.add<std::vector<std::string>>("RecoveredRecHitBits");
-    desc.add<std::vector<std::string>>("DropChannelStatusBits");
-    descriptions.add("hcalRecAlgos",desc);
-
-    edm::ParameterSetDescription desc_sevlvl;
-    desc_sevlvl.add<uint32_t>("Level");
-    desc_sevlvl.add<std::vector<std::string>>("RecHitFlags");
-    desc_sevlvl.add<std::vector<std::string>>("ChannelStatus");
-    desc_sevlvl.addVPSet("SeverityLevels",desc_sevlvl);
+    edm::ParameterSetDescription desc; 
+    desc.add<unsigned int>("phase", 0);
+    desc.add<std::vector<std::string>>("RecoveredRecHitBits", {
+            "TimingAddedBit",
+            "TimingSubtractedBit",
+            });
+    {
+        edm::ParameterSetDescription vpsd1;
+        vpsd1.add<std::vector<std::string>>("RecHitFlags", {
+                "",
+                });
+        vpsd1.add<std::vector<std::string>>("ChannelStatus", {
+                "",
+                });
+        vpsd1.add<int>("Level", 0);
+        std::vector<edm::ParameterSet> temp1;
+        temp1.reserve(8);
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "",
+                    });
+            temp2.addParameter<int>("Level", 0);
+            temp1.push_back(temp2);
+        }
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "HcalCellCaloTowerProb",
+                    });
+            temp2.addParameter<int>("Level", 1);
+            temp1.push_back(temp2);
+        }
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "HSCP_R1R2",
+                    "HSCP_FracLeader",
+                    "HSCP_OuterEnergy",
+                    "HSCP_ExpFit",
+                    "ADCSaturationBit",
+                    "HBHEIsolatedNoise",
+                    "AddedSimHcalNoise",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "HcalCellExcludeFromHBHENoiseSummary",
+                    });
+            temp2.addParameter<int>("Level", 5);
+            temp1.push_back(temp2);
+        }
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "HBHEHpdHitMultiplicity",
+                    "HBHEPulseShape",
+                    "HOBit",
+                    "HFDigiTime",
+                    "HFInTimeWindow",
+                    "ZDCBit",
+                    "CalibrationBit",
+                    "TimingErrorBit",
+                    "HBHEFlatNoise",
+                    "HBHESpikeNoise",
+                    "HBHETriangleNoise",
+                    "HBHETS4TS5Noise",
+                    "HBHENegativeNoise",
+                    "HBHEOOTPU",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "",
+                    });
+            temp2.addParameter<int>("Level", 8);
+            temp1.push_back(temp2);
+        }
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "HFLongShort",
+                    "HFPET",
+                    "HFS8S1Ratio",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "",
+                    });
+            temp2.addParameter<int>("Level", 11);
+            temp1.push_back(temp2);
+        }
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "HcalCellCaloTowerMask",
+                    });
+            temp2.addParameter<int>("Level", 12);
+            temp1.push_back(temp2);
+        }
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "HcalCellHot",
+                    });
+            temp2.addParameter<int>("Level", 15);
+            temp1.push_back(temp2);
+        }
+        {
+            edm::ParameterSet temp2;
+            temp2.addParameter<std::vector<std::string>>("RecHitFlags", {
+                    "",
+                    });
+            temp2.addParameter<std::vector<std::string>>("ChannelStatus", {
+                    "HcalCellOff",
+                    "HcalCellDead",
+                    });
+            temp2.addParameter<int>("Level", 20);
+            temp1.push_back(temp2);
+        }
+        desc.addVPSet("SeverityLevels", vpsd1, temp1);
+    }
+    desc.add<std::vector<std::string>>("DropChannelStatusBits", {
+            "HcalCellMask",
+            "HcalCellOff",
+            "HcalCellDead",
+            });
+    descriptions.add("hcalRecAlgos", desc);
 }
 
 //define this as a plug-in

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
@@ -42,6 +42,8 @@ class HcalRecAlgoESProducer : public edm::ESProducer {
 
       ~HcalRecAlgoESProducer();
 
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
       typedef std::shared_ptr<HcalSeverityLevelComputer> ReturnType;
 
       ReturnType produce(const HcalSeverityLevelComputerRcd&);
@@ -92,6 +94,13 @@ HcalRecAlgoESProducer::produce(const HcalSeverityLevelComputerRcd& iRecord)
    using namespace edm::es;
 
    return myComputer ;
+}
+
+void HcalRecAlgoESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setAllowAnything();
+  desc.add<uint32_t>("phase",0);
+  descriptions.add("hcalRecAlgos",desc);
 }
 
 //define this as a plug-in

--- a/RecoLocalCalo/HcalRecAlgos/python/RemoveAddSevLevel.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/RemoveAddSevLevel.py
@@ -42,7 +42,7 @@ def PrintLevels(SLComp):
     return
 
 
-def AddFlag(sevLevelComputer,flag="UserDefinedBit0",severity=10):
+def AddFlag(sevLevelComputer,flag="UserDefinedBit0",severity=10,verbose=True):
     ''' Adds specified flag to severity level computer using specified severity level.
         If flag already exists at another severity level, it is removed from that level.
         '''
@@ -58,7 +58,7 @@ def AddFlag(sevLevelComputer,flag="UserDefinedBit0",severity=10):
             allowedflags.append(j)
             
     #print "Allowed flags = ",allowedflags
-    if flag not in allowedflags:
+    if flag not in allowedflags and verbose:
         print "\n\n"
         for j in range(0,3):
             print "###################################################"

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -88,6 +88,7 @@ hcalRecAlgos = cms.ESProducer("HcalRecAlgoESProducer",
     DropChannelStatusBits = cms.vstring('HcalCellMask','HcalCellOff', 'HcalCellDead')
 ) 
 
+# This is to use phase1 flags defined in DataFormats/METReco/interface/HcalPhase1FlagLabels.h
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = cms.uint32(1),

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -93,10 +93,6 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = cms.uint32(1),
     SeverityLevels = {
-        0 : dict( RecHitFlags = cms.vstring('TimingFromTDC', 
-                                            'HBHEPulseFitBit'
-                )
-            ),
         2 : dict( RecHitFlags = cms.vstring('HBHEIsolatedNoise') ),
         3 : dict( RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
                                             'HBHEFlatNoise', 

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -93,15 +93,16 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = cms.uint32(1),
     SeverityLevels = {
-        0 : dict( RecHitFlags = cms.vstring('TimingFromTDC') ),
-        2 : dict( RecHitFlags = cms.vstring('') ),
+        0 : dict( RecHitFlags = cms.vstring('TimingFromTDC', 
+                                            'HBHEPulseFitBit'
+                )
+            ),
+        2 : dict( RecHitFlags = cms.vstring('HBHEIsolatedNoise') ),
         3 : dict( RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
-                                            'HBHEIsolatedNoise',
                                             'HBHEFlatNoise', 
                                             'HBHESpikeNoise', 
                                             'HBHETS4TS5Noise', 
                                             'HBHENegativeNoise', 
-                                            'HBHEPulseFitBit',
                                             'HBHEOOTPU'
                 )
             ),

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -25,70 +25,8 @@ essourceSev =  cms.ESSource("EmptyESSource",
                    iovIsRunNotTime = cms.bool(True)
 )
 
+from RecoLocalCalo.HcalRecAlgos.hcalRecAlgos_cfi import hcalRecAlgos
 
-hcalRecAlgos = cms.ESProducer("HcalRecAlgoESProducer",
-    phase = cms.uint32(0),
-    SeverityLevels = cms.VPSet(
-        # the following is the default level, please do not modify its definition:
-        cms.PSet( Level = cms.int32(0),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('')
-                ),
-        cms.PSet( Level = cms.int32(1),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellCaloTowerProb')
-                ),
-        cms.PSet( Level = cms.int32(5),
-                  RecHitFlags = cms.vstring('HSCP_R1R2','HSCP_FracLeader','HSCP_OuterEnergy',
-                                            'HSCP_ExpFit','ADCSaturationBit', 'HBHEIsolatedNoise',
-                                            'AddedSimHcalNoise'),
-                  ChannelStatus = cms.vstring('HcalCellExcludeFromHBHENoiseSummary')
-                ),
-        cms.PSet( Level = cms.int32(8),
-                  RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',
-                                            'HBHEPulseShape',
-                                            'HOBit',
-                                            'HFDigiTime',
-                                            'HFInTimeWindow',
-                                            'ZDCBit', 'CalibrationBit',
-                                            'TimingErrorBit',
-                                            'HBHEFlatNoise',
-                                            'HBHESpikeNoise',
-                                            'HBHETriangleNoise',
-                                            'HBHETS4TS5Noise',
-                                            'HBHENegativeNoise',
-                                            'HBHEOOTPU'
-                                           ),
-                  ChannelStatus = cms.vstring('')
-                ),
-        # March 2010:  HFLongShort now tested, and should be excluded from CaloTowers by default
-        cms.PSet( Level = cms.int32(11),
-                  RecHitFlags = cms.vstring('HFLongShort',
-                                            # HFPET and HFS8S1Ratio feed HFLongShort, and should be at the same severity
-                                            'HFPET',
-                                            'HFS8S1Ratio'
-                                            #'HFDigiTime'  # This should be set to 11 in data ONLY.  We can't set it to 11 by default, because default values should reflect MC settings, and the flag can't be used in MC
-                                            ),
-                  ChannelStatus = cms.vstring('')
-                ),
-        cms.PSet( Level = cms.int32(12),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellCaloTowerMask')
-                ),
-        cms.PSet( Level = cms.int32(15),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellHot')
-                ),
-        cms.PSet( Level = cms.int32(20),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellOff', 'HcalCellDead')
-                )
-        ),
-    RecoveredRecHitBits = cms.vstring('TimingAddedBit','TimingSubtractedBit'),
-    DropChannelStatusBits = cms.vstring('HcalCellMask','HcalCellOff', 'HcalCellDead')
-) 
-
-# This is to use phase1 flags defined in DataFormats/METReco/interface/HcalPhase1FlagLabels.h
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = cms.uint32(1),

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -27,7 +27,7 @@ essourceSev =  cms.ESSource("EmptyESSource",
 
 
 hcalRecAlgos = cms.ESProducer("HcalRecAlgoESProducer",
-    phase = cms.uint32(1), 
+    phase = cms.uint32(0),
     SeverityLevels = cms.VPSet(
         # the following is the default level, please do not modify its definition:
         cms.PSet( Level = cms.int32(0),
@@ -103,9 +103,6 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
                 ),
         cms.PSet( Level = cms.int32(5),
                   RecHitFlags = cms.vstring(''),
-        #          RecHitFlags = cms.vstring('HSCP_R1R2','HSCP_FracLeader','HSCP_OuterEnergy',
-        #                                    'HSCP_ExpFit','ADCSaturationBit', 'HBHEIsolatedNoise',
-        #                                    'AddedSimHcalNoise'),
                   ChannelStatus = cms.vstring('HcalCellExcludeFromHBHENoiseSummary')
                 ),
         cms.PSet( Level = cms.int32(8),
@@ -143,6 +140,4 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
                   ChannelStatus = cms.vstring('HcalCellOff', 'HcalCellDead')
                 )
         ),
-    #RecoveredRecHitBits = cms.vstring('TimingAddedBit','TimingSubtractedBit'),
-    DropChannelStatusBits = cms.vstring('HcalCellMask','HcalCellOff', 'HcalCellDead')
 )

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -90,54 +90,25 @@ hcalRecAlgos = cms.ESProducer("HcalRecAlgoESProducer",
 
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
-    phase = cms.uint32(1), 
-    SeverityLevels = cms.VPSet(
-        # the following is the default level, please do not modify its definition:
-        cms.PSet( Level = cms.int32(0),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('')
-                ),
-        cms.PSet( Level = cms.int32(1),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellCaloTowerProb')
-                ),
-        cms.PSet( Level = cms.int32(5),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellExcludeFromHBHENoiseSummary')
-                ),
-        cms.PSet( Level = cms.int32(8),
-                  RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
+    phase = cms.uint32(1),
+    SeverityLevels = {
+        2 : dict( RecHitFlags = cms.vstring('') ),
+        3 : dict( RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
                                             'HBHEFlatNoise', 
                                             'HBHESpikeNoise', 
                                             'HBHETriangleNoise',
                                             'HBHETS4TS5Noise', 
                                             'HBHENegativeNoise', 
                                             'HBHEOOTPU',
-                                            'HBHEPulseFitBit' 
-                                           ),
-                  ChannelStatus = cms.vstring('')
-                ),
-        cms.PSet( Level = cms.int32(11),
-                  RecHitFlags = cms.vstring('HFLongShort', 
-                                            # HFPET and HFS8S1Ratio feed HFLongShort, and should be at the same severity
-                                            'HFS8S1Ratio',  
-                                            'HFPET', 
-                                            'HFSignalAsymmetry',
-                                            'TimingFromTDC'
-                                            ),
-                  ChannelStatus = cms.vstring('')
-                ),
-        cms.PSet( Level = cms.int32(12),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellCaloTowerMask')
-                ),
-        cms.PSet( Level = cms.int32(15),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellHot')
-                ),
-        cms.PSet( Level = cms.int32(20),
-                  RecHitFlags = cms.vstring(''),
-                  ChannelStatus = cms.vstring('HcalCellOff', 'HcalCellDead')
+                                            'HBHEPulseFitBit'
                 )
-        ),
+            ),
+        4: dict( RecHitFlags = cms.vstring('HFLongShort', 
+                                           'HFPET', 
+                                           'HFS8S1Ratio',  
+                                           'HFSignalAsymmetry',
+                                           'TimingFromTDC'
+                )
+            ),
+    },
 )

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -27,6 +27,7 @@ essourceSev =  cms.ESSource("EmptyESSource",
 
 
 hcalRecAlgos = cms.ESProducer("HcalRecAlgoESProducer",
+    phase = cms.uint32(1), 
     SeverityLevels = cms.VPSet(
         # the following is the default level, please do not modify its definition:
         cms.PSet( Level = cms.int32(0),

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -93,21 +93,23 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = cms.uint32(1),
     SeverityLevels = {
         0 : dict( RecHitFlags = cms.vstring('TimingFromTDC') ),
+        2 : dict( RecHitFlags = cms.vstring('') ),
         3 : dict( RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
+                                            'HBHEIsolatedNoise',
                                             'HBHEFlatNoise', 
                                             'HBHESpikeNoise', 
-                                            'HBHETriangleNoise',
                                             'HBHETS4TS5Noise', 
                                             'HBHENegativeNoise', 
-                                            'HBHEOOTPU',
-                                            'HBHEPulseFitBit'
+                                            'HBHEPulseFitBit',
+                                            'HBHEOOTPU'
                 )
             ),
         4: dict( RecHitFlags = cms.vstring('HFLongShort', 
-                                           'HFPET', 
                                            'HFS8S1Ratio',  
+                                           'HFPET', 
                                            'HFSignalAsymmetry'
                 )
             ),
     },
+    RecoveredRecHitBits = cms.vstring('')
 )

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -86,4 +86,62 @@ hcalRecAlgos = cms.ESProducer("HcalRecAlgoESProducer",
         ),
     RecoveredRecHitBits = cms.vstring('TimingAddedBit','TimingSubtractedBit'),
     DropChannelStatusBits = cms.vstring('HcalCellMask','HcalCellOff', 'HcalCellDead')
+) 
+
+from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+run2_HCAL_2017.toModify(hcalRecAlgos,
+    phase = cms.uint32(1), 
+    SeverityLevels = cms.VPSet(
+        # the following is the default level, please do not modify its definition:
+        cms.PSet( Level = cms.int32(0),
+                  RecHitFlags = cms.vstring(''),
+                  ChannelStatus = cms.vstring('')
+                ),
+        cms.PSet( Level = cms.int32(1),
+                  RecHitFlags = cms.vstring(''),
+                  ChannelStatus = cms.vstring('HcalCellCaloTowerProb')
+                ),
+        cms.PSet( Level = cms.int32(5),
+                  RecHitFlags = cms.vstring('HSCP_R1R2','HSCP_FracLeader','HSCP_OuterEnergy',
+                                            'HSCP_ExpFit','ADCSaturationBit', 'HBHEIsolatedNoise',
+                                            'AddedSimHcalNoise'),
+                  ChannelStatus = cms.vstring('HcalCellExcludeFromHBHENoiseSummary')
+                ),
+        cms.PSet( Level = cms.int32(8),
+                  RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity', # 
+                                            'HBHEFlatNoise', #
+                                            'HBHESpikeNoise', #
+                                            'HBHETriangleNoise',
+                                            'HBHETS4TS5Noise', #
+                                            'HBHENegativeNoise', #
+                                            'HBHEOOTPU' #
+                                            'HBHEPulseFitBit' # new: why not in phase 0?
+                                           ),
+                  ChannelStatus = cms.vstring('')
+                ),
+        cms.PSet( Level = cms.int32(11),
+                  RecHitFlags = cms.vstring('HFLongShort', #
+                                            # HFPET and HFS8S1Ratio feed HFLongShort, and should be at the same severity
+                                            'HFS8S1Ratio', # 
+                                            'HFPET', #
+                                            'HFSignalAsymmetry' # new
+                                            'TimingFromTDC' # new
+                                            ),
+                  ChannelStatus = cms.vstring('')
+                ),
+        cms.PSet( Level = cms.int32(12),
+                  RecHitFlags = cms.vstring(''),
+                  ChannelStatus = cms.vstring('HcalCellCaloTowerMask')
+                ),
+        cms.PSet( Level = cms.int32(15),
+                  RecHitFlags = cms.vstring(''),
+                  ChannelStatus = cms.vstring('HcalCellHot')
+                ),
+        cms.PSet( Level = cms.int32(20),
+                  RecHitFlags = cms.vstring(''),
+                  ChannelStatus = cms.vstring('HcalCellOff', 'HcalCellDead')
+                )
+        ),
+    RecoveredRecHitBits = cms.vstring('TimingAddedBit','TimingSubtractedBit'),
+    DropChannelStatusBits = cms.vstring('HcalCellMask','HcalCellOff', 'HcalCellDead')
 )

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -102,30 +102,31 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
                   ChannelStatus = cms.vstring('HcalCellCaloTowerProb')
                 ),
         cms.PSet( Level = cms.int32(5),
-                  RecHitFlags = cms.vstring('HSCP_R1R2','HSCP_FracLeader','HSCP_OuterEnergy',
-                                            'HSCP_ExpFit','ADCSaturationBit', 'HBHEIsolatedNoise',
-                                            'AddedSimHcalNoise'),
+                  RecHitFlags = cms.vstring(''),
+        #          RecHitFlags = cms.vstring('HSCP_R1R2','HSCP_FracLeader','HSCP_OuterEnergy',
+        #                                    'HSCP_ExpFit','ADCSaturationBit', 'HBHEIsolatedNoise',
+        #                                    'AddedSimHcalNoise'),
                   ChannelStatus = cms.vstring('HcalCellExcludeFromHBHENoiseSummary')
                 ),
         cms.PSet( Level = cms.int32(8),
-                  RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity', # 
-                                            'HBHEFlatNoise', #
-                                            'HBHESpikeNoise', #
+                  RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
+                                            'HBHEFlatNoise', 
+                                            'HBHESpikeNoise', 
                                             'HBHETriangleNoise',
-                                            'HBHETS4TS5Noise', #
-                                            'HBHENegativeNoise', #
-                                            'HBHEOOTPU' #
-                                            'HBHEPulseFitBit' # new: why not in phase 0?
+                                            'HBHETS4TS5Noise', 
+                                            'HBHENegativeNoise', 
+                                            'HBHEOOTPU',
+                                            'HBHEPulseFitBit' 
                                            ),
                   ChannelStatus = cms.vstring('')
                 ),
         cms.PSet( Level = cms.int32(11),
-                  RecHitFlags = cms.vstring('HFLongShort', #
+                  RecHitFlags = cms.vstring('HFLongShort', 
                                             # HFPET and HFS8S1Ratio feed HFLongShort, and should be at the same severity
-                                            'HFS8S1Ratio', # 
-                                            'HFPET', #
-                                            'HFSignalAsymmetry' # new
-                                            'TimingFromTDC' # new
+                                            'HFS8S1Ratio',  
+                                            'HFPET', 
+                                            'HFSignalAsymmetry',
+                                            'TimingFromTDC'
                                             ),
                   ChannelStatus = cms.vstring('')
                 ),
@@ -142,6 +143,6 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
                   ChannelStatus = cms.vstring('HcalCellOff', 'HcalCellDead')
                 )
         ),
-    RecoveredRecHitBits = cms.vstring('TimingAddedBit','TimingSubtractedBit'),
+    #RecoveredRecHitBits = cms.vstring('TimingAddedBit','TimingSubtractedBit'),
     DropChannelStatusBits = cms.vstring('HcalCellMask','HcalCellOff', 'HcalCellDead')
 )

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -92,7 +92,7 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = cms.uint32(1),
     SeverityLevels = {
-        2 : dict( RecHitFlags = cms.vstring('') ),
+        0 : dict( RecHitFlags = cms.vstring('TimingFromTDC') ),
         3 : dict( RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
                                             'HBHEFlatNoise', 
                                             'HBHESpikeNoise', 
@@ -106,8 +106,7 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
         4: dict( RecHitFlags = cms.vstring('HFLongShort', 
                                            'HFPET', 
                                            'HFS8S1Ratio',  
-                                           'HFSignalAsymmetry',
-                                           'TimingFromTDC'
+                                           'HFSignalAsymmetry'
                 )
             ),
     },

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
@@ -1,7 +1,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelStatus.h"
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
-#include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h" //FIXME: Jae 
+#include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -141,7 +141,7 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
   typedef std::vector< edm::ParameterSet > myParameters;
   myParameters myLevels = iConfig.getParameter<myParameters>((std::string)"SeverityLevels");
 
-  int phase_   = iConfig.getUntrackedParameter<bool>("phase"); // FIXME: Jae
+  int phase_   = iConfig.getParameter<int>("phase");
 
   // now run through the parameter set vector:
   for ( myParameters::iterator itLevels = myLevels.begin(); itLevels != myLevels.end(); ++itLevels)
@@ -177,7 +177,7 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
 	{
 	  if (myRecHitFlags[k].empty()) break; // empty string
 	  bnonempty++;
-	  bvalid+=getRecHitFlag(mydef, myRecHitFlags[k], phase_); // FIXME: Jae
+	  bvalid+=getRecHitFlag(mydef, myRecHitFlags[k], phase_);
 	}
 
       //      std::cout << "Made Severity Level:" << std::endl;
@@ -240,7 +240,7 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
   for (unsigned k=0; k < myRecovered.size(); k++)
     {
       if (myRecovered[k].empty()) break;
-      getRecHitFlag( (*RecoveredRecHit_), myRecovered[k], phase_); // FIXME: Jae
+      getRecHitFlag( (*RecoveredRecHit_), myRecovered[k], phase_);
     }
 
   //

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 bool HcalSeverityLevelComputer::getChStBit(HcalSeverityDefinition& mydef, 
 					   const std::string& mybit)
 {
@@ -37,16 +36,16 @@ bool HcalSeverityLevelComputer::getRecHitFlag(HcalSeverityDefinition& mydef,
         int phase)
 {
     if(phase==1) // Phase 1 Rechit flags 
-    {
+    { 
         // HB, HE ++++++++++++++++++++
         if (mybit == "HBHEHpdHitMultiplicity")  setBit(HcalPhase1FlagLabels::HBHEHpdHitMultiplicity, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEIsolatedNoise")  setBit(HcalPhase1FlagLabels::HBHEIsolatedNoise, mydef.HBHEFlagMask );
         else if (mybit == "HBHEFlatNoise")      setBit(HcalPhase1FlagLabels::HBHEFlatNoise, mydef.HBHEFlagMask);
         else if (mybit == "HBHESpikeNoise")     setBit(HcalPhase1FlagLabels::HBHESpikeNoise, mydef.HBHEFlagMask);
         else if (mybit == "HBHETS4TS5Noise")    setBit(HcalPhase1FlagLabels::HBHETS4TS5Noise, mydef.HBHEFlagMask);
         else if (mybit == "HBHENegativeNoise")  setBit(HcalPhase1FlagLabels::HBHENegativeNoise, mydef.HBHEFlagMask);
         else if (mybit == "HBHEPulseFitBit")    setBit(HcalPhase1FlagLabels::HBHEPulseFitBit, mydef.HBHEFlagMask);
         else if (mybit == "HBHEOOTPU")          setBit(HcalPhase1FlagLabels::HBHEOOTPU, mydef.HBHEFlagMask);
-        else if (mybit == "HBHEIsolatedNoise")  setBit(HcalPhase1FlagLabels::HBHEIsolatedNoise, mydef.HBHEFlagMask );
 
         // HF ++++++++++++++++++++
         else if (mybit == "HFLongShort")        setBit(HcalPhase1FlagLabels::HFLongShort, mydef.HFFlagMask);
@@ -141,7 +140,7 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
   typedef std::vector< edm::ParameterSet > myParameters;
   myParameters myLevels = iConfig.getParameter<myParameters>((std::string)"SeverityLevels");
 
-  int phase_   = iConfig.getParameter<int>("phase");
+  unsigned int phase_   = iConfig.getParameter<unsigned int>("phase");
 
   // now run through the parameter set vector:
   for ( myParameters::iterator itLevels = myLevels.begin(); itLevels != myLevels.end(); ++itLevels)
@@ -177,7 +176,7 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
 	{
 	  if (myRecHitFlags[k].empty()) break; // empty string
 	  bnonempty++;
-	  bvalid+=getRecHitFlag(mydef, myRecHitFlags[k], phase_);
+	  bvalid+=getRecHitFlag(mydef, myRecHitFlags[k], phase_); 
 	}
 
       //      std::cout << "Made Severity Level:" << std::endl;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc
@@ -1,6 +1,7 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "CondFormats/HcalObjects/interface/HcalChannelStatus.h"
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+#include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h" //FIXME: Jae 
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -32,72 +33,106 @@ bool HcalSeverityLevelComputer::getChStBit(HcalSeverityDefinition& mydef,
 }
 
 bool HcalSeverityLevelComputer::getRecHitFlag(HcalSeverityDefinition& mydef, 
-					      const std::string& mybit)
+        const std::string& mybit, 
+        int phase)
 {
-  // HB, HE ++++++++++++++++++++
-  if (mybit == "HBHEHpdHitMultiplicity") setBit(HcalCaloFlagLabels::HBHEHpdHitMultiplicity, mydef.HBHEFlagMask);
-  else if (mybit == "HBHEPulseShape")    setBit(HcalCaloFlagLabels::HBHEPulseShape, mydef.HBHEFlagMask);
-  else if (mybit == "HSCP_R1R2")         setBit(HcalCaloFlagLabels::HSCP_R1R2, mydef.HBHEFlagMask);
-  else if (mybit == "HSCP_FracLeader")   setBit(HcalCaloFlagLabels::HSCP_FracLeader, mydef.HBHEFlagMask);
-  else if (mybit == "HSCP_OuterEnergy")  setBit(HcalCaloFlagLabels::HSCP_OuterEnergy, mydef.HBHEFlagMask);
-  else if (mybit == "HSCP_ExpFit")       setBit(HcalCaloFlagLabels::HSCP_ExpFit, mydef.HBHEFlagMask);
-  else if (mybit == "HBHEFlatNoise")     setBit(HcalCaloFlagLabels::HBHEFlatNoise, mydef.HBHEFlagMask);
-  else if (mybit == "HBHESpikeNoise")    setBit(HcalCaloFlagLabels::HBHESpikeNoise, mydef.HBHEFlagMask);
-  else if (mybit == "HBHETriangleNoise") setBit(HcalCaloFlagLabels::HBHETriangleNoise, mydef.HBHEFlagMask);
-  else if (mybit == "HBHETS4TS5Noise")   setBit(HcalCaloFlagLabels::HBHETS4TS5Noise, mydef.HBHEFlagMask);
-  else if (mybit == "HBHENegativeNoise") setBit(HcalCaloFlagLabels::HBHENegativeNoise, mydef.HBHEFlagMask);
-  else if (mybit == "HBHEPulseFitBit")   setBit(HcalCaloFlagLabels::HBHEPulseFitBit, mydef.HBHEFlagMask);
-  else if (mybit == "HBHEOOTPU")         setBit(HcalCaloFlagLabels::HBHEOOTPU, mydef.HBHEFlagMask);
-
-
-  // These are multi-bit counters; we may have to revisit how to set them in the SLComputer in the future
-  else if (mybit=="HBHETimingTrustBits") setBit(HcalCaloFlagLabels::HBHETimingTrustBits, mydef.HBHEFlagMask );
-  else if (mybit=="HBHETimingShapedCutsBits") setBit(HcalCaloFlagLabels::HBHETimingShapedCutsBits, mydef.HBHEFlagMask);
-  else if (mybit=="HBHEIsolatedNoise")   setBit(HcalCaloFlagLabels::HBHEIsolatedNoise, mydef.HBHEFlagMask );
-
-  // HO ++++++++++++++++++++
-  else if (mybit == "HOBit")    setBit(HcalCaloFlagLabels::HOBit, mydef.HOFlagMask);
-  
-  // HF ++++++++++++++++++++
-  else if (mybit == "HFLongShort")    setBit(HcalCaloFlagLabels::HFLongShort, mydef.HFFlagMask);
-  else if (mybit == "HFDigiTime")    setBit(HcalCaloFlagLabels::HFDigiTime, mydef.HFFlagMask);
-  else if (mybit == "HFInTimeWindow") setBit(HcalCaloFlagLabels::HFInTimeWindow, mydef.HFFlagMask);
-  else if (mybit == "HFS8S1Ratio") setBit(HcalCaloFlagLabels::HFS8S1Ratio, mydef.HFFlagMask);
-  else if (mybit == "HFPET")  setBit(HcalCaloFlagLabels::HFPET, mydef.HFFlagMask);
-  else if (mybit == "HFTimingTrustBits")  setBit(HcalCaloFlagLabels::HFTimingTrustBits, mydef.HFFlagMask); // multi-bit counter
-
-  // ZDC ++++++++++++++++++++
-  else if (mybit == "ZDCBit")     setBit(HcalCaloFlagLabels::ZDCBit, mydef.ZDCFlagMask);
-  
-  // Calib ++++++++++++++++++++
-  else if (mybit == "CalibrationBit")     setBit(HcalCaloFlagLabels::CalibrationBit, mydef.CalibFlagMask);
-
-  // Common subdetector bits ++++++++++++++++++++++
-  else if (mybit == "TimingSubtractedBit")  setAllRHMasks(HcalCaloFlagLabels::TimingSubtractedBit, mydef);
-  else if (mybit == "TimingAddedBit")       setAllRHMasks(HcalCaloFlagLabels::TimingAddedBit,      mydef);
-  else if (mybit == "TimingErrorBit")       setAllRHMasks(HcalCaloFlagLabels::TimingErrorBit,      mydef);
-  else if (mybit == "ADCSaturationBit")     setAllRHMasks(HcalCaloFlagLabels::ADCSaturationBit,    mydef);
-  else if (mybit== "AddedSimHcalNoise")     setAllRHMasks(HcalCaloFlagLabels::AddedSimHcalNoise,   mydef);
-
-  else if (mybit == "UserDefinedBit0")      setAllRHMasks(HcalCaloFlagLabels::UserDefinedBit0,     mydef);
-    
-
-  // additional defined diagnostic bits; not currently used for rejection
-  else if (mybit == "PresampleADC")         setAllRHMasks(HcalCaloFlagLabels::PresampleADC,     mydef);
-  else if (mybit == "Fraction2TS")         setAllRHMasks(HcalCaloFlagLabels::Fraction2TS,     mydef); // should deprecate this at some point; it's been replaced by PresampleADC
-
-
-
-  // unknown -------------------
-  else
+    if(phase==1) // Phase 1 Rechit flags 
     {
-      // error: unrecognized flag name
-      edm::LogWarning  ("HcalSeverityLevelComputer") 
-	<< "HcalSeverityLevelComputer: Error: RecHitFlag >>" << mybit 
-	<< "<< unknown. Ignoring.";
-      return false;
+        // HB, HE ++++++++++++++++++++
+        if (mybit == "HBHEHpdHitMultiplicity")  setBit(HcalPhase1FlagLabels::HBHEHpdHitMultiplicity, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEFlatNoise")      setBit(HcalPhase1FlagLabels::HBHEFlatNoise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHESpikeNoise")     setBit(HcalPhase1FlagLabels::HBHESpikeNoise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHETS4TS5Noise")    setBit(HcalPhase1FlagLabels::HBHETS4TS5Noise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHENegativeNoise")  setBit(HcalPhase1FlagLabels::HBHENegativeNoise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEPulseFitBit")    setBit(HcalPhase1FlagLabels::HBHEPulseFitBit, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEOOTPU")          setBit(HcalPhase1FlagLabels::HBHEOOTPU, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEIsolatedNoise")  setBit(HcalPhase1FlagLabels::HBHEIsolatedNoise, mydef.HBHEFlagMask );
+
+        // HF ++++++++++++++++++++
+        else if (mybit == "HFLongShort")        setBit(HcalPhase1FlagLabels::HFLongShort, mydef.HFFlagMask);
+        else if (mybit == "HFS8S1Ratio")        setBit(HcalPhase1FlagLabels::HFS8S1Ratio, mydef.HFFlagMask);
+        else if (mybit == "HFPET")              setBit(HcalPhase1FlagLabels::HFPET, mydef.HFFlagMask);
+        else if (mybit == "HFSignalAsymmetry")  setBit(HcalPhase1FlagLabels::HFSignalAsymmetry, mydef.HFFlagMask);
+
+        // Common subdetector bits ++++++++++++++++++++++
+        else if (mybit == "TimingFromTDC")      setAllRHMasks(HcalPhase1FlagLabels::TimingFromTDC, mydef);
+        else if (mybit == "UserDefinedBit0")    setAllRHMasks(HcalPhase1FlagLabels::UserDefinedBit0, mydef);
+
+        // unknown -------------------
+        else
+        {
+            // error: unrecognized flag name
+            edm::LogWarning  ("HcalSeverityLevelComputer")
+                << "HcalSeverityLevelComputer: Error: RecHitFlag >>" << mybit
+                << "<< unknown. Ignoring.";
+            return false;
+        }
     }
-  return true;
+    else // Phase 0 Rechit flags 
+    {
+        // HB, HE ++++++++++++++++++++
+        if (mybit == "HBHEHpdHitMultiplicity") setBit(HcalCaloFlagLabels::HBHEHpdHitMultiplicity, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEPulseShape")    setBit(HcalCaloFlagLabels::HBHEPulseShape, mydef.HBHEFlagMask);
+        else if (mybit == "HSCP_R1R2")         setBit(HcalCaloFlagLabels::HSCP_R1R2, mydef.HBHEFlagMask);
+        else if (mybit == "HSCP_FracLeader")   setBit(HcalCaloFlagLabels::HSCP_FracLeader, mydef.HBHEFlagMask);
+        else if (mybit == "HSCP_OuterEnergy")  setBit(HcalCaloFlagLabels::HSCP_OuterEnergy, mydef.HBHEFlagMask);
+        else if (mybit == "HSCP_ExpFit")       setBit(HcalCaloFlagLabels::HSCP_ExpFit, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEFlatNoise")     setBit(HcalCaloFlagLabels::HBHEFlatNoise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHESpikeNoise")    setBit(HcalCaloFlagLabels::HBHESpikeNoise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHETriangleNoise") setBit(HcalCaloFlagLabels::HBHETriangleNoise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHETS4TS5Noise")   setBit(HcalCaloFlagLabels::HBHETS4TS5Noise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHENegativeNoise") setBit(HcalCaloFlagLabels::HBHENegativeNoise, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEPulseFitBit")   setBit(HcalCaloFlagLabels::HBHEPulseFitBit, mydef.HBHEFlagMask);
+        else if (mybit == "HBHEOOTPU")         setBit(HcalCaloFlagLabels::HBHEOOTPU, mydef.HBHEFlagMask);
+
+
+        // These are multi-bit counters; we may have to revisit how to set them in the SLComputer in the future
+        else if (mybit=="HBHETimingTrustBits") setBit(HcalCaloFlagLabels::HBHETimingTrustBits, mydef.HBHEFlagMask );
+        else if (mybit=="HBHETimingShapedCutsBits") setBit(HcalCaloFlagLabels::HBHETimingShapedCutsBits, mydef.HBHEFlagMask);
+        else if (mybit=="HBHEIsolatedNoise")   setBit(HcalCaloFlagLabels::HBHEIsolatedNoise, mydef.HBHEFlagMask );
+
+        // HO ++++++++++++++++++++
+        else if (mybit == "HOBit")    setBit(HcalCaloFlagLabels::HOBit, mydef.HOFlagMask);
+
+        // HF ++++++++++++++++++++
+        else if (mybit == "HFLongShort")    setBit(HcalCaloFlagLabels::HFLongShort, mydef.HFFlagMask);
+        else if (mybit == "HFDigiTime")    setBit(HcalCaloFlagLabels::HFDigiTime, mydef.HFFlagMask);
+        else if (mybit == "HFInTimeWindow") setBit(HcalCaloFlagLabels::HFInTimeWindow, mydef.HFFlagMask);
+        else if (mybit == "HFS8S1Ratio") setBit(HcalCaloFlagLabels::HFS8S1Ratio, mydef.HFFlagMask);
+        else if (mybit == "HFPET")  setBit(HcalCaloFlagLabels::HFPET, mydef.HFFlagMask);
+        else if (mybit == "HFTimingTrustBits")  setBit(HcalCaloFlagLabels::HFTimingTrustBits, mydef.HFFlagMask); // multi-bit counter
+
+        // ZDC ++++++++++++++++++++
+        else if (mybit == "ZDCBit")     setBit(HcalCaloFlagLabels::ZDCBit, mydef.ZDCFlagMask);
+
+        // Calib ++++++++++++++++++++
+        else if (mybit == "CalibrationBit")     setBit(HcalCaloFlagLabels::CalibrationBit, mydef.CalibFlagMask);
+
+        // Common subdetector bits ++++++++++++++++++++++
+        else if (mybit == "TimingSubtractedBit")  setAllRHMasks(HcalCaloFlagLabels::TimingSubtractedBit, mydef);
+        else if (mybit == "TimingAddedBit")       setAllRHMasks(HcalCaloFlagLabels::TimingAddedBit,      mydef);
+        else if (mybit == "TimingErrorBit")       setAllRHMasks(HcalCaloFlagLabels::TimingErrorBit,      mydef);
+        else if (mybit == "ADCSaturationBit")     setAllRHMasks(HcalCaloFlagLabels::ADCSaturationBit,    mydef);
+        else if (mybit== "AddedSimHcalNoise")     setAllRHMasks(HcalCaloFlagLabels::AddedSimHcalNoise,   mydef);
+
+        else if (mybit == "UserDefinedBit0")      setAllRHMasks(HcalCaloFlagLabels::UserDefinedBit0,     mydef);
+
+
+        // additional defined diagnostic bits; not currently used for rejection
+        else if (mybit == "PresampleADC")         setAllRHMasks(HcalCaloFlagLabels::PresampleADC,     mydef);
+        else if (mybit == "Fraction2TS")         setAllRHMasks(HcalCaloFlagLabels::Fraction2TS,     mydef); // should deprecate this at some point; it's been replaced by PresampleADC
+
+        // unknown -------------------
+        else
+        {
+            // error: unrecognized flag name
+            edm::LogWarning  ("HcalSeverityLevelComputer") 
+                << "HcalSeverityLevelComputer: Error: RecHitFlag >>" << mybit 
+                << "<< unknown. Ignoring.";
+            return false;
+        }
+    }
+    return true;
 }
 
 HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& iConfig)
@@ -105,6 +140,8 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
   // initialize: get the levels and masks from the cfg:
   typedef std::vector< edm::ParameterSet > myParameters;
   myParameters myLevels = iConfig.getParameter<myParameters>((std::string)"SeverityLevels");
+
+  int phase_   = iConfig.getUntrackedParameter<bool>("phase"); // FIXME: Jae
 
   // now run through the parameter set vector:
   for ( myParameters::iterator itLevels = myLevels.begin(); itLevels != myLevels.end(); ++itLevels)
@@ -140,7 +177,7 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
 	{
 	  if (myRecHitFlags[k].empty()) break; // empty string
 	  bnonempty++;
-	  bvalid+=getRecHitFlag(mydef, myRecHitFlags[k]);
+	  bvalid+=getRecHitFlag(mydef, myRecHitFlags[k], phase_); // FIXME: Jae
 	}
 
       //      std::cout << "Made Severity Level:" << std::endl;
@@ -203,7 +240,7 @@ HcalSeverityLevelComputer::HcalSeverityLevelComputer( const edm::ParameterSet& i
   for (unsigned k=0; k < myRecovered.size(); k++)
     {
       if (myRecovered[k].empty()) break;
-      getRecHitFlag( (*RecoveredRecHit_), myRecovered[k]);
+      getRecHitFlag( (*RecoveredRecHit_), myRecovered[k], phase_); // FIXME: Jae
     }
 
   //

--- a/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HFPhase1Reconstructor_cfi.py
@@ -60,7 +60,7 @@ hfreco = cms.EDProducer("HFPhase1Reconstructor",
     algoConfigClass = cms.string("HFPhase1PMTParams"),
 
     # Turn on/off the noise cleanup algorithms
-    setNoiseFlags = cms.bool(False),
+    setNoiseFlags = cms.bool(True),
 
     # Parameters for the S9S1 test.
     #


### PR DESCRIPTION
This request is based on the PR for offline (https://github.com/cms-sw/cmssw/pull/19532) so that HLT configs can be updated accordingly.  