### PR TITLE
Fixes to TwoBodyDecay dictionary and KFFitter/smoother nhits checks

### DIFF
--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
@@ -118,7 +118,7 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
       try {
 	theAlgo.runWithMomentum(theG.product(), theMF.product(), *theTCollectionWithConstraint, 
 				theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack." << "\n" << e << "\n"; throw; }
+      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithMomentum." << "\n" << e << "\n"; throw; }
       break;
     }
   case  vertex :
@@ -135,7 +135,7 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
       try {
       theAlgo.runWithVertex(theG.product(), theMF.product(), *theTCollectionWithConstraint, 
 			    theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);      
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack." << "\n" << e << "\n"; throw; }
+      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithVertex." << "\n" << e << "\n"; throw; }
     }
   case trackParameters :
     {
@@ -152,7 +152,7 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
       try {
       theAlgo.runWithTrackParameters(theG.product(), theMF.product(), *theTCollectionWithConstraint, 
 				     theFitter.product(), thePropagator.product(), theBuilder.product(), bs, algoResults);      
-      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrack." << "\n" << e << "\n"; throw; }
+      }catch (cms::Exception &e){ edm::LogError("TrackProducer") << "cms::Exception caught during theAlgo.runWithTrackParameters." << "\n" << e << "\n"; throw; }
     }
     //default... there cannot be any other possibility due to the check in the ctor
   }

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmoother.h
@@ -118,7 +118,7 @@ namespace {
     Trajectory smoothingStep(Trajectory && fitted) const {
       if (theEstimateCut>0) {
 	// remove "outlier" at the end of Traj
-	while (!fitted.empty() &&
+	while (!fitted.empty() && fitted.foundHits()>=theMinNumberOfHits &&
 	       ( !fitted.lastMeasurement().recHitR().isValid()
 		 || ( fitted.lastMeasurement().recHitR().det()!=nullptr && fitted.lastMeasurement().estimate()>theEstimateCut)
 		 )

--- a/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
@@ -264,7 +264,6 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
 
   LogDebug("TrackFitters") << "Found 1 trajectory with " << myTraj.foundHits() << " valid hits\n";
 
-  if (ret.foundHits() < minHits_) return Trajectory();
   return ret;
 }
 

--- a/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectoryFitter.cc
@@ -264,6 +264,7 @@ Trajectory KFTrajectoryFitter::fitOne(const TrajectorySeed& aSeed,
 
   LogDebug("TrackFitters") << "Found 1 trajectory with " << myTraj.foundHits() << " valid hits\n";
 
+  if (ret.foundHits() < minHits_) return Trajectory();
   return ret;
 }
 

--- a/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
@@ -298,10 +298,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
     }
   } // for loop
 
-    if (!retry){
-      if (ret.foundHits() < minHits_) return Trajectory();
-      return ret;
-    }
+    if (!retry) return ret;
   } while(true);
   
   return Trajectory(); 

--- a/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
@@ -298,7 +298,10 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
     }
   } // for loop
 
-   if (!retry) return ret;
+    if (!retry){
+      if (ret.foundHits() < minHits_) return Trajectory();
+      return ret;
+    }
   } while(true);
   
   return Trajectory(); 

--- a/TrackingTools/TrajectoryState/src/classes.h
+++ b/TrackingTools/TrajectoryState/src/classes.h
@@ -31,6 +31,7 @@ typedef edm::RefVector<TrackParamConstraintAssociationCollection> TrackParamCons
 
 namespace TrackingTools_TrajectoryState {
   struct dictionary {
+    TrajectoryStateOnSurface dummytsos;
     std::vector<TrajectoryStateOnSurface> jjj2;
     edm::Wrapper<std::vector<TrajectoryStateOnSurface> > jjj3;
   

--- a/TrackingTools/TrajectoryState/src/classes_def.xml
+++ b/TrackingTools/TrajectoryState/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
   <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
+  <class name="TrajectoryStateOnSurface"/>
   <class name="std::vector<TrajectoryStateOnSurface>" persistent="false"/>
   <class name="edm::Wrapper<std::vector<TrajectoryStateOnSurface> >" persistent="false"/>
   <class name="edm::RefProd<std::vector<TrajectoryStateOnSurface> >"/>


### PR DESCRIPTION
- Dictionary fix is needed for TwoBodyDecay constraint to produce the appropriate products when trackParameter constraint is used
- KFFitter/smoother nhits/n measurements=1 is possible when TBD constraint is applied. A cms::Exception is given if the following checks are not implemented.
- cms exception texts did not refer to the correct function, this is fixed as well.
- See relevant discussion after https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1648/1/1/1/1/1/1/1.html