### PR TITLE
Make the CalibTracker/SiStripCommon unit test be meaningful again

### DIFF
--- a/CalibTracker/SiStripCommon/python/shallowTree_test_template.py
+++ b/CalibTracker/SiStripCommon/python/shallowTree_test_template.py
@@ -1,19 +1,38 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpGENSIMRECO
-import das 
+import Utilities.General.cmssw_das_client as cmssw_das_client
 #from pdb import set_trace
 
+######
+#
+# Ideally to be used, unfortunately sample is not at CERN
+#
+# from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
+# filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
+#    pickRelValInputFiles( cmsswVersion  = 'CMSSW_9_2_3'
+#                          , relVal        = 'RelValTTbar_13'
+#                          , globalTag     = 'PUpmx25ns_92X_upgrade2017_realistic_v2_earlyBS2017'
+#                          , dataTier      = 'GEN-SIM-RECO'
+#                          , maxVersions   = 1
+#                          , numberOfFiles = 1
+#                          , useDAS        = True
+#                          )
+#    )
+
 def add_rawRelVals(process):   
-   dataset = das.query('dataset file=%s' % process.source.fileNames[0], verbose=True)
+   query='dataset file=%s' % process.source.fileNames[0]
+   dataset = cmssw_das_client.get_data(query, limit = 0)
    if not dataset:
       raise RuntimeError(
          'Das returned no dataset parent of the input file: %s \n'
          'The parenthood is needed to add RAW secondary input files' % process.source.fileNames[0]
          )
-   raw_dataset = dataset[0].replace('GEN-SIM-RECO','GEN-SIM-DIGI-RAW-HLTDEBUG')
-   raw_files = das.query('file dataset=%s' % raw_dataset, verbose=True)
+   raw_dataset = dataset['data'][0]['dataset'][0]['name'].replace('GEN-SIM-RECO','GEN-SIM-DIGI-RAW-HLTDEBUG')
+   raw_files = cmssw_das_client.get_data('file dataset=%s' % raw_dataset, limit=0)['data']
+   
    if not raw_files:
       raise RuntimeError('No files found belonging to the GEN-SIM-DIGI-RAW-HLTDEBUG sample!')
+
    #convert from unicode into normal string since vstring does not pick it up
    raw_files = [str(i) for i in raw_files]
    process.source.secondaryFileNames = cms.untracked.vstring(*raw_files)
@@ -24,7 +43,7 @@ process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cf
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic')
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.StandardSequences.Services_cff')

--- a/CalibTracker/SiStripCommon/test/test_all.sh
+++ b/CalibTracker/SiStripCommon/test/test_all.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
+function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING CalibTracker/SiStripCommon ..."
-cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py
-echo "... SUCCESSFUL!"
+cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_CalibTrackerSiStripCommon_cfg.py" $? 

--- a/CalibTracker/SiStripCommon/test/test_all_cfg.py
+++ b/CalibTracker/SiStripCommon/test/test_all_cfg.py
@@ -17,7 +17,7 @@ process.load('CalibTracker.SiStripCommon.ShallowRechitClustersProducer_cfi')
 process.load('RecoTracker.TrackProducer.TrackRefitters_cff')
 process.load('SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi')
 process.load("SimTracker.TrackAssociatorProducers.trackAssociatorByHits_cfi")
-add_rawRelVals(process)
+#add_rawRelVals(process)
 
 process.tracksRefit = process.TrackRefitter.clone()
 process.shallowGainCalibration.Tracks = 'tracksRefit'
@@ -42,17 +42,17 @@ process.testTree = cms.EDAnalyzer(
 process.p = cms.Path(
    process.MeasurementTrackerEvent*
    process.tracksRefit*
-   process.simHitTPAssocProducer*
-   process.trackAssociatorByHits*
+   #process.simHitTPAssocProducer*
+   #process.trackAssociatorByHits*
    process.siStripMatchedRecHits*
    # Shallow stuff
    process.shallowEventRun*
-   process.shallowSimTracks*
+   #process.shallowSimTracks*
    process.shallowTrackClusters*
    process.shallowGainCalibration*
    process.shallowDigis*
    process.shallowTracks*
-   process.shallowSimhitClusters*
+   #process.shallowSimhitClusters*
    process.shallowClusters*
    process.shallowRechitClusters*
    #tree dumping


### PR DESCRIPTION
Title says it all (right now the [test was silently failing]( https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc630/CMSSW_9_3_X_2017-07-04-1100/unitTestLogs/CalibTracker/SiStripCommon)).
Ideally to test fully would need also a `GEN-SIM-DIGI-RAW-HLTDEBUG` sample (nothing recent for which the corresponding `GEN-SIM-RECO` also at CERN is available), hence removing few modules from the test sequence. 