### PR TITLE
HCALDQM: bugfix, QIE11DataFrame::size() should be samples()

### DIFF
--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -761,7 +761,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps):
 		if (sumQ>_cutSumQ_HEP17)
 		{
 			//double timing = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
-			double timing = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size()-1);
+			double timing = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples()-1);
 
 			_cOccupancyCut_depth.fill(did);
 			_cTimingCut_depth.fill(did, timing);


### PR DESCRIPTION
As @slava77 pointed out in https://github.com/cms-sw/cmssw/pull/18841, there was a bug introduced that caused a plot to be filled with random values (Hcal/DigiTask/TimingCut/depth/*, for QIE11 channels; the timing is basically the charge-weighted average time slice). QIE11DataFrame::size() should be QIE11DataFrame::samples(); size() includes the digi header/footer, so the charge lookup was going past the last element of the vector storing the charge per time slice. 