### PR TITLE
Fix crash in ExternalLHEProducer in case of earler exception

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -66,7 +66,7 @@ class ExternalLHEProducer : public edm::one::EDProducer<edm::BeginRunProducer,
                                                         edm::EndRunProducer> {
 public:
   explicit ExternalLHEProducer(const edm::ParameterSet& iConfig);
-  virtual ~ExternalLHEProducer();
+  virtual ~ExternalLHEProducer() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
@@ -81,7 +81,7 @@ private:
   void executeScript();
   std::unique_ptr<std::string> readOutput();
 
-  virtual void nextEvent();
+  void nextEvent();
   
   // ----------member data ---------------------------
   std::string scriptName_;
@@ -92,7 +92,7 @@ private:
   unsigned int nThreads_{1};
   std::string outputContents_;
 
-  std::auto_ptr<lhef::LHEReader>		reader_;
+  std::unique_ptr<lhef::LHEReader>	reader_;
   boost::shared_ptr<lhef::LHERunInfo>	runInfoLast;
   boost::shared_ptr<lhef::LHERunInfo>	runInfo;
   boost::shared_ptr<lhef::LHEEvent>	partonLevel;
@@ -267,8 +267,7 @@ ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& es)
 
   std::vector<std::string> infiles(1, outputFile_);
   unsigned int skip = 0;
-  std::auto_ptr<lhef::LHEReader> thisRead(new lhef::LHEReader(infiles, skip));
-  reader_ = thisRead;
+  reader_ = std::make_unique<lhef::LHEReader>(infiles, skip);
 
   nextEvent();
   if (runInfoLast) {
@@ -496,6 +495,7 @@ void ExternalLHEProducer::nextEvent()
   if (partonLevel)
     return;
 
+  if(not reader_) { return;}
   partonLevel = reader_->next();
   if (!partonLevel)
     return;


### PR DESCRIPTION
If ExternalLHEProducer throws an exception in begin run, the code will
no longer crash when the module is called in end run.