### PR TITLE
HcalUnpacker: Backport 19562 to 9_2_X

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -603,6 +603,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
     //Check to make sure uMNio is not unpacked here
     if(uhtr.getFormatVersion() != 1) {
       unpackUMNio(raw, slot, colls);
+      continue;
     }  
 #ifdef DebugLog
     //debug printouts


### PR DESCRIPTION
Backport https://github.com/cms-sw/cmssw/pull/19562 to 9_2_X.