### PR TITLE
Fixed bug in tracking sequence

### DIFF
--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -125,6 +125,8 @@ void Vx3DHLTAnalyzer::analyze (const Event& iEvent, const EventSetup& iSetup)
 	  if (internalDebug == true)
 	    {
 	      cout << "[Vx3DHLTAnalyzer]::\tVertex selections:" << endl;
+	      cout << "[Vx3DHLTAnalyzer]::\tEvent ID = " << iEvent.id() << endl;
+              cout << "[Vx3DHLTAnalyzer]::\tVertex number = " << it3DVx - Vx3DCollection->begin() << endl;
 	      cout << "[Vx3DHLTAnalyzer]::\tisValid = " << it3DVx->isValid() << endl;
 	      cout << "[Vx3DHLTAnalyzer]::\tisFake = " << it3DVx->isFake() << endl;
 	      cout << "[Vx3DHLTAnalyzer]::\tnodof = " << it3DVx->ndof() << endl;

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -800,7 +800,7 @@ void Vx3DHLTAnalyzer::writeToFile (vector<double>* vals,
       outputFile << "rmsPV 0"      << endl;
       outputFile << "rmsErrPV 0"   << endl;
       outputFile << "maxPV 0"      << endl;
-      outputFile << "nPV 0"        << endl;
+      outputFile << "nPV " << counterVx << endl;
     }
   outputFile.close();
   
@@ -859,14 +859,14 @@ void Vx3DHLTAnalyzer::writeToFile (vector<double>* vals,
 	  
       outputDebugFile << "EmittanceX 0" << endl;
       outputDebugFile << "EmittanceY 0" << endl;
-      outputDebugFile << "BetaStar 0" << endl;
-      outputDebugFile << "events 0" << endl;
-      outputDebugFile << "meanPV 0" << endl;
-      outputDebugFile << "meanErrPV 0" << endl;
-      outputDebugFile << "rmsPV 0" << endl;
-      outputDebugFile << "rmsErrPV 0" << endl;
-      outputDebugFile << "maxPV 0" << endl;
-      outputDebugFile << "nPV 0" << endl;
+      outputDebugFile << "BetaStar 0"   << endl;
+      outputDebugFile << "events 0"     << endl;
+      outputDebugFile << "meanPV 0"     << endl;
+      outputDebugFile << "meanErrPV 0"  << endl;
+      outputDebugFile << "rmsPV 0"      << endl;
+      outputDebugFile << "rmsErrPV 0"   << endl;
+      outputDebugFile << "maxPV 0"      << endl;
+      outputDebugFile << "nPV " << counterVx << endl;
 
       outputDebugFile << "\n" << "Used vertices: " << counterVx << "\n" << endl;
     }

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -84,13 +84,13 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.siPixelDigis.InputLabel          = cms.InputTag("rawDataCollector")
     process.siStripDigis.ProductLabel        = cms.InputTag("rawDataCollector")
 
+    process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
     process.load("RecoLocalTracker.Configuration.RecoLocalTracker_cff")
     process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
     from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
-    process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(
-        src = 'siPixelClustersPreSplitting'
-    )
+    process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(src = 'siPixelClustersPreSplitting')
     process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
+
 
     #----------------------------
     # pixelVertexDQM Config
@@ -130,18 +130,21 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.load("RecoPixelVertexing.PixelTrackFitting.PixelTracks_2017_cff")
     process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
-    process.pixelVertices.TkFilterParameters.minPt = cms.double(0.9)
+    process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
     process.pixelTracksTrackingRegions.RegionPSet.originRadius = 0.4
-    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 3
+    process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 6
     process.pixelTracksTrackingRegions.RegionPSet.originXPos = 0.08
     process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
-    process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1.
+    process.pixelTracksTrackingRegions.RegionPSet.originZPos = 1
+
+
     #----------------------------
     # Pixel-Tracks&Vertices Reco
     #----------------------------
     process.reconstructionStep = cms.Sequence(process.siPixelDigis*
                                               process.siStripDigis*
                                               process.striptrackerlocalreco*
+                                              process.offlineBeamSpot*
                                               process.siPixelClustersPreSplitting*
                                               process.siPixelRecHitsPreSplitting*
                                               process.siPixelClusterShapeCachePreSplitting*

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -87,9 +87,6 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
     process.load("RecoLocalTracker.Configuration.RecoLocalTracker_cff")
     process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
-    from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
-    process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(src = 'siPixelClustersPreSplitting')
-    process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
 
 
     #----------------------------
@@ -127,6 +124,9 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     #----------------------------
     # Pixel-Tracks&Vertices Config
     #----------------------------
+    from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
+    process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(src = 'siPixelClustersPreSplitting')
+    process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
     process.load("RecoPixelVertexing.PixelTrackFitting.PixelTracks_2017_cff")
     process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
     process.recopixelvertexing = cms.Sequence(process.pixelTracksSequence + process.pixelVertices)
@@ -219,21 +219,16 @@ if (process.runType.getRunType() == process.runType.hi_run):
     # Pixel-Tracks&Vertices Config
     #----------------------------
     from RecoHI.HiTracking.HIPixelVerticesPreSplitting_cff import *
-    
     process.PixelLayerTriplets.BPix.HitProducer = cms.string("siPixelRecHitsPreSplitting")
     process.PixelLayerTriplets.FPix.HitProducer = cms.string("siPixelRecHitsPreSplitting")
-
     process.hiPixel3PrimTracksFilter = process.hiFilter.clone(VertexCollection     = cms.InputTag("hiSelectedVertexPreSplitting"),
                                                               clusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCachePreSplitting"))
-
-    process.hiPixel3PrimTracks.Filter               = cms.InputTag("hiPixel3PrimTracksFilter")
-    process.hiPixel3PrimTracks.ComponentName        = cms.string("GlobalTrackingRegionWithVerticesProducer")
-    process.hiPixel3PrimTracks.VertexCollection     = cms.InputTag("hiSelectedVertexPreSplitting")
-    process.hiPixel3PrimTracks.ptMin                = cms.double(0.9)
-    process.hiPixel3PrimTracks.clusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCachePreSplitting")
-
+    process.hiPixel3PrimTracks.Filter                    = cms.InputTag("hiPixel3PrimTracksFilter")
+    process.hiPixel3PrimTracks.ComponentName             = cms.string("GlobalTrackingRegionWithVerticesProducer")
+    process.hiPixel3PrimTracks.VertexCollection          = cms.InputTag("hiSelectedVertexPreSplitting")
+    process.hiPixel3PrimTracks.ptMin                     = cms.double(0.9)
+    process.hiPixel3PrimTracks.clusterShapeCacheSrc      = cms.InputTag("siPixelClusterShapeCachePreSplitting")
     process.hiPixel3ProtoTracksPreSplitting.originRadius = cms.double(0.4)
-
     process.hiPixelAdaptiveVertexPreSplitting.vertexCollections.useBeamConstraint = cms.bool(False)
 
 


### PR DESCRIPTION
I've fixed a bug in the tracking sequence, I've simply added the lines
`process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi)`
and then
`process.offlineBeamSpot*`
in the sequence.