### PR TITLE
TOP DQM: muon selections for topSingleMediumDQM_MINIAOD are updated

### DIFF
--- a/DQM/Physics/python/singleTopDQM_cfi.py
+++ b/DQM/Physics/python/singleTopDQM_cfi.py
@@ -1,8 +1,29 @@
 import FWCore.ParameterSet.Config as cms
 
-EletightIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.1"
-ElelooseIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.15"
+#Primary vertex selection
+PVCut = "abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake"
 
+#Jet selection
+looseJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.99 && neutralEmEnergyFraction()<0.99 && (chargedMultiplicity()+neutralMultiplicity())>1) && abs(eta)<=2.4 "
+
+tightJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.90 && neutralEmEnergyFraction()<0.90 && (chargedMultiplicity()+neutralMultiplicity())>1) && abs(eta)<=2.4 "
+
+#Loose muon selection
+looseMuonCut  = "(muonRef.isNonnull && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) && muonRef.isPFMuon)"
+looseIsoCut   = "((muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.25)"
+
+#Medium muon selection. Also requires either good global muon or tight segment compatibility
+mediumMuonCut = looseMuonCut + " muonRef.innerTrack.validFraction > 0.8"
+
+#Tight muon selection. Lacks distance to primary vertex variables, dz<0.5, dxy < 0.2. Now done at .cc
+tightMuonCut  = "muonRef.isNonnull && muonRef.isGlobalMuon && muonRef.isPFMuon && muonRef.globalTrack.normalizedChi2 < 10. && muonRef.globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
+               "muonRef.numberOfMatchedStations > 1 && muonRef.innerTrack.hitPattern.numberOfValidPixelHits > 0 && muonRef.innerTrack.hitPattern.trackerLayersWithMeasurement > 5 "
+tightIsoCut   = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.15"
+
+#Electron selections
+looseEleCut = "(( gsfElectronRef.full5x5_sigmaIetaIeta() < 0.011 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00477 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.222 && gsfElectronRef.hadronicOverEm() < 0.298 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.241 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) || (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0314 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00868 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.213 && gsfElectronRef.hadronicOverEm() < 0.101  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.14 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
+
+tightEleCut = "((gsfElectronRef.full5x5_sigmaIetaIeta() < 0.00998 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00308  && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0816 && gsfElectronRef.hadronicOverEm() < 0.0414 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) ||  (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0292 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00605 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0394  && gsfElectronRef.hadronicOverEm() < 0.0641  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() <	0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 singleTopTChannelLeptonDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
@@ -46,7 +67,7 @@ singleTopTChannelLeptonDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
       select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<1 & abs(gsfElectronRef.gsfTrack.dz)<20"),
       ## when omitted isolated electron multiplicity plot will be equi-
       ## valent to inclusive electron multiplicity plot 
-      isolation = cms.string(ElelooseIsoCut),
+      #isolation = cms.string(ElelooseIsoCut),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
@@ -141,155 +162,73 @@ singleTopMuonMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
   ## [mandatory] : optional PSets may be omitted
   ##
     setup = cms.PSet(
-    ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
-    ## communication to TopCom!
     directory = cms.string("Physics/Top/SingleTopMuonMediumDQM/"),
-    ## [mandatory]
     sources = cms.PSet(
     muons = cms.InputTag("pfIsolatedMuonsEI"),
-    elecs_gsf = cms.InputTag("gedGsfElectrons"),
     elecs = cms.InputTag("pfIsolatedElectronsEI"),
     jets  = cms.InputTag("ak4PFJetsCHS"),
-    mets  = cms.VInputTag("met", "tcMet", "pfMetEI"),
+    mets  = cms.VInputTag("pfMet"),
     pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
-    ## [optional] : when omitted the verbosity level is set to STANDARD
     monitoring = cms.PSet(
       verbosity = cms.string("DEBUG")
     ),
-    ## [optional] : when omitted all monitoring plots for primary vertices
-    ## will be filled w/o extras
-#    pvExtras = cms.PSet(
-      ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates                                                                                            
-#      select = cms.string("") #abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
-#    ),
-    ## [optional] : when omitted all monitoring plots for muons
-    ## will be filled w/o extras                                           
-    muonExtras = cms.PSet(  
-      ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates 
-      select    = cms.string("abs(muonRef.eta)<2.1")
-      ## & isGlobalMuon & innerTrack.numberOfValidHits>10 & globalTrack.normalizedChi2>-1 & globalTrack.normalizedChi2<10
-      ##& (isolationR03.sumPt+isolationR03.emEt+isolationR03.hadEt)/pt<0.1"),  
-      ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot                                                    
-   ##   isolation = cms.string("(muonRef.isolationR03.sumPt+muonRef.isolationR03.emEt+muonRef.isolationR03.hadEt)/muonRef.pt<10" )
-      ##    isolation = cms.string("(muonRef.isolationR03.sumPt+muonRef.isolationR03.emEt+muonRef.isolationR03.hadEt)/muonRef.pt<0.1")
+    pvExtras = cms.PSet(
+      select = cms.string(PVCut)
     ),
-    ## [optional] : when omitted all monitoring plots for jets
-    ## will be filled w/o extras
+    elecExtras = cms.PSet(
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+    ),                                     
+    muonExtras = cms.PSet(                                               
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),                                              
+      isolation = cms.string(looseIsoCut)
+    ),
     jetExtras = cms.PSet(
-      ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID                                                                                                   
-#      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
-#        select = cms.string(""), ##fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-#     ),
-      ## when omitted no extra selection will be applied on jets before
-      ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets                                                
-      select = cms.string("pt>15 & abs(eta)<2.5"), # & neutralEmEnergyFraction >0.01 & chargedEmEnergyFraction>0.01"),
-      ## when omitted monitor histograms for b-tagging will not be filled                                                                                                   
+      jetCorrector = cms.InputTag("ak4PFCHSL1FastL2L3Corrector"),  #Use pak4PFCHSL1FastL2L3Residual for data!!!                                            
+      select = cms.string("pt>30 & abs(eta)< 2.4"),
       jetBTaggers  = cms.PSet(
-        trackCountingEff = cms.PSet(
-          label = cms.InputTag("pfTrackCountingHighEffBJetTags" ),
-          workingPoint = cms.double(1.25)
-        ),
-        trackCountingPur = cms.PSet(
-          label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
-          workingPoint = cms.double(3.41)
-        ),
-        secondaryVertex  = cms.PSet(
-          label = cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
-          workingPoint = cms.double(2.05)
-        ),
-        combinedSecondaryVertex  = cms.PSet(
-          label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-          workingPoint = cms.double(0.970)
+      	cvsVertex = cms.PSet(
+      	label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
+	    	workingPoint = cms.double(0.890)
         )
-     )                                                
-   )
-    ## [optional] : when omitted no mass window will be applied
-    ## for the W mass before filling the event monitoring plots
-#    massExtras = cms.PSet(
-#      lowerEdge = cms.double( 70.),
-#      upperEdge = cms.double(110.)
-#    ),
-    ## [optional] : when omitted the monitoring plots for triggering
-    ## will be empty
-#    triggerExtras = cms.PSet(
-#      src   = cms.InputTag("TriggerResults","","HLT"),
-#     paths = cms.vstring(['HLT_IsoMu17_eta2p1_CentralPFNoPUJet30_BTagIPIter_v1'])
-#                          'HLT_IsoMu24_eta2p1_v12',
-#                          'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter_v2',
-#                          'HLT_IsoMu20_eta2p1_CentralPFJet30_BTagIPIter_v3'])      
-#    )
+      ),
+    ),
+    massExtras = cms.PSet(
+    	lowerEdge = cms.double( 70.),
+    	upperEdge = cms.double(110.)
+  	),
   ),
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
-  ## setup of the event preselection, which will not
-  ## be monitored
-  ## [mandatory] : but may be empty
-  ##
   preselection = cms.PSet(
-    ## [optional] : when omitted no preselection is applied
-#    trigger = cms.PSet(
-#    src    = cms.InputTag("TriggerResults","","HLT"),
-#      select = cms.vstring(['HLT_IsoMu17_eta2p1_CentralPFNoPUJet30_BTagIPIter_v1'])
-#    ),
-    ## [optional] : when omitted no preselection is applied
-#    vertex = cms.PSet(
-#      src    = cms.InputTag("offlinePrimaryVertices"),
-#      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0')
-#    )
+    vertex = cms.PSet(
+      src    = cms.InputTag("offlinePrimaryVertices"),
+      select = cms.string(PVCut)
+    )
   ),
   ## ------------------------------------------------------
   ## SELECTION
   ##
-  ## monitor histrograms are filled after each selection
-  ## step, the selection is applied in the order defined
-  ## by this vector
-  ## [mandatory] : may be empty or contain an arbitrary
-  ## number of PSets
   selection = cms.VPSet(
-   cms.PSet(
-      label  = cms.string("presel"),
-      src    = cms.InputTag("offlinePrimaryVertices"),
-      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0 '),
-     
-   ),
-   cms.PSet(
+    cms.PSet(
       label  = cms.string("muons/pf:step0"),
       src    = cms.InputTag("pfIsolatedMuonsEI"),
-      select = cms.string("muonRef.pt>20 & abs(muonRef.eta)<2.1 & muonRef.isNonnull & muonRef.innerTrack.isNonnull & muonRef.isGlobalMuon & muonRef.isTrackerMuon & muonRef.innerTrack.numberOfValidHits>10 & muonRef.globalTrack.hitPattern.numberOfValidMuonHits>0 & muonRef.globalTrack.normalizedChi2<10 & muonRef.innerTrack.hitPattern.pixelLayersWithMeasurement>=1 &  muonRef.numberOfMatches>1 & abs(muonRef.innerTrack.dxy)<0.02 & (muonRef.pfIsolationR04.sumChargedHadronPt + muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt)/muonRef.pt < 0.15"),
-
+      select = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),     
       min    = cms.int32(1),
-      max    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string(" pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"), 
-
-      min = cms.int32(1),
-      max = cms.int32(1),
+      select = cms.string("pt>30 & abs(eta)<2.4"),
+      min = cms.int32(2),
     ), 
     cms.PSet(
-     label  = cms.string("jets/pf:step2"),
-     src    = cms.InputTag("ak4PFJetsCHS"),
-     jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-     select = cms.string(" pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
-     
-     min = cms.int32(2),
-     max = cms.int32(2),
-    )
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("pfMet"),
+      select = cms.string("pt>30"),                                             
+    ),
   )
 )
 
@@ -305,150 +244,84 @@ singleTopElectronMediumDQM = DQMEDAnalyzer('SingleTopTChannelLeptonDQM',
     ## [mandatory] : should not be changed w/o explicit
     ## communication to TopCom!
     directory = cms.string("Physics/Top/SingleTopElectronMediumDQM/"),
-    ## [mandatory]
     sources = cms.PSet(
-      muons = cms.InputTag("pfIsolatedMuonsEI"),
-      elecs_gsf = cms.InputTag("gedGsfElectrons"),
-      elecs = cms.InputTag("pfIsolatedElectronsEI"),
-      jets  = cms.InputTag("ak4PFJetsCHS"),
-      mets  = cms.VInputTag("met", "tcMet", "pfMetEI"),
-      pvs   = cms.InputTag("offlinePrimaryVertices")
-
+    muons = cms.InputTag("pfIsolatedMuonsEI"),
+    elecs = cms.InputTag("pfIsolatedElectronsEI"),
+    jets  = cms.InputTag("ak4PFJetsCHS"),
+    mets  = cms.VInputTag("pfMet"),
+    pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
-    ## [optional] : when omitted the verbosity level is set to STANDARD
     monitoring = cms.PSet(
       verbosity = cms.string("DEBUG")
     ),
-    ## [optional] : when omitted all monitoring plots for primary vertices
-    ## will be filled w/o extras
-#    pvExtras = cms.PSet(
-      ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates                                                                                            
-#      select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
-#    ),
-    ## [optional] : when omitted all monitoring plots for electrons
-    ## will be filled w/o extras
+    pvExtras = cms.PSet(
+      select = cms.string(PVCut)
+    ),
     elecExtras = cms.PSet(
-      ## when omitted electron plots will be filled w/o cut on electronId
-      ##electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),  
-      ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
-      select     = cms.string("pt>25"), ##  & abs(eta)<2.5 & (dr03TkSumPt+dr03EcalRecHitSumEt+dr03HcalTowerSumEt)/pt<0.1"),
-      ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot 
-     ## isolation  = cms.string(ElelooseIsoCut),
-
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+    ),                                     
+    muonExtras = cms.PSet(                                               
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),                                              
+      isolation = cms.string(looseIsoCut)
     ),
-    ## [optional] : when omitted all monitoring plots for jets
-    ## will be filled w/o extras
     jetExtras = cms.PSet(
-      ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
-#      jetID  = cms.PSet(
-#        label  = cms.InputTag("ak4JetID"),
-#        select = cms.string(" ")
-#      ),
-      ## when omitted no extra selection will be applied on jets before
-      ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets 
-      select = cms.string("pt>15 & abs(eta)<2.5"), ## & emEnergyFraction>0.01"),
-      ## when omitted monitor histograms for b-tagging will not be filled
+      jetCorrector = cms.InputTag("ak4PFCHSL1FastL2L3Corrector"),  #Use pak4PFCHSL1FastL2L3Residual for data!!!                                            
+      select = cms.string("pt>30 & abs(eta)< 2.4"),
       jetBTaggers  = cms.PSet(
-        trackCountingEff = cms.PSet(
-          label = cms.InputTag("pfTrackCountingHighEffBJetTags" ),
-          workingPoint = cms.double(1.25)
-        ),
-        trackCountingPur = cms.PSet(
-          label = cms.InputTag("pfTrackCountingHighPurBJetTags" ),
-          workingPoint = cms.double(3.41)
-        ),
-        secondaryVertex  = cms.PSet(
-          label = cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
-          workingPoint = cms.double(2.05)
-        ),
-        combinedSecondaryVertex  = cms.PSet(
-          label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-          workingPoint = cms.double(0.970)
+      	cvsVertex = cms.PSet(
+      	label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
+	    	workingPoint = cms.double(0.890)
         )
-      )
+      ),
     ),
-    ## [optional] : when omitted no mass window will be applied
-    ## for the W mass before filling the event monitoring plots
-#    massExtras = cms.PSet(
-#      lowerEdge = cms.double( 70.),
-#      upperEdge = cms.double(110.)
-#    ),
-    ## [optional] : when omitted the monitoring plots for triggering
-    ## will be empty
-#    triggerExtras = cms.PSet(
-#      src   = cms.InputTag("TriggerResults","","HLT"),
-#      paths = cms.vstring([ 'HLT_Ele15_LW_L1R:HLT_QuadJetU15'])
-##      paths = cms.vstring([''])
-#    )
+    massExtras = cms.PSet(
+    	lowerEdge = cms.double( 70.),
+    	upperEdge = cms.double(110.)
+  	),
   ),
   ## ------------------------------------------------------
   ## PRESELECTION
   ##
-  ## setup of the event preselection, which will not
-  ## be monitored
-  ## [mandatory] : but may be empty
-  ##
   preselection = cms.PSet(
-    ## [optional] : when omitted no preselection is applied
-#    trigger = cms.PSet(
-#     src    = cms.InputTag("TriggerResults","","HLT"),
-#     select = cms.vstring(['HLT_Ele15_SW_CaloEleId_L1R'])
-#    ),
-    ## [optional] : when omitted no preselection is applied
-#    vertex = cms.PSet(
-#      src    = cms.InputTag("offlinePrimaryVertices"),
-#      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0')
-#    )
+    vertex = cms.PSet(
+      src    = cms.InputTag("offlinePrimaryVertices"),
+      select = cms.string(PVCut)
+    )
   ),
   ## ------------------------------------------------------
   ## SELECTION
   ##
-  ## monitor histrograms are filled after each selection
-  ## step, the selection is applied in the order defined
-  ## by this vector
-  ## [mandatory] : may be empty or contain an arbitrary
-  ## number of PSets
   selection = cms.VPSet(
-   cms.PSet(
-      label  = cms.string("presel"),
-      src    = cms.InputTag("offlinePrimaryVertices"),
-      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0'),
-   ),
-   cms.PSet(
-      label = cms.string("elecs/pf:step0"),
-      src   = cms.InputTag("pfIsolatedElectronsEI"),
-##      electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),  
-      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 && (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) && " + EletightIsoCut),
-      min = cms.int32(1),
-      max = cms.int32(1),
+#   cms.PSet(
+#      label  = cms.string("presel"),
+#      src    = cms.InputTag("offlinePrimaryVertices"),
+#      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0'),
+#   ),
+#   cms.PSet(
+#      label = cms.string("elecs/pf:step0"),
+#      src   = cms.InputTag("pfIsolatedElectronsEI"),
+#      electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.5) ),  
+#      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 && (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) && " + EletightIsoCut),
+#      min = cms.int32(1),
+#      max = cms.int32(1),
+#    ),*/
+    cms.PSet(
+      label  = cms.string("elecs/pf:step0"),
+      src    = cms.InputTag("pfIsolatedElectronsEI"),
+      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660) &&" + tightEleCut),  
+      min    = cms.int32(1),
     ),
     cms.PSet(
-      label = cms.string("jets/pf:step1"),
-      src   = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"), 
-
-      min = cms.int32(1),
-      max = cms.int32(1),
-      
-    ),
-    cms.PSet(
-      label = cms.string("jets/pf:step2"),
-      src   = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
-
+      label  = cms.string("jets/pf:step1"),
+      src    = cms.InputTag("ak4PFJetsCHS"),
+      select = cms.string("pt>30 & abs(eta)<2.4"),
       min = cms.int32(2),
-      max = cms.int32(2),
-
+    ), 
+    cms.PSet(
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("pfMet"),
+      select = cms.string("pt>30"),                                             
     ),
   )
 )

--- a/DQM/Physics/python/singleTopDQM_miniAOD_cfi.py
+++ b/DQM/Physics/python/singleTopDQM_miniAOD_cfi.py
@@ -1,8 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
+looseMuonCut = " (isGlobalMuon || isTrackerMuon) && isPFMuon"
+looseIsoCut  = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.25"
+
+tightMuonCut = " isGlobalMuon && isPFMuon && globalTrack.normalizedChi2 < 10. && globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
+    "numberOfMatchedStations > 1 && innerTrack.hitPattern.numberOfValidPixelHits > 0 && innerTrack.hitPattern.trackerLayersWithMeasurement > 5"
+# CB PV cut!
+tightIsoCut  = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.15"
+
+
 EletightIsoCut  = "(pfIsolationVariables.sumChargedHadronPt + max(0., pfIsolationVariables.sumNeutralHadronEt + pfIsolationVariables.sumPhotonEt - 0.5 * pfIsolationVariables.sumPUPt) ) / pt < 0.1"
 ElelooseIsoCut  = "(pfIsolationVariables.sumChargedHadronPt + max(0., pfIsolationVariables.sumNeutralHadronEt + pfIsolationVariables.sumPhotonEt - 0.5 * pfIsolationVariables.sumPUPt) ) / pt < 0.15"
 
+
+looseElecCut = "((full5x5_sigmaIetaIeta < 0.011 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00477 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.222 && hadronicOverEm < 0.298 && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.241 && gsfTrack.hitPattern.numberOfHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) < 1.479) ||  (full5x5_sigmaIetaIeta() < 0.0314 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00868 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.213 && hadronicOverEm < 0.101  && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.14 && gsfTrack.hitPattern.numberOfHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) > 1.479))"
+
+elecIPcut = "(abs(gsfTrack.d0)<0.05 & abs(gsfTrack.dz)<0.1 & abs(superCluster.eta) < 1.479)||(abs(gsfTrack.d0)<0.1 && abs(gsfTrack.dz)<0.2 && abs(superCluster.eta) > 1.479)"
+
+
+tightElecCut = "((full5x5_sigmaIetaIeta < 0.00998 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00308 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.0816 && hadronicOverEm < 0.0414 && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) < 1.479) ||  (full5x5_sigmaIetaIeta() < 0.0292 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00605 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.0394 && hadronicOverEm < 0.0641  && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) > 1.479))"
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 singleTopTChannelLeptonDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_miniAOD',
@@ -23,22 +39,26 @@ singleTopTChannelLeptonDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_m
       verbosity = cms.string("DEBUG")
     ),
 
+    pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
+    ),
     elecExtras = cms.PSet(
                                                                         
-      select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfTrack.d0)<1 & abs(gsfTrack.dz)<20"),
- 
-      isolation = cms.string(ElelooseIsoCut),
+      select = cms.string(looseElecCut+ "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+      #isolation = cms.string(ElelooseIsoCut),
+                          
     ),
 
     muonExtras = cms.PSet(
                                                                                
-      select = cms.string("pt>10 & abs(eta)<2.1 & isGlobalMuon & abs(globalTrack.d0)<1 & abs(globalTrack.dz)<20"),
- 
+      select = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),
+      isolation = cms.string(looseIsoCut),
     ),
  
     jetExtras = cms.PSet(
 
-      select = cms.string("pt>15 & abs(eta)<2.5 & emEnergyFraction>0.01"),
+      select = cms.string("pt>30 & abs(eta)<2.4"),
     ),
 
     triggerExtras = cms.PSet(
@@ -64,38 +84,42 @@ singleTopTChannelLeptonDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_m
         select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
       ),
       min = cms.int32(2),
-    )
+    ),
   )
 )
 
 singleTopMuonMediumDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_miniAOD',
-
-    setup = cms.PSet(
+  setup = cms.PSet(
 
     directory = cms.string("Physics/Top/SingleTopMuonMediumDQM_miniAOD/"),
-
     sources = cms.PSet(
-    muons = cms.InputTag("slimmedMuons"),
-    elecs_gsf = cms.InputTag("slimmedElectrons"),
-    elecs = cms.InputTag("slimmedElectrons"),
-    jets  = cms.InputTag("slimmedJets"),
-    mets  = cms.VInputTag("slimmedMETs", "slimmedMETsNoHF", "slimmedMETsPuppi"),
-    pvs   = cms.InputTag("offlineSlimmedPrimaryVertices")
+      muons = cms.InputTag("slimmedMuons"),
+      elecs = cms.InputTag("slimmedElectrons"),
+      jets  = cms.InputTag("slimmedJets"),
+      mets  = cms.VInputTag("slimmedMETs", "slimmedMETsNoHF", "slimmedMETsPuppi"),
+      pvs   = cms.InputTag("offlineSlimmedPrimaryVertices")
     ),
 
     monitoring = cms.PSet(
       verbosity = cms.string("DEBUG")
     ),
 
-    muonExtras = cms.PSet(  
- 
-      select    = cms.string("abs(eta)<2.1")
-
+    pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     ),
-
+    elecExtras = cms.PSet(
+      select = cms.string(tightElecCut + "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+      #isolation = cms.string(ElelooseIsoCut),
+    ),
+                     
+    muonExtras = cms.PSet(
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),
+      isolation = cms.string(looseIsoCut)
+    ),
     jetExtras = cms.PSet(
 
-      select = cms.string("pt>15 & abs(eta)<2.5"), # & neutralEmEnergyFraction >0.01 & chargedEmEnergyFraction>0.01"),
+      select = cms.string("pt>30 & abs(eta)<2.4"), # & neutralEmEnergyFraction >0.01 & chargedEmEnergyFraction>0.01"),
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -113,48 +137,40 @@ singleTopMuonMediumDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_miniA
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
           workingPoint = cms.double(0.898)
         )
-     )                                                
-   )
-
+     ),
+   ),
+   massExtras = cms.PSet(
+     lowerEdge = cms.double( 70.),
+     upperEdge = cms.double(110.)
+   ),
   ),
-
   preselection = cms.PSet(
-
+    vertex = cms.PSet(
+      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),#,
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
+    )
   ),
 
   selection = cms.VPSet(
-   cms.PSet(
-      label  = cms.string("presel"),
-      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),
-
-     
-   ),
-   cms.PSet(
+    cms.PSet(
       label  = cms.string("muons:step0"),
       src    = cms.InputTag("slimmedMuons"),
-      select = cms.string("pt>20 & abs(eta)<2.1 &  isGlobalMuon & isTrackerMuon & innerTrack.numberOfValidHits>10 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & innerTrack.hitPattern.pixelLayersWithMeasurement>=1 &  numberOfMatches>1 & abs(innerTrack.dxy)<0.02 & (pfIsolationR04.sumChargedHadronPt + pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt)/pt < 0.15"),
-
+      select = cms.string(looseMuonCut + " && pt > 20 & abs(eta)<2.1"), #tightMuonCut +"&&"+ tightIsoCut + " && pt>20 & abs(eta)<2.1"), # CB what about iso? CD Added tightIso
       min    = cms.int32(1),
-      max    = cms.int32(1),
+      #max    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets:step1"),
       src    = cms.InputTag("slimmedJets"),
-
-      select = cms.string(" pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"), 
-
-      min = cms.int32(1),
-      max = cms.int32(1),
-    ), 
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
+      min = cms.int32(2),
+    ),
     cms.PSet(
-     label  = cms.string("jets:step2"),
-     src    = cms.InputTag("slimmedJets"),
-
-     select = cms.string(" pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
-     
-     min = cms.int32(2),
-     max = cms.int32(2),
-    )
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("slimmedMETs"),
+      select = cms.string("pt>30"),
+      #min = cms.int32(2),
+    ),
   )
 )
 
@@ -166,7 +182,6 @@ singleTopElectronMediumDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_m
 
     sources = cms.PSet(
       muons = cms.InputTag("slimmedMuons"),
-      elecs_gsf = cms.InputTag("slimmedElectrons"),
       elecs = cms.InputTag("slimmedElectrons"),
       jets  = cms.InputTag("slimmedJets"),
       mets  = cms.VInputTag("slimmedMETs", "slimmedMETsNoHF", "slimmedMETsPuppi"),
@@ -178,16 +193,23 @@ singleTopElectronMediumDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_m
       verbosity = cms.string("DEBUG")
     ),
 
+    pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
+    ),
     elecExtras = cms.PSet(
- 
-      select     = cms.string("pt>25"),
- 
-
+      select = cms.string(tightElecCut + " && pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      #select     = cms.string(looseElecCut+ "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+      #isolation  = cms.string(ElelooseIsoCut),
+    ),
+    muonExtras = cms.PSet(
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),
+      isolation = cms.string(looseIsoCut)
     ),
 
     jetExtras = cms.PSet(
 
-      select = cms.string("pt>15 & abs(eta)<2.5"), 
+      select = cms.string("pt>30 & abs(eta)<2.4"),
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -204,44 +226,42 @@ singleTopElectronMediumDQM_miniAOD = DQMEDAnalyzer('SingleTopTChannelLeptonDQM_m
         combinedSecondaryVertex  = cms.PSet(
           label = cms.InputTag("combinedSecondaryVertexBJetTags"),
           workingPoint = cms.double(0.898)
-        )
-      )
+        ),
+      ),
     ),
+    massExtras = cms.PSet(
+      lowerEdge = cms.double( 70.),
+      upperEdge = cms.double(110.)
+    ),
+               
   ),
 
   preselection = cms.PSet(
- 
+    vertex = cms.PSet(
+      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),#,
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
+    )
   ),
 
   selection = cms.VPSet(
-   cms.PSet(
-      label  = cms.string("presel"),
-      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),
-   ),
-   cms.PSet(
-      label = cms.string("elecs:step0"),
-      src   = cms.InputTag("slimmedElectrons"),
-      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfTrack.d0)<0.02 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 && (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) && " + EletightIsoCut),
-      min = cms.int32(1),
-      max = cms.int32(1),
+    cms.PSet(
+      label  = cms.string("elecs:step0"),
+      src    = cms.InputTag("slimmedElectrons"),
+      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) &&" + tightElecCut),
+      min    = cms.int32(1),
+      max    = cms.int32(1),
     ),
     cms.PSet(
-      label = cms.string("jets:step1"),
-      src   = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"), 
-
-      min = cms.int32(1),
-      max = cms.int32(1),
-      
-    ),
-    cms.PSet(
-      label = cms.string("jets:step2"),
-      src   = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<4.5 & numberOfDaughters>1 & ((abs(eta)>2.4) || ( chargedHadronEnergyFraction > 0 & chargedMultiplicity>0 & chargedEmEnergyFraction<0.99)) & neutralEmEnergyFraction < 0.99 & neutralHadronEnergyFraction < 0.99"),
-
+      label  = cms.string("jets:step1"),
+      src    = cms.InputTag("slimmedJets"),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(2),
-      max = cms.int32(2),
-
+    ),
+    cms.PSet(
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("slimmedMETs"),
+      select = cms.string("pt>30"),
+      #min = cms.int32(2),
     ),
   )
 )

--- a/DQM/Physics/python/topSingleLeptonDQM_cfi.py
+++ b/DQM/Physics/python/topSingleLeptonDQM_cfi.py
@@ -1,15 +1,30 @@
 import FWCore.ParameterSet.Config as cms
 
-looseMuonCut = "muonRef.isNonnull && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) && muonRef.isPFMuon"
-looseIsoCut  = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.2"
+#Primary vertex selection
+PVCut = "abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake"
 
-tightMuonCut = "muonRef.isNonnull && muonRef.isGlobalMuon && muonRef.isPFMuon && muonRef.globalTrack.normalizedChi2 < 10. && muonRef.globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
-               "muonRef.numberOfMatchedStations > 1 && muonRef.innerTrack.hitPattern.numberOfValidPixelHits > 0 && muonRef.innerTrack.hitPattern.trackerLayersWithMeasurement > 8"
-               # CB PV cut!
-tightIsoCut  = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.12"
+#Jet selection
+looseJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.99 && neutralEmEnergyFraction()<0.99 && (chargedMultiplicity()+neutralMultiplicity())>1) && abs(eta)<=2.4 "
 
-EletightIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.1"
-ElelooseIsoCut  = "(gsfElectronRef.pfIsolationVariables.sumChargedHadronPt + max(0., gsfElectronRef.pfIsolationVariables.sumNeutralHadronEt + gsfElectronRef.pfIsolationVariables.sumPhotonEt - 0.5 * gsfElectronRef.pfIsolationVariables.sumPUPt) ) / gsfElectronRef.pt < 0.15"
+tightJetCut = "(chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.90 && neutralEmEnergyFraction()<0.90 && (chargedMultiplicity()+neutralMultiplicity())>1) && abs(eta)<=2.4 "
+
+#Loose muon selection
+looseMuonCut  = "(muonRef.isNonnull && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) && muonRef.isPFMuon)"
+looseIsoCut   = "((muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.25)"
+
+#Medium muon selection. Also requires either good global muon or tight segment compatibility
+mediumMuonCut = looseMuonCut + " muonRef.innerTrack.validFraction > 0.8"
+
+#Tight muon selection. Lacks distance to primary vertex variables, dz<0.5, dxy < 0.2. Now done at .cc
+tightMuonCut  = "muonRef.isNonnull && muonRef.isGlobalMuon && muonRef.isPFMuon && muonRef.globalTrack.normalizedChi2 < 10. && muonRef.globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
+               "muonRef.numberOfMatchedStations > 1 && muonRef.innerTrack.hitPattern.numberOfValidPixelHits > 0 && muonRef.innerTrack.hitPattern.trackerLayersWithMeasurement > 5 "
+tightIsoCut   = "(muonRef.pfIsolationR04.sumChargedHadronPt + max(0., muonRef.pfIsolationR04.sumNeutralHadronEt + muonRef.pfIsolationR04.sumPhotonEt - 0.5 * muonRef.pfIsolationR04.sumPUPt) ) / muonRef.pt < 0.15"
+
+#Electron selections
+looseEleCut = "(( gsfElectronRef.full5x5_sigmaIetaIeta() < 0.011 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00477 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.222 && gsfElectronRef.hadronicOverEm() < 0.298 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.241 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) || (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0314 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00868 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.213 && gsfElectronRef.hadronicOverEm() < 0.101  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.14 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
+
+tightEleCut = "((gsfElectronRef.full5x5_sigmaIetaIeta() < 0.00998 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00308  && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0816 && gsfElectronRef.hadronicOverEm() < 0.0414 && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() < 0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) < 1.479) ||  (gsfElectronRef.full5x5_sigmaIetaIeta() < 0.0292 && gsfElectronRef.superCluster().isNonnull() && gsfElectronRef.superCluster().seed().isNonnull() && (gsfElectronRef.deltaEtaSuperClusterTrackAtVtx() - gsfElectronRef.superCluster().eta() + gsfElectronRef.superCluster().seed().eta()) < 0.00605 && abs(gsfElectronRef.deltaPhiSuperClusterTrackAtVtx()) < 0.0394  && gsfElectronRef.hadronicOverEm() < 0.0641  && abs(1.0 - gsfElectronRef.eSuperClusterOverP())*1.0/gsfElectronRef.ecalEnergy() <	0.0129 && gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(gsfElectronRef.superCluster().eta()) > 1.479))"
+
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 topSingleLeptonDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
@@ -29,7 +44,7 @@ topSingleLeptonDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       muons = cms.InputTag("pfIsolatedMuonsEI"),
       elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
-      mets  = cms.VInputTag("caloMet", "tcMet", "pfMet"),
+      mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
     ## [optional] : when omitted the verbosity level is set to STANDARD
@@ -53,7 +68,8 @@ topSingleLeptonDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfTrack.d0)<1 & abs(gsfTrack.dz)<20"),
       ## when omitted isolated electron multiplicity plot will be equi-
       ## valent to inclusive electron multiplicity plot 
-      isolation = cms.string(ElelooseIsoCut),
+      #isolation = cms.string(ElelooseIsoCut),
+			rho = cms.InputTag("fixedGridRhoFastjetAll"),
     ),
     ## [optional] : when omitted all monitoring plots for muons
     ## will be filled w/o extras
@@ -70,7 +86,7 @@ topSingleLeptonDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets                                            
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      ## jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
       ## jetID                                                   
       #jetID  = cms.PSet(
@@ -80,7 +96,7 @@ topSingleLeptonDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
     ),
     ## [optional] : when omitted no mass window will be applied
     ## for the W mass befor filling the event monitoring plots
@@ -130,7 +146,7 @@ topSingleLeptonDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
     cms.PSet(
       label  = cms.string("jets/pf:step0"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       #jetID  = cms.PSet(
         #label  = cms.InputTag("ak5JetID"),
         #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
@@ -157,7 +173,7 @@ topSingleMuonLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       muons = cms.InputTag("pfIsolatedMuonsEI"),
       elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
-      mets  = cms.VInputTag("caloMet", "tcMet", "pfMet"),
+      mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
     ),
     ## [optional] : when omitted the verbosity level is set to STANDARD
@@ -184,7 +200,7 @@ topSingleMuonLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
     jetExtras = cms.PSet(
       ## when omitted monitor plots for pt will be filled from uncorrected
       ## jets                                               
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
+      ## jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
       ## when omitted monitor plots will be filled w/o additional cut on
       ## jetID                                                                                                                     
       #jetID  = cms.PSet(
@@ -194,13 +210,13 @@ topSingleMuonLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       ## when omitted no extra selection will be applied on jets before
       ## filling the monitor histograms; if jetCorrector is present the
       ## selection will be applied to corrected jets                                                
-      select = cms.string("pt>30 & abs(eta)<2.5"),
+      select = cms.string("pt>30 & abs(eta)<2.4"),
       ## when omitted monitor histograms for b-tagging will not be filled 
       jetBTaggers  = cms.PSet(
 		cvsVertex = cms.PSet(
           label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-	          workingPoint = cms.double(0.970)
-	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
+	          workingPoint = cms.double(0.890)
+	          # CSV Medium from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
         )
       ),                                                
     ),
@@ -229,12 +245,6 @@ topSingleMuonLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   ## [mandatory] : but may be empty
   ##
   preselection = cms.PSet(
-    ## [optional] : when omitted no preselection is applied
-    #trigger = cms.PSet(
-    #  src    = cms.InputTag("TriggerResults","","HLT"),
-    #  select = cms.vstring(['HLT_Mu11'])
-    #),
-    ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
       select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
@@ -258,47 +268,25 @@ topSingleMuonLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-   #   ),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(1),                                               
     ), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-    #  ),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(2),                                               
     ), 
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-     # ),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(3),                                               
     ), 
     cms.PSet(
       label  = cms.string("jets/pf:step4"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-#      ),
-      min = cms.int32(4),                                               
+      src    = cms.InputTag("pfMet"),
+      select = cms.string("pt>30"),                                          
     ), 
   )
 )
@@ -310,163 +298,70 @@ topSingleMuonMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   ## [mandatory] : optional PSets may be omitted
   ##
   setup = cms.PSet(
-    ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
-    ## communication to TopCom!
     directory = cms.string("Physics/Top/TopSingleMuonMediumDQM/"),
-    ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("pfIsolatedMuonsEI"),
       elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
-      mets  = cms.VInputTag("caloMet", "tcMet", "pfMet"),
+      mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
     ),
-    ## [optional] : when omitted the verbosity level is set to STANDARD
     monitoring = cms.PSet(
       verbosity = cms.string("DEBUG")
     ),
-    ## [optional] : when omitted all monitoring plots for primary vertices
-    ## will be filled w/o extras
     pvExtras = cms.PSet(
-      ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates                                                                                            
-      select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
+      select = cms.string(PVCut)
     ),
-    ## [optional] : when omitted all monitoring plots for muons
-    ## will be filled w/o extras                                           
-    muonExtras = cms.PSet(
-      ## when omitted muon plots will be filled w/o additional pre-
-      ## selection of the muon candidates                                                
-      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),  
-      ## when omitted isolated muon multiplicity plot will be equi-
-      ## valent to inclusive muon multiplicity plot                                                    
+    elecExtras = cms.PSet(
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+			rho = cms.InputTag("fixedGridRhoFastjetAll"),
+    ),                                     
+    muonExtras = cms.PSet(                                               
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),                                              
       isolation = cms.string(looseIsoCut)
     ),
-    ## [optional] : when omitted all monitoring plots for jets
-    ## will be filled w/o extras
     jetExtras = cms.PSet(
-      ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID                                                                                                   
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
- #     ),
-      ## when omitted no extra selection will be applied on jets before
-      ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets                                                
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      ## when omitted monitor histograms for b-tagging will not be filled                                                                                                   
+      jetCorrector = cms.InputTag("ak4PFCHSL1FastL2L3Corrector"),  #Use pak4PFCHSL1FastL2L3Residual for data!!!                                            
+      select = cms.string("pt>30 & abs(eta)< 2.4"),                                                                                               
       jetBTaggers  = cms.PSet(
-		cvsVertex = cms.PSet(
+				cvsVertex = cms.PSet(
           label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-	          workingPoint = cms.double(0.970)
-	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
+	          workingPoint = cms.double(0.890)
+	          # CSV Medium from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
         )
       ),                                                                                                
     ),
-    ## [optional] : when omitted no mass window will be applied
-    ## for the W mass before filling the event monitoring plots
     massExtras = cms.PSet(
       lowerEdge = cms.double( 70.),
       upperEdge = cms.double(110.)
     ),
-    ## [optional] : when omitted the monitoring plots for triggering
-    ## will be empty
-#    triggerExtras = cms.PSet(
-#      src   = cms.InputTag("TriggerResults","","HLT"),
-#     paths = cms.vstring(['HLT_Mu3:HLT_QuadJet15U',
-#                          'HLT_Mu5:HLT_QuadJet15U',
-#                          'HLT_Mu7:HLT_QuadJet15U',
-#                          'HLT_Mu9:HLT_QuadJet15U',
-#                          'HLT_Mu11:HLT_QuadJet15U'])      
-#    )
   ),
-  ## ------------------------------------------------------
-  ## PRESELECTION
-  ##
-  ## setup of the event preselection, which will not
-  ## be monitored
-  ## [mandatory] : but may be empty
-  ##
+
   preselection = cms.PSet(
-    ## [optional] : when omitted no preselection is applied
-    #trigger = cms.PSet(
-    #  src    = cms.InputTag("TriggerResults","","HLT"),
-    #  select = cms.vstring(['HLT_Mu15_v2'])
-    #),
-    ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
-      select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
+      select = cms.string(PVCut)
     )
   ),
-  ## ------------------------------------------------------
-  ## SELECTION
-  ##
-  ## monitor histrograms are filled after each selection
-  ## step, the selection is applied in the order defined
-  ## by this vector
-  ## [mandatory] : may be empty or contain an arbitrary
-  ## number of PSets
+
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("muons:step0"),
       src    = cms.InputTag("pfIsolatedMuonsEI"),
-      select = cms.string(tightMuonCut +"&&"+ tightIsoCut + " && pt>20 & abs(eta)<2.1"), # CB what about iso? CD Added tightIso      
+      select = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),     
       min    = cms.int32(1),
-      max    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
-      #src    = cms.InputTag("ak4PFJetsCHS"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-#      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-  #    ),
-      min = cms.int32(1),
+      select = cms.string("pt>30 & abs(eta)<2.4"),
+      min = cms.int32(4),
     ), 
     cms.PSet(
-      label  = cms.string("jets/pf:step2"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-   #   ),
-      min = cms.int32(2),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets/pf:step3"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
- #     ),
-      min = cms.int32(3),                                                
-    ), 
-    cms.PSet(
-      label  = cms.string("jets/pf:step4"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-#      ),
-      min = cms.int32(4),                                                
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("pfMet"),
+      select = cms.string("pt>30"),                                             
     ),
   )
 )
@@ -488,7 +383,7 @@ topSingleElectronLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
       muons = cms.InputTag("pfIsolatedMuonsEI"),
       elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
-      mets  = cms.VInputTag("caloMet", "tcMet", "pfMet"),
+      mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
     ),
@@ -506,32 +401,14 @@ topSingleElectronLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
     ## [optional] : when omitted all monitoring plots for electrons
     ## will be filled w/o extras
     elecExtras = cms.PSet(
-      ## when omitted electron plots will be filled w/o cut on electronId
-      #electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),
       ## when omitted electron plots will be filled w/o additional pre-
       ## selection of the electron candidates
-      select     = cms.string("pt>20 & abs(eta)<2.5"),
-      ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot                                                    
-      isolation  = cms.string(ElelooseIsoCut),                                                   
+      select     = cms.string("pt>20 & abs(eta)<2.5"),                                                 
     ),
     ## [optional] : when omitted all monitoring plots for jets
     ## will be filled w/o extras
     jetExtras = cms.PSet(
-      ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID                                                   
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-    #  ),
-      ## when omitted no extra selection will be applied on jets before
-      ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets
-      #select = cms.string("pt>30 & abs(eta)<2.5 & emEnergyFraction>0.01"), 
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       ## when omitted monitor histograms for b-tagging will not be filled                                                   
       jetBTaggers  = cms.PSet(
 		cvsVertex = cms.PSet(
@@ -562,12 +439,6 @@ topSingleElectronLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   ## [mandatory] : but may be empty
   ##
   preselection = cms.PSet(
-    ## [optional] : when omitted no preselection is applied
-    #trigger = cms.PSet(
-    #  src    = cms.InputTag("TriggerResults","","HLT"),
-    #  select = cms.vstring(['HLT_Ele15_SW_CaloEleId_L1R'])
-    #),
-    ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
       select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
@@ -579,57 +450,35 @@ topSingleElectronLooseDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   ## monitor histrograms are filled after each selection
   ## step, the selection is applied in the order defined
   ## by this vector
-  ## [mandatory] : may be empty or contain an arbitrary
-  ## number of PSets
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("elecs:step0"),
       src    = cms.InputTag("pfIsolatedElectronsEI"),
-      select = cms.string("pt>20 & abs(eta)<2.5 && "+ElelooseIsoCut),
+      select = cms.string("pt>20 & abs(eta)<2.5 "),
       min    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets/pf:step1"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-     # ),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(1),                                                   
     ), 
     cms.PSet(
       label  = cms.string("jets/pf:step2"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-#      ),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(2),
     ), 
     cms.PSet(
       label  = cms.string("jets/pf:step3"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
- #     ),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(3),
     ), 
     cms.PSet(
       label  = cms.string("jets/pf:step4"),
       src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-  #    ),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(4),
     ),
   )
@@ -643,158 +492,70 @@ topSingleElectronMediumDQM = DQMEDAnalyzer('TopSingleLeptonDQM',
   ## [mandatory] : optional PSets may be omitted
   ##
   setup = cms.PSet(
-    ## sub-directory to write the monitor histograms to
-    ## [mandatory] : should not be changed w/o explicit
-    ## communication to TopCom!
     directory = cms.string("Physics/Top/TopSingleElectronMediumDQM/"),
-    ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("pfIsolatedMuonsEI"),
       elecs = cms.InputTag("pfIsolatedElectronsEI"),
       jets  = cms.InputTag("ak4PFJetsCHS"),
-      mets  = cms.VInputTag("caloMet", "tcMet", "pfMet"),
+      mets  = cms.VInputTag("pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
 
     ),
-    ## [optional] : when omitted the verbosity level is set to STANDARD
     monitoring = cms.PSet(
       verbosity = cms.string("DEBUG")
     ),
-    ## [optional] : when omitted all monitoring plots for primary vertices
-    ## will be filled w/o extras
-    pvExtras = cms.PSet(
-      ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the primary vertex candidates                                                                                            
-      select = cms.string("abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake")
+    pvExtras = cms.PSet(                                                                                           
+      select   = cms.string(PVCut)
     ),
-    ## [optional] : when omitted all monitoring plots for electrons
-    ## will be filled w/o extras
     elecExtras = cms.PSet(
-      ## when omitted electron plots will be filled w/o cut on electronId
-      #electronId = cms.PSet( src = cms.InputTag("mvaTrigV0"), cutValue = cms.double(0.0) ),
-      ## when omitted electron plots will be filled w/o additional pre-
-      ## selection of the electron candidates
-      select     = cms.string("pt>20 & abs(eta)<2.5"),
-      ## when omitted isolated electron multiplicity plot will be equi-
-      ## valent to inclusive electron multiplicity plot 
-      isolation  = cms.string(ElelooseIsoCut),
+      select     = cms.string(tightEleCut + "& pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660)"),
+			rho = cms.InputTag("fixedGridRhoFastjetAll"),
     ),
-    ## [optional] : when omitted all monitoring plots for jets
-    ## will be filled w/o extras
+    muonExtras = cms.PSet(
+      select     = cms.string(looseMuonCut + " & pt>20 & abs(eta)<2.1"),
+			isolation  = cms.string(looseIsoCut),
+    ),
     jetExtras = cms.PSet(
-      ## when omitted monitor plots for pt will be filled from uncorrected
-      ## jets
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      ## when omitted monitor plots will be filled w/o additional cut on
-      ## jetID
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-   #   ),
-      ## when omitted no extra selection will be applied on jets before
-      ## filling the monitor histograms; if jetCorrector is present the
-      ## selection will be applied to corrected jets 
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      ## when omitted monitor histograms for b-tagging will not be filled
+			jetCorrector = cms.InputTag("ak4PFCHSL1FastL2L3Corrector"), #Use pak4PFCHSL1FastL2L3Residual for data!!!
+      select = cms.string("pt>30 & abs(eta)<2.4"),
       jetBTaggers  = cms.PSet(
-		cvsVertex = cms.PSet(
+			cvsVertex = cms.PSet(
           label = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-	          workingPoint = cms.double(0.970)
-	          # CSV Tight from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
+	          workingPoint = cms.double(0.890)
+	          # CSV Medium from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X
         )
       ),                                                
     ),
-    ## [optional] : when omitted no mass window will be applied
-    ## for the W mass before filling the event monitoring plots
     massExtras = cms.PSet(
       lowerEdge = cms.double( 70.),
       upperEdge = cms.double(110.)
     ),
-    ## [optional] : when omitted the monitoring plots for triggering
-    ## will be empty
-    #triggerExtras = cms.PSet(
-    #  src   = cms.InputTag("TriggerResults","","HLT"),
-    #  paths = cms.vstring([ 'HLT_Ele15_LW_L1R:HLT_QuadJetU15'])
-    #)
   ),
-  ## ------------------------------------------------------
-  ## PRESELECTION
-  ##
-  ## setup of the event preselection, which will not
-  ## be monitored
-  ## [mandatory] : but may be empty
-  ##
   preselection = cms.PSet(
-    ## [optional] : when omitted no preselection is applied
-    #trigger = cms.PSet(
-    #  src    = cms.InputTag("TriggerResults","","HLT"),
-    #  select = cms.vstring(['HLT_Ele15_SW_CaloEleId_L1R'])
-    #),
-    ## [optional] : when omitted no preselection is applied
     vertex = cms.PSet(
       src    = cms.InputTag("offlinePrimaryVertices"),
-      select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
+      select = cms.string(PVCut)
     )
   ),
-  ## ------------------------------------------------------
-  ## SELECTION
-  ##
-  ## monitor histrograms are filled after each selection
-  ## step, the selection is applied in the order defined
-  ## by this vector
-  ## [mandatory] : may be empty or contain an arbitrary
-  ## number of PSets
   selection = cms.VPSet(
     cms.PSet(
       label = cms.string("elecs:step0"),
       src   = cms.InputTag("pfIsolatedElectronsEI"),
-      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 & gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 & (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) & " + EletightIsoCut),
+      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(gsfElectronRef.superCluster().eta()) <= 1.4442 || abs(gsfElectronRef.superCluster().eta()) >= 1.5660) &&" + tightEleCut),
+ #     select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfElectronRef.gsfTrack.d0)<0.02 & gsfElectronRef.gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 & (abs(gsfElectronRef.superCluster.eta) <= 1.4442 || abs(gsfElectronRef.superCluster.eta) >= 1.5660) & " + EletightIsoCut),
       min = cms.int32(1),
-      max = cms.int32(1),
     ),
     cms.PSet(
       label = cms.string("jets/pf:step1"),
       src   = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-#      ),
-      min = cms.int32(1),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets/pf:step2"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
- #     ),
-      min = cms.int32(2),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets/pf:step3"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-  #    ),
-      min = cms.int32(3),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets/pf:step4"),
-      src    = cms.InputTag("ak4PFJetsCHS"),
-      jetCorrector = cms.string("topDQMak5PFCHSL2L3"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      #jetID  = cms.PSet(
-        #label  = cms.InputTag("ak5JetID"),
-        #select = cms.string("fHPD < 0.98 & n90Hits>1 & restrictedEMF<1")
-   #   ),
+      select = cms.string("pt>30 & abs(eta)<2.4"),
       min = cms.int32(4),
+    ), 
+    cms.PSet(
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("pfMet"),
+      select = cms.string("pt>30"),
     ),
   )
 )
+

--- a/DQM/Physics/python/topSingleLeptonDQM_miniAOD_cfi.py
+++ b/DQM/Physics/python/topSingleLeptonDQM_miniAOD_cfi.py
@@ -1,15 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 
 looseMuonCut = " (isGlobalMuon || isTrackerMuon) && isPFMuon"
-looseIsoCut  = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.2"
+looseIsoCut  = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.25"
 
 tightMuonCut = " isGlobalMuon && isPFMuon && globalTrack.normalizedChi2 < 10. && globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + \
-               "numberOfMatchedStations > 1 && innerTrack.hitPattern.numberOfValidPixelHits > 0 && innerTrack.hitPattern.trackerLayersWithMeasurement > 8"
+               "numberOfMatchedStations > 1 && innerTrack.hitPattern.numberOfValidPixelHits > 0 && innerTrack.hitPattern.trackerLayersWithMeasurement > 5"
                # CB PV cut!
-tightIsoCut  = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.12"
+tightIsoCut  = "(pfIsolationR04.sumChargedHadronPt + max(0., pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - 0.5 * pfIsolationR04.sumPUPt) ) / pt < 0.15"
+
 
 EletightIsoCut  = "(pfIsolationVariables.sumChargedHadronPt + max(0., pfIsolationVariables.sumNeutralHadronEt + pfIsolationVariables.sumPhotonEt - 0.5 * pfIsolationVariables.sumPUPt) ) / pt < 0.1"
 ElelooseIsoCut  = "(pfIsolationVariables.sumChargedHadronPt + max(0., pfIsolationVariables.sumNeutralHadronEt + pfIsolationVariables.sumPhotonEt - 0.5 * pfIsolationVariables.sumPUPt) ) / pt < 0.15"
+
+looseElecCut = "((full5x5_sigmaIetaIeta < 0.011 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00477 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.222 && hadronicOverEm < 0.298 && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.241 && gsfTrack.hitPattern.numberOfHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) < 1.479) ||  (full5x5_sigmaIetaIeta() < 0.0314 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00868 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.213 && hadronicOverEm < 0.101  && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.14 && gsfTrack.hitPattern.numberOfHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) > 1.479))"
+
+elecIPcut = "(abs(gsfTrack.d0)<0.05 & abs(gsfTrack.dz)<0.1 & abs(superCluster.eta) < 1.479)||(abs(gsfTrack.d0)<0.1 && abs(gsfTrack.dz)<0.2 && abs(superCluster.eta) > 1.479)"
+
+
+tightElecCut = "((full5x5_sigmaIetaIeta < 0.00998 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00308 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.0816 && hadronicOverEm < 0.0414 && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) < 1.479) ||  (full5x5_sigmaIetaIeta() < 0.0292 && superCluster.isNonnull && superCluster.seed.isNonnull && (deltaEtaSuperClusterTrackAtVtx - superCluster.eta + superCluster.seed.eta) < 0.00605 && abs(deltaPhiSuperClusterTrackAtVtx) < 0.0394 && hadronicOverEm < 0.0641  && abs(1.0 - eSuperClusterOverP)*1.0/ecalEnergy < 0.0129 && gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 1 && abs(superCluster.eta) > 1.479))"
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 topSingleLeptonDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
@@ -20,25 +28,25 @@ topSingleLeptonDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
       elecs = cms.InputTag("slimmedElectrons"),
       jets  = cms.InputTag("slimmedJets"),
       mets  = cms.VInputTag("slimmedMETs", "slimmedMETsNoHF", "slimmedMETsPuppi"),
-  
       pvs   = cms.InputTag("offlineSlimmedPrimaryVertices")
     ),
     monitoring = cms.PSet(
       verbosity = cms.string("DEBUG")
     ),
     pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     ),
-
     elecExtras = cms.PSet(                                                                                 
-      select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfTrack.d0)<1 & abs(gsfTrack.dz)<20"),
-      isolation = cms.string(ElelooseIsoCut),
+      select = cms.string(looseElecCut+ "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+                          #isolation = cms.string(ElelooseIsoCut),
     ),
     muonExtras = cms.PSet(
-      select = cms.string(looseMuonCut + " && pt>10 & abs(eta)<2.4"),
+      select = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),
       isolation = cms.string(looseIsoCut),
     ),
     jetExtras = cms.PSet(
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
     ),
     massExtras = cms.PSet(
       lowerEdge = cms.double( 70.),
@@ -55,14 +63,15 @@ topSingleLeptonDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
   preselection = cms.PSet(
 
     vertex = cms.PSet(
-      src    = cms.InputTag("offlineSlimmedPrimaryVertices")#,
+      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),#,
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     )                                        
   ),  
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("jets:step0"),
       src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(2),
     ),
   )
@@ -83,13 +92,14 @@ topSingleMuonLooseDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
       verbosity = cms.string("DEBUG")
     ),
     pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     ),
     muonExtras = cms.PSet(
-      select = cms.string(looseMuonCut + " && pt > 10 & abs(eta)<2.4"),
+      select = cms.string(looseMuonCut + " && pt > 15 & abs(eta)<2.4"),
       isolation = cms.string(looseIsoCut)                                               
     ),
     jetExtras = cms.PSet(
-      select = cms.string("pt>30 & abs(eta)<2.5"),
+      select = cms.string("pt>30 & abs(eta)<2.4"),
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -125,14 +135,15 @@ topSingleMuonLooseDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
   ),
   preselection = cms.PSet(
     vertex = cms.PSet(
-      src    = cms.InputTag("offlineSlimmedPrimaryVertices")#,
+      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),#,
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     )
   ),
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("muons:step0"),
       src    = cms.InputTag("slimmedMuons"),
-      select = cms.string(looseMuonCut + looseIsoCut + " && pt>10 & abs(eta)<2.4"), # CB what about iso? CD Added looseIso
+      select = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.4"), # CB what about iso? CD Added looseIso
       min    = cms.int32(1),
     ),
     cms.PSet(
@@ -176,13 +187,20 @@ topSingleMuonMediumDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
       verbosity = cms.string("DEBUG")
     ),
     pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     ),
+    elecExtras = cms.PSet(
+      select = cms.string(tightElecCut + "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+    #isolation = cms.string(ElelooseIsoCut),
+    ),
+               
     muonExtras = cms.PSet(
-      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),  
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),
       isolation = cms.string(looseIsoCut)
     ),
     jetExtras = cms.PSet(                       
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -209,41 +227,42 @@ topSingleMuonMediumDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
   ),
   preselection = cms.PSet(
     vertex = cms.PSet(
-      src    = cms.InputTag("offlineSlimmedPrimaryVertices")#,
+      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),#,
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     )
   ),
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("muons:step0"),
       src    = cms.InputTag("slimmedMuons"),
-      select = cms.string(tightMuonCut +"&&"+ tightIsoCut + " && pt>20 & abs(eta)<2.1"), # CB what about iso? CD Added tightIso      
+      select = cms.string(looseMuonCut + " && pt > 20 & abs(eta)<2.1"), #tightMuonCut +"&&"+ tightIsoCut + " && pt>20 & abs(eta)<2.1"), # CB what about iso? CD Added tightIso
       min    = cms.int32(1),
-      max    = cms.int32(1),
+      #max    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets:step1"),
       src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(1),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
+      min = cms.int32(4),
     ), 
     cms.PSet(
-      label  = cms.string("jets:step2"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(2),
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("slimmedMETs"),
+      select = cms.string("pt>30"),
+      #min = cms.int32(2),
     ), 
-    cms.PSet(
-      label  = cms.string("jets:step3"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(3),                                                
-    ), 
-    cms.PSet(
-      label  = cms.string("jets:step4"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(4),                                                
-    ),
+#    cms.PSet(
+#      label  = cms.string("jets:step3"),
+#      src    = cms.InputTag("slimmedJets"),
+#      select = cms.string("pt>30 & abs(eta)<2.5 "),
+#      min = cms.int32(3),                                                
+#    ), 
+#    cms.PSet(
+#      label  = cms.string("jets:step4"),
+#      src    = cms.InputTag("slimmedJets"),
+#      select = cms.string("pt>30 & abs(eta)<2.5 "),
+#      min = cms.int32(4),                                                
+#    ),
   )
 )
 
@@ -262,11 +281,14 @@ topSingleElectronLooseDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
       verbosity = cms.string("DEBUG")
     ),
     pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     ),
     elecExtras = cms.PSet(
-      select     = cms.string("pt>20 & abs(eta)<2.5"),
-      isolation  = cms.string(ElelooseIsoCut),                                                   
+      select     = cms.string(tightElecCut + "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),                    
+                          #isolation  = cms.string(ElelooseIsoCut),
     ),
+                   
     jetExtras = cms.PSet(
       select = cms.string("pt>30 & abs(eta)<2.5 "),
       jetBTaggers  = cms.PSet(
@@ -299,40 +321,41 @@ topSingleElectronLooseDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
   ),
   preselection = cms.PSet(
     vertex = cms.PSet(
-      src    = cms.InputTag("offlineSlimmedPrimaryVertices")#,
+      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),#,
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     )
   ),
   selection = cms.VPSet(
     cms.PSet(
       label  = cms.string("elecs:step0"),
       src    = cms.InputTag("slimmedElectrons"),
-      select = cms.string("pt>20 & abs(eta)<2.5 && "+ElelooseIsoCut),
+      select = cms.string(tightElecCut + "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
       min    = cms.int32(1),
     ),
     cms.PSet(
       label  = cms.string("jets:step1"),
       src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(1),                                                   
-    ), 
-    cms.PSet(
-      label  = cms.string("jets:step2"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(2),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets:step3"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(3),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets:step4"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(4),
     ),
+    cms.PSet(
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("slimmedMETs"),
+      select = cms.string("pt>30"),
+      #min = cms.int32(2),
+    ),
+                        #cms.PSet(
+                        #label  = cms.string("jets:step3"),
+                        #src    = cms.InputTag("slimmedJets"),
+                        #select = cms.string("pt>30 & abs(eta)<2.5 "),
+                        #min = cms.int32(3),
+                        #),
+                        #cms.PSet(
+                        #label  = cms.string("jets:step4"),
+                        #src    = cms.InputTag("slimmedJets"),
+                        #select = cms.string("pt>30 & abs(eta)<2.5 "),
+                        #min = cms.int32(4),
+                        #),
   )
 )
 
@@ -352,13 +375,20 @@ topSingleElectronMediumDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
       verbosity = cms.string("DEBUG")
     ),
     pvExtras = cms.PSet(
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     ),
     elecExtras = cms.PSet(
-      select     = cms.string("pt>20 & abs(eta)<2.5"),
-      isolation  = cms.string(ElelooseIsoCut),
+      select = cms.string(tightElecCut + " && pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+                          #select     = cms.string(looseElecCut+ "&& pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660)"),
+      rho = cms.InputTag("fixedGridRhoFastjetAll"),
+                          #isolation  = cms.string(ElelooseIsoCut),
+    ),
+    muonExtras = cms.PSet(
+      select    = cms.string(looseMuonCut + " && pt>20 & abs(eta)<2.1"),
+      isolation = cms.string(looseIsoCut)
     ),
     jetExtras = cms.PSet(
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       jetBTaggers  = cms.PSet(
         trackCountingEff = cms.PSet(
           label = cms.InputTag("trackCountingHighEffBJetTags" ),
@@ -385,40 +415,41 @@ topSingleElectronMediumDQM_miniAOD = DQMEDAnalyzer('TopSingleLeptonDQM_miniAOD',
   ),
   preselection = cms.PSet(
     vertex = cms.PSet(
-      src    = cms.InputTag("offlineSlimmedPrimaryVertices")#,
+      src    = cms.InputTag("offlineSlimmedPrimaryVertices"),#,
+      select = cms.string("abs(z) < 24. & position.rho < 2. & ndof > 4 & !isFake")
     )
   ),
   selection = cms.VPSet(
     cms.PSet(
-      label = cms.string("elecs:step0"),
-      src   = cms.InputTag("slimmedElectrons"),
-      select = cms.string("pt>30 & abs(eta)<2.5 & abs(gsfTrack.d0)<0.02 & gsfTrack.hitPattern().numberOfLostHits('MISSING_INNER_HITS') <= 0 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) & " + EletightIsoCut),
-      min = cms.int32(1),
-      max = cms.int32(1),
+      label  = cms.string("elecs:step0"),
+      src    = cms.InputTag("slimmedElectrons"),
+      select = cms.string("pt>20 & abs(eta)<2.5 & (abs(superCluster.eta) <= 1.4442 || abs(superCluster.eta) >= 1.5660) &" + tightElecCut),
+      min    = cms.int32(1),
+      max    = cms.int32(1),
     ),
     cms.PSet(
-      label = cms.string("jets:step1"),
-      src   = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(1),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets:step2"),
+      label  = cms.string("jets:step1"),
       src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(2),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets:step3"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
-      min = cms.int32(3),
-    ), 
-    cms.PSet(
-      label  = cms.string("jets:step4"),
-      src    = cms.InputTag("slimmedJets"),
-      select = cms.string("pt>30 & abs(eta)<2.5 "),
+      select = cms.string("pt>30 & abs(eta)<2.4 "),
       min = cms.int32(4),
     ),
+    cms.PSet(
+      label  = cms.string("met:step2"),
+      src    = cms.InputTag("slimmedMETs"),
+      select = cms.string("pt>30"),
+      #min = cms.int32(2),
+    ),
+                        #cms.PSet(
+                        #label  = cms.string("jets:step3"),
+                        #src    = cms.InputTag("slimmedJets"),
+                        #select = cms.string("pt>30 & abs(eta)<2.5 "),
+                        #min = cms.int32(3),
+                        #),
+                        #cms.PSet(
+                        #label  = cms.string("jets:step4"),
+                        #src    = cms.InputTag("slimmedJets"),
+                        #select = cms.string("pt>30 & abs(eta)<2.5 "),
+                        #min = cms.int32(4),
+                        #),
   )
 )

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DQM/Physics/src/SingleTopTChannelLeptonDQM.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include <iostream>
@@ -26,8 +27,13 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
                                  const edm::VParameterSet& vcfg,
                                  edm::ConsumesCollector&& iC)
     : label_(label),
+      elecSelect_(nullptr),
       pvSelect_(nullptr),
-      jetIDSelect_(nullptr),
+      muonIso_(nullptr),
+      muonSelect_(nullptr),
+			jetIDSelect_(nullptr),
+      jetlooseSelection_(nullptr),
+      jetSelection_(nullptr),
       includeBTag_(false),
       lowerEdge_(-1.),
       upperEdge_(-1.),
@@ -36,8 +42,6 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
   edm::ParameterSet sources = cfg.getParameter<edm::ParameterSet>("sources");
   muons_ = iC.consumes<edm::View<reco::PFCandidate>>(
       sources.getParameter<edm::InputTag>("muons"));
-  elecs_gsf_ = iC.consumes<edm::View<reco::GsfElectron>>(
-      sources.getParameter<edm::InputTag>("elecs_gsf"));
   elecs_ = iC.consumes<edm::View<reco::PFCandidate>>(
       sources.getParameter<edm::InputTag>("elecs"));
   jets_ = iC.consumes<edm::View<reco::Jet>>(
@@ -50,31 +54,33 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
   // electronExtras are optional; they may be omitted or
   // empty
   if (cfg.existsAs<edm::ParameterSet>("elecExtras")) {
+    // rho for PF isolation with EA corrections
+    // eventrhoToken_ =
+    // iC.consumes<double>(edm::InputTag("fixedGridRhoFastjetAll"));
+
     edm::ParameterSet elecExtras =
         cfg.getParameter<edm::ParameterSet>("elecExtras");
     // select is optional; in case it's not found no
     // selection will be applied
     if (elecExtras.existsAs<std::string>("select")) {
-      elecSelect_ = vcfg[1].getParameter<std::string>("select");
-    }
-    // isolation is optional; in case it's not found no
-    // isolation will be applied
-    if (elecExtras.existsAs<std::string>("isolation")) {
-      elecIso_ = elecExtras.getParameter<std::string>("isolation");
+      elecSelect_.reset( new StringCutObjectSelector<reco::PFCandidate>(
+          elecExtras.getParameter<std::string>("select")));
     }
 
-
+    if (elecExtras.existsAs<std::string>("rho")) {
+			rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+    }
     // electronId is optional; in case it's not found the
     // InputTag will remain empty
     if (elecExtras.existsAs<edm::ParameterSet>("electronId")) {
       edm::ParameterSet elecId =
           elecExtras.getParameter<edm::ParameterSet>("electronId");
-      electronId_ = iC.consumes<edm::ValueMap<float>>(
+      electronId_ = iC.consumes<edm::ValueMap<float> >(
           elecId.getParameter<edm::InputTag>("src"));
       eidCutValue_ = elecId.getParameter<double>("cutValue");
     }
   }
-  // pvExtras are opetional; they may be omitted or empty
+  // pvExtras are optional; they may be omitted or empty
   if (cfg.existsAs<edm::ParameterSet>("pvExtras")) {
     edm::ParameterSet pvExtras =
         cfg.getParameter<edm::ParameterSet>("pvExtras");
@@ -86,21 +92,20 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     }
   }
   // muonExtras are optional; they may be omitted or empty
-  if (cfg.existsAs<edm::ParameterSet>(
-          "muonExtras")) {  // && vcfg.existsAs<std::vector<edm::ParameterSet>
-                            // >("selection")){
+  if (cfg.existsAs<edm::ParameterSet>("muonExtras")) {
     edm::ParameterSet muonExtras =
         cfg.getParameter<edm::ParameterSet>("muonExtras");
-
     // select is optional; in case it's not found no
     // selection will be applied
     if (muonExtras.existsAs<std::string>("select")) {
-      muonSelect_ = vcfg[1].getParameter<std::string>("select");
+      muonSelect_.reset(new StringCutObjectSelector<reco::PFCandidate>(
+          muonExtras.getParameter<std::string>("select")));
     }
     // isolation is optional; in case it's not found no
     // isolation will be applied
     if (muonExtras.existsAs<std::string>("isolation")) {
-      muonIso_ = muonExtras.getParameter<std::string>("isolation");
+      muonIso_.reset(new StringCutObjectSelector<reco::PFCandidate>(
+          muonExtras.getParameter<std::string>("isolation")));
     }
   }
 
@@ -112,8 +117,8 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
         cfg.getParameter<edm::ParameterSet>("jetExtras");
     // jetCorrector is optional; in case it's not found
     // the InputTag will remain empty
-    if (jetExtras.existsAs<std::string>("jetCorrector")) {
-      jetCorrector_ = jetExtras.getParameter<std::string>("jetCorrector");
+    if (jetExtras.existsAs<edm::InputTag>("jetCorrector")) {
+			mJetCorrector  = iC.consumes<reco::JetCorrector>(jetExtras.getParameter<edm::InputTag>("jetCorrector"));
     }
     // read jetID information if it exists
     if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
@@ -128,9 +133,9 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     // selection will be applied (only implemented for
     // CaloJets at the moment)
     if (jetExtras.existsAs<std::string>("select")) {
-
       jetSelect_ = jetExtras.getParameter<std::string>("select");
-      jetSelect_ = vcfg[2].getParameter<std::string>("select");
+			jetSelection_.reset(new StringCutObjectSelector<reco::PFJet>(jetSelect_));
+			jetlooseSelection_.reset(new StringCutObjectSelector<reco::PFJet>("chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.99 && neutralEmEnergyFraction()<0.99 && (chargedMultiplicity()+neutralMultiplicity())>1"));
     }
 
     // jetBDiscriminators are optional; in case they are
@@ -139,13 +144,13 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     // corresponding working points
     includeBTag_ = jetExtras.existsAs<edm::ParameterSet>("jetBTaggers");
     if (includeBTag_) {
- 
-      edm::ParameterSet btagCombVtx =
+
+      edm::ParameterSet btagCSV =
           jetExtras.getParameter<edm::ParameterSet>("jetBTaggers")
-              .getParameter<edm::ParameterSet>("combinedSecondaryVertex");
-      btagCombVtx_ = iC.consumes<reco::JetTagCollection>(
-          btagCombVtx.getParameter<edm::InputTag>("label"));
-      btagCombVtxWP_ = btagCombVtx.getParameter<double>("workingPoint");
+              .getParameter<edm::ParameterSet>("cvsVertex");
+      btagCSV_ = iC.consumes<reco::JetTagCollection>(
+          btagCSV.getParameter<edm::InputTag>("label"));
+      btagCSVWP_ = btagCSV.getParameter<double>("workingPoint");
     }
   }
 
@@ -186,16 +191,6 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
   }
   // and don't forget to do the histogram booking
   directory_ = cfg.getParameter<std::string>("directory");
-
-
-  muonSelect.reset(new StringCutObjectSelector<reco::PFCandidate, true>(muonSelect_)); 
-  muonIso.reset(new StringCutObjectSelector<reco::PFCandidate, true>(muonIso_)); 
-  
-
-  
-  elecSelect.reset(new StringCutObjectSelector<reco::PFCandidate, true>(elecSelect_)); 
-  elecIso.reset(new StringCutObjectSelector<reco::PFCandidate, true>(elecIso_)); 
-
 }
 
 void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
@@ -204,34 +199,26 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   current += label_;
   ibooker.setCurrentFolder(current);
 
-  // determine number of bins for trigger monitoring
-  unsigned int nPaths = triggerPaths_.size();
 
   // --- [STANDARD] --- //
   // number of selected primary vertices
-  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{pvs}", 100, 0., 100.);
+  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
   // pt of the leading muon
-  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu)", 50, 0., 250.);
+  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
   // muon multiplicity before std isolation
-  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{20}(#mu)", 10, 0., 10.);
-  // muon multiplicity after  std isolation
-  hists_["muonMultIso_"] = ibooker.book1D("MuonMultIso", "N_{Iso}(#mu)", 10, 0., 10.);
+  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{loose}(#mu)", 10, 0., 10.);
+	// muon multiplicity tight Id and tight Iso
+  hists_["muonMultTight_"] = ibooker.book1D("MuonMultTight",
+      "N_{TightIso,TightId}(#mu)", 10, 0., 10.);
   // pt of the leading electron
-  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e)", 50, 0., 250.);
-  // electron multiplicity before std isolation
-  hists_["elecMult_"] = ibooker.book1D("ElecMult", "N_{30}(e)", 10, 0., 10.);
-  // electron multiplicity after  std isolation
-  hists_["elecMultIso_"] = ibooker.book1D("ElecMultIso", "N_{Iso}(e)", 10, 0., 10.);
-  // multiplicity of jets with pt>20 (corrected to L2+L3)
+  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e TightId, TightIso)", 40, 0., 200.);
+  // multiplicity of jets with pt>30 (corrected to L1+L2+L3)
   hists_["jetMult_"] = ibooker.book1D("JetMult", "N_{30}(jet)", 10, 0., 10.);
-  // trigger efficiency estimates for single lepton triggers
-  hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
-      "Eff(trigger)", nPaths, 0., nPaths);
-  // monitored trigger occupancy for single lepton triggers
-  hists_["triggerMon_"] = ibooker.book1D("TriggerMon",
-      "Mon(trigger)", nPaths, 0., nPaths);
-  // MET (calo)
-  hists_["metCalo_"] = ibooker.book1D("METCalo", "MET_{Calo}", 50, 0., 200.);
+	// multiplicity of loose Id jets with pt>30
+  hists_["jetLooseMult_"] = ibooker.book1D("JetLooseMult", "N_{30,loose}(jet)", 10, 0., 10.);
+
+  // MET (pflow)
+  hists_["metPflow_"] = ibooker.book1D("METPflow", "MET_{Pflow}", 50, 0., 200.);
   // W mass estimate
   hists_["massW_"] = ibooker.book1D("MassW", "M(W)", 60, 0., 300.);
   // Top mass estimate
@@ -254,67 +241,29 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   // --- [VERBOSE] --- //
 
   // eta of the leading muon
-  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu)", 30, -3., 3.);
-  // std isolation variable of the leading muon
-  hists_["muonPFRelIso_"] = ibooker.book1D("MuonPFRelIso",
-      "PFIso_{Rel}(#mu)", 50, 0., 1.);
-  hists_["muonRelIso_"] = ibooker.book1D("MuonRelIso", "Iso_{Rel}(#mu)", 50, 0., 1.);
-
+  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu TightId, TightIso)", 30, -3., 3.);
+  // relative isolation of the candidate muon (depending on the decay channel)
+  hists_["muonRelIso_"] = ibooker.book1D("MuonRelIso", "Iso_{Rel}(#mu TightId) (#Delta#beta Corrected)", 50, 0., 1.);
+	// phi of the leading muon
+  hists_["muonPhi_"] = ibooker.book1D("MuonPhi", "#phi(#mu TightId, TightIso)", 40, -4., 4.);
   // eta of the leading electron
-  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e)", 30, -3., 3.);
+  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e tightId, TightIso)", 30, -3., 3.);
   // std isolation variable of the leading electron
-  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e)", 50, 0., 1.);
-  hists_["elecPFRelIso_"] = ibooker.book1D("ElecPFRelIso",
-      "PFIso_{Rel}(e)", 50, 0., 1.);
+  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e TightId)", 50, 0., 1.);
+	// phi of the leading electron
+  hists_["elecPhi_"] = ibooker.book1D("ElecPhi", "#phi(e tightId, TightIso)", 40, -4., 4.);
+	// multiplicity of tight Id, tight Iso electorns
+  hists_["elecMultTight_"] = ibooker.book1D("ElecMultTight",
+                                              "N_{TightIso,TightId}(e)", 10, 0., 10.);
 
-  // multiplicity of btagged jets (for track counting high efficiency) with
-  // pt(L2L3)>30
- // hists_["jetMultBEff_"] = ibooker.book1D("JetMultBEff",
-    //  "N_{30}(b/eff)", 10, 0., 10.);
-  // btag discriminator for track counting high efficiency for jets with
-  // pt(L2L3)>30
- // hists_["jetBDiscEff_"] = ibooker.book1D("JetBDiscEff",
-  //    "Disc_{b/eff}(jet)", 100, 0., 10.);
 
-  // eta of the 1. leading jet
-  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta (jet1)", 50, -5., 5.);
-  // eta of the 2. leading jet
-  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta (jet2)", 50, -5., 5.);
-
+  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta_{30,loose}(jet1)", 60, -3., 3.);
   // pt of the 1. leading jet (corrected to L2+L3)
-  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{L2L3}(jet1)", 60, 0., 300.);
+  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{30,loose}(jet1)", 60, 0., 300.);
+  // eta of the 2. leading jet (corrected to L2+L3)
+  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta_{30,loose}(jet2)", 60, -3., 3.);
   // pt of the 2. leading jet (corrected to L2+L3)
-  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{L2L3}(jet2)", 60, 0., 300.);
-
-  // eta and pt of the b-tagged jet (filled only when nJets==2)
-  hists_["TaggedJetEta_"] = ibooker.book1D("TaggedJetEta",
-      "#eta (Tagged jet)", 50, -5., 5.);
-  hists_["TaggedJetPt_"] = ibooker.book1D("TaggedJetPt",
-      "pt_{L2L3}(Tagged jet)", 60, 0., 300.);
-
-  // eta and pt of the jet not passing b-tag (filled only when nJets==2)
-  hists_["UnTaggedJetEta_"] = ibooker.book1D("UnTaggedJetEta",
-      "#eta (UnTagged jet)", 50, -5., 5.);
-  hists_["UnTaggedJetPt_"] = ibooker.book1D("UnTaggedJetPt",
-      "pt_{L2L3}(UnTagged jet)", 60, 0., 300.);
-
-  // eta and pt of the most forward jet in the event with nJets==2
-  hists_["FwdJetEta_"] = ibooker.book1D("FwdJetEta", "#eta (Fwd jet)", 50, -5., 5.);
-  hists_["FwdJetPt_"] = ibooker.book1D("FwdJetPt",
-      "pt_{L2L3}(Fwd jet)", 60, 0., 300.);
-
-  // 2D histogram (pt,eta) of the b-tagged jet (filled only when nJets==2)
-  hists_["TaggedJetPtEta_"] = ibooker.book2D("TaggedJetPt_Eta",
-      "(pt vs #eta)_{L2L3}(Tagged jet)", 60, 0., 300., 50, -5., 5.);
-
-  // 2D histogram (pt,eta) of the not-b tagged jet (filled only when nJets==2)
-  hists_["UnTaggedJetPtEta_"] = ibooker.book2D("UnTaggedJetPt_Eta",
-    "(pt vs #eta)_{L2L3}(UnTagged jet)", 60, 0., 300., 50, -5., 5.);
-
-  // MET (tc)
-  hists_["metTC_"] = ibooker.book1D("METTC", "MET_{TC}", 50, 0., 200.);
-  // MET (pflow)
-  hists_["metPflow_"] = ibooker.book1D("METPflow", "MET_{Pflow}", 50, 0., 200.);
+  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{30,loose}(jet2)", 60, 0., 300.);
 
   // dz for muons (to suppress cosmis)
   hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
@@ -329,46 +278,44 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   if (verbosity_ == VERBOSE) return;
 
   // --- [DEBUG] --- //
-
-  // relative muon isolation from charged hadrons  for the leading muon
-  hists_["muonChHadIso_"] = ibooker.book1D("MuonChHadIso",
-      "Iso_{ChHad}(#mu)", 100, 0., 1.);
-  // relative muon isolation from neutral hadrons for the leading muon
-  hists_["muonNeuHadIso_"] = ibooker.book1D("MuonNeuHadIso",
-      "Iso_{NeuHad}(#mu)", 100, 0., 1.);
-  // relative muon isolation from photons for the leading muon
-  hists_["muonPhIso_"] = ibooker.book1D("MuonPhIso", "Iso_{Ph}(#mu)", 100, 0., 1.);
-
-  // relative electron isolation from charged hadrons for the leading electron
-  hists_["elecChHadIso_"] = ibooker.book1D("ElecChHadIso",
-      "Iso_{ChHad}(e)", 100, 0., 1.);
-  // relative electron isolation from neutral hadrons for the leading electron
-  hists_["elecNeuHadIso_"] = ibooker.book1D("ElecNeuHadIso",
-      "Iso_{NeuHad}(e)", 100, 0., 1.);
-  // relative electron isolation from photons for the leading electron
-  hists_["elecPhIso_"] = ibooker.book1D("ElecPhIso", "Iso_{Ph}(e)", 100, 0., 1.);
-
-
-
-  // multiplicity of btagged jets (for combined secondary vertex) with
-  // pt(L2L3)>30
-  hists_["jetMultBCombVtx_"] = ibooker.book1D("JetMultBCombVtx",
-      "N_{30}(b/CSV)", 10, 0., 10.);
+  // charged hadron isolation component of the candidate muon (depending on the
+  // decay channel)
+  hists_["muonChHadIso_"] = ibooker.book1D("MuonChHadIsoComp",
+      "ChHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
+  // neutral hadron isolation component of the candidate muon (depending on the
+  // decay channel)
+  hists_["muonNeHadIso_"] = ibooker.book1D("MuonNeHadIsoComp",
+      "NeHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
+  // photon isolation component of the candidate muon (depending on the decay
+  // channel)
+  hists_["muonPhIso_"] = ibooker.book1D("MuonPhIsoComp",
+      "Photon_{IsoComponent}(#mu TightId)", 50, 0., 5.);
+  // charged hadron isolation component of the candidate electron (depending on
+  // the decay channel)
+  hists_["elecChHadIso_"] = ibooker.book1D("ElectronChHadIsoComp",
+      "ChHad_{IsoComponent}(e tightId)", 50, 0., 5.);
+  // neutral hadron isolation component of the candidate electron (depending on
+  // the decay channel)
+  hists_["elecNeHadIso_"] = ibooker.book1D("ElectronNeHadIsoComp",
+      "NeHad_{IsoComponent}(e tightId)", 50, 0., 5.);
+  // photon isolation component of the candidate electron (depending on the
+  // decay channel)
+  hists_["elecPhIso_"] = ibooker.book1D("ElectronPhIsoComp",
+      "Photon_{IsoComponent}(e tightId)", 50, 0., 5.);
+ 
+  // multiplicity for combined secondary vertex
+  hists_["jetMultBCSVM_"] = ibooker.book1D("JetMultBCSVM", "N_{30}(CSVM)", 10, 0., 10.);
   // btag discriminator for combined secondary vertex
-  hists_["jetBDiscCombVtx_"] = ibooker.book1D("JetBDiscCombVtx",
-      "Disc_{b/CSV}(Jet)", 60, -1., 2.);
-  // btag discriminator for combined secondary vertex for 1. leading jet
-  hists_["jet1BDiscCombVtx_"] = ibooker.book1D("Jet1BDiscCombVtx",
-      "Disc_{b/CSV}(Jet1)", 60, -1., 2.);
-  // btag discriminator for combined secondary vertex for 2. leading jet
-  hists_["jet2BDiscCombVtx_"] = ibooker.book1D("Jet2BDiscCombVtx",
-      "Disc_{b/CSV}(Jet2)", 60, -1., 2.);
-
+  hists_["jetBCSV_"] = ibooker.book1D("JetDiscCSV",
+      "BJet Disc_{CSV}(JET)", 100, -1., 2.);
   // pt of the 1. leading jet (uncorrected)
-  hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
+  // hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
   // pt of the 2. leading jet (uncorrected)
-  hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
-
+  // hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
+  // pt of the 3. leading jet (uncorrected)
+  // hists_["jet3PtRaw_"] = ibooker.book1D("Jet3PtRaw", "pt_{Raw}(jet3)", 60, 0., 300.);
+  // pt of the 4. leading jet (uncorrected)
+  // hists_["jet4PtRaw_"] = ibooker.book1D("Jet4PtRaw", "pt_{Raw}(jet4)", 60, 0., 300.);
   // selected events
   hists_["eventLogger_"] = ibooker.book2D("EventLogger",
       "Logged Events", 9, 0., 9., 10, 0., 10.);
@@ -378,10 +325,10 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   hists_["eventLogger_"]->setBinLabel(1, "Run", 1);
   hists_["eventLogger_"]->setBinLabel(2, "Block", 1);
   hists_["eventLogger_"]->setBinLabel(3, "Event", 1);
-  hists_["eventLogger_"]->setBinLabel(4, "pt_{L2L3}(jet1)", 1);
-  hists_["eventLogger_"]->setBinLabel(5, "pt_{L2L3}(jet2)", 1);
-  hists_["eventLogger_"]->setBinLabel(6, "pt_{L2L3}(jet3)", 1);
-  hists_["eventLogger_"]->setBinLabel(7, "pt_{L2L3}(jet4)", 1);
+  hists_["eventLogger_"]->setBinLabel(4, "pt_{30,loose}(jet1)", 1);
+  hists_["eventLogger_"]->setBinLabel(5, "pt_{30,loose}(jet2)", 1);
+  hists_["eventLogger_"]->setBinLabel(6, "pt_{30,loose}(jet3)", 1);
+  hists_["eventLogger_"]->setBinLabel(7, "pt_{30,loose}(jet4)", 1);
   hists_["eventLogger_"]->setBinLabel(8, "M_{W}", 1);
   hists_["eventLogger_"]->setBinLabel(9, "M_{Top}", 1);
   hists_["eventLogger_"]->setAxisTitle("logged evts", 2);
@@ -392,9 +339,6 @@ void MonitorEnsemble::fill(const edm::Event& event,
                            const edm::EventSetup& setup) {
   // fetch trigger event if configured such
   edm::Handle<edm::TriggerResults> triggerTable;
-  if (!triggerTable_.isUninitialized()) {
-    if (!event.getByToken(triggerTable_, triggerTable)) return;
-  }
 
   /*
     ------------------------------------------------------------
@@ -404,16 +348,17 @@ void MonitorEnsemble::fill(const edm::Event& event,
     ------------------------------------------------------------
   */
 
-  // fill monitoring plots for primary vertices
-  edm::Handle<edm::View<reco::Vertex>> pvs;
+  // fill monitoring plots for primary verices
+  edm::Handle<edm::View<reco::Vertex> > pvs;
+  
   if (!event.getByToken(pvs_, pvs)) return;
+	const reco::Vertex& Pvertex = pvs->front(); 
   unsigned int pvMult = 0;
   for (edm::View<reco::Vertex>::const_iterator pv = pvs->begin();
        pv != pvs->end(); ++pv) {
     if (!pvSelect_ || (*pvSelect_)(*pv)) pvMult++;
   }
   fill("pvMult_", pvMult);
-
   /*
      ------------------------------------------------------------
 
@@ -423,15 +368,13 @@ void MonitorEnsemble::fill(const edm::Event& event,
   */
 
   // fill monitoring plots for electrons
-  edm::Handle<edm::View<reco::GsfElectron>> elecs_gsf;
   edm::Handle<edm::View<reco::PFCandidate>> elecs;
-  edm::View<reco::PFCandidate>::const_iterator elec_it;
-
-  reco::GsfElectronRef elec;
+  reco::GsfElectron e;
+  edm::Handle< double > _rhoHandle;
+	event.getByLabel(rhoTag,_rhoHandle);
 
   if (!event.getByToken(elecs_, elecs)) return;
 
-  if (!event.getByToken(elecs_gsf_, elecs_gsf)) return;
 
   // check availability of electron id
   edm::Handle<edm::ValueMap<float>> electronId;
@@ -442,68 +385,62 @@ void MonitorEnsemble::fill(const edm::Event& event,
   }
   // loop electron collection
   unsigned int eMult = 0, eMultIso = 0;
-  std::vector<const reco::GsfElectron*> isoElecs;
-  reco::GsfElectron e;
+  std::vector<const reco::PFCandidate*> isoElecs;
 
-  unsigned int idx_gsf = 0;
-  for (elec_it = elecs->begin(); elec_it != elecs->end(); ++elec_it) {
-    if (elec_it->gsfElectronRef().isNull()) continue;
-
-    reco::GsfElectronRef elec = elec_it->gsfElectronRef();
-    if (elec->gsfTrack().isNull()) continue;
-
+  for (edm::View<reco::PFCandidate>::const_iterator elec = elecs->begin();
+       elec != elecs->end(); ++elec) {
+    if (elec->gsfElectronRef().isNull()) {
+      continue;
+    }
+    reco::GsfElectronRef gsf_el = elec->gsfElectronRef();
     // restrict to electrons with good electronId
-    if (electronId_.isUninitialized() ? true : ((double)(*electronId)[elec] >=
-                                                eidCutValue_)) {
-      if ((*elecSelect)(*elec_it)) {
-        double isolationRel =
-            (elec->dr03TkSumPt() + elec->dr03EcalRecHitSumEt() +
-             elec->dr03HcalTowerSumEt()) /
-            elec->pt();
+    if (electronId_.isUninitialized() ? true : ((double)(*electronId)[gsf_el] >=
+                                                eidCutValue_)) { //This Electron Id is not currently used, but we can keep this for future needs
+      if (!elecSelect_ || (*elecSelect_)(*elec)) {
 
-        double isolationChHad =
-            elec->pt() /
-            (elec->pt() + elec->pfIsolationVariables().sumChargedHadronPt);
-        double isolationNeuHad =
-            elec->pt() /
-            (elec->pt() + elec->pfIsolationVariables().sumNeutralHadronEt);
-        double isolationPhoton =
-            elec->pt() /
-            (elec->pt() + elec->pfIsolationVariables().sumPhotonEt);
-        double el_ChHadIso = elec->pfIsolationVariables().sumChargedHadronPt;
-        double el_NeHadIso = elec->pfIsolationVariables().sumNeutralHadronEt;
-        double el_PhIso = elec->pfIsolationVariables().sumPhotonEt;
-        double PFisolationRel =
-            (el_ChHadIso +
-             max(0., el_NeHadIso + el_PhIso -
-                         0.5 * elec->pfIsolationVariables().sumPUPt)) /
-            elec->pt();
+        double el_ChHadIso = gsf_el->pfIsolationVariables().sumChargedHadronPt;
+        double el_NeHadIso = gsf_el->pfIsolationVariables().sumNeutralHadronEt;
+        double el_PhIso = gsf_el->pfIsolationVariables().sumPhotonEt;
+				double absEta = std::abs(gsf_el->superCluster()->eta());
 
-        if (eMult == 0) {
-          // restrict to the leading electron
-          fill("elecPt_", elec->pt());
-          fill("elecEta_", elec->eta());
-          fill("elecRelIso_", isolationRel);
-          fill("elecPFRelIso_", PFisolationRel);
-          fill("elecChHadIso_", isolationChHad);
-          fill("elecNeuHadIso_", isolationNeuHad);
-          fill("elecPhIso_", isolationPhoton);
+				//Effective Area computation				
+				double eA = 0;
+				if      (absEta < 1.000) eA = 0.1703;
+				else if (absEta < 1.479) eA = 0.1715;
+				else if (absEta < 2.000) eA = 0.1213;
+				else if (absEta < 2.200) eA = 0.1230;
+				else if (absEta < 2.300) eA = 0.1635;
+				else if (absEta < 2.400) eA = 0.1937;
+				else if (absEta < 5.000) eA = 0.2393;
+	
+				double rho = _rhoHandle.isValid() ? (float)(*_rhoHandle) : 0;
+        double el_pfRelIso = (el_ChHadIso + max(0., el_NeHadIso + el_PhIso - rho * eA)) /gsf_el->pt();
+
+				//Only TightId
+        if (eMult == 0) {// Restricted to the leading tight electron
+          fill("elecRelIso_", el_pfRelIso);
+          fill("elecChHadIso_", el_ChHadIso);
+          fill("elecNeHadIso_", el_NeHadIso);
+          fill("elecPhIso_", el_PhIso);
         }
-        // in addition to the multiplicity counter buffer the iso
-        // electron candidates for later overlap check with jets
         ++eMult;
-        if ((*elecIso)(*elec_it)) {
-          if (eMultIso == 0) e = *elec;
-          isoElecs.push_back(&(*elec));
-          ++eMultIso;
-        }
+
+				if (!((el_pfRelIso<0.0588 && absEta<1.479)||(el_pfRelIso<0.0571 && absEta>1.479))) continue; // PF Isolation with Effective Area Corrections according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
+
+
+				// TightId and TightIso
+				if (eMultIso == 0){//Only leading
+					e = *gsf_el;
+				  fill("elecPt_", gsf_el->pt());
+          fill("elecEta_", gsf_el->eta());
+          fill("elecPhi_", gsf_el->phi());
+				}
+        ++eMultIso;
       }
     }
-    idx_gsf++;
   }
-
-  fill("elecMult_", eMult);
-  fill("elecMultIso_", eMultIso);
+  //fill("elecMult_", eMult);
+  fill("elecMultTight_", eMultIso);
 
   /*
      ------------------------------------------------------------
@@ -514,248 +451,195 @@ void MonitorEnsemble::fill(const edm::Event& event,
   */
 
   // fill monitoring plots for muons
-  unsigned int mMult = 0, mMultIso = 0;
+  unsigned int mMult = 0, mTight=0, mTightId = 0;
 
-  edm::Handle<edm::View<reco::PFCandidate>> muons;
+  edm::Handle<edm::View<reco::PFCandidate> > muons;
   edm::View<reco::PFCandidate>::const_iterator muonit;
   reco::MuonRef muon;
-  reco::Muon mu;
+	reco::Muon mu;
 
   if (!event.getByToken(muons_, muons)) return;
-  for (muonit = muons->begin(); muonit != muons->end();
-       ++muonit) {  // for now, to use Reco::Muon need to substitute  muonit
-                    // with muon
-                    // and comment the MuonRef and PFCandidate parts
+
+  for (edm::View<reco::PFCandidate>::const_iterator muonit = muons->begin(); muonit != muons->end(); ++muonit) {
 
     if (muonit->muonRef().isNull()) continue;
     reco::MuonRef muon = muonit->muonRef();
 
-    if (muon->innerTrack().isNull()) continue;
-
     // restrict to globalMuons
     if (muon->isGlobalMuon()) {
-      fill("muonDelZ_", muon->globalTrack()->vz());
-      fill("muonDelXY_", muon->globalTrack()->vx(), muon->globalTrack()->vy());
+      fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
+      fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
 
-      // apply selection
-      if ((*muonSelect)(*muonit)) {
+      // apply preselection
+      if ((!muonSelect_ || (*muonSelect_)(*muonit))) {
+				mMult++;
+        double chHadPt = muon->pfIsolationR04().sumChargedHadronPt;
+        double neHadEt = muon->pfIsolationR04().sumNeutralHadronEt;
+        double phoEt   = muon->pfIsolationR04().sumPhotonEt;
+        double pfRelIso = (chHadPt + max(0., neHadEt + phoEt - 0.5 * muon->pfIsolationR04().sumPUPt)) / muon->pt();  // CB dBeta corrected iso!
 
-        double isolationRel =
-            (muon->isolationR03().sumPt + muon->isolationR03().emEt +
-             muon->isolationR03().hadEt) /
-            muon->pt();
-        double isolationChHad =
-            muon->pt() /
-            (muon->pt() + muon->pfIsolationR04().sumChargedHadronPt);
-        double isolationNeuHad =
-            muon->pt() /
-            (muon->pt() + muon->pfIsolationR04().sumNeutralHadronEt);
-        double isolationPhoton =
-            muon->pt() / (muon->pt() + muon->pfIsolationR04().sumPhotonEt);
-        double PFisolationRel = (muon->pfIsolationR04().sumChargedHadronPt +
-                                 muon->pfIsolationR04().sumNeutralHadronEt +
-                                 muon->pfIsolationR04().sumPhotonEt) /
-                                muon->pt();
+        if(!(muon->isGlobalMuon() && muon->isPFMuon() && muon->globalTrack()->normalizedChi2() < 10. && muon->globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && muon->numberOfMatchedStations() > 1 && muon->innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && muon->innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 && fabs(muon->muonBestTrack()->dxy(Pvertex.position())) < 0.2 && fabs(muon->muonBestTrack()->dz(Pvertex.position())) < 0.5) ) continue; //Only tight muons
+				
+				if (mTightId == 0){
+  	        fill("muonRelIso_", pfRelIso);
+  	        fill("muonChHadIso_", chHadPt);
+  	        fill("muonNeHadIso_", neHadEt);
+  	        fill("muonPhIso_", phoEt);
+				}
+				mTightId++;
+				
+				if(!(pfRelIso < 0.15)) continue; //Tight Iso
 
-        if (mMult == 0) {
-          // restrict to leading muon
-          fill("muonPt_", muon->pt());
-          fill("muonEta_", muon->eta());
-          fill("muonRelIso_", isolationRel);
-          fill("muonChHadIso_", isolationChHad);
-          fill("muonNeuHadIso_", isolationNeuHad);
-          fill("muonPhIso_", isolationPhoton);
-          fill("muonPFRelIso_", PFisolationRel);
-        }
-        ++mMult;
-
-        if ((*muonIso)(*muonit)) {
-          if (mMultIso == 0) mu = *muon;
-          ++mMultIso;
-        }
-      }
+				if (mTight == 0){//Leading tightId tightIso muon
+					mu = *(muon);
+  	      fill("muonPt_", muon->pt());
+  	      fill("muonEta_", muon->eta());
+  	      fill("muonPhi_", muon->phi());
+  	    }
+				mTight++;
+			}
     }
   }
   fill("muonMult_", mMult);
-  fill("muonMultIso_", mMultIso);
+  fill("muonMultTight_", mTight);
 
-  /*
-     ------------------------------------------------------------
+    /*
+  ------------------------------------------------------------
 
-     Jet Monitoring
+  Jet Monitoring
 
-     ------------------------------------------------------------
+  ------------------------------------------------------------
   */
+
   // check availability of the btaggers
-  edm::Handle<reco::JetTagCollection> btagCombVtx;
+  edm::Handle<reco::JetTagCollection> btagEff, btagPur, btagVtx, btagCSV;
   if (includeBTag_) {
 
-    if (!event.getByToken(btagCombVtx_, btagCombVtx)) return;
+    if (!event.getByToken(btagCSV_, btagCSV)) return;
   }
 
-  // load jet corrector if configured such
-  const JetCorrector* corrector = nullptr;
-  if (!jetCorrector_.empty()) {
+	edm::Handle<reco::JetCorrector> corrector;
+	event.getByToken(mJetCorrector, corrector);
+ // load jet
+// corrector if configured such
+//  const JetCorrector* corrector = 0;
+//  if (!jetCorrector_.empty()) {
+
     // check whether a jet correcto is in the event setup or not
-    if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<
-            JetCorrectionsRecord>())) {
-      corrector = JetCorrector::getJetCorrector(jetCorrector_, setup);
-    } else {
-      edm::LogVerbatim("SingleTopTChannelLeptonDQM")
-          << "\n"
-          << "-----------------------------------------------------------------"
-             "-------------------- \n"
-          << " No JetCorrectionsRecord available from EventSetup:\n"
-          << "  - Jets will not be corrected.\n"
-          << "  - If you want to change this add the following lines to your "
-             "cfg file:\n"
-          << "\n"
-          << "  ## load jet corrections\n"
-          << "  "
-             "process.load(\"JetMETCorrections.Configuration."
-             "JetCorrectionServicesAllAlgos_cff\") \n"
-          << "  process.prefer(\"ak5CaloL2L3\")\n"
-          << "\n"
-          << "-----------------------------------------------------------------"
-             "-------------------- \n";
-    }
-  }
-
+//    if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<
+//            JetCorrectionsRecord>())) {
+//      corrector = JetCorrector::getJetCorrector(jetCorrector_, setup);
+//    } else {
+//      edm::LogVerbatim("SingleTopTChannelLeptonDQM")
+//          << "\n"
+//          << "-----------------------------------------------------------------"
+//             "-------------------- \n"
+//          << " No JetCorrectionsRecord available from EventSetup:\n"
+//          << "  - Jets will not be corrected.\n"
+//          << "  - If you want to change this add the following lines to your "
+//             "cfg file:\n"
+//          << "\n"
+//          << "  ## load jet corrections\n"
+//          << "  "
+//             "process.load(\"JetMETCorrections.Configuration."
+//             "JetCorrectionServicesAllAlgos_cff\") \n"
+//          << "  process.prefer(\"ak5CaloL2L3\")\n"
+//          << "\n"
+//          << "-----------------------------------------------------------------"
+//             "-------------------- \n";
+//    }
+//}
   // loop jet collection
   std::vector<reco::Jet> correctedJets;
-  unsigned int mult = 0, 
-               multBCombVtx = 0,multNoBCombVtx = 0;
+  std::vector<double> JetTagValues;
+	reco::Jet TaggedJetCand;
+  unsigned int mult = 0, multLoose = 0, multCSV = 0;
+  vector<double> bJetDiscVal;
 
-  edm::Handle<edm::View<reco::Jet>> jets;
-  if (!event.getByToken(jets_, jets)) return;
-
-  edm::Handle<reco::JetIDValueMap> jetID;
-  if (jetIDSelect_) {
-    if (!event.getByToken(jetIDLabel_, jetID)) return;
+  edm::Handle<edm::View<reco::Jet> > jets;
+  if (!event.getByToken(jets_, jets)) {
+    return;
   }
 
-  vector<double> bJetDiscVal;
-  vector<double> NobJetDiscVal;
-  reco::Jet TaggedJetCand;
-  reco::Jet UnTaggedJetCand;
-  reco::Jet FwdJetCand;
   for (edm::View<reco::Jet>::const_iterator jet = jets->begin();
        jet != jets->end(); ++jet) {
-    // check jetID for calo jets
-    unsigned int idx = jet - jets->begin();
-    if (dynamic_cast<const reco::CaloJet*>(&*jet)) {
-      if (jetIDSelect_ &&
-          dynamic_cast<const reco::CaloJet*>(jets->refAt(idx).get())) {
-        if (!(*jetIDSelect_)((*jetID)[jets->refAt(idx)])) continue;
-      }
-    }
+		bool isLoose = false;
+    // check jetID for calo jets, keep functionality if we ever want to go back to those
+//    unsigned int idx = jet - jets->begin();
+//    if (dynamic_cast<const reco::CaloJet*>(&*jet)) {
+//      if (jetIDSelect_ &&
+//          dynamic_cast<const reco::CaloJet*>(jets->refAt(idx).get())) {
+//        if (!(*jetIDSelect_)((*jetID)[jets->refAt(idx)])) continue;
+//      }
+//    }
 
-    // check additional jet selection for calo, pf and bare reco jets
-    if (dynamic_cast<const reco::CaloJet*>(&*jet)) {
-      reco::CaloJet sel = dynamic_cast<const reco::CaloJet&>(*jet);
-      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-      if ( jetSelectCalo==nullptr)
-	jetSelectCalo.reset(new StringCutObjectSelector<reco::CaloJet>(jetSelect_));
-      if (!((*jetSelectCalo)(sel))) {
-        continue;
-      }
-    } else if (dynamic_cast<const reco::PFJet*>(&*jet)) {
+    // check additional jet selection for pf jets
+		if (dynamic_cast<const reco::PFJet*>(&*jet)) {
       reco::PFJet sel = dynamic_cast<const reco::PFJet&>(*jet);
-      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-      if ( jetSelectPF==nullptr)
-	jetSelectPF.reset(new StringCutObjectSelector<reco::PFJet>(jetSelect_));
-      if (!((*jetSelectPF)(sel))) continue;
-    } else {
-      reco::Jet sel = *jet;
-      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-      if ( jetSelectJet==nullptr)
-	jetSelectJet.reset(new StringCutObjectSelector<reco::Jet>(jetSelect_));
-
-      if (!((*jetSelectJet)(sel))) continue;
+			if ((*jetlooseSelection_)(sel)) isLoose = true;
+      sel.scaleEnergy(corrector->correction(*jet));
+      if (!(*jetSelection_)(sel)) continue;
+//    else if (dynamic_cast<const reco::CaloJet*>(&*jet)) {
+//      reco::CaloJet sel = dynamic_cast<const reco::CaloJet&>(*jet);
+//      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
+//      if ( jetSelectCalo==nullptr)
+//	jetSelectCalo.reset(new StringCutObjectSelector<reco::CaloJet>(jetSelect_));
+//      if (!((*jetSelectCalo)(sel))) {
+//        continue;
+//      }
     }
-
+//    else {
+//      reco::Jet sel = *jet;
+//      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
+//      if ( jetSelectJet==nullptr)
+//	jetSelectJet.reset(new StringCutObjectSelector<reco::Jet>(jetSelect_));
+//
+//      if (!((*jetSelectJet)(sel))) continue;
+//    }
 
     // prepare jet to fill monitor histograms
     reco::Jet monitorJet = *jet;
-    monitorJet.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-    correctedJets.push_back(monitorJet);
+		
+    ++mult;  // determine jet (no Id) multiplicity 
+		monitorJet.scaleEnergy(corrector->correction(*jet));
 
-    ++mult;  // determine jet multiplicity
-    if (includeBTag_) {
-      // fill b-discriminators
-      edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
-      if ((*btagCombVtx)[jetRef] > btagCombVtxWP_){
+		if (isLoose){ //Loose Id
+			unsigned int idx = jet - jets->begin();
+    	correctedJets.push_back(monitorJet);
+    	if (includeBTag_) {
+      	// fill b-discriminators
+      	edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
+ 	     fill("jetBCSV_", (*btagCSV)[jetRef]);
+ 	     if ((*btagCSV)[jetRef] > btagCSVWP_){
+        	if (multCSV == 0){
+         	  TaggedJetCand = monitorJet;
+	       		bJetDiscVal.push_back((*btagCSV)[jetRef]);
+        	}
+					else if(multCSV == 1){
+       		bJetDiscVal.push_back((*btagCSV)[jetRef]);
+        	if (bJetDiscVal[1] > bJetDiscVal[0]) TaggedJetCand = monitorJet;
+        	}
+				 	++multCSV;
+				}
+      	JetTagValues.push_back((*btagCSV)[jetRef]);
+			}
 
-       if (multBCombVtx == 0) {
-          TaggedJetCand = monitorJet;
-          // TaggedJetCand = *jet;
-          bJetDiscVal.push_back((*btagCombVtx)[jetRef]);
+  	  // fill pt/eta for the leading four jets
+  	  if (multLoose == 0) {
+  	    fill("jet1Pt_", monitorJet.pt());
+  	    fill("jet1Eta_", monitorJet.eta());
+  	  };
+  	  if (multLoose == 1) {
+  	    fill("jet2Pt_", monitorJet.pt());
+  		  fill("jet2Eta_", monitorJet.eta());
+  	  }
+			multLoose++;
+		}
+	}
+	fill("jetMult_"     , mult);
+  fill("jetMultLoose_", multLoose);
+  fill("jetMultBCSVM_", multCSV);
 
-        } else if (multBCombVtx == 1) {
-          bJetDiscVal.push_back((*btagCombVtx)[jetRef]);
-          if (bJetDiscVal[1] > bJetDiscVal[0]) TaggedJetCand = monitorJet;
-          // TaggedJetCand = *jet;
-        }
-        ++multBCombVtx;
-      } else {
-        if (multNoBCombVtx == 0) {
-          UnTaggedJetCand = monitorJet;
-          NobJetDiscVal.push_back((*btagCombVtx)[jetRef]);
-
-        } else if (multNoBCombVtx == 1) {
-          NobJetDiscVal.push_back((*btagCombVtx)[jetRef]);
-          if (NobJetDiscVal[1] < NobJetDiscVal[0]) UnTaggedJetCand = monitorJet;
-        }
-
-        ++multNoBCombVtx;
-      }
-
-
-
-
-      if (mult == 1) {
-        fill("jet1BDiscCombVtx_", (*btagCombVtx)[jetRef]);
-      } else if (mult == 2) {
-        fill("jet2BDiscCombVtx_", (*btagCombVtx)[jetRef]);
-      }
-
-      fill("jetBDiscCombVtx_", (*btagCombVtx)[jetRef]);
-    }
-    // fill pt (raw or L2L3) for the leading jets
-    if (mult == 1) {
-      fill("jet1Pt_", monitorJet.pt());
-      fill("jet1Eta_", monitorJet.eta());
-      fill("jet1PtRaw_", jet->pt());
-      FwdJetCand = monitorJet;
-    }
-
-    if (mult == 2) {
-      fill("jet2Pt_", monitorJet.pt());
-      fill("jet2Eta_", monitorJet.eta());
-      fill("jet2PtRaw_", jet->pt());
-
-      if (abs(monitorJet.eta()) > abs(FwdJetCand.eta())) {
-        FwdJetCand = monitorJet;
-      }
-
-      fill("FwdJetPt_", FwdJetCand.pt());
-      fill("FwdJetEta_", FwdJetCand.eta());
-    }
-  }
-
-  if (multNoBCombVtx == 1 && multBCombVtx == 1) {
-
-    fill("TaggedJetPtEta_", TaggedJetCand.pt(), TaggedJetCand.eta());
-    fill("UnTaggedJetPtEta_", UnTaggedJetCand.pt(), UnTaggedJetCand.eta());
-
-    fill("TaggedJetPt_", TaggedJetCand.pt());
-    fill("TaggedJetEta_", TaggedJetCand.eta());
-    fill("UnTaggedJetPt_", UnTaggedJetCand.pt());
-    fill("UnTaggedJetEta_", UnTaggedJetCand.eta());
-  }
-
-  fill("jetMult_", mult);
-  fill("jetMultBCombVtx_", multBCombVtx);
 
   /*
   ------------------------------------------------------------
@@ -775,14 +659,8 @@ void MonitorEnsemble::fill(const edm::Event& event,
     if (met->begin() != met->end()) {
       unsigned int idx = met_ - mets_.begin();
       if (idx == 0) {
-        fill("metCalo_", met->begin()->et());
-      }
-      if (idx == 1) {
-        fill("metTC_", met->begin()->et());
-      }
-      if (idx == 2) {
         fill("metPflow_", met->begin()->et());
-        mET = *(met->begin());
+				mET = *(met->begin());
       }
     }
   }
@@ -828,7 +706,7 @@ void MonitorEnsemble::fill(const edm::Event& event,
       ++logged_;
     }
   }
-  if (multBCombVtx != 0 && mMultIso == 1) {
+  if (multCSV != 0 && mTight == 1) {
 
     double mtW = eventKinematics.tmassWBoson(&mu, mET, TaggedJetCand);
     fill("MTWm_", mtW);
@@ -836,13 +714,13 @@ void MonitorEnsemble::fill(const edm::Event& event,
     fill("mMTT_", MTT);
   }
 
-  if (multBCombVtx != 0 && eMultIso == 1) {
+  if (multCSV != 0 && eMultIso == 1) {
     double mtW = eventKinematics.tmassWBoson(&e, mET, TaggedJetCand);
     fill("MTWe_", mtW);
     double MTT = eventKinematics.tmassTopQuark(&e, mET, TaggedJetCand);
     fill("eMTT_", MTT);
   }
-}
+ }
 }
 
 SingleTopTChannelLeptonDQM::SingleTopTChannelLeptonDQM(
@@ -859,7 +737,6 @@ SingleTopTChannelLeptonDQM::SingleTopTChannelLeptonDQM(
   JetSteps.clear();
   CaloJetSteps.clear();
   PFJetSteps.clear();
-
   // configure preselection
   edm::ParameterSet presel =
       cfg.getParameter<edm::ParameterSet>("preselection");
@@ -870,14 +747,6 @@ SingleTopTChannelLeptonDQM::SingleTopTChannelLeptonDQM(
         trigger.getParameter<edm::InputTag>("src"));
     triggerPaths_ = trigger.getParameter<std::vector<std::string>>("select");
   }
-  if (presel.existsAs<edm::ParameterSet>("vertex")) {
-    edm::ParameterSet vertex = presel.getParameter<edm::ParameterSet>("vertex");
-    vertex_ = vertex.getParameter<edm::InputTag>("src");
-    vertex__ =
-        consumes<reco::Vertex>(vertex.getParameter<edm::InputTag>("src"));
-    vertexSelect_.reset(new StringCutObjectSelector<reco::Vertex>(
-        vertex.getParameter<std::string>("select")));
-  }
   if (presel.existsAs<edm::ParameterSet>("beamspot")) {
     edm::ParameterSet beamspot =
         presel.getParameter<edm::ParameterSet>("beamspot");
@@ -887,7 +756,7 @@ SingleTopTChannelLeptonDQM::SingleTopTChannelLeptonDQM(
     beamspotSelect_.reset(new StringCutObjectSelector<reco::BeamSpot>(
         beamspot.getParameter<std::string>("select")));
   }
-  // conifgure the selection
+  // configure the selection
    std::vector<edm::ParameterSet> sel = 
       cfg.getParameter<std::vector<edm::ParameterSet>>("selection");
 
@@ -952,7 +821,6 @@ SingleTopTChannelLeptonDQM::SingleTopTChannelLeptonDQM(
 }
 void SingleTopTChannelLeptonDQM::bookHistograms(DQMStore::IBooker & ibooker,
   edm::Run const &, edm::EventSetup const & ){
-
   for (auto selIt = selection_.begin(); selIt != selection_.end(); ++selIt) {
     selIt->second.second->book(ibooker);
   }
@@ -969,14 +837,6 @@ void SingleTopTChannelLeptonDQM::analyze(const edm::Event& event,
     if (!event.getByToken(beamspot__, beamspot)) return;
     if (!(*beamspotSelect_)(*beamspot)) return;
   }
-
-  if (!vertex__.isUninitialized()) {
-    edm::Handle<edm::View<reco::Vertex>> vertex;
-    if (!event.getByToken(vertex__, vertex)) return;
-    edm::View<reco::Vertex>::const_iterator pv = vertex->begin();
-    if (!(*vertexSelect_)(*pv)) return;
-  }
-
   // apply selection steps
   unsigned int passed = 0;
   unsigned int nJetSteps = -1;

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -20,6 +20,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 
 /**
    \class   MonitorEnsemble TopDQMHelpers.h
@@ -140,7 +141,8 @@ class MonitorEnsemble {
   /// electronId label
   //    edm::InputTag electronId_;
   edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
-
+	// Jet corrector
+  edm::EDGetTokenT<reco::JetCorrector> mJetCorrector;
   /// electronId pattern we expect the following pattern:
   ///  0: fails
   ///  1: passes electron ID only
@@ -158,17 +160,18 @@ class MonitorEnsemble {
   /// extra isolation criterion on electron
   std::string elecIso_;
   /// extra selection on electrons
-  std::string elecSelect_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > elecSelect_;
+	edm::InputTag rhoTag;
 
   /// extra selection on primary vertices; meant to investigate the pile-up
   /// effect
   std::unique_ptr<StringCutObjectSelector<reco::Vertex> > pvSelect_;
 
   /// extra isolation criterion on muon
-  std::string muonIso_;
-  /// extra selection on muons
-  std::string muonSelect_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonIso_;
 
+  /// extra selection on muons
+  std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonSelect_;
   /// jetCorrector
   std::string jetCorrector_;
   /// jetID as an extra selection type
@@ -176,7 +179,8 @@ class MonitorEnsemble {
 
   /// extra jetID selection on calo jets
   std::unique_ptr<StringCutObjectSelector<reco::JetID> > jetIDSelect_;
-
+	std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetlooseSelection_;
+  std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetSelection_;
   /// extra selection on jets (here given as std::string as it depends
   /// on the the jet type, which selections are valid and which not)
   std::string jetSelect_;
@@ -185,11 +189,11 @@ class MonitorEnsemble {
   bool includeBTag_;
   /// btag discriminator labels
   //    edm::InputTag btagEff_, btagPur_, btagVtx_, btagCombVtx_;
-  edm::EDGetTokenT<reco::JetTagCollection> btagEff_, btagPur_, btagVtx_,
+  edm::EDGetTokenT<reco::JetTagCollection> btagEff_, btagPur_, btagVtx_, btagCSV_,
       btagCombVtx_;
 
   /// btag working points
-  double btagEffWP_, btagPurWP_, btagVtxWP_, btagCombVtxWP_;
+  double btagEffWP_, btagPurWP_, btagVtxWP_, btagCSVWP_, btagCombVtxWP_;
   /// mass window upper and lower edge
   double lowerEdge_, upperEdge_;
 
@@ -205,9 +209,6 @@ class MonitorEnsemble {
   std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > muonSelect;
   std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > muonIso;
   
-  std::unique_ptr<StringCutObjectSelector<reco::CaloJet> > jetSelectCalo;
-  std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetSelectPF;
-  std::unique_ptr<StringCutObjectSelector<reco::Jet> > jetSelectJet;
   
   std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > elecSelect;
   std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > elecIso;

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -2,16 +2,20 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/BTauReco/interface/JetTag.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include <iostream>
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+
+#include "JetMETCorrections/Objects/interface/JetCorrector.h"
+
 using namespace std;
 namespace SingleTopTChannelLepton_miniAOD {
 
@@ -24,52 +28,68 @@ static const double WMASS = 80.4;
 
 MonitorEnsemble::MonitorEnsemble(const char* label,
                                  const edm::ParameterSet& cfg,
-                                 const edm::VParameterSet& vcfg,
                                  edm::ConsumesCollector&& iC)
     : label_(label),
+      elecIso_(nullptr),
+      elecSelect_(nullptr),
       pvSelect_(nullptr),
+      muonIso_(nullptr),
+      muonSelect_(nullptr),
       jetIDSelect_(nullptr),
+      jetSelect(nullptr),
       includeBTag_(false),
       lowerEdge_(-1.),
       upperEdge_(-1.),
       logged_(0) {
+
   // sources have to be given; this PSet is not optional
   edm::ParameterSet sources = cfg.getParameter<edm::ParameterSet>("sources");
-  muons_ = iC.consumes<edm::View<pat::Muon>>(
-      sources.getParameter<edm::InputTag>("muons"));
-  elecs_gsf_ = iC.consumes<edm::View<pat::Electron>>(
-      sources.getParameter<edm::InputTag>("elecs_gsf"));
+ // muons_ = iC.consumes<edm::View<reco::PFCandidate> >(
+ //     sources.getParameter<edm::InputTag>("muons"));
 
-  jets_ = iC.consumes<edm::View<pat::Jet>>(
+
+  muons_ = iC.consumes<edm::View<pat::Muon> >(
+    sources.getParameter<edm::InputTag>("muons"));
+
+
+  elecs_ = iC.consumes<edm::View<pat::Electron> >(
+      sources.getParameter<edm::InputTag>("elecs"));
+  pvs_ = iC.consumes<edm::View<reco::Vertex> >(
+      sources.getParameter<edm::InputTag>("pvs"));
+  jets_ = iC.consumes<edm::View<pat::Jet> >(
       sources.getParameter<edm::InputTag>("jets"));
   for (edm::InputTag const& tag :
-       sources.getParameter<std::vector<edm::InputTag>>("mets"))
-    mets_.push_back(iC.consumes<edm::View<pat::MET>>(tag));
-  pvs_ = iC.consumes<edm::View<reco::Vertex>>(
-      sources.getParameter<edm::InputTag>("pvs"));
+       sources.getParameter<std::vector<edm::InputTag> >("mets"))
+    mets_.push_back(iC.consumes<edm::View<pat::MET> >(tag));
   // electronExtras are optional; they may be omitted or
   // empty
   if (cfg.existsAs<edm::ParameterSet>("elecExtras")) {
+
+
     edm::ParameterSet elecExtras =
         cfg.getParameter<edm::ParameterSet>("elecExtras");
     // select is optional; in case it's not found no
     // selection will be applied
     if (elecExtras.existsAs<std::string>("select")) {
-      elecSelect_ = vcfg[1].getParameter<std::string>("select");
+      elecSelect_.reset( new StringCutObjectSelector<pat::Electron>(
+          elecExtras.getParameter<std::string>("select")));
     }
     // isolation is optional; in case it's not found no
     // isolation will be applied
     if (elecExtras.existsAs<std::string>("isolation")) {
-      elecIso_ = elecExtras.getParameter<std::string>("isolation");
+      elecIso_.reset( new StringCutObjectSelector<pat::Electron>(
+          elecExtras.getParameter<std::string>("isolation")));
     }
-
-
+      
+    if (elecExtras.existsAs<std::string>("rho")) {
+        rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
+    }
     // electronId is optional; in case it's not found the
     // InputTag will remain empty
     if (elecExtras.existsAs<edm::ParameterSet>("electronId")) {
       edm::ParameterSet elecId =
           elecExtras.getParameter<edm::ParameterSet>("electronId");
-      electronId_ = iC.consumes<edm::ValueMap<float>>(
+      electronId_ = iC.consumes<edm::ValueMap<float> >(
           elecId.getParameter<edm::InputTag>("src"));
       eidCutValue_ = elecId.getParameter<double>("cutValue");
     }
@@ -86,23 +106,22 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     }
   }
   // muonExtras are optional; they may be omitted or empty
-  if (cfg.existsAs<edm::ParameterSet>(
-          "muonExtras")) { 
+  if (cfg.existsAs<edm::ParameterSet>("muonExtras")) {
     edm::ParameterSet muonExtras =
         cfg.getParameter<edm::ParameterSet>("muonExtras");
-
     // select is optional; in case it's not found no
     // selection will be applied
     if (muonExtras.existsAs<std::string>("select")) {
-      muonSelect_ = vcfg[1].getParameter<std::string>("select");
+      muonSelect_.reset(new StringCutObjectSelector<pat::Muon>(
+          muonExtras.getParameter<std::string>("select")));
     }
     // isolation is optional; in case it's not found no
     // isolation will be applied
     if (muonExtras.existsAs<std::string>("isolation")) {
-      muonIso_ = muonExtras.getParameter<std::string>("isolation");
+      muonIso_.reset(new StringCutObjectSelector<pat::Muon>(
+          muonExtras.getParameter<std::string>("isolation")));
     }
   }
-
 
   // jetExtras are optional; they may be omitted or
   // empty
@@ -127,11 +146,9 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     // selection will be applied (only implemented for
     // CaloJets at the moment)
     if (jetExtras.existsAs<std::string>("select")) {
-
       jetSelect_ = jetExtras.getParameter<std::string>("select");
-      jetSelect_ = vcfg[2].getParameter<std::string>("select");
+      jetSelect.reset(new StringCutObjectSelector<pat::Jet> (jetSelect_));
     }
-
   }
 
   // triggerExtras are optional; they may be omitted or empty
@@ -141,7 +158,7 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     triggerTable_ = iC.consumes<edm::TriggerResults>(
         triggerExtras.getParameter<edm::InputTag>("src"));
     triggerPaths_ =
-        triggerExtras.getParameter<std::vector<std::string>>("paths");
+        triggerExtras.getParameter<std::vector<std::string> >("paths");
   }
 
   // massExtras is optional; in case it's not found no mass
@@ -171,14 +188,7 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
   }
   // and don't forget to do the histogram booking
   directory_ = cfg.getParameter<std::string>("directory");
-
-
-  muonSelect.reset(new StringCutObjectSelector<pat::Muon, true>(muonSelect_)); 
-  muonIso.reset(new StringCutObjectSelector<pat::Muon, true>(muonIso_)); 
-  
-  elecSelect.reset(new StringCutObjectSelector<pat::Electron, true>(elecSelect_)); 
-  elecIso.reset(new StringCutObjectSelector<pat::Electron, true>(elecIso_)); 
-
+  // book(ibooker);
 }
 
 void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
@@ -188,119 +198,114 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   ibooker.setCurrentFolder(current);
 
   // determine number of bins for trigger monitoring
-  unsigned int nPaths = triggerPaths_.size();
+  //unsigned int nPaths = triggerPaths_.size();
 
   // --- [STANDARD] --- //
+  // Run Number
+  //hists_["RunNumb_"] = ibooker.book1D("RunNumber", "Run Nr.", 1.e4, 1.5e5, 3.e5);
+  // instantaneous luminosity
+  //hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
   // number of selected primary vertices
-  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{pvs}", 100, 0., 100.);
+  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
   // pt of the leading muon
-  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu)", 50, 0., 250.);
+  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
   // muon multiplicity before std isolation
-  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{20}(#mu)", 10, 0., 10.);
+  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{loose}(#mu)", 10, 0., 10.);
   // muon multiplicity after  std isolation
-  hists_["muonMultIso_"] = ibooker.book1D("MuonMultIso", "N_{Iso}(#mu)", 10, 0., 10.);
-  // pt of the leading electron
-  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e)", 50, 0., 250.);
+  //hists_["muonMultIso_"] = ibooker.book1D("MuonMultIso",
+  //    "N_{TightIso}(#mu)", 10, 0., 10.);
+ 
+  hists_["muonMultTight_"] = ibooker.book1D("MuonMultTight",
+      "N_{TightIso,TightId}(#mu)", 10, 0., 10.);
+
+ // pt of the leading electron
+  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e TightId, TightIso)", 40, 0., 200.);
   // electron multiplicity before std isolation
-  hists_["elecMult_"] = ibooker.book1D("ElecMult", "N_{30}(e)", 10, 0., 10.);
+  //hists_["elecMult_"] = ibooker.book1D("ElecMult", "N_{looseId}(e)", 10, 0., 10.);
   // electron multiplicity after  std isolation
-  hists_["elecMultIso_"] = ibooker.book1D("ElecMultIso", "N_{Iso}(e)", 10, 0., 10.);
+  //hists_["elecMultIso_"] = ibooker.book1D("ElecMultIso", "N_{Iso}(e)", 10, 0., 10.);
   // multiplicity of jets with pt>20 (corrected to L2+L3)
   hists_["jetMult_"] = ibooker.book1D("JetMult", "N_{30}(jet)", 10, 0., 10.);
+  hists_["jetLooseMult_"] = ibooker.book1D("JetLooseMult", "N_{30,loose}(jet)", 10, 0., 10.);
+
   // trigger efficiency estimates for single lepton triggers
-  hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
-      "Eff(trigger)", nPaths, 0., nPaths);
+  //hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
+  //    "Eff(trigger)", nPaths, 0., nPaths);
   // monitored trigger occupancy for single lepton triggers
-  hists_["triggerMon_"] = ibooker.book1D("TriggerMon",
-      "Mon(trigger)", nPaths, 0., nPaths);
-
-  hists_["slimmedMETs_"] = ibooker.book1D("slimmedMETs", "MET_{slimmed}", 50, 0., 200.);
-
+  //hists_["triggerMon_"] = ibooker.book1D("TriggerMon",
+  //    "Mon(trigger)", nPaths, 0., nPaths);
   // MET (calo)
-  hists_["slimmedMETsNoHF_"] = ibooker.book1D("slimmedMETsNoHF", "MET_{slimmedNoHF}", 50, 0., 200.);
-  // MET (pflow)
-  hists_["slimmedMETsPuppi_"] = ibooker.book1D("slimmedMETsPuppi", "MET_{slimmedPuppi}", 50, 0., 200.);
+  hists_["slimmedMETs_"] = ibooker.book1D("slimmedMETs", "MET_{slimmed}", 40, 0., 200.);
   // W mass estimate
   hists_["massW_"] = ibooker.book1D("MassW", "M(W)", 60, 0., 300.);
   // Top mass estimate
   hists_["massTop_"] = ibooker.book1D("MassTop", "M(Top)", 50, 0., 500.);
-  // W mass transverse estimate mu
-  hists_["MTWm_"] = ibooker.book1D("MTWm", "M_{T}^{W}(#mu)", 60, 0., 300.);
-  // Top mass transverse estimate mu
-  hists_["mMTT_"] = ibooker.book1D("mMTT", "M_{T}^{t}(#mu)", 50, 0., 500.);
-
-  // W mass transverse estimate e
-  hists_["MTWe_"] = ibooker.book1D("MTWe", "M_{T}^{W}(e)", 60, 0., 300.);
-  // Top mass transverse estimate e
-  hists_["eMTT_"] = ibooker.book1D("eMTT", "M_{T}^{t}(e)", 50, 0., 500.);
-
+  // b-tagged Top mass
+  //hists_["massBTop_"] = ibooker.book1D("MassBTop", "M(Top, 1 b-tag)", 50, 0., 500.);
+  
+    // W mass transverse estimate mu
+    hists_["MTWm_"] = ibooker.book1D("MTWm", "M_{T}^{W}(#mu)", 60, 0., 300.);
+    // Top mass transverse estimate mu
+    hists_["mMTT_"] = ibooker.book1D("mMTT", "M_{T}^{t}(#mu)", 50, 0., 500.);
+    
+    // W mass transverse estimate e
+    hists_["MTWe_"] = ibooker.book1D("MTWe", "M_{T}^{W}(e)", 60, 0., 300.);
+    // Top mass transverse estimate e
+    hists_["eMTT_"] = ibooker.book1D("eMTT", "M_{T}^{t}(e)", 50, 0., 500.);
+    
+    
+    
   // set bin labels for trigger monitoring
   triggerBinLabels(std::string("trigger"), triggerPaths_);
 
   if (verbosity_ == STANDARD) return;
 
   // --- [VERBOSE] --- //
-
   // eta of the leading muon
-  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu)", 30, -3., 3.);
-  // std isolation variable of the leading muon
-  hists_["muonPFRelIso_"] = ibooker.book1D("MuonPFRelIso",
-      "PFIso_{Rel}(#mu)", 50, 0., 1.);
-  hists_["muonRelIso_"] = ibooker.book1D("MuonRelIso", "Iso_{Rel}(#mu)", 50, 0., 1.);
-
+  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu TightId,TightIso)", 30, -3., 3.);
+  // relative isolation of the candidate muon (depending on the decay channel)
+  hists_["muonPhi_"] = ibooker.book1D("MuonPhi", "#phi(#mu TightId,TightIso)", 40, -4., 4.);
+  hists_["muonRelIso_"] = ibooker.book1D(
+      "MuonRelIso", "Iso_{Rel}(#mu TightId) (#Delta#beta Corrected)", 50, 0., 1.);
+    
   // eta of the leading electron
-  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e)", 30, -3., 3.);
+  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e TightId, TightIso)", 30, -3., 3.);
+  hists_["elecPhi_"] = ibooker.book1D("ElecPhi", "#phi(e TightId, TightIso)", 40, -4., 4.);
   // std isolation variable of the leading electron
-  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e)", 50, 0., 1.);
-  hists_["elecPFRelIso_"] = ibooker.book1D("ElecPFRelIso",
-      "PFIso_{Rel}(e)", 50, 0., 1.);
-
+  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e TightId)", 50, 0., 1.);
+    
+  hists_["elecMultTight_"] = ibooker.book1D("ElecMultTight",
+                                              "N_{TightIso,TightId}(e)", 10, 0., 10.);
+  
+    
   // multiplicity of btagged jets (for track counting high efficiency) with
   // pt(L2L3)>30
-  hists_["jetMultBEff_"] = ibooker.book1D("JetMultBEff",
-      "N_{30}(b/eff)", 10, 0., 10.);
+  //hists_["jetMultBEff_"] = ibooker.book1D("JetMultBEff",
+  //    "N_{30}(TCHE)", 10, 0., 10.);
   // btag discriminator for track counting high efficiency for jets with
   // pt(L2L3)>30
-  hists_["jetBDiscEff_"] = ibooker.book1D("JetBDiscEff",
-      "Disc_{b/eff}(jet)", 100, 0., 10.);
-
-  // eta of the 1. leading jet
-  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta (jet1)", 50, -5., 5.);
-  // eta of the 2. leading jet
-  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta (jet2)", 50, -5., 5.);
-
+  //hists_["jetBDiscEff_"] = ibooker.book1D("JetBDiscEff",
+  //    "Disc_{TCHE}(jet)", 100, 0., 10.);
+  // eta of the 1. leading jet (corrected to L2+L3)
+  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta_{30,loose}(jet1)", 60, -3., 3.);
   // pt of the 1. leading jet (corrected to L2+L3)
-  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{L2L3}(jet1)", 60, 0., 300.);
+  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{30,loose}(jet1)", 60, 0., 300.);
+  // eta of the 2. leading jet (corrected to L2+L3)
+  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta_{30,loose}(jet2)", 60, -3., 3.);
   // pt of the 2. leading jet (corrected to L2+L3)
-  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{L2L3}(jet2)", 60, 0., 300.);
-
-  // eta and pt of the b-tagged jet (filled only when nJets==2)
-  hists_["TaggedJetEta_"] = ibooker.book1D("TaggedJetEta",
-      "#eta (Tagged jet)", 50, -5., 5.);
-  hists_["TaggedJetPt_"] = ibooker.book1D("TaggedJetPt",
-      "pt_{L2L3}(Tagged jet)", 60, 0., 300.);
-
-  // eta and pt of the jet not passing b-tag (filled only when nJets==2)
-  hists_["UnTaggedJetEta_"] = ibooker.book1D("UnTaggedJetEta",
-      "#eta (UnTagged jet)", 50, -5., 5.);
-  hists_["UnTaggedJetPt_"] = ibooker.book1D("UnTaggedJetPt",
-      "pt_{L2L3}(UnTagged jet)", 60, 0., 300.);
-
-  // eta and pt of the most forward jet in the event with nJets==2
-  hists_["FwdJetEta_"] = ibooker.book1D("FwdJetEta", "#eta (Fwd jet)", 50, -5., 5.);
-  hists_["FwdJetPt_"] = ibooker.book1D("FwdJetPt",
-      "pt_{L2L3}(Fwd jet)", 60, 0., 300.);
-
-  // 2D histogram (pt,eta) of the b-tagged jet (filled only when nJets==2)
-  hists_["TaggedJetPtEta_"] = ibooker.book2D("TaggedJetPt_Eta",
-      "(pt vs #eta)_{L2L3}(Tagged jet)", 60, 0., 300., 50, -5., 5.);
-
-  // 2D histogram (pt,eta) of the not-b tagged jet (filled only when nJets==2)
-  hists_["UnTaggedJetPtEta_"] = ibooker.book2D("UnTaggedJetPt_Eta",
-    "(pt vs #eta)_{L2L3}(UnTagged jet)", 60, 0., 300., 50, -5., 5.);
-
-
-
+  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{30,loose}(jet2)", 60, 0., 300.);
+  // eta of the 3. leading jet (corrected to L2+L3)
+  //hists_["jet3Eta_"] = ibooker.book1D("Jet3Eta", "#eta_{30,loose}(jet3)", 60, -3., 3.);
+  // pt of the 3. leading jet (corrected to L2+L3)
+  //hists_["jet3Pt_"] = ibooker.book1D("Jet3Pt", "pt_{30,loose}(jet3)", 60, 0., 300.);
+  // eta of the 4. leading jet (corrected to L2+L3)
+  //hists_["jet4Eta_"] = ibooker.book1D("Jet4Eta", "#eta_{30,loose}(jet4)", 60, -3., 3.);
+  // pt of the 4. leading jet (corrected to L2+L3)
+  //hists_["jet4Pt_"] = ibooker.book1D("Jet4Pt", "pt_{30,loose}(jet4)", 60, 0., 300.);
+  // MET (tc)
+  hists_["slimmedMETsNoHF_"] = ibooker.book1D("slimmedMETsNoHF", "MET_{slimmedNoHF}", 40, 0., 200.);
+  // MET (pflow)
+  hists_["slimmedMETsPuppi_"] = ibooker.book1D("slimmedMETsPuppi", "MET_{slimmedPuppi}", 40, 0., 200.);
   // dz for muons (to suppress cosmis)
   hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
   // dxy for muons (to suppress cosmics)
@@ -314,65 +319,55 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   if (verbosity_ == VERBOSE) return;
 
   // --- [DEBUG] --- //
-
-  // relative muon isolation from charged hadrons  for the leading muon
-  hists_["muonChHadIso_"] = ibooker.book1D("MuonChHadIso",
-      "Iso_{ChHad}(#mu)", 100, 0., 1.);
-  // relative muon isolation from neutral hadrons for the leading muon
-  hists_["muonNeuHadIso_"] = ibooker.book1D("MuonNeuHadIso",
-      "Iso_{NeuHad}(#mu)", 100, 0., 1.);
-  // relative muon isolation from photons for the leading muon
-  hists_["muonPhIso_"] = ibooker.book1D("MuonPhIso", "Iso_{Ph}(#mu)", 100, 0., 1.);
-
-  // relative electron isolation from charged hadrons for the leading electron
-  hists_["elecChHadIso_"] = ibooker.book1D("ElecChHadIso",
-      "Iso_{ChHad}(e)", 100, 0., 1.);
-  // relative electron isolation from neutral hadrons for the leading electron
-  hists_["elecNeuHadIso_"] = ibooker.book1D("ElecNeuHadIso",
-      "Iso_{NeuHad}(e)", 100, 0., 1.);
-  // relative electron isolation from photons for the leading electron
-  hists_["elecPhIso_"] = ibooker.book1D("ElecPhIso", "Iso_{Ph}(e)", 100, 0., 1.);
-
+  // charged hadron isolation component of the candidate muon (depending on the
+  // decay channel)
+  hists_["muonChHadIso_"] = ibooker.book1D("MuonChHadIsoComp",
+      "ChHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
+  // neutral hadron isolation component of the candidate muon (depending on the
+  // decay channel)
+  hists_["muonNeHadIso_"] = ibooker.book1D("MuonNeHadIsoComp",
+      "NeHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
+  // photon isolation component of the candidate muon (depending on the decay
+  // channel)
+  hists_["muonPhIso_"] = ibooker.book1D("MuonPhIsoComp",
+      "Photon_{IsoComponent}(#mu TightId)", 50, 0., 5.);
+  // charged hadron isolation component of the candidate electron (depending on
+  // the decay channel)
+  hists_["elecChHadIso_"] = ibooker.book1D("ElectronChHadIsoComp",
+      "ChHad_{IsoComponent}(e TightId)", 50, 0., 5.);
+  // neutral hadron isolation component of the candidate electron (depending on
+  // the decay channel)
+  hists_["elecNeHadIso_"] = ibooker.book1D("ElectronNeHadIsoComp",
+      "NeHad_{IsoComponent}(e TightId)", 50, 0., 5.);
+  // photon isolation component of the candidate electron (depending on the
+  // decay channel)
+  hists_["elecPhIso_"] = ibooker.book1D("ElectronPhIsoComp",
+      "Photon_{IsoComponent}(e TightId)", 50, 0., 5.);
   // multiplicity of btagged jets (for track counting high purity) with
   // pt(L2L3)>30
-  hists_["jetMultBPur_"] = ibooker.book1D("JetMultBPur",
-      "N_{30}(b/pur)", 10, 0., 10.);
+  //hists_["jetMultBPur_"] = ibooker.book1D("JetMultBPur",
+  //    "N_{30}(TCHP)", 10, 0., 10.);
   // btag discriminator for track counting high purity
-  hists_["jetBDiscPur_"] = ibooker.book1D("JetBDiscPur",
-      "Disc_{b/pur}(Jet)", 200, -10., 10.);
-  // btag discriminator for track counting high purity for 1. leading jet
-  hists_["jet1BDiscPur_"] = ibooker.book1D("Jet1BDiscPur",
-      "Disc_{b/pur}(Jet1)", 200, -10., 10.);
-  // btag discriminator for track counting high purity for 2. leading jet
-  hists_["jet2BDiscPur_"] = ibooker.book1D("Jet2BDiscPur",
-      "Disc_{b/pur}(Jet2)", 200, -10., 10.);
-
+  //hists_["jetBDiscPur_"] = ibooker.book1D("JetBDiscPur",
+  //    "Disc_{TCHP}(Jet)", 100, 0., 10.);
   // multiplicity of btagged jets (for simple secondary vertex) with pt(L2L3)>30
-  hists_["jetMultBVtx_"] = ibooker.book1D("JetMultBVtx",
-      "N_{30}(b/vtx)", 10, 0., 10.);
+  //hists_["jetMultBVtx_"] = ibooker.book1D("JetMultBVtx",
+  //    "N_{30}(SSVHE)", 10, 0., 10.);
   // btag discriminator for simple secondary vertex
-  hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
-      "Disc_{b/vtx}(Jet)", 35, -1., 6.);
-
-  // multiplicity of btagged jets (for combined secondary vertex) with
-  // pt(L2L3)>30
-  hists_["jetMultBCombVtx_"] = ibooker.book1D("JetMultBCombVtx",
-      "N_{30}(b/CSV)", 10, 0., 10.);
+  //hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
+  //    "Disc_{SSVHE}(Jet)", 35, -1., 6.);
+  // multiplicity for combined secondary vertex
+  hists_["jetMultBCSVM_"] = ibooker.book1D("JetMultBCSVM", "N_{30}(CSVM)", 10, 0., 10.);
   // btag discriminator for combined secondary vertex
-  hists_["jetBDiscCombVtx_"] = ibooker.book1D("JetBDiscCombVtx",
-      "Disc_{b/CSV}(Jet)", 60, -1., 2.);
-  // btag discriminator for combined secondary vertex for 1. leading jet
-  hists_["jet1BDiscCombVtx_"] = ibooker.book1D("Jet1BDiscCombVtx",
-      "Disc_{b/CSV}(Jet1)", 60, -1., 2.);
-  // btag discriminator for combined secondary vertex for 2. leading jet
-  hists_["jet2BDiscCombVtx_"] = ibooker.book1D("Jet2BDiscCombVtx",
-      "Disc_{b/CSV}(Jet2)", 60, -1., 2.);
-
+  hists_["jetBCSV_"] = ibooker.book1D("JetDiscCSV","BJet Disc_{CSV}(JET)", 100, -1., 2.);
   // pt of the 1. leading jet (uncorrected)
-  hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
+  //hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
   // pt of the 2. leading jet (uncorrected)
-  hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
-
+  //hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
+  // pt of the 3. leading jet (uncorrected)
+  //hists_["jet3PtRaw_"] = ibooker.book1D("Jet3PtRaw", "pt_{Raw}(jet3)", 60, 0., 300.);
+  // pt of the 4. leading jet (uncorrected)
+  //hists_["jet4PtRaw_"] = ibooker.book1D("Jet4PtRaw", "pt_{Raw}(jet4)", 60, 0., 300.);
   // selected events
   hists_["eventLogger_"] = ibooker.book2D("EventLogger",
       "Logged Events", 9, 0., 9., 10, 0., 10.);
@@ -396,283 +391,304 @@ void MonitorEnsemble::fill(const edm::Event& event,
                            const edm::EventSetup& setup) {
   // fetch trigger event if configured such
   edm::Handle<edm::TriggerResults> triggerTable;
+
   if (!triggerTable_.isUninitialized()) {
     if (!event.getByToken(triggerTable_, triggerTable)) return;
   }
+    
   /*
-    ------------------------------------------------------------
+  ------------------------------------------------------------
 
-    Primary Vertex Monitoring
+  Primary Vertex Monitoring
 
-    ------------------------------------------------------------
+  ------------------------------------------------------------
   */
-
-  // fill monitoring plots for primary vertices
-  edm::Handle<edm::View<reco::Vertex>> pvs;
+  // fill monitoring plots for primary verices
+  edm::Handle<edm::View<reco::Vertex> > pvs;
   if (!event.getByToken(pvs_, pvs)) return;
-  unsigned int pvMult = 0;
-  for (edm::View<reco::Vertex>::const_iterator pv = pvs->begin();
+  const reco::Vertex& pver= pvs->front();
+
+  unsigned int pvMult = 0; 
+  if(pvs.isValid()){
+    for (edm::View<reco::Vertex>::const_iterator pv = pvs->begin();
        pv != pvs->end(); ++pv) {
-    if (!pvSelect_ || (*pvSelect_)(*pv)) pvMult++;
-  }
+
+      bool isGood = ( !(pv->isFake()) &&
+			  (pv->ndof() > 4.0) &&
+			  (abs(pv->z()) < 24.0) &&
+			  (abs(pv->position().Rho()) < 2.0) 
+			  );
+      if( !isGood ) continue;
+      pvMult++;
+    }
+    //std::cout<<" npv  "<<testn<<endl;
+  }    
+  
   fill("pvMult_", pvMult);
 
   /*
-     ------------------------------------------------------------
+  ------------------------------------------------------------
 
-     Electron Monitoring
+  Run and Inst. Luminosity information (Inst. Lumi. filled now with a dummy
+  value=5.0)
 
-     ------------------------------------------------------------
+  ------------------------------------------------------------
+  */
+    
+  //if (!event.eventAuxiliary().run()) return;
+    
+  //fill("RunNumb_", event.eventAuxiliary().run());
+
+  //double dummy = 5.;
+  //fill("InstLumi_", dummy);
+    
+  /*
+  ------------------------------------------------------------
+
+  Electron Monitoring
+
+  ------------------------------------------------------------
   */
 
   // fill monitoring plots for electrons
-  edm::Handle<edm::View<pat::Electron>> elecs_gsf;
+  edm::Handle<edm::View<pat::Electron> > elecs;
+  if (!event.getByToken(elecs_, elecs)) return;
+    
+  edm::Handle< double > _rhoHandle;
+  event.getByLabel(rhoTag,_rhoHandle);
+  //if (!event.getByToken(elecs_, elecs)) return;
+    
 
+  // check availability of electron id
+  edm::Handle<edm::ValueMap<float> > electronId;
+  if (!electronId_.isUninitialized()) {
+    if (!event.getByToken(electronId_, electronId)) return;
+  }
 
-
-
-
-
-  if (!event.getByToken(elecs_gsf_, elecs_gsf)) return;
- 
   // loop electron collection
-  unsigned int eMult = 0, eMultIso = 0;
+  unsigned int eMultIso = 0, eMult = 0;
   std::vector<const pat::Electron*> isoElecs;
+
   pat::Electron e;
+    
+  for (edm::View<pat::Electron>::const_iterator elec = elecs->begin();
+       elec != elecs->end(); ++elec) {
 
-  unsigned int idx_gsf = 0;
-  for ( edm::View<pat::Electron>::const_iterator elec = elecs_gsf->begin(); elec != elecs_gsf->end(); ++elec) {
-
-   if (true){
-      if ((*elecSelect)(*elec)) {
-        double isolationRel =
-            (elec->dr03TkSumPt() + elec->dr03EcalRecHitSumEt() +
-             elec->dr03HcalTowerSumEt()) /
-            elec->pt();
-
-        double isolationChHad =
-            elec->pt() /
-            (elec->pt() + elec->pfIsolationVariables().sumChargedHadronPt);
-        double isolationNeuHad =
-            elec->pt() /
-            (elec->pt() + elec->pfIsolationVariables().sumNeutralHadronEt);
-        double isolationPhoton =
-            elec->pt() /
-            (elec->pt() + elec->pfIsolationVariables().sumPhotonEt);
+      if(true){//loose id
+      if (!elecSelect_ || (*elecSelect_)(*elec)) {
+          
         double el_ChHadIso = elec->pfIsolationVariables().sumChargedHadronPt;
         double el_NeHadIso = elec->pfIsolationVariables().sumNeutralHadronEt;
         double el_PhIso = elec->pfIsolationVariables().sumPhotonEt;
-        double PFisolationRel =
-            (el_ChHadIso +
-             max(0., el_NeHadIso + el_PhIso -
-                         0.5 * elec->pfIsolationVariables().sumPUPt)) /
-            elec->pt();
-
-        if (eMult == 0) {
+          
+        double rho = _rhoHandle.isValid() ? (float)(*_rhoHandle) : 0;
+        double absEta = abs(elec->superCluster()->eta());
+        double eA = 0;
+        if      (absEta < 1.000) eA = 0.1703;
+        else if (absEta < 1.479) eA = 0.1715;
+        else if (absEta < 2.000) eA = 0.1213;
+        else if (absEta < 2.200) eA = 0.1230;
+        else if (absEta < 2.300) eA = 0.1635;
+        else if (absEta < 2.400) eA = 0.1937;
+        else if (absEta < 5.000) eA = 0.2393;
+          
+          
+        double el_pfRelIso = (el_ChHadIso + max(0., el_NeHadIso + el_PhIso - rho * eA)) /elec->pt();
+          
+        ++eMult;
+          
+        if(eMult==1){
+          fill("elecRelIso_", el_pfRelIso);
+          fill("elecChHadIso_", el_ChHadIso);
+          fill("elecNeHadIso_", el_NeHadIso);
+          fill("elecPhIso_", el_PhIso);
+        }
+        //loose Iso
+        //if(!((el_pfRelIso<0.0994 && absEta<1.479)||(el_pfRelIso<0.107 && absEta>1.479)))continue;
+        
+        //tight Iso
+        if(!((el_pfRelIso<0.0588 && absEta<1.479)||(el_pfRelIso<0.0571 && absEta>1.479)))continue;
+        ++eMultIso;
+        
+          
+        if (eMultIso == 1) {
+          // restrict to the leading electron
+          e = *elec;
+            
           fill("elecPt_", elec->pt());
           fill("elecEta_", elec->eta());
-          fill("elecRelIso_", isolationRel);
-          fill("elecPFRelIso_", PFisolationRel);
-          fill("elecChHadIso_", isolationChHad);
-          fill("elecNeuHadIso_", isolationNeuHad);
-          fill("elecPhIso_", isolationPhoton);
-        }
-
-        ++eMult;
-        if ((*elecIso)(*elec)) {
-          if (eMultIso == 0) e = *elec;
-          isoElecs.push_back(&(*elec));
-          ++eMultIso;
+          fill("elecPhi_", elec->phi());
         }
       }
     }
-    idx_gsf++;
   }
-
-  fill("elecMult_", eMult);
-  fill("elecMultIso_", eMultIso);
+  //fill("elecMult_", eMult);
+  fill("elecMultTight_", eMultIso);
+    
+    
+    
+    
 
   /*
-     ------------------------------------------------------------
+  ------------------------------------------------------------
 
-     Muon Monitoring
+  Muon Monitoring
 
-     ------------------------------------------------------------
+  ------------------------------------------------------------
   */
 
   // fill monitoring plots for muons
-  unsigned int mMult = 0, mMultIso = 0;
+  unsigned int mMult = 0,  mTight=0;
 
-  edm::Handle<edm::View<pat::Muon>> muons;
-
+  edm::Handle<edm::View<pat::Muon> > muons;
+    
   pat::Muon mu;
+    
+  edm::View<pat::Muon>::const_iterator muonit;
 
   if (!event.getByToken(muons_, muons)) return;
-  for (edm::View<pat::Muon>::const_iterator muon = muons->begin(); muon != muons->end();
-       ++muon) {  
+
+  for (edm::View<pat::Muon>::const_iterator muon = muons->begin();
+       muon != muons->end(); ++muon) {
+
 
     // restrict to globalMuons
     if (muon->isGlobalMuon()) {
-      fill("muonDelZ_", muon->globalTrack()->vz());
-      fill("muonDelXY_", muon->globalTrack()->vx(), muon->globalTrack()->vy());
+      fill("muonDelZ_", muon->innerTrack()->vz());  // CB using inner track!
+      fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
 
-      // apply selection
-      if ((*muonSelect)(*muon)) {
 
-        double isolationRel =
-            (muon->isolationR03().sumPt + muon->isolationR03().emEt +
-             muon->isolationR03().hadEt) /
-            muon->pt();
-        double isolationChHad =
-            muon->pt() /
-            (muon->pt() + muon->pfIsolationR04().sumChargedHadronPt);
-        double isolationNeuHad =
-            muon->pt() /
-            (muon->pt() + muon->pfIsolationR04().sumNeutralHadronEt);
-        double isolationPhoton =
-            muon->pt() / (muon->pt() + muon->pfIsolationR04().sumPhotonEt);
-        double PFisolationRel = (muon->pfIsolationR04().sumChargedHadronPt +
-                                 muon->pfIsolationR04().sumNeutralHadronEt +
-                                 muon->pfIsolationR04().sumPhotonEt) /
-                                muon->pt();
 
-        if (mMult == 0) {
-          // restrict to leading muon
-          fill("muonPt_", muon->pt());
-          fill("muonEta_", muon->eta());
-          fill("muonRelIso_", isolationRel);
-          fill("muonChHadIso_", isolationChHad);
-          fill("muonNeuHadIso_", isolationNeuHad);
-          fill("muonPhIso_", isolationPhoton);
-          fill("muonPFRelIso_", PFisolationRel);
-        }
+      // apply preselection loose muon
+      if (!muonSelect_ || (*muonSelect_)(*muon)) {
+          
+        //loose muon count
         ++mMult;
 
-        if ((*muonIso)(*muon)) {
-          if (mMultIso == 0) mu = *muon;
-          ++mMultIso;
+        double chHadPt = muon->pfIsolationR04().sumChargedHadronPt;
+        double neHadEt = muon->pfIsolationR04().sumNeutralHadronEt;
+        double phoEt = muon->pfIsolationR04().sumPhotonEt;
+
+        double pfRelIso = (chHadPt + max(0., neHadEt + phoEt - 0.5 * muon->pfIsolationR04().sumPUPt)) / muon->pt();  // CB dBeta corrected iso!
+
+        if(!(muon->isGlobalMuon() && muon->isPFMuon() && muon->globalTrack()->normalizedChi2() < 10. && muon->globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && muon->numberOfMatchedStations() > 1 && fabs(muon->muonBestTrack()->dxy(pver.position())) < 0.2  && fabs(muon->muonBestTrack()->dz(pver.position())) < 0.5 && muon->innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && muon->innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5   ) )continue;
+          
+        if (mMult == 1) {
+              // restrict to leading muon
+          fill("muonRelIso_", pfRelIso);
+          fill("muonChHadIso_", chHadPt);
+          fill("muonNeHadIso_", neHadEt);
+          fill("muonPhIso_", phoEt);
+          fill("muonRelIso_",pfRelIso);
+            
+        }
+          
+        if(!(pfRelIso<0.15))continue;
+          
+        ++mTight;
+          
+          
+        //tight id
+        if (mTight == 1) {
+          // restrict to leading muon
+          mu = *muon;
+          fill("muonPt_", muon->pt());
+          fill("muonEta_", muon->eta());
+          fill("muonPhi_", muon->phi());
+            
         }
       }
     }
   }
-  fill("muonMult_", mMult);
-  fill("muonMultIso_", mMultIso);
-
+  fill("muonMult_", mMult); //loose
+  fill("muonMultTight_", mTight); //tight id & iso
+    
   /*
-     ------------------------------------------------------------
+  ------------------------------------------------------------
 
-     Jet Monitoring
+  Jet Monitoring
 
-     ------------------------------------------------------------
+  ------------------------------------------------------------
   */
+
+  
 
   // loop jet collection
   std::vector<pat::Jet> correctedJets;
-  unsigned int mult = 0, multBEff = 0, multBPur = 0, multNoBPur = 0,
-               multBVtx = 0, multBCombVtx = 0;
-
-  edm::Handle<edm::View<pat::Jet>> jets;
-  if (!event.getByToken(jets_, jets)) return;
-
-  vector<double> bJetDiscVal;
-  vector<double> NobJetDiscVal;
+  std::vector<double> JetTagValues;
   pat::Jet TaggedJetCand;
-  pat::Jet UnTaggedJetCand;
-  pat::Jet FwdJetCand;
+  vector<double> bJetDiscVal;
+  
+  unsigned int mult = 0, loosemult=0, multBCSVM = 0;
+
+  edm::Handle<edm::View<pat::Jet> > jets;
+  if (!event.getByToken(jets_, jets)) {
+    return;
+  }
+
   for (edm::View<pat::Jet>::const_iterator jet = jets->begin();
        jet != jets->end(); ++jet) {
+    // check jetID for calo jets
+    //unsigned int idx = jet - jets->begin();
 
       pat::Jet sel = *jet;
 
-      if ( jetSelectJet==nullptr)
-	jetSelectJet.reset(new StringCutObjectSelector<pat::Jet>(jetSelect_));
-
-      if (!((*jetSelectJet)(sel))) continue;
+      if ( jetSelect==nullptr)
+	jetSelect.reset(new StringCutObjectSelector<pat::Jet>(jetSelect_));
+   
+      if(!(*jetSelect)(sel))continue;
+//      if (!jetSelect(sel)) continue;
 
     // prepare jet to fill monitor histograms
     pat::Jet monitorJet = *jet;
-    correctedJets.push_back(monitorJet);
-
-    ++mult;  // determine jet multiplicity
 
 
-      fill("jetBDiscEff_", monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")); //hard coded discriminator and value right now.
-      if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89) ++multBEff;
+    ++mult;
+      
+    if(monitorJet.chargedHadronEnergyFraction()>0 && monitorJet.chargedMultiplicity()>0 && monitorJet.chargedEmEnergyFraction()<0.99 && monitorJet.neutralHadronEnergyFraction()<0.99 && monitorJet.neutralEmEnergyFraction()<0.99 && (monitorJet.chargedMultiplicity()+monitorJet.neutralMultiplicity())>1 ){
 
-
-
-      if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89) {
-        if (multBPur == 0) {
-          TaggedJetCand = monitorJet;
-          bJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-
-        } else if (multBPur == 1) {
-          bJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-          if (bJetDiscVal[1] > bJetDiscVal[0]) TaggedJetCand = monitorJet;
+      correctedJets.push_back(monitorJet);
+      ++loosemult;  // determine jet multiplicity
+    
+      fill("jetBCSV_", monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")); //hard coded discriminator and value right now.
+      if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89){
+            
+        if (multBCSVM == 0){
+           TaggedJetCand = monitorJet;
+       bJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
+        }else if(multBCSVM == 1){
+       bJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
+           if (bJetDiscVal[1] > bJetDiscVal[0]) TaggedJetCand = monitorJet;
         }
-        ++multBPur;
-      } else {
-        if (multNoBPur == 0) {
-          UnTaggedJetCand = monitorJet;
-          NobJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-
-        } else if (multNoBPur == 1) {
-          NobJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-          if (NobJetDiscVal[1] < NobJetDiscVal[0]) UnTaggedJetCand = monitorJet;
-        }
-
-        ++multNoBPur;
+          
+        ++multBCSVM;
       }
 
+        
 
-      if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89) ++multBEff;
-      if (mult == 1) {
-        fill("jet1BDiscPur_", monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-      } else if (mult == 2) {
-        fill("jet2BDiscPur_", monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
+      // Fill a vector with Jet b-tag WP for later M3+1tag calculation: CSV
+      // tagger
+      JetTagValues.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
+      //    }
+      // fill pt (raw or L2L3) for the leading four jets
+      if (loosemult == 1) {
+      //cout<<" jet id= "<<monitorJet.chargedHadronEnergyFraction()<<endl;
+
+        fill("jet1Pt_", monitorJet.pt());
+        //fill("jet1PtRaw_", jet->pt());
+        fill("jet1Eta_", monitorJet.eta());
+      };
+      if (loosemult == 2) {
+        fill("jet2Pt_", monitorJet.pt());
+        //fill("jet2PtRaw_", jet->pt());
+        fill("jet2Eta_", monitorJet.eta());
       }
-
-      fill("jetBDiscPur_", monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-
-
-    // fill pt (raw or L2L3) for the leading jets
-    if (mult == 1) {
-      fill("jet1Pt_", monitorJet.pt());
-      fill("jet1Eta_", monitorJet.eta());
-      fill("jet1PtRaw_", jet->pt());
-      FwdJetCand = monitorJet;
-    }
-
-    if (mult == 2) {
-      fill("jet2Pt_", monitorJet.pt());
-      fill("jet2Eta_", monitorJet.eta());
-      fill("jet2PtRaw_", jet->pt());
-
-      if (abs(monitorJet.eta()) > abs(FwdJetCand.eta())) {
-        FwdJetCand = monitorJet;
-      }
-
-      fill("FwdJetPt_", FwdJetCand.pt());
-      fill("FwdJetEta_", FwdJetCand.eta());
+      
     }
   }
-
-  if (multNoBPur == 1 && multBPur == 1) {
-
-    fill("TaggedJetPtEta_", TaggedJetCand.pt(), TaggedJetCand.eta());
-    fill("UnTaggedJetPtEta_", UnTaggedJetCand.pt(), UnTaggedJetCand.eta());
-
-    fill("TaggedJetPt_", TaggedJetCand.pt());
-    fill("TaggedJetEta_", TaggedJetCand.eta());
-    fill("UnTaggedJetPt_", UnTaggedJetCand.pt());
-    fill("UnTaggedJetEta_", UnTaggedJetCand.eta());
-  }
-
   fill("jetMult_", mult);
-  fill("jetMultBEff_", multBEff);
-  fill("jetMultBPur_", multBPur);
-  fill("jetMultBVtx_", multBVtx);
-  fill("jetMultBCombVtx_", multBCombVtx);
+  fill("jetLooseMult_", loosemult);
+  fill("jetMultBCSVM_", multBCSVM);
 
   /*
   ------------------------------------------------------------
@@ -683,32 +699,32 @@ void MonitorEnsemble::fill(const edm::Event& event,
   */
 
   // fill monitoring histograms for met
+    
   pat::MET mET;
-
-  for (std::vector<edm::EDGetTokenT<edm::View<pat::MET>>>::const_iterator
+    
+  for (std::vector<edm::EDGetTokenT<edm::View<pat::MET> > >::const_iterator
            met_ = mets_.begin();
        met_ != mets_.end(); ++met_) {
-    edm::Handle<edm::View<pat::MET>> met;
+    edm::Handle<edm::View<pat::MET> > met;
     if (!event.getByToken(*met_, met)) continue;
-    mET = *(met->begin());
     if (met->begin() != met->end()) {
       unsigned int idx = met_ - mets_.begin();
       if (idx == 0) fill("slimmedMETs_", met->begin()->et());
       if (idx == 1) fill("slimmedMETsNoHF_", met->begin()->et());
       if (idx == 2) fill("slimmedMETsPuppi_", met->begin()->et());
-
     }
   }
 
   /*
-     ------------------------------------------------------------
+  ------------------------------------------------------------
 
-     Event Monitoring
+  Event Monitoring
 
-     ------------------------------------------------------------
+  ------------------------------------------------------------
   */
 
   // fill W boson and top mass estimates
+    
   Calculate_miniAOD eventKinematics(MAXJETS, WMASS);
   double wMass = eventKinematics.massWBoson(correctedJets);
   double topMass = eventKinematics.massTopQuark(correctedJets);
@@ -716,19 +732,28 @@ void MonitorEnsemble::fill(const edm::Event& event,
     fill("massW_", wMass);
     fill("massTop_", topMass);
   }
+
+  // Fill M3 with Btag (CSV Tight) requirement
+
+ // if (!includeBTag_) return;
+  //if (correctedJets.size() != JetTagValues.size()) return;
+  //double btopMass =
+  //    eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.89); //hard coded CSVv2 value
+  
+  //if (btopMass >= 0) fill("massBTop_", btopMass);
+    
   // fill plots for trigger monitoring
   if ((lowerEdge_ == -1. && upperEdge_ == -1.) ||
-      (lowerEdge_ < wMass && wMass < upperEdge_)) {
+    (lowerEdge_ < wMass && wMass < upperEdge_)) {
     if (!triggerTable_.isUninitialized())
       fill(event, *triggerTable, "trigger", triggerPaths_);
     if (logged_ <= hists_.find("eventLogger_")->second->getNbinsY()) {
       // log runnumber, lumi block, event number & some
       // more pysics infomation for interesting events
       fill("eventLogger_", 0.5, logged_ + 0.5, event.eventAuxiliary().run());
-      fill("eventLogger_", 1.5, logged_ + 0.5,
-           event.eventAuxiliary().luminosityBlock());
+      fill("eventLogger_", 1.5, logged_ + 0.5,event.eventAuxiliary().luminosityBlock());
       fill("eventLogger_", 2.5, logged_ + 0.5, event.eventAuxiliary().event());
-      if (!correctedJets.empty())
+      if (correctedJets.size() > 0)
         fill("eventLogger_", 3.5, logged_ + 0.5, correctedJets[0].pt());
       if (correctedJets.size() > 1)
         fill("eventLogger_", 4.5, logged_ + 0.5, correctedJets[1].pt());
@@ -736,39 +761,43 @@ void MonitorEnsemble::fill(const edm::Event& event,
         fill("eventLogger_", 5.5, logged_ + 0.5, correctedJets[2].pt());
       if (correctedJets.size() > 3)
         fill("eventLogger_", 6.5, logged_ + 0.5, correctedJets[3].pt());
+
       fill("eventLogger_", 7.5, logged_ + 0.5, wMass);
       fill("eventLogger_", 8.5, logged_ + 0.5, topMass);
       ++logged_;
     }
   }
-  if (multBPur != 0 && mMultIso == 1) {
+    
+    if (multBCSVM != 0 && mTight == 1) {
+        
+        double mtW = eventKinematics.tmassWBoson(&mu, mET, TaggedJetCand);
+        fill("MTWm_", mtW);
+        double MTT = eventKinematics.tmassTopQuark(&mu, mET, TaggedJetCand);
+        fill("mMTT_", MTT);
+    }
+    
+    if (multBCSVM != 0 && eMultIso == 1) {
+        double mtW = eventKinematics.tmassWBoson(&e, mET, TaggedJetCand);
+        fill("MTWe_", mtW);
+        double MTT = eventKinematics.tmassTopQuark(&e, mET, TaggedJetCand);
+        fill("eMTT_", MTT);
+    }
+  
+    
+    
 
-    double mtW = eventKinematics.tmassWBoson(&mu, mET, TaggedJetCand);
-    fill("MTWm_", mtW);
-    double MTT = eventKinematics.tmassTopQuark(&mu, mET, TaggedJetCand);
-    fill("mMTT_", MTT);
-  }
-
-  if (multBPur != 0 && eMultIso == 1) {
-    double mtW = eventKinematics.tmassWBoson(&e, mET, TaggedJetCand);
-    fill("MTWe_", mtW);
-    double MTT = eventKinematics.tmassTopQuark(&e, mET, TaggedJetCand);
-    fill("eMTT_", MTT);
-  }
 }
 }
 
-SingleTopTChannelLeptonDQM_miniAOD::SingleTopTChannelLeptonDQM_miniAOD(
-    const edm::ParameterSet& cfg)
+SingleTopTChannelLeptonDQM_miniAOD::SingleTopTChannelLeptonDQM_miniAOD(const edm::ParameterSet& cfg)
     : vertexSelect_(nullptr),
       beamspot_(""),
       beamspotSelect_(nullptr),
-      muonStep_(nullptr),
-      electronStep_(nullptr),
-      pvStep_(nullptr),
-      metStep_(nullptr) {
-  jetSteps_.clear();
-
+      MuonStep(nullptr),
+      ElectronStep(nullptr),
+      PvStep(nullptr),
+      METStep(nullptr) {
+  JetSteps.clear();
 
   // configure preselection
   edm::ParameterSet presel =
@@ -778,15 +807,7 @@ SingleTopTChannelLeptonDQM_miniAOD::SingleTopTChannelLeptonDQM_miniAOD(
         presel.getParameter<edm::ParameterSet>("trigger");
     triggerTable__ = consumes<edm::TriggerResults>(
         trigger.getParameter<edm::InputTag>("src"));
-    triggerPaths_ = trigger.getParameter<std::vector<std::string>>("select");
-  }
-  if (presel.existsAs<edm::ParameterSet>("vertex")) {
-    edm::ParameterSet vertex = presel.getParameter<edm::ParameterSet>("vertex");
-    vertex_ = vertex.getParameter<edm::InputTag>("src");
-    vertex__ =
-        consumes<reco::Vertex>(vertex.getParameter<edm::InputTag>("src"));
-    vertexSelect_.reset(new StringCutObjectSelector<reco::Vertex>(
-        vertex.getParameter<std::string>("select")));
+    triggerPaths_ = trigger.getParameter<std::vector<std::string> >("select");
   }
   if (presel.existsAs<edm::ParameterSet>("beamspot")) {
     edm::ParameterSet beamspot =
@@ -797,48 +818,43 @@ SingleTopTChannelLeptonDQM_miniAOD::SingleTopTChannelLeptonDQM_miniAOD(
     beamspotSelect_.reset(new StringCutObjectSelector<reco::BeamSpot>(
         beamspot.getParameter<std::string>("select")));
   }
-  // conifgure the selection
-   std::vector<edm::ParameterSet> sel = 
-      cfg.getParameter<std::vector<edm::ParameterSet>>("selection");
 
-  for (unsigned int i = 0; i < sel.size(); ++i) {
-    selectionOrder_.push_back(sel.at(i).getParameter<std::string>("label"));
+  // conifgure the selection
+  sel_ = cfg.getParameter<std::vector<edm::ParameterSet> >("selection");
+  setup_ = cfg.getParameter<edm::ParameterSet>("setup");
+  for (unsigned int i = 0; i < sel_.size(); ++i) {
+    selectionOrder_.push_back(sel_.at(i).getParameter<std::string>("label"));
     selection_[selectionStep(selectionOrder_.back())] = std::make_pair(
-        sel.at(i),
+        sel_.at(i),
         std::unique_ptr<SingleTopTChannelLepton_miniAOD::MonitorEnsemble>(
-        new SingleTopTChannelLepton_miniAOD::MonitorEnsemble(
+          new SingleTopTChannelLepton_miniAOD::MonitorEnsemble(
             selectionStep(selectionOrder_.back()).c_str(),
-            cfg.getParameter<edm::ParameterSet>("setup"),
-            cfg.getParameter<std::vector<edm::ParameterSet>>("selection"),
-            consumesCollector())));
+            setup_, consumesCollector())));
   }
   for (std::vector<std::string>::const_iterator selIt = selectionOrder_.begin();
        selIt != selectionOrder_.end(); ++selIt) {
     std::string key = selectionStep(*selIt), type = objectType(*selIt);
     if (selection_.find(key) != selection_.end()) {
-      using std::unique_ptr;
-
       if (type == "muons") {
-        muonStep_.reset(new SelectionStep<pat::Muon>(selection_[key].first,
-                                                     consumesCollector()));
+        MuonStep.reset(new SelectionStep<pat::Muon>(selection_[key].first,
+                                                        consumesCollector()));
       }
       if (type == "elecs") {
-        electronStep_.reset(new SelectionStep<pat::Electron>(
+        ElectronStep.reset(new SelectionStep<pat::Electron>(
             selection_[key].first, consumesCollector()));
       }
-
       if (type == "pvs") {
-        pvStep_.reset(new SelectionStep<reco::Vertex>(selection_[key].first,
-                                                     consumesCollector()));
+        PvStep.reset(new SelectionStep<reco::Vertex>(selection_[key].first,
+                                                 consumesCollector()));
       }
       if (type == "jets") {
-        jetSteps_.push_back(std::unique_ptr<SelectionStep<pat::Jet>>(
-            new SelectionStep<pat::Jet>(selection_[key].first,
-                                         consumesCollector())));
+        JetSteps.push_back(std::unique_ptr<SelectionStep<pat::Jet>>(
+            new SelectionStep<pat::Jet>(selection_[key].first, consumesCollector())));
       }
+
       if (type == "met") {
-        metStep_.reset(new SelectionStep<pat::MET>(selection_[key].first,
-                                                   consumesCollector()));
+        METStep.reset(new SelectionStep<pat::MET>(selection_[key].first,
+                                               consumesCollector()));
       }
     }
   }
@@ -851,7 +867,8 @@ void SingleTopTChannelLeptonDQM_miniAOD::bookHistograms(DQMStore::IBooker & iboo
   }
 }
 void SingleTopTChannelLeptonDQM_miniAOD::analyze(const edm::Event& event,
-                                         const edm::EventSetup& setup) {
+                                 const edm::EventSetup& setup) {
+
   if (!triggerTable__.isUninitialized()) {
     edm::Handle<edm::TriggerResults> triggerTable;
     if (!event.getByToken(triggerTable__, triggerTable)) return;
@@ -863,14 +880,6 @@ void SingleTopTChannelLeptonDQM_miniAOD::analyze(const edm::Event& event,
     if (!(*beamspotSelect_)(*beamspot)) return;
   }
 
-  if (!vertex__.isUninitialized()) {
-    edm::Handle<edm::View<reco::Vertex>> vertex;
-    if (!event.getByToken(vertex__, vertex)) return;
-    edm::View<reco::Vertex>::const_iterator pv = vertex->begin();
-    if (!(*vertexSelect_)(*pv)) return;
-  }
-
-  // apply selection steps
   unsigned int passed = 0;
   unsigned int nJetSteps = -1;
 
@@ -881,35 +890,45 @@ void SingleTopTChannelLeptonDQM_miniAOD::analyze(const edm::Event& event,
       if (type == "empty") {
         selection_[key].second->fill(event, setup);
       }
-      if (type == "presel") {
-        selection_[key].second->fill(event, setup);
+      if (type == "muons" && MuonStep != nullptr) {
+        if (MuonStep->select(event)) {
+          ++passed;
+
+          selection_[key].second->fill(event, setup);
+        } else
+          break;
       }
-      if (type == "elecs" && electronStep_ != nullptr) {
-        if (electronStep_->select(event)) {
+
+      if (type == "elecs" && ElectronStep != nullptr) {
+
+        if (ElectronStep->select(event)) {
           ++passed;
           selection_[key].second->fill(event, setup);
         } else
           break;
       }
-      if (type == "muons" && muonStep_ != nullptr) {
-        if (muonStep_->select(event)) {
+
+      if (type == "pvs" && PvStep != nullptr) {
+        if (PvStep->selectVertex(event)) {
           ++passed;
           selection_[key].second->fill(event, setup);
         } else
           break;
       }
+
       if (type == "jets") {
         nJetSteps++;
-        if (jetSteps_[nJetSteps]) {
-          if (jetSteps_[nJetSteps]->select(event, setup)) {
+        if (JetSteps[nJetSteps] != NULL) {
+          if (JetSteps[nJetSteps]->select(event, setup)) {
             ++passed;
             selection_[key].second->fill(event, setup);
           } else
             break;
         }
       }
-      if (type == "met" && metStep_ != nullptr) {
-        if (metStep_->select(event)) {
+
+      if (type == "met" && METStep != nullptr) {
+        if (METStep->select(event)) {
           ++passed;
           selection_[key].second->fill(event, setup);
         } else
@@ -918,3 +937,8 @@ void SingleTopTChannelLeptonDQM_miniAOD::analyze(const edm::Event& event,
     }
   }
 }
+
+// Local Variables:
+// show-trailing-whitespace: t
+// truncate-lines: t
+// End:

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 
+
 using namespace std;
 namespace TopSingleLepton {
 
@@ -23,12 +24,13 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
                                  const edm::ParameterSet& cfg,
                                  edm::ConsumesCollector&& iC)
     : label_(label),
-      elecIso_(nullptr),
       elecSelect_(nullptr),
       pvSelect_(nullptr),
       muonIso_(nullptr),
       muonSelect_(nullptr),
-      jetIDSelect_(nullptr),
+			jetIDSelect_(nullptr),
+      jetlooseSelection_(nullptr),
+      jetSelection_(nullptr),
       includeBTag_(false),
       lowerEdge_(-1.),
       upperEdge_(-1.),
@@ -62,11 +64,9 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
       elecSelect_.reset( new StringCutObjectSelector<reco::PFCandidate>(
           elecExtras.getParameter<std::string>("select")));
     }
-    // isolation is optional; in case it's not found no
-    // isolation will be applied
-    if (elecExtras.existsAs<std::string>("isolation")) {
-      elecIso_.reset( new StringCutObjectSelector<reco::PFCandidate>(
-          elecExtras.getParameter<std::string>("isolation")));
+
+    if (elecExtras.existsAs<std::string>("rho")) {
+			rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
     }
     // electronId is optional; in case it's not found the
     // InputTag will remain empty
@@ -78,7 +78,7 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
       eidCutValue_ = elecId.getParameter<double>("cutValue");
     }
   }
-  // pvExtras are opetional; they may be omitted or empty
+  // pvExtras are optional; they may be omitted or empty
   if (cfg.existsAs<edm::ParameterSet>("pvExtras")) {
     edm::ParameterSet pvExtras =
         cfg.getParameter<edm::ParameterSet>("pvExtras");
@@ -114,8 +114,8 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
         cfg.getParameter<edm::ParameterSet>("jetExtras");
     // jetCorrector is optional; in case it's not found
     // the InputTag will remain empty
-    if (jetExtras.existsAs<std::string>("jetCorrector")) {
-      jetCorrector_ = jetExtras.getParameter<std::string>("jetCorrector");
+    if (jetExtras.existsAs<edm::InputTag>("jetCorrector")) {
+			mJetCorrector  = iC.consumes<reco::JetCorrector>(jetExtras.getParameter<edm::InputTag>("jetCorrector"));
     }
     // read jetID information if it exists
     if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
@@ -131,6 +131,8 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     // CaloJets at the moment)
     if (jetExtras.existsAs<std::string>("select")) {
       jetSelect_ = jetExtras.getParameter<std::string>("select");
+			jetSelection_.reset(new StringCutObjectSelector<reco::PFJet>(jetSelect_));
+			jetlooseSelection_.reset(new StringCutObjectSelector<reco::PFJet>("chargedHadronEnergyFraction()>0 && chargedMultiplicity()>0 && chargedEmEnergyFraction()<0.99 && neutralHadronEnergyFraction()<0.99 && neutralEmEnergyFraction()<0.99 && (chargedMultiplicity()+neutralMultiplicity())>1"));
     }
     // jetBDiscriminators are optional; in case they are
     // not found the InputTag will remain empty; they
@@ -185,7 +187,6 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
   }
   // and don't forget to do the histogram booking
   directory_ = cfg.getParameter<std::string>("directory");
-  // book(ibooker);
 }
 
 void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
@@ -195,38 +196,44 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   ibooker.setCurrentFolder(current);
 
   // determine number of bins for trigger monitoring
-  unsigned int nPaths = triggerPaths_.size();
+  // unsigned int nPaths = triggerPaths_.size();
 
   // --- [STANDARD] --- //
   // Run Number
-  hists_["RunNumb_"] = ibooker.book1D("RunNumber", "Run Nr.", 1.e4, 1.5e5, 3.e5);
+  // hists_["RunNumb_"] = ibooker.book1D("RunNumber", "Run Nr.", 10, 0, 10);
   // instantaneous luminosity
-  hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
+  // hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
   // number of selected primary vertices
-  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{pvs}", 100, 0., 100.);
+  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
   // pt of the leading muon
-  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu)", 50, 0., 250.);
-  // muon multiplicity before std isolation
-  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{All}(#mu)", 10, 0., 10.);
-  // muon multiplicity after  std isolation
-  hists_["muonMultIso_"] = ibooker.book1D("MuonMultIso",
-      "N_{Iso}(#mu)", 10, 0., 10.);
+  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
+  // muon multiplicity after  tight Id
+  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{loose}(#mu)", 10, 0., 10.);
+  // muon multiplicity after  isolation
+  //hists_["muonMultIso_"] = ibooker.book1D("MuonMultIso",
+  //    "N_{TightIso}(#mu)", 10, 0., 10.);
+  // muon multiplicity after  tight Id and isolation
+  hists_["muonMultTight_"] = ibooker.book1D("MuonMultTight",
+      "N_{TightIso,TightId}(#mu)", 10, 0., 10.);
   // pt of the leading electron
-  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e)", 50, 0., 250.);
+  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e TightId, TightIso)", 40, 0., 200.);
   // electron multiplicity before std isolation
-  hists_["elecMult_"] = ibooker.book1D("ElecMult", "N_{All}(e)", 10, 0., 10.);
+  //hists_["elecMult_"] = ibooker.book1D("ElecMult", "N_{All}(e, tightId)", 10, 0., 10.);
   // electron multiplicity after  std isolation
-  hists_["elecMultIso_"] = ibooker.book1D("ElecMultIso", "N_{Iso}(e)", 10, 0., 10.);
-  // multiplicity of jets with pt>20 (corrected to L2+L3)
+  //hists_["elecMultIso_"] = ibooker.book1D("ElecMultIso", "N_{Iso}(e, tightId, tightIso)", 10, 0., 10.);
+  // multiplicity of jets with pt>30
   hists_["jetMult_"] = ibooker.book1D("JetMult", "N_{30}(jet)", 10, 0., 10.);
+  // multiplicity of loose jets with pt>30
+  hists_["jetMultLoose_"] = ibooker.book1D("JetMultLoose", "N_{30, loose}(jet)", 10, 0., 10.);
+
   // trigger efficiency estimates for single lepton triggers
-  hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
-      "Eff(trigger)", nPaths, 0., nPaths);
+  // hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
+  //    "Eff(trigger)", nPaths, 0., nPaths);
   // monitored trigger occupancy for single lepton triggers
-  hists_["triggerMon_"] = ibooker.book1D("TriggerMon",
-      "Mon(trigger)", nPaths, 0., nPaths);
-  // MET (calo)
-  hists_["metCalo_"] = ibooker.book1D("METCalo", "MET_{Calo}", 50, 0., 200.);
+  // hists_["triggerMon_"] = ibooker.book1D("TriggerMon",
+  //    "Mon(trigger)", nPaths, 0., nPaths);
+  // MET (pflow)
+  hists_["metPflow_"] = ibooker.book1D("METPflow", "MET_{Pflow}", 50, 0., 200.);
   // W mass estimate
   hists_["massW_"] = ibooker.book1D("MassW", "M(W)", 60, 0., 300.);
   // Top mass estimate
@@ -240,14 +247,21 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
 
   // --- [VERBOSE] --- //
   // eta of the leading muon
-  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu)", 30, -3., 3.);
+  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu TightId, TightIso)", 30, -3., 3.);
   // relative isolation of the candidate muon (depending on the decay channel)
   hists_["muonRelIso_"] = ibooker.book1D(
-      "MuonRelIso", "Iso_{Rel}(#mu) (#Delta#beta Corrected)", 50, 0., 1.);
+      "MuonRelIso", "Iso_{Rel}(#mu TightId) (#Delta#beta Corrected)", 50, 0., 1.);
+	// phi of the leading muon
+  hists_["muonPhi_"] = ibooker.book1D("MuonPhi", "#phi(#mu TightId, TightIso)", 40, -4., 4.);
   // eta of the leading electron
-  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e)", 30, -3., 3.);
+  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e tightId)", 30, -3., 3.);
   // std isolation variable of the leading electron
-  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e)", 50, 0., 1.);
+  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e TightId, TightIso)", 50, 0., 1.);
+	// phi of the leading electron
+  hists_["elecPhi_"] = ibooker.book1D("ElecPhi", "#phi(e tightId)", 40, -4., 4.);
+	// multiplicity of tight Id, tight Iso electorns
+  hists_["elecMultTight_"] = ibooker.book1D("ElecMultTight",
+                                              "N_{TightIso,TightId}(e)", 10, 0., 10.);
   // multiplicity of btagged jets (for track counting high efficiency) with
   // pt(L2L3)>30
  // hists_["jetMultBEff_"] = ibooker.book1D("JetMultBEff",
@@ -257,25 +271,21 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   //hists_["jetBDiscEff_"] = ibooker.book1D("JetBDiscEff",
   //    "Disc_{TCHE}(jet)", 100, 0., 10.);
   // eta of the 1. leading jet (corrected to L2+L3)
-  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta_{L2L3}(jet1)", 60, -3., 3.);
+  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta_{30,loose}(jet1)", 60, -3., 3.);
   // pt of the 1. leading jet (corrected to L2+L3)
-  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{L2L3}(jet1)", 60, 0., 300.);
+  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{30,loose}(jet1)", 60, 0., 300.);
   // eta of the 2. leading jet (corrected to L2+L3)
-  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta_{L2L3}(jet2)", 60, -3., 3.);
+  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta_{30,loose}(jet2)", 60, -3., 3.);
   // pt of the 2. leading jet (corrected to L2+L3)
-  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{L2L3}(jet2)", 60, 0., 300.);
+  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{30,loose}(jet2)", 60, 0., 300.);
   // eta of the 3. leading jet (corrected to L2+L3)
-  hists_["jet3Eta_"] = ibooker.book1D("Jet3Eta", "#eta_{L2L3}(jet3)", 60, -3., 3.);
+  hists_["jet3Eta_"] = ibooker.book1D("Jet3Eta", "#eta_{30,loose}(jet3)", 60, -3., 3.);
   // pt of the 3. leading jet (corrected to L2+L3)
-  hists_["jet3Pt_"] = ibooker.book1D("Jet3Pt", "pt_{L2L3}(jet3)", 60, 0., 300.);
+  hists_["jet3Pt_"] = ibooker.book1D("Jet3Pt", "pt_{30,loose}(jet3)", 60, 0., 300.);
   // eta of the 4. leading jet (corrected to L2+L3)
-  hists_["jet4Eta_"] = ibooker.book1D("Jet4Eta", "#eta_{L2L3}(jet4)", 60, -3., 3.);
+  hists_["jet4Eta_"] = ibooker.book1D("Jet4Eta", "#eta_{30,loose}(jet4)", 60, -3., 3.);
   // pt of the 4. leading jet (corrected to L2+L3)
-  hists_["jet4Pt_"] = ibooker.book1D("Jet4Pt", "pt_{L2L3}(jet4)", 60, 0., 300.);
-  // MET (tc)
-  hists_["metTC_"] = ibooker.book1D("METTC", "MET_{TC}", 50, 0., 200.);
-  // MET (pflow)
-  hists_["metPflow_"] = ibooker.book1D("METPflow", "MET_{Pflow}", 50, 0., 200.);
+  hists_["jet4Pt_"] = ibooker.book1D("Jet4Pt", "pt_{30,loose}(jet4)", 60, 0., 300.);
   // dz for muons (to suppress cosmis)
   hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
   // dxy for muons (to suppress cosmics)
@@ -292,41 +302,41 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   // charged hadron isolation component of the candidate muon (depending on the
   // decay channel)
   hists_["muonChHadIso_"] = ibooker.book1D("MuonChHadIsoComp",
-      "ChHad_{IsoComponent}(#mu)", 50, 0., 5.);
+      "ChHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
   // neutral hadron isolation component of the candidate muon (depending on the
   // decay channel)
   hists_["muonNeHadIso_"] = ibooker.book1D("MuonNeHadIsoComp",
-      "NeHad_{IsoComponent}(#mu)", 50, 0., 5.);
+      "NeHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
   // photon isolation component of the candidate muon (depending on the decay
   // channel)
   hists_["muonPhIso_"] = ibooker.book1D("MuonPhIsoComp",
-      "Photon_{IsoComponent}(#mu)", 50, 0., 5.);
+      "Photon_{IsoComponent}(#mu )", 50, 0., 5.);
   // charged hadron isolation component of the candidate electron (depending on
   // the decay channel)
   hists_["elecChHadIso_"] = ibooker.book1D("ElectronChHadIsoComp",
-      "ChHad_{IsoComponent}(e)", 50, 0., 5.);
+      "ChHad_{IsoComponent}(e tightId)", 50, 0., 5.);
   // neutral hadron isolation component of the candidate electron (depending on
   // the decay channel)
   hists_["elecNeHadIso_"] = ibooker.book1D("ElectronNeHadIsoComp",
-      "NeHad_{IsoComponent}(e)", 50, 0., 5.);
+      "NeHad_{IsoComponent}(e tightId)", 50, 0., 5.);
   // photon isolation component of the candidate electron (depending on the
   // decay channel)
   hists_["elecPhIso_"] = ibooker.book1D("ElectronPhIsoComp",
-      "Photon_{IsoComponent}(e)", 50, 0., 5.);
+      "Photon_{IsoComponent}(e tightId)", 50, 0., 5.);
  
   // multiplicity for combined secondary vertex
-  hists_["jetMultCSVtx_"] = ibooker.book1D("JetMultCSV", "N_{30}(CSV)", 10, 0., 10.);
+  hists_["jetMultBCSVM_"] = ibooker.book1D("JetMultBCSVM", "N_{30}(CSVM)", 10, 0., 10.);
   // btag discriminator for combined secondary vertex
-  hists_["jetBCVtx_"] = ibooker.book1D("JetDiscCSV",
-      "Disc_{CSV}(JET)", 100, -1., 2.);
+  hists_["jetBCSV_"] = ibooker.book1D("JetDiscCSV",
+      "BJet Disc_{CSV}(JET)", 100, -1., 2.);
   // pt of the 1. leading jet (uncorrected)
-  hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
+  // hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
   // pt of the 2. leading jet (uncorrected)
-  hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
+  // hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
   // pt of the 3. leading jet (uncorrected)
-  hists_["jet3PtRaw_"] = ibooker.book1D("Jet3PtRaw", "pt_{Raw}(jet3)", 60, 0., 300.);
+  // hists_["jet3PtRaw_"] = ibooker.book1D("Jet3PtRaw", "pt_{Raw}(jet3)", 60, 0., 300.);
   // pt of the 4. leading jet (uncorrected)
-  hists_["jet4PtRaw_"] = ibooker.book1D("Jet4PtRaw", "pt_{Raw}(jet4)", 60, 0., 300.);
+  // hists_["jet4PtRaw_"] = ibooker.book1D("Jet4PtRaw", "pt_{Raw}(jet4)", 60, 0., 300.);
   // selected events
   hists_["eventLogger_"] = ibooker.book2D("EventLogger",
       "Logged Events", 9, 0., 9., 10, 0., 10.);
@@ -336,10 +346,10 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   hists_["eventLogger_"]->setBinLabel(1, "Run", 1);
   hists_["eventLogger_"]->setBinLabel(2, "Block", 1);
   hists_["eventLogger_"]->setBinLabel(3, "Event", 1);
-  hists_["eventLogger_"]->setBinLabel(4, "pt_{L2L3}(jet1)", 1);
-  hists_["eventLogger_"]->setBinLabel(5, "pt_{L2L3}(jet2)", 1);
-  hists_["eventLogger_"]->setBinLabel(6, "pt_{L2L3}(jet3)", 1);
-  hists_["eventLogger_"]->setBinLabel(7, "pt_{L2L3}(jet4)", 1);
+  hists_["eventLogger_"]->setBinLabel(4, "pt_{30,loose}(jet1)", 1);
+  hists_["eventLogger_"]->setBinLabel(5, "pt_{30,loose}(jet2)", 1);
+  hists_["eventLogger_"]->setBinLabel(6, "pt_{30,loose}(jet3)", 1);
+  hists_["eventLogger_"]->setBinLabel(7, "pt_{30,loose}(jet4)", 1);
   hists_["eventLogger_"]->setBinLabel(8, "M_{W}", 1);
   hists_["eventLogger_"]->setBinLabel(9, "M_{Top}", 1);
   hists_["eventLogger_"]->setAxisTitle("logged evts", 2);
@@ -364,27 +374,16 @@ void MonitorEnsemble::fill(const edm::Event& event,
   */
   // fill monitoring plots for primary verices
   edm::Handle<edm::View<reco::Vertex> > pvs;
+  
+
   if (!event.getByToken(pvs_, pvs)) return;
+	const reco::Vertex& Pvertex = pvs->front(); 
   unsigned int pvMult = 0;
   for (edm::View<reco::Vertex>::const_iterator pv = pvs->begin();
        pv != pvs->end(); ++pv) {
     if (!pvSelect_ || (*pvSelect_)(*pv)) pvMult++;
   }
   fill("pvMult_", pvMult);
-
-  /*
-  ------------------------------------------------------------
-
-  Run and Inst. Luminosity information (Inst. Lumi. filled now with a dummy
-  value=5.0)
-
-  ------------------------------------------------------------
-  */
-  if (!event.eventAuxiliary().run()) return;
-  fill("RunNumb_", event.eventAuxiliary().run());
-
-  double dummy = 5.;
-  fill("InstLumi_", dummy);
 
   /*
   ------------------------------------------------------------
@@ -396,6 +395,8 @@ void MonitorEnsemble::fill(const edm::Event& event,
 
   // fill monitoring plots for electrons
   edm::Handle<edm::View<reco::PFCandidate> > elecs;
+  edm::Handle< double > _rhoHandle;
+	event.getByLabel(rhoTag,_rhoHandle);
   if (!event.getByToken(elecs_, elecs)) return;
 
   // check availability of electron id
@@ -415,38 +416,51 @@ void MonitorEnsemble::fill(const edm::Event& event,
     reco::GsfElectronRef gsf_el = elec->gsfElectronRef();
     // restrict to electrons with good electronId
     if (electronId_.isUninitialized() ? true : ((double)(*electronId)[gsf_el] >=
-                                                eidCutValue_)) {
+                                                eidCutValue_)) { //This Electron Id is not currently used, but we can keep this for future needs
       if (!elecSelect_ || (*elecSelect_)(*elec)) {
 
         double el_ChHadIso = gsf_el->pfIsolationVariables().sumChargedHadronPt;
         double el_NeHadIso = gsf_el->pfIsolationVariables().sumNeutralHadronEt;
         double el_PhIso = gsf_el->pfIsolationVariables().sumPhotonEt;
-        double el_pfRelIso =
-            (el_ChHadIso +
-             max(0., el_NeHadIso + el_PhIso -
-                         0.5 * gsf_el->pfIsolationVariables().sumPUPt)) /
-            gsf_el->pt();
-        if (eMult == 0) {
-          // restrict to the leading electron
-          fill("elecPt_", elec->pt());
-          fill("elecEta_", elec->eta());
+				double absEta = std::fabs(gsf_el->superCluster()->eta());
+
+				//Effective Area computation				
+				double eA = 0;
+				if      (absEta < 1.000) eA = 0.1703;
+				else if (absEta < 1.479) eA = 0.1715;
+				else if (absEta < 2.000) eA = 0.1213;
+				else if (absEta < 2.200) eA = 0.1230;
+				else if (absEta < 2.300) eA = 0.1635;
+				else if (absEta < 2.400) eA = 0.1937;
+				else if (absEta < 5.000) eA = 0.2393;
+	
+				double rho = _rhoHandle.isValid() ? (float)(*_rhoHandle) : 0;
+        double el_pfRelIso = (el_ChHadIso + max(0., el_NeHadIso + el_PhIso - rho * eA)) /gsf_el->pt();
+
+				//Only TightId
+        if (eMult == 0) {// Restricted to the leading tight electron
           fill("elecRelIso_", el_pfRelIso);
           fill("elecChHadIso_", el_ChHadIso);
           fill("elecNeHadIso_", el_NeHadIso);
           fill("elecPhIso_", el_PhIso);
         }
-        // in addition to the multiplicity counter buffer the iso
-        // electron candidates for later overlap check with jets
         ++eMult;
-        if (!elecIso_ || (*elecIso_)(*elec)) {
-          isoElecs.push_back(&(*elec));
-          ++eMultIso;
-        }
+
+				if (!((el_pfRelIso<0.0588 && absEta<1.479)||(el_pfRelIso<0.0571 && absEta>1.479))) continue; // PF Isolation with Effective Area Corrections according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
+
+
+				// TightId and TightIso
+				if (eMultIso == 0){//Only leading
+				  fill("elecPt_", elec->pt());
+          fill("elecEta_", elec->eta());
+          fill("elecPhi_", elec->phi());
+				}
+        ++eMultIso;
       }
     }
   }
-  fill("elecMult_", eMult);
-  fill("elecMultIso_", eMultIso);
+  //fill("elecMult_", eMult);
+  fill("elecMultTight_", eMultIso);
 
   /*
   ------------------------------------------------------------
@@ -457,15 +471,14 @@ void MonitorEnsemble::fill(const edm::Event& event,
   */
 
   // fill monitoring plots for muons
-  unsigned int mMult = 0, mMultIso = 0;
+  unsigned int mMult = 0, mTight=0, mTightId = 0;
 
   edm::Handle<edm::View<reco::PFCandidate> > muons;
   edm::View<reco::PFCandidate>::const_iterator muonit;
 
   if (!event.getByToken(muons_, muons)) return;
 
-  for (edm::View<reco::PFCandidate>::const_iterator muonit = muons->begin();
-       muonit != muons->end(); ++muonit) {
+  for (edm::View<reco::PFCandidate>::const_iterator muonit = muons->begin(); muonit != muons->end(); ++muonit) {
 
     if (muonit->muonRef().isNull()) continue;
     reco::MuonRef muon = muonit->muonRef();
@@ -476,35 +489,36 @@ void MonitorEnsemble::fill(const edm::Event& event,
       fill("muonDelXY_", muon->innerTrack()->vx(), muon->innerTrack()->vy());
 
       // apply preselection
-      if (!muonSelect_ || (*muonSelect_)(*muonit)) {
-
+      if ((!muonSelect_ || (*muonSelect_)(*muonit))) {
+				mMult++;
         double chHadPt = muon->pfIsolationR04().sumChargedHadronPt;
         double neHadEt = muon->pfIsolationR04().sumNeutralHadronEt;
-        double phoEt = muon->pfIsolationR04().sumPhotonEt;
+        double phoEt   = muon->pfIsolationR04().sumPhotonEt;
+        double pfRelIso = (chHadPt + max(0., neHadEt + phoEt - 0.5 * muon->pfIsolationR04().sumPUPt)) / muon->pt();  // CB dBeta corrected iso!
 
-        double pfRelIso =
-            (chHadPt +
-             max(0., neHadEt + phoEt - 0.5 * muon->pfIsolationR04().sumPUPt)) /
-            muon->pt();  // CB dBeta corrected iso!
+        if(!(muon->isGlobalMuon() && muon->isPFMuon() && muon->globalTrack()->normalizedChi2() < 10. && muon->globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && muon->numberOfMatchedStations() > 1 && muon->innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && muon->innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 && fabs(muon->muonBestTrack()->dxy(Pvertex.position())) < 0.2 && fabs(muon->muonBestTrack()->dz(Pvertex.position())) < 0.5) ) continue; //Only tight muons
+				
+				if (mTightId == 0){
+  	        fill("muonRelIso_", pfRelIso);
+  	        fill("muonChHadIso_", chHadPt);
+  	        fill("muonNeHadIso_", neHadEt);
+  	        fill("muonPhIso_", phoEt);
+				}
+				mTightId++;
+				
+				if(!(pfRelIso < 0.15)) continue; //Tight Iso
 
-        if (mMult == 0) {
-          // restrict to leading muon
-          fill("muonPt_", muon->pt());
-          fill("muonEta_", muon->eta());
-
-          fill("muonRelIso_", pfRelIso);
-
-          fill("muonChHadIso_", chHadPt);
-          fill("muonNeHadIso_", neHadEt);
-          fill("muonPhIso_", phoEt);
-        }
-        ++mMult;
-        if (!muonIso_ || (*muonIso_)(*muonit)) ++mMultIso;
-      }
+				if (mTight == 0){//Leading tightId tightIso muon
+  	      fill("muonPt_", muon->pt());
+  	      fill("muonEta_", muon->eta());
+  	      fill("muonPhi_", muon->phi());
+  	    }
+				mTight++;
+			}
     }
   }
   fill("muonMult_", mMult);
-  fill("muonMultIso_", mMultIso);
+  fill("muonMultTight_", mTight);
 
   /*
   ------------------------------------------------------------
@@ -520,124 +534,73 @@ void MonitorEnsemble::fill(const edm::Event& event,
 
     if (!event.getByToken(btagCSV_, btagCSV)) return;
   }
-  // load jet corrector if configured such
-  const JetCorrector* corrector = 0;
-  if (!jetCorrector_.empty()) {
-    // check whether a jet correcto is in the event setup or not
-    if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<
-            JetCorrectionsRecord>())) {
-      corrector = JetCorrector::getJetCorrector(jetCorrector_, setup);
-    } else {
-      edm::LogVerbatim("TopSingleLeptonDQM")
-          << "\n"
-          << "-----------------------------------------------------------------"
-             "-------------------- \n"
-          << " No JetCorrectionsRecord available from EventSetup:              "
-             "                     \n"
-          << "  - Jets will not be corrected.                                  "
-             "                     \n"
-          << "  - If you want to change this add the following lines to your "
-             "cfg file:              \n"
-          << "                                                                 "
-             "                     \n"
-          << "  ## load jet corrections                                        "
-             "                     \n"
-          << "  "
-             "process.load(\"JetMETCorrections.Configuration."
-             "JetCorrectionServicesAllAlgos_cff\") \n"
-          << "  process.prefer(\"ak5CaloL2L3\")                                "
-             "                     \n"
-          << "                                                                 "
-             "                     \n"
-          << "-----------------------------------------------------------------"
-             "-------------------- \n";
-    }
-  }
+
+	edm::Handle<reco::JetCorrector> corrector;
+	event.getByToken(mJetCorrector, corrector);
 
   // loop jet collection
   std::vector<reco::Jet> correctedJets;
   std::vector<double> JetTagValues;
-  unsigned int mult = 0, multCSV = 0;
+  unsigned int mult = 0, multLoose = 0, multCSV = 0;
 
   edm::Handle<edm::View<reco::Jet> > jets;
   if (!event.getByToken(jets_, jets)) {
     return;
   }
 
-  edm::Handle<reco::JetIDValueMap> jetID;
-  if (jetIDSelect_) {
-    if (!event.getByToken(jetIDLabel_, jetID)) return;
-  }
-
   for (edm::View<reco::Jet>::const_iterator jet = jets->begin();
        jet != jets->end(); ++jet) {
-    // check jetID for calo jets
-    unsigned int idx = jet - jets->begin();
-    if (jetIDSelect_ &&
-        dynamic_cast<const reco::CaloJet*>(jets->refAt(idx).get())) {
-      if (!(*jetIDSelect_)((*jetID)[jets->refAt(idx)])) continue;
-    }
-    // chekc additional jet selection for calo, pf and bare reco jets
-    if (dynamic_cast<const reco::CaloJet*>(&*jet)) {
-      reco::CaloJet sel = dynamic_cast<const reco::CaloJet&>(*jet);
-      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-      StringCutObjectSelector<reco::CaloJet> jetSelect(jetSelect_);
-      if (!jetSelect(sel)) {
-        continue;
-      }
-    } else if (dynamic_cast<const reco::PFJet*>(&*jet)) {
+		bool isLoose = false;
+    // check additional jet selection for pf jets
+		if (dynamic_cast<const reco::PFJet*>(&*jet)) {
       reco::PFJet sel = dynamic_cast<const reco::PFJet&>(*jet);
-      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-      StringCutObjectSelector<reco::PFJet> jetSelect(jetSelect_);
-      if (!jetSelect(sel)) continue;
-    } else {
-      reco::Jet sel = *jet;
-      sel.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-      StringCutObjectSelector<reco::Jet> jetSelect(jetSelect_);
-      if (!jetSelect(sel)) continue;
+			if ((*jetlooseSelection_)(sel)) isLoose = true;
+      sel.scaleEnergy(corrector->correction(*jet));
+      if (!(*jetSelection_)(sel)) continue;
     }
 
     // prepare jet to fill monitor histograms
     reco::Jet monitorJet = *jet;
-    monitorJet.scaleEnergy(corrector ? corrector->correction(*jet) : 1.);
-    correctedJets.push_back(monitorJet);
-    ++mult;  // determine jet multiplicity
-    if (includeBTag_) {
-      // fill b-discriminators
-      edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
+		
+    ++mult;  // determine jet (no Id) multiplicity 
+		monitorJet.scaleEnergy(corrector->correction(*jet));
 
-      fill("jetBCVtx_", (*btagCSV)[jetRef]);
-      if ((*btagCSV)[jetRef] > btagCSVWP_) ++multCSV;
+		if (isLoose){ //Loose Id
+			unsigned int idx = jet - jets->begin();
+    	correctedJets.push_back(monitorJet);
+    	if (includeBTag_) {
+      	// fill b-discriminators
+      	edm::RefToBase<reco::Jet> jetRef = jets->refAt(idx);
+ 	     fill("jetBCSV_", (*btagCSV)[jetRef]);
+ 	     if ((*btagCSV)[jetRef] > btagCSVWP_) ++multCSV;
+      	// Fill a vector with Jet b-tag WP for later M3+1tag calculation: CSV
+      	// tagger
+      	JetTagValues.push_back((*btagCSV)[jetRef]);
+			}
 
-      // Fill a vector with Jet b-tag WP for later M3+1tag calculation: CSV
-      // tagger
-      JetTagValues.push_back((*btagCSV)[jetRef]);
-    }
-    // fill pt (raw or L2L3) for the leading four jets
-    if (idx == 0) {
-      fill("jet1Pt_", monitorJet.pt());
-      fill("jet1PtRaw_", jet->pt());
-      fill("jet1Eta_", monitorJet.eta());
-    };
-    if (idx == 1) {
-      fill("jet2Pt_", monitorJet.pt());
-      fill("jet2PtRaw_", jet->pt());
-      fill("jet2Eta_", monitorJet.eta());
-    }
-    if (idx == 2) {
-      fill("jet3Pt_", monitorJet.pt());
-      fill("jet3PtRaw_", jet->pt());
-      fill("jet3Eta_", monitorJet.eta());
-    }
-    if (idx == 3) {
-      fill("jet4Pt_", monitorJet.pt());
-      fill("jet4PtRaw_", jet->pt());
-      fill("jet4Eta_", monitorJet.eta());
-    }
-  }
-  fill("jetMult_", mult);
-
-  fill("jetMultCSVtx_", multCSV);
+  	  // fill pt/eta for the leading four jets
+  	  if (multLoose == 0) {
+  	    fill("jet1Pt_", monitorJet.pt());
+  	    fill("jet1Eta_", monitorJet.eta());
+  	  };
+  	  if (multLoose == 1) {
+  	    fill("jet2Pt_", monitorJet.pt());
+  		  fill("jet2Eta_", monitorJet.eta());
+  	  }
+  	  if (multLoose == 2) {
+  	    fill("jet3Pt_", monitorJet.pt());
+  	    fill("jet3Eta_", monitorJet.eta());
+  	  }
+  	  if (multLoose == 3) {
+  	    fill("jet4Pt_", monitorJet.pt());
+    	  fill("jet4Eta_", monitorJet.eta());
+  	  }
+			multLoose++;
+		}
+	}
+	fill("jetMult_"     , mult);
+  fill("jetMultLoose_", multLoose);
+  fill("jetMultBCSVM_", multCSV);
 
   /*
   ------------------------------------------------------------
@@ -653,11 +616,9 @@ void MonitorEnsemble::fill(const edm::Event& event,
        met_ != mets_.end(); ++met_) {
     edm::Handle<edm::View<reco::MET> > met;
     if (!event.getByToken(*met_, met)) continue;
-    if (met->begin() != met->end()) {
+    if (met->begin() != met->end()) {//If we ever have to use more than one type of met again
       unsigned int idx = met_ - mets_.begin();
-      if (idx == 0) fill("metCalo_", met->begin()->et());
-      if (idx == 1) fill("metTC_", met->begin()->et());
-      if (idx == 2) fill("metPflow_", met->begin()->et());
+      if (idx == 0) fill("metPflow_", met->begin()->et());
     }
   }
 
@@ -746,7 +707,7 @@ TopSingleLeptonDQM::TopSingleLeptonDQM(const edm::ParameterSet& cfg)
         beamspot.getParameter<std::string>("select")));
   }
 
-  // conifgure the selection
+  // configure the selection
   sel_ = cfg.getParameter<std::vector<edm::ParameterSet> >("selection");
   setup_ = cfg.getParameter<edm::ParameterSet>("setup");
   for (unsigned int i = 0; i < sel_.size(); ++i) {

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include "FWCore/Utilities/interface/EDGetToken.h"
+
 #include "FWCore/Framework/interface/Event.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -19,6 +19,9 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+
+
 /**
    \class   MonitorEnsemble TopDQMHelpers.h
    "DQM/Physics/interface/TopDQMHelpers.h"
@@ -130,6 +133,8 @@ class MonitorEnsemble {
 
   /// electronId label
   edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
+  edm::EDGetTokenT<reco::JetCorrector> mJetCorrector;
+
   /// electronId pattern we expect the following pattern:
   ///  0: fails
   ///  1: passes electron ID only
@@ -144,9 +149,12 @@ class MonitorEnsemble {
   // int eidPattern_;
   // the cut for the MVA Id
   double eidCutValue_;
-  /// extra isolation criterion on electron
-  std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > elecIso_;
+	// electron ISO things
+
+	edm::InputTag rhoTag;
+
   /// extra selection on electrons
+
   std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > elecSelect_;
 
   /// extra selection on primary vertices; meant to investigate the pile-up
@@ -161,13 +169,15 @@ class MonitorEnsemble {
 
   /// jetCorrector
   std::string jetCorrector_;
+
   /// jetID as an extra selection type
   edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
-  /// extra jetID selection on calo jets
+
   std::unique_ptr<StringCutObjectSelector<reco::JetID> > jetIDSelect_;
-  /// extra selection on jets (here given as std::string as it depends
-  /// on the the jet type, which selections are valid and which not)
+  /// extra selection on jets 
   std::string jetSelect_;
+	std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetlooseSelection_;
+	std::unique_ptr<StringCutObjectSelector<reco::PFJet> > jetSelection_;
   /// include btag information or not
   /// to be determined from the cfg
   bool includeBTag_;

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -13,6 +13,9 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
+
+#include "JetMETCorrections/Objects/interface/JetCorrector.h"
+
 using namespace std;
 namespace TopSingleLepton_miniAOD {
 
@@ -33,7 +36,7 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
       muonIso_(nullptr),
       muonSelect_(nullptr),
       jetIDSelect_(nullptr),
-     jetSelect(nullptr),
+      jetSelect(nullptr),
       includeBTag_(false),
       lowerEdge_(-1.),
       upperEdge_(-1.),
@@ -76,6 +79,10 @@ MonitorEnsemble::MonitorEnsemble(const char* label,
     if (elecExtras.existsAs<std::string>("isolation")) {
       elecIso_.reset( new StringCutObjectSelector<pat::Electron>(
           elecExtras.getParameter<std::string>("isolation")));
+    }
+      
+    if (elecExtras.existsAs<std::string>("rho")) {
+        rhoTag = elecExtras.getParameter<edm::InputTag>("rho");
     }
     // electronId is optional; in case it's not found the
     // InputTag will remain empty
@@ -191,38 +198,44 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   ibooker.setCurrentFolder(current);
 
   // determine number of bins for trigger monitoring
-  unsigned int nPaths = triggerPaths_.size();
+  //unsigned int nPaths = triggerPaths_.size();
 
   // --- [STANDARD] --- //
   // Run Number
-  hists_["RunNumb_"] = ibooker.book1D("RunNumber", "Run Nr.", 1.e4, 1.5e5, 3.e5);
+  //hists_["RunNumb_"] = ibooker.book1D("RunNumber", "Run Nr.", 1.e4, 1.5e5, 3.e5);
   // instantaneous luminosity
-  hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
+  //hists_["InstLumi_"] = ibooker.book1D("InstLumi", "Inst. Lumi.", 100, 0., 1.e3);
   // number of selected primary vertices
-  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{pvs}", 100, 0., 100.);
+  hists_["pvMult_"] = ibooker.book1D("PvMult", "N_{good pvs}", 50, 0., 50.);
   // pt of the leading muon
-  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu)", 50, 0., 250.);
+  hists_["muonPt_"] = ibooker.book1D("MuonPt", "pt(#mu TightId, TightIso)", 40, 0., 200.);
   // muon multiplicity before std isolation
-  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{All}(#mu)", 10, 0., 10.);
+  hists_["muonMult_"] = ibooker.book1D("MuonMult", "N_{loose}(#mu)", 10, 0., 10.);
   // muon multiplicity after  std isolation
-  hists_["muonMultIso_"] = ibooker.book1D("MuonMultIso",
-      "N_{Iso}(#mu)", 10, 0., 10.);
-  // pt of the leading electron
-  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e)", 50, 0., 250.);
+  //hists_["muonMultIso_"] = ibooker.book1D("MuonMultIso",
+  //    "N_{TightIso}(#mu)", 10, 0., 10.);
+ 
+  hists_["muonMultTight_"] = ibooker.book1D("MuonMultTight",
+      "N_{TightIso,TightId}(#mu)", 10, 0., 10.);
+
+ // pt of the leading electron
+  hists_["elecPt_"] = ibooker.book1D("ElecPt", "pt(e TightId, TightIso)", 40, 0., 200.);
   // electron multiplicity before std isolation
-  hists_["elecMult_"] = ibooker.book1D("ElecMult", "N_{All}(e)", 10, 0., 10.);
+  //hists_["elecMult_"] = ibooker.book1D("ElecMult", "N_{looseId}(e)", 10, 0., 10.);
   // electron multiplicity after  std isolation
-  hists_["elecMultIso_"] = ibooker.book1D("ElecMultIso", "N_{Iso}(e)", 10, 0., 10.);
+  //hists_["elecMultIso_"] = ibooker.book1D("ElecMultIso", "N_{Iso}(e)", 10, 0., 10.);
   // multiplicity of jets with pt>20 (corrected to L2+L3)
   hists_["jetMult_"] = ibooker.book1D("JetMult", "N_{30}(jet)", 10, 0., 10.);
+  hists_["jetLooseMult_"] = ibooker.book1D("JetLooseMult", "N_{30,loose}(jet)", 10, 0., 10.);
+
   // trigger efficiency estimates for single lepton triggers
-  hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
-      "Eff(trigger)", nPaths, 0., nPaths);
+  //hists_["triggerEff_"] = ibooker.book1D("TriggerEff",
+  //    "Eff(trigger)", nPaths, 0., nPaths);
   // monitored trigger occupancy for single lepton triggers
-  hists_["triggerMon_"] = ibooker.book1D("TriggerMon",
-      "Mon(trigger)", nPaths, 0., nPaths);
+  //hists_["triggerMon_"] = ibooker.book1D("TriggerMon",
+  //    "Mon(trigger)", nPaths, 0., nPaths);
   // MET (calo)
-  hists_["slimmedMETs_"] = ibooker.book1D("slimmedMETs", "MET_{slimmed}", 50, 0., 200.);
+  hists_["slimmedMETs_"] = ibooker.book1D("slimmedMETs", "MET_{slimmed}", 40, 0., 200.);
   // W mass estimate
   hists_["massW_"] = ibooker.book1D("MassW", "M(W)", 60, 0., 300.);
   // Top mass estimate
@@ -236,42 +249,50 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
 
   // --- [VERBOSE] --- //
   // eta of the leading muon
-  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu)", 30, -3., 3.);
+  hists_["muonEta_"] = ibooker.book1D("MuonEta", "#eta(#mu TightId,TightIso)", 30, -3., 3.);
   // relative isolation of the candidate muon (depending on the decay channel)
+  hists_["muonPhi_"] = ibooker.book1D("MuonPhi", "#phi(#mu TightId,TightIso)", 40, -4., 4.);
   hists_["muonRelIso_"] = ibooker.book1D(
-      "MuonRelIso", "Iso_{Rel}(#mu) (#Delta#beta Corrected)", 50, 0., 1.);
+      "MuonRelIso", "Iso_{Rel}(#mu TightId) (#Delta#beta Corrected)", 50, 0., 1.);
+    
   // eta of the leading electron
-  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e)", 30, -3., 3.);
+  hists_["elecEta_"] = ibooker.book1D("ElecEta", "#eta(e TightId, TightIso)", 30, -3., 3.);
+  hists_["elecPhi_"] = ibooker.book1D("ElecPhi", "#phi(e TightId, TightIso)", 40, -4., 4.);
   // std isolation variable of the leading electron
-  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e)", 50, 0., 1.);
+  hists_["elecRelIso_"] = ibooker.book1D("ElecRelIso", "Iso_{Rel}(e TightId)", 50, 0., 1.);
+    
+  hists_["elecMultTight_"] = ibooker.book1D("ElecMultTight",
+                                              "N_{TightIso,TightId}(e)", 10, 0., 10.);
+  
+    
   // multiplicity of btagged jets (for track counting high efficiency) with
   // pt(L2L3)>30
-  hists_["jetMultBEff_"] = ibooker.book1D("JetMultBEff",
-      "N_{30}(TCHE)", 10, 0., 10.);
+  //hists_["jetMultBEff_"] = ibooker.book1D("JetMultBEff",
+  //    "N_{30}(TCHE)", 10, 0., 10.);
   // btag discriminator for track counting high efficiency for jets with
   // pt(L2L3)>30
-  hists_["jetBDiscEff_"] = ibooker.book1D("JetBDiscEff",
-      "Disc_{TCHE}(jet)", 100, 0., 10.);
+  //hists_["jetBDiscEff_"] = ibooker.book1D("JetBDiscEff",
+  //    "Disc_{TCHE}(jet)", 100, 0., 10.);
   // eta of the 1. leading jet (corrected to L2+L3)
-  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta_{L2L3}(jet1)", 60, -3., 3.);
+  hists_["jet1Eta_"] = ibooker.book1D("Jet1Eta", "#eta_{30,loose}(jet1)", 60, -3., 3.);
   // pt of the 1. leading jet (corrected to L2+L3)
-  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{L2L3}(jet1)", 60, 0., 300.);
+  hists_["jet1Pt_"] = ibooker.book1D("Jet1Pt", "pt_{30,loose}(jet1)", 60, 0., 300.);
   // eta of the 2. leading jet (corrected to L2+L3)
-  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta_{L2L3}(jet2)", 60, -3., 3.);
+  hists_["jet2Eta_"] = ibooker.book1D("Jet2Eta", "#eta_{30,loose}(jet2)", 60, -3., 3.);
   // pt of the 2. leading jet (corrected to L2+L3)
-  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{L2L3}(jet2)", 60, 0., 300.);
+  hists_["jet2Pt_"] = ibooker.book1D("Jet2Pt", "pt_{30,loose}(jet2)", 60, 0., 300.);
   // eta of the 3. leading jet (corrected to L2+L3)
-  hists_["jet3Eta_"] = ibooker.book1D("Jet3Eta", "#eta_{L2L3}(jet3)", 60, -3., 3.);
+  hists_["jet3Eta_"] = ibooker.book1D("Jet3Eta", "#eta_{30,loose}(jet3)", 60, -3., 3.);
   // pt of the 3. leading jet (corrected to L2+L3)
-  hists_["jet3Pt_"] = ibooker.book1D("Jet3Pt", "pt_{L2L3}(jet3)", 60, 0., 300.);
+  hists_["jet3Pt_"] = ibooker.book1D("Jet3Pt", "pt_{30,loose}(jet3)", 60, 0., 300.);
   // eta of the 4. leading jet (corrected to L2+L3)
-  hists_["jet4Eta_"] = ibooker.book1D("Jet4Eta", "#eta_{L2L3}(jet4)", 60, -3., 3.);
+  hists_["jet4Eta_"] = ibooker.book1D("Jet4Eta", "#eta_{30,loose}(jet4)", 60, -3., 3.);
   // pt of the 4. leading jet (corrected to L2+L3)
-  hists_["jet4Pt_"] = ibooker.book1D("Jet4Pt", "pt_{L2L3}(jet4)", 60, 0., 300.);
+  hists_["jet4Pt_"] = ibooker.book1D("Jet4Pt", "pt_{30,loose}(jet4)", 60, 0., 300.);
   // MET (tc)
-  hists_["slimmedMETsNoHF_"] = ibooker.book1D("slimmedMETsNoHF", "MET_{slimmedNoHF}", 50, 0., 200.);
+  hists_["slimmedMETsNoHF_"] = ibooker.book1D("slimmedMETsNoHF", "MET_{slimmedNoHF}", 40, 0., 200.);
   // MET (pflow)
-  hists_["slimmedMETsPuppi_"] = ibooker.book1D("slimmedMETsPuppi", "MET_{slimmedPuppi}", 50, 0., 200.);
+  hists_["slimmedMETsPuppi_"] = ibooker.book1D("slimmedMETsPuppi", "MET_{slimmedPuppi}", 40, 0., 200.);
   // dz for muons (to suppress cosmis)
   hists_["muonDelZ_"] = ibooker.book1D("MuonDelZ", "d_{z}(#mu)", 50, -25., 25.);
   // dxy for muons (to suppress cosmics)
@@ -288,53 +309,52 @@ void MonitorEnsemble::book(DQMStore::IBooker & ibooker) {
   // charged hadron isolation component of the candidate muon (depending on the
   // decay channel)
   hists_["muonChHadIso_"] = ibooker.book1D("MuonChHadIsoComp",
-      "ChHad_{IsoComponent}(#mu)", 50, 0., 5.);
+      "ChHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
   // neutral hadron isolation component of the candidate muon (depending on the
   // decay channel)
   hists_["muonNeHadIso_"] = ibooker.book1D("MuonNeHadIsoComp",
-      "NeHad_{IsoComponent}(#mu)", 50, 0., 5.);
+      "NeHad_{IsoComponent}(#mu TightId)", 50, 0., 5.);
   // photon isolation component of the candidate muon (depending on the decay
   // channel)
   hists_["muonPhIso_"] = ibooker.book1D("MuonPhIsoComp",
-      "Photon_{IsoComponent}(#mu)", 50, 0., 5.);
+      "Photon_{IsoComponent}(#mu TightId)", 50, 0., 5.);
   // charged hadron isolation component of the candidate electron (depending on
   // the decay channel)
   hists_["elecChHadIso_"] = ibooker.book1D("ElectronChHadIsoComp",
-      "ChHad_{IsoComponent}(e)", 50, 0., 5.);
+      "ChHad_{IsoComponent}(e TightId)", 50, 0., 5.);
   // neutral hadron isolation component of the candidate electron (depending on
   // the decay channel)
   hists_["elecNeHadIso_"] = ibooker.book1D("ElectronNeHadIsoComp",
-      "NeHad_{IsoComponent}(e)", 50, 0., 5.);
+      "NeHad_{IsoComponent}(e TightId)", 50, 0., 5.);
   // photon isolation component of the candidate electron (depending on the
   // decay channel)
   hists_["elecPhIso_"] = ibooker.book1D("ElectronPhIsoComp",
-      "Photon_{IsoComponent}(e)", 50, 0., 5.);
+      "Photon_{IsoComponent}(e TightId)", 50, 0., 5.);
   // multiplicity of btagged jets (for track counting high purity) with
   // pt(L2L3)>30
-  hists_["jetMultBPur_"] = ibooker.book1D("JetMultBPur",
-      "N_{30}(TCHP)", 10, 0., 10.);
+  //hists_["jetMultBPur_"] = ibooker.book1D("JetMultBPur",
+  //    "N_{30}(TCHP)", 10, 0., 10.);
   // btag discriminator for track counting high purity
-  hists_["jetBDiscPur_"] = ibooker.book1D("JetBDiscPur",
-      "Disc_{TCHP}(Jet)", 100, 0., 10.);
+  //hists_["jetBDiscPur_"] = ibooker.book1D("JetBDiscPur",
+  //    "Disc_{TCHP}(Jet)", 100, 0., 10.);
   // multiplicity of btagged jets (for simple secondary vertex) with pt(L2L3)>30
-  hists_["jetMultBVtx_"] = ibooker.book1D("JetMultBVtx",
-      "N_{30}(SSVHE)", 10, 0., 10.);
+  //hists_["jetMultBVtx_"] = ibooker.book1D("JetMultBVtx",
+  //    "N_{30}(SSVHE)", 10, 0., 10.);
   // btag discriminator for simple secondary vertex
-  hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
-      "Disc_{SSVHE}(Jet)", 35, -1., 6.);
+  //hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
+  //    "Disc_{SSVHE}(Jet)", 35, -1., 6.);
   // multiplicity for combined secondary vertex
-  hists_["jetMultCSVtx_"] = ibooker.book1D("JetMultCSV", "N_{30}(CSV)", 10, 0., 10.);
+  hists_["jetMultBCSVM_"] = ibooker.book1D("JetMultBCSVM", "N_{30}(CSVM)", 10, 0., 10.);
   // btag discriminator for combined secondary vertex
-  hists_["jetBCVtx_"] = ibooker.book1D("JetDiscCSV",
-      "Disc_{CSV}(JET)", 100, -1., 2.);
+  hists_["jetBCSV_"] = ibooker.book1D("JetDiscCSV","BJet Disc_{CSV}(JET)", 100, -1., 2.);
   // pt of the 1. leading jet (uncorrected)
-  hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
+  //hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
   // pt of the 2. leading jet (uncorrected)
-  hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
+  //hists_["jet2PtRaw_"] = ibooker.book1D("Jet2PtRaw", "pt_{Raw}(jet2)", 60, 0., 300.);
   // pt of the 3. leading jet (uncorrected)
-  hists_["jet3PtRaw_"] = ibooker.book1D("Jet3PtRaw", "pt_{Raw}(jet3)", 60, 0., 300.);
+  //hists_["jet3PtRaw_"] = ibooker.book1D("Jet3PtRaw", "pt_{Raw}(jet3)", 60, 0., 300.);
   // pt of the 4. leading jet (uncorrected)
-  hists_["jet4PtRaw_"] = ibooker.book1D("Jet4PtRaw", "pt_{Raw}(jet4)", 60, 0., 300.);
+  //hists_["jet4PtRaw_"] = ibooker.book1D("Jet4PtRaw", "pt_{Raw}(jet4)", 60, 0., 300.);
   // selected events
   hists_["eventLogger_"] = ibooker.book2D("EventLogger",
       "Logged Events", 9, 0., 9., 10, 0., 10.);
@@ -362,7 +382,7 @@ void MonitorEnsemble::fill(const edm::Event& event,
   if (!triggerTable_.isUninitialized()) {
     if (!event.getByToken(triggerTable_, triggerTable)) return;
   }
-
+    
   /*
   ------------------------------------------------------------
 
@@ -373,11 +393,24 @@ void MonitorEnsemble::fill(const edm::Event& event,
   // fill monitoring plots for primary verices
   edm::Handle<edm::View<reco::Vertex> > pvs;
   if (!event.getByToken(pvs_, pvs)) return;
-  unsigned int pvMult = 0;
-  for (edm::View<reco::Vertex>::const_iterator pv = pvs->begin();
+  const reco::Vertex& pver= pvs->front();
+
+  unsigned int pvMult = 0; 
+  if(pvs.isValid()){
+    for (edm::View<reco::Vertex>::const_iterator pv = pvs->begin();
        pv != pvs->end(); ++pv) {
-    if (!pvSelect_ || (*pvSelect_)(*pv)) pvMult++;
-  }
+
+      bool isGood = ( !(pv->isFake()) &&
+			  (pv->ndof() > 4.0) &&
+			  (abs(pv->z()) < 24.0) &&
+			  (abs(pv->position().Rho()) < 2.0) 
+			  );
+      if( !isGood ) continue;
+      pvMult++;
+    }
+    //std::cout<<" npv  "<<testn<<endl;
+  }    
+  
   fill("pvMult_", pvMult);
 
   /*
@@ -388,12 +421,14 @@ void MonitorEnsemble::fill(const edm::Event& event,
 
   ------------------------------------------------------------
   */
-  if (!event.eventAuxiliary().run()) return;
-  fill("RunNumb_", event.eventAuxiliary().run());
+    
+  //if (!event.eventAuxiliary().run()) return;
+    
+  //fill("RunNumb_", event.eventAuxiliary().run());
 
-  double dummy = 5.;
-  fill("InstLumi_", dummy);
-
+  //double dummy = 5.;
+  //fill("InstLumi_", dummy);
+    
   /*
   ------------------------------------------------------------
 
@@ -405,6 +440,11 @@ void MonitorEnsemble::fill(const edm::Event& event,
   // fill monitoring plots for electrons
   edm::Handle<edm::View<pat::Electron> > elecs;
   if (!event.getByToken(elecs_, elecs)) return;
+    
+  edm::Handle< double > _rhoHandle;
+  event.getByLabel(rhoTag,_rhoHandle);
+  //if (!event.getByToken(elecs_, elecs)) return;
+    
 
   // check availability of electron id
   edm::Handle<edm::ValueMap<float> > electronId;
@@ -413,44 +453,64 @@ void MonitorEnsemble::fill(const edm::Event& event,
   }
 
   // loop electron collection
-  unsigned int eMult = 0, eMultIso = 0;
+  unsigned int eMultIso = 0, eMult = 0;
   std::vector<const pat::Electron*> isoElecs;
 
 
- for (edm::View<pat::Electron>::const_iterator elec = elecs->begin();
+  for (edm::View<pat::Electron>::const_iterator elec = elecs->begin();
        elec != elecs->end(); ++elec) {
 
-      if(true){//no electron id applied yet!
+      if(true){//loose id
       if (!elecSelect_ || (*elecSelect_)(*elec)) {
-
+          
         double el_ChHadIso = elec->pfIsolationVariables().sumChargedHadronPt;
         double el_NeHadIso = elec->pfIsolationVariables().sumNeutralHadronEt;
         double el_PhIso = elec->pfIsolationVariables().sumPhotonEt;
-        double el_pfRelIso =
-            (el_ChHadIso +
-             max(0., el_NeHadIso + el_PhIso -
-                         0.5 * elec->pfIsolationVariables().sumPUPt)) /
-            elec->pt();
-        if (eMult == 0) {
-          // restrict to the leading electron
-          fill("elecPt_", elec->pt());
-          fill("elecEta_", elec->eta());
+          
+        double rho = _rhoHandle.isValid() ? (float)(*_rhoHandle) : 0;
+        double absEta = abs(elec->superCluster()->eta());
+        double eA = 0;
+        if      (absEta < 1.000) eA = 0.1703;
+        else if (absEta < 1.479) eA = 0.1715;
+        else if (absEta < 2.000) eA = 0.1213;
+        else if (absEta < 2.200) eA = 0.1230;
+        else if (absEta < 2.300) eA = 0.1635;
+        else if (absEta < 2.400) eA = 0.1937;
+        else if (absEta < 5.000) eA = 0.2393;
+          
+          
+        double el_pfRelIso = (el_ChHadIso + max(0., el_NeHadIso + el_PhIso - rho * eA)) /elec->pt();
+          
+        ++eMult;
+          
+        if(eMult==1){
           fill("elecRelIso_", el_pfRelIso);
           fill("elecChHadIso_", el_ChHadIso);
           fill("elecNeHadIso_", el_NeHadIso);
           fill("elecPhIso_", el_PhIso);
         }
-
-        ++eMult;
-        if (!elecIso_ || (*elecIso_)(*elec)) {
-          isoElecs.push_back(&(*elec));
-          ++eMultIso;
+        //loose Iso
+        //if(!((el_pfRelIso<0.0994 && absEta<1.479)||(el_pfRelIso<0.107 && absEta>1.479)))continue;
+        
+        //tight Iso
+        if(!((el_pfRelIso<0.0588 && absEta<1.479)||(el_pfRelIso<0.0571 && absEta>1.479)))continue;
+        ++eMultIso;
+          
+        if (eMultIso == 1) {
+          // restrict to the leading electron
+          fill("elecPt_", elec->pt());
+          fill("elecEta_", elec->eta());
+          fill("elecPhi_", elec->phi());
         }
       }
     }
   }
-  fill("elecMult_", eMult);
-  fill("elecMultIso_", eMultIso);
+  //fill("elecMult_", eMult);
+  fill("elecMultTight_", eMultIso);
+    
+    
+    
+    
 
   /*
   ------------------------------------------------------------
@@ -461,14 +521,12 @@ void MonitorEnsemble::fill(const edm::Event& event,
   */
 
   // fill monitoring plots for muons
-  unsigned int mMult = 0, mMultIso = 0;
+  unsigned int mMult = 0,  mTight=0;
 
   edm::Handle<edm::View<pat::Muon> > muons;
   edm::View<pat::Muon>::const_iterator muonit;
 
   if (!event.getByToken(muons_, muons)) return;
-
-
 
   for (edm::View<pat::Muon>::const_iterator muon = muons->begin();
        muon != muons->end(); ++muon) {
@@ -481,38 +539,51 @@ void MonitorEnsemble::fill(const edm::Event& event,
 
 
 
-      // apply preselection
+      // apply preselection loose muon
       if (!muonSelect_ || (*muonSelect_)(*muon)) {
- 
+          
+        //loose muon count
+        ++mMult;
 
         double chHadPt = muon->pfIsolationR04().sumChargedHadronPt;
         double neHadEt = muon->pfIsolationR04().sumNeutralHadronEt;
         double phoEt = muon->pfIsolationR04().sumPhotonEt;
 
-        double pfRelIso =
-            (chHadPt +
-             max(0., neHadEt + phoEt - 0.5 * muon->pfIsolationR04().sumPUPt)) /
-            muon->pt();  // CB dBeta corrected iso!
+        double pfRelIso = (chHadPt + max(0., neHadEt + phoEt - 0.5 * muon->pfIsolationR04().sumPUPt)) / muon->pt();  // CB dBeta corrected iso!
 
-        if (mMult == 0) {
-          // restrict to leading muon
-          fill("muonPt_", muon->pt());
-          fill("muonEta_", muon->eta());
-
+        if(!(muon->isGlobalMuon() && muon->isPFMuon() && muon->globalTrack()->normalizedChi2() < 10. && muon->globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && muon->numberOfMatchedStations() > 1 && fabs(muon->muonBestTrack()->dxy(pver.position())) < 0.2  && fabs(muon->muonBestTrack()->dz(pver.position())) < 0.5 && muon->innerTrack()->hitPattern().numberOfValidPixelHits() > 0 && muon->innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5   ) )continue;
+          
+        if (mMult == 1) {
+              // restrict to leading muon
           fill("muonRelIso_", pfRelIso);
-
           fill("muonChHadIso_", chHadPt);
           fill("muonNeHadIso_", neHadEt);
           fill("muonPhIso_", phoEt);
+          fill("muonRelIso_",pfRelIso);
+            
         }
-        ++mMult;
-        if (!muonIso_ || (*muonIso_)(*muon)) ++mMultIso;
+          
+        if(!(pfRelIso<0.15))continue;
+          
+          
+        ++mTight;
+          
+          
+        //tight id
+        if (mTight == 1) {
+          // restrict to leading muon
+            
+          fill("muonPt_", muon->pt());
+          fill("muonEta_", muon->eta());
+          fill("muonPhi_", muon->phi());
+            
+        }
       }
     }
   }
-  fill("muonMult_", mMult);
-  fill("muonMultIso_", mMultIso);
-
+  fill("muonMult_", mMult); //loose
+  fill("muonMultTight_", mTight); //tight id & iso
+    
   /*
   ------------------------------------------------------------
 
@@ -521,11 +592,12 @@ void MonitorEnsemble::fill(const edm::Event& event,
   ------------------------------------------------------------
   */
 
+  
 
   // loop jet collection
   std::vector<pat::Jet> correctedJets;
   std::vector<double> JetTagValues;
-  unsigned int mult = 0, multBEff = 0, multBPur = 0, multBVtx = 0, multCSV = 0;
+  unsigned int mult = 0, loosemult=0, multBCSVM = 0;
 
   edm::Handle<edm::View<pat::Jet> > jets;
   if (!event.getByToken(jets_, jets)) {
@@ -535,7 +607,7 @@ void MonitorEnsemble::fill(const edm::Event& event,
   for (edm::View<pat::Jet>::const_iterator jet = jets->begin();
        jet != jets->end(); ++jet) {
     // check jetID for calo jets
-    unsigned int idx = jet - jets->begin();
+    //unsigned int idx = jet - jets->begin();
 
       pat::Jet sel = *jet;
 
@@ -545,44 +617,51 @@ void MonitorEnsemble::fill(const edm::Event& event,
     // prepare jet to fill monitor histograms
     pat::Jet monitorJet = *jet;
 
-    correctedJets.push_back(monitorJet);
-    ++mult;  // determine jet multiplicity
 
-      fill("jetBDiscEff_", monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")); //hard coded discriminator and value right now.
-      if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89) ++multBEff;
+    ++mult;
+      
+    if(monitorJet.chargedHadronEnergyFraction()>0 && monitorJet.chargedMultiplicity()>0 && monitorJet.chargedEmEnergyFraction()<0.99 && monitorJet.neutralHadronEnergyFraction()<0.99 && monitorJet.neutralEmEnergyFraction()<0.99 && (monitorJet.chargedMultiplicity()+monitorJet.neutralMultiplicity())>1 ){
+
+      correctedJets.push_back(monitorJet);
+      ++loosemult;  // determine jet multiplicity
+    
+      fill("jetBCSV_", monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags")); //hard coded discriminator and value right now.
+      if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89) ++multBCSVM;
 
 
       // Fill a vector with Jet b-tag WP for later M3+1tag calculation: CSV
       // tagger
       JetTagValues.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-//    }
-    // fill pt (raw or L2L3) for the leading four jets
-    if (idx == 0) {
-      fill("jet1Pt_", monitorJet.pt());
-      fill("jet1PtRaw_", jet->pt());
-      fill("jet1Eta_", monitorJet.eta());
-    };
-    if (idx == 1) {
-      fill("jet2Pt_", monitorJet.pt());
-      fill("jet2PtRaw_", jet->pt());
-      fill("jet2Eta_", monitorJet.eta());
-    }
-    if (idx == 2) {
-      fill("jet3Pt_", monitorJet.pt());
-      fill("jet3PtRaw_", jet->pt());
-      fill("jet3Eta_", monitorJet.eta());
-    }
-    if (idx == 3) {
-      fill("jet4Pt_", monitorJet.pt());
-      fill("jet4PtRaw_", jet->pt());
-      fill("jet4Eta_", monitorJet.eta());
+      //    }
+      // fill pt (raw or L2L3) for the leading four jets
+      if (loosemult == 1) {
+      //cout<<" jet id= "<<monitorJet.chargedHadronEnergyFraction()<<endl;
+
+        fill("jet1Pt_", monitorJet.pt());
+        //fill("jet1PtRaw_", jet->pt());
+        fill("jet1Eta_", monitorJet.eta());
+      };
+      if (loosemult == 2) {
+        fill("jet2Pt_", monitorJet.pt());
+        //fill("jet2PtRaw_", jet->pt());
+        fill("jet2Eta_", monitorJet.eta());
+      }
+      if (loosemult == 3) {
+        fill("jet3Pt_", monitorJet.pt());
+        //fill("jet3PtRaw_", jet->pt());
+        fill("jet3Eta_", monitorJet.eta());
+      }
+      if (loosemult == 4) {
+        fill("jet4Pt_", monitorJet.pt());
+        //fill("jet4PtRaw_", jet->pt());
+        fill("jet4Eta_", monitorJet.eta());
+      }
+
     }
   }
   fill("jetMult_", mult);
-  fill("jetMultBEff_", multBEff);
-  fill("jetMultBPur_", multBPur);
-  fill("jetMultBVtx_", multBVtx);
-  fill("jetMultCSVtx_", multCSV);
+  fill("jetLooseMult_", loosemult);
+  fill("jetMultBCSVM_", multBCSVM);
 
   /*
   ------------------------------------------------------------
@@ -615,7 +694,7 @@ void MonitorEnsemble::fill(const edm::Event& event,
   */
 
   // fill W boson and top mass estimates
-
+    
   Calculate_miniAOD eventKinematics(MAXJETS, WMASS);
   double wMass = eventKinematics.massWBoson(correctedJets);
   double topMass = eventKinematics.massTopQuark(correctedJets);
@@ -632,6 +711,33 @@ void MonitorEnsemble::fill(const edm::Event& event,
       eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.89); //hard coded CSVv2 value
   
   if (btopMass >= 0) fill("massBTop_", btopMass);
+    
+  // fill plots for trigger monitoring
+  if ((lowerEdge_ == -1. && upperEdge_ == -1.) ||
+    (lowerEdge_ < wMass && wMass < upperEdge_)) {
+    if (!triggerTable_.isUninitialized())
+      fill(event, *triggerTable, "trigger", triggerPaths_);
+    if (logged_ <= hists_.find("eventLogger_")->second->getNbinsY()) {
+    // log runnumber, lumi block, event number & some
+    // more pysics infomation for interesting events
+     fill("eventLogger_", 0.5, logged_ + 0.5, event.eventAuxiliary().run());
+     fill("eventLogger_", 1.5, logged_ + 0.5,
+        event.eventAuxiliary().luminosityBlock());
+     fill("eventLogger_", 2.5, logged_ + 0.5, event.eventAuxiliary().event());
+     //if (correctedJets.size() > 0)
+     if(!correctedJets.empty())fill("eventLogger_", 3.5, logged_ + 0.5, correctedJets[0].pt());
+     if (correctedJets.size() > 1)fill("eventLogger_", 4.5, logged_ + 0.5, correctedJets[1].pt());
+     if (correctedJets.size() > 2)fill("eventLogger_", 5.5, logged_ + 0.5, correctedJets[2].pt());
+     if (correctedJets.size() > 3)fill("eventLogger_", 6.5, logged_ + 0.5, correctedJets[3].pt());
+     fill("eventLogger_", 7.5, logged_ + 0.5, wMass);
+     fill("eventLogger_", 8.5, logged_ + 0.5, topMass);
+     ++logged_;
+     }
+  }
+    
+    
+    
+    
 
 }
 }

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
@@ -108,6 +108,8 @@ class MonitorEnsemble {
   /// to be of form signalPath:MonitorPath
   std::vector<std::string> triggerPaths_;
 
+  edm::InputTag rhoTag;
+
   /// electronId label
   edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
  

--- a/DQM/Physics/test/topDQM_production_cfg.py
+++ b/DQM/Physics/test/topDQM_production_cfg.py
@@ -3,9 +3,10 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process('TOPDQM')
 
 ## imports of standard configurations
-process.load('DQMOffline.Configuration.DQMOffline_cff')
+#process.load('DQMOffline.Configuration.DQMOffline_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.Services_cff')
 
 ## --------------------------------------------------------------------
 ## Frontier Conditions: (adjust accordingly!!!)
@@ -17,9 +18,11 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 ## For more details have a look at: WGuideFrontierConditions
 ## --------------------------------------------------------------------
 ##process.GlobalTag.globaltag = 'GR_R_42_V14::All' 
-process.GlobalTag.globaltag = 'MCRUN2_74_V9'
+#process.GlobalTag.globaltag = 'MCRUN2_74_V9'
 #process.GlobalTag.globaltag = 'auto:startup_GRun'
-
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:100X_mc2017_realistic', '')
 #dbs search --query 'find file where site=srm-eoscms.cern.ch and dataset=/RelValTTbar/CMSSW_7_0_0_pre3-PRE_ST62_V8-v1/GEN-SIM-RECO'
 #dbs search --query 'find dataset where dataset=/RelValTTbar/CMSSW_7_0_0_pre6*/GEN-SIM-RECO'
 
@@ -27,6 +30,11 @@ process.GlobalTag.globaltag = 'MCRUN2_74_V9'
 process.source = cms.Source("PoolSource",
     #fileNames = cms.untracked.vstring("file:input.root',")
     fileNames = cms.untracked.vstring(
+	"/store/relval/CMSSW_10_0_0_pre2/RelValTTbar_13/GEN-SIM-RECO/100X_mc2017_realistic_v1-v1/20000/1CD8D6F0-AFDC-E711-B2BC-0CC47A78A478.root"
+
+#    "/store/relval/CMSSW_9_4_0_pre2/RelValTTbar_13/GEN-SIM-RECO/94X_upgrade2018_realistic_v1-v1/10000/5CD4DB82-83A9-E711-B067-0025905B8560.root",
+#    "/store/relval/CMSSW_9_4_0_pre2/RelValTTbar_13/GEN-SIM-RECO/94X_upgrade2018_realistic_v1-v1/10000/74FB294F-7FA9-E711-9582-0CC47A4D7626.root",
+#    "/store/relval/CMSSW_9_4_0_pre2/RelValTTbar_13/GEN-SIM-RECO/94X_upgrade2018_realistic_v1-v1/10000/78446D4B-7FA9-E711-A556-0CC47A78A42C.root",
     #"/store/relval/CMSSW_6_2_0_pre1-START61_V8/RelValTTbarLepton/GEN-SIM-RECO/v1/00000/C6CC53CC-6E6D-E211-8EAB-003048D3756A.root',"
     
     #/RelValTTbar/CMSSW_7_0_0_pre6-PRE_ST62_V8-v1/GEN-SIM-RECO
@@ -34,7 +42,7 @@ process.source = cms.Source("PoolSource",
     #'/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/72477A84-F93B-E311-BF63-003048FFD720.root',
     #'/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/12A06D7A-F93B-E311-AA64-003048678BEA.root'
         #    '/store/relval/CMSSW_7_1_0_pre4/RelValTTbarLepton_13/GEN-SIM-RECO/POSTLS171_V1-v2/00000/48ED95A2-66AA-E311-9865-02163E00E5AE.root'
-    '/store/relval/CMSSW_8_0_0_pre5/RelValTTbarLepton_13/GEN-SIM-RECO/80X_mcRun2_asymptotic_v1-v1/00000/120469B3-20C5-E511-A321-0026189438CB.root'
+    #'/store/relval/CMSSW_8_0_0_pre5/RelValTTbarLepton_13/GEN-SIM-RECO/80X_mcRun2_asymptotic_v1-v1/00000/120469B3-20C5-E511-A321-0026189438CB.root'
 #'/store/relval/CMSSW_7_6_0_pre1/RelValTTbarLepton_13/GEN-SIM-RECO/75X_mcRun2_asymptotic_v1-v1/00000/303083D5-F82F-E511-8B50-0025905B8576.root'
     )
 )
@@ -70,8 +78,7 @@ process.output = cms.OutputModule("PoolOutputModule",
 )
 
 ## load jet corrections
-#process.load("JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff")
-#process.prefer("ak4PFL2L3")
+process.load("JetMETCorrections.Configuration.JetCorrectors_cff")
 
 ## check the event content
 process.content = cms.EDAnalyzer("EventContentAnalyzer")
@@ -89,18 +96,22 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 100
 process.MEtoEDMConverter.deleteAfterCopy = cms.untracked.bool(False)  ## line added to avoid crash when changing run number
 
 
+process.load("DQM.Physics.topSingleLeptonDQM_cfi")
+process.load("DQM.Physics.singleTopDQM_cfi")
+
+
 ## path definitions
 process.p      = cms.Path(
 #    process.simpleEleId70cIso          *
-    process.DiMuonDQM                  +
-    process.DiElectronDQM              +
-    process.ElecMuonDQM                +
+    #process.DiMuonDQM                  +
+    #process.DiElectronDQM              +
+    #process.ElecMuonDQM                +
     #process.topSingleMuonLooseDQM      +
-    process.topSingleMuonMediumDQM     +
+    process.ak4PFCHSL1FastL2L3CorrectorChain * process.topSingleMuonMediumDQM     +
     #process.topSingleElectronLooseDQM  +
-    process.topSingleElectronMediumDQM +
-    process.singleTopMuonMediumDQM     +
-    process.singleTopElectronMediumDQM
+    process.ak4PFCHSL1FastL2L3CorrectorChain * process.topSingleElectronMediumDQM +
+    process.ak4PFCHSL1FastL2L3CorrectorChain * process.singleTopMuonMediumDQM      +
+    process.ak4PFCHSL1FastL2L3CorrectorChain * process.singleTopElectronMediumDQM
 )
 process.endjob = cms.Path(
     process.endOfProcess

--- a/DQM/Physics/test/topDQM_production_miniAOD.py
+++ b/DQM/Physics/test/topDQM_production_miniAOD.py
@@ -17,7 +17,11 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 ## For more details have a look at: WGuideFrontierConditions
 ## --------------------------------------------------------------------
 ##process.GlobalTag.globaltag = 'GR_R_42_V14::All' 
-process.GlobalTag.globaltag = 'MCRUN2_74_V9'
+#process.GlobalTag.globaltag = 'MCRUN2_74_V9'
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
+ 
 
 
 #dbs search --query 'find file where site=srm-eoscms.cern.ch and dataset=/RelValTTbar/CMSSW_7_0_0_pre3-PRE_ST62_V8-v1/GEN-SIM-RECO'
@@ -27,123 +31,12 @@ process.GlobalTag.globaltag = 'MCRUN2_74_V9'
 process.source = cms.Source("PoolSource",
     #fileNames = cms.untracked.vstring("file:input.root',")
     fileNames = cms.untracked.vstring(
-    #"/store/relval/CMSSW_6_2_0_pre1-START61_V8/RelValTTbarLepton/GEN-SIM-RECO/v1/00000/C6CC53CC-6E6D-E211-8EAB-003048D3756A.root',"
+
+	'/store/relval/CMSSW_10_0_0_pre2/RelValTTbar_13/MINIAODSIM/100X_mc2017_realistic_v1-v1/20000/4E3E8C73-C1DC-E711-9DAC-0CC47A7C340E.root'
+#    	'/store/relval/CMSSW_9_2_4/RelValTTbarLepton_13/MINIAODSIM/92X_upgrade2017_realistic_v2-v1/00000/A4DA3BEB-3C5C-E711-AA32-003048FFD79E.root',
+#'/store/relval/CMSSW_9_2_4/RelValTTbarLepton_13/MINIAODSIM/92X_upgrade2017_realistic_v2-v1/00000/D83C1AEF-3C5C-E711-82F4-0CC47A4D7600.root'
+
     
-    #/RelValTTbar/CMSSW_7_0_0_pre6-PRE_ST62_V8-v1/GEN-SIM-RECO
-    #    '/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/B627D32C-0B3C-E311-BBE6-0026189438E6.root',
-    #    '/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/72477A84-F93B-E311-BF63-003048FFD720.root',
-    #    '/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/12A06D7A-F93B-E311-AA64-003048678BEA.root'
-        #        '/store/relval/CMSSW_7_1_0_pre4/RelValTTbarLepton_13/GEN-SIM-RECO/POSTLS171_V1-v2/00000/48ED95A2-66AA-E311-9865-02163E00E5AE.root'
-#        '/store/relval/CMSSW_7_1_0_pre9/RelValTTbarLepton_13/GEN-SIM-RECO/POSTLS171_V11-v1/00000/90D92DC6-67F0-E311-8D2E-0025905A613C.root'
-
-         '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2_ext3-v1/10000/003964D7-D06E-E511-A8DA-001517F7F524.root',
-         '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2_ext3-v1/10000/0041D4C0-D86E-E511-8D6B-001E67A3E8F9.root',
-         '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2_ext3-v1/10000/00962466-E86E-E511-9105-0026189438D7.root',
-         '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2_ext3-v1/10000/00A7C4B3-766E-E511-973F-002618943904.root',
-         '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2_ext3-v1/10000/020B5100-426E-E511-888A-0026189437F9.root',
-         '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2_ext3-v1/10000/024E3A40-706F-E511-AE4B-68B5996BD98E.root',
-         '/store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2_ext3-v1/10000/025CB88B-706F-E511-9F87-6CC2173D46A0.root'
-
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/00000/B4414D37-CF97-E511-B2C4-002590747DE2.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/00000/B4414D37-CF97-E511-B2C4-002590747DE2.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/006945CA-3088-E511-96C4-0025905A497A.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/04B296F0-2A88-E511-A760-002618943856.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/04F9A001-2888-E511-ABEC-0025905A60B6.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/0A37E1C7-668B-E511-81DC-FACADE0000AF.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/0A401EEE-2A88-E511-AFBC-0026189438AD.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/0A5583EC-2A88-E511-A990-0CC47A4D768C.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/0E9802F4-2A88-E511-B4EE-002618943970.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/1609D954-5D87-E511-AB94-0025907B4F64.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/1646260C-189A-E511-9854-0025904C66E4.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/16DF38A8-2388-E511-B447-0CC47A4C8E56.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/182952B2-6C89-E511-9CF7-0CC47A4D76C0.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/1A473DEA-2A88-E511-8DC0-00261894393E.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/1A5653A9-2388-E511-BE59-0025905A60AA.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/2002E1DA-2A88-E511-B93C-0CC47A78A4B8.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/2031DEEF-2A88-E511-ADF1-0CC47A4C8EEA.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/20ED3D7F-2588-E511-AC35-00505602077D.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/22B66702-2188-E511-AB24-20CF305616E2.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/24B786E8-A087-E511-80C3-002618943950.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/2A2AF453-2188-E511-9918-0025907B503A.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/2AEC7850-1F88-E511-832C-0025907B503A.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/2C573255-009A-E511-A1DB-0025905C2CD2.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/30F9373F-3188-E511-9769-0CC47A4C8ECA.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/34BFD4ED-2A88-E511-8609-0CC47A4D7634.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/366DF93F-3188-E511-BF1D-0CC47A4C8EB6.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/3ACD13F0-2A88-E511-9FD6-0CC47A4C8F12.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/4467632E-2188-E511-A5F1-002590D0B044.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/508CF007-189A-E511-AB08-0025905C3D6A.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/5204AAEB-9F87-E511-AA0B-0026189438CC.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/642A7DD7-2A88-E511-BB53-0CC47A4D767E.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/64395FEB-2A88-E511-929E-0026189437FD.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/689CC1E6-3888-E511-8D89-0CC47A4C8E0E.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/6A1E3BFF-2788-E511-B16D-0CC47A4D767E.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/6E848416-7D8B-E511-82A9-047D7BD6DF34.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/74096A0B-189A-E511-AC3C-0025905C9742.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/74788752-1F88-E511-9F39-20CF305616E2.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/748ED45E-3C88-E511-8E27-0025905964B6.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/7C7F85C8-668B-E511-A3D0-FACADE0000AF.root',
-#    '/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/7CACA6D7-2A88-E511-83D9-0CC47A78A472.root',
-
-
-
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/7E65204F-1F88-E511-8D2C-002590D0B044.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/8072C45A-948B-E511-9106-00266CFFA1AC.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/82F384FF-2788-E511-B894-0CC47A78A4B8.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/8414FF0E-7D8B-E511-8007-047D7B881D26.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/848000A9-2388-E511-B9D2-0025905A60FE.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/868B6D02-2888-E511-B667-0CC47A78A472.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/86F0A513-0A89-E511-9D31-A01D48EE8318.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/8C081F49-AD91-E511-A1FA-0025904CDDFA.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/8C9B920B-189A-E511-8523-0025904C63FA.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/8EB36200-2888-E511-8DC3-0025905A6136.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/90D9B150-1F88-E511-BD7A-002590D0B058.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/924B4D60-3C88-E511-BEA7-0025905A60BE.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/949C8F64-FF99-E511-B8DE-0025905BA734.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/94FD91A8-2388-E511-9F33-0CC47A78A42E.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/96BFF2B0-2888-E511-8916-002590D0B0D4.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/9A33A5D1-668B-E511-93F1-002590AC4BF8.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/A06767EC-2A88-E511-BE75-00261894398C.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/AA123970-FF99-E511-A864-0025904C641C.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/AA8972DE-5787-E511-9DCB-002590D0AFC6.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/AE9D38EE-5A87-E511-A5B2-002590D0AFB6.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/B66A08F1-2A88-E511-A98F-0025905A6094.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/B80D1283-5E87-E511-B089-002590D0B046.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/BAB37002-2888-E511-BBE0-0CC47A78A472.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/C02D41A7-2388-E511-8C02-0CC47A4D761A.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/C041AD83-5E87-E511-8258-002590D0B052.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/C05800A4-2388-E511-ADE5-0026189438FD.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/C84167BF-9C87-E511-A3C2-002618943940.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/D221EED8-2588-E511-9A68-002590D0AFF4.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/D63C75F1-2A88-E511-8B15-0025905B860E.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/DA0B72BF-9C87-E511-8734-002618943916.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/DE080BE8-3888-E511-B2BD-0CC47A4C8E0E.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/E240F1C1-9C87-E511-9374-0026189438CC.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/EE697B2B-3788-E511-857E-0CC47A7452D0.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/F231403E-3E88-E511-A3E6-0025905B855E.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/F4FD5AF0-2A88-E511-8C28-0CC47A4C8F10.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/F675A30B-189A-E511-B35B-0025904C63FA.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/FA529E5B-5987-E511-8F30-005056020786.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/FAA42B44-A087-E511-9D9E-00248C0BE005.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/FAC5E021-3788-E511-8953-0CC47A4D7618.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/0028B733-4C87-E511-BBEE-002590D0B052.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/12DF8FB8-5C87-E511-88A1-0025907B5002.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/1607DD10-5E87-E511-BEC7-0025905A60D2.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/2821C96A-5087-E511-86F9-002590D0B086.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/2A04A99D-7187-E511-A3B5-0025905A6088.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/2EA9647A-5887-E511-8BF8-002590D0B09A.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/2EEA626F-D18E-E511-9FDE-02163E00F449.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/368618C7-2F8E-E511-BCB2-6CC2173C3DD0.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/48DCFD10-5E87-E511-8193-0025905A6138.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/4A2F3EE2-6087-E511-8D3F-0025905A612E.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/524B846A-5087-E511-81AE-002590D0B0CC.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/76FAB9E2-6087-E511-B1E0-0025905A6080.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/A625DC4C-4C87-E511-A0C6-002590D0B052.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/A69D21E3-5C87-E511-BCF5-0CC47A4DEEF8.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/B8AFEA2D-B786-E511-964E-0025905AA9CC.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/F828D2E2-6087-E511-BDBD-0025905A6138.root',
-    #'/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/30000/FEEE3F10-5E87-E511-B346-0025905B85D6.root',
-
 
     )
 )
@@ -209,10 +102,10 @@ process.p      = cms.Path(
 #    process.DiElectronDQM              +
 #    process.ElecMuonDQM                +
     #process.topSingleMuonLooseDQM      +
-    process.topSingleMuonMediumDQM_miniAOD +
+    process.topSingleMuonMediumDQM_miniAOD  +
     #process.topSingleElectronLooseDQM  +
     process.topSingleElectronMediumDQM_miniAOD +
-     process.singleTopMuonMediumDQM_miniAOD     +
+    process.singleTopMuonMediumDQM_miniAOD     +
     process.singleTopElectronMediumDQM_miniAOD
 )
 process.endjob = cms.Path(


### PR DESCRIPTION
Muon id selections are updated.
Lepton phi plot is added.
Muon relIso and its plot are updated.
Muon multiplicity plots are updated as function of tight id,iso selection.

Talk at TOP PAG: 
https://indico.cern.ch/event/649877/contributions/2643741/attachments/1487397/2310529/topdqm_jul4.pdf