### PR TITLE
Tracker alignment validation das client

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -26,7 +26,7 @@ except RuntimeError:
 else:
     dasgoversion = dasgoversion.split()[1].split("git=v")[1]
     dasgoversion = tuple(int(_) for _ in dasgoversion.split("."))
-    if dasgoversion < (1, 0, 4):
+    if dasgoversion < (1, 0, 5):
         olddas = True
     else:
         olddas = False
@@ -550,7 +550,11 @@ class Dataset(object):
                         return float(line.replace("#magnetic field: ", "").split(",")[1].split("#")[0].strip())
 
         if run > 0:
-            dasQuery = ('run=%s instance=%s'%(run, self.__dasinstance))                         #for data
+            dasQuery = ('run=%s instance=%s detail=true'%(run, self.__dasinstance))   #for data
+            #####################################################################
+            #can remove this once dasgoclient is updated
+            if olddas: dasQuery = dasQuery.replace("detail=true", "")
+            #####################################################################
             data = self.__getData(dasQuery)
             try:
                 return self.__findInJson(data, ["run","bfield"])

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -14,6 +14,23 @@ from FWCore.PythonUtilities.LumiList import LumiList
 from helperFunctions import cache
 from TkAlExceptions import AllInOneError
 
+#####################################################################
+#can remove this section and others below once dasgoclient is updated
+#(search for olddas)
+from helperFunctions import getCommandOutput2
+try:
+    dasgoversion = getCommandOutput2("dasgoclient --version")
+except RuntimeError:
+    olddas = True
+    #could be no proxy inited, but this will pop up later in any case
+else:
+    dasgoversion = dasgoversion.split()[1].split("git=v")[1]
+    dasgoversion = tuple(int(_) for _ in dasgoversion.split("."))
+    if dasgoversion < (1, 0, 4):
+        olddas = True
+    else:
+        olddas = False
+#####################################################################
 
 class Dataset(object):
     def __init__( self, datasetName, dasLimit = 0, tryPredefinedFirst = True,
@@ -352,7 +369,12 @@ class Dataset(object):
         return forcerunrangefunction
 
     def __getData( self, dasQuery, dasLimit = 0 ):
-	dasData = das_client.get_data(dasQuery, dasLimit)
+	dasData = das_client.get_data(dasQuery, dasLimit,
+        ############################################
+        #can remove this once dasgoclient is updated
+        cmd="das_client" if olddas else None
+        ############################################
+        )
         if isinstance(dasData, str):
             jsondict = json.loads( dasData )
         else:
@@ -395,8 +417,12 @@ class Dataset(object):
                         return datatype
                 return "unknown"
 
-        dasQuery_type = ( 'dataset dataset=%s instance=%s | grep dataset.datatype,'
+        dasQuery_type = ( 'dataset dataset=%s instance=%s detail=true | grep dataset.datatype,'
                           'dataset.name'%( self.__name, self.__dasinstance ) )
+        #####################################################################
+        #can remove this once dasgoclient is updated
+        if olddas: dasQuery_type = dasQuery_type.replace("detail=true", "")
+        #####################################################################
         data = self.__getData( dasQuery_type )
 
         try:
@@ -578,9 +604,13 @@ class Dataset(object):
             searchdataset = self.parentDataset()
         else:
             searchdataset = self.__name
-        dasQuery_files = ( 'file dataset=%s instance=%s | grep file.name, file.nevents, '
+        dasQuery_files = ( 'file dataset=%s instance=%s detail=true | grep file.name, file.nevents, '
                            'file.creation_time, '
                            'file.modification_time'%( searchdataset, self.__dasinstance ) )
+        #####################################################################
+        #can remove this once dasgoclient is updated
+        if olddas: dasQuery_files = dasQuery_files.replace("detail=true", "")
+        #####################################################################
         print "Requesting file information for '%s' from DAS..."%( searchdataset ),
         sys.stdout.flush()
         data = self.__getData( dasQuery_files, dasLimit )

--- a/Alignment/OfflineValidation/test/testValidate.ini
+++ b/Alignment/OfflineValidation/test/testValidate.ini
@@ -13,18 +13,18 @@ eosdir = Test
 ###############################################################################
 # configuration of several alignments
 
-[alignment:2016G_prompt]
-title = 2016G (prompt)
-globaltag = 80X_dataRun2_Prompt_v10
+[alignment:prompt]
+title = prompt ;unnecessary here, since it defaults to the alignment name, but can contain spaces, TLatex, etc.
+globaltag = 92X_dataRun2_Prompt_v2
 color = 1
 #first digits = marker style for track splitting and Z->mumu.  Last 2 digits = line style.
 #if you use a <=2 digit number, it will be the line style
 #track splitting histograms will use markers if you give a >=3 digit number here, otherwise they will be shown as histograms (i.e. lines)
 style = 2001
 
-[alignment:2016G_express]
-title = 2016G (express)
-globaltag = 80X_dataRun2_Express_v12
+[alignment:express]
+title = express
+globaltag = 92X_dataRun2_Express_v2
 color = 2
 #first 2 digits = marker style for track splitting and Z->mumu.  Last 2 digits = line style.
 style = 2402
@@ -32,15 +32,15 @@ style = 2402
 ###############################################################################
 # configuration of individual validations
 
-[offline:validation_IsoMu]
+[offline:validation_MinBias]
 maxevents = 1000
-dataset = /SingleMuon/Run2016G-TkAlMuonIsolated-PromptReco-v1/ALCARECO
-trackcollection = ALCARECOTkAlMuonIsolated
+dataset = /MinimumBias/Run2017A-TkAlMinBias-PromptReco-v1/ALCARECO
+trackcollection = ALCARECOTkAlMinBias
 
 [offline:validation_cosmics]
 maxevents = 1000
-dataset = /NoBPTX/Run2016G-TkAlCosmicsInCollisions-PromptReco-v1/ALCARECO
-trackcollection = ALCARECOTkAlCosmicsInCollisions
+dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
+trackcollection = ALCARECOTkAlCosmicsCTF0T
 
 [compare:Tracker]
 levels = "Tracker","DetUnit"
@@ -48,7 +48,7 @@ dbOutput = false
 
 [zmumu:some_zmumu_validation]
 maxevents = 1000
-dataset = /DoubleMuon/Run2016G-TkAlZMuMu-PromptReco-v1/ALCARECO
+dataset = /DoubleMuon/Run2017A-TkAlZMuMu-PromptReco-v3/ALCARECO
 etamaxneg = 2.4
 etaminneg = -2.4
 etamaxpos = 2.4
@@ -56,8 +56,8 @@ etaminpos = -2.4
 
 [split:some_split_validation]
 maxevents = 1000
-dataset = /NoBPTX/Run2016G-TkAlCosmicsInCollisions-PromptReco-v1/ALCARECO
-trackcollection = ALCARECOTkAlCosmicsInCollisions
+dataset = /Cosmics/Run2017A-TkAlCosmics0T-PromptReco-v1/ALCARECO
+trackcollection = ALCARECOTkAlCosmicsCTF0T
 
 #[mcValidate:some_mc_validation]
 #maxevents = 1000
@@ -75,7 +75,7 @@ legendoptions = meanerror rmserror modules outside
 #uncomment these to get titles
 
 #customtitle = #CMS{Preliminary}
-customrighttitle = 2016G cosmics and collisions data
+customrighttitle = 2017A cosmics and collisions data
 #legendheader = header
 
 #to ensure the legend font is readable, but it gets messy if you have >~3 curves
@@ -95,7 +95,7 @@ subdetector = none
 #outliercut = 0.95
 
 #customtitle = #CMS{Preliminary}
-customrighttitle = 2016G cosmics during collisions data
+customrighttitle = 2017A 3.8T cosmics data
 #legendheader = header
 
 [plots:zmumu]
@@ -108,15 +108,15 @@ customrighttitle = 2016G Z#rightarrow#mu#mu data, |#eta|<2.4
 # configure which validation to run on which alignment
 
 [validation]
-offline validation_IsoMu : 2016G_prompt
-offline validation_IsoMu : 2016G_express
-offline validation_cosmics : 2016G_prompt
-offline validation_cosmics : 2016G_express
+offline validation_MinBias : prompt
+offline validation_MinBias : express
+offline validation_cosmics : prompt
+offline validation_cosmics : express
 #278819 is the run number.  Note that the plots will show (first geometry) - (second geometry), in this case prompt - express
-compare Tracker: 2016G_prompt 278819, 2016G_express 278819
-zmumu some_zmumu_validation : 2016G_prompt
-zmumu some_zmumu_validation : 2016G_express
-split some_split_validation : 2016G_prompt
-split some_split_validation : 2016G_express
+compare Tracker: prompt 278819, express 278819
+zmumu some_zmumu_validation : prompt
+zmumu some_zmumu_validation : express
+split some_split_validation : prompt
+split some_split_validation : express
 #mcValidate some_mc_validation : alignment_0
 


### PR DESCRIPTION
Make the dataset class compatible with the new das go client.

Some sections are there temporarily to revert to the old das_client until the dasgoclient is updated in cvmfs.  Once it's updated, those sections can be removed without any effect on the code.

The dasgoclient makes `validateAlignments.py -c testValidate.ini -N testValidate -n` a factor of 3 faster.  I checked that we get equivalent behavior with either the new or the old clients.

https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/2504.html