### PR TITLE
add hltTracksMerged monitoring (both DQM and Validation)

### DIFF
--- a/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
@@ -226,7 +226,7 @@ hltTrackRefitterForSiStripMonitorTrack.Propagator              = cms.string('hlt
 hltTrackRefitterForSiStripMonitorTrack.Fitter                  = cms.string('hltESPFittingSmootherIT')
 hltTrackRefitterForSiStripMonitorTrack.MeasurementTrackerEvent = cms.InputTag('hltMeasurementTrackerEvent')
 hltTrackRefitterForSiStripMonitorTrack.NavigationSchool        = cms.string('navigationSchoolESProducer')
-hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltIter2Merged")
+hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltTracksMerged") # hltIter2Merged
 
 HLTSiStripMonitorTrack.TopFolderName = cms.string('HLT/SiStrip')
 HLTSiStripMonitorTrack.TrackProducer = 'hltTrackRefitterForSiStripMonitorTrack'

--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
@@ -11,7 +11,8 @@ from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 
 trackingMonitoringHLTsequence = cms.Sequence(
     pixelTracksMonitoringHLT # hltPixel tracks monitoring
-    * iterHLTTracksMonitoringHLT # hltIter2Merged tracks monitoring
+    * iter2MergedTracksMonitoringHLT # hltIter2Merged tracks monitoring    
+    * iterHLTTracksMonitoringHLT # hltTracksMerged tracks monitoring
 )
 
 egmTrackingMonitorHLTsequence = cms.Sequence(

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -138,7 +138,7 @@ hltSiPixelPhase1TrackClustersConf = cms.VPSet(
 
 hltSiPixelPhase1TrackClustersAnalyzer = cms.EDAnalyzer("SiPixelPhase1TrackClusters",
         clusters   = cms.InputTag("hltSiPixelClusters"),
-        tracks     = cms.InputTag("hltIter2Merged"),
+        tracks     = cms.InputTag("hltTracksMerged"), #hltIter2Merged"
         histograms = hltSiPixelPhase1TrackClustersConf,
         geometry   = hltSiPixelPhase1Geometry
 )

--- a/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
@@ -138,7 +138,7 @@ hltTrackRefitterForSiStripMonitorTrack.MeasurementTrackerEvent = cms.InputTag('M
 hltTrackRefitterForSiStripMonitorTrack.TrajectoryInEvent       = cms.bool(True)
 hltTrackRefitterForSiStripMonitorTrack.useHitsSplitting        = cms.bool(False)
 #hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltIter4Merged") # scenario 0
-hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltIter2Merged") # scenario 1
+hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltTracksMerged") # hltIter2Merged # scenario 1
 #hltTrackRefitterForSiStripMonitorTrack.TTRHBuilder             = cms.string('hltESPTTRHBuilderAngleAndTemplate')
 hltTrackRefitterForSiStripMonitorTrack.TTRHBuilder             = cms.string('hltESPTTRHBWithTrackAngle')
 

--- a/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
@@ -6,7 +6,8 @@ trackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone()
 trackingEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
    "HLT/Tracking/pixelTracks/HitEffFromHitPattern*",
    "HLT/Tracking/iter0HP/HitEffFromHitPattern*",
-   "HLT/Tracking/iter2Merged/HitEffFromHitPattern*"
+   "HLT/Tracking/iter2Merged/HitEffFromHitPattern*",
+   "HLT/Tracking/tracks/HitEffFromHitPattern*"
 )
 
 # Sequence

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -53,10 +53,15 @@ iter2HPTracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter2HP'
 iter2HPTracksMonitoringHLT.TrackProducer    = 'hltIter2PFlowTrackSelectionHighPurity'
 iter2HPTracksMonitoringHLT.allTrackProducer = 'hltIter2PFlowTrackSelectionHighPurity'
 
+iter2MergedTracksMonitoringHLT = trackingMonHLT.clone()
+iter2MergedTracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter2Merged'
+iter2MergedTracksMonitoringHLT.TrackProducer    = 'hltIter2Merged'
+iter2MergedTracksMonitoringHLT.allTrackProducer = 'hltIter2Merged'
+
 iterHLTTracksMonitoringHLT = trackingMonHLT.clone()
-iterHLTTracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter2Merged'
-iterHLTTracksMonitoringHLT.TrackProducer    = 'hltIter2Merged'
-iterHLTTracksMonitoringHLT.allTrackProducer = 'hltIter2Merged'
+iterHLTTracksMonitoringHLT.FolderName       = 'HLT/Tracking/tracks'
+iterHLTTracksMonitoringHLT.TrackProducer    = 'hltTracksMerged'
+iterHLTTracksMonitoringHLT.allTrackProducer = 'hltTracksMerged'
 
 iter3TracksMonitoringHLT = trackingMonHLT.clone()
 iter3TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter3Merged'
@@ -73,6 +78,7 @@ trackingMonitorHLT = cms.Sequence(
     + iter0HPTracksMonitoringHLT
 #    + iter1HPTracksMonitoringHLT
 #    + iter2HPTracksMonitoringHLT
+    + iter2MergedTracksMonitoringHLT
     + iterHLTTracksMonitoringHLT
 )    
 
@@ -84,6 +90,7 @@ trackingMonitorHLTall = cms.Sequence(
     + iter1HPTracksMonitoringHLT
     + iter2TracksMonitoringHLT
     + iter2HPTracksMonitoringHLT
+    + iter2MergedTracksMonitoringHLT
     + iterHLTTracksMonitoringHLT
 #    + iter3TracksMonitoringHLT
 #    + iter4TracksMonitoringHLT

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -11,6 +11,7 @@ hltTrackValidator = hltMultiTrackValidator.clone(
         "hltIter1Merged",
         "hltIter2PFlowTrackSelectionHighPurity",
         "hltIter2Merged",
+        "hltTracksMerged",
 #        "hltIter3PFlowTrackSelectionHighPurity",
 #        "hltIter3Merged",
 #        "hltIter4PFlowTrackSelectionHighPurity",


### PR DESCRIPTION
new tracking @HLT strategy for the pixel bad components mitigation [https://its.cern.ch/jira/browse/CMSHLT-1360]
has updated the name of the final tracks collection
=> this PR adds both the DQM and Validation for the new hltTracksMerged collection