### PR TITLE
Make compression settings more aggressive.

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -122,7 +122,6 @@ CommonEventContent = cms.PSet(
 LHEEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -134,7 +133,6 @@ RAWEventContent = cms.PSet(
         'keep  FEDRawDataCollection_rawDataCollector_*_*',
         'keep  FEDRawDataCollection_source_*_*'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -144,17 +142,15 @@ RAWEventContent = cms.PSet(
 RECOEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
-# RAWRECO Data Tiere definition
+# RAWRECO Data Tier definition
 #
 #
 RAWRECOEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
     )
 #
 #
@@ -163,7 +159,7 @@ RAWRECOEventContent = cms.PSet(
 #
 AODEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    eventAutoFlushCompressedSize=cms.untracked.int32(30*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )
@@ -186,7 +182,7 @@ RAWSIMEventContent = cms.PSet(
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
-    compressionLevel=cms.untracked.int32(9),
+    compressionLevel=cms.untracked.int32(9)
 )
 #
 #
@@ -196,7 +192,6 @@ RAWSIMEventContent = cms.PSet(
 RAWSIMHLTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -206,7 +201,6 @@ RAWSIMHLTEventContent = cms.PSet(
 RAWRECOSIMHLTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -216,7 +210,6 @@ RAWRECOSIMHLTEventContent = cms.PSet(
 RAWRECODEBUGHLTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -226,7 +219,6 @@ RAWRECODEBUGHLTEventContent = cms.PSet(
 RECOSIMEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -236,7 +228,6 @@ RECOSIMEventContent = cms.PSet(
 GENRAWEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -245,9 +236,9 @@ GENRAWEventContent = cms.PSet(
 #
 AODSIMEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    eventAutoFlushCompressedSize=cms.untracked.int32(30*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
-    compressionLevel=cms.untracked.int32(4)
+    compressionLevel=cms.untracked.int32(4),
 )
 #
 #
@@ -257,12 +248,10 @@ AODSIMEventContent = cms.PSet(
 FEVTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 FEVTHLTALLEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 
 #
@@ -273,7 +262,6 @@ FEVTHLTALLEventContent = cms.PSet(
 FEVTSIMEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -283,7 +271,6 @@ FEVTSIMEventContent = cms.PSet(
 RAWDEBUGEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -293,7 +280,6 @@ RAWDEBUGEventContent = cms.PSet(
 RAWDEBUGHLTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -303,7 +289,6 @@ RAWDEBUGHLTEventContent = cms.PSet(
 FEVTDEBUGEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 
 
@@ -315,7 +300,6 @@ FEVTDEBUGEventContent = cms.PSet(
 FEVTDEBUGHLTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(10*1024*1024)
 )
 
 #
@@ -326,7 +310,6 @@ FEVTDEBUGHLTEventContent = cms.PSet(
 RECODEBUGEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 
 
@@ -339,7 +322,6 @@ HLTDEBUGEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *',
         'keep *_logErrorHarvester_*_*'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 
 #
@@ -379,20 +361,17 @@ DATAMIXEREventContent = cms.PSet(
                                                'keep EEDigiCollection_ecalDigis_*_*',
                                                'keep ESDigiCollection_ecalPreshowerDigis_*_*'),
         splitLevel = cms.untracked.int32(0),
-        eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
         )
 
 PREMIXEventContent = cms.PSet(
         outputCommands = cms.untracked.vstring('drop *'),
         splitLevel = cms.untracked.int32(0),
-        eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
         )
 
 MIXINGMODULEEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *',
                                            'keep *_cfWriter_*_*'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
     )
 
 # PREMIXRAW Data Tier definition
@@ -401,7 +380,6 @@ MIXINGMODULEEventContent = cms.PSet(
 PREMIXRAWEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 
 #
@@ -416,12 +394,10 @@ REPACKRAWEventContent = cms.PSet(
       'keep FEDRawDataCollection_rawDataRepacker_*_*',
       'keep FEDRawDataCollection_virginRawDataRepacker_*_*'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
     )
 REPACKRAWSIMEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring(),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 
 LHEEventContent.outputCommands.extend(GeneratorInterfaceLHE.outputCommands)
@@ -766,17 +742,21 @@ REDIGIEventContent.inputCommands.append('drop *_randomEngineStateProducer_*_*')
 
 
 ########### and mini AOD
+#
+# MiniAOD is a bit special: the files tend to be so small that letting
+# ROOT automatically determine when to flush is a surprisingly big overhead.
+#
 
 MINIAODEventContent= cms.PSet(    
     outputCommands = cms.untracked.vstring('drop *'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    eventAutoFlushCompressedSize=cms.untracked.int32(-900),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )
 
 MINIAODSIMEventContent= cms.PSet(    
     outputCommands = cms.untracked.vstring('drop *'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    eventAutoFlushCompressedSize=cms.untracked.int32(-900),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )
@@ -790,14 +770,14 @@ MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
 
 RAWMINIAODEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )
 
 RAWMINIAODSIMEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )
@@ -815,7 +795,7 @@ RAWMINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputComman
 #
 RAWAODSIMEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
-    eventAutoFlushCompressedSize=cms.untracked.int32(15*1024*1024),
+    eventAutoFlushCompressedSize=cms.untracked.int32(20*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -436,13 +436,14 @@ namespace edm {
     desc.addUntracked<int>("maxSize", 0x7f000000)
         ->setComment("Maximum output file size, in kB.\n"
                      "If over maximum, new output file will be started at next input file transition.");
-    desc.addUntracked<int>("compressionLevel", 7)
+    desc.addUntracked<int>("compressionLevel", 9)
         ->setComment("ROOT compression level of output file.");
     desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
         ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
     desc.addUntracked<int>("basketSize", 16384)
         ->setComment("Default ROOT basket size in output file.");
-    desc.addUntracked<int>("eventAutoFlushCompressedSize",-1)->setComment("Set ROOT auto flush stored data size (in bytes) for event TTree. The value sets how large the compressed buffer is allowed to get. The uncompressed buffer can be quite a bit larger than this depending on the average compression ratio. The value of -1 just uses ROOT's default value. The value of 0 turns off this feature.");
+    desc.addUntracked<int>("eventAutoFlushCompressedSize",20*1024*1024)
+        ->setComment("Set ROOT auto flush stored data size (in bytes) for event TTree. The value sets how large the compressed buffer is allowed to get. The uncompressed buffer can be quite a bit larger than this depending on the average compression ratio. The value of -1 just uses ROOT's default value. The value of 0 turns off this feature.");
     desc.addUntracked<int>("splitLevel", 99)
         ->setComment("Default ROOT branch split level in output file.");
     desc.addUntracked<std::string>("sortBaskets", std::string("sortbasketsbyoffset"))


### PR DESCRIPTION
Summary:
- Keep LZMA-4 as a default for data tiers that are not transient.
- Change default auto-flush to 20MB (currently 10MB).
- Change auto-flush for *AOD* to 30MB (currently 15MB).

Details:
Did a bit of investigating inside ROOT compression settings (which maybe hasn't been done since Run I?)

I took a file (/store/data/Run2017A/SingleMuon/AOD/PromptReco-v3/000/296/888/00000/002DA5DA-6455-E711-9F13-02163E014259.root) from what should be the most prevalent data tier (AOD) and recompressed it under a variety of settings (ZLIB-7, ZLIB-9, LZMA-4, LZMA-9).  A few findings.

Relative speed:
- ZLIB-7: 15MB/s, 0.021s/evt
- ZLIB-9: 2.7MB/s, 0.11s/evt
- LZMA-4: 1.9MB/s, 0.15s/evt
- LZMA-9: 1.1MB/s, 0.26s/evt

Nothing new here.  LZMA-9 is about an order-magnitude slower than ZLIB-7; this is consistent with prior measurements.

The default compression settings for this file is LZMA-4 with 15MB auto-flush buffer, resulting in a 2,816MB file.

Relative file sizes (10MB auto-flush buffer):
- ZLIB-7: 3,150MB
- ZLIB-9: 3,129MB
- LZMA-4: 2,925MB, (+3.9% file size increase, 26MB RSS buffer savings)
- LZMA-9: 2,891MB, (+2.7%, 19MB RSS buffer savings)

Relative file sizes (20MB auto-flush buffer):
- ZLIB-7: 2,996MB
- ZLIB-9: 2,974MB
- LZMA-4: 2,739MB (-2.7% smaller than original, additional 29MB RSS in buffer usage)
- LZMA-9: 2,701MB (-4.1% smaller, additional 23MB RSS)

Using a 30MB auto-flush buffer:
- ZLIB-7: 2,941
- ZLIB-9: 2,918
- LZMA-4: 2,666 (-5.3% smaller, +91MB RSS)
- LZMA-9: 2,626 (-6.5% smaller, +94MB RSS)

So, for about 90MB per output file, we can get 5% additional file size savings.

Other thoughts:
- With multithreading, we have additional room in the memory budget.
- Until ROOT 6.12 is available (which multithreads compression using TBB), we ought to be careful about significantly increasing CPU usage per-event for output, is it can cause significant stalls.

@davidlange6 