### PR TITLE
HcalUnpacker: don't unpack uMNIO digi again as QIE11 digi

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -603,6 +603,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
     //Check to make sure uMNio is not unpacked here
     if(uhtr.getFormatVersion() != 1) {
       unpackUMNio(raw, slot, colls);
+      continue;
     }  
 #ifdef DebugLog
     //debug printouts


### PR DESCRIPTION
A continue statement is needed to prevent the uMNIO digi from being unpacked again as a QIE11 digi. This has been causing warnings and early termination of the unpacking, as the uMNIO digi has a different number of samples from the QIE11 digis.