### PR TITLE
Integration of constituent subtracted jets into heavy ion reconstruction

### DIFF
--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -41,9 +41,55 @@ akPu4PFJets = akPu5PFJets.clone(rParam       = cms.double(0.4), puPtMin = 20)
 akPu6PFJets = akPu5PFJets.clone(rParam       = cms.double(0.6), puPtMin = 30)
 akPu7PFJets = akPu5PFJets.clone(rParam       = cms.double(0.7), puPtMin = 35)
 
+kt4PFJetsForRho = cms.EDProducer(
+    "FastjetJetProducer",
+    HiPFJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm = cms.string("Kt"),
+    rParam       = cms.double(0.4)
+)
+kt4PFJetsForRho.src = cms.InputTag('particleFlowTmp')
+kt4PFJetsForRho.doAreaFastjet = cms.bool(True)
+kt4PFJetsForRho.jetPtMin      = cms.double(0.0)
+kt4PFJetsForRho.GhostArea     = cms.double(0.005)
+
+hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
+                                 jetSource = cms.InputTag('kt4PFJetsForRho'),
+                                 nExcl = cms.int32(2),
+                                 etaMaxExcl = cms.double(2.),
+                                 ptMinExcl = cms.double(20.),
+                                 nExcl2 = cms.int32(1),
+                                 etaMaxExcl2 = cms.double(3.),
+                                 ptMinExcl2 = cms.double(20.),
+                                 etaRanges = cms.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
+)
+
+akCs4PFJets = cms.EDProducer(
+    "CSJetProducer",
+    HiPFJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm  = cms.string("AntiKt"),
+    rParam        = cms.double(0.4),
+    etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+    rho       = cms.InputTag('hiFJRhoProducer','mapToRho'),
+    rhom      = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+    csRParam  = cms.double(-1.),
+    csAlpha   = cms.double(2.),
+    writeJetsWithConst = cms.bool(True),
+    jetCollInstanceName = cms.string("pfParticlesCs")
+)
+akCs4PFJets.src           = cms.InputTag('particleFlowTmp')
+akCs4PFJets.doAreaFastjet = cms.bool(True)
+akCs4PFJets.jetPtMin      = cms.double(0.0)
+akCs4PFJets.useExplicitGhosts = cms.bool(True)
+akCs4PFJets.GhostArea     = cms.double(0.005)
+
+akCs3PFJets = akCs4PFJets.clone(rParam       = cms.double(0.3))
 
 hiRecoPFJets = cms.Sequence(
     PFTowers
     *akPu3PFJets*akPu4PFJets*akPu5PFJets
+    *kt4PFJetsForRho*hiFJRhoProducer
+    *akCs3PFJets*akCs4PFJets
     )
 

--- a/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
+++ b/RecoHI/HiJetAlgos/python/RecoHiJets_EventContent_cff.py
@@ -9,8 +9,12 @@ RecoHiJetsRECO = cms.PSet(
                                             'keep *_akPu3PFJets_*_*',
                                             'keep *_akPu4PFJets_*_*',
                                             'keep *_akPu5PFJets_*_*',
+                                            'keep *_akCs3PFJets_*_*',
+                                            'keep *_akCs4PFJets_*_*',
+                                            'keep *_kt4PFJetsForRho_*_*',
                                             'keep *_*HiGenJets_*_*',
-                                            'keep *_PFTowers_*_*'
+                                            'keep *_PFTowers_*_*',
+                                            'keep *_hiFJRhoProducer_*_*'
 
                                            )
     )
@@ -19,7 +23,8 @@ RecoHiJetsFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_*CaloJets_*_*',
                                            'keep *_*PFJets_*_*',
                                            'keep *_*HiGenJets_*_*',
-                                           'keep *_*PFTowers_*_*'
+                                           'keep *_*PFTowers_*_*',
+                                           'keep *_*hiFJRhoProducer_*_*'
                                            )
     )
 
@@ -28,6 +33,7 @@ RecoHiJetsAOD = cms.PSet(
                                            'keep *_*PFJets_*_*',
                                            'keep *_*HiGenJets_*_*',
                                            'keep *_*PFTowers_*_*',
+                                           'keep *_*hiFJRhoProducer_*_*',
                                            'keep CaloTowersSorted_towerMaker_*_*',
                                            'drop recoCandidatesOwned_caloTowers_*_*',
                                            'keep recoPFCandidates_particleFlowTmp_*_*'

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -1,0 +1,155 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "RecoJets/JetProducers/plugins/CSJetProducer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "RecoJets/JetProducers/interface/JetSpecific.h"
+
+#include "fastjet/contrib/ConstituentSubtractor.hh"
+
+using namespace std;
+using namespace reco;
+using namespace edm;
+using namespace cms;
+
+CSJetProducer::CSJetProducer(edm::ParameterSet const& conf):
+  VirtualJetProducer( conf ),
+  csRParam_(-1.0),
+  csAlpha_(0.)
+{
+  //get eta range, rho and rhom map
+  etaToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "etaMap" ));
+  rhoToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rho" ));
+  rhomToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rhom" ));
+  csRParam_ = conf.getParameter<double>("csRParam");
+  csAlpha_ = conf.getParameter<double>("csAlpha");
+}
+
+void CSJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup )
+{
+  // use the default production from one collection
+  VirtualJetProducer::produce( iEvent, iSetup );
+  //use runAlgorithm of this class
+
+  //Delete allocated memory. It is allocated every time runAlgorithm is called
+  fjClusterSeq_.reset();
+}
+
+//______________________________________________________________________________
+void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup)
+{
+  // run algorithm
+  if ( !doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+  } else if (voronoiRfact_ <= 0) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+  } else {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+  }
+
+  fjJets_.clear();
+  std::vector<fastjet::PseudoJet> tempJets = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
+
+  //Get local rho and rhom map
+  edm::Handle<std::vector<double>> etaRanges;
+  edm::Handle<std::vector<double>> rhoRanges;
+  edm::Handle<std::vector<double>> rhomRanges;
+  
+  iEvent.getByToken(etaToken_, etaRanges);
+  iEvent.getByToken(rhoToken_, rhoRanges);
+  iEvent.getByToken(rhomToken_, rhomRanges);
+
+  //Check if size of eta and background density vectors is the same
+  unsigned int bkgVecSize = etaRanges->size();
+  if(bkgVecSize<1) { throw cms::Exception("WrongBkgInput") << "Producer needs vector with background estimates\n"; }
+  if(bkgVecSize != (rhoRanges->size()+1) || bkgVecSize != (rhomRanges->size()+1) ) {
+    throw cms::Exception("WrongBkgInput") << "Size of etaRanges (" << bkgVecSize << ") and rhoRanges (" << rhoRanges->size() << ") and/or rhomRanges (" << rhomRanges->size() << ") vectors inconsistent\n";
+  }
+
+  
+  //Allow the background densities to change within the jet
+
+  for(fastjet::PseudoJet& ijet : tempJets ) {
+  
+    //----------------------------------------------------------------------
+    // sift ghosts and particles in the input jet
+    std::vector<fastjet::PseudoJet> particles, ghosts;
+    fastjet::SelectorIsPureGhost().sift(ijet.constituents(), ghosts, particles);
+    unsigned long nGhosts=ghosts.size();
+    unsigned long nParticles=particles.size();
+    if(nParticles==0) continue; //don't subtract ghost jets
+    
+    //assign rho and rhom to ghosts according to local eta-dependent map
+    std::vector<double> rho;
+    std::vector<double> rhom;
+    for (unsigned int j=0;j<nGhosts; j++) {
+      
+      if(ghosts[j].eta()<=etaRanges->at(0)) {
+        rho.push_back(rhoRanges->at(0));
+        rhom.push_back(rhomRanges->at(0));
+      } else if(ghosts[j].eta()>=etaRanges->at(bkgVecSize-1)) {
+        rho.push_back(rhoRanges->at(bkgVecSize-2));
+        rhom.push_back(rhomRanges->at(bkgVecSize-2));
+      } else {
+        for(int ie = 0; ie<(int)(bkgVecSize-1); ie++) {
+          if(ghosts[j].eta()>=etaRanges->at(ie) && ghosts[j].eta()<etaRanges->at(ie+1)) {
+            rho.push_back(rhoRanges->at(ie));
+            rhom.push_back(rhomRanges->at(ie));
+            break;
+          }
+        }
+      }
+      
+    }
+
+    //----------------------------------------------------------------------
+    //from here use official fastjet contrib package
+    
+    fastjet::contrib::ConstituentSubtractor subtractor;
+    subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); // distance in eta-phi plane
+    subtractor.set_max_distance(csRParam_); // free parameter for the maximal allowed distance between particle i and ghost k
+    subtractor.set_alpha(csAlpha_);  // free parameter for the distance measure (the exponent of particle pt). Note that in older versions of the package alpha was multiplied by two but in newer versions this is not the case anymore
+
+    std::vector<fastjet::PseudoJet> subtracted_particles = subtractor.do_subtraction(particles,ghosts);
+
+    //Create subtracted jets
+    fastjet::PseudoJet subtracted_jet=join(subtracted_particles);
+    if(subtracted_jet.perp()>0.)
+      fjJets_.push_back( subtracted_jet );
+  }
+  fjJets_ = fastjet::sorted_by_pt(fjJets_); 
+}
+
+bool  CSJetProducer::function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j){
+    return (i.first < j.first);
+}
+
+void CSJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  edm::ParameterSetDescription descCSJetProducer;
+  ////// From CSJetProducer
+  fillDescriptionsFromCSJetProducer(descCSJetProducer);
+  ///// From VirtualJetProducer
+  descCSJetProducer.add<string>("jetCollInstanceName", ""    );
+  VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(descCSJetProducer);
+  descCSJetProducer.add<bool> ("sumRecHits", false);
+  
+  /////////////////////
+  descriptions.add("CSJetProducer",descCSJetProducer);
+  
+}
+
+void CSJetProducer::fillDescriptionsFromCSJetProducer(edm::ParameterSetDescription& desc) {
+
+  desc.add<double>("csRParam",-1.);
+  desc.add<double>("csAlpha",2.);
+
+  desc.add<edm::InputTag>("etaMap",edm::InputTag("hiFJRhoProducer","mapEtaEdges") );
+  desc.add<edm::InputTag>("rho",edm::InputTag("hiFJRhoProducer","mapToRho") );
+  desc.add<edm::InputTag>("rhom",edm::InputTag("hiFJRhoProducer","mapToRhoM") );
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// define as cmssw plugin
+////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_FWK_MODULE(CSJetProducer);

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -96,12 +96,12 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
             break;
           }
         }
-        double pt = rho*ghosts[j].area();
-        double mass_squared=pow(rhom*ghosts[j].area()+pt,2)-pow(pt,2);
-        double mass=0;
-        if (mass_squared>0) mass=sqrt(mass_squared);
-        ghosts[j].reset_momentum_PtYPhiM(pt,ghosts[j].rap(),ghosts[j].phi(),mass);
       }
+      double pt = rho*ghosts[j].area();
+      double mass_squared=pow(rhom*ghosts[j].area()+pt,2)-pow(pt,2);
+      double mass=0;
+      if (mass_squared>0) mass=sqrt(mass_squared);
+      ghosts[j].reset_momentum_PtYPhiM(pt,ghosts[j].rap(),ghosts[j].phi(),mass);
     }
 
     //----------------------------------------------------------------------
@@ -111,6 +111,7 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
     subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); // distance in eta-phi plane
     subtractor.set_max_distance(csRParam_); // free parameter for the maximal allowed distance between particle i and ghost k
     subtractor.set_alpha(csAlpha_);  // free parameter for the distance measure (the exponent of particle pt). Note that in older versions of the package alpha was multiplied by two but in newer versions this is not the case anymore
+    subtractor.set_do_mass_subtraction(true);
 
     std::vector<fastjet::PseudoJet> subtracted_particles = subtractor.do_subtraction(particles,ghosts);
 

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -73,7 +73,6 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
     // sift ghosts and particles in the input jet
     std::vector<fastjet::PseudoJet> particles, ghosts;
     fastjet::SelectorIsPureGhost().sift(ijet.constituents(), ghosts, particles);
-    //unsigned long nGhosts=ghosts.size();
     unsigned long nParticles=particles.size();
     if(nParticles==0) continue; //don't subtract ghost jets
     

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -78,26 +78,30 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
     if(nParticles==0) continue; //don't subtract ghost jets
     
     //assign rho and rhom to ghosts according to local eta-dependent map
-    std::vector<double> rho;
-    std::vector<double> rhom;
+    double rho  = 1e-6;
+    double rhom = 1e-6;
     for (unsigned int j=0;j<nGhosts; j++) {
       
       if(ghosts[j].eta()<=etaRanges->at(0)) {
-        rho.push_back(rhoRanges->at(0));
-        rhom.push_back(rhomRanges->at(0));
+        rho = rhoRanges->at(0);
+        rhom = rhomRanges->at(0);
       } else if(ghosts[j].eta()>=etaRanges->at(bkgVecSize-1)) {
-        rho.push_back(rhoRanges->at(bkgVecSize-2));
-        rhom.push_back(rhomRanges->at(bkgVecSize-2));
+        rho = rhoRanges->at(bkgVecSize-2);
+        rhom = rhomRanges->at(bkgVecSize-2);
       } else {
         for(int ie = 0; ie<(int)(bkgVecSize-1); ie++) {
           if(ghosts[j].eta()>=etaRanges->at(ie) && ghosts[j].eta()<etaRanges->at(ie+1)) {
-            rho.push_back(rhoRanges->at(ie));
-            rhom.push_back(rhomRanges->at(ie));
+            rho = rhoRanges->at(ie);
+            rhom = rhomRanges->at(ie);
             break;
           }
         }
+        double pt = rho*ghosts[j].area();
+        double mass_squared=pow(rhom*ghosts[j].area()+pt,2)-pow(pt,2);
+        double mass=0;
+        if (mass_squared>0) mass=sqrt(mass_squared);
+        ghosts[j].reset_momentum_PtYPhiM(pt,ghosts[j].rap(),ghosts[j].phi(),mass);
       }
-      
     }
 
     //----------------------------------------------------------------------

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -82,14 +82,14 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
     double rhom = 1e-6;
     for (unsigned int j=0;j<nGhosts; j++) {
       
-      if(ghosts[j].eta()<=etaRanges->at(0)) {
+      if(ghosts[j].eta()<=etaRanges->at(0) || bkgVecSize==1) {
         rho = rhoRanges->at(0);
         rhom = rhomRanges->at(0);
       } else if(ghosts[j].eta()>=etaRanges->at(bkgVecSize-1)) {
         rho = rhoRanges->at(bkgVecSize-2);
         rhom = rhomRanges->at(bkgVecSize-2);
       } else {
-        for(int ie = 0; ie<(int)(bkgVecSize-1); ie++) {
+        for(unsigned int ie = 0; ie<(bkgVecSize-1); ie++) {
           if(ghosts[j].eta()>=etaRanges->at(ie) && ghosts[j].eta()<etaRanges->at(ie+1)) {
             rho = rhoRanges->at(ie);
             rhom = rhomRanges->at(ie);

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -73,35 +73,35 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
     // sift ghosts and particles in the input jet
     std::vector<fastjet::PseudoJet> particles, ghosts;
     fastjet::SelectorIsPureGhost().sift(ijet.constituents(), ghosts, particles);
-    unsigned long nGhosts=ghosts.size();
+    //unsigned long nGhosts=ghosts.size();
     unsigned long nParticles=particles.size();
     if(nParticles==0) continue; //don't subtract ghost jets
     
     //assign rho and rhom to ghosts according to local eta-dependent map
     double rho  = 1e-6;
     double rhom = 1e-6;
-    for (unsigned int j=0;j<nGhosts; j++) {
+    for(fastjet::PseudoJet& ighost : ghosts) {
       
-      if(ghosts[j].eta()<=etaRanges->at(0) || bkgVecSize==1) {
+      if(ighost.eta()<=etaRanges->at(0) || bkgVecSize==1) {
         rho = rhoRanges->at(0);
         rhom = rhomRanges->at(0);
-      } else if(ghosts[j].eta()>=etaRanges->at(bkgVecSize-1)) {
+      } else if(ighost.eta()>=etaRanges->at(bkgVecSize-1)) {
         rho = rhoRanges->at(bkgVecSize-2);
         rhom = rhomRanges->at(bkgVecSize-2);
       } else {
         for(unsigned int ie = 0; ie<(bkgVecSize-1); ie++) {
-          if(ghosts[j].eta()>=etaRanges->at(ie) && ghosts[j].eta()<etaRanges->at(ie+1)) {
+          if(ighost.eta()>=etaRanges->at(ie) && ighost.eta()<etaRanges->at(ie+1)) {
             rho = rhoRanges->at(ie);
             rhom = rhomRanges->at(ie);
             break;
           }
         }
       }
-      double pt = rho*ghosts[j].area();
-      double mass_squared=pow(rhom*ghosts[j].area()+pt,2)-pow(pt,2);
+      double pt = rho*ighost.area();
+      double mass_squared=std::pow(rhom*ighost.area()+pt,2)-std::pow(pt,2);
       double mass=0;
       if (mass_squared>0) mass=sqrt(mass_squared);
-      ghosts[j].reset_momentum_PtYPhiM(pt,ghosts[j].rap(),ghosts[j].phi(),mass);
+      ighost.reset_momentum_PtYPhiM(pt,ighost.rap(),ighost.phi(),mass);
     }
 
     //----------------------------------------------------------------------
@@ -121,10 +121,6 @@ void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iS
       fjJets_.push_back( subtracted_jet );
   }
   fjJets_ = fastjet::sorted_by_pt(fjJets_); 
-}
-
-bool  CSJetProducer::function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j){
-    return (i.first < j.first);
 }
 
 void CSJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -37,8 +37,6 @@ namespace cms
 
     virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup );
 
-    static bool function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j);
-    
     double csRParam_;           /// for constituent subtraction : R parameter
     double csAlpha_;            /// for HI constituent subtraction : alpha (power of pt in metric)
 

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -1,0 +1,51 @@
+#ifndef RecoJets_JetProducers_CSJetProducer_h
+#define RecoJets_JetProducers_CSJetProducer_h
+
+/* *********************************************************
+  \class CSJetProducer
+
+  \brief Jet producer to produce CMS-style constituent subtracted jets
+
+  \author   Marta Verweij
+  \version  
+
+         Notes on implementation:
+
+         Constituent subtraction using fastjet contrib package
+         The background densities change within the jet as function of eta.
+
+ ************************************************************/
+
+
+#include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
+
+namespace cms
+{
+  class CSJetProducer : public VirtualJetProducer
+  {
+  public:
+
+    CSJetProducer(const edm::ParameterSet& ps);
+
+    virtual ~CSJetProducer() {}
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    static void fillDescriptionsFromCSJetProducer(edm::ParameterSetDescription& desc);
+
+    virtual void produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) override;
+    
+  protected:
+
+    virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup );
+
+    static bool function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j);
+    
+    double csRParam_;           /// for constituent subtraction : R parameter
+    double csAlpha_;            /// for HI constituent subtraction : alpha (power of pt in metric)
+
+    //input rho and rho_m + eta map
+    edm::EDGetTokenT<std::vector<double>>                       etaToken_;
+    edm::EDGetTokenT<std::vector<double>>                       rhoToken_;
+    edm::EDGetTokenT<std::vector<double>>                       rhomToken_;
+  };
+}
+#endif

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -906,17 +906,9 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
       fastjet::SelectorIsPureGhost().sift(it->constituents(), ghosts, constituents); //filter out ghosts
 
     //loop over constituents of jet (can be subjets or normal constituents)
+    indices[jetIndex].reserve(constituents.size());
+    constituentsSub.reserve(constituentsSub.size()+constituents.size());
     for (fastjet::PseudoJet const& constit : constituents) {
-      if ( verbosity_ >= 1 ) {
-        std::cout << "jet #" << jetIndex <<
-          ": Pt = " << constit.pt() <<
-          ", eta = " << constit.eta() <<
-          ", phi = " << constit.phi() <<
-          ", mass = " << constit.m() <<
-          ", uid: " << constit.user_index() <<
-          ", pos: " << constituentsSub.size() <<
-          ")" << std::endl;
-      }
       indices[jetIndex].push_back( constituentsSub.size() );
       constituentsSub.push_back(constit);
     }
@@ -956,7 +948,7 @@ void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::E
       reco::PFJet jet;
       reco::writeSpecific(jet,*ip4,point,i_jetConstituents,iSetup);
       jet.setJetArea( area_Jets[ip4 - ip4Begin] );
-      jetCollection->push_back( jet );
+      jetCollection->emplace_back( jet );
     }
   }
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -94,23 +94,28 @@ void VirtualJetProducer::makeProduces( std::string alias, std::string tag )
     produces<reco::BasicJetCollection>();
   }
 
-  if (makeCaloJet(jetTypeE)) {
-    produces<reco::CaloJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makePFJet(jetTypeE)) {
-    produces<reco::PFJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makeGenJet(jetTypeE)) {
-    produces<reco::GenJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makeTrackJet(jetTypeE)) {
-    produces<reco::TrackJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makePFClusterJet(jetTypeE)) {
-    produces<reco::PFClusterJetCollection>(tag).setBranchAlias(alias);
-  }
-  else if (makeBasicJet(jetTypeE)) {
-    produces<reco::BasicJetCollection>(tag).setBranchAlias(alias);
+  if ( writeJetsWithConst_ ) {
+    produces<reco::PFCandidateCollection>(tag).setBranchAlias(alias);
+    produces<reco::PFJetCollection>();
+  } else {
+    if (makeCaloJet(jetTypeE)) {
+      produces<reco::CaloJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makePFJet(jetTypeE)) {
+      produces<reco::PFJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makeGenJet(jetTypeE)) {
+      produces<reco::GenJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makeTrackJet(jetTypeE)) {
+      produces<reco::TrackJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makePFClusterJet(jetTypeE)) {
+      produces<reco::PFClusterJetCollection>(tag).setBranchAlias(alias);
+    }
+    else if (makeBasicJet(jetTypeE)) {
+      produces<reco::BasicJetCollection>(tag).setBranchAlias(alias);
+    }
   }
 }
 
@@ -146,6 +151,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 	restrictInputs_ 	= iConfig.getParameter<bool>	("restrictInputs"); 	// restrict inputs to first "maxInputs" towers?
 	maxInputs_      	= iConfig.getParameter<unsigned int>("maxInputs");
 	writeCompound_ 		= iConfig.getParameter<bool>	("writeCompound"); 	// Check to see if we are writing compound jets for substructure and jet grooming
+        writeJetsWithConst_     = iConfig.getParameter<bool>("writeJetsWithConst"); //write subtracted jet constituents
 	doFastJetNonUniform_ 	= iConfig.getParameter<bool>   	("doFastJetNonUniform");
 	puCenters_ 		= iConfig.getParameter<vector<double> >("puCenters");
 	puWidth_ 		= iConfig.getParameter<double>	("puWidth");
@@ -233,9 +239,9 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig) {
 
 	if( ( doFastJetNonUniform_ ) && ( puCenters_.size() == 0 ) ) 
 		throw cms::Exception("doFastJetNonUniform") << "Parameter puCenters for doFastJetNonUniform is not defined." << std::endl;
-
-	// make the "produces" statements
-	makeProduces( moduleLabel_, jetCollInstanceName_ );
+  
+        // make the "produces" statements
+        makeProduces( moduleLabel_, jetCollInstanceName_ );
 	produces<vector<double> >("rhos");
 	produces<vector<double> >("sigmas");
 	produces<double>("rho");
@@ -492,7 +498,29 @@ void VirtualJetProducer::output(edm::Event & iEvent, edm::EventSetup const& iSet
   // Write jets and constitutents. Will use fjJets_, inputs_
   // and fjClusterSeq_
 
-  if ( !writeCompound_ ) {
+  if ( writeCompound_ ) {
+    // Write jets and subjets
+    switch( jetTypeE ) {
+    case JetType::CaloJet :
+      writeCompoundJets<reco::CaloJet>( iEvent, iSetup );
+      break;
+    case JetType::PFJet :
+      writeCompoundJets<reco::PFJet>( iEvent, iSetup );
+      break;
+    case JetType::GenJet :
+      writeCompoundJets<reco::GenJet>( iEvent, iSetup );
+      break;
+    case JetType::BasicJet :
+      writeCompoundJets<reco::BasicJet>( iEvent, iSetup );
+      break;
+    default:
+      throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
+      break;
+    };
+  } else if ( writeJetsWithConst_ ) {
+    // Write jets and new constituents.
+    writeJetsWithConstituents<reco::PFJet>( iEvent, iSetup );
+  } else {
     switch( jetTypeE ) {
     case JetType::CaloJet :
       writeJets<reco::CaloJet>( iEvent, iSetup);
@@ -513,29 +541,11 @@ void VirtualJetProducer::output(edm::Event & iEvent, edm::EventSetup const& iSet
       writeJets<reco::BasicJet>( iEvent, iSetup);
       break;
     default:
-      throw cms::Exception("InvalidInput") << "invalid jet type in VirtualJetProducer\n";
-      break;
-    };
-  } else {
-    // Write jets and constitutents.
-    switch( jetTypeE ) {
-    case JetType::CaloJet :
-      writeCompoundJets<reco::CaloJet>( iEvent, iSetup );
-      break;
-    case JetType::PFJet :
-      writeCompoundJets<reco::PFJet>( iEvent, iSetup );
-      break;
-    case JetType::GenJet :
-      writeCompoundJets<reco::GenJet>( iEvent, iSetup );
-      break;
-    case JetType::BasicJet :
-      writeCompoundJets<reco::BasicJet>( iEvent, iSetup );
-      break;
-    default:
-      throw cms::Exception("InvalidInput") << "invalid jet type in CompoundJetProducer\n";
+           throw cms::Exception("InvalidInput") << "invalid jet type in VirtualJetProducer\n";
       break;
     };
   }
+  
 }
 
 namespace {
@@ -846,6 +856,114 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
 
 }
 
+/// function template to write out the outputs
+template< class T>
+void VirtualJetProducer::writeJetsWithConstituents(  edm::Event & iEvent, edm::EventSetup const& iSetup)
+{
+  if ( verbosity_ >= 1 ) {
+    std::cout << "<VirtualJetProducer::writeJetsWithConstituents (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
+  }
+
+  // get a list of output jets  MV: make this compatible with template
+  auto jetCollection = std::make_unique<reco::PFJetCollection>();
+  
+  // this is the mapping of jet to constituents
+  std::vector< std::vector<int> > indices;
+  // this is the list of jet 4-momenta
+  std::vector<math::XYZTLorentzVector> p4_Jets;
+  // this is the jet areas
+  std::vector<double> area_Jets;
+
+  // get a list of output constituents
+  auto constituentCollection = std::make_unique<reco::PFCandidateCollection>();
+  
+  // This will store the handle for the constituents after we write them
+  edm::OrphanHandle<reco::PFCandidateCollection> constituentHandleAfterPut;
+    
+  // Loop over the jets and extract constituents
+  std::vector<fastjet::PseudoJet> constituentsSub;
+  std::vector<fastjet::PseudoJet>::const_iterator it = fjJets_.begin(),
+    iEnd = fjJets_.end(),
+    iBegin = fjJets_.begin();
+  indices.resize( fjJets_.size() );
+
+  for ( ; it != iEnd; ++it ) {
+    fastjet::PseudoJet const & localJet = *it;
+    unsigned int jetIndex = it - iBegin;
+    // Get the 4-vector for the hard jet
+    p4_Jets.push_back( math::XYZTLorentzVector(localJet.px(), localJet.py(), localJet.pz(), localJet.e() ));
+    double localJetArea = 0.0;
+    if ( doAreaFastjet_ && localJet.has_area() ) {
+      localJetArea = localJet.area();
+    }
+    area_Jets.push_back( localJetArea );
+
+    // create the constituent list
+    std::vector<fastjet::PseudoJet> constituents,ghosts;
+    if ( it->has_pieces() )
+      constituents = it->pieces();
+    else if ( it->has_constituents() )
+      fastjet::SelectorIsPureGhost().sift(it->constituents(), ghosts, constituents); //filter out ghosts
+
+    //loop over constituents of jet (can be subjets or normal constituents)
+    for (fastjet::PseudoJet const& constit : constituents) {
+      if ( verbosity_ >= 1 ) {
+        std::cout << "jet #" << jetIndex <<
+          ": Pt = " << constit.pt() <<
+          ", eta = " << constit.eta() <<
+          ", phi = " << constit.phi() <<
+          ", mass = " << constit.m() <<
+          ", uid: " << constit.user_index() <<
+          ", pos: " << constituentsSub.size() <<
+          ")" << std::endl;
+      }
+      indices[jetIndex].push_back( constituentsSub.size() );
+      constituentsSub.push_back(constit);
+    }
+  }
+
+  //Loop over constituents and store in the event
+  static const reco::PFCandidate dummySinceTranslateIsNotStatic;
+  for (fastjet::PseudoJet const& constit : constituentsSub) {
+    auto orig = inputs_[constit.user_index()];
+    auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(orig->pdgId());
+    reco::PFCandidate pCand( reco::PFCandidate(orig->charge(), orig->p4(), id) );
+    math::XYZTLorentzVector pVec;
+    pVec.SetPxPyPzE(constit.px(),constit.py(),constit.pz(),constit.e());
+    pCand.setP4(pVec);
+    pCand.setSourceCandidatePtr( orig->sourceCandidatePtr(0) );
+    constituentCollection->push_back(pCand);
+  }
+  // put constituents into event record
+  constituentHandleAfterPut = iEvent.put(std::move(constituentCollection), jetCollInstanceName_ );
+
+  // Now create the jets with ptr's to the constituents
+  std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_Jets.begin(),
+    ip4Begin = p4_Jets.begin(),
+    ip4End = p4_Jets.end();
+
+  for ( ; ip4 != ip4End; ++ip4 ) {
+    int p4_index = ip4 - ip4Begin;
+    std::vector<int> & ind = indices[p4_index];
+    std::vector<reco::CandidatePtr> i_jetConstituents;
+    // Add the constituents to the jet
+    for( std::vector<int>::const_iterator iconst = ind.begin(); iconst != ind.end(); ++iconst ) {
+      reco::CandidatePtr candPtr( constituentHandleAfterPut, *iconst, false );
+      i_jetConstituents.push_back( candPtr );
+    }
+    if(i_jetConstituents.size()>0) { //only keep jets which have constituents after subtraction
+      reco::Particle::Point point(0,0,0);
+      reco::PFJet jet;
+      reco::writeSpecific(jet,*ip4,point,i_jetConstituents,iSetup);
+      jet.setJetArea( area_Jets[ip4 - ip4Begin] );
+      jetCollection->push_back( jet );
+    }
+  }
+
+  // put jets into event record
+  iEvent.put(std::move(jetCollection));
+}
+
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void VirtualJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
@@ -883,6 +1001,7 @@ void VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(edm::ParameterSe
 	desc.add<bool> 	("restrictInputs", 	false 	);
 	desc.add<unsigned int> 	("maxInputs", 	1 	);
 	desc.add<bool> 	("writeCompound", 	false 	);
+        desc.add<bool> 	("writeJetsWithConst", 	false 	);
 	desc.add<bool> 	("doFastJetNonUniform", false 	);
 	desc.add<bool> 	("useDeterministicSeed",false 	);
 	desc.add<unsigned int> 	("minSeed", 	14327 	);
@@ -898,4 +1017,3 @@ void VirtualJetProducer::fillDescriptionsFromVirtualJetProducer(edm::ParameterSe
 	vector<double>  puCentersDefault;
 	desc.add<vector<double>>("puCenters", 	puCentersDefault);
 }
-

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -149,6 +149,8 @@ protected:
   template< typename T>
   void writeCompoundJets(  edm::Event & iEvent, edm::EventSetup const& iSetup);
 
+  template< typename T>
+    void writeJetsWithConstituents(  edm::Event & iEvent, edm::EventSetup const& iSetup);
 
   // This method copies the constituents from the fjConstituents method
   // to an output of CandidatePtr's. 
@@ -210,6 +212,7 @@ protected:
 
   std::string                     jetCollInstanceName_;       // instance name for output jet collection
   bool                            writeCompound_;    // write compound jets (i.e. jets of jets)
+  bool                            writeJetsWithConst_;    // write jets with constituents
   boost::shared_ptr<PileUpSubtractor>  subtractor_;
 
   bool                            useDeterministicSeed_; // If desired, use a deterministic seed to fastjet


### PR DESCRIPTION
This PR replaces #18883

This PR implements Constituent Subtraction for underlying event removal for jets in heavy ion collisions.

Implementation was discussed in Reco and Analysis tools meeting:
https://indico.cern.ch/event/648883/

1. added possibility to VirtualJetProducer to write the jet and its constituents to the event record. This is relevant since the constituent subtraction is particle-by-particle subtraction and therefore produces a new set of PF candidates.
2. added the production of background estimates (HiFJRhoProducer) to the heavy ion reconstruction.
3. CS algo is run with the fastjet contrib package. pT and mass of ghosts is assigned in the CSJetProducer
4. The Cs jet production for R=0.3 and R=0.4 is added to the standard heavy ion workflow.

The PR was tested on wf 140.53 and 145

A report on this method in heavy ion collision at the JMAR meeting can be found here:
https://indico.cern.ch/event/502737/contributions/2012693/attachments/1237496/1817780/160302_ConstituentSubtraction.pdf

@rappoccio @mandrenguyen @cfmcginn @kurtejung @ahinzmann @knash